### PR TITLE
[WFLY-543] : Provide an operation to request service status report after server has been started

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -114,6 +114,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
     private volatile ModelControllerImpl controller;
     private ConfigurationPersister configurationPersister;
     private final ManagedAuditLogger auditLogger;
+    private final BootErrorCollector bootErrorCollector;
 
     /**
      * Construct a new instance.
@@ -150,11 +151,35 @@ public abstract class AbstractControllerService implements Service<ModelControll
      * @param expressionResolver      the expression resolver
      * @param auditLogger             the audit logger
      */
+    @Deprecated
     protected AbstractControllerService(final ProcessType processType, final RunningModeControl runningModeControl,
                                         final ConfigurationPersister configurationPersister,
                                         final ControlledProcessState processState, final ResourceDefinition rootResourceDefinition,
                                         final OperationStepHandler prepareStep, final ExpressionResolver expressionResolver,
                                         final ManagedAuditLogger auditLogger, final DelegatingConfigurableAuthorizer authorizer) {
+        this(processType, runningModeControl, configurationPersister, processState, rootResourceDefinition, null,
+                prepareStep, expressionResolver, auditLogger, authorizer);
+    }
+
+    /**
+     * Construct a new instance.
+     *
+     * @param processType             the type of process being controlled
+     * @param runningModeControl      the controller of the process' running mode
+     * @param configurationPersister  the configuration persister
+     * @param processState            the controlled process state
+     * @param rootResourceDefinition  the root resource definition
+     * @param prepareStep             the prepare step to prepend to operation execution
+     * @param expressionResolver      the expression resolver
+     * @param auditLogger             the audit logger
+     * @param bootErrorCollector      the boot error collector
+     */
+    protected AbstractControllerService(final ProcessType processType, final RunningModeControl runningModeControl,
+                                        final ConfigurationPersister configurationPersister,
+                                        final ControlledProcessState processState, final ResourceDefinition rootResourceDefinition,
+                                        final OperationStepHandler prepareStep, final ExpressionResolver expressionResolver,
+                                        final ManagedAuditLogger auditLogger, final DelegatingConfigurableAuthorizer authorizer,
+                                        final BootErrorCollector bootErrorCollector) {
         this(processType, runningModeControl, configurationPersister, processState, rootResourceDefinition, null,
                 prepareStep, expressionResolver, auditLogger, authorizer);
     }
@@ -223,8 +248,10 @@ public abstract class AbstractControllerService implements Service<ModelControll
         this.expressionResolver = expressionResolver;
         this.auditLogger = auditLogger;
         this.authorizer = authorizer;
+        this.bootErrorCollector = new BootErrorCollector();
     }
 
+    @Override
     public void start(final StartContext context) throws StartException {
 
         if (configurationPersister == null) {
@@ -245,7 +272,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
                 rootResourceRegistration,
                 new ContainerStateMonitor(container),
                 configurationPersister, processType, runningModeControl, prepareStep,
-                processState, executorService, expressionResolver, authorizer, auditLogger, notificationSupport);
+                processState, executorService, expressionResolver, authorizer, auditLogger, notificationSupport, bootErrorCollector);
 
         // Initialize the model
         initModel(controller.getRootResource(), controller.getRootRegistration(), controller.getModelControllerResource());
