### PR TITLE
Don't run patching testsuite by default

### DIFF
--- a/testsuite-core/pom.xml
+++ b/testsuite-core/pom.xml
@@ -417,7 +417,6 @@
                 </property>
             </activation>
             <modules>
-                <module>patching</module>
                 <module>domain</module>
             </modules>
         </profile>


### PR DESCRIPTION
We discussed this with Brian & Emanuel and come to conclusion that PR jobs should not run patching testsuite.
but they will still be run by all other jobs we run on brontes.
