### PR TITLE
[WFLY-3406] :  Renaming invalidated jars.

### DIFF
--- a/patching/pom.xml
+++ b/patching/pom.xml
@@ -114,5 +114,26 @@
             <scope>test</scope>
         </dependency>
 
+         <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-submit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-install</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-bmunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/patching/src/main/java/org/jboss/as/patching/installation/InstallationManagerService.java
+++ b/patching/src/main/java/org/jboss/as/patching/installation/InstallationManagerService.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.jboss.as.patching.logging.PatchLogger;
+import org.jboss.as.patching.validation.PatchingFileRenamingCollector;
 import org.jboss.as.patching.validation.PatchingGarbageLocator;
 import org.jboss.as.version.ProductConfig;
 import org.jboss.msc.service.Service;
@@ -68,6 +69,15 @@ public class InstallationManagerService implements Service<InstallationManager> 
                     cleanupMaker.delete();
                 } catch (Exception e) {
                     PatchLogger.ROOT_LOGGER.debugf(e, "failed to garbage collect changes");
+                }
+            }
+            final File renamingMaker = new File(manager.getInstalledImage().getInstallationMetadata(), "cleanup-renaming-files");
+            if (renamingMaker.exists()) {
+                try {
+                    final PatchingFileRenamingCollector renaming = new PatchingFileRenamingCollector(renamingMaker);
+                    renaming.renameFiles();
+                } catch (Exception e) {
+                    PatchLogger.ROOT_LOGGER.debugf(e, "failed to rename files");
                 }
             }
         } catch (Exception e) {

--- a/patching/src/main/java/org/jboss/as/patching/logging/PatchLogger.java
+++ b/patching/src/main/java/org/jboss/as/patching/logging/PatchLogger.java
@@ -230,4 +230,14 @@ public interface PatchLogger extends BasicLogger {
 
     @Message(id = 34, value = "in error: '%s'")
     String artifactInError(PatchingArtifact.ArtifactState state);
+
+    @LogMessage(level = WARN)
+    @Message(id = 35, value = "Cannot rename file %s")
+    void cannotRenameFile(String name);
+
+    @Message(id = 36, value = "Cannot process backup by renaming file %s")
+    IllegalStateException cannotRenameFileDuringBackup(String name);
+
+    @Message(id = 37, value = "Cannot process restore by renaming file %s")
+    IllegalStateException cannotRenameFileDuringRestore(String name);
 }

--- a/patching/src/main/java/org/jboss/as/patching/runner/FailedFileRenaming.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/FailedFileRenaming.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.patching.runner;
+
+import java.io.File;
+import java.util.Objects;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class FailedFileRenaming {
+
+    private final String sourceFile;
+    private final String targetFile;
+    private final String patchId;
+
+    public FailedFileRenaming(final File sourceFile, final File targetFile, final String applyPatchId) {
+        this.sourceFile = sourceFile.getAbsolutePath();
+        this.targetFile = targetFile.getAbsolutePath();
+        this.patchId = applyPatchId;
+    }
+
+    public String getSourceFile() {
+        return sourceFile;
+    }
+
+    public String getTargetFile() {
+        return targetFile;
+    }
+
+    public String getPatchId() {
+        return patchId;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 29 * hash + Objects.hashCode(this.sourceFile);
+        hash = 29 * hash + Objects.hashCode(this.targetFile);
+        hash = 29 * hash + Objects.hashCode(this.patchId);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final FailedFileRenaming other = (FailedFileRenaming) obj;
+        if (!Objects.equals(this.sourceFile, other.sourceFile)) {
+            return false;
+        }
+        if (!Objects.equals(this.targetFile, other.targetFile)) {
+            return false;
+        }
+        if (!Objects.equals(this.patchId, other.patchId)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/patching/src/main/java/org/jboss/as/patching/runner/PatchReenableJarTool.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/PatchReenableJarTool.java
@@ -39,7 +39,7 @@ public class PatchReenableJarTool {
         findModuleRoots(base, jars);
 
         for (final File file : jars) {
-            PatchModuleInvalidationUtils.processFile(file, PatchingTaskContext.Mode.ROLLBACK);
+            PatchModuleInvalidationUtils.processFile(null, file, PatchingTaskContext.Mode.ROLLBACK);
         }
     }
 

--- a/patching/src/main/java/org/jboss/as/patching/runner/PatchUtils.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/PatchUtils.java
@@ -53,6 +53,9 @@ import org.jboss.as.patching.installation.PatchableTarget;
  */
 public final class PatchUtils {
 
+    public static final String JAR_EXT = ".jar";
+    public static final String BACKUP_EXT = ".jar.patched";
+
     public static String readRef(final Properties properties, final String name) {
         final String ref = (String) properties.get(name);
         if(ref == null) {
@@ -147,9 +150,9 @@ public final class PatchUtils {
         }
     }
 
-    public static void writeRefs(final File file, final List<String> refs) throws IOException {
+    public static void writeRefs(final File file, final List<String> refs, boolean append) throws IOException {
         mkdir(file.getParentFile());
-        final OutputStream os = new FileOutputStream(file);
+        final OutputStream os = new FileOutputStream(file, append);
         try {
             writeRefs(os, refs);
             os.flush();
@@ -157,6 +160,10 @@ public final class PatchUtils {
         } finally {
             safeClose(os);
         }
+    }
+
+    public static void writeRefs(final File file, final List<String> refs) throws IOException {
+        writeRefs(file, refs, false);
     }
 
     static void writeRefs(final OutputStream os, final List<String> refs) throws IOException {
@@ -243,5 +250,15 @@ public final class PatchUtils {
         } finally {
             safeClose(reader);
         }
+    }
+
+    public static File getRenamedFileName(final File file) {
+        String fileName = file.getName();
+        if (fileName.endsWith(BACKUP_EXT)) {
+            return new File(file.getParentFile(), fileName.substring(0, fileName.length() - BACKUP_EXT.length()) + JAR_EXT);
+        } else if (fileName.endsWith(JAR_EXT)) {
+            return new File(file.getParentFile(), fileName.substring(0, fileName.length() - JAR_EXT.length()) + BACKUP_EXT);
+        }
+        return file;
     }
 }

--- a/patching/src/main/java/org/jboss/as/patching/validation/PatchingFileRenamingCollector.java
+++ b/patching/src/main/java/org/jboss/as/patching/validation/PatchingFileRenamingCollector.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.patching.validation;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.jboss.as.patching.logging.PatchLogger;
+import org.jboss.as.patching.runner.PatchUtils;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
+ */
+public class PatchingFileRenamingCollector {
+
+    private static final PatchLogger log = PatchLogger.ROOT_LOGGER;
+    private final File renamingFailureMarker;
+
+    public PatchingFileRenamingCollector(final File renamingFailureMarker) {
+        this.renamingFailureMarker = renamingFailureMarker;
+    }
+
+    public void renameFiles() throws IOException {
+        List<String> failures = PatchUtils.readRefs(renamingFailureMarker);
+        for(String path : failures) {
+           File toBeRenamed = new File(path);
+           if(toBeRenamed.exists()) {
+               if(!toBeRenamed.renameTo(PatchUtils.getRenamedFileName(toBeRenamed))) {
+                   log.cannotDeleteFile(path);
+               }
+           }
+        }
+        renamingFailureMarker.delete();
+    }
+}

--- a/patching/src/test/java/org/jboss/as/patching/tests/PatchModuleInvalidationTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/PatchModuleInvalidationTestCase.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.patching.tests;
 
-import static org.jboss.as.patching.runner.TestUtils.createModule0;
-import static org.jboss.as.patching.runner.TestUtils.randomString;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,9 +42,15 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.jboss.as.patching.runner.PatchUtils.BACKUP_EXT;
+import static org.jboss.as.patching.runner.PatchUtils.JAR_EXT;
+import static org.jboss.as.patching.runner.TestUtils.createModule0;
+import static org.jboss.as.patching.runner.TestUtils.randomString;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 
 /**
  * @author Emanuel Muckenhuber
@@ -77,9 +81,10 @@ public class PatchModuleInvalidationTestCase extends AbstractPatchingTest {
 
         final File root = test.getRoot();
         final File installation = new File(root, JBOSS_INSTALLATION);
-        final File moduleRoot = new File(installation, "modules/system/layers/base");
+        final File moduleRoot = new File(installation, "modules/system/layers/base".replace('/', File.separatorChar));
         final File module0 = createModule0(moduleRoot, MODULE_NAME, CONTENT_TASK);
-        final File resource = new File(module0, "main/resource0.jar");
+        final File resource = new File(module0, "main/resource0.jar".replace('/', File.separatorChar));
+        final File resourceBackup = new File(module0, "main/resource0.jar.patched".replace('/', File.separatorChar));
         assertLoadable(resource);
 
         final byte[] existingHash = HashUtils.hashFile(module0);
@@ -93,11 +98,16 @@ public class PatchModuleInvalidationTestCase extends AbstractPatchingTest {
                 ;
 
         apply(oop1);
-        assertNotLoadable(resource);
+        assertThat(resourceBackup.exists(), is(true));
+        assertThat(resource.exists(), is(false));
+        assertNotLoadable(resourceBackup);
 
         // Module in patch oop1
         final File resource1 = getModuleResource("base-oop1", MODULE_NAME);
         assertLoadable(resource1);
+        final File resource1Backup = getBackupFile(resource1);
+        assertThat(resource1Backup.exists(), is(false));
+        assertThat(resource1.exists(), is(true));
 
         final PatchingTestStepBuilder oop2 = test.createStepBuilder();
         oop2.setPatchId("oop2")
@@ -110,9 +120,14 @@ public class PatchModuleInvalidationTestCase extends AbstractPatchingTest {
 
         // Module in patch oop2
         final File resource2 = getModuleResource("base-oop2", MODULE_NAME);
+        final File resource2Backup = getBackupFile(resource2);
+        assertThat(resource2Backup.exists(), is(false));
+        assertThat(resource2.exists(), is(true));
 
-        assertNotLoadable(resource);
-        assertNotLoadable(resource1);
+        assertNotLoadable(resourceBackup);
+        assertThat(resource1Backup.exists(), is(true));
+        assertThat(resource1.exists(), is(false));
+        assertNotLoadable(resource1Backup);
         assertLoadable(resource2);
 
         final PatchingTestStepBuilder cp1 = test.createStepBuilder();
@@ -126,10 +141,15 @@ public class PatchModuleInvalidationTestCase extends AbstractPatchingTest {
 
         // Module in patch cp1
         final File resource3 = getModuleResource("base-cp1", MODULE_NAME);
+        final File resource3Backup = getBackupFile(resource3);
+        assertThat(resource3Backup.exists(), is(false));
+        assertThat(resource3.exists(), is(true));
 
-        assertNotLoadable(resource);
-        assertNotLoadable(resource1);
-        assertNotLoadable(resource2);
+        assertNotLoadable(resourceBackup);
+        assertNotLoadable(resource1Backup);
+        assertThat(resource2Backup.exists(), is(true));
+        assertThat(resource2.exists(), is(false));
+        assertNotLoadable(resource2Backup);
         assertLoadable(resource3);
 
         final PatchingTestStepBuilder cp2 = test.createStepBuilder();
@@ -144,30 +164,40 @@ public class PatchModuleInvalidationTestCase extends AbstractPatchingTest {
         // Module in patch cp2
         final File resource4 = getModuleResource("base-cp2", MODULE_NAME);
 
-        assertNotLoadable(resource);
-        assertNotLoadable(resource1);
-        assertNotLoadable(resource2);
-        assertNotLoadable(resource3);
+        assertNotLoadable(resourceBackup);
+        assertNotLoadable(resource1Backup);
+        assertNotLoadable(resource2Backup);
+        assertThat(resource3Backup.exists(), is(true));
+        assertThat(resource3.exists(), is(false));
+        assertNotLoadable(resource3Backup);
         assertLoadable(resource4);
 
         rollback(cp2);
 
-        assertNotLoadable(resource);
-        assertNotLoadable(resource1);
-        assertNotLoadable(resource2);
+        assertNotLoadable(resourceBackup);
+        assertNotLoadable(resource1Backup);
+        assertNotLoadable(resource2Backup);
+        assertThat(resource3Backup.exists(), is(false));
+        assertThat(resource3.exists(), is(true));
         assertLoadable(resource3);
 
         rollback(cp1);
 
-        assertNotLoadable(resource);
-        assertNotLoadable(resource1);
+        assertNotLoadable(resourceBackup);
+        assertNotLoadable(resource1Backup);
+        assertThat(resource2Backup.exists(), is(false));
+        assertThat(resource2.exists(), is(true));
         assertLoadable(resource2);
 
         rollback(oop2);
-        assertNotLoadable(resource);
+        assertNotLoadable(resourceBackup);
+        assertThat(resource1Backup.exists(), is(false));
+        assertThat(resource1.exists(), is(true));
         assertLoadable(resource1);
 
         rollback(oop1);
+        assertThat(resourceBackup.exists(), is(false));
+        assertThat(resource.exists(), is(true));
         assertLoadable(resource);
     }
 
@@ -192,7 +222,7 @@ public class PatchModuleInvalidationTestCase extends AbstractPatchingTest {
     }
 
     static void assertLoadable(final File jar) throws Exception {
-        final URL[] urls = new URL[] { jar.toURL() };
+        final URL[] urls = new URL[] { jar.toURI().toURL() };
         final URLClassLoader cl = new URLClassLoader(urls);
         try {
             Assert.assertNotNull(cl.getResource("testResource"));
@@ -206,7 +236,7 @@ public class PatchModuleInvalidationTestCase extends AbstractPatchingTest {
     }
 
     static void assertNotLoadable(final File jar) throws Exception {
-        final URL[] urls = new URL[] { jar.toURL() };
+        final URL[] urls = new URL[] { jar.toURI().toURL() };
         final URLClassLoader cl = new URLClassLoader(urls, null);
         try {
             Assert.assertNull(cl.getResource("testResource"));
@@ -232,5 +262,11 @@ public class PatchModuleInvalidationTestCase extends AbstractPatchingTest {
         }
     }
 
-
+    private File getBackupFile(File file) {
+        String fileName = file.getName();
+        if (fileName.endsWith(JAR_EXT)) {
+            return new File(file.getParentFile(), fileName.substring(0, fileName.length() - JAR_EXT.length()) + BACKUP_EXT);
+        }
+        return file;
+    }
 }

--- a/patching/src/test/java/org/jboss/as/patching/tests/PatchModuleInvalidationWithRenamingFailureTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/PatchModuleInvalidationWithRenamingFailureTestCase.java
@@ -1,0 +1,157 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.patching.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+
+import org.jboss.as.patching.HashUtils;
+import org.jboss.as.patching.IoUtils;
+import org.jboss.as.patching.installation.PatchableTarget;
+import org.jboss.as.patching.runner.PatchUtils;
+import org.jboss.as.patching.runner.TestUtils;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.jboss.as.patching.runner.TestUtils.createModule0;
+import static org.jboss.as.patching.runner.TestUtils.randomString;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+/**
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+@RunWith(BMUnitRunner.class)
+public class PatchModuleInvalidationWithRenamingFailureTestCase extends AbstractPatchingTest {
+
+    private static final String MODULE_NAME = "org.jboss.test.module";
+    private static final String RESOURCE = "SimpleResource.jar";
+
+    private static final TestUtils.ContentTask CONTENT_TASK = new TestUtils.ContentTask() {
+        @Override
+        public String[] writeContent(File target) throws IOException {
+            writeJar(new File(target, RESOURCE));
+            return new String[]{RESOURCE};
+        }
+    };
+
+    @Test
+    @BMRule(name = "Test renaming failure",
+            targetClass = "java.io.File",
+            targetMethod = "isInvalid",
+            targetLocation = "AT EXIT",
+            condition = "\"SimpleResource.jar.patched\".equals($0.getName())",
+            action = "return true"
+    )
+    public void test() throws Exception {
+        final PatchingTestBuilder test = createDefaultBuilder();
+        final File root = test.getRoot();
+        final File installation = new File(root, JBOSS_INSTALLATION);
+        final File moduleRoot = new File(installation, "modules/system/layers/base".replace('/', File.separatorChar));
+        final File module0 = createModule0(moduleRoot, MODULE_NAME, CONTENT_TASK);
+        final File resource = new File(module0, "main/SimpleResource.jar".replace('/', File.separatorChar));
+        final File resourceBackup = new File(module0, "main/SimpleResource.jar.patched".replace('/', File.separatorChar));
+        final byte[] existingHash = HashUtils.hashFile(module0);
+        final byte[] resultingHash = Arrays.copyOf(existingHash, existingHash.length);
+        assertLoadable(resource);
+        final PatchingTestStepBuilder oop1 = test.createStepBuilder();
+        oop1.setPatchId("oop1")
+                .oneOffPatchIdentity(PRODUCT_VERSION)
+                .oneOffPatchElement("base-oop1", "base", false)
+                .updateModule(MODULE_NAME, existingHash, resultingHash, CONTENT_TASK);
+
+        apply(oop1);
+        assertThat(resourceBackup.exists(), is(false));
+        assertThat(resource.exists(), is(true));
+        final File failures = new File(new File(installation, ".installation"), "cleanup-renaming-files");
+        assertThat(failures.exists(), is(true));
+        List<String> failedRenaming = PatchUtils.readRefs(failures);
+        assertThat(failedRenaming.size(), is(1));
+        assertThat(failedRenaming.get(0), is(resource.getAbsolutePath()));
+    }
+
+    File getModuleResource(final String patchID, final String moduleName) throws IOException {
+        return getModuleResource("base", patchID, moduleName);
+    }
+
+    File getModuleResource(final String layer, final String patchID, final String moduleName) throws IOException {
+        final PatchableTarget.TargetInfo info = getLayer(layer).loadTargetInfo();
+        final File root = info.getDirectoryStructure().getModulePatchDirectory(patchID);
+        final File moduleRoot = TestUtils.getModuleRoot(root, moduleName);
+        return new File(moduleRoot, RESOURCE);
+    }
+
+    static File writeJar(final File target) {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+                .addClass(TestClass.class)
+                .add(new StringAsset(randomString()), "testResource")
+                .addManifest();
+        archive.as(ZipExporter.class).exportTo(target);
+        return target;
+    }
+
+    static void assertLoadable(final File jar) throws Exception {
+        final URL[] urls = new URL[]{jar.toURI().toURL()};
+        final URLClassLoader cl = new URLClassLoader(urls);
+        Assert.assertNotNull(cl.getResource("testResource"));
+        final Class<?> clazz = cl.loadClass("org.jboss.as.patching.tests.TestClass");
+        final Constructor<?> constructor = clazz.getConstructor(String.class);
+        final Object instance = constructor.newInstance("test");
+        Assert.assertNotNull(instance);
+    }
+
+    static void assertNotLoadable(final File jar) throws Exception {
+        final URL[] urls = new URL[]{jar.toURI().toURL()};
+        final URLClassLoader cl = new URLClassLoader(urls, null);
+        Assert.assertNull(cl.getResource("testResource"));
+        try {
+            cl.loadClass("org.jboss.as.patching.tests.TestClass");
+            Assert.fail("shouldn't be able to load the test class");
+        } catch (ClassNotFoundException ok) {
+        }
+
+        ZipFile file = null;
+        try {
+            file = new ZipFile(jar);
+            Assert.fail("should not be able to open" + jar);
+        } catch (ZipException expected) {
+            // ok
+            return;
+        } finally {
+            IoUtils.safeClose(file);
+        }
+    }
+}


### PR DESCRIPTION
 If the renaming couldn't be done during the patch application then it is tried during the next restart of the server.
Jira: https://issues.jboss.org/browse/WFLY-3406