@@ -403,6 +430,10 @@ public abstract class AbstractControllerService implements Service<ModelControll
 
     protected ManagedAuditLogger getAuditLogger() {
         return auditLogger;
+    }
+
+    protected BootErrorCollector getBootErrorCollector() {
+        return bootErrorCollector;
     }
 }
 

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -131,6 +131,7 @@ abstract class AbstractOperationContext implements OperationContext {
     private final List<ModelNode> controllerOperations = new ArrayList<ModelNode>(2);
     private boolean auditLogged;
     private final AuditLogger auditLogger;
+    private final ModelControllerImpl controller;
 
     enum ContextFlag {
         ROLLBACK_ON_FAIL, ALLOW_RESOURCE_SERVICE_RESTART,
@@ -141,7 +142,8 @@ abstract class AbstractOperationContext implements OperationContext {
                              final ControlledProcessState processState,
                              final boolean booting,
                              final AuditLogger auditLogger,
-                             final NotificationSupport notificationSupport) {
+                             final NotificationSupport notificationSupport,
+                             final ModelControllerImpl controller) {
         this.processType = processType;
         this.runningMode = runningMode;
         this.transactionControl = transactionControl;
@@ -150,6 +152,7 @@ abstract class AbstractOperationContext implements OperationContext {
         this.auditLogger = auditLogger;
         this.notificationSupport = notificationSupport;
         this.notifications = new ConcurrentLinkedQueue<Notification>();
+        this.controller = controller;
         steps = new EnumMap<Stage, Deque<Step>>(Stage.class);
         for (Stage stage : Stage.values()) {
             if (booting && stage == Stage.VERIFY) {
@@ -618,6 +621,12 @@ abstract class AbstractOperationContext implements OperationContext {
         }
     }
 
+    private void addBootFailureDescription() {
+        if (isBooting() && activeStep != null && activeStep.response != null && activeStep.response.hasDefined(FAILURE_DESCRIPTION)) {
+            controller.addFailureDescription(activeStep.operation, activeStep.response.get(FAILURE_DESCRIPTION).clone());
+        }
+    }
+
     private boolean canContinueProcessing() {
 
         // Cancellation is detected via interruption.
@@ -636,7 +645,7 @@ abstract class AbstractOperationContext implements OperationContext {
                 activeStep.response.get(ROLLED_BACK).set(true);
             }
             resultAction = ResultAction.ROLLBACK;
-        } else if (activeStep != null && activeStep.response.hasDefined(FAILURE_DESCRIPTION)
+        } else if (activeStep != null && activeStep.hasFailed()
                 && (isRollbackOnRuntimeFailure() || currentStage == Stage.MODEL)) {
             activeStep.response.get(OUTCOME).set(FAILED);
             activeStep.response.get(ROLLED_BACK).set(true);
@@ -656,7 +665,7 @@ abstract class AbstractOperationContext implements OperationContext {
                 try {
                     step.handler.execute(this, step.operation);
                     // AS7-6046
-                    if (isErrorLoggingNecessary() && step.response.hasDefined(FAILURE_DESCRIPTION)) {
+                    if (isErrorLoggingNecessary() && step.hasFailed()) {
                         MGMT_OP_LOGGER.operationFailed(step.operation.get(OP), step.operation.get(OP_ADDR),
                                 step.response.get(FAILURE_DESCRIPTION));
                     }
@@ -707,7 +716,7 @@ abstract class AbstractOperationContext implements OperationContext {
             // completeStep()?
             if (currentStage != Stage.DONE) {
                 // It failed before, so consider the operation a failure.
-                if (!step.response.hasDefined(FAILURE_DESCRIPTION)) {
+                if (!step.hasFailed()) {
                     // If the failure is an OperationClientException we just want its localized message, no class name
                     String cause = t instanceof OperationClientException ? t.getLocalizedMessage() : t.toString();
                     if (cause == null) {
@@ -725,6 +734,7 @@ abstract class AbstractOperationContext implements OperationContext {
                 report(MessageSeverity.WARN, ControllerLogger.ROOT_LOGGER.stepHandlerFailed(step.handler));
             }
         } finally {
+            addBootFailureDescription();
             // Make sure non-recursive steps finalize
             finishStep(step);
         }
@@ -968,6 +978,10 @@ abstract class AbstractOperationContext implements OperationContext {
             response.get(OUTCOME);
         }
 
+        private boolean hasFailed() {
+            return this.response.hasDefined(FAILURE_DESCRIPTION);
+        }
+
         /**
          * Perform any rollback needed to reverse this step (if this context is
          * rolling back), and release any locks taken by this step.
@@ -1030,7 +1044,7 @@ abstract class AbstractOperationContext implements OperationContext {
                     // fixing the context state and treating
                     // the overall operation as a failure.
                     currentStage = Stage.DONE;
-                    if (!response.hasDefined(FAILURE_DESCRIPTION)) {
+                    if (!hasFailed()) {
                         response.get(FAILURE_DESCRIPTION).set(ControllerLogger.ROOT_LOGGER.operationHandlerFailedToComplete());
                     }
                     response.get(OUTCOME).set(cancelled ? CANCELLED : FAILED);
@@ -1040,7 +1054,7 @@ abstract class AbstractOperationContext implements OperationContext {
                     response.get(OUTCOME).set(cancelled ? CANCELLED : FAILED);
                     response.get(ROLLED_BACK).set(true);
                 } else {
-                    response.get(OUTCOME).set(response.hasDefined(FAILURE_DESCRIPTION) ? FAILED : SUCCESS);
+                    response.get(OUTCOME).set(hasFailed() ? FAILED : SUCCESS);
                 }
 
             } finally {

--- a/controller/src/main/java/org/jboss/as/controller/BootErrorCollector.java
+++ b/controller/src/main/java/org/jboss/as/controller/BootErrorCollector.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.controller;
+
+import org.jboss.as.controller.access.management.AuthorizedAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BOOT_ERROR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BOOT_ERRORS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MISSING_DEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class BootErrorCollector {
+
+    private final ModelNode errors;
+    private final OperationStepHandler listBootErrorsHandler;
+
+    public BootErrorCollector() {
+        errors = new ModelNode();
+        errors.get(BOOT_ERRORS).setEmptyList();
+        listBootErrorsHandler = new ListBootErrorsHandler(this);
+    }
+    void addFailureDescription(final ModelNode operation, final ModelNode failureDescription) {
+        ModelNode error = new ModelNode();
+        ModelNode failure = new ModelNode();
+        // for security reasons failure.get(FAILED).set(operation.clone());
+        ModelNode failed = failure.get(FAILED);
+        failed.get(OP).set(operation.get(OP));
+        failed.get(OP_ADDR).set(operation.get(OP_ADDR));
+        if (failureDescription != null) {
+            if (failureDescription.hasDefined(ControllerLogger.ROOT_LOGGER.failedServices())) {
+                failure.get(FAILURES).add(failureDescription.get(ControllerLogger.ROOT_LOGGER.failedServices()));
+            }
+            if (failureDescription.hasDefined(ControllerLogger.ROOT_LOGGER.servicesMissingDependencies())) {
+                failure.get(MISSING_DEPS).add(failureDescription.get(ControllerLogger.ROOT_LOGGER.servicesMissingDependencies()));
+            }
+            if (failureDescription.getType() == ModelType.STRING) {
+                failure.get(FAILURES).add(failureDescription.asString());
+            }
+        }
+        error.get(BOOT_ERROR).set(failure);
+        errors.get(BOOT_ERRORS).add(error);
+    }
+
+    private ModelNode getErrors() {
+        return errors.clone();
+    }
+
+    public OperationStepHandler getReadBootErrorsHandler() {
+        return this.listBootErrorsHandler;
+    }
+
+    public static class ListBootErrorsHandler implements OperationStepHandler {
+
+        private static final String OPERATION_NAME = "read-boot-errors";
+        private final BootErrorCollector errors;
+
+        private static final AttributeDefinition OP_DEFINITION = ObjectTypeAttributeDefinition.Builder.of(OP,
+                SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.OPERATION_NAME, ModelType.STRING, false).build(),
+                SimpleListAttributeDefinition.Builder.of(OP_ADDR,
+                        SimpleAttributeDefinitionBuilder.create("address", ModelType.PROPERTY, false).build())
+                        .build())
+                .build();
+        private static final AttributeDefinition BOOT_ERROR_DEFINITION = ObjectTypeAttributeDefinition.Builder.of(BOOT_ERROR,
+                ObjectTypeAttributeDefinition.Builder.of(FAILED, OP_DEFINITION).build(),
+                SimpleListAttributeDefinition.Builder.of(MISSING_DEPS,
+                        SimpleAttributeDefinitionBuilder.create("missing-dep", ModelType.STRING, false).build())
+                        .build(),
+                SimpleListAttributeDefinition.Builder.of(FAILURES,
+                        SimpleAttributeDefinitionBuilder.create("failure", ModelType.STRING, false).build())
+                        .build())
+                .build();
+        private static final AttributeDefinition RETURN_DEFINITION = ObjectTypeAttributeDefinition.Builder.of(
+                BOOT_ERRORS, BOOT_ERROR_DEFINITION).build();
+
+        public static final SimpleOperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(OPERATION_NAME,
+                ControllerResolver.getResolver("errors")).setRuntimeOnly()
+                .setReplyParameters(ObjectTypeAttributeDefinition.Builder.of(BOOT_ERRORS, RETURN_DEFINITION).build()).build();
+
+        ListBootErrorsHandler(final BootErrorCollector errors) {
+            this.errors = errors;
+        }
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            context.addStep(new OperationStepHandler() {
+                @Override
+                public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+                    ModelNode bootErrors = new ModelNode();
+                    if(errors.getErrors().get(BOOT_ERRORS).isDefined()) {
+                        for (ModelNode bootError : errors.getErrors().get(BOOT_ERRORS).asList()) {
+                            secureOperationAddress(context, bootError);
+                            bootErrors.get(BOOT_ERRORS).add(bootError);
+                        }
+                    }
+                    context.getResult().set(errors.getErrors());
+                    context.stepCompleted();
+                }
+            }, OperationContext.Stage.RUNTIME);
+            context.stepCompleted();
+        }
+
+        private void secureOperationAddress(OperationContext context, ModelNode error) throws OperationFailedException {
+            ModelNode bootError = error.get(BOOT_ERROR);
+            if (bootError.hasDefined(FAILED)) {
+                ModelNode failedOperation = bootError.get(FAILED);
+                ModelNode address = failedOperation.get(OP_ADDR);
+                ModelNode fakeOperation = new ModelNode();
+                fakeOperation.get(ModelDescriptionConstants.OP).set(READ_RESOURCE_OPERATION);
+                fakeOperation.get(ModelDescriptionConstants.OP_ADDR).set(address);
+                AuthorizedAddress authorizedAddress = AuthorizedAddress.authorizeAddress(context, fakeOperation);
+                if(authorizedAddress.isElided()) {
+                    failedOperation.get(OP_ADDR).set(authorizedAddress.getAddress());
+                }
+            }
+        }
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -125,6 +125,7 @@ class ModelControllerImpl implements ModelController {
 
     private final ConcurrentMap<Integer, OperationContextImpl> activeOperations = new ConcurrentHashMap<>();
     private final ManagedAuditLogger auditLogger;
+    private final BootErrorCollector bootErrorCollector;
 
     private final NotificationSupport notificationSupport;
 
@@ -137,7 +138,7 @@ class ModelControllerImpl implements ModelController {
                         final ProcessType processType, final RunningModeControl runningModeControl,
                         final OperationStepHandler prepareStep, final ControlledProcessState processState, final ExecutorService executorService,
                         final ExpressionResolver expressionResolver, final Authorizer authorizer,
-                        final ManagedAuditLogger auditLogger, NotificationSupport notificationSupport) {
+                        final ManagedAuditLogger auditLogger, NotificationSupport notificationSupport, final BootErrorCollector bootErrorCollector) {
         this.serviceRegistry = serviceRegistry;
         this.serviceTarget = serviceTarget;
         this.rootRegistration = rootRegistration;
@@ -153,6 +154,7 @@ class ModelControllerImpl implements ModelController {
         this.expressionResolver = expressionResolver;
         this.authorizer = authorizer;
         this.auditLogger = auditLogger;
+        this.bootErrorCollector = bootErrorCollector;
         this.hostServerGroupTracker = processType.isManagedDomain() ? new HostServerGroupTracker() : null;
         this.modelControllerResource = new ModelControllerResource();
         auditLogger.startBoot();
@@ -739,6 +741,12 @@ class ModelControllerImpl implements ModelController {
 
     AuditLogger getAuditLogger() {
         return auditLogger;
+    }
+
+    void addFailureDescription(ModelNode operation, ModelNode failure) {
+        if(bootErrorCollector != null) {
+            bootErrorCollector.addFailureDescription(operation, failure);
+        }
     }
 
     private class DefaultPrepareStepHandler implements OperationStepHandler {

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -196,7 +196,7 @@ final class OperationContextImpl extends AbstractOperationContext {
                          final ModelNode blockingTimeoutConfig,
                          final AccessMechanism accessMechanism,
                          final NotificationSupport notificationSupport) {
-        super(processType, runningMode, transactionControl, processState, booting, auditLogger, notificationSupport);
+        super(processType, runningMode, transactionControl, processState, booting, auditLogger, notificationSupport, modelController);
         this.operationId = operationId;
         this.operationName = operationName;
         this.operationAddress = operationAddress.isDefined()

--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
@@ -63,7 +63,7 @@ class ParallelBootOperationContext extends AbstractOperationContext {
                                  final ControlledProcessState processState, final AbstractOperationContext primaryContext,
                                  final List<ParsedBootOp> runtimeOps, final Thread controllingThread,
                                  final ModelControllerImpl controller, final int operationId, final AuditLogger auditLogger, final Resource model) {
-        super(primaryContext.getProcessType(), primaryContext.getRunningMode(), transactionControl, processState, true, auditLogger, controller.getNotificationSupport());
+        super(primaryContext.getProcessType(), primaryContext.getRunningMode(), transactionControl, processState, true, auditLogger, controller.getNotificationSupport(), controller);
         this.primaryContext = primaryContext;
         this.runtimeOps = runtimeOps;
         AbstractOperationContext.controllingThread.set(controllingThread);

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -58,7 +58,7 @@ class ReadOnlyContext extends AbstractOperationContext {
     ReadOnlyContext(final ProcessType processType, final RunningMode runningMode, final ModelController.OperationTransactionControl transactionControl,
                     final ControlledProcessState processState, final boolean booting,
                     final AbstractOperationContext primaryContext, final ModelControllerImpl controller, final int operationId) {
-        super(processType, runningMode, transactionControl, processState, booting, controller.getAuditLogger(), controller.getNotificationSupport());
+        super(processType, runningMode, transactionControl, processState, booting, controller.getAuditLogger(), controller.getNotificationSupport(), controller);
         this.primaryContext = primaryContext;
         this.controller = controller;
         this.operationId = operationId;

--- a/controller/src/main/java/org/jboss/as/controller/SimpleListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleListAttributeDefinition.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
 
 /**
  * Date: 13.10.2011
@@ -102,22 +103,30 @@ public class SimpleListAttributeDefinition extends ListAttributeDefinition {
 
     @Override
     protected void addValueTypeDescription(final ModelNode node, final ResourceBundle bundle) {
-        addValueTypeDescription(node);
+        addValueTypeDescription(node, null, bundle);
     }
 
 
     protected void addValueTypeDescription(final ModelNode node, final String prefix, final ResourceBundle bundle) {
-        addValueTypeDescription(node);
+        if (valueType.getType() == ModelType.OBJECT) {
+            final ModelNode param = valueType.getNoTextDescription(true);
+            final ModelNode childType = node.get(ModelDescriptionConstants.VALUE_TYPE, valueType.getName()).set(param);
+            if (valueType instanceof ObjectTypeAttributeDefinition) {
+                ObjectTypeAttributeDefinition.class.cast(valueType).addOperationParameterDescription(bundle, prefix, childType);
+            }
+        } else {
+            addSimpleValueTypeDescription(node);
+        }
     }
 
     @Override
     protected void addAttributeValueTypeDescription(final ModelNode node, final ResourceDescriptionResolver resolver, final Locale locale, final ResourceBundle bundle) {
-        addValueTypeDescription(node);
+        addValueTypeDescription(node, bundle);
     }
 
     @Override
     protected void addOperationParameterValueTypeDescription(final ModelNode node, final String operationName, final ResourceDescriptionResolver resolver, final Locale locale, final ResourceBundle bundle) {
-        addValueTypeDescription(node);
+        addValueTypeDescription(node, bundle);
     }
 
     /**
@@ -140,7 +149,7 @@ public class SimpleListAttributeDefinition extends ListAttributeDefinition {
         return allowExp ? convertStringExpression(parameterElement) : parameterElement;
     }
 
-    private void addValueTypeDescription(final ModelNode node) {
+    private void addSimpleValueTypeDescription(final ModelNode node) {
         node.get(ModelDescriptionConstants.VALUE_TYPE).set(valueType.getType());
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/access/management/AuthorizedAddress.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/management/AuthorizedAddress.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.controller.access.management;
+
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.access.Action;
+import org.jboss.as.controller.access.AuthorizationResult;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class AuthorizedAddress {
+
+    private static final String HIDDEN = "<hidden>";
+    private static final Set<Action.ActionEffect> ADDRESS_EFFECT = EnumSet.of(Action.ActionEffect.ADDRESS);
+
+    private final ModelNode address;
+    private final boolean elided;
+
+    AuthorizedAddress(ModelNode address, boolean elided) {
+        this.address = address;
+        this.elided = elided;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 37 * hash + Objects.hashCode(this.address);
+        hash = 37 * hash + (this.elided ? 1 : 0);
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return "AuthorizedAddress{" + "address=" + address + ", elided=" + elided + '}';
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final AuthorizedAddress other = (AuthorizedAddress) obj;
+        if (!Objects.equals(this.address, other.address)) {
+            return false;
+        }
+        if (this.elided != other.elided) {
+            return false;
+        }
+        return true;
+    }
+
+    public ModelNode getAddress() {
+        return address;
+    }
+
+    public boolean isElided() {
+        return elided;
+    }
+
+    public static AuthorizedAddress authorizeAddress(OperationContext context, ModelNode operation) {
+        ModelNode address = operation.get(ModelDescriptionConstants.OP_ADDR);
+        ModelNode testOp = new ModelNode();
+        testOp.get(OP).set(READ_RESOURCE_OPERATION);
+        testOp.get(OP_ADDR).set(address);
+
+        AuthorizationResult authResult = context.authorize(testOp, ADDRESS_EFFECT);
+        if (authResult.getDecision() == AuthorizationResult.Decision.PERMIT) {
+            return new AuthorizedAddress(address, false);
+        }
+
+        // Failed. Now we need to see how far we can go
+        ModelNode partialAddress = new ModelNode().setEmptyList();
+        ModelNode elidedAddress = new ModelNode().setEmptyList();
+        for (Property prop : address.asPropertyList()) {
+            partialAddress.add(prop);
+            testOp.get(OP_ADDR).set(partialAddress);
+            authResult = context.authorize(testOp, ADDRESS_EFFECT);
+            if (authResult.getDecision() == AuthorizationResult.Decision.DENY) {
+                elidedAddress.add(prop.getName(), HIDDEN);
+                return new AuthorizedAddress(elidedAddress, true);
+            } else {
+                elidedAddress.add(prop);
+            }
+        }
+
+        // Should not be reachable, but in case of a bug, be conservative and hide data
+        ModelNode strange = new ModelNode();
+        strange.add(HIDDEN, HIDDEN);
+        return new AuthorizedAddress(strange, true);
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -71,6 +71,8 @@ public class ModelDescriptionConstants {
     public static final String BLOCKING = "blocking";
     public static final String BLOCKING_TIMEOUT = "blocking-timeout";
     public static final String BOOT_TIME = "boot-time";
+    public static final String BOOT_ERROR = "boot-error";
+    public static final String BOOT_ERRORS = "boot-errors";
     public static final String BYTES = "bytes";
     public static final String CALLER_THREAD = "caller-thread";
     public static final String CALLER_TYPE = "caller-type";
@@ -142,6 +144,7 @@ public class ModelDescriptionConstants {
     public static final String EXTENSION = "extension";
     public static final String FAILED = "failed";
     public static final String FACILITY = "facility";
+    public static final String FAILURES = "failures";
     public static final String FAILURE_COUNT = "failure-count";
     public static final String FAILURE_DESCRIPTION = "failure-description";
     public static final String FILE = "file";
@@ -227,6 +230,7 @@ public class ModelDescriptionConstants {
     public static final String MAX_OCCURS = "max-occurs";
     public static final String MAX_THREADS = "max-threads";
     public static final String MESSAGE_TRANSFER = "message-transfer";
+    public static final String MISSING_DEPS = "missing-deps";
     public static final String MIN = "min";
     public static final String MIN_LENGTH = "min-length";
     public static final String MIN_OCCURS = "min-occurs";

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -508,3 +508,14 @@ deployment-overlay.content.content.input-stream-index=The index into the operati
 deployment-overlay.content.content.bytes=Byte array containing the deployment content that should uploaded to the domain's or standalone server's deployment content repository..
 deployment-overlay.content.content.url=The URL at which the deployment content is available for upload to the domain's or standalone server's deployment content repository.. Note that the URL must be accessible from the target of the operation (i.e. the Domain Controller or standalone server).
 deployment-overlay.content.read-content=Gets the content of the deployment overlay file
+
+errors.read-boot-errors=List all errors that occurred during boot.
+errors.read-boot-errors.boot-errors=Errors that occurred during boot.
+errors.boot-errors.boot-errors=Errors that occurred during boot.
+errors.boot-errors.boot-error=Error that occurred during boot.
+errors.boot-errors.failed=Operation that caused the failure.
+errors.boot-errors.missing-deps=Missing dependencies.
+errors.boot-errors.failures=List of failures.
+errors.boot-errors.operation=Operation that caused the failure.
+errors.boot-errors.address=Address of the failing operation.
+errors.boot-errors.operation-name=Name of the failing operation.

--- a/controller/src/test/java/org/jboss/as/controller/access/management/AuthorizedAddressTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/management/AuthorizedAddressTest.java
@@ -1,0 +1,478 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+package org.jboss.as.controller.access.management;
+
+import java.io.InputStream;
+import java.util.Set;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.access.Action;
+import org.jboss.as.controller.access.AuthorizationResult;
+import org.jboss.as.controller.access.Caller;
+import org.jboss.as.controller.access.Environment;
+import org.jboss.as.controller.access.ResourceAuthorization;
+import org.jboss.as.controller.client.MessageSeverity;
+import org.jboss.as.controller.notification.Notification;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
+import org.junit.Test;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class AuthorizedAddressTest {
+
+    /**
+     * Test of authorizeAddress method, of class AuthorizedAddress.
+     */
+    @Test
+    public void testAccessAuthorizedAddress() {
+        ModelNode address = PathAddress.pathAddress(PathElement.pathElement(DEPLOYMENT,"test.war"), PathElement.pathElement(SUBSYSTEM, "Undertow")).toModelNode();
+        ModelNode authorizedAddress = address;
+        OperationContext context = new AuthorizationOperationContext(authorizedAddress.asString());
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+        AuthorizedAddress expResult = new AuthorizedAddress(authorizedAddress, false);
+        AuthorizedAddress result = AuthorizedAddress.authorizeAddress(context, operation);
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of authorizeAddress method, of class AuthorizedAddress.
+     */
+    @Test
+    public void testAccessUnauthorizedAddress() {
+        ModelNode address = PathAddress.pathAddress(PathElement.pathElement(DEPLOYMENT,"test.war"), PathElement.pathElement(SUBSYSTEM, "Undertow")).toModelNode();
+        ModelNode authorizedAddress = PathAddress.EMPTY_ADDRESS.toModelNode();
+        OperationContext context = new AuthorizationOperationContext(authorizedAddress.asString());
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+        AuthorizedAddress expResult = new AuthorizedAddress(PathAddress.pathAddress(PathElement.pathElement(DEPLOYMENT,"<hidden>")).toModelNode(), true);
+        AuthorizedAddress result = AuthorizedAddress.authorizeAddress(context, operation);
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of authorizeAddress method, of class AuthorizedAddress.
+     */
+    @Test
+    public void testAccessParialUnauthorizedAddress() {
+        ModelNode address = PathAddress.pathAddress(PathElement.pathElement(DEPLOYMENT,"test.war"), PathElement.pathElement(SUBSYSTEM, "Undertow")).toModelNode();
+        ModelNode authorizedAddress = PathAddress.pathAddress(PathElement.pathElement(DEPLOYMENT,"test.war")).toModelNode();
+        OperationContext context = new AuthorizationOperationContext(authorizedAddress.asString());
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+        AuthorizedAddress expResult = new AuthorizedAddress(PathAddress.pathAddress(PathElement.pathElement(DEPLOYMENT,"test.war"), PathElement.pathElement(SUBSYSTEM,"<hidden>")).toModelNode(), true);
+        AuthorizedAddress result = AuthorizedAddress.authorizeAddress(context, operation);
+        assertEquals(expResult, result);
+    }
+
+
+    private static class AuthorizationOperationContext implements OperationContext {
+        private final String authorizedAddress;
+
+        private AuthorizationOperationContext(String authorizedAddress) {
+            this.authorizedAddress = authorizedAddress;
+        }
+
+
+        @Override
+        public void addStep(OperationStepHandler step, Stage stage) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void addStep(OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void addStep(ModelNode operation, OperationStepHandler step, Stage stage) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void addStep(ModelNode operation, OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, Stage stage) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public InputStream getAttachmentStream(int index) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public int getAttachmentStreamCount() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ModelNode getResult() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean hasResult() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ModelNode getFailureDescription() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean hasFailureDescription() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ModelNode getServerResults() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ModelNode getResponseHeaders() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void completeStep(RollbackHandler rollbackHandler) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void completeStep(ResultHandler resultHandler) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void stepCompleted() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ProcessType getProcessType() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public RunningMode getRunningMode() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isBooting() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isNormalServer() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isRollbackOnly() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void setRollbackOnly() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isRollbackOnRuntimeFailure() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isResourceServiceRestartAllowed() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void reloadRequired() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void restartRequired() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void revertReloadRequired() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void revertRestartRequired() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void runtimeUpdateSkipped() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ImmutableManagementResourceRegistration getResourceRegistration() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ManagementResourceRegistration getResourceRegistrationForUpdate() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ImmutableManagementResourceRegistration getRootResourceRegistration() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ServiceRegistry getServiceRegistry(boolean modify) throws UnsupportedOperationException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ServiceController<?> removeService(ServiceName name) throws UnsupportedOperationException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void removeService(ServiceController<?> controller) throws UnsupportedOperationException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ServiceTarget getServiceTarget() throws UnsupportedOperationException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void acquireControllerLock() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Resource createResource(PathAddress address) throws UnsupportedOperationException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void addResource(PathAddress address, Resource toAdd) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Resource readResource(PathAddress relativeAddress) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Resource readResource(PathAddress relativeAddress, boolean recursive) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Resource readResourceFromRoot(PathAddress address) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Resource readResourceFromRoot(PathAddress address, boolean recursive) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Resource readResourceForUpdate(PathAddress relativeAddress) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Resource removeResource(PathAddress relativeAddress) throws UnsupportedOperationException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Resource getOriginalRootResource() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isModelAffected() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isResourceRegistryAffected() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean isRuntimeAffected() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Stage getCurrentStage() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void report(MessageSeverity severity, String message) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean markResourceRestarted(PathAddress resource, Object owner) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public boolean revertResourceRestarted(PathAddress resource, Object owner) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ModelNode resolveExpressions(ModelNode node) throws OperationFailedException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public <T> T getAttachment(AttachmentKey<T> key) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public <T> T attach(AttachmentKey<T> key, T value) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public <T> T attachIfAbsent(AttachmentKey<T> key, T value) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public <T> T detach(AttachmentKey<T> key) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public AuthorizationResult authorize(ModelNode operation) {
+            String address = operation.get(OP_ADDR).asString();
+            if(authorizedAddress.contains(address)) {
+                return AuthorizationResult.PERMITTED;
+            }
+            return new AuthorizationResult(AuthorizationResult.Decision.DENY);
+        }
+
+        @Override
+        public AuthorizationResult authorize(ModelNode operation, Set<Action.ActionEffect> effects) {
+            String address = operation.get(OP_ADDR).asString();
+            if(authorizedAddress.contains(address)) {
+                return AuthorizationResult.PERMITTED;
+            }
+            return new AuthorizationResult(AuthorizationResult.Decision.DENY);
+        }
+
+        @Override
+        public ResourceAuthorization authorizeResource(boolean attributes, boolean isDefaultResource) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public AuthorizationResult authorize(ModelNode operation, String attribute, ModelNode currentValue) {
+            String address = operation.get(OP_ADDR).asString();
+            if(authorizedAddress.contains(address)) {
+                return AuthorizationResult.PERMITTED;
+            }
+            return new AuthorizationResult(AuthorizationResult.Decision.DENY);
+        }
+
+        @Override
+        public AuthorizationResult authorize(ModelNode operation, String attribute, ModelNode currentValue, Set<Action.ActionEffect> effects) {
+            String address = operation.get(OP_ADDR).asString();
+            if(authorizedAddress.contains(address)) {
+                return AuthorizationResult.PERMITTED;
+            }
+            return new AuthorizationResult(AuthorizationResult.Decision.DENY);
+        }
+
+        @Override
+        public AuthorizationResult authorizeOperation(ModelNode operation) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Caller getCaller() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public Environment getCallEnvironment() {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void emit(Notification notification) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+    }
+
+}

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -413,7 +413,8 @@ class TestModelControllerService extends ModelTestModelControllerService {
                     pathManagerService,
                     null,
                     authorizer,
-                    AuditLogger.NO_OP_LOGGER));
+                    AuditLogger.NO_OP_LOGGER,
+                    getBootErrorCollector()));
         }
 
         @Override
@@ -458,7 +459,8 @@ class TestModelControllerService extends ModelTestModelControllerService {
                             processState,
                             pathManagerService,
                             authorizer,
-                            AuditLogger.NO_OP_LOGGER));
+                            AuditLogger.NO_OP_LOGGER,
+                            getBootErrorCollector()));
         }
 
         @Override
@@ -491,7 +493,8 @@ class TestModelControllerService extends ModelTestModelControllerService {
                     processState,
                     pathManagerService,
                     authorizer,
-                    AuditLogger.NO_OP_LOGGER);
+                    AuditLogger.NO_OP_LOGGER,
+                    getBootErrorCollector());
         }
     }
 

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/AbstractBootErrorTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/AbstractBootErrorTestCase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.core.model.test.boot;
+
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
+import org.jboss.as.core.model.test.KernelServicesBuilder;
+import org.jboss.as.core.model.test.ModelInitializer;
+import org.jboss.as.core.model.test.TestModelType;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2014 Red Hat, inc.
+ */
+public abstract class AbstractBootErrorTestCase extends AbstractCoreModelTest {
+
+    private final TestModelType type;
+
+    public AbstractBootErrorTestCase(TestModelType type) {
+        this.type = type;
+    }
+
+    KernelServicesBuilder createKernelServicesBuilder() {
+        return createKernelServicesBuilder(type);
+    }
+
+    protected abstract String getXmlResource();
+
+    protected ModelInitializer createEmptyModelInitalizer() {
+        return new ModelInitializer() {
+            @Override
+            public void populateModel(Resource rootResource) {
+                //Default is no-op
+            }
+        };
+    }
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/HostBootErrorsTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/HostBootErrorsTestCase.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.core.model.test.boot;
+
+import java.util.List;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BOOT_ERROR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BOOT_ERRORS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MISSING_DEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class HostBootErrorsTestCase extends AbstractBootErrorTestCase {
+
+    public HostBootErrorsTestCase() {
+        super(TestModelType.HOST);
+    }
+
+    @Override
+    protected String getXmlResource() {
+        return "host.xml";
+    }
+
+    @Test
+    public void testBootErrors() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder()
+                .setXmlResource(getXmlResource())
+                .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+        String marshalled = kernelServices.getPersistedSubsystemXml();
+        ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), getXmlResource()), marshalled);
+
+        kernelServices = createKernelServicesBuilder()
+                .setXml(marshalled)
+                .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+        ModelNode readBootErrorsOp = Util.createOperation("read-boot-errors", PathAddress.pathAddress(PathElement.pathElement(CORE_SERVICE, MANAGEMENT)));
+        ModelNode result = kernelServices.executeForResult(readBootErrorsOp);
+        Assert.assertThat(result, is(notNullValue()));
+        Assert.assertThat(result.hasDefined(BOOT_ERRORS), is(true));
+        List<ModelNode> errors = result.get(BOOT_ERRORS).asList();
+        Assert.assertThat(errors.size(), is(4));
+        ModelNode error = errors.get(0).get(BOOT_ERROR);
+        Assert.assertThat(error.get(FAILED).get(OP).asString(), is(ADD));
+        Assert.assertThat(error.get(FAILED).get(ADDRESS).asString(), is("[(\"host\" => \"master\"),(\"core-service\" => \"management\"),(\"management-interface\" => \"native-interface\")]"));
+        Assert.assertThat(error.hasDefined(FAILURES), is(false));
+        Assert.assertThat(error.hasDefined(MISSING_DEPS), is(true));
+        error = errors.get(1).get(BOOT_ERROR);
+        Assert.assertThat(error.get(FAILED).get(OP).asString(), is(ADD));
+        Assert.assertThat(error.get(FAILED).get(ADDRESS).asString(), is("[(\"host\" => \"master\"),(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-tls\")]"));
+        Assert.assertThat(error.hasDefined(FAILURES), is(true));
+        Assert.assertThat(error.get(FAILURES).asString(), is("[\"testhost\"]"));
+        Assert.assertThat(error.hasDefined(MISSING_DEPS), is(false));
+        error = errors.get(2).get(BOOT_ERROR);
+        Assert.assertThat(error.get(FAILED).get(OP).asString(), is(ADD));
+        Assert.assertThat(error.get(FAILED).get(ADDRESS).asString(), is("[(\"host\" => \"master\"),(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-tcp\")]"));
+        Assert.assertThat(error.hasDefined(FAILURES), is(true));
+        Assert.assertThat(error.get(FAILURES).asString(), is("[\"testhost\"]"));
+        Assert.assertThat(error.hasDefined(MISSING_DEPS), is(false));
+        error = errors.get(3).get(BOOT_ERROR);
+        Assert.assertThat(error.get(FAILED).get(OP).asString(), is(ADD));
+        Assert.assertThat(error.get(FAILED).get(ADDRESS).asString(), is("[(\"host\" => \"master\"),(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-udp\")]"));
+        Assert.assertThat(error.hasDefined(FAILURES), is(true));
+        Assert.assertThat(error.get(FAILURES).asString(), is("[\"testhost\"]"));
+        Assert.assertThat(error.hasDefined(MISSING_DEPS), is(false));
+    }
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/StandaloneBootErrorsTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/StandaloneBootErrorsTestCase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.core.model.test.boot;
+
+import java.util.List;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BOOT_ERROR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BOOT_ERRORS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class StandaloneBootErrorsTestCase extends AbstractBootErrorTestCase {
+
+    public StandaloneBootErrorsTestCase() {
+        super(TestModelType.STANDALONE);
+    }
+
+    @Override
+    protected String getXmlResource() {
+        return "standalone.xml";
+    }
+
+    @Test
+    public void testBootErrors() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder()
+                .setXmlResource(getXmlResource())
+                .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+        String marshalled = kernelServices.getPersistedSubsystemXml();
+        ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), getXmlResource()), marshalled);
+
+        kernelServices = createKernelServicesBuilder()
+                .setXml(marshalled)
+                .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+        ModelNode readBootErrorsOp = Util.createOperation("read-boot-errors", PathAddress.pathAddress(PathElement.pathElement(CORE_SERVICE, MANAGEMENT)));
+        ModelNode result = kernelServices.executeForResult(readBootErrorsOp);
+        Assert.assertThat(result, is(notNullValue()));
+        Assert.assertThat(result.hasDefined(BOOT_ERRORS), is(true));
+        List<ModelNode> errors = result.get(BOOT_ERRORS).asList();
+        Assert.assertThat(errors.size(), is(3));
+        ModelNode error = errors.get(0).get(BOOT_ERROR);
+        Assert.assertThat(error.get(FAILED).get(OP).asString(), is(ADD));
+        Assert.assertThat(error.get(FAILED).get(ADDRESS).asString(), is("[(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-tls\")]"));
+        Assert.assertThat(error.hasDefined(FAILURES), is(true));
+        Assert.assertThat(error.get(FAILURES).asString(), is("[\"testhost\"]"));
+        error = errors.get(1).get(BOOT_ERROR);
+        Assert.assertThat(error.get(FAILED).get(OP).asString(), is(ADD));
+        Assert.assertThat(error.get(FAILED).get(ADDRESS).asString(), is("[(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-tcp\")]"));
+        Assert.assertThat(error.hasDefined(FAILURES), is(true));
+        Assert.assertThat(error.get(FAILURES).asString(), is("[\"testhost\"]"));
+        error = errors.get(2).get(BOOT_ERROR);
+        Assert.assertThat(error.get(FAILED).get(OP).asString(), is(ADD));
+        Assert.assertThat(error.get(FAILED).get(ADDRESS).asString(), is("[(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-udp\")]"));
+        Assert.assertThat(error.hasDefined(FAILURES), is(true));
+        Assert.assertThat(error.get(FAILURES).asString(), is("[\"testhost\"]"));
+    }
+}

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/boot/host.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/boot/host.xml
@@ -1,0 +1,69 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ /*
+  ~  * JBoss, Home of Professional Open Source.
+  ~  * Copyright 2013, Red Hat, Inc., and individual contributors
+  ~  * as indicated by the @author tags. See the copyright.txt file in the
+  ~  * distribution for a full listing of individual contributors.
+  ~  *
+  ~  * This is free software; you can redistribute it and/or modify it
+  ~  * under the terms of the GNU Lesser General Public License as
+  ~  * published by the Free Software Foundation; either version 2.1 of
+  ~  * the License, or (at your option) any later version.
+  ~  *
+  ~  * This software is distributed in the hope that it will be useful,
+  ~  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~  * Lesser General Public License for more details.
+  ~  *
+  ~  * You should have received a copy of the GNU Lesser General Public
+  ~  * License along with this software; if not, write to the Free
+  ~  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~  */
+  -->
+
+<host xmlns="urn:jboss:domain:3.0">
+    <management>
+        <audit-log>
+            <formatters>
+               <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+               <syslog-handler name="syslog-udp" formatter="json-formatter" max-failure-count="${udp.max-failure-count:30}" syslog-format="${udp.format:RFC3164}"
+                  max-length="${udp.max-length:3064}" truncate="${udp.truncate:true}" facility="${facility:KERNEL}" app-name="${app.name:MyAppName}">
+                  <udp host="${udp.host:testhost}" port="${udp.port:1514}"/>
+               </syslog-handler>
+               <syslog-handler name="syslog-tcp" formatter="json-formatter" max-failure-count="${tcp.max-failure-count:30}" syslog-format="${tcp.format:RFC5424}" max-length="${tcp.max-length:3064}" truncate="${tcp.truncate:true}">
+                  <tcp host="${tcp.host:testhost}" port="${tcp.port:1514}" message-transfer="${tcp.transfer:OCTET_COUNTING}" reconnect-timeout="${tcp.reconnect-timeout:10}"/>
+               </syslog-handler>
+               <syslog-handler name="syslog-tls" formatter="json-formatter" max-failure-count="${tls.max-failure-count:30}" syslog-format="${tls.format:RFC3164}" max-length="${tls.max-length:3064}" truncate="${tls.truncate:true}">
+                    <tls host="${tls.host:testhost}" port="${tls.port:1514}" message-transfer="${tls.transfer:NON_TRANSPARENT_FRAMING}" reconnect-timeout="${tls.reconnect-timeout:10}">
+                        <truststore path="${tls.truststore-path:truststore}"
+                                    relative-to="jboss.server.data.dir"
+                                    keystore-password="${tls.truststore-keystore-password:blah}"/>
+                        <client-certificate-store path="${tls.clientstore-path:truststore}"
+                                                  relative-to="jboss.server.data.dir"
+                                                  keystore-password="${tls.clientstore-keystore-password:blah}"
+                                                  key-password="${tls.clientstore-key-password:blah}"/>
+                    </tls>
+                </syslog-handler>
+            </handlers>
+            <logger log-boot="${config.log-boot:true}" log-read-only="${config.read-only:true}" enabled="${config.enabled:true}">
+                <handlers>
+                    <handler name="syslog-udp"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="${config.log-boot:true}" log-read-only="${config.read-only:true}" enabled="${config.enabled:true}">
+                <handlers>
+                    <handler name="syslog-tcp"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="111"/>
+            </native-interface>
+        </management-interfaces>
+    </management>
+</host>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/boot/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/boot/standalone.xml
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<server xmlns="urn:jboss:domain:3.0">
+    <management>
+        <audit-log>
+            <formatters>
+               <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+               <syslog-handler name="syslog-udp" formatter="json-formatter" max-failure-count="${udp.max-failure-count:30}" syslog-format="${udp.format:RFC3164}"
+                     max-length="${udp.max-length:3064}" truncate="${udp.truncate:true}" facility="${facility:KERNEL}" app-name="${app.name:MyAppName}">
+                  <udp host="${udp.host:testhost}" port="${udp.port:1514}"/>
+               </syslog-handler>
+               <syslog-handler name="syslog-tcp" formatter="json-formatter" max-failure-count="${tcp.max-failure-count:30}" syslog-format="${tcp.format:RFC5424}" max-length="${tcp.max-length:3064}" truncate="${tcp.truncate:true}">
+                  <tcp host="${tcp.host:testhost}" port="${tcp.port:1514}" message-transfer="${tcp.transfer:OCTET_COUNTING}" reconnect-timeout="${tcp.reconnect-timeout:10}"/>
+               </syslog-handler>
+               <syslog-handler name="syslog-tls" formatter="json-formatter" max-failure-count="${tls.max-failure-count:30}" syslog-format="${tls.format:RFC3164}" max-length="${tls.max-length:3064}" truncate="${tls.truncate:true}">
+                  <tls host="${tls.host:testhost}" port="${tls.port:1514}" message-transfer="${tls.transfer:NON_TRANSPARENT_FRAMING}" reconnect-timeout="${tcp.reconnect-timeout:10}">
+                     <truststore path="${tls.truststore-path:truststore}"
+                                 relative-to="jboss.server.data.dir"
+                                 keystore-password="${tls.truststore-keystore-password:blah}"/>
+                     <client-certificate-store path="${tls.clientstore-path:truststore}"
+                                               relative-to="jboss.server.data.dir"
+                                               keystore-password="${tls.clientstore-keystore-password:blah}"
+                                               key-password="${tls.clientstore-key-password:blah}"/>
+                  </tls>
+               </syslog-handler>
+            </handlers>
+            <logger log-boot="${config.log-boot:true}" log-read-only="${config.read-only:true}" enabled="${config.enabled:true}">
+               <handlers>
+                  <handler name="syslog-udp"/>
+               </handlers>
+            </logger>
+        </audit-log>
+    </management>
+</server>

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/util/ManagementControllerTestBase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/util/ManagementControllerTestBase.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.controller.CompositeOperationHandler;
+import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
 import org.jboss.as.controller.audit.ManagedAuditLogger;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
