### PR TITLE
Fix for JAVA_OPTS not being picked up properly in the powershell scripts...

### DIFF
--- a/core-build/src/main/resources/bin/standalone.conf.ps1
+++ b/core-build/src/main/resources/bin/standalone.conf.ps1
@@ -17,6 +17,15 @@
 if( Test-Path env:JAVA_OPTS ) {
   $JAVA_OPTS = Get-Env JAVA_OPTS
   echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
+
+  # This is Powershell, so split the incoming string on a space.
+  $tmpArr = $JAVA_OPTS.split()
+  $JAVA_OPTS = @('')
+  foreach ($str in $tmpArr) {
+    if ($str -ne '') {
+	  $JAVA_OPTS += $str
+	}
+  }
   return
 }
 


### PR DESCRIPTION
Found a bug where-in the PowerShell script is passing in the environment variable as a single argument, which meant that the JVM would not start.

Verified patch locally.
