### PR TITLE
[WFLY-3603] Add Global Resource Notifications

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -38,6 +38,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUIRED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_ADDED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_REMOVED_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_TIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
@@ -76,6 +78,7 @@ import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.notification.Notification;
 import org.jboss.as.controller.notification.NotificationSupport;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.operations.global.ReadResourceHandler;
@@ -759,6 +762,9 @@ final class OperationContextImpl extends AbstractOperationContext {
                 }
             }
         }
+
+        Notification notification = new Notification(RESOURCE_ADDED_NOTIFICATION, absoluteAddress, ControllerLogger.ROOT_LOGGER.resourceWasAdded(absoluteAddress));
+        emit(notification);
     }
 
     @Override
@@ -805,6 +811,10 @@ final class OperationContextImpl extends AbstractOperationContext {
                 model = requireChild(model, element, address);
             }
         }
+
+        Notification notification = new Notification(RESOURCE_REMOVED_NOTIFICATION, address, ControllerLogger.ROOT_LOGGER.resourceWasRemoved(address));
+        emit(notification);
+
         return model;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -58,6 +58,7 @@ public class ModelDescriptionConstants {
     public static final String APPLIES_TO = "applies-to";
     public static final String ARCHIVE = "archive";
     public static final String ATTRIBUTE = "attribute";
+    public static final String ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION = "attribute-value-written";
     public static final String ATTRIBUTES = "attributes";
     public static final String ATTRIBUTES_ONLY = "attributes-only";
     public static final String AUDIT = "audit";
@@ -317,6 +318,8 @@ public class ModelDescriptionConstants {
     public static final String REQUEST_PROPERTIES = "request-properties";
     public static final String REQUIRED = "required";
     public static final String REQUIRES = "requires";
+    public static final String RESOURCE_ADDED_NOTIFICATION = "resource-added";
+    public static final String RESOURCE_REMOVED_NOTIFICATION = "resource-removed";
     public static final String RESPONSE = "response";
     public static final String RESPONSE_HEADERS = "response-headers";
     public static final String RESTART = "restart";

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3207,4 +3207,13 @@ public interface ControllerLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 357, value = "Notification of type %s is not described for the resource at the address %s")
     void notificationIsNotDescribed(String type, PathAddress source);
+
+    @Message(id = 358, value = "The resource was added at the address %s.")
+    String resourceWasAdded(PathAddress address);
+
+    @Message(id = 359, value = "The resource was removed at the address %s.")
+    String resourceWasRemoved(PathAddress address);
+
+    @Message(id = 360, value = "The attribute %s value has been changed from %s to %s.")
+    String attributeValueWritten(String attributeName, ModelNode currentValue, ModelNode newVal);
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalNotifications.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalNotifications.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.operations.global;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_ADDED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_REMOVED_NOTIFICATION;
+
+import java.util.ResourceBundle;
+
+import org.jboss.as.controller.NotificationDefinition;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Global notifications emitted by all resources:
+ *  * resource-added
+ *  * resource-removed
+ *  * attribute-value-written that contains in its data the old-value and new-value of the attribute that has been written
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class GlobalNotifications {
+
+    private static final NotificationDefinition RESOURCE_ADDED = NotificationDefinition.Builder.create(RESOURCE_ADDED_NOTIFICATION, ControllerResolver.getResolver("global"))
+            .build();
+    private static final NotificationDefinition RESOURCE_REMOVED = NotificationDefinition.Builder.create(RESOURCE_REMOVED_NOTIFICATION, ControllerResolver.getResolver("global"))
+            .build();
+
+    public static final String OLD_VALUE = "old-value";
+    public static final String NEW_VALUE = "new-value";
+
+    private static final NotificationDefinition ATTRIBUTE_VALUE_WRITTEN = NotificationDefinition.Builder.create(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION, ControllerResolver.getResolver("global"))
+            .setDataValueDescriptor(new NotificationDefinition.DataValueDescriptor() {
+                @Override
+                public ModelNode describe(ResourceBundle bundle) {
+                    String prefix = "global." + ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION + ".";
+                    final ModelNode desc = new ModelNode();
+                    desc.get(NAME, DESCRIPTION).set(bundle.getString(prefix + NAME));
+                    desc.get(OLD_VALUE, DESCRIPTION).set(bundle.getString(prefix + OLD_VALUE));
+                    desc.get(NEW_VALUE, DESCRIPTION).set(bundle.getString(prefix + NEW_VALUE));
+                    return desc;
+                }
+            })
+            .build();
+
+    public static void registerGlobalNotifications(ManagementResourceRegistration root, ProcessType processType) {
+        root.registerNotification(RESOURCE_ADDED, true);
+        root.registerNotification(RESOURCE_REMOVED, true);
+
+        if (processType != ProcessType.DOMAIN_SERVER) {
+            root.registerNotification(ATTRIBUTE_VALUE_WRITTEN, true);
+        }
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/WriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/WriteAttributeHandler.java
@@ -22,12 +22,12 @@
 
 package org.jboss.as.controller.operations.global;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.operations.global.GlobalOperationAttributes.NAME;
 import static org.jboss.as.controller.operations.global.GlobalOperationAttributes.VALUE;
 
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
@@ -37,6 +37,8 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.access.AuthorizationResult;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.notification.Notification;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -92,13 +94,32 @@ public class WriteAttributeHandler implements OperationStepHandler {
                 throw ControllerLogger.ROOT_LOGGER.unauthorized(operation.require(OP).asString(), PathAddress.pathAddress(operation.get(OP_ADDR)), authorizationResult.getExplanation());
             }
 
+            // clone the current value before the model is modified
+            final ModelNode oldValue = currentValue.clone();
+
             OperationStepHandler handler = attributeAccess.getWriteHandler();
             ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(handler.getClass());
             try {
                 handler.execute(context, operation);
+
+                ModelNode newValue = context.readResource(PathAddress.EMPTY_ADDRESS).getModel().get(attributeName);
+                // only emit a notification if the value has been successfully changed
+                if (!oldValue.equals(newValue)) {
+                    emitAttributeValueWrittenNotification(context, PathAddress.pathAddress(operation.get(OP_ADDR)), attributeName, oldValue, newValue);
+                }
+
             } finally {
                 WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
             }
         }
+    }
+
+    private void emitAttributeValueWrittenNotification(OperationContext context, PathAddress address, String attributeName, ModelNode oldValue, ModelNode newValue) {
+        ModelNode data = new ModelNode();
+        data.get(NAME.getName()).set(attributeName);
+        data.get(GlobalNotifications.OLD_VALUE).set(oldValue);
+        data.get(GlobalNotifications.NEW_VALUE).set(newValue);
+        Notification notification = new Notification(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION, address, ControllerLogger.ROOT_LOGGER.attributeValueWritten(attributeName, oldValue, newValue), data);
+        context.emit(notification);
     }
 }

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -456,6 +456,14 @@ global.validate-address.problem=Is included only if the address is not valid and
 global.validate-operation=Validates that an operation is valid according to its description. Any errors present will be shown in the operation's failure-description.
 global.validate-operation.value=The operation to validate.
 
