### PR TITLE
[WFLY-3603] Add global resource notifications

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/WriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/WriteAttributeHandler.java
@@ -25,6 +25,8 @@ package org.jboss.as.controller.operations.global;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.operations.global.GlobalOperationAttributes.NAME;
 import static org.jboss.as.controller.operations.global.GlobalOperationAttributes.VALUE;
 
@@ -39,6 +41,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.notification.Notification;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -70,6 +73,7 @@ public class WriteAttributeHandler implements OperationStepHandler {
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         nameValidator.validate(operation);
         final String attributeName = operation.require(NAME.getName()).asString();
+        final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
         final ImmutableManagementResourceRegistration registry = context.getResourceRegistration();
         if (registry == null) {
             throw new OperationFailedException(ControllerLogger.ROOT_LOGGER.noSuchResourceType(PathAddress.pathAddress(operation.get(OP_ADDR))));
@@ -91,30 +95,86 @@ public class WriteAttributeHandler implements OperationStepHandler {
             }
             AuthorizationResult authorizationResult = context.authorize(operation, attributeName, currentValue);
             if (authorizationResult.getDecision() == AuthorizationResult.Decision.DENY) {
-                throw ControllerLogger.ROOT_LOGGER.unauthorized(operation.require(OP).asString(), PathAddress.pathAddress(operation.get(OP_ADDR)), authorizationResult.getExplanation());
+                throw ControllerLogger.ROOT_LOGGER.unauthorized(operation.require(OP).asString(), address, authorizationResult.getExplanation());
             }
 
-            // clone the current value before the model is modified
-            final ModelNode oldValue = currentValue.clone();
-
-            OperationStepHandler handler = attributeAccess.getWriteHandler();
-            ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(handler.getClass());
-            try {
-                handler.execute(context, operation);
-
-                ModelNode newValue = context.readResource(PathAddress.EMPTY_ADDRESS).getModel().get(attributeName);
-                // only emit a notification if the value has been successfully changed
-                if (!oldValue.equals(newValue)) {
-                    emitAttributeValueWrittenNotification(context, PathAddress.pathAddress(operation.get(OP_ADDR)), attributeName, oldValue, newValue);
+            if (attributeAccess.getStorageType() == AttributeAccess.Storage.CONFIGURATION
+                    && !registry.isRuntimeOnly()) {
+                // if the attribute is stored in the configuration, we can read its
+                // old and new value from the resource's model before and after executing its write handler
+                final ModelNode oldValue = currentValue.clone();
+                OperationStepHandler writeHandler = attributeAccess.getWriteHandler();
+                ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(writeHandler.getClass());
+                try {
+                    writeHandler.execute(context, operation);
+                    ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
+                    ModelNode newValue = model.has(attributeName) ? model.get(attributeName) : new ModelNode();
+                    emitAttributeValueWrittenNotification(context, address, attributeName, oldValue, newValue);
+                } finally {
+                    WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
                 }
+            } else {
+                assert attributeAccess.getStorageType() == AttributeAccess.Storage.RUNTIME;
 
-            } finally {
-                WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
+                // if the attribute is a runtime attribute, its old and new values must
+                // be read using the attribute's read handler and the write operation
+                // must be sandwiched between the 2 calls to the read handler.
+                // Each call to the read handlers will have their own results while
+                // the call to the write handler will use this OSH context result.
+
+                OperationContext.Stage currentStage = context.getCurrentStage();
+
+                final ModelNode readAttributeOperation = Util.createOperation(READ_ATTRIBUTE_OPERATION, address);
+                readAttributeOperation.get(NAME.getName()).set(attributeName);
+                ReadAttributeHandler readAttributeHandler = new ReadAttributeHandler(null, null);
+
+                // create 2 model nodes to store the result of the read-attribute operations
+                // before and after writing the value
+                final ModelNode oldValue = new ModelNode();
+                final ModelNode newValue = new ModelNode();
+
+                // 1st OSH is to read the old value
+                context.addStep(oldValue, readAttributeOperation, readAttributeHandler, currentStage);
+
+                // 2nd OSH is to write the value
+                context.addStep(new OperationStepHandler() {
+                    @Override
+                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                        doExecuteInternal(context, operation, attributeAccess);
+                    }
+                }, currentStage);
+
+                // 3rd OSH is to read the new value
+                context.addStep(newValue, readAttributeOperation, readAttributeHandler, currentStage);
+                // 4th OSH is to emit the notification
+                context.addStep(new OperationStepHandler() {
+                    @Override
+                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                        // aggregate data from the 2 read-attribute operations
+                        emitAttributeValueWrittenNotification(context, address, attributeName, oldValue.get(RESULT), newValue.get(RESULT));
+                        context.stepCompleted();
+                    }
+                }, currentStage);
+
+                context.stepCompleted();
             }
         }
     }
 
+    private void doExecuteInternal(OperationContext context, ModelNode operation, AttributeAccess attributeAccess) throws OperationFailedException {
+        OperationStepHandler writeHandler = attributeAccess.getWriteHandler();
+        ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(writeHandler.getClass());
+        try {
+            writeHandler.execute(context, operation);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
+        }
+    }
     private void emitAttributeValueWrittenNotification(OperationContext context, PathAddress address, String attributeName, ModelNode oldValue, ModelNode newValue) {
+        // only emit a notification if the value has been successfully changed
+        if (oldValue.equals(newValue)) {
+            return;
+        }
         ModelNode data = new ModelNode();
         data.get(NAME.getName()).set(attributeName);
         data.get(GlobalNotifications.OLD_VALUE).set(oldValue);


### PR DESCRIPTION
Runtime attributes does not store their values in the resource models
and their read handler must be called before and after their write
handler to get the old and new value of the attribute.

JIRA: https://issues.jboss.org/browse/WFLY-3603