@@ -101,7 +102,7 @@ public class ManagementControllerTestBase extends AbstractControllerTestBase {
             public String getProductName() {
                 return null;
             }
-        }));
+        }, null, new ResourceDefinition[0]));
 
 
         pathManagerService.addPathManagerResources(rootResource);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -809,7 +809,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
     public void registerHostModel(String hostName, ManagementResourceRegistration root) {
         HostModelUtil.createHostRegistry(hostName, root, hostControllerConfigurationPersister, environment, runningModeControl,
                 localFileRepository, hostControllerInfo, new DelegatingServerInventory(), remoteFileRepository, contentRepository,
-                this, extensionRegistry,vaultReader, ignoredRegistry, processState, pathManager, authorizer, getAuditLogger());
+                this, extensionRegistry,vaultReader, ignoredRegistry, processState, pathManager, authorizer, getAuditLogger(),
+                getBootErrorCollector());
     }
 
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
@@ -20,6 +20,7 @@ package org.jboss.as.host.controller;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 
+import org.jboss.as.controller.BootErrorCollector;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.PathAddress;
@@ -111,14 +112,15 @@ public class HostModelUtil {
                                           final ControlledProcessState processState,
                                           final PathManagerService pathManager,
                                           final DelegatingConfigurableAuthorizer authorizer,
-                                          final ManagedAuditLogger auditLogger) {
+                                          final ManagedAuditLogger auditLogger,
+                                          final BootErrorCollector bootErrorCollector) {
         // Add of the host itself
         ManagementResourceRegistration hostRegistration = root.registerSubModel(
                 new HostResourceDefinition(hostName, configurationPersister,
                         environment, runningModeControl, localFileRepository,
                         hostControllerInfo, serverInventory, remoteFileRepository,
                         contentRepository, domainController, extensionRegistry,
-                        vaultReader, ignoredRegistry, processState, pathManager, authorizer, auditLogger));
+                        vaultReader, ignoredRegistry, processState, pathManager, authorizer, auditLogger, bootErrorCollector));
 
         //TODO See if some of all these parameters can come from domain controller
         LocalDomainControllerAddHandler localDcAddHandler = LocalDomainControllerAddHandler.getInstance(root, hostControllerInfo,

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -24,6 +24,7 @@ package org.jboss.as.host.controller.model.host;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 
+import org.jboss.as.controller.BootErrorCollector;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.PathElement;
@@ -197,6 +198,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
     private final PathManagerService pathManager;
     private final DelegatingConfigurableAuthorizer authorizer;
     private final ManagedAuditLogger auditLogger;
+    private final BootErrorCollector bootErrorCollector;
 
     public HostResourceDefinition(final String hostName,
                                   final HostControllerConfigurationPersister configurationPersister,
@@ -214,7 +216,8 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
                                   final ControlledProcessState processState,
                                   final PathManagerService pathManager,
                                   final DelegatingConfigurableAuthorizer authorizer,
-                                  final ManagedAuditLogger auditLogger) {
+                                  final ManagedAuditLogger auditLogger,
+                                  final BootErrorCollector bootErrorCollector) {
         super(PathElement.pathElement(HOST, hostName), HostModelUtil.getResourceDescriptionResolver());
         this.configurationPersister = configurationPersister;
         this.environment = environment;
@@ -232,6 +235,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
         this.pathManager = pathManager;
         this.authorizer = authorizer;
         this.auditLogger = auditLogger;
+        this.bootErrorCollector = bootErrorCollector;
     }
 
     @Override
@@ -346,7 +350,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
                 return null;
             }
         };
