### PR TITLE
[WFLY-266] Notification Support

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.notification.NotificationSupport;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.ConfigurationPersister;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -233,6 +234,8 @@ public abstract class AbstractControllerService implements Service<ModelControll
         final ServiceContainer container = serviceController.getServiceContainer();
         final ServiceTarget target = context.getChildTarget();
         final ExecutorService executorService = injectedExecutorService.getOptionalValue();
+
+        final NotificationSupport notificationSupport = NotificationSupport.Factory.create(executorService);
         WritableAuthorizerConfiguration authorizerConfig = authorizer.getWritableAuthorizerConfiguration();
         authorizerConfig.reset();
         ManagementResourceRegistration rootResourceRegistration = rootDescriptionProvider != null
@@ -242,7 +245,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
                 rootResourceRegistration,
                 new ContainerStateMonitor(container),
                 configurationPersister, processType, runningModeControl, prepareStep,
-                processState, executorService, expressionResolver, authorizer, auditLogger);
+                processState, executorService, expressionResolver, authorizer, auditLogger, notificationSupport);
 
         // Initialize the model
         initModel(controller.getRootResource(), controller.getRootRegistration(), controller.getModelControllerResource());

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -47,12 +47,16 @@ import java.security.Principal;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -64,8 +68,11 @@ import org.jboss.as.controller.access.Environment;
 import org.jboss.as.controller.audit.AuditLogger;
 import org.jboss.as.controller.client.MessageSeverity;
 import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.notification.Notification;
+import org.jboss.as.controller.notification.NotificationSupport;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.ConfigurationPersister;
+import org.jboss.as.controller.registry.NotificationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.security.InetAddressPrincipal;
 import org.jboss.dmr.ModelNode;