+# Global Notifications
+global.resource-added=This notification is emitted when a resource is created at this address.
+global.resource-removed=This notification is emitted when a resource is removed at this address.
+global.attribute-value-written=This notification is emitted when a resource's attribute has been written to a new value.
+global.attribute-value-written.name=The name of the attribute
+global.attribute-value-written.old-value=The old value of the attribute
+global.attribute-value-written.new-value=The new value of the attribute
+
 # Root Operations
 root.composite=An operation that groups multiple operation requests into a single operation request.
 root.composite.steps=A list of the operation requests that constitute the composite request.

--- a/controller/src/test/java/org/jboss/as/controller/notification/GlobalNotificationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/GlobalNotificationsTestCase.java
@@ -1,0 +1,331 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.notification;
+
+import static org.jboss.as.controller.PathAddress.pathAddress;
+import static org.jboss.as.controller.PathElement.pathElement;
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_ADDED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_REMOVED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.operations.global.GlobalNotifications.NEW_VALUE;
+import static org.jboss.as.controller.operations.global.GlobalNotifications.OLD_VALUE;
+import static org.jboss.dmr.ModelType.BOOLEAN;
+import static org.jboss.dmr.ModelType.LONG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ResourceBuilder;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.test.AbstractControllerTestBase;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.junit.Test;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
+
+    public static final SimpleAttributeDefinition MY_ATTRIBUTE = create("my-attribute", LONG)
+            .setDefaultValue(new ModelNode(12345))
+            .build();
+    public static final SimpleAttributeDefinition FAIL_ADD_OPERATION = create("fail-add-operation", BOOLEAN)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+    public static final SimpleAttributeDefinition FAIL_REMOVE_OPERATION = create("fail-remove-operation", BOOLEAN)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+
+    private static final PathAddress RESOURCE_ADDRESS_PATTERN = pathAddress(pathElement("profile", "*"));
+    private final PathAddress resourceAddress = pathAddress(pathElement("profile", "myprofile"));
+
+    @Override
+    protected void initModel(Resource rootResource, final ManagementResourceRegistration rootRegistration) {
+        // register the global operations to be able to call :read-attribute and :write-attribute
+        GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+        // register the global notifications so there is no warning that emitted notifications are not described by the resource.
+        GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
+
+        ResourceDefinition profileDefinition = createDummyProfileResourceDefinition();
+        rootRegistration.registerSubModel(profileDefinition);
+    }
+
+    private static ResourceDefinition createDummyProfileResourceDefinition() {
+        return ResourceBuilder.Factory.create(RESOURCE_ADDRESS_PATTERN.getElement(0),
+                new NonResolvingResourceDescriptionResolver())
+                .setAddOperation(new AbstractAddStepHandler() {
+
+                    @Override
+                    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+                        MY_ATTRIBUTE.validateAndSet(operation, model);
+                        FAIL_ADD_OPERATION.validateAndSet(operation, model);
+                        FAIL_REMOVE_OPERATION.validateAndSet(operation, model);
+                    }
+
+                    @Override
+                    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+                        boolean fail = FAIL_ADD_OPERATION.resolveModelAttribute(context, model).asBoolean();
+                        if (fail) {
+                            throw new OperationFailedException("add operation failed");
+                        }
+                    }
+                })
+                .setRemoveOperation(new AbstractRemoveStepHandler() {
+                    @Override
+                    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+                        boolean fail = FAIL_REMOVE_OPERATION.resolveModelAttribute(context, model).asBoolean();
+                        if (fail) {
+                            throw new OperationFailedException("remove operation failed");
+                        }
+                    }
+                    // no-op
+                })
+                .addReadWriteAttribute(MY_ATTRIBUTE, null, new AbstractWriteAttributeHandler<Long>(MY_ATTRIBUTE) {
+                    @Override
+                    protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Long> handbackHolder) throws OperationFailedException {
+                        return false;
+                    }
+
+                    @Override
+                    protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode valueToRestore, ModelNode valueToRevert, Long handback) throws OperationFailedException {
+                    }
+                })
+                .build();
+    }
+
+    @Test
+    public void test_RESOURCE_ADDED_NOTIFICATION() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        NotificationFilter filter = new TestNotificationHandler(resourceAddress, RESOURCE_ADDED_NOTIFICATION);
+        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+
+        executeForResult(createOperation(ADD, resourceAddress));
+        assertEquals("the notification handler did not receive the " + RESOURCE_ADDED_NOTIFICATION, 1, handler.getNotifications().size());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+    }
+
+    @Test
+    public void test_RESOURCE_ADDED_NOTIFICATION_isNotSentWhenAddOperationFails() throws Exception {
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        NotificationFilter filter = new TestNotificationHandler(resourceAddress, RESOURCE_ADDED_NOTIFICATION);
+        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+
+        ModelNode addOperation = createOperation(ADD, resourceAddress);
+        addOperation.get(FAIL_ADD_OPERATION.getName()).set(true);
+        executeForFailure(addOperation);
+
+        assertTrue("the notification handler unexpectedly receives the " + RESOURCE_ADDED_NOTIFICATION, handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+    }
+
+    @Test
+    public void test_RESOURCE_REMOVED_NOTIFICATION() throws Exception {
+        executeForResult(createOperation(ADD, resourceAddress));
+
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        NotificationFilter filter = new TestNotificationHandler(resourceAddress, RESOURCE_REMOVED_NOTIFICATION);
+        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+
+        executeForResult(createOperation(REMOVE, resourceAddress));
+        assertEquals("the notification handler did not receive the " + RESOURCE_REMOVED_NOTIFICATION, 1, handler.getNotifications().size());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+    }
+
+    @Test
+    public void test_RESOURCE_REMOVED_NOTIFICATION_isNotSentWhenRemoveOperationFails() throws Exception {
+        ModelNode addOperation = createOperation(ADD, resourceAddress);
+        addOperation.get(FAIL_REMOVE_OPERATION.getName()).set(true);
+        executeForResult(addOperation);
+
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        NotificationFilter filter = new TestNotificationHandler(resourceAddress, RESOURCE_REMOVED_NOTIFICATION);
+        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+
+        executeForFailure(createOperation(REMOVE, resourceAddress));
+        assertTrue("the notification handler unexpectedly receives the " + RESOURCE_REMOVED_NOTIFICATION, handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+    }
+
+    @Test
+    public void test_ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION() throws Exception {
+        executeForResult(createOperation(ADD, resourceAddress));
+
+        ModelNode readAttribute = createOperation(READ_ATTRIBUTE_OPERATION, resourceAddress);
+        readAttribute.get(NAME).set(MY_ATTRIBUTE.getName());
+        ModelNode result = executeForResult(readAttribute);
+        // read-attribute returns the default value
+        assertEquals(MY_ATTRIBUTE.getDefaultValue().asLong(), result.asLong());
+
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
+        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+
+        long newValue = System.currentTimeMillis();
+        ModelNode writeAttribute = createOperation(WRITE_ATTRIBUTE_OPERATION, resourceAddress);
+        writeAttribute.get(NAME).set(MY_ATTRIBUTE.getName());
+        writeAttribute.get(VALUE).set(newValue);
+        executeForResult(writeAttribute);
+
+        assertEquals("the notification handler did not receive the " + ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION, 1, handler.getNotifications().size());
+        Notification notification = handler.getNotifications().get(0);
+        assertEquals(MY_ATTRIBUTE.getName(), notification.getData().require(NAME).asString());
+        // the value was not defined initially: the notification does not return the default value but undefined instead.
+        assertFalse(notification.getData().require(OLD_VALUE).isDefined());
+        assertEquals(newValue, notification.getData().require(NEW_VALUE).asLong());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+    }
+
+    @Test
+    public void test_ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION_isNotSentWhenWriteAttributeOperationFails() throws Exception {
+
+        executeForResult(createOperation(ADD, resourceAddress));
+
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
+        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+
+        String incorrectValue = UUID.randomUUID().toString();
+        ModelNode writeAttribute = createOperation(WRITE_ATTRIBUTE_OPERATION, resourceAddress);
+        writeAttribute.get(NAME).set(MY_ATTRIBUTE.getName());
+        writeAttribute.get(VALUE).set(incorrectValue);
+        executeForFailure(writeAttribute);
+        assertTrue("the notification handler unexpectedly receives the " + ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION, handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+    }
+
+    @Test
+    public void test_ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION_isNotSentWhenAttributeValueIsTheSame() throws Exception {
+        long value = System.currentTimeMillis();
+        ModelNode add = createOperation(ADD, resourceAddress);
+        add.get(MY_ATTRIBUTE.getName()).set(value);
+        executeForResult(add);
+
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
+        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+
+        ModelNode writeAttribute = createOperation(WRITE_ATTRIBUTE_OPERATION, resourceAddress);
+        writeAttribute.get(NAME).set(MY_ATTRIBUTE.getName());
+        writeAttribute.get(VALUE).set(value);
+        executeForResult(writeAttribute);
+        assertEquals("the notification handler unexpectedly receives the " + ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION, 0, handler.getNotifications().size());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+    }
+
+    @Test
+    public void test_ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION_isSentWhenUndefineAttributeIsCalled() throws Exception {
+        long initialValue = System.currentTimeMillis();
+        ModelNode add = createOperation(ADD, resourceAddress);
+        add.get(MY_ATTRIBUTE.getName()).set(initialValue);
+        executeForResult(add);
+
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
+        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+
+        ModelNode undefineAttribute = createOperation(UNDEFINE_ATTRIBUTE_OPERATION, resourceAddress);
+        undefineAttribute.get(NAME).set(MY_ATTRIBUTE.getName());
+        executeForResult(undefineAttribute);
+
+        assertEquals("the notification handler did not receive the " + ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION, 1, handler.getNotifications().size());
+        Notification notification = handler.getNotifications().get(0);
+        assertEquals(MY_ATTRIBUTE.getName(), notification.getData().require(NAME).asString());
+        assertEquals(initialValue, notification.getData().require(OLD_VALUE).asLong());
+        assertFalse(notification.getData().require(NEW_VALUE).isDefined());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+    }
+
+    @Test
+    public void test_ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION_isSentWhenUndefineAttributeIsCalledOnAnUndefinedAttribute() throws Exception {
+        // MY_ATTRIBUTE is not defined when the resource is created.
+        ModelNode add = createOperation(ADD, resourceAddress);
+        executeForResult(add);
+
+        ListBackedNotificationHandler handler = new ListBackedNotificationHandler();
+        NotificationFilter filter = new TestNotificationHandler(resourceAddress, ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION);
+        getController().getNotificationRegistry().registerNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+
+        ModelNode undefineAttribute = createOperation(UNDEFINE_ATTRIBUTE_OPERATION, resourceAddress);
+        undefineAttribute.get(NAME).set(MY_ATTRIBUTE.getName());
+        executeForResult(undefineAttribute);
+
+        assertTrue("the notification handler unexpectedly receives the " + ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION, handler.getNotifications().isEmpty());
+
+        getController().getNotificationRegistry().unregisterNotificationHandler(RESOURCE_ADDRESS_PATTERN, handler, filter);
+    }
+
+    private static class TestNotificationHandler implements NotificationFilter {
+
+        private final PathAddress expectedAddress;
+        private final String expectedType;
+
+        /**
+         * Filters out notifications so that the handler will handle only those that are from the {@code expectedType}
+         * and emitted from the {@code expectedAddress}.
+         */
+        TestNotificationHandler(PathAddress expectedAddress, String expectedType) {
+
+            this.expectedAddress = expectedAddress;
+            this.expectedType = expectedType;
+        }
+
+        @Override
+        public boolean isNotificationEnabled(Notification notification) {
+            return notification.getSource().equals(expectedAddress) &&
+                    notification.getType().equals(expectedType);
+        }
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
@@ -127,7 +127,6 @@ public abstract class AbstractControllerTestBase {
     public void executeForFailure(ModelNode operation) throws OperationFailedException {
         try {
             executeForResult(operation);
-            Assert.fail("Should have given error");
         } catch (OperationFailedException expected) {
             // ignore
         }

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
@@ -23,6 +23,7 @@ package org.jboss.as.controller.test;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
@@ -32,6 +33,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MOD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATION_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
@@ -46,6 +48,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_OPERATION_NAMES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_ADDED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_REMOVED_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
@@ -74,7 +78,9 @@ import org.jboss.as.controller.ResourceBuilder;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.AttributeAccess.AccessType;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -104,6 +110,8 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
     @Override
     protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
         GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+        GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
+
         rootRegistration.registerOperationHandler(TestUtils.SETUP_OPERATION_DEF, new OperationStepHandler() {
                     @Override
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
@@ -342,17 +350,17 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
             assertFalse(result.get(OPERATIONS).isDefined());
         }
 
-        // TODO WFLY-3603 - add assertions for global notifications
-        /*
         if (notifications) {
             assertTrue(result.require(NOTIFICATIONS).isDefined());
             Set<String> notifs = result.require(NOTIFICATIONS).keys();
             assertEquals(processType == ProcessType.DOMAIN_SERVER ? 2 : 3, notifs.size());
             boolean runtimeOnly = processType != ProcessType.DOMAIN_SERVER;
+            assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+            assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+            assertEquals(runtimeOnly, notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
         } else {
             assertFalse(result.get(NOTIFICATIONS).isDefined());
         }
-        */
 
         if (!recursive) {
             assertFalse(result.require(CHILDREN).require("type1").require(MODEL_DESCRIPTION).isDefined());
@@ -393,6 +401,12 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
             assertTrue(result.require(NOTIFICATIONS).isDefined());
             Set<String> notifs = result.require(NOTIFICATIONS).keys();
             assertEquals(processType == ProcessType.DOMAIN_SERVER ? 2 : 3, notifs.size());
+            assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+            assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+            assertEquals(processType != ProcessType.DOMAIN_SERVER, notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
+            for (String notif : notifs) {
+                assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
+            }
         }
     }
 
@@ -421,6 +435,9 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
             assertTrue(result.require(NOTIFICATIONS).isDefined());
             Set<String> notifs = result.require(NOTIFICATIONS).keys();
             assertEquals(processType == ProcessType.DOMAIN_SERVER ? 2 : 3, notifs.size());
+            assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+            assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+            assertEquals(processType != ProcessType.DOMAIN_SERVER, notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
@@ -23,6 +23,7 @@ package org.jboss.as.controller.test;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
@@ -51,6 +52,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REPLY_PROPERTIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUEST_PROPERTIES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_ADDED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_REMOVED_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
@@ -89,8 +92,10 @@ import org.jboss.as.controller.TestModelControllerService;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.ValidateOperationHandler;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -464,13 +469,13 @@ public abstract class AbstractProxyControllerTest {
         }
 
         if (notifications) {
-            // TODO WFLY-3603 - add assertions for global notifications
-            /*
             Set<String> notifs = result.require(NOTIFICATIONS).keys();
+            assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+            assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+            assertTrue(notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
             for (String notif : notifs) {
                 assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
             }
-            */
         }
 
         ModelNode proxy = result.get(CHILDREN, SERVER, MODEL_DESCRIPTION, "serverA");
@@ -501,13 +506,13 @@ public abstract class AbstractProxyControllerTest {
         }
 
         if (notifications) {
-            // TODO WFLY-3603 - add assertions for global notifications
-            /*
             Set<String> notifs = result.require(NOTIFICATIONS).keys();
+            assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+            assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+            assertTrue(notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
             for (String notif : notifs) {
                 assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
             }
-            */
         }
 
         checkHostChildSubModelDescription(result.get(CHILDREN, "serverchild", MODEL_DESCRIPTION, "*"), operations, notifications);
@@ -543,13 +548,13 @@ public abstract class AbstractProxyControllerTest {
         }
 
         if (notifications) {
-            // TODO WFLY-3603 - add assertions for global notifications
-            /*
             Set<String> notifs = result.require(NOTIFICATIONS).keys();
             for (String notif : notifs) {
                 assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
             }
-            */
+            assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+            assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+            assertTrue(notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
         }
 
         checkHostChildChildSubModelDescription(result.get(CHILDREN, "child", MODEL_DESCRIPTION, "*"), operations, notifications);
@@ -577,17 +582,17 @@ public abstract class AbstractProxyControllerTest {
             }
         }
 
-        // TODO WFLY-3603 - add assertions for global notifications
-        /*
         if (!notifications) {
             assertFalse(result.hasDefined(NOTIFICATIONS));
         } else {
             Set<String> notifs = result.require(NOTIFICATIONS).keys();
+            assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+            assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+            assertTrue(notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
             for (String notif : notifs) {
                 assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
             }
         }
-        */
     }
 
     private void checkRootNode(ModelNode result) {
@@ -632,6 +637,7 @@ public abstract class AbstractProxyControllerTest {
 
         protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+            GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
             rootRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION, ValidateOperationHandler.INSTANCE);
 
             rootRegistration.registerOperationHandler(TestUtils.SETUP_OPERATION_DEF, new OperationStepHandler() {
@@ -663,6 +669,7 @@ public abstract class AbstractProxyControllerTest {
 
         protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+            GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
             rootRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION, ValidateOperationHandler.INSTANCE);
             rootRegistration.registerOperationHandler(createOperationDefinition("Test"),
                     new OperationStepHandler() {

--- a/controller/src/test/java/org/jboss/as/controller/test/DomainServerGlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/DomainServerGlobalOperationsTestCase.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.controller.test;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATION_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
@@ -33,6 +34,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_ADDED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_REMOVED_NOTIFICATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -40,6 +43,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Set;
 
 import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.AttributeAccess.AccessType;
 import org.jboss.dmr.ModelNode;
 import org.junit.Test;
@@ -220,14 +224,15 @@ public class DomainServerGlobalOperationsTestCase extends AbstractGlobalOperatio
         ModelNode result = executeForResult(operation);
         checkRootNodeDescription(result, false, false, true);
 
-        // TODO WFLY-3603 - add assertions for global notifications
-        assertFalse(result.require(NOTIFICATIONS).isDefined());
-        /*
+        assertTrue(result.require(NOTIFICATIONS).isDefined());
         Set<String> notifs = result.require(NOTIFICATIONS).keys();
+        assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+        assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+        // not available on the domain server
+        assertFalse(notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
         for (String notif : notifs) {
             assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
         }
-        */
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         operation.get(NOTIFICATIONS).set(true);

--- a/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsTestCase.java
@@ -22,6 +22,7 @@
 package org.jboss.as.controller.test;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES_ONLY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_DEFAULTS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
@@ -42,6 +43,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUEST_PROPERTIES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_ADDED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_REMOVED_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_ONLY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
@@ -59,6 +62,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
@@ -786,14 +790,14 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
         ModelNode result = executeForResult(operation);
         checkRootNodeDescription(result, false, false, true);
 
-        // TODO WFLY-3603 - add assertions for global notifications
-        /*
         assertTrue(result.require(NOTIFICATIONS).isDefined());
         Set<String> notifs = result.require(NOTIFICATIONS).keys();
+        assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+        assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+        assertTrue(notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
         for (String notif : notifs) {
             assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
         }
-        */
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         operation.get(NOTIFICATIONS).set(true);
         result = executeForResult(operation);
@@ -822,14 +826,15 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
         operation.get(INHERITED).set(false);
         ModelNode result = executeForResult(operation);
         checkRootNodeDescription(result, false, false, true);
-        // TODO WFLY-3603 - add assertions for global notifications
-        /*
+
         assertTrue(result.require(NOTIFICATIONS).isDefined());
         Set<String> notifs = result.require(NOTIFICATIONS).keys();
+        assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+        assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+        assertTrue(notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
         for (String notif : notifs) {
             assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
         }
-        */
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         operation.get(NOTIFICATIONS).set(true);
@@ -846,6 +851,14 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
         ModelNode result = executeForResult(operation);
         checkRootNodeDescription(result, true, false, true);
 
+        assertTrue(result.require(NOTIFICATIONS).isDefined());
+        Set<String> notifs = result.require(NOTIFICATIONS).keys();
+        assertTrue(notifs.contains(RESOURCE_ADDED_NOTIFICATION));
+        assertTrue(notifs.contains(RESOURCE_REMOVED_NOTIFICATION));
+        assertTrue(notifs.contains(ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION));
+        for (String notif : notifs) {
+            assertEquals(notif, result.require(NOTIFICATIONS).require(notif).require(NOTIFICATION_TYPE).asString());
+        }
 
         operation = createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, "profile", "profileA", "subsystem", "subsystem1");
         operation.get(NOTIFICATIONS).set(true);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
@@ -29,6 +29,7 @@ import org.jboss.as.controller.audit.ManagedAuditLogger;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.common.ValidateOperationHandler;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -84,6 +85,8 @@ public class HostModelUtil {
 
         // Global operations
         GlobalOperationHandlers.registerGlobalOperations(root, processType);
+        // Global notifications
+        GlobalNotifications.registerGlobalNotifications(root, processType);
 
         if (root.getOperationEntry(PathAddress.EMPTY_ADDRESS, ValidateOperationHandler.DEFINITION.getName())==null){//this is hack
             root.registerOperationHandler(ValidateOperationHandler.DEFINITION, ValidateOperationHandler.INSTANCE);

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -56,6 +56,7 @@ import org.jboss.as.controller.operations.common.SocketBindingGroupRemoveHandler
 import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
 import org.jboss.as.controller.operations.common.ValidateOperationHandler;
 import org.jboss.as.controller.operations.common.XmlMarshallingHandler;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
@@ -230,6 +231,7 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         GlobalOperationHandlers.registerGlobalOperations(resourceRegistration, ProcessType.STANDALONE_SERVER);
+        GlobalNotifications.registerGlobalNotifications(resourceRegistration, ProcessType.STANDALONE_SERVER);
 
         if (serverEnvironment != null) {
             resourceRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION, ValidateOperationHandler.INSTANCE);

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.model.test.ModelTestModelControllerService;
@@ -89,7 +90,7 @@ class TestModelControllerService extends ModelTestModelControllerService impleme
         //Hack to be able to access the registry for the jmx facade
 
         rootRegistration.registerOperationHandler(RootResourceHack.DEFINITION, RootResourceHack.INSTANCE);
-
+        GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
         extensionRegistry.setSubsystemParentResourceRegistrations(rootRegistration, deployments);
         controllerInitializer.setTestModelControllerAccessor(this);
         controllerInitializer.initializeModel(rootResource, rootRegistration);


### PR DESCRIPTION
- add global notifications for resources:
  - resource-added when a resource is added to the management model
  - resource-removed when a resource is removed from the management
    model
  - attribute-value-written for resources that allow to write
    attributes when an attribute value is successfully changed.
    This notification contains a data set composed of:
    - name - the name of the attribute that has been changed
    - old-value - the value of the attribute before it was changed
    - new-value - the value of the attribute after it was changed

The old-value and new-value are _not_ resolved (an attribute that is
undefined and has a default value will return "undefined" as its
old-value).

JIRA: https://issues.jboss.org/browse/WFLY-3603