-        hostRegistration.registerSubModel(CoreManagementResourceDefinition.forHost(authorizer, auditLogger, pathManager, environmentNameReader, nativeManagement, httpManagement));
+        hostRegistration.registerSubModel(CoreManagementResourceDefinition.forHost(authorizer, auditLogger, pathManager, environmentNameReader, bootErrorCollector, nativeManagement, httpManagement));
 
         // Other core services
         // TODO get a DumpServicesHandler that works on the domain

--- a/jmx/src/test/java/org/jboss/as/jmx/auditlog/JmxAuditLogHandlerTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/auditlog/JmxAuditLogHandlerTestCase.java
@@ -46,6 +46,7 @@ import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
@@ -771,7 +772,7 @@ public class JmxAuditLogHandlerTestCase extends AbstractControllerTestBase {
             public String getProductName() {
                 return null;
             }
-        }));
+        }, null, new ResourceDefinition[0]));
 
 
         pathManagerService.addPathManagerResources(rootResource);

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
@@ -794,7 +794,7 @@ public class JmxFacadeRbacEnabledTestCase extends AbstractControllerTestBase {
             public String getProductName() {
                 return null;
             }
-        }));
+        }, null, new ResourceDefinition[0]));
 
 
         pathManagerService.addPathManagerResources(rootResource);

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
@@ -52,6 +52,7 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
@@ -575,7 +576,7 @@ public abstract class JmxRbacTestCase extends AbstractControllerTestBase {
             public String getProductName() {
                 return null;
             }
-        }));
+        }, null, new ResourceDefinition[0]));
 
 
         pathManagerService.addPathManagerResources(rootResource);

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.TreeSet;
+import org.jboss.as.controller.BootErrorCollector;
 
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.RunningModeControl;
@@ -140,7 +141,7 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         ModuleIndexService.addService(serviceTarget);
         final AbstractVaultReader vaultReader = service(AbstractVaultReader.class);
         ServerLogger.AS_ROOT_LOGGER.debugf("Using VaultReader %s", vaultReader);