@@ -91,6 +98,7 @@ abstract class AbstractOperationContext implements OperationContext {
     private final EnumMap<Stage, Deque<Step>> steps;
     private final ModelController.OperationTransactionControl transactionControl;
     final ControlledProcessState processState;
+    private final NotificationSupport notificationSupport;
     private final boolean booting;
     private final ProcessType processType;
     private final RunningMode runningMode;
@@ -101,6 +109,12 @@ abstract class AbstractOperationContext implements OperationContext {
     // an uninterruptible form. This is to ensure rollback changes are not
     // interrupted
     boolean respectInterruption = true;
+
+    /**
+     * The notifications are stored when {@code emit(Notification)} is callend and effectively
+     * emitted at the end of the operation execution if it is successful
+     */
+    private final Queue<Notification> notifications;
 
     Stage currentStage = Stage.MODEL;
 
@@ -126,13 +140,16 @@ abstract class AbstractOperationContext implements OperationContext {
                              final ModelController.OperationTransactionControl transactionControl,
                              final ControlledProcessState processState,
                              final boolean booting,
-                             final AuditLogger auditLogger) {
+                             final AuditLogger auditLogger,
+                             final NotificationSupport notificationSupport) {
         this.processType = processType;
         this.runningMode = runningMode;
         this.transactionControl = transactionControl;
         this.processState = processState;
         this.booting = booting;
         this.auditLogger = auditLogger;
+        this.notificationSupport = notificationSupport;
+        this.notifications = new ConcurrentLinkedQueue<Notification>();
         steps = new EnumMap<Stage, Deque<Step>>(Stage.class);
         for (Stage stage : Stage.values()) {
             if (booting && stage == Stage.VERIFY) {
@@ -562,6 +579,43 @@ abstract class AbstractOperationContext implements OperationContext {
         }
 
         logAuditRecord();
+
+        // fire the notifications only after the eventual persistent resource is committed
+        emitNotifications();
+    }
+
+    @Override
+    public void emit(Notification notification) {
+        // buffer the notifications but emit them only when an operation is successful.
+        notifications.add(notification);
+    }
+
+    private void emitNotifications() {
+        // emit notifications only if the action is kept
+        if (resultAction != ResultAction.ROLLBACK) {
+            synchronized (notifications) {
+                if (notifications.isEmpty()) {
+                    return;
+                }
+                checkUndefinedNotifications(notifications);
+                notificationSupport.emit(notifications.toArray(new Notification[notifications.size()]));
+                notifications.clear();
+            }
+        }
+    }
+
+    /**
+     * Check that each emitted notification is properly described by its source.
+     */
+    private void checkUndefinedNotifications(Collection<Notification> notifications) {
+        for (Notification notification : notifications) {
+            String type = notification.getType();
+            PathAddress source = notification.getSource();
+            Map<String, NotificationEntry> descriptions = getRootResourceRegistration().getNotificationDescriptions(source, true);
+            if (!descriptions.keySet().contains(type)) {
+                ControllerLogger.ROOT_LOGGER.notificationIsNotDescribed(type, source);
+            }
+        }
     }
 
     private boolean canContinueProcessing() {

--- a/controller/src/main/java/org/jboss/as/controller/ModelController.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelController.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executor;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.notification.NotificationRegistry;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -65,6 +66,13 @@ public interface ModelController {
      * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
      */
     ModelControllerClient createClient(Executor executor);
+
+    /**
+     * Returns the {@code NotificationRegistry} that registers notification handlers for this model controller.
+     *
+     * @return the notification registry
+     */
+    NotificationRegistry getNotificationRegistry();
 
     /**
      * A callback interface for the operation's completion status.  Implemented in order to control whether a complete

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -73,6 +73,8 @@ import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.extension.ExtensionAddHandler;
 import org.jboss.as.controller.extension.ParallelExtensionAddHandler;
 import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.notification.NotificationRegistry;
+import org.jboss.as.controller.notification.NotificationSupport;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.ConfigurationPersister;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
@@ -124,6 +126,8 @@ class ModelControllerImpl implements ModelController {
     private final ConcurrentMap<Integer, OperationContextImpl> activeOperations = new ConcurrentHashMap<>();
     private final ManagedAuditLogger auditLogger;
 
+    private final NotificationSupport notificationSupport;
+
     /** Tracks the relationship between domain resources and hosts and server groups */
     private final HostServerGroupTracker hostServerGroupTracker;
     private final Resource.ResourceEntry modelControllerResource;
@@ -133,7 +137,7 @@ class ModelControllerImpl implements ModelController {
                         final ProcessType processType, final RunningModeControl runningModeControl,
                         final OperationStepHandler prepareStep, final ControlledProcessState processState, final ExecutorService executorService,
                         final ExpressionResolver expressionResolver, final Authorizer authorizer,
-                        final ManagedAuditLogger auditLogger) {
+                        final ManagedAuditLogger auditLogger, NotificationSupport notificationSupport) {
         this.serviceRegistry = serviceRegistry;
         this.serviceTarget = serviceTarget;
         this.rootRegistration = rootRegistration;
@@ -141,6 +145,7 @@ class ModelControllerImpl implements ModelController {
         this.persister = persister;
         this.processType = processType;
         this.runningModeControl = runningModeControl;
+        this.notificationSupport = notificationSupport;
         this.prepareStep = prepareStep == null ? new DefaultPrepareStepHandler() : prepareStep;
         this.processState = processState;
         this.serviceTarget.addListener(stateMonitor);
@@ -277,7 +282,7 @@ class ModelControllerImpl implements ModelController {
             final OperationContextImpl context = new OperationContextImpl(operationID, operation.get(OP).asString(),
                     operation.get(OP_ADDR), this, processType, runningModeControl.getRunningMode(),
                     contextFlags, handler, attachments, model, originalResultTxControl, processState, auditLogger,
-                    bootingFlag.get(), hostServerGroupTracker, blockingTimeoutConfig, accessMechanism);
+                    bootingFlag.get(), hostServerGroupTracker, blockingTimeoutConfig, accessMechanism, notificationSupport);
             // Try again if the operation-id is already taken
             if(activeOperations.putIfAbsent(operationID, context) == null) {
                 CurrentOperationIdHolder.setCurrentOperationID(operationID);
@@ -331,7 +336,7 @@ class ModelControllerImpl implements ModelController {
         final OperationContextImpl context = new OperationContextImpl(operationID, INITIAL_BOOT_OPERATION, EMPTY_ADDRESS,
                 this, processType, runningModeControl.getRunningMode(),
                 contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(),
-                hostServerGroupTracker, null, null);
+                hostServerGroupTracker, null, null, notificationSupport);
 
         // Add to the context all ops prior to the first ExtensionAddHandler as well as all ExtensionAddHandlers; save the rest.
         // This gets extensions registered before proceeding to other ops that count on these registrations
@@ -350,7 +355,7 @@ class ModelControllerImpl implements ModelController {
             // Success. Now any extension handlers are registered. Continue with remaining ops
             final OperationContextImpl postExtContext = new OperationContextImpl(operationID, POST_EXTENSION_BOOT_OPERATION,
                     EMPTY_ADDRESS, this, processType, runningModeControl.getRunningMode(),
-                    contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(), hostServerGroupTracker, null, null);
+                    contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(), hostServerGroupTracker, null, null, notificationSupport);
 
             for (ParsedBootOp parsedOp : bootOperations.postExtensionOps) {
                 if (parsedOp.handler == null) {
@@ -703,6 +708,15 @@ class ModelControllerImpl implements ModelController {
 
     ServiceTarget getServiceTarget() {
         return serviceTarget;
+    }
+
+    @Override
+    public NotificationRegistry getNotificationRegistry() {
+        return notificationSupport.getNotificationRegistry();
+    }
+
+    NotificationSupport getNotificationSupport() {
+        return notificationSupport;
     }
 
     ModelNode resolveExpressions(ModelNode node) throws OperationFailedException {

--- a/controller/src/main/java/org/jboss/as/controller/NotificationDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/NotificationDefinition.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.NotificationDefinition.DataValueDescriptor.NO_DATA;
+
+import java.util.ResourceBundle;
+
+import org.jboss.as.controller.descriptions.DefaultNotificationDescriptionProvider;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Defining characteristics of notification in a {@link org.jboss.as.controller.registry.Resource}
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class NotificationDefinition {
+
+    private final String type;
+    private final ResourceDescriptionResolver resolver;
+    private final DataValueDescriptor dataValueDescriptor;
+
+    private NotificationDefinition(final String type, final ResourceDescriptionResolver resolver, final DataValueDescriptor dataValueDescriptor) {
+        this.type = type;
+        this.resolver = resolver;
+        this.dataValueDescriptor = dataValueDescriptor;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public DescriptionProvider getDescriptionProvider() {
+        return new DefaultNotificationDescriptionProvider(type, resolver, dataValueDescriptor);
+    }
+
+    public static class Builder {
+        private final String type;
+        private final ResourceDescriptionResolver resolver;
+        private DataValueDescriptor dataValueDescriptor = NO_DATA;
+
+        private Builder(String type, ResourceDescriptionResolver resolver) {
+            this.type = type;
+            this.resolver = resolver;
+        }
+
+        public static Builder create(String type, ResourceDescriptionResolver resolver) {
+            return new Builder(type, resolver);
+        }
+
+        public Builder setDataValueDescriptor(DataValueDescriptor dataValueDescriptor) {
+            this.dataValueDescriptor = dataValueDescriptor;
+            return this;
+        }
+
+        public NotificationDefinition build() {
+            return new NotificationDefinition(type, resolver, dataValueDescriptor);
+        }
+    }
+
+    public interface DataValueDescriptor {
+        ModelNode describe(ResourceBundle bundle);
+
+        DataValueDescriptor NO_DATA = new DataValueDescriptor() {
+            @Override
+            public ModelNode describe(ResourceBundle bundle) {
+                return null;
+            }
+        };
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -31,6 +31,7 @@ import org.jboss.as.controller.access.ResourceAuthorization;
 import org.jboss.as.controller.access.AuthorizationResult;
 import org.jboss.as.controller.access.Caller;
 import org.jboss.as.controller.client.MessageSeverity;
+import org.jboss.as.controller.notification.Notification;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -681,6 +682,13 @@ public interface OperationContext extends ExpressionResolver {
      * @return The current caller.
      */
     Caller getCaller();
+
+    /**
+     * Emit a {@link org.jboss.as.controller.notification.Notification}.
+     *
+     * @param notification the notification to emit
+     */
+    void emit(final Notification notification);
 
     /**
      * Gets the caller environment for the current request.

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -76,6 +76,7 @@ import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.notification.NotificationSupport;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.operations.global.ReadResourceHandler;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
@@ -190,8 +191,9 @@ final class OperationContextImpl extends AbstractOperationContext {
                          final ControlledProcessState processState, final AuditLogger auditLogger, final boolean booting,
                          final HostServerGroupTracker hostServerGroupTracker,
                          final ModelNode blockingTimeoutConfig,
-                         final AccessMechanism accessMechanism) {
-        super(processType, runningMode, transactionControl, processState, booting, auditLogger);
+                         final AccessMechanism accessMechanism,
+                         final NotificationSupport notificationSupport) {
+        super(processType, runningMode, transactionControl, processState, booting, auditLogger, notificationSupport);
         this.operationId = operationId;
         this.operationName = operationName;
         this.operationAddress = operationAddress.isDefined()

--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.access.ResourceAuthorization;
 import org.jboss.as.controller.audit.AuditLogger;
 import org.jboss.as.controller.client.MessageSeverity;
 import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.notification.Notification;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.ConfigurationPersister;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
@@ -62,7 +63,7 @@ class ParallelBootOperationContext extends AbstractOperationContext {
                                  final ControlledProcessState processState, final AbstractOperationContext primaryContext,
                                  final List<ParsedBootOp> runtimeOps, final Thread controllingThread,
                                  final ModelControllerImpl controller, final int operationId, final AuditLogger auditLogger, final Resource model) {
-        super(primaryContext.getProcessType(), primaryContext.getRunningMode(), transactionControl, processState, true, auditLogger);
+        super(primaryContext.getProcessType(), primaryContext.getRunningMode(), transactionControl, processState, true, auditLogger, controller.getNotificationSupport());
         this.primaryContext = primaryContext;
         this.runtimeOps = runtimeOps;
         AbstractOperationContext.controllingThread.set(controllingThread);
@@ -298,6 +299,11 @@ class ParallelBootOperationContext extends AbstractOperationContext {
     ConfigurationPersister.PersistenceResource createPersistenceResource() throws ConfigurationPersistenceException {
         // We don't persist
         return null;
+    }
+
+    @Override
+    public void emit(Notification notification) {
+        primaryContext.emit(notification);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -58,7 +58,7 @@ class ReadOnlyContext extends AbstractOperationContext {
     ReadOnlyContext(final ProcessType processType, final RunningMode runningMode, final ModelController.OperationTransactionControl transactionControl,
                     final ControlledProcessState processState, final boolean booting,
                     final AbstractOperationContext primaryContext, final ModelControllerImpl controller, final int operationId) {
-        super(processType, runningMode, transactionControl, processState, booting, controller.getAuditLogger());
+        super(processType, runningMode, transactionControl, processState, booting, controller.getAuditLogger(), controller.getNotificationSupport());
         this.primaryContext = primaryContext;
         this.controller = controller;
         this.operationId = operationId;

--- a/controller/src/main/java/org/jboss/as/controller/ResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ResourceDefinition.java
@@ -67,6 +67,13 @@ public interface ResourceDefinition {
     void registerAttributes(final ManagementResourceRegistration resourceRegistration);
 
     /**
+     * Register notifications associated with this resource.
+     *
+     * @param resourceRegistration a {@link ManagementResourceRegistration} created from this definition
+     */
+    void registerNotifications(final ManagementResourceRegistration resourceRegistration);
+
+    /**
      * Register child resources associated with this resource.
      *
      * @param resourceRegistration a {@link ManagementResourceRegistration} created from this definition

--- a/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
@@ -215,6 +215,11 @@ public class SimpleResourceDefinition implements ResourceDefinition {
     }
 
     @Override
+    public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+        // no-op
+    }
+
+    @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         // no-op
     }

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultNotificationDescriptionProvider.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultNotificationDescriptionProvider.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.descriptions;
+
+import static org.jboss.as.controller.NotificationDefinition.DataValueDescriptor;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATION_DATA_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATION_TYPE;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Provides a default description of a notification.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat Inc.
+ */
+public class DefaultNotificationDescriptionProvider implements DescriptionProvider {
+
+    private final String notificationType;
+    private final ResourceDescriptionResolver descriptionResolver;
+    private final DataValueDescriptor dataValueDescriptor;
+
+    public DefaultNotificationDescriptionProvider(final String notificationType,
+                                                  final ResourceDescriptionResolver descriptionResolver,
+                                                  final DataValueDescriptor dataValueDescriptor) {
+        this.notificationType = notificationType;
+        this.descriptionResolver = descriptionResolver;
+        this.dataValueDescriptor = dataValueDescriptor;
+    }
+
+    @Override
+    public ModelNode getModelDescription(Locale locale) {
+        ModelNode result = new ModelNode();
+
+        final ResourceBundle bundle = descriptionResolver.getResourceBundle(locale);
+        result.get(NOTIFICATION_TYPE).set(notificationType);
+        result.get(DESCRIPTION).set(descriptionResolver.getNotificationDescription(notificationType, locale, bundle));
+        if (dataValueDescriptor != null) {
+            ModelNode dataDescription = dataValueDescriptor.describe(bundle);
+            if (dataDescription != null && dataDescription.isDefined()) {
+                result.get(NOTIFICATION_DATA_TYPE).set(dataDescription);
+            }
+        }
+
+        return result;
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultResourceDescriptionProvider.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultResourceDescriptionProvider.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 
 import java.util.HashSet;
@@ -96,6 +97,8 @@ public class DefaultResourceDescriptionProvider implements DescriptionProvider {
         }
 
         result.get(OPERATIONS); // placeholder
+
+        result.get(NOTIFICATIONS); // placeholder
 
         final ModelNode children = result.get(CHILDREN).setEmptyObject();
 

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -245,6 +245,10 @@ public class ModelDescriptionConstants {
     public static final String NILLABLE = "nillable";
     public static final String NIL_SIGNIFICANT = "nil-significant";
     public static final String NOT = "not";
+    public static final String NOTIFICATION = "notification";
+    public static final String NOTIFICATION_DATA_TYPE = "data-type";
+    public static final String NOTIFICATION_TYPE = "notification-type";
+    public static final String NOTIFICATIONS = "notifications";
     /** Use this as the standard operation name field in the operation *request* ModelNode */
     public static final String OP = "operation";
     /** Use this standard operation address field in the operation *request* ModelNode */

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ResourceDescriptionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ResourceDescriptionResolver.java
@@ -140,6 +140,16 @@ public interface ResourceDescriptionResolver {
      */
     String getOperationReplyValueTypeDescription(String operationName, Locale locale, ResourceBundle bundle, String... suffixes);
 
+    /**
+     * Gets the description of one of the resource's notification.
+     *
+     * @param notificationType the type of the notification
+     * @param locale the locale
+     * @param bundle a resource bundle previously obtained from a call to {@link #getResourceBundle(java.util.Locale)},
+     *               or {@code null} if that call returned {@code null}
+     * @return the localized description
+     */
+    String getNotificationDescription(String notificationType, Locale locale, ResourceBundle bundle);
 
     /**
      * Gets the description of one of the resource's child types.

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/StandardResourceDescriptionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/StandardResourceDescriptionResolver.java
@@ -227,6 +227,12 @@ public class StandardResourceDescriptionResolver implements ResourceDescriptionR
 
     /** {@inheritDoc} */
     @Override
+    public String getNotificationDescription(String notificationType, Locale locale, ResourceBundle bundle) {
+        return bundle.getString(getBundleKey(notificationType));
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public String getChildTypeDescription(String childType, Locale locale, ResourceBundle bundle) {
         final String bundleKey = useUnprefixedChildTypes ? childType : getBundleKey(childType);
         return bundle.getString(bundleKey);

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ConcurrentMap;
 import javax.xml.namespace.QName;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersionRange;
@@ -73,6 +74,7 @@ import org.jboss.as.controller.persistence.SubsystemXmlWriterRegistry;
 import org.jboss.as.controller.registry.AliasEntry;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.NotificationEntry;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.PathManager;
@@ -784,6 +786,11 @@ public class ExtensionRegistry {
         }
 
         @Override
+        public Map<String, NotificationEntry> getNotificationDescriptions(PathAddress address, boolean inherited) {
+            return deployments.getNotificationDescriptions(address, inherited);
+        }
+
+        @Override
         public Set<String> getChildNames(PathAddress address) {
             return deployments.getChildNames(address);
         }
@@ -948,6 +955,24 @@ public class ExtensionRegistry {
         public void unregisterAttribute(String attributeName) {
             deployments.unregisterAttribute(attributeName);
             subdeployments.unregisterAttribute(attributeName);
+        }
+
+        @Override
+        public void registerNotification(NotificationDefinition notification, boolean inherited) {
+            deployments.registerNotification(notification, inherited);
+            subdeployments.registerNotification(notification, inherited);
+        }
+
+        @Override
+        public void registerNotification(NotificationDefinition notification) {
+            deployments.registerNotification(notification);
+            subdeployments.registerNotification(notification);
+        }
+
+        @Override
+        public void unregisterNotification(String notificationType) {
+            deployments.unregisterNotification(notificationType);
+            subdeployments.unregisterNotification(notificationType);
         }
 
         @Override

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -54,6 +54,7 @@ import org.jboss.as.controller._private.OperationCancellationException;
 import org.jboss.as.controller._private.OperationFailedRuntimeException;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.interfaces.InterfaceCriteria;
+import org.jboss.as.controller.notification.Notification;
 import org.jboss.as.controller.parsing.Element;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -3199,4 +3200,11 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = 355, value = "Reconnecting to syslog handler '%s failed")
     void reconnectToSyslogFailed(String name, @Cause Throwable e);
 
+    @LogMessage(level = WARN)
+    @Message(id = 356, value = "Failed to emit notification %s")
+    void failedToEmitNotification(Notification notification, @Cause Throwable cause);
+
+    @LogMessage(level = WARN)
+    @Message(id = 357, value = "Notification of type %s is not described for the resource at the address %s")
+    void notificationIsNotDescribed(String type, PathAddress source);
 }

--- a/controller/src/main/java/org/jboss/as/controller/notification/Notification.java
+++ b/controller/src/main/java/org/jboss/as/controller/notification/Notification.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * A notification emitted by a resource and handled by {@link NotificationHandler}.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class Notification {
+
+    public static final String SOURCE = "source";
+    public static final String TYPE = "type";
+    public static final String MESSAGE = "message";
+    public static final String TIMESTAMP = "timestamp";
+    public static final String DATA = "data";
+
+    private final String type;
+    private final PathAddress source;
+    private final String message;
+    private final long timestamp;
+    private final ModelNode data;
+
+    public Notification(String type, PathAddress source, String message) {
+        this(type, source, message, null);
+    }
+
+    /**
+     *
+     * @param data can be {@code null}
+     */
+    public Notification(String type, PathAddress source, String message, ModelNode data) {
+        this(type, source, message, System.currentTimeMillis(), data);
+    }
+
+    private Notification(String type, PathAddress source, String message, long timestamp, ModelNode data) {
+        this.type = type;
+        this.source = source;
+        this.message = message;
+        this.timestamp = timestamp;
+        this.data = data;
+    }
+
+    /**
+     * @return the type of notification
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @return the address of the resource that emitted the notification (its source)
+     */
+    public PathAddress getSource() {
+        return source;
+    }
+
+    /**
+     * @return a human-readable i18end description of the notification
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * The timestamp is set when the notification is instantiaged.
+     *
+     * @return the timestamp (in ms since the Unix Epoch) of the notification.
+     */
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * @return data contextual to the notification or {@code null}
+     */
+    public ModelNode getData() {
+        return data;
+    }
+
+    /**
+     * @return a detyped representation of the notification
+     */
+    public ModelNode toModelNode() {
+        ModelNode node = new ModelNode();
+        node.get(TYPE).set(type);
+        node.get(SOURCE).set(source.toModelNode());
+        node.get(TIMESTAMP).set(timestamp);
+        node.get(MESSAGE).set(message);
+        if (data != null) {
+            node.get(DATA).set(data);
+        }
+        node.protect();
+        return node;
+    }
+
+    /**
+     * @return a Notification created from the detyped representation in {@code node}
+     */
+    public static Notification fromModelNode(ModelNode node) {
+        String type = node.require(TYPE).asString();
+        PathAddress source = PathAddress.pathAddress(node.require(SOURCE));
+        long timestamp = node.require(TIMESTAMP).asLong();
+        String message = node.require(MESSAGE).asString();
+        ModelNode data = node.hasDefined(DATA)? node.get(DATA): null;
+        return new Notification(type, source, message, timestamp, data);
+    }
+
+    @Override
+    public String toString() {
+        return "Notification{" +
+                "type='" + type + '\'' +
+                ", source=" + source +
+                ", message='" + message + '\'' +
+                ", timestamp=" + timestamp +
+                ", data=" + data +
+                '}';
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/notification/NotificationFilter.java
+++ b/controller/src/main/java/org/jboss/as/controller/notification/NotificationFilter.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+/**
+ * A filter to let {@link NotificationHandler} filters out notifications they are not interested to handle.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public interface NotificationFilter {
+
+    boolean isNotificationEnabled(Notification notification);
+
+    NotificationFilter ALL = new NotificationFilter() {
+        @Override
+        public boolean isNotificationEnabled(Notification notification) {
+            return true;
+        }
+    };
+}

--- a/controller/src/main/java/org/jboss/as/controller/notification/NotificationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/notification/NotificationHandler.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+/**
+ * A notification handler is used to be notified of events on the server.
+ * Its {@code handleNotification} is called every time a notification is emitted by a resource it was registered for.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public interface NotificationHandler {
+    void handleNotification(Notification notification);
+}

--- a/controller/src/main/java/org/jboss/as/controller/notification/NotificationRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/notification/NotificationRegistry.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import org.jboss.as.controller.PathAddress;
+
+/**
+ * The NotificationRegistry can be used to register and unregister notification handlers.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+public interface NotificationRegistry {
+
+    /**
+     * Special path address to register a notification handler for *any* source.
+     */
+    PathAddress ANY_ADDRESS = PathAddress.EMPTY_ADDRESS;
+
+    /**
+     * Register the given NotificationHandler to receive notifications emitted by the resource at the given source address.
+     * The {@link NotificationHandler#handleNotification(Notification)} method will only be called on the registered handler if the filter's {@link NotificationFilter#isNotificationEnabled(Notification)}
+     * returns {@code true} for the given notification.
+     * <br />
+     * The source PathAddress can be a pattern if at least one of its element value is a wildcard ({@link org.jboss.as.controller.PathElement#getValue()} is {@code *}).
+     * For example:
+     * <ul>
+     *     <li>{@code /subsystem=messaging/hornetq-server=default/jms-queue=&#42;} is an address pattern.</li>
+     *     <li>{@code /subsystem=messaging/hornetq-server=&#42;/jms-queue=&#42;} is an address pattern.</li>
+     *     <li>{@code /subsystem=messaging/hornetq-server=default/jms-queue=myQueue} is <strong>not</strong> an address pattern.</li>
+     * </ul>
+     *
+     * @param source the path address of the resource that emit notifications.
+     * @param handler the notification handler
+     * @param filter the notification filter. Use {@link NotificationFilter#ALL} to let the handler always handle notifications
+     */
+    void registerNotificationHandler(PathAddress source, NotificationHandler handler, NotificationFilter filter);
+
+    /**
+     * Unregister the given NotificationHandler to stop receiving notifications emitted by the resource at the given source address.
+     *
+     * The source, handler and filter must match the values that were used during registration to be effectively unregistered.
+     *
+     * @param source the path address of the resource that emit notifications.
+     * @param handler the notification handler
+     * @param filter the notification filter
+     */
+    void unregisterNotificationHandler(PathAddress source, NotificationHandler handler, NotificationFilter filter);
+}

--- a/controller/src/main/java/org/jboss/as/controller/notification/NotificationRegistryImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/notification/NotificationRegistryImpl.java
@@ -1,0 +1,123 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jboss.as.controller.PathAddress;
+
+/**
+ * Implementation of a NotificationRegistry.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+class NotificationRegistryImpl implements NotificationRegistry {
+    /**
+     * Keys of the map can be wildcard path addresses.
+     * Values are sets of NotificationHandlerEntry (composed of an handler and filter).
+     */
+    private final Map<PathAddress, Set<NotificationHandlerEntry>> notificationHandlers = new ConcurrentHashMap<PathAddress, Set<NotificationHandlerEntry>>();
+
+    @Override
+    public synchronized void registerNotificationHandler(PathAddress source, NotificationHandler handler, NotificationFilter filter) {
+        Set<NotificationHandlerEntry> handlers = notificationHandlers.get(source);
+        if (handlers == null) {
+            handlers = new HashSet<NotificationHandlerEntry>();
+        }
+        handlers.add(new NotificationHandlerEntry(handler, filter));
+        notificationHandlers.put(source, handlers);
+    }
+
+    @Override
+    public synchronized void unregisterNotificationHandler(PathAddress source, NotificationHandler handler, NotificationFilter filter) {
+        NotificationHandlerEntry entry = new NotificationHandlerEntry(handler, filter);
+        Set<NotificationHandlerEntry> handlers = notificationHandlers.get(source);
+        if (handlers != null) {
+            handlers.remove(entry);
+        }
+    }
+
+    /**
+     * Find all the notification handlers that are registered for the notification's source (including those that are
+     * registered against a path address pattern) provived their filters accept the notification.
+     *
+     * @param notification the notification
+     * @return the notification handlers that will effectively handled the notification
+     */
+    List<NotificationHandler> findMatchingNotificationHandlers(Notification notification) {
+        final List<NotificationHandler> handlers = new ArrayList<NotificationHandler>();
+        for (Map.Entry<PathAddress, Set<NotificationHandlerEntry>> entries : notificationHandlers.entrySet()) {
+            if (PathAddressUtil.matches(notification.getSource(), entries.getKey())) {
+                for (NotificationHandlerEntry entry : entries.getValue()) {
+                    if (entry.getFilter().isNotificationEnabled(notification)) {
+                        handlers.add(entry.getHandler());
+                    }
+                }
+            }
+        }
+        return handlers;
+    }
+
+    private class NotificationHandlerEntry {
+        private final NotificationHandler handler;
+        private final NotificationFilter filter;
+
+        private NotificationHandlerEntry(NotificationHandler handler, NotificationFilter filter) {
+            this.handler = handler;
+            this.filter = filter;
+        }
+
+        public NotificationHandler getHandler() {
+            return handler;
+        }
+
+        public NotificationFilter getFilter() {
+            return filter;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            NotificationHandlerEntry that = (NotificationHandlerEntry) o;
+
+            if (filter != null ? !filter.equals(that.filter) : that.filter != null) return false;
+            if (handler != null ? !handler.equals(that.handler) : that.handler != null) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = handler != null ? handler.hashCode() : 0;
+            result = 31 * result + (filter != null ? filter.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/notification/NotificationSupport.java
+++ b/controller/src/main/java/org/jboss/as/controller/notification/NotificationSupport.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import java.util.concurrent.ExecutorService;
+
+/**
+ * The NotificationSupport can be used to emit notifications.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public interface NotificationSupport {
+
+    /**
+     * Get the notification registry to register/unregister notification handlers
+     */
+    NotificationRegistry getNotificationRegistry();
+
+    /**
+     * Emit {@link Notification}(s).
+     *
+     * @param notifications the notifications to emit
+     */
+    void emit(final Notification... notifications);
+
+    class Factory {
+        private Factory() {
+        }
+
+        /**
+         * If the {@code executorService} parameter is null, the notifications will be emitted synchronously
+         * and may be subject to handlers blocking the execution.
+         *
+         * @param executorService can be {@code null}.
+         */
+        public static NotificationSupport create(ExecutorService executorService) {
+            NotificationRegistryImpl registry = new NotificationRegistryImpl();
+            if (executorService == null) {
+                return new NotificationSupports.BlockingNotificationSupport(registry);
+            } else {
+                return new NotificationSupports.NonBlockingNotificationSupport(registry, executorService);
+            }
+        }
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/notification/NotificationSupports.java
+++ b/controller/src/main/java/org/jboss/as/controller/notification/NotificationSupports.java
@@ -1,0 +1,132 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import java.util.Arrays;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.jboss.as.controller.logging.ControllerLogger;
+
+/**
+ * Provides implementation of the {@code NotificationSupport}.
+ *
+ * The {@code BlockingNotificationSupport} will fire the notifications and deliver them to the handlers on the current thread.
+ * Its {@code emit()} method will return after the notifications have all been delivered (and blocks the code execution until it is done).
+ *
+ * The {@code NonBlockingNotificationSupport} will fire the notifications in a separate thread (provided by its {@code
+ *  executorService}.
+ * Its {@code emit()} method will return immediately and will not block the code execution.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+class NotificationSupports {
+
+    static class BlockingNotificationSupport implements NotificationSupport {
+
+        private final NotificationRegistryImpl registry;
+
+        public BlockingNotificationSupport(NotificationRegistryImpl registry) {
+            this.registry = registry;
+        }
+
+        @Override
+        public void emit(Notification... notifications) {
+            fireNotifications(registry, notifications);
+        }
+
+        @Override
+        public NotificationRegistry getNotificationRegistry() {
+            return registry;
+        }
+    }
+
+    static class NonBlockingNotificationSupport implements  NotificationSupport {
+
+        private final NotificationRegistryImpl registry;
+        private final ExecutorService executor;
+
+        /**
+         * Use a concurrent queue to put the notifications in it when {@code emit()} is called.
+         * The queue will be drained in a separate thread and the notifications effectively delivered to the handlers.
+         *
+         * This ensures that the notifications will be delivered in the same order they were emitted.
+         */
+        private final Queue<Notification> queue = new ConcurrentLinkedQueue<Notification>();
+
+        /**
+         * use the lock's exclusive writeLock to ensure only one thread can drain the queue at a given time.
+         */
+        private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
+        public NonBlockingNotificationSupport(NotificationRegistryImpl registry, ExecutorService executor) {
+            this.registry = registry;
+            this.executor = executor;
+        }
+
+        @Override
+        public synchronized void emit(Notification... notifications) {
+            queue.addAll(Arrays.asList(notifications));
+
+            executor.execute(new Runnable() {
+                @Override
+                public void run() {
+                    lock.writeLock().lock();
+                    try {
+                        while (true) {
+                            Notification notification = queue.poll();
+                            if (notification == null) {
+                                break;
+                            }
+                            fireNotifications(registry, notification);
+                        }
+                    } finally {
+                        lock.writeLock().unlock();
+                    }
+                }
+            });
+        }
+
+        @Override
+        public NotificationRegistry getNotificationRegistry() {
+            return registry;
+        }
+    }
+
+
+    private static void fireNotifications(NotificationRegistryImpl registry, final Notification... notifications) {
+        for (Notification notification : notifications) {
+            try {
+                // each notification may have a different subset of handlers depending on their filters
+                for (NotificationHandler handler : registry.findMatchingNotificationHandlers(notification)) {
+                    handler.handleNotification(notification);
+                }
+            } catch (Throwable t) {
+                ControllerLogger.ROOT_LOGGER.failedToEmitNotification(notification, t);
+            }
+        }
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/notification/PathAddressUtil.java
+++ b/controller/src/main/java/org/jboss/as/controller/notification/PathAddressUtil.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import java.util.ListIterator;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class PathAddressUtil {
+    /**
+     * Check if the given address matches the other address that can be a pattern.
+     *
+     * @param address a path address
+     * @param other another path address that can be a pattern
+     *
+     * @return {@code true} if the address matches the other address
+     */
+    public static boolean matches(PathAddress address, PathAddress other) {
+        if (other == NotificationRegistry.ANY_ADDRESS) {
+            return true;
+        }
+        if (!other.isMultiTarget()) {
+            return address.equals(other);
+        }
+        if (address.size() != other.size()) {
+            return false;
+        }
+        ListIterator<PathElement> addressIter = address.iterator();
+        ListIterator<PathElement> otherIterator = other.iterator();
+        while (addressIter.hasNext() && otherIterator.hasNext()) {
+            PathElement element = addressIter.next();
+            PathElement otherElement = otherIterator.next();
+            if (!otherElement.isMultiTarget()) {
+                if (!element.equals(otherElement)) {
+                    return false;
+                }
+            } else {
+                if (!element.getKey().equals(otherElement.getKey())) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/registry/AbstractResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AbstractResourceRegistration.java
@@ -273,6 +273,29 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
 
     abstract void getOperationDescriptions(ListIterator<PathElement> iterator, Map<String, OperationEntry> providers, boolean inherited);
 
+    /**
+     * Get all the handlers at a specific address.
+     *
+     * @param address the address
+     * @param inherited true to include the inherited notifcations
+     * @return the handlers
+     */
+    @Override
+    public final Map<String, NotificationEntry> getNotificationDescriptions(final PathAddress address, boolean inherited) {
+
+        if (parent != null) {
+            RootInvocation ri = getRootInvocation();
+            return ri.root.getNotificationDescriptions(ri.pathAddress.append(address), inherited);
+        }
+        // else we are the root
+        Map<String, NotificationEntry> providers = new TreeMap<String, NotificationEntry>();
+        getNotificationDescriptions(address.iterator(), providers, inherited);
+        return providers;
+    }
+
+    abstract void getNotificationDescriptions(ListIterator<PathElement> iterator, Map<String, NotificationEntry> providers, boolean inherited);
+
+
     /** {@inheritDoc} */
     @Override
     public final DescriptionProvider getModelDescription(final PathAddress address) {
@@ -421,12 +444,23 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
         }
     }
 
+    final void getInheritedNotifications(final Map<String, NotificationEntry> providers, boolean skipSelf) {
+        if (!skipSelf) {
+            getInheritedNotificationEntries(providers);
+        }
+        if (parent != null) {
+            parent.getParent().getInheritedNotifications(providers, false);
+        }
+    }
+
     /** Gets whether this registration has an alternative wildcard registration */
     boolean hasNoAlternativeWildcardRegistration() {
         return parent == null || PathElement.WILDCARD_VALUE.equals(valueString) || !parent.getChildNames().contains(PathElement.WILDCARD_VALUE);
     }
 
     abstract void getInheritedOperationEntries(final Map<String, OperationEntry> providers);
+
+    abstract void getInheritedNotificationEntries(final Map<String, NotificationEntry> providers);
 
     private RootInvocation getRootInvocation() {
         RootInvocation result = null;

--- a/controller/src/main/java/org/jboss/as/controller/registry/AliasResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AliasResourceRegistration.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
@@ -190,6 +191,21 @@ final class AliasResourceRegistration extends AbstractResourceRegistration imple
     }
 
     @Override
+    public void registerNotification(NotificationDefinition notification, boolean inherited) {
+        throw alreadyRegistered();
+    }
+
+    @Override
+    public void registerNotification(NotificationDefinition notification) {
+        throw alreadyRegistered();
+    }
+
+    @Override
+    public void unregisterNotification(String notificationType) {
+        throw alreadyRegistered();
+    }
+
+    @Override
     void getOperationDescriptions(final ListIterator<PathElement> iterator, final Map<String, OperationEntry> providers, final boolean inherited) {
         Map<String, OperationEntry> temp = new HashMap<String, OperationEntry>();
         target.getOperationDescriptions(iterator, temp, inherited);
@@ -204,6 +220,21 @@ final class AliasResourceRegistration extends AbstractResourceRegistration imple
     @Override
     void getInheritedOperationEntries(final Map<String, OperationEntry> providers) {
         target.getInheritedOperationEntries(providers);
+    }
+
+    @Override
+    void getNotificationDescriptions(ListIterator<PathElement> iterator, Map<String, NotificationEntry> providers, boolean inherited) {
+        Map<String, NotificationEntry> temp = new HashMap<String, NotificationEntry>();
+        target.getNotificationDescriptions(iterator, temp, inherited);
+        for (Map.Entry<String, NotificationEntry> entry : providers.entrySet()) {
+            providers.put(entry.getKey(),
+                    new NotificationEntry(entry.getValue().getDescriptionProvider(), entry.getValue().isInherited()));
+        }
+    }
+
+    @Override
+    void getInheritedNotificationEntries(Map<String, NotificationEntry> providers) {
+        target.getInheritedNotificationEntries(providers);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -23,6 +23,7 @@
 package org.jboss.as.controller.registry;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATION;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -61,6 +63,9 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
     @SuppressWarnings("unused")
     private volatile Map<String, OperationEntry> operations;
 
+    @SuppressWarnings("unused")
+    private volatile Map<String, NotificationEntry> notifications;
+
     private final ResourceDefinition resourceDefinition;
     private final List<AccessConstraintDefinition> accessConstraintDefinitions;
 
@@ -72,6 +77,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     private static final AtomicMapFieldUpdater<ConcreteResourceRegistration, String, NodeSubregistry> childrenUpdater = AtomicMapFieldUpdater.newMapUpdater(AtomicReferenceFieldUpdater.newUpdater(ConcreteResourceRegistration.class, Map.class, "children"));
     private static final AtomicMapFieldUpdater<ConcreteResourceRegistration, String, OperationEntry> operationsUpdater = AtomicMapFieldUpdater.newMapUpdater(AtomicReferenceFieldUpdater.newUpdater(ConcreteResourceRegistration.class, Map.class, "operations"));
+    private static final AtomicMapFieldUpdater<ConcreteResourceRegistration, String, NotificationEntry> notificationsUpdater = AtomicMapFieldUpdater.newMapUpdater(AtomicReferenceFieldUpdater.newUpdater(ConcreteResourceRegistration.class, Map.class, "notifications"));
     private static final AtomicMapFieldUpdater<ConcreteResourceRegistration, String, AttributeAccess> attributesUpdater = AtomicMapFieldUpdater.newMapUpdater(AtomicReferenceFieldUpdater.newUpdater(ConcreteResourceRegistration.class, Map.class, "attributes"));
 
     ConcreteResourceRegistration(final String valueString, final NodeSubregistry parent, final ResourceDefinition definition,
@@ -81,6 +87,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         childrenUpdater.clear(this);
         operationsUpdater.clear(this);
         attributesUpdater.clear(this);
+        notificationsUpdater.clear(this);
         this.resourceDefinition = definition;
         this.runtimeOnly.set(runtimeOnly);
         this.accessConstraintDefinitions = buildAccessConstraints();
@@ -147,6 +154,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         final ManagementResourceRegistration resourceRegistration = child.register(address.getValue(), resourceDefinition, false);
         resourceDefinition.registerAttributes(resourceRegistration);
         resourceDefinition.registerOperations(resourceRegistration);
+        resourceDefinition.registerNotifications(resourceRegistration);
         resourceDefinition.registerChildren(resourceRegistration);
         if (constraintUtilizationRegistry != null) {
             PathAddress childAddress = getPathAddress().append(address);
@@ -305,6 +313,27 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
     }
 
     @Override
+    public void registerNotification(NotificationDefinition notification, boolean inherited) {
+        NotificationEntry entry = new NotificationEntry(notification.getDescriptionProvider(), inherited);
+        checkPermission();
+        if (notificationsUpdater.putIfAbsent(this, notification.getType(), entry) != null) {
+            throw alreadyRegistered(NOTIFICATION, notification.getType());
+        }
+    }
+
+    @Override
+    public void registerNotification(NotificationDefinition notification) {
+        registerNotification(notification, false);
+    }
+
+    @Override
+         public void unregisterNotification(String notificationType) {
+        checkPermission();
+        notificationsUpdater.remove(this, notificationType);
+    }
+
+
+    @Override
     public void registerMetric(AttributeDefinition definition, OperationStepHandler metricHandler) {
         checkPermission();
         AttributeAccess aa = new AttributeAccess(AccessType.METRIC, AttributeAccess.Storage.RUNTIME, metricHandler, null, definition, definition.getFlags());
@@ -335,6 +364,41 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             constraintUtilizationRegistry.unregisterAccessConstraintUtilizations(getPathAddress().append(childAddress));
         }
     }
+
+    @Override
+    void getNotificationDescriptions(final ListIterator<PathElement> iterator, final Map<String, NotificationEntry> providers, final boolean inherited) {
+
+        if (!iterator.hasNext() ) {
+            checkPermission();
+            providers.putAll(notificationsUpdater.get(this));
+            if (inherited) {
+                getInheritedNotifications(providers, true);
+            }
+            return;
+        }
+        final PathElement next = iterator.next();
+        try {
+            final String key = next.getKey();
+            final Map<String, NodeSubregistry> snapshot = childrenUpdater.get(this);
+            final NodeSubregistry subregistry = snapshot.get(key);
+            if (subregistry != null) {
+                subregistry.getNotificationDescriptions(iterator, next.getValue(), providers, inherited);
+            }
+        } finally {
+            iterator.previous();
+        }
+    }
+
+    @Override
+    void getInheritedNotificationEntries(final Map<String, NotificationEntry> providers) {
+        checkPermission();
+        for (final Map.Entry<String, NotificationEntry> entry : notificationsUpdater.get(this).entrySet()) {
+            if (entry.getValue().isInherited() && !providers.containsKey(entry.getKey())) {
+                providers.put(entry.getKey(), entry.getValue());
+            }
+        }
+    }
+
 
     @Override
     public void registerProxyController(final PathElement address, final ProxyController controller) throws IllegalArgumentException {

--- a/controller/src/main/java/org/jboss/as/controller/registry/DelegatingImmutableManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/DelegatingImmutableManagementResourceRegistration.java
@@ -119,6 +119,11 @@ public class DelegatingImmutableManagementResourceRegistration implements Immuta
     }
 
     @Override
+    public Map<String, NotificationEntry> getNotificationDescriptions(PathAddress address, boolean inherited) {
+        return delegate.getNotificationDescriptions(address, inherited);
+    }
+
+    @Override
     public ProxyController getProxyController(PathAddress address) {
         return delegate.getProxyController(address);
     }

--- a/controller/src/main/java/org/jboss/as/controller/registry/DelegatingManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/DelegatingManagementResourceRegistration.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -122,6 +123,11 @@ public class DelegatingManagementResourceRegistration implements ManagementResou
     @Override
     public Map<String, OperationEntry> getOperationDescriptions(PathAddress address, boolean inherited) {
         return delegate.getOperationDescriptions(address, inherited);
+    }
+
+    @Override
+    public Map<String, NotificationEntry> getNotificationDescriptions(PathAddress address, boolean inherited) {
+        return delegate.getNotificationDescriptions(address, inherited);
     }
 
     @Override
@@ -242,6 +248,21 @@ public class DelegatingManagementResourceRegistration implements ManagementResou
     @Override
     public void unregisterAttribute(String attributeName) {
         delegate.unregisterAttribute(attributeName);
+    }
+
+    @Override
+    public void registerNotification(NotificationDefinition notification, boolean inherited) {
+        delegate.registerNotification(notification, inherited);
+    }
+
+    @Override
+    public void registerNotification(NotificationDefinition notification) {
+        delegate.registerNotification(notification);
+    }
+
+    @Override
+    public void unregisterNotification(String notificationType) {
+        delegate.unregisterNotification(notificationType);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
@@ -146,6 +146,16 @@ public interface ImmutableManagementResourceRegistration {
     AttributeAccess getAttributeAccess(PathAddress address, String attributeName);
 
     /**
+     * Get a map of descriptions of all notifications emitted by the resources at an address.
+     *
+     * @param address the address
+     * @param inherited true to include inherited notifications
+     * @return the notifications map
+     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
+     */
+    Map<String, NotificationEntry> getNotificationDescriptions(PathAddress address, boolean inherited);
+
+    /**
      * Get the names of the types of children for a node
      *
      * @param address the address, relative to this node

--- a/controller/src/main/java/org/jboss/as/controller/registry/LegacyResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/LegacyResourceDefinition.java
@@ -110,6 +110,11 @@ public class LegacyResourceDefinition implements ResourceDefinition {
 
     }
 
+    @Override
+    public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+        // no-op
+    }
+
     /**
      * Register operations associated with this resource.
      *

--- a/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
@@ -27,6 +27,7 @@ import java.util.EnumSet;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -93,12 +94,13 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
     /**
      * Register the existence of an addressable sub-resource of this resource. Before this method returns the provided
      * {@code resourceDefinition} will be given the opportunity to
-     * {@link ResourceDefinition#registerAttributes(ManagementResourceRegistration) register attributes}
-     * and {@link ResourceDefinition#registerOperations(ManagementResourceRegistration) register operations}.
+     * {@link ResourceDefinition#registerAttributes(ManagementResourceRegistration) register attributes},
+     * {@link ResourceDefinition#registerOperations(ManagementResourceRegistration) register operations},
+     * and {@link ResourceDefinition#registerNotifications(ManagementResourceRegistration) register notifications}
      *
      * @param resourceDefinition source for descriptive information describing this
      *                            portion of the model (must not be {@code null})
-     * @return a resource registration which may be used to add attributes, operations and sub-models
+     * @return a resource registration which may be used to add attributes, operations, notifications and sub-models
      *
      * @throws IllegalArgumentException if a submodel is already registered at {@code address}
      * @throws IllegalStateException if {@link #isRuntimeOnly()} returns {@code true}
@@ -370,6 +372,38 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
     void unregisterAlias(PathElement address);
 
     /**
+     * Record that the given notification can be emitted by this resource.
+     *
+     * @param notification the definition of the notification. Cannot be {@code null}
+     * @param inherited  {@code true} if the notification is inherited to child nodes, {@code false} otherwise
+     *
+     * @throws IllegalArgumentException if {@code notification} is {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
+     */
+    void registerNotification(NotificationDefinition notification, boolean inherited);
+
+    /**
+     * Record that the given notification can be emitted by this resource.
+     *
+     * The notification is not inherited by child nodes.
+     *
+     * @param notification the definition of the notification. Cannot be {@code null}
+     *
+     * @throws IllegalArgumentException if {@code notificationType} or {@code notificationEntry} is {@code null}
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
+     */
+    void registerNotification(NotificationDefinition notification);
+
+    /**
+     * Remove that the given notification can be emitted by this resource.
+     *
+     * @param notificationType the type of the notification. Cannot be {@code null}
+     *
+     * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
+     */
+    void unregisterNotification(String notificationType);
+
+    /**
      * A factory for creating a new, root model node registration.
      */
     class Factory {
@@ -428,6 +462,11 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
 
                 @Override
                 public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+                    //  no-op
+                }
+
+                @Override
+                public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
                     //  no-op
                 }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
@@ -156,6 +156,22 @@ final class NodeSubregistry {
         }
     }
 
+    void getNotificationDescriptions(final ListIterator<PathElement> iterator, final String child, final Map<String, NotificationEntry> providers, final boolean inherited) {
+
+        final RegistrySearchControl searchControl = new RegistrySearchControl(iterator, child);
+
+        // First search the wildcard child, then if there is a non-wildcard child search it
+        // Non-wildcard goes second so its description overwrites in case of duplicates
+
+        if (searchControl.getWildCardRegistry() != null) {
+            searchControl.getWildCardRegistry().getNotificationDescriptions(searchControl.getIterator(), providers, inherited);
+        }
+
+        if (searchControl.getSpecifiedRegistry() != null) {
+            searchControl.getSpecifiedRegistry().getNotificationDescriptions(searchControl.getIterator(), providers, inherited);
+        }
+    }
+
     String getLocationString() {
         return parent.getLocationString() + "(" + keyName + " => ";
     }

--- a/controller/src/main/java/org/jboss/as/controller/registry/NotificationEntry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/NotificationEntry.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.registry;
+
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+
+/**
+ * Information about a registered notification.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class NotificationEntry {
+
+    private final DescriptionProvider descriptionProvider;
+    private final boolean inherited;
+
+    public NotificationEntry(final DescriptionProvider descriptionProvider, final boolean inherited) {
+        this.descriptionProvider = descriptionProvider;
+        this.inherited = inherited;
+    }
+
+    public DescriptionProvider getDescriptionProvider() {
+        return descriptionProvider;
+    }
+
+    public boolean isInherited() {
+        return inherited;
+    }
+
+}

--- a/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
@@ -225,12 +226,38 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
     }
 
     @Override
+    public void registerNotification(NotificationDefinition notification, boolean inherited) {
+        throw alreadyRegistered();
+    }
+
+    @Override
+    public void registerNotification(NotificationDefinition notification) {
+        throw alreadyRegistered();
+    }
+
+    @Override
+    public void unregisterNotification(String notificationType) {
+        throw alreadyRegistered();
+    }
+
+    @Override
     void getOperationDescriptions(final ListIterator<PathElement> iterator, final Map<String, OperationEntry> providers, final boolean inherited) {
         checkPermission();
     }
 
+
     @Override
     void getInheritedOperationEntries(final Map<String, OperationEntry> providers) {
+        checkPermission();
+    }
+
+    @Override
+    void getNotificationDescriptions(ListIterator<PathElement> iterator, Map<String, NotificationEntry> providers, boolean inherited) {
+        checkPermission();
+    }
+
+    @Override
+    void getInheritedNotificationEntries(Map<String, NotificationEntry> providers) {
         checkPermission();
     }
 

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -431,6 +431,7 @@ global.read-resource-description=Gets the description of a resource's attributes
 global.read-resource-description.attributes=Whether to include descriptions of the resource's attributes.
 global.read-resource-description.locale=The locale to get the resource description in. If null, the default locale will be used
 global.read-resource-description.operations=Whether to include descriptions of the resource's operations. Default is false
+global.read-resource-description.notifications=Whether to include descriptions of the resource's notifications. Default is false
 global.read-resource-description.inherited=If 'operations' is true, whether to include descriptions of the resource's inherited operations. Default is true.
 global.read-resource-description.recursive=Whether to include recursively descriptions of child resources. Default is false.
 global.read-resource-description.proxies=Whether to include remote resources in a recursive query (i.e. host level resources in a query of the domain root; running server resources in a query of a host). If absent, false is the default

--- a/controller/src/test/java/org/jboss/as/controller/ListAttributeDefinitionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ListAttributeDefinitionTestCase.java
@@ -48,6 +48,10 @@ public class ListAttributeDefinitionTestCase {
             }
 
             @Override
+            public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+            }
+
+            @Override
             public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
                 final PrimitiveListAttributeDefinition attr = PrimitiveListAttributeDefinition.Builder.of(MY_LIST_OF_STRINGS, STRING).build();
                 resourceRegistration.registerReadOnlyAttribute(attr, null);
@@ -85,6 +89,10 @@ public class ListAttributeDefinitionTestCase {
 
             @Override
             public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+            }
+
+            @Override
+            public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
             }
 
             @Override

--- a/controller/src/test/java/org/jboss/as/controller/ModelControllerClientTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModelControllerClientTestCase.java
@@ -44,6 +44,8 @@ import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.impl.ExistingChannelModelControllerClient;
 import org.jboss.as.controller.client.impl.InputStreamEntry;
+import org.jboss.as.controller.notification.NotificationRegistry;
+import org.jboss.as.controller.notification.NotificationSupport;
 import org.jboss.as.controller.remote.ModelControllerClientOperationHandler;
 import org.jboss.as.controller.support.RemoteChannelPairSetup;
 import org.jboss.as.protocol.mgmt.ManagementChannelHandler;
@@ -345,6 +347,7 @@ public class ModelControllerClientTestCase {
 
     private static abstract class MockModelController implements ModelController {
         protected volatile ModelNode operation;
+        private final NotificationRegistry notificationRegistry = NotificationSupport.Factory.create(null).getNotificationRegistry();
 
         ModelNode getOperation() {
             return operation;
@@ -355,6 +358,10 @@ public class ModelControllerClientTestCase {
             return null;
         }
 
+        @Override
+        public NotificationRegistry getNotificationRegistry() {
+            return notificationRegistry;
+        }
     }
 
     static class TestEntry extends FilterInputStream implements InputStreamEntry {

--- a/controller/src/test/java/org/jboss/as/controller/notification/CountdownListBackedNotificationHandler.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/CountdownListBackedNotificationHandler.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * NotificationHandler that stores its notifications in a list and countdown a latch every time it handles a notification.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+public class CountdownListBackedNotificationHandler implements NotificationHandler {
+
+    private final CountDownLatch latch;
+    final List<Notification> notifications = new CopyOnWriteArrayList<>();
+
+    public CountdownListBackedNotificationHandler(CountDownLatch latch) {
+        this.latch = latch;
+    }
+
+    @Override
+    public void handleNotification(Notification notification) {
+        notifications.add(notification);
+        latch.countDown();
+    }
+
+    public List<Notification> getNotifications() {
+        return notifications;
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/notification/ListBackedNotificationHandler.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/ListBackedNotificationHandler.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A notification handler that stores its notifications in a list.
+ *
+* @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+*/
+class ListBackedNotificationHandler implements NotificationHandler {
+
+    final List<Notification> notifications = new ArrayList<>();
+
+    @Override
+    public void handleNotification(Notification notification) {
+        notifications.add(notification);
+    }
+
+    List<Notification> getNotifications() {
+        return notifications;
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/notification/NotificationCompositeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/NotificationCompositeOperationTestCase.java
@@ -1,0 +1,158 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import static org.jboss.as.controller.PathAddress.pathAddress;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.notification.NotificationFilter.ALL;
+import static org.jboss.as.controller.notification.NotificationRegistry.ANY_ADDRESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.as.controller.CompositeOperationHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.test.AbstractControllerTestBase;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.Test;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class NotificationCompositeOperationTestCase extends AbstractControllerTestBase {
+
+    private static final String MY_OPERATION = "my-operation";
+    private static final String MY_NOTIFICATION_TYPE = "my-notification-type";
+
+    private static final SimpleAttributeDefinition FAIL_OPERATION = SimpleAttributeDefinitionBuilder.create("fail-operation", ModelType.BOOLEAN)
+            .setAllowNull(true)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+
+    @Override
+    protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
+        registration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
+
+        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(MY_OPERATION, new NonResolvingResourceDescriptionResolver())
+                        .setParameters(FAIL_OPERATION)
+                .setPrivateEntry()
+                .build(),
+                new OperationStepHandler() {
+                    @Override
+                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                        Notification notification = new Notification(MY_NOTIFICATION_TYPE, pathAddress(operation.get(OP_ADDR)), operation.get("param").asString());
+                        context.emit(notification);
+
+                        boolean failOperation = FAIL_OPERATION.resolveModelAttribute(context, operation).asBoolean();
+                        if (failOperation) {
+                            throw new OperationFailedException("failed operation");
+                        }
+                        context.stepCompleted();
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void testCompositeOperationThatEmitsNotifications() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("composite");
+        operation.get(OP_ADDR).setEmptyList();
+        ModelNode op1 = createOperation(MY_OPERATION);
+        op1.get("param").set("param1");
+        ModelNode op2 = createOperation(MY_OPERATION);
+        op2.get("param").set("param2");
+        operation.get(ModelDescriptionConstants.STEPS).add(op1);
+        operation.get(ModelDescriptionConstants.STEPS).add(op2);
+        ModelNode result = executeForResult(operation);
+        System.out.println("operation = " + operation);
+        System.out.println("result = " + result);
+
+        // the notifications are received in the order they were emitted
+        assertEquals("the notification were not emitted", 2, handler.getNotifications().size());
+        assertEquals("param1", handler.getNotifications().get(0).getMessage());
+        assertEquals("param2", handler.getNotifications().get(1).getMessage());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+
+    @Test
+    public void testCompositeOperationWithFirstOperationFailing() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("composite");
+        operation.get(OP_ADDR).setEmptyList();
+        ModelNode op1 = createOperation(MY_OPERATION);
+        op1.get(FAIL_OPERATION.getName()).set(true);
+        op1.get("param").set("param1");
+        ModelNode op2 = createOperation(MY_OPERATION);
+        op2.get("param").set("param2");
+        operation.get(ModelDescriptionConstants.STEPS).add(op1);
+        operation.get(ModelDescriptionConstants.STEPS).add(op2);
+
+        executeForFailure(operation);
+
+        assertTrue("the notification were emitted", handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+
+    @Test
+    public void testCompositeOperationWithSecondOperationFailing() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("composite");
+        operation.get(OP_ADDR).setEmptyList();
+        ModelNode op1 = createOperation(MY_OPERATION);
+        op1.get("param").set("param1");
+        ModelNode op2 = createOperation(MY_OPERATION);
+        op2.get("param").set("param2");
+        op2.get(FAIL_OPERATION.getName()).set(true);
+        operation.get(ModelDescriptionConstants.STEPS).add(op1);
+        operation.get(ModelDescriptionConstants.STEPS).add(op2);
+
+        executeForFailure(operation);
+
+        assertTrue("the notification were emitted", handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+
+}

--- a/controller/src/test/java/org/jboss/as/controller/notification/NotificationSupportImplTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/NotificationSupportImplTestCase.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.jboss.as.controller.PathAddress.pathAddress;
+import static org.jboss.as.controller.notification.NotificationFilter.ALL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+public class NotificationSupportImplTestCase {
+
+    @Before
+    public void setUp() {
+    }
+
+    @Test
+    public void testNotificationOrderingWithExecutor() throws Exception {
+        doNotificationOrdering(Executors.newFixedThreadPool(12));
+    }
+
+    @Test
+    public void testNotificationOrderingWithoutExecutor() throws Exception {
+        doNotificationOrdering(null);
+    }
+
+    @Ignore
+    @Test
+    public void doManyNotificationOrderingWithExecutor() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(12);
+        for (int i = 0; i < 100000; i++) {
+            doNotificationOrdering(executor);
+        }
+    }
+
+    private void  doNotificationOrdering(ExecutorService executor) throws Exception {
+        int numberOfNotificationsEmitted = 12;
+        final CountDownLatch latch = new CountDownLatch(numberOfNotificationsEmitted);
+
+        NotificationSupport notificationSupport = NotificationSupport.Factory.create(executor);
+
+        CountdownListBackedNotificationHandler handler = new CountdownListBackedNotificationHandler(latch);
+
+        notificationSupport.getNotificationRegistry().registerNotificationHandler(NotificationRegistry.ANY_ADDRESS, handler, ALL);
+
+        List<Notification> notifications1 = new ArrayList<Notification>();
+        notifications1.add(new Notification("foo", pathAddress("resource", "foo"), "foo"));
+        notifications1.add(new Notification("foo", pathAddress("resource", "foo"), "bar"));
+        notifications1.add(new Notification("foo", pathAddress("resource", "foo"), "baz"));
+
+        List<Notification> notifications2 = new ArrayList<Notification>();
+        notifications2.add(new Notification("bar", pathAddress("resource", "bar"), "foo"));
+        notifications2.add(new Notification("bar", pathAddress("resource", "bar"), "bar"));
+        notifications2.add(new Notification("bar", pathAddress("resource", "bar"), "baz"));
+
+        final Notification[] notifs1 = notifications1.toArray(new Notification[notifications1.size()]);
+        final Notification[] notifs2 = notifications2.toArray(new Notification[notifications2.size()]);
+
+        // emit the notifications1 a 1st time
+        notificationSupport.emit(notifs1);
+        // emit the notifications2 a 1st time
+        notificationSupport.emit(notifs2);
+        // emit the notifications1 a 2nd time
+        notificationSupport.emit(notifs1);
+        // emit the notifications2 a 2nd time
+        notificationSupport.emit(notifs2);
+
+        assertTrue(latch.await(5, SECONDS));
+
+        assertEquals(handler.getNotifications().toString(), numberOfNotificationsEmitted, handler.getNotifications().size());
+
+        for (Notification notification : handler.getNotifications()) {
+            assertNotNull(notification);
+        }
+
+        // handled the 1st notifications1 that were emitted
+        assertEquals(notifications1, handler.getNotifications().subList(0, 3));
+        // handled the 1st notifications2 that were emitted
+        assertEquals(notifications2, handler.getNotifications().subList(3, 6));
+        // handled the 2nd notifications1 that were emitted
+        assertEquals(notifications1, handler.getNotifications().subList(6, 9));
+        // handled the 2nd notifications2 that were emitted
+        assertEquals(notifications2, handler.getNotifications().subList(9, 12));
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/notification/OperationWithManyStepsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/OperationWithManyStepsTestCase.java
@@ -1,0 +1,193 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import static org.jboss.as.controller.OperationContext.Stage.RUNTIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.notification.NotificationFilter.ALL;
+import static org.jboss.as.controller.notification.NotificationRegistry.ANY_ADDRESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.test.AbstractControllerTestBase;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.Test;
+
+/**
+ * Test emitting notifications for an operation composed of many steps.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
+
+    private static final String MY_OPERATION = "my-operation";
+    private static final String MY_NOTIFICATION_TYPE = "my-notification-type";
+
+    private static final String MESSAGE1 = "first notification message";
+    private static final String MESSAGE2 = "second notification message";
+
+    private static final SimpleAttributeDefinition FAIL_FIRST_STEP = SimpleAttributeDefinitionBuilder.create("fail-first-step", ModelType.BOOLEAN)
+            .setAllowNull(true)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+    private static final AttributeDefinition FAIL_SECOND_STEP = SimpleAttributeDefinitionBuilder.create("fail-second-step", FAIL_FIRST_STEP)
+            .build();
+    private static final SimpleAttributeDefinition ROLLBACK = SimpleAttributeDefinitionBuilder.create("rollback", ModelType.BOOLEAN)
+            .setAllowNull(true)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+
+    @Override
+    protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
+        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(MY_OPERATION, new NonResolvingResourceDescriptionResolver())
+                        .setParameters(FAIL_FIRST_STEP, FAIL_SECOND_STEP)
+                        .setPrivateEntry()
+                        .build(),
+                new OperationStepHandler() {
+                    @Override
+                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                        boolean failFirstStep = FAIL_FIRST_STEP.resolveModelAttribute(context, operation).asBoolean();
+                        boolean rollback = ROLLBACK.resolveModelAttribute(context, operation).asBoolean();
+
+                        System.out.println("send 1st notification");
+                        context.emit(new Notification(MY_NOTIFICATION_TYPE, PathAddress.pathAddress(operation.get(OP_ADDR)), MESSAGE1));
+
+                        if (failFirstStep) {
+                            throw new OperationFailedException("1st step failed");
+                        }
+
+                        context.addStep(new OperationStepHandler() {
+                            @Override
+                            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                                boolean failSecondStep = FAIL_SECOND_STEP.resolveModelAttribute(context, operation).asBoolean();
+
+                                System.out.println("send 2nd notification");
+                                context.emit(new Notification(MY_NOTIFICATION_TYPE, PathAddress.pathAddress(operation.get(OP_ADDR)), MESSAGE2));
+
+                                if (failSecondStep) {
+                                    throw new OperationFailedException("2nd step failed");
+                                }
+
+                                context.stepCompleted();
+                            }
+                        }, RUNTIME);
+
+                        if (rollback) {
+                            context.getFailureDescription().set("rolled back");
+                            context.setRollbackOnly();
+                        }
+                        context.stepCompleted();
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void testSendNotificationForSuccessfulOperation() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+
+        // register the handler...
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        executeForResult(createOperation(MY_OPERATION));
+
+        assertEquals("the notification handler did not receive the notifications", 2, handler.getNotifications().size());
+        // notifications are received in the order they were emitted
+        assertEquals(MESSAGE1, handler.getNotifications().get(0).getMessage());
+        assertEquals(MESSAGE2, handler.getNotifications().get(1).getMessage());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+
+
+    @Test
+    public void testSendNotificationForFailingOperationInFirstStep() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+
+        ModelNode operation = createOperation(MY_OPERATION);
+        operation.get(FAIL_FIRST_STEP.getName()).set(true);
+
+        try {
+            executeForResult(operation);
+            fail("operation must fail");
+        } catch (OperationFailedException e) {
+            assertEquals("1st step failed", e.getFailureDescription().asString());
+        }
+
+        assertTrue("the notification handler did not receive any notifications", handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+
+
+    @Test
+    public void testSendNotificationForFailingOperationInSecondStep() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+
+        ModelNode operation = createOperation(MY_OPERATION);
+        operation.get(FAIL_SECOND_STEP.getName()).set(true);
+        try {
+            executeForResult(operation);
+            fail("operation must fail");
+        } catch (OperationFailedException e) {
+            assertEquals("2nd step failed", e.getFailureDescription().asString());
+        }
+
+        assertTrue("the notification handler did not receive any notifications", handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+
+    @Test
+    public void testSendNotificationForRollingBackOperation() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+
+        ModelNode operation = createOperation(MY_OPERATION);
+        operation.get(ROLLBACK.getName()).set(true);
+        try {
+            executeForResult(operation);
+            fail("operation must have been rolled back");
+        } catch (OperationFailedException e) {
+            assertEquals("rolled back", e.getFailureDescription().asString());
+        }
+
+        assertTrue("the notification handler did not receive any notifications", handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/notification/OperationWithNotificationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/OperationWithNotificationTestCase.java
@@ -1,0 +1,156 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.notification.NotificationFilter.ALL;
+import static org.jboss.as.controller.notification.NotificationRegistry.ANY_ADDRESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.test.AbstractControllerTestBase;
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+/**
+ *
+ * Test handling notifications and filtering them.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class OperationWithNotificationTestCase extends AbstractControllerTestBase {
+
+    private static final String MY_OPERATION = "my-operation";
+    private static final String MY_NOTIFICATION_TYPE = "my-notification-type";
+
+    @Override
+    protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
+        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(MY_OPERATION, new NonResolvingResourceDescriptionResolver())
+                        .setPrivateEntry()
+                        .build(),
+                new OperationStepHandler() {
+                    @Override
+                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                        Notification notification = new Notification(MY_NOTIFICATION_TYPE, PathAddress.pathAddress(operation.get(OP_ADDR)), "notification message");
+                        context.emit(notification);
+                        context.stepCompleted();
+                    }
+                }
+        );
+    }
+
+    @Test
+    public void testSendNotification() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, new NotificationFilter() {
+
+                    @Override
+                    public boolean isNotificationEnabled(Notification notification) {
+                        return MY_NOTIFICATION_TYPE.equals(notification.getType());
+                    }
+                }
+        );
+
+        executeForResult(createOperation(MY_OPERATION));
+        assertEquals("the notification handler did not receive the notification", 1, handler.getNotifications().size());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+
+    @Test
+    public void testSendNotificationWithFilter() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, new NotificationFilter() {
+
+            @Override
+            public boolean isNotificationEnabled(Notification notification) {
+                return false;
+            }
+        });
+
+        executeForResult(createOperation(MY_OPERATION));
+        assertTrue("the notification handler must not receive the filtered out notification", handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+
+    @Test
+    public void testSendNotificationToFailingHandler() throws Exception {
+        final AtomicBoolean gotNotification = new AtomicBoolean(false);
+        NotificationHandler handler = new NotificationHandler() {
+            @Override
+            public void handleNotification(Notification notification) {
+                // the handler receives the notification
+                gotNotification.set(true);
+                // but fails to process it
+                throw new IllegalStateException("somehow, the handler throws an exception");
+            }
+        };
+
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+
+        // having a failing notification handler has no incidence on the operation that triggered the notification emission
+        executeForResult(createOperation(MY_OPERATION));
+        assertTrue("the notification handler did receive the notification", gotNotification.get());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+
+    @Test
+    public void testSendNotificationWithFailingFilter() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, new NotificationFilter() {
+            @Override
+            public boolean isNotificationEnabled(Notification notification) {
+                throw new IllegalStateException("somehow, the filter throws an exception");
+            }
+        });
+        // having a failing notification filter has no incidence on the operation that triggered the notification emission
+        executeForResult(createOperation(MY_OPERATION));
+        // but the handler will not be notified
+        assertTrue("the notification handler did receive the notification", handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+    }
+
+    @Test
+    public void testSendNotificationAfterUnregisteringHandler() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        // register the handler...
+        getController().getNotificationRegistry().registerNotificationHandler(ANY_ADDRESS, handler, ALL);
+        // ... and unregister it
+        getController().getNotificationRegistry().unregisterNotificationHandler(ANY_ADDRESS, handler, ALL);
+        executeForResult(createOperation(MY_OPERATION));
+        assertTrue("the unregistered notification handler did not receive the notification", handler.getNotifications().isEmpty());
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/notification/PathAddressUtilTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/PathAddressUtilTestCase.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import static org.jboss.as.controller.PathAddress.pathAddress;
+import static org.jboss.as.controller.PathElement.pathElement;
+import static org.jboss.as.controller.notification.NotificationRegistry.ANY_ADDRESS;
+import static org.jboss.as.controller.notification.PathAddressUtil.matches;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.as.controller.PathAddress;
+import org.junit.Test;
+
+/**
+ * Tests for path address wildcard syntax.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat Inc.
+ */
+public class PathAddressUtilTestCase {
+
+    @Test
+    public void testPathAddressMatches() {
+        // address is /subsystem=messaging/hornetq-server=default/jms-queue=myQueue
+        PathAddress address = pathAddress(pathElement("subsystem", "messaging"), pathElement("hornetq-server", "default"), pathElement("jms-queue", "myQueue"));
+        assertTrue(matches(address, address));
+        assertTrue(matches(address, ANY_ADDRESS));
+
+        // address does not match its parent /subsystem=messaging/hornetq-server=default
+        PathAddress parent = address.subAddress(0, address.size() - 1);
+        assertFalse(matches(address, parent));
+
+        // address does not match its sibling /subsystem=messaging/hornetq-server=default/jms-topic=*
+        PathAddress sibling = parent.append("jms-topic", "*");
+        assertFalse(matches(address, sibling));
+
+        // address does not match its child /subsystem=messaging/hornetq-server=default/jms-queue=myQueue/subresource=mySubresource
+        PathAddress child = address.append("subresource", "mySubresource");
+        assertFalse(matches(address, child));
+
+        // address matches the pattern /subsystem=messaging/hornetq-server=default/jms-queue=*
+        PathAddress pattern = pathAddress(pathElement("subsystem", "messaging"), pathElement("hornetq-server", "default"), pathElement("jms-queue", "*"));
+        assertTrue(matches(address, pattern));
+        // address matches the pattern /subsystem=messaging/hornetq-server=*/jms-queue=*
+        pattern = pathAddress(pathElement("subsystem", "messaging"), pathElement("hornetq-server", "*"), pathElement("jms-queue", "*"));
+        assertTrue(matches(address, pattern));
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/notification/ResourceWithNotificationDefinitionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/ResourceWithNotificationDefinitionTestCase.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATION_DATA_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATION_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.jboss.as.controller.NotificationDefinition;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.test.AbstractControllerTestBase;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.junit.Test;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class ResourceWithNotificationDefinitionTestCase extends AbstractControllerTestBase {
+
+    private static final String MY_TYPE = "my-notification-type";
+    private static final String NOTIFICATION_DESCRIPTION = "My Notification Description";
+    private static final ModelNode DATA_TYPE_DESCRIPTION;
+
+    static {
+        DATA_TYPE_DESCRIPTION = new ModelNode();
+        DATA_TYPE_DESCRIPTION.get("foo", DESCRIPTION).set("description of foo");
+        DATA_TYPE_DESCRIPTION.get("bar", DESCRIPTION).set("description of bar");
+
+    }
+
+    @Override
+    protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
+        GlobalOperationHandlers.registerGlobalOperations(registration, ProcessType.STANDALONE_SERVER);
+        NotificationDefinition notificationDefinition = NotificationDefinition.Builder.create(MY_TYPE,
+                new NonResolvingResourceDescriptionResolver() {
+                    @Override
+                    public String getNotificationDescription(String notificationType, Locale locale, ResourceBundle bundle) {
+                        return NOTIFICATION_DESCRIPTION;
+                    }
+                })
+                .setDataValueDescriptor(new NotificationDefinition.DataValueDescriptor() {
+                    @Override
+                    public ModelNode describe(ResourceBundle bundle) {
+                        return DATA_TYPE_DESCRIPTION;
+                    }
+                })
+                .build();
+
+        registration.registerNotification(notificationDefinition);
+    }
+
+    @Test
+    public void testReadResourceDescriptionWithNotification() throws Exception {
+        ModelNode readResourceDescription = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
+        readResourceDescription.get(NOTIFICATIONS).set(true);
+
+        ModelNode description = executeForResult(readResourceDescription);
+        assertTrue(description.hasDefined(NOTIFICATIONS));
+
+        List<Property> notifications = description.require(NOTIFICATIONS).asPropertyList();
+        assertEquals(1, notifications.size());
+        Property notification = notifications.get(0);
+        assertEquals(MY_TYPE, notification.getName());
+        assertEquals(MY_TYPE, notification.getValue().get(NOTIFICATION_TYPE).asString());
+        assertEquals(NOTIFICATION_DESCRIPTION, notification.getValue().get(DESCRIPTION).asString());
+        assertEquals(DATA_TYPE_DESCRIPTION, notification.getValue().get(NOTIFICATION_DATA_TYPE));
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
@@ -105,6 +105,21 @@ public abstract class AbstractControllerTestBase {
         return operation;
     }
 
+    protected ModelNode createOperation(String operationName, PathAddress address) {
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set(operationName);
+        if (address.size() > 0) {
+            for (PathElement element : address) {
+                operation.get(OP_ADDR).add(element.getKey());
+                operation.get(OP_ADDR).add(element.getValue());
+            }
+        } else {
+            operation.get(OP_ADDR).setEmptyList();
+        }
+
+        return operation;
+    }
+
     public ModelNode executeForResult(ModelNode operation) throws OperationFailedException {
         return executeCheckNoFailure(operation).get(RESULT);
     }

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
@@ -31,6 +31,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
@@ -248,7 +249,7 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
 
     }
 
-    protected void checkRootNodeDescription(ModelNode result, boolean recursive, boolean operations) {
+    protected void checkRootNodeDescription(ModelNode result, boolean recursive, boolean operations, boolean notifications) {
         assertEquals("description", result.require(DESCRIPTION).asString());
         assertEquals("profile", result.require(CHILDREN).require(PROFILE).require(DESCRIPTION).asString());
 
@@ -270,17 +271,17 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
             assertFalse(result.get(OPERATIONS).isDefined());
         }
 
-
         if (!recursive) {
             assertFalse(result.require(CHILDREN).require(PROFILE).require(MODEL_DESCRIPTION).isDefined());
             return;
         }
         assertTrue(result.require(CHILDREN).require(PROFILE).require(MODEL_DESCRIPTION).isDefined());
         assertEquals(1, result.require(CHILDREN).require(PROFILE).require(MODEL_DESCRIPTION).keys().size());
-        checkProfileNodeDescription(result.require(CHILDREN).require(PROFILE).require(MODEL_DESCRIPTION).require("*"), true, operations);
+        checkProfileNodeDescription(result.require(CHILDREN).require(PROFILE).require(MODEL_DESCRIPTION).require("*"), true, operations, notifications);
+
     }
 
-    protected void checkProfileNodeDescription(ModelNode result, boolean recursive, boolean operations) {
+    protected void checkProfileNodeDescription(ModelNode result, boolean recursive, boolean operations, boolean notifications) {
         assertEquals(ModelType.STRING, result.require(ATTRIBUTES).require(NAME).require(TYPE).asType());
         assertEquals(false, result.require(ATTRIBUTES).require(NAME).require(NILLABLE).asBoolean());
         assertEquals(1, result.require(ATTRIBUTES).require(NAME).require(MIN_LENGTH).asInt());
@@ -291,10 +292,10 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
         }
         assertTrue(result.require(CHILDREN).require(SUBSYSTEM).require(MODEL_DESCRIPTION).isDefined());
         assertEquals(6, result.require(CHILDREN).require(SUBSYSTEM).require(MODEL_DESCRIPTION).keys().size());
-        checkSubsystem1Description(result.require(CHILDREN).require(SUBSYSTEM).require(MODEL_DESCRIPTION).require("subsystem1"), recursive, operations);
+        checkSubsystem1Description(result.require(CHILDREN).require(SUBSYSTEM).require(MODEL_DESCRIPTION).require("subsystem1"), recursive, operations, notifications);
     }
 
-    protected void checkSubsystem1Description(ModelNode result, boolean recursive, boolean operations) {
+    protected void checkSubsystem1Description(ModelNode result, boolean recursive, boolean operations, boolean notifications) {
         assertNotNull(result);
 
         assertEquals(ModelType.LIST, result.require(ATTRIBUTES).require("attr1").require(TYPE).asType());
@@ -341,6 +342,18 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
             assertFalse(result.get(OPERATIONS).isDefined());
         }
 
+        // TODO WFLY-3603 - add assertions for global notifications
+        /*
+        if (notifications) {
+            assertTrue(result.require(NOTIFICATIONS).isDefined());
+            Set<String> notifs = result.require(NOTIFICATIONS).keys();
+            assertEquals(processType == ProcessType.DOMAIN_SERVER ? 2 : 3, notifs.size());
+            boolean runtimeOnly = processType != ProcessType.DOMAIN_SERVER;
+        } else {
+            assertFalse(result.get(NOTIFICATIONS).isDefined());
+        }
+        */
+
         if (!recursive) {
             assertFalse(result.require(CHILDREN).require("type1").require(MODEL_DESCRIPTION).isDefined());
             assertFalse(result.require(CHILDREN).require("type2").require(MODEL_DESCRIPTION).isDefined());
@@ -376,6 +389,11 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
 
         }
 
+        if (result.hasDefined(NOTIFICATIONS)) {
+            assertTrue(result.require(NOTIFICATIONS).isDefined());
+            Set<String> notifs = result.require(NOTIFICATIONS).keys();
+            assertEquals(processType == ProcessType.DOMAIN_SERVER ? 2 : 3, notifs.size());
+        }
     }
 
     protected void checkType2Description(ModelNode result) {
@@ -397,6 +415,12 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
             assertTrue(ops.contains(READ_OPERATION_NAMES_OPERATION));
             assertTrue(ops.contains(READ_OPERATION_DESCRIPTION_OPERATION));
             assertEquals(processType != ProcessType.DOMAIN_SERVER, ops.contains(WRITE_ATTRIBUTE_OPERATION));
+        }
+
+        if (result.hasDefined(NOTIFICATIONS)) {
+            assertTrue(result.require(NOTIFICATIONS).isDefined());
+            Set<String> notifs = result.require(NOTIFICATIONS).keys();
+            assertEquals(processType == ProcessType.DOMAIN_SERVER ? 2 : 3, notifs.size());
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/test/DomainServerGlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/DomainServerGlobalOperationsTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.controller.test;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATION_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
@@ -57,12 +59,12 @@ public class DomainServerGlobalOperationsTestCase extends AbstractGlobalOperatio
     public void testReadResourceDescriptionOperation() throws Exception {
         ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
         ModelNode result = executeForResult(operation);
-        checkRootNodeDescription(result, false, false);
+        checkRootNodeDescription(result, false, false, false);
         assertFalse(result.get(OPERATIONS).isDefined());
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA");
         result = executeForResult(operation);
-        checkProfileNodeDescription(result, false, false);
+        checkProfileNodeDescription(result, false, false, false);
 
         //TODO this is not possible - the wildcard address does not correspond to anything in the real model
         //operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "*");
@@ -71,7 +73,7 @@ public class DomainServerGlobalOperationsTestCase extends AbstractGlobalOperatio
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         result = executeForResult(operation);
-        checkSubsystem1Description(result, false, false);
+        checkSubsystem1Description(result, false, false, false);
         assertFalse(result.get(OPERATIONS).isDefined());
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
@@ -83,6 +85,7 @@ public class DomainServerGlobalOperationsTestCase extends AbstractGlobalOperatio
         result = executeForResult(operation);
         checkType1Description(result);
         assertFalse(result.get(OPERATIONS).isDefined());
+        assertFalse(result.get(NOTIFICATIONS).isDefined());
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type2", "other");
         result = executeForResult(operation);
@@ -95,13 +98,14 @@ public class DomainServerGlobalOperationsTestCase extends AbstractGlobalOperatio
         ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
         operation.get(RECURSIVE).set(true);
         ModelNode result = executeForResult(operation);
-        checkRootNodeDescription(result, true, false);
+        checkRootNodeDescription(result, true, false, false);
         assertFalse(result.get(OPERATIONS).isDefined());
+        assertFalse(result.get(NOTIFICATIONS).isDefined());
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA");
         operation.get(RECURSIVE).set(true);
         result = executeForResult(operation);
-        checkProfileNodeDescription(result, true, false);
+        checkProfileNodeDescription(result, true, false, false);
 
         //TODO this is not possible - the wildcard address does not correspond to anything in the real model
         //operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "*");
@@ -112,8 +116,9 @@ public class DomainServerGlobalOperationsTestCase extends AbstractGlobalOperatio
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         operation.get(RECURSIVE).set(true);
         result = executeForResult(operation);
-        checkSubsystem1Description(result, true, false);
+        checkSubsystem1Description(result, true, false, false);
         assertFalse(result.get(OPERATIONS).isDefined());
+        assertFalse(result.get(NOTIFICATIONS).isDefined());
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
         operation.get(RECURSIVE).set(true);
@@ -139,7 +144,7 @@ public class DomainServerGlobalOperationsTestCase extends AbstractGlobalOperatio
         ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
         operation.get(OPERATIONS).set(true);
         ModelNode result = executeForResult(operation);
-        checkRootNodeDescription(result, false, true);
+        checkRootNodeDescription(result, false, true, false);
         assertTrue(result.require(OPERATIONS).isDefined());
         Set<String> ops = result.require(OPERATIONS).keys();
         assertTrue(ops.contains(READ_ATTRIBUTE_OPERATION));
@@ -156,7 +161,7 @@ public class DomainServerGlobalOperationsTestCase extends AbstractGlobalOperatio
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         operation.get(OPERATIONS).set(true);
         result = executeForResult(operation);
-        checkSubsystem1Description(result, false, true);
+        checkSubsystem1Description(result, false, true, false);
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
         operation.get(OPERATIONS).set(true);
@@ -180,14 +185,14 @@ public class DomainServerGlobalOperationsTestCase extends AbstractGlobalOperatio
         operation.get(OPERATIONS).set(true);
         operation.get(RECURSIVE).set(true);
         ModelNode result = executeForResult(operation);
-        checkRootNodeDescription(result, true, true);
+        checkRootNodeDescription(result, true, true, false);
 
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         operation.get(OPERATIONS).set(true);
         operation.get(RECURSIVE).set(true);
         result = executeForResult(operation);
-        checkSubsystem1Description(result, true, true);
+        checkSubsystem1Description(result, true, true, false);
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
         operation.get(OPERATIONS).set(true);
@@ -203,6 +208,77 @@ public class DomainServerGlobalOperationsTestCase extends AbstractGlobalOperatio
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type2", "other");
         operation.get(OPERATIONS).set(true);
+        operation.get(RECURSIVE).set(true);
+        result = executeForResult(operation);
+        checkType2Description(result);
+    }
+
+    @Test
+    public void testReadResourceDescriptionOperationWithNotifications() throws Exception {
+        ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
+        operation.get(NOTIFICATIONS).set(true);
+        ModelNode result = executeForResult(operation);
+        checkRootNodeDescription(result, false, false, true);
+
+        // TODO WFLY-3603 - add assertions for global notifications
+        assertFalse(result.require(NOTIFICATIONS).isDefined());
+        /*
+        Set<String> notifs = result.require(NOTIFICATIONS).keys();
+        for (String notif : notifs) {
+            assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
+        }
+        */
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        operation.get(NOTIFICATIONS).set(true);
+        result = executeForResult(operation);
+        checkSubsystem1Description(result, false, false, true);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
+        operation.get(NOTIFICATIONS).set(true);
+        result = executeForResult(operation);
+        checkType1Description(result);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing2");
+        operation.get(NOTIFICATIONS).set(true);
+        result = executeForResult(operation);
+        checkType1Description(result);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type2", "other");
+        operation.get(NOTIFICATIONS).set(true);
+        result = executeForResult(operation);
+        checkType2Description(result);
+    }
+
+    @Test
+    public void testRecursiveReadResourceDescriptionOperationWithNotifications() throws Exception {
+        ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
+        operation.get(NOTIFICATIONS).set(true);
+        operation.get(RECURSIVE).set(true);
+        ModelNode result = executeForResult(operation);
+        checkRootNodeDescription(result, true, false, true);
+
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        operation.get(NOTIFICATIONS).set(true);
+        operation.get(RECURSIVE).set(true);
+        result = executeForResult(operation);
+        checkSubsystem1Description(result, true, false, true);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
+        operation.get(NOTIFICATIONS).set(true);
+        operation.get(RECURSIVE).set(true);
+        result = executeForResult(operation);
+        checkType1Description(result);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing2");
+        operation.get(NOTIFICATIONS).set(true);
+        operation.get(RECURSIVE).set(true);
+        result = executeForResult(operation);
+        checkType1Description(result);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type2", "other");
+        operation.get(NOTIFICATIONS).set(true);
         operation.get(RECURSIVE).set(true);
         result = executeForResult(operation);
         checkType2Description(result);

--- a/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsTestCase.java
@@ -25,7 +25,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_DEFAULTS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INHERITED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATION_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -625,12 +628,12 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
     public void testReadResourceDescriptionOperation() throws Exception {
         ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
         ModelNode result = executeForResult(operation);
-        checkRootNodeDescription(result, false, false);
+        checkRootNodeDescription(result, false, false, false);
         assertFalse(result.get(OPERATIONS).isDefined());
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA");
         result = executeForResult(operation);
-        checkProfileNodeDescription(result, false, false);
+        checkProfileNodeDescription(result, false, false, false);
 
         //TODO this is not possible - the wildcard address does not correspond to anything in the real model
         //operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "*");
@@ -639,7 +642,7 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         result = executeForResult(operation);
-        checkSubsystem1Description(result, false, false);
+        checkSubsystem1Description(result, false, false, false);
         assertFalse(result.get(OPERATIONS).isDefined());
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
@@ -663,13 +666,13 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
         ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
         operation.get(RECURSIVE).set(true);
         ModelNode result = executeForResult(operation);
-        checkRootNodeDescription(result, true, false);
+        checkRootNodeDescription(result, true, false, false);
         assertFalse(result.get(OPERATIONS).isDefined());
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA");
         operation.get(RECURSIVE).set(true);
         result = executeForResult(operation);
-        checkProfileNodeDescription(result, true, false);
+        checkProfileNodeDescription(result, true, false, false);
 
         //TODO this is not possible - the wildcard address does not correspond to anything in the real model
         //operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "*");
@@ -680,7 +683,7 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         operation.get(RECURSIVE).set(true);
         result = executeForResult(operation);
-        checkSubsystem1Description(result, true, false);
+        checkSubsystem1Description(result, true, false, false);
         assertFalse(result.get(OPERATIONS).isDefined());
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
@@ -707,7 +710,7 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
         ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
         operation.get(OPERATIONS).set(true);
         ModelNode result = executeForResult(operation);
-        checkRootNodeDescription(result, false, true);
+        checkRootNodeDescription(result, false, true, false);
         assertTrue(result.require(OPERATIONS).isDefined());
         Set<String> ops = result.require(OPERATIONS).keys();
         assertTrue(ops.contains(READ_ATTRIBUTE_OPERATION));
@@ -724,7 +727,7 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         operation.get(OPERATIONS).set(true);
         result = executeForResult(operation);
-        checkSubsystem1Description(result, false, true);
+        checkSubsystem1Description(result, false, true, false);
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
         operation.get(OPERATIONS).set(true);
@@ -748,14 +751,14 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
         operation.get(OPERATIONS).set(true);
         operation.get(RECURSIVE).set(true);
         ModelNode result = executeForResult(operation);
-        checkRootNodeDescription(result, true, true);
+        checkRootNodeDescription(result, true, true, false);
 
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         operation.get(OPERATIONS).set(true);
         operation.get(RECURSIVE).set(true);
         result = executeForResult(operation);
-        checkSubsystem1Description(result, true, true);
+        checkSubsystem1Description(result, true, true, false);
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
         operation.get(OPERATIONS).set(true);
@@ -771,6 +774,99 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type2", "other");
         operation.get(OPERATIONS).set(true);
+        operation.get(RECURSIVE).set(true);
+        result = executeForResult(operation);
+        checkType2Description(result);
+    }
+
+    @Test
+    public void testReadResourceDescriptionOperationWithNotifications() throws Exception {
+        ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
+        operation.get(NOTIFICATIONS).set(true);
+        ModelNode result = executeForResult(operation);
+        checkRootNodeDescription(result, false, false, true);
+
+        // TODO WFLY-3603 - add assertions for global notifications
+        /*
+        assertTrue(result.require(NOTIFICATIONS).isDefined());
+        Set<String> notifs = result.require(NOTIFICATIONS).keys();
+        for (String notif : notifs) {
+            assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
+        }
+        */
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        operation.get(NOTIFICATIONS).set(true);
+        result = executeForResult(operation);
+        checkSubsystem1Description(result, false, false, true);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
+        operation.get(NOTIFICATIONS).set(true);
+        result = executeForResult(operation);
+        checkType1Description(result);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing2");
+        operation.get(NOTIFICATIONS).set(true);
+        result = executeForResult(operation);
+        checkType1Description(result);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type2", "other");
+        operation.get(NOTIFICATIONS).set(true);
+        result = executeForResult(operation);
+        checkType2Description(result);
+    }
+
+    @Test
+    public void testReadResourceDescriptionOperationWithNotInheritedNotifications() throws Exception {
+        ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
+        operation.get(NOTIFICATIONS).set(true);
+        operation.get(INHERITED).set(false);
+        ModelNode result = executeForResult(operation);
+        checkRootNodeDescription(result, false, false, true);
+        // TODO WFLY-3603 - add assertions for global notifications
+        /*
+        assertTrue(result.require(NOTIFICATIONS).isDefined());
+        Set<String> notifs = result.require(NOTIFICATIONS).keys();
+        for (String notif : notifs) {
+            assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
+        }
+        */
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        operation.get(NOTIFICATIONS).set(true);
+        operation.get(INHERITED).set(false);
+        result = executeForResult(operation);
+        checkSubsystem1Description(result, false, false, false);
+    }
+
+    @Test
+    public void testRecursiveReadResourceDescriptionOperationWithNotifications() throws Exception {
+        ModelNode operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION);
+        operation.get(NOTIFICATIONS).set(true);
+        operation.get(RECURSIVE).set(true);
+        ModelNode result = executeForResult(operation);
+        checkRootNodeDescription(result, true, false, true);
+
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
+        operation.get(NOTIFICATIONS).set(true);
+        operation.get(RECURSIVE).set(true);
+        result = executeForResult(operation);
+        checkSubsystem1Description(result, true, false, true);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing1");
+        operation.get(NOTIFICATIONS).set(true);
+        operation.get(RECURSIVE).set(true);
+        result = executeForResult(operation);
+        checkType1Description(result);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type1", "thing2");
+        operation.get(NOTIFICATIONS).set(true);
+        operation.get(RECURSIVE).set(true);
+        result = executeForResult(operation);
+        checkType1Description(result);
+
+        operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1", "type2", "other");
+        operation.get(NOTIFICATIONS).set(true);
         operation.get(RECURSIVE).set(true);
         result = executeForResult(operation);
         checkType2Description(result);

--- a/controller/src/test/java/org/jboss/as/controller/test/RemoteProxyControllerProtocolTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/RemoteProxyControllerProtocolTestCase.java
@@ -53,6 +53,7 @@ import org.jboss.as.controller.client.MessageSeverity;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.notification.NotificationRegistry;
 import org.jboss.as.controller.remote.RemoteProxyController;
 import org.jboss.as.controller.remote.TransactionalProtocolOperationHandler;
 import org.jboss.as.controller.support.RemoteChannelPairSetup;
@@ -597,6 +598,10 @@ public class RemoteProxyControllerProtocolTestCase {
             return null;
         }
 
+        @Override
+        public NotificationRegistry getNotificationRegistry() {
+            return null;
+        }
     }
 
     private static class CommitProxyOperationControl implements ProxyOperationControl {

--- a/controller/src/test/java/org/jboss/as/controller/test/TransactionalProtocolClientTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/TransactionalProtocolClientTestCase.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.notification.NotificationRegistry;
 import org.jboss.as.controller.remote.BlockingQueueOperationListener;
 import org.jboss.as.controller.remote.TransactionalOperationImpl;
 import org.jboss.as.controller.remote.TransactionalProtocolHandlers;
@@ -420,6 +421,11 @@ public class TransactionalProtocolClientTestCase {
 
         @Override
         public ModelControllerClient createClient(Executor executor) {
+            throw new IllegalStateException();
+        }
+
+        @Override
+        public NotificationRegistry getNotificationRegistry() {
             throw new IllegalStateException();
         }
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -1053,6 +1053,11 @@ public class DomainModelControllerService extends AbstractControllerService impl
         }
 
         @Override
+        public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+            //These will be registered later
+        }
+
+        @Override
         public PathElement getPathElement() {
             return delegate.getPathElement();
         }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -56,6 +56,7 @@ import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.NoopOperationStepHandler;
 import org.jboss.as.controller.OperationContext;
@@ -79,10 +80,12 @@ import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.OverrideDescriptionProvider;
+import org.jboss.as.controller.notification.Notification;
 import org.jboss.as.controller.registry.AliasEntry;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.NotificationEntry;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
@@ -590,6 +593,11 @@ public abstract class AbstractOperationTestCase {
             //TODO implement getCallEnvironment
             throw null;
         }
+
+        @Override
+        public void emit(Notification notification) {
+            // no-op
+        }
     }
 
     Resource createRootResource() {
@@ -769,6 +777,21 @@ public abstract class AbstractOperationTestCase {
 
         }
 
+        @Override
+        public void registerNotification(NotificationDefinition notification, boolean inherited) {
+
+        }
+
+        @Override
+        public void registerNotification(NotificationDefinition notification) {
+
+        }
+
+        @Override
+        public void unregisterNotification(String notificationType) {
+
+        }
+
         public void registerProxyController(PathElement address, ProxyController proxyController) {
 
         }
@@ -827,6 +850,11 @@ public abstract class AbstractOperationTestCase {
 
         @Override
         public AliasEntry getAliasEntry() {
+            return null;
+        }
+
+        @Override
+        public Map<String, NotificationEntry> getNotificationDescriptions(PathAddress address, boolean inherited) {
             return null;
         }
 

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -353,6 +353,11 @@ public abstract class ModelTestModelControllerService extends AbstractController
         }
 
         @Override
+        public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+            delegate.registerNotifications(resourceRegistration);
+        }
+
+        @Override
         public PathElement getPathElement() {
             return delegate.getPathElement();
         }

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelDescriptionValidator.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelDescriptionValidator.java
@@ -41,6 +41,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAMESPACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REASON;
@@ -72,7 +73,7 @@ import org.jboss.dmr.ModelType;
 
 /**
  * Validates the types and entries of the of the description providers in the model, as read by
- * {@code /some/path:read-resource-description(recursive=true,inherited=false,operations=true)}
+ * {@code /some/path:read-resource-description(recursive=true,inherited=false,operations=true,notifications=true)}
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
@@ -82,6 +83,7 @@ public class ModelTestModelDescriptionValidator {
     private static final Map<String, ArbitraryDescriptorValidator> VALID_CHILD_TYPE_KEYS;
     private static final Map<String, AttributeOrParameterArbitraryDescriptorValidator> VALID_ATTRIBUTE_KEYS;
     private static final Map<String, ArbitraryDescriptorValidator> VALID_OPERATION_KEYS;
+    private static final Map<String, ArbitraryDescriptorValidator> VALID_NOTIFICATION_KEYS;
     private static final Map<String, AttributeOrParameterArbitraryDescriptorValidator> VALID_PARAMETER_KEYS;
     static {
         Map<String, ArbitraryDescriptorValidator> validResourceKeys = new HashMap<String, ArbitraryDescriptorValidator>();
@@ -91,6 +93,7 @@ public class ModelTestModelDescriptionValidator {
         validResourceKeys.put(NAMESPACE, NullDescriptorValidator.INSTANCE);
         validResourceKeys.put(ATTRIBUTES, NullDescriptorValidator.INSTANCE);
         validResourceKeys.put(OPERATIONS, NullDescriptorValidator.INSTANCE);
+        validResourceKeys.put(NOTIFICATIONS, NullDescriptorValidator.INSTANCE);
         validResourceKeys.put(CHILDREN, NullDescriptorValidator.INSTANCE);
         validResourceKeys.put(DEPRECATED, DeprecatedDescriptorValidator.INSTANCE);
         validResourceKeys.put(ACCESS_CONSTRAINTS, AccessConstraintValidator.INSTANCE);
@@ -148,6 +151,12 @@ public class ModelTestModelDescriptionValidator {
         Map<String, AttributeOrParameterArbitraryDescriptorValidator> validParameterKeys = new HashMap<String, AttributeOrParameterArbitraryDescriptorValidator>();
         validParameterKeys.putAll(paramAndAttributeKeys);
         VALID_PARAMETER_KEYS = Collections.unmodifiableMap(validParameterKeys);
+
+        Map<String, ArbitraryDescriptorValidator> validNotificationKeys = new HashMap<String, ArbitraryDescriptorValidator>();
+        validNotificationKeys.put("notification-type", NullDescriptorValidator.INSTANCE);
+        validNotificationKeys.put(DESCRIPTION, NullDescriptorValidator.INSTANCE);
+        validNotificationKeys.put("data-type", NullDescriptorValidator.INSTANCE);
+        VALID_NOTIFICATION_KEYS = Collections.unmodifiableMap(validNotificationKeys);
     }
 
     private final List<ValidationFailure> errors;
@@ -195,7 +204,7 @@ public class ModelTestModelDescriptionValidator {
                         errors.add(new MessageValidationFailure(error, address));
                     }
                 } else {
-                    if (!key.equals(OPERATIONS) && !key.equals(CHILDREN)) {
+                    if (!key.equals(OPERATIONS) && !key.equals(NOTIFICATIONS) && !key.equals(CHILDREN)) {
                         errors.add(new MessageValidationFailure("Empty key '" + key + "'", address));
                     }
                 }
@@ -210,6 +219,9 @@ public class ModelTestModelDescriptionValidator {
         }
         if (description.hasDefined("operations")) {
             validateOperations(description.get("operations"));
+        }
+        if (description.hasDefined(NOTIFICATIONS)) {
+            validateNotifications(description.get(NOTIFICATIONS));
         }
         if (description.hasDefined("children")) {
             validateChildren(description.get("children"));
@@ -250,6 +262,22 @@ public class ModelTestModelDescriptionValidator {
                 OperationParameterValidationElement parameterValidationElement = new OperationParameterValidationElement(operation, REPLY_PROPERTIES);
                 validateAttributeOrParameter(parameterValidationElement, reply);
             }
+        }
+    }
+
+    private void validateNotifications(ModelNode notifications) {
+        for (String key : notifications.keys()) {
+            ModelNode notification = notifications.get(key);
+            NotificationValidationElement notificationValidationElement = new NotificationValidationElement(key);
+
+            if (!notification.hasDefined(DESCRIPTION)) {
+                errors.add(notificationValidationElement.createValidationFailure("Missing description"));
+            }
+            if (!notification.hasDefined("notification-type")) {
+                errors.add(notificationValidationElement.createValidationFailure("Missing notification-type"));
+            }
+
+            notificationValidationElement.validateKeys(notification);
         }
     }
 
@@ -1058,6 +1086,57 @@ public class ModelTestModelDescriptionValidator {
 
         boolean allowNullValueTypeForObject() {
             return validationConfiguration.isAllowNullValueTypeForOperationParameter(address, operation.getName(), name);
+        }
+    }
+
+    private static class NotificationValidationFailure extends MessageValidationFailure {
+        private final String notificationType;
+        private NotificationValidationFailure(String message, ModelNode address, String notificationType) {
+            super(message, address);
+            this.notificationType = notificationType;
+        }
+
+        public String toString() {
+            return message + " for notification '" + notificationType +
+                    "'" + address;
+        }
+    }
+
+    private class NotificationValidationElement extends ValidationElement {
+        NotificationValidationElement(String name) {
+            super(name);
+        }
+
+        @Override
+        public String toString() {
+            return "Notification '" + name + "' @" + address;
+        }
+
+        ValidationFailure createValidationFailure(String message) {
+            return new NotificationValidationFailure(message, address, name);
+        }
+
+        void validateKeys(ModelNode description) {
+            if (!description.isDefined()) {
+                errors.add(createValidationFailure("Missing description for operation"));
+                return;
+            }
+            for (String opKey : description.keys()) {
+                ArbitraryDescriptorValidator validator = VALID_NOTIFICATION_KEYS.get(opKey);
+                if (validator == null) {
+                    errors.add(createValidationFailure("Invalid key '" + opKey + "'"));
+                } else {
+                    if (description.hasDefined(opKey)) {
+                        String error = validator.validate(description, opKey);
+                        if (error != null) {
+                            errors.add(createValidationFailure(error));
+
+                        }
+                    } else {
+                        errors.add(createValidationFailure("Empty key '" + opKey + "'"));
+                    }
+                }
+            }
         }
     }
 }

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -458,6 +458,11 @@ public final class ServerService extends AbstractControllerService {
         }
 
         @Override
+        public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+            delegate.registerNotifications(resourceRegistration);
+        }
+
+        @Override
         public PathElement getPathElement() {
             return delegate.getPathElement();
         }

--- a/server/src/main/java/org/jboss/as/server/operations/RootResourceHack.java
+++ b/server/src/main/java/org/jboss/as/server/operations/RootResourceHack.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.registry.AliasEntry;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.NotificationEntry;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.as.controller.registry.Resource;
@@ -193,6 +194,11 @@ public class RootResourceHack implements OperationStepHandler {
 
         @Override
         public Map<String, OperationEntry> getOperationDescriptions(PathAddress address, boolean inherited) {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public Map<String, NotificationEntry> getNotificationDescriptions(PathAddress address, boolean inherited) {
             return Collections.emptyMap();
         }
 

--- a/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
@@ -345,6 +345,11 @@ public class ServerControllerUnitTestCase {
         }
 
         @Override
+        public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+            delegate.registerNotifications(resourceRegistration);
+        }
+
+        @Override
         public PathElement getPathElement() {
             return delegate.getPathElement();
         }

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -54,6 +54,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -78,6 +79,7 @@ import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.AttributeAccess.Storage;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.NotificationEntry;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.OperationEntry.EntryType;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
@@ -529,6 +531,7 @@ final class SubsystemTestDelegate {
         op.get("recursive").set(true);
         op.get("inherited").set(false);
         op.get("operations").set(true);
+        op.get("notifications").set(true);
         op.get("include-aliases").set(true);
         ModelNode result = kernelServices.executeOperation(op);
         if (result.hasDefined(FAILURE_DESCRIPTION)) {
@@ -946,6 +949,11 @@ final class SubsystemTestDelegate {
         }
 
         @Override
+        public Map<String, NotificationEntry> getNotificationDescriptions(PathAddress address, boolean inherited) {
+            return null;
+        }
+
+        @Override
         public ProxyController getProxyController(PathAddress address) {
             return null;
         }
@@ -1061,6 +1069,21 @@ final class SubsystemTestDelegate {
 
         @Override
         public void unregisterAttribute(String attributeName) {
+        }
+
+        @Override
+        public void registerNotification(NotificationDefinition notification, boolean inherited) {
+            // no-op
+        }
+
+        @Override
+        public void registerNotification(NotificationDefinition notification) {
+            // no-op
+        }
+
+        @Override
+        public void unregisterNotification(String notificationType) {
+            // no-op
         }
 
         @Override


### PR DESCRIPTION
- add notifications to AS7 resources description
  notifications are described in :read-resource-description operation if
  the notifications boolean is true
- NotificationDefinition let any resources describe the notifications
  they can emit by registering them in the ManagementResourceRegistration
- add NotificationSupport to let AS7 resource register/unregister
  notification handlers and emit notifications

Notifications emitted by OperationContext.emit(Notification) are
effectively sent at the end of the operation execution if it is
successful. This ensure that the order of notifications emitted by a
single OperationContext will be received in the same order (unless they
are emitted during the ResultHandler execuion).

   JIRA: https://issues.jboss.org/browse/WFLY-266

---

This PR adds support for notifications to WildFly resources but does not add any (that'll be done in a later PR for [WFLY-3603](https://issues.jboss.org/browse/WFLY-3603). The added tests shows how notifications can be defined and emitted and notification handler registered.
However, I already modified the tests that checks the resources operations and notifications. They'll be filled with assertions on the notifications as we add them.

This PR is for WildFly 9 so I added notifications support directly in the API (ModelController, ResourceDefinition). When we backport this feature for 8.2, I am not sure whether I can also modify directly the API or create subinterface.
