### PR TITLE
[WFLY-3566], don't remove jmx resource in config if proper header is unset

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
@@ -92,7 +92,7 @@ public abstract class AbstractRemoveStepHandler implements OperationStepHandler 
         return context.isNormalServer();
     }
 
-    private List<PathElement> getChildren(Resource resource) {
+    protected List<PathElement> getChildren(Resource resource) {
         final List<PathElement> pes = new ArrayList<PathElement>();
         for (String childType : resource.getChildTypes()) {
             for (Resource.ResourceEntry entry : resource.getChildren(childType)) {

--- a/controller/src/main/java/org/jboss/as/controller/ContainerStateMonitor.java
+++ b/controller/src/main/java/org/jboss/as/controller/ContainerStateMonitor.java
@@ -202,6 +202,16 @@ public final class ContainerStateMonitor extends AbstractServiceListener<Object>
             problems.clear();
         }
 
+        // add previous missing dependencies if they're still missing
+        if (!previousMissing.isEmpty()) {
+            for (ServiceName name : previousMissing)
+                if (!missingServices.entrySet().contains(name)) {
+                    ServiceController<?> controller = serviceRegistry.getService(name);
+                    boolean unavailable = controller != null;
+                    missingServices.put(name, new MissingDependencyInfo(name, unavailable, missingDeps.get(name)));
+                }
+        }
+
         boolean needReport = !missingServices.isEmpty() || !currentFailedControllers.isEmpty() || !noLongerMissingServices.isEmpty();
         return needReport ? new ContainerStateChangeReport(missingServices, currentFailedControllers, noLongerMissingServices) : null;
     }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3216,4 +3216,7 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = 360, value = "The attribute %s value has been changed from %s to %s.")
     String attributeValueWritten(String attributeName, ModelNode currentValue, ModelNode newVal);
+
+    @Message(id = 361, value = "Cannot remove resource without allow-resource-service-start setup")
+    OperationFailedException cannotRemoveResourceWithoutResourceServiceRestartAllowed();
 }

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -21,9 +21,11 @@
 */
 package org.jboss.as.subsystem.test;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
@@ -364,7 +366,10 @@ final class SubsystemTestDelegate {
         composite.get(OP).set(CompositeOperationHandler.NAME);
         composite.get(OP_ADDR).setEmptyList();
         composite.get("rollback-on-runtime-failure").set(true);
-
+        // JMX subsystem remove requires "allow-resource-service-restart"
+        if (mainSubsystemName == "jmx"){
+            composite.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        }
 
         for (ListIterator<PathAddress> iterator = addresses.listIterator(addresses.size()); iterator.hasPrevious(); ) {
             PathAddress cur = iterator.previous();
@@ -375,7 +380,6 @@ final class SubsystemTestDelegate {
                 composite.get("steps").add(remove);
             }
         }
-
 
         kernelServices.executeOperation(composite);
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3566
only perform context.removeResource() if allow-resource-service-restart header is set,  otherwise, it will remove jmx subsystem from configuration file in previous fix, services are missed after a reload operation.

And missingServices is empty since it does not add previousMissing dependencies at the second remove action, this causes the situation mentioned in https://bugzilla.redhat.com/show_bug.cgi?id=1087711 comment 1.