-        ServerService.addService(serviceTarget, configuration, processState, bootstrapListener, runningModeControl, vaultReader, configuration.getAuditLogger(), configuration.getAuthorizer());
+        ServerService.addService(serviceTarget, configuration, processState, bootstrapListener, runningModeControl, vaultReader, configuration.getAuditLogger(), configuration.getAuthorizer(), new BootErrorCollector());
         final ServiceActivatorContext serviceActivatorContext = new ServiceActivatorContext() {
             @Override
             public ServiceTarget getServiceTarget() {

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -25,6 +25,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.BootErrorCollector;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
@@ -200,6 +201,7 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
     private final DomainServerCommunicationServices.OperationIDUpdater operationIDUpdater;
     private final DelegatingConfigurableAuthorizer authorizer;
     private final ManagedAuditLogger auditLogger;
+    private final BootErrorCollector bootErrorCollector;
 
     public ServerRootResourceDefinition(
             final ContentRepository contentRepository,
@@ -213,7 +215,8 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
             final PathManagerService pathManager,
             final DomainServerCommunicationServices.OperationIDUpdater operationIDUpdater,
             final DelegatingConfigurableAuthorizer authorizer,
-            final ManagedAuditLogger auditLogger) {
+            final ManagedAuditLogger auditLogger,
+            final BootErrorCollector bootErrorCollector) {
         super(null, ServerDescriptions.getResourceDescriptionResolver(SERVER, false));
         this.contentRepository = contentRepository;
         this.extensibleConfigurationPersister = extensibleConfigurationPersister;
@@ -229,6 +232,7 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
 
         this.isDomain = serverEnvironment == null || serverEnvironment.getLaunchType() == LaunchType.DOMAIN;
         this.authorizer = authorizer;
+        this.bootErrorCollector = bootErrorCollector;
     }
 
     @Override
@@ -397,9 +401,9 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
         };
         final ResourceDefinition managementDefinition;
         if (isDomain) {
-            managementDefinition = CoreManagementResourceDefinition.forDomainServer(authorizer, auditLogger, pathManager, environmentReader);
+            managementDefinition = CoreManagementResourceDefinition.forDomainServer(authorizer, auditLogger, pathManager, environmentReader, bootErrorCollector);
         } else {
-            managementDefinition = CoreManagementResourceDefinition.forStandaloneServer(authorizer, auditLogger, pathManager, environmentReader,
+            managementDefinition = CoreManagementResourceDefinition.forStandaloneServer(authorizer, auditLogger, pathManager, environmentReader, bootErrorCollector,
                     NativeManagementResourceDefinition.INSTANCE, NativeRemotingManagementResourceDefinition.INSTANCE,
                     HttpManagementResourceDefinition.INSTANCE);
         }

--- a/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
@@ -39,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.BootErrorCollector;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.ModelController;
@@ -317,7 +318,7 @@ public class ServerControllerUnitTestCase {
         @Override
         public void start(StartContext context) throws StartException {
             rootResourceDefinition.setDelegate(new ServerRootResourceDefinition(MockRepository.INSTANCE,
-                    persister, environment, processState, null, null, extensionRegistry, false, MOCK_PATH_MANAGER, null, authorizer, AuditLogger.NO_OP_LOGGER));
+                    persister, environment, processState, null, null, extensionRegistry, false, MOCK_PATH_MANAGER, null, authorizer, AuditLogger.NO_OP_LOGGER, new BootErrorCollector()));
             super.start(context);
         }
     }

