### PR TITLE
Added SyslogHandlerResourceDefinition to the set of handlers that are considered when detecting unused handlers

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
@@ -114,6 +114,7 @@ class LoggingSubsystemAdd extends AbstractAddStepHandler {
         subsystemHandlers.addAll(resource.getChildrenNames(FileHandlerResourceDefinition.FILE_HANDLER));
         subsystemHandlers.addAll(resource.getChildrenNames(PeriodicHandlerResourceDefinition.PERIODIC_ROTATING_FILE_HANDLER));
         subsystemHandlers.addAll(resource.getChildrenNames(SizeRotatingHandlerResourceDefinition.SIZE_ROTATING_FILE_HANDLER));
+        subsystemHandlers.addAll(resource.getChildrenNames(SyslogHandlerResourceDefinition.SYSLOG_HANDLER));
 
         // handlers
         final List<String> configuredHandlerNames = logContextConfiguration.getHandlerNames();


### PR DESCRIPTION
This commit fixed issue when setting up an instance of SyslogHandler for logging. This happened because my SyslogHandler was consiedered unused nad it was being closed during startup of servergroup.