--- a/testsuite-core/shared/pom.xml
+++ b/testsuite-core/shared/pom.xml
@@ -94,6 +94,10 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-launcher</artifactId>
+       </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-host-controller</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>

--- a/testsuite-core/shared/src/main/java/org/jboss/as/test/shared/ModelParserUtils.java
+++ b/testsuite-core/shared/src/main/java/org/jboss/as/test/shared/ModelParserUtils.java
@@ -1,0 +1,624 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.test.shared;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.xml.namespace.QName;
+import org.jboss.as.controller.AbstractControllerService;
+import org.jboss.as.controller.BootErrorCollector;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.ModelController;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.ResourceBuilder;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
+import org.jboss.as.controller.audit.AuditLogger;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.operations.common.NamespaceAddHandler;
+import org.jboss.as.controller.operations.common.SchemaLocationAddHandler;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.common.XmlMarshallingHandler;
+import org.jboss.as.controller.parsing.Namespace;
+import org.jboss.as.controller.persistence.NullConfigurationPersister;
+import org.jboss.as.controller.persistence.XmlConfigurationPersister;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.resource.InterfaceDefinition;
+import org.jboss.as.controller.services.path.PathManagerService;
+import org.jboss.as.controller.services.path.PathResourceDefinition;
+import org.jboss.as.domain.controller.LocalHostControllerInfo;
+import org.jboss.as.domain.controller.resources.DomainRootDefinition;
+import org.jboss.as.domain.management.CoreManagementResourceDefinition;
+import org.jboss.as.domain.management.audit.EnvironmentNameReader;
+import org.jboss.as.host.controller.discovery.DiscoveryOption;
+import org.jboss.as.host.controller.model.host.HostResourceDefinition;
+import org.jboss.as.host.controller.model.jvm.JvmResourceDefinition;
+import org.jboss.as.host.controller.operations.HostSpecifiedInterfaceAddHandler;
+import org.jboss.as.host.controller.operations.HostSpecifiedInterfaceRemoveHandler;
+import org.jboss.as.host.controller.operations.IsMasterHandler;
+import org.jboss.as.host.controller.operations.LocalDomainControllerAddHandler;
+import org.jboss.as.host.controller.operations.LocalHostControllerInfoImpl;
+import org.jboss.as.host.controller.operations.RemoteDomainControllerAddHandler;
+import org.jboss.as.host.controller.parsing.DomainXml;
+import org.jboss.as.host.controller.parsing.HostXml;
+import org.jboss.as.host.controller.resources.NativeManagementResourceDefinition;
+import org.jboss.as.host.controller.resources.ServerConfigResourceDefinition;
+import org.jboss.as.repository.ContentRepository;
+import org.jboss.as.repository.HostFileRepository;
+import org.jboss.as.server.controller.resources.ServerRootResourceDefinition;
+import org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition;
+import org.jboss.as.server.parsing.StandaloneXml;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.jboss.modules.Module;
+import org.jboss.msc.service.AbstractServiceListener;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.vfs.VirtualFile;
+import org.junit.Assert;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class ModelParserUtils {
+
+    public static ModelNode standaloneXmlTest(File original, File target) throws Exception {
+        ServiceContainer serviceContainer = setupServiceContainer();
+        try {
+            FileUtils.copyFile(original, target);
+            ModelNode originalModel = loadServerModel(serviceContainer, target);
+            ModelNode reparsedModel = loadServerModel(serviceContainer, target);
+            compare(originalModel, reparsedModel);
+            return reparsedModel;
+        } finally {
+            cleanup(serviceContainer);
+        }
+    }
+
+    public static void hostXmlTest(final File original, File target) throws Exception {
+        ServiceContainer serviceContainer = setupServiceContainer();
+        try {
+            FileUtils.copyFile(original, target);
+            ModelNode originalModel = loadHostModel(serviceContainer, target);
+            ModelNode reparsedModel = loadHostModel(serviceContainer, target);
+            compare(originalModel, reparsedModel);
+        } finally {
+            cleanup(serviceContainer);
+        }
+    }
+
+    public static ModelNode domainXmlTest(File original, File target) throws Exception {
+        ServiceContainer serviceContainer = setupServiceContainer();
+        try {
+            FileUtils.copyFile(original, target);
+            ModelNode originalModel = loadDomainModel(serviceContainer, target);
+            ModelNode reparsedModel = loadDomainModel(serviceContainer, target);
+            compare(originalModel, reparsedModel);
+            return reparsedModel;
+        } finally {
+            cleanup(serviceContainer);
+        }
+    }
+
+    private static ServiceContainer setupServiceContainer() {
+        return ServiceContainer.Factory.create("test");
+    }
+
+    private static void cleanup(final ServiceContainer serviceContainer) throws Exception {
+        if (serviceContainer != null) {
+            serviceContainer.shutdown();
+            try {
+                serviceContainer.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static void compare(ModelNode node1, ModelNode node2) {
+        Assert.assertEquals(node1.getType(), node2.getType());
+        if (node1.getType() == ModelType.OBJECT) {
+            final Set<String> keys1 = node1.keys();
+            final Set<String> keys2 = node2.keys();
+            Assert.assertEquals(node1 + "\n" + node2, keys1.size(), keys2.size());
+
+            for (String key : keys1) {
+                final ModelNode child1 = node1.get(key);
+                Assert.assertTrue("Missing: " + key + "\n" + node1 + "\n" + node2, node2.has(key));
+                final ModelNode child2 = node2.get(key);
+                if (child1.isDefined()) {
+                    Assert.assertTrue(child1.toString(), child2.isDefined());
+                    compare(child1, child2);
+                } else {
+                    Assert.assertFalse(child2.asString(), child2.isDefined());
+                }
+            }
+        } else if (node1.getType() == ModelType.LIST) {
+            List<ModelNode> list1 = node1.asList();
+            List<ModelNode> list2 = node2.asList();
+            Assert.assertEquals(list1 + "\n" + list2, list1.size(), list2.size());
+
+            for (int i = 0; i < list1.size(); i++) {
+                compare(list1.get(i), list2.get(i));
+            }
+
+        } else if (node1.getType() == ModelType.PROPERTY) {
+            Property prop1 = node1.asProperty();
+            Property prop2 = node2.asProperty();
+            Assert.assertEquals(prop1 + "\n" + prop2, prop1.getName(), prop2.getName());
+            compare(prop1.getValue(), prop2.getValue());
+
+        } else {
+            Assert.assertEquals("\n\"" + node1.asString() + "\"\n\"" + node2.asString() + "\"\n-----", node1.asString().trim(), node2.asString().trim());
+        }
+    }
+
+    private static ModelController createController(final ServiceContainer serviceContainer, final ProcessType processType, final ModelNode model, final Setup registration) throws InterruptedException {
+        final ServiceController<?> existingController = serviceContainer.getService(ServiceName.of("ModelController"));
+        if (existingController != null) {
+            final CountDownLatch latch = new CountDownLatch(1);
+            existingController.addListener(new AbstractServiceListener<Object>() {
+                public void listenerAdded(ServiceController<?> serviceController) {
+                    serviceController.setMode(ServiceController.Mode.REMOVE);
+                }
+
+                public void transition(ServiceController<?> serviceController, ServiceController.Transition transition) {
+                    if (transition.equals(ServiceController.Transition.REMOVING_to_REMOVED)) {
+                        latch.countDown();
+                    }
+                }
+            });
+            latch.await();
+        }
+
+        ServiceTarget target = serviceContainer.subTarget();
+        ModelControllerService svc = new ModelControllerService(processType, registration, model);
+        ServiceBuilder<ModelController> builder = target.addService(ServiceName.of("ModelController"), svc);
+        builder.install();
+        svc.latch.await(30, TimeUnit.SECONDS);
+        ModelController controller = svc.getValue();
+        ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
+        controller.execute(setup, null, null, null);
+
+        return controller;
+    }
+
+    private static void executeOperations(ModelController controller, List<ModelNode> ops) {
+        for (final ModelNode op : ops) {
+            op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+            controller.execute(op, null, null, null);
+        }
+    }
+
+    private static ModelNode loadServerModel(final ServiceContainer serviceContainer, final File file) throws Exception {
+        final ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.STANDALONE_SERVER, new RunningModeControl(RunningMode.ADMIN_ONLY), null, null);
+        final QName rootElement = new QName(Namespace.CURRENT.getUriString(), "server");
+        final StandaloneXml parser = new StandaloneXml(Module.getBootModuleLoader(), null, extensionRegistry);
+        final XmlConfigurationPersister persister = new XmlConfigurationPersister(file, rootElement, parser, parser);
+        for (Namespace namespace : Namespace.domainValues()) {
+            if (namespace != Namespace.CURRENT) {
+                persister.registerAdditionalRootElement(new QName(namespace.getUriString(), "server"), parser);
+            }
+        }
+        extensionRegistry.setWriterRegistry(persister);
+        final List<ModelNode> ops = persister.load();
+
+        final ModelNode model = new ModelNode();
+        final ModelController controller = createController(serviceContainer, ProcessType.STANDALONE_SERVER, model, new Setup() {
+            @Override
+            public void setup(Resource resource, ManagementResourceRegistration rootRegistration, DelegatingConfigurableAuthorizer authorizer) {
+                ServerRootResourceDefinition def = new ServerRootResourceDefinition(new MockContentRepository(), persister, null, null, null, null, extensionRegistry, false, MOCK_PATH_MANAGER, null, authorizer, AuditLogger.NO_OP_LOGGER, null);
+                def.registerAttributes(rootRegistration);
+                def.registerOperations(rootRegistration);
+                def.registerChildren(rootRegistration);
+            }
+        });
+
+        final ModelNode caputreModelOp = new ModelNode();
+        caputreModelOp.get(OP_ADDR).set(PathAddress.EMPTY_ADDRESS.toModelNode());
+        caputreModelOp.get(OP).set("capture-model");
+
+        final List<ModelNode> toRun = new ArrayList<ModelNode>(ops);
+        toRun.add(caputreModelOp);
+        executeOperations(controller, toRun);
+        persister.store(model, null).commit();
+        return model;
+    }
+
+    //TODO use HostInitializer & TestModelControllerService
+    private static ModelNode loadHostModel(final ServiceContainer serviceContainer, final File file) throws Exception {
+        final QName rootElement = new QName(Namespace.CURRENT.getUriString(), "host");
+        final HostXml parser = new HostXml("host-controller", RunningMode.NORMAL, false);
+        final XmlConfigurationPersister persister = new XmlConfigurationPersister(file, rootElement, parser, parser);
+        for (Namespace namespace : Namespace.domainValues()) {
+            if (namespace != Namespace.CURRENT) {
+                persister.registerAdditionalRootElement(new QName(namespace.getUriString(), "host"), parser);
+            }
+        }
+        final List<ModelNode> ops = persister.load();
+
+        final ModelNode model = new ModelNode();
+
+        final ModelController controller = createController(serviceContainer, ProcessType.HOST_CONTROLLER, model, new Setup() {
+            public void setup(Resource resource, ManagementResourceRegistration root, DelegatingConfigurableAuthorizer authorizer) {
+
+                final Resource host = Resource.Factory.create();
+                resource.registerChild(PathElement.pathElement(HOST, "master"), host);
+
+                // TODO maybe make creating of empty nodes part of the MNR description
+                host.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT), Resource.Factory.create());
+                host.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.SERVICE_CONTAINER), Resource.Factory.create());
+
+                // Add of the host itself
+                ManagementResourceRegistration hostRegistration = root.registerSubModel(
+                        ResourceBuilder.Factory.create(PathElement.pathElement(HOST), new NonResolvingResourceDescriptionResolver()).build());
+
+                // Other root resource operations
+                XmlMarshallingHandler xmh = new XmlMarshallingHandler(persister);
+                hostRegistration.registerOperationHandler(XmlMarshallingHandler.DEFINITION, xmh);
+                hostRegistration.registerOperationHandler(NamespaceAddHandler.DEFINITION, NamespaceAddHandler.INSTANCE);
+                hostRegistration.registerOperationHandler(SchemaLocationAddHandler.DEFINITION, SchemaLocationAddHandler.INSTANCE);
+                hostRegistration.registerReadOnlyAttribute(HostResourceDefinition.MASTER, IsMasterHandler.INSTANCE);
+
+                // System Properties
+                ManagementResourceRegistration sysProps = hostRegistration.registerSubModel(SystemPropertyResourceDefinition.createForDomainOrHost(SystemPropertyResourceDefinition.Location.HOST));
+
+                // Central Management
+                final LocalHostControllerInfoImpl hostControllerInfo = new LocalHostControllerInfoImpl(new ControlledProcessState(false), "master");
+                ResourceDefinition nativeDef = new NativeManagementResourceDefinition(hostControllerInfo);
+
+                ResourceDefinition core = CoreManagementResourceDefinition.forHost(authorizer,
+                        AuditLogger.NO_OP_LOGGER, MOCK_PATH_MANAGER, new EnvironmentNameReader() {
+
+                            @Override
+                            public boolean isServer() {
+                                return false;
+                            }
+
+                            @Override
+                            public String getServerName() {
+                                return null;
+                            }
+
+                            @Override
+                            public String getProductName() {
+                                return null;
+                            }
+
+                            @Override
+                            public String getHostName() {
+                                return null;
+                            }
+                        }, new BootErrorCollector(), nativeDef);
+                hostRegistration.registerSubModel(core);
+
+                // Domain controller
+                LocalDomainControllerAddHandler localDcAddHandler = new MockLocalDomainControllerAddHandler();
+                hostRegistration.registerOperationHandler(LocalDomainControllerAddHandler.DEFINITION, localDcAddHandler, false);
+                RemoteDomainControllerAddHandler remoteDcAddHandler = new MockRemoteDomainControllerAddHandler();
+                hostRegistration.registerOperationHandler(RemoteDomainControllerAddHandler.DEFINITION, remoteDcAddHandler, false);
+
+                // Jvms
+                final ManagementResourceRegistration jvms = hostRegistration.registerSubModel(JvmResourceDefinition.GLOBAL);
+
+                //Paths
+                ManagementResourceRegistration paths = hostRegistration.registerSubModel(PathResourceDefinition.createSpecified(MOCK_PATH_MANAGER));
+
+                //interface
+                ManagementResourceRegistration interfaces = hostRegistration.registerSubModel(new InterfaceDefinition(
+                        HostSpecifiedInterfaceAddHandler.INSTANCE,
+                        HostSpecifiedInterfaceRemoveHandler.INSTANCE,
+                        true
+                ));
+
+                //server configurations
+                hostRegistration.registerSubModel(new ServerConfigResourceDefinition(MOCK_HOST_CONTROLLER_INFO, null, MOCK_PATH_MANAGER));
+            }
+        });
+
+        final ModelNode caputreModelOp = new ModelNode();
+        caputreModelOp.get(OP_ADDR).set(PathAddress.EMPTY_ADDRESS.toModelNode());
+        caputreModelOp.get(OP).set("capture-model");
+
+        final List<ModelNode> toRun = new ArrayList<ModelNode>(ops);
+        toRun.add(caputreModelOp);
+        executeOperations(controller, toRun);
+
+        model.get(HOST, "master", NAME).set("master");
+        persister.store(model.get(HOST, "master"), null).commit();
+        return model;
+    }
+
+    private static ModelNode loadDomainModel(final ServiceContainer serviceContainer, File file) throws Exception {
+        final ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.HOST_CONTROLLER, new RunningModeControl(RunningMode.NORMAL), null, null);
+        final QName rootElement = new QName(Namespace.CURRENT.getUriString(), "domain");
+        final DomainXml parser = new DomainXml(Module.getBootModuleLoader(), null, extensionRegistry);
+        final XmlConfigurationPersister persister = new XmlConfigurationPersister(file, rootElement, parser, parser);
+        for (Namespace namespace : Namespace.domainValues()) {
+            if (namespace != Namespace.CURRENT) {
+                persister.registerAdditionalRootElement(new QName(namespace.getUriString(), "domain"), parser);
+            }
+        }
+        extensionRegistry.setWriterRegistry(persister);
+        final List<ModelNode> ops = persister.load();
+        final ModelNode model = new ModelNode();
+        final ModelController controller = createController(serviceContainer, ProcessType.HOST_CONTROLLER, model, new Setup() {
+            public void setup(Resource resource, ManagementResourceRegistration rootRegistration, DelegatingConfigurableAuthorizer authorizer) {
+                DomainRootDefinition def = new DomainRootDefinition(null, null, persister, new MockContentRepository(), new MockFileRepository(), true, null, extensionRegistry, null, MOCK_PATH_MANAGER, null, authorizer, null);
+                def.initialize(rootRegistration);
+            }
+        });
+
+        final ModelNode caputreModelOp = new ModelNode();
+        caputreModelOp.get(OP_ADDR).set(PathAddress.EMPTY_ADDRESS.toModelNode());
+        caputreModelOp.get(OP).set("capture-model");
+
+        final List<ModelNode> toRun = new ArrayList<ModelNode>(ops);
+        toRun.add(caputreModelOp);
+
+        executeOperations(controller, toRun);
+
+        persister.store(model, null).commit();
+        return model;
+    }
+
+    interface Setup {
+
+        void setup(Resource resource, ManagementResourceRegistration rootRegistration, DelegatingConfigurableAuthorizer authorizer);
+    }
+
+    static class ModelControllerService extends AbstractControllerService {
+
+        private final CountDownLatch latch = new CountDownLatch(2);
+        private final ModelNode model;
+        private final Setup registration;
+
+        ModelControllerService(final ProcessType processType, final Setup registration, final ModelNode model) {
+            super(processType, new RunningModeControl(RunningMode.ADMIN_ONLY), new NullConfigurationPersister(), new ControlledProcessState(true),
+                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build(), null, ExpressionResolver.TEST_RESOLVER, AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer());
+            this.model = model;
+            this.registration = registration;
+        }
+
+        @Override
+        public void start(StartContext context) throws StartException {
+            super.start(context);
+            latch.countDown();
+        }
+
+        @Override
+        protected void bootThreadDone() {
+            super.bootThreadDone();
+            latch.countDown();
+        }
+
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
+            registration.setup(rootResource, rootRegistration, authorizer);
+
+            rootRegistration.registerOperationHandler(new SimpleOperationDefinitionBuilder("capture-model", new NonResolvingResourceDescriptionResolver()).build(), new OperationStepHandler() {
+                public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                    model.set(Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS)));
+                }
+            });
+            // TODO maybe make creating of empty nodes part of the MNR description
+            rootResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT), Resource.Factory.create());
+            rootResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.SERVICE_CONTAINER), Resource.Factory.create());
+        }
+
+    }
+
+    private static class MockContentRepository implements ContentRepository {
+
+        @Override
+        public byte[] addContent(InputStream stream) throws IOException {
+            return null;
+        }
+
+        @Override
+        public VirtualFile getContent(byte[] hash) {
+            return null;
+        }
+
+        @Override
+        public boolean syncContent(byte[] hash) {
+            return hasContent(hash);
+        }
+
+        @Override
+        public boolean hasContent(byte[] hash) {
+            return false;
+        }
+
+        @Override
+        public void removeContent(byte[] hash, Object reference) {
+        }
+
+        @Override
+        public void addContentReference(byte[] hash, Object reference) {
+        }
+
+    }
+
+    private static class MockFileRepository implements HostFileRepository {
+
+        @Override
+        public File getFile(String relativePath) {
+            return null;
+        }
+
+        @Override
+        public File getConfigurationFile(String relativePath) {
+            return null;
+        }
+
+        @Override
+        public File[] getDeploymentFiles(byte[] deploymentHash) {
+            return null;
+        }
+
+        @Override
+        public File getDeploymentRoot(byte[] deploymentHash) {
+            return null;
+        }
+
+        @Override
+        public void deleteDeployment(byte[] deploymentHash) {
+        }
+    }
+
+    private static class MockLocalDomainControllerAddHandler extends LocalDomainControllerAddHandler {
+
+        /**
+         * Create the ServerAddHandler
+         */
+        protected MockLocalDomainControllerAddHandler() {
+            super(null, null, null, null, null, null, null, MOCK_PATH_MANAGER);
+        }
+
+        @Override
+        protected void initializeDomain() {
+            // no-op
+        }
+    }
+
+    private static class MockRemoteDomainControllerAddHandler extends RemoteDomainControllerAddHandler {
+
+        /**
+         * Create the ServerAddHandler
+         */
+        protected MockRemoteDomainControllerAddHandler() {
+            super(null, null, null, null, null, null, null, null, MOCK_PATH_MANAGER);
+        }
+
+        @Override
+        protected void initializeDomain(OperationContext context, ModelNode remoteDC) throws OperationFailedException {
+            // no-op
+        }
+    }
+
+    private static PathManagerService MOCK_PATH_MANAGER = new PathManagerService() {
+    };
+
+    static final LocalHostControllerInfo MOCK_HOST_CONTROLLER_INFO = new LocalHostControllerInfo() {
+
+        @Override
+        public boolean isMasterDomainController() {
+            return true;
+        }
+
+        @Override
+        public String getRemoteDomainControllerUsername() {
+            return null;
+        }
+
+        @Override
+        public List<DiscoveryOption> getRemoteDomainControllerDiscoveryOptions() {
+            return null;
+        }
+
+        @Override
+        public ControlledProcessState.State getProcessState() {
+            return null;
+        }
+
+        @Override
+        public String getNativeManagementSecurityRealm() {
+            return null;
+        }
+
+        @Override
+        public int getNativeManagementPort() {
+            return 0;
+        }
+
+        @Override
+        public String getNativeManagementInterface() {
+            return null;
+        }
+
+        @Override
+        public String getLocalHostName() {
+            return null;
+        }
+
+        @Override
+        public String getHttpManagementSecurityRealm() {
+            return null;
+        }
+
+        @Override
+        public int getHttpManagementSecurePort() {
+            return 0;
+        }
+
+        @Override
+        public int getHttpManagementPort() {
+            return 0;
+        }
+
+        @Override
+        public String getHttpManagementInterface() {
+            return null;
+        }
+
+        @Override
+        public String getHttpManagementSecureInterface() {
+            return null;
+        }
+
+        @Override
+        public boolean isRemoteDomainControllerIgnoreUnaffectedConfiguration() {
+            return false;
+        }
+    };
+}


### PR DESCRIPTION
Adding the new command "read-boot-errors" available from core-service=management to list all operations that failed during boot.
It displays all boot errors with the failed operation and the failure description / exception of the error.
Jira: https://issues.jboss.org/browse/WFLY-543

Issue for removing deprecated stuff from core/wildfly
https://issues.jboss.org/browse/WFCORE-11
https://issues.jboss.org/browse/WFLY-3638
