### PR TITLE
[WFLY-3169] Emit local JMX notifications

### DIFF
--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -99,4 +99,20 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- Always fork the JVM used to run the jmx tests as they modify the
+                     PlatformMBeanServer and this must not impact any other tests outside
+                     of this module -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jmx/src/main/java/org/jboss/as/jmx/BlockingNotificationMBeanServer.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/BlockingNotificationMBeanServer.java
@@ -1,0 +1,413 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jmx;
+
+import java.io.ObjectInputStream;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.InvalidAttributeValueException;
+import javax.management.ListenerNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerNotification;
+import javax.management.NotCompliantMBeanException;
+import javax.management.Notification;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.OperationsException;
+import javax.management.QueryExp;
+import javax.management.ReflectionException;
+import javax.management.RuntimeOperationsException;
+import javax.management.loading.ClassLoaderRepository;
+
+import org.jboss.as.jmx.logging.JmxLogger;
+
+/**
+ * MBeanServer wrapper that does <strong>not</strong> forward calls
+ * to add/remove a notification listener for domains exposing WildFly model controllers
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+public class BlockingNotificationMBeanServer implements MBeanServer {
+
+    private MBeanServer mbs;
+    private final String resolvedDomain;
+    private final String expressionsDomain;
+
+    /**
+     * Keep an association between the incoming &lt;name,listener,filter,handback&gt; tuple and a BlockingNotificationFilter
+     * that prevents leaking out WildFly notifications.
+     * The PlatformMBeanServer is checking the object identity when it is removing a notification listener. This association makes
+     * sure we will pass the same {@code BlockingNotificationFilter} to the removeNotificationListener() method that the one passed in the
+     * addNotificationListener().
+     */
+    private final Map<Association, BlockingNotificationFilter> associations = new ConcurrentHashMap<>();
+
+    /**
+     *
+     * @param mbs the JMX MBeanServer (can not be {@code null}
+     * @param resolvedDomain JMX domain name for the 'resolved' model controller (can be {@code null} if the model controller is not exposed)
+     * @param expressionsDomain JMX domain name for the 'expression' model controller (can be {@code null} if the model controller is not exposed)
+     */
+    public BlockingNotificationMBeanServer(MBeanServer mbs, String resolvedDomain, String expressionsDomain) {
+        this.mbs = mbs;
+        this.resolvedDomain = resolvedDomain;
+        this.expressionsDomain = expressionsDomain;
+    }
+
+    @Override
+    public ObjectInstance createMBean(String className, ObjectName name) throws ReflectionException, InstanceAlreadyExistsException, MBeanException, NotCompliantMBeanException {
+        return mbs.createMBean(className, name);
+    }
+
+    @Override
+    public ObjectInstance createMBean(String className, ObjectName name, ObjectName loaderName) throws ReflectionException, InstanceAlreadyExistsException, MBeanException, NotCompliantMBeanException, InstanceNotFoundException {
+        return mbs.createMBean(className, name, loaderName);
+    }
+
+    @Override
+    public ObjectInstance createMBean(String className, ObjectName name, Object[] params, String[] signature) throws ReflectionException, InstanceAlreadyExistsException, MBeanException, NotCompliantMBeanException {
+        return mbs.createMBean(className, name, params, signature);
+    }
+
+    @Override
+    public ObjectInstance createMBean(String className, ObjectName name, ObjectName loaderName, Object[] params, String[] signature) throws ReflectionException, InstanceAlreadyExistsException, MBeanException, NotCompliantMBeanException, InstanceNotFoundException {
+        return mbs.createMBean(className, name, loaderName, params, signature);
+    }
+
+    @Override
+    public ObjectInstance registerMBean(Object object, ObjectName name) throws InstanceAlreadyExistsException, MBeanRegistrationException, NotCompliantMBeanException {
+        return mbs.registerMBean(object, name);
+    }
+
+    @Override
+    public void unregisterMBean(ObjectName name) throws InstanceNotFoundException, MBeanRegistrationException {
+        mbs.unregisterMBean(name);
+    }
+
+    @Override
+    public ObjectInstance getObjectInstance(ObjectName name) throws InstanceNotFoundException {
+        return mbs.getObjectInstance(name);
+    }
+
+    @Override
+    public Set<ObjectInstance> queryMBeans(ObjectName name, QueryExp query) {
+        return mbs.queryMBeans(name, query);
+    }
+
+    @Override
+    public Set<ObjectName> queryNames(ObjectName name, QueryExp query) {
+        return mbs.queryNames(name, query);
+    }
+
+    @Override
+    public boolean isRegistered(ObjectName name) {
+        return mbs.isRegistered(name);
+    }
+
+    @Override
+    public Integer getMBeanCount() {
+        return mbs.getMBeanCount();
+    }
+
+    @Override
+    public Object getAttribute(ObjectName name, String attribute) throws MBeanException, AttributeNotFoundException, InstanceNotFoundException, ReflectionException {
+        return mbs.getAttribute(name, attribute);
+    }
+
+    @Override
+    public AttributeList getAttributes(ObjectName name, String[] attributes) throws InstanceNotFoundException, ReflectionException {
+        return mbs.getAttributes(name, attributes);
+    }
+
+    @Override
+    public void setAttribute(ObjectName name, Attribute attribute) throws InstanceNotFoundException, AttributeNotFoundException, InvalidAttributeValueException, MBeanException, ReflectionException {
+        mbs.setAttribute(name, attribute);
+    }
+
+    @Override
+    public AttributeList setAttributes(ObjectName name, AttributeList attributes) throws InstanceNotFoundException, ReflectionException {
+        return mbs.setAttributes(name, attributes);
+    }
+
+    @Override
+    public Object invoke(ObjectName name, String operationName, Object[] params, String[] signature) throws InstanceNotFoundException, MBeanException, ReflectionException {
+        return mbs.invoke(name, operationName, params, signature);
+    }
+
+    @Override
+    public String getDefaultDomain() {
+        return mbs.getDefaultDomain();
+    }
+
+    @Override
+    public String[] getDomains() {
+        return mbs.getDomains();
+    }
+
+    @Override
+    public void addNotificationListener(ObjectName name, NotificationListener listener, NotificationFilter filter, Object handback) throws InstanceNotFoundException {
+        boolean inExposedModelControllerDomains = isInExposedModelControllerDomains(name);
+
+        if (inExposedModelControllerDomains) {
+            throw new RuntimeOperationsException(JmxLogger.ROOT_LOGGER.addNotificationListenerNotAllowed(name));
+        }
+
+        BlockingNotificationFilter blockingFilter = new BlockingNotificationFilter(filter);
+        associations.put(new Association(name, listener, filter, handback), blockingFilter);
+        mbs.addNotificationListener(name, listener, blockingFilter, handback);
+    }
+
+    @Override
+    public void addNotificationListener(ObjectName name, ObjectName listener, NotificationFilter filter, Object handback) throws InstanceNotFoundException {
+        boolean inExposedModelControllerDomains = isInExposedModelControllerDomains(name);
+
+        if (inExposedModelControllerDomains) {
+            throw new RuntimeOperationsException(JmxLogger.ROOT_LOGGER.addNotificationListenerNotAllowed(name));
+        }
+
+        BlockingNotificationFilter blockingFilter = new BlockingNotificationFilter(filter);
+        associations.put(new Association(name, listener, filter, handback), blockingFilter);
+        mbs.addNotificationListener(name, listener, new BlockingNotificationFilter(filter), handback);
+    }
+
+    @Override
+    public void removeNotificationListener(ObjectName name, ObjectName listener) throws InstanceNotFoundException, ListenerNotFoundException {
+        if (isInExposedModelControllerDomains(name)) {
+            throw new RuntimeOperationsException(JmxLogger.ROOT_LOGGER.removeNotificationListenerNotAllowed(name));
+        }
+        mbs.removeNotificationListener(name, listener);
+    }
+
+    @Override
+    public void removeNotificationListener(ObjectName name, ObjectName listener, NotificationFilter filter, Object handback) throws InstanceNotFoundException, ListenerNotFoundException {
+        if (isInExposedModelControllerDomains(name)) {
+            throw new RuntimeOperationsException(JmxLogger.ROOT_LOGGER.removeNotificationListenerNotAllowed(name));
+        }
+        BlockingNotificationFilter blockingFilter = associations.get(new Association(name, listener, filter, handback));
+        if (blockingFilter != null) {
+            mbs.removeNotificationListener(name, listener, blockingFilter, handback);
+        } else {
+            mbs.removeNotificationListener(name, listener, filter, handback);
+        }
+    }
+
+    @Override
+    public void removeNotificationListener(ObjectName name, NotificationListener listener) throws InstanceNotFoundException, ListenerNotFoundException {
+        if (isInExposedModelControllerDomains(name)) {
+            throw new RuntimeOperationsException(JmxLogger.ROOT_LOGGER.removeNotificationListenerNotAllowed(name));
+        }
+        mbs.removeNotificationListener(name, listener);
+    }
+
+    @Override
+    public void removeNotificationListener(ObjectName name, NotificationListener listener, NotificationFilter filter, Object handback) throws InstanceNotFoundException, ListenerNotFoundException {
+        if (isInExposedModelControllerDomains(name)) {
+            throw new RuntimeOperationsException(JmxLogger.ROOT_LOGGER.removeNotificationListenerNotAllowed(name));
+        }
+        BlockingNotificationFilter blockingFilter = associations.get(new Association(name, listener, filter, handback));
+        if (blockingFilter != null) {
+            mbs.removeNotificationListener(name, listener, blockingFilter, handback);
+        } else {
+            mbs.removeNotificationListener(name, listener, filter, handback);
+        }
+    }
+
+    @Override
+    public MBeanInfo getMBeanInfo(ObjectName name) throws InstanceNotFoundException, IntrospectionException, ReflectionException {
+        return mbs.getMBeanInfo(name);
+    }
+
+    @Override
+    public boolean isInstanceOf(ObjectName name, String className) throws InstanceNotFoundException {
+        return mbs.isInstanceOf(name, className);
+    }
+
+    @Override
+    public Object instantiate(String className) throws ReflectionException, MBeanException {
+        return mbs.instantiate(className);
+    }
+
+    @Override
+    public Object instantiate(String className, ObjectName loaderName) throws ReflectionException, MBeanException, InstanceNotFoundException {
+        return mbs.instantiate(className, loaderName);
+    }
+
+    @Override
+    public Object instantiate(String className, Object[] params, String[] signature) throws ReflectionException, MBeanException {
+        return mbs.instantiate(className, params, signature);
+    }
+
+    @Override
+    public Object instantiate(String className, ObjectName loaderName, Object[] params, String[] signature) throws ReflectionException, MBeanException, InstanceNotFoundException {
+        return mbs.instantiate(className, loaderName, params, signature);
+    }
+
+    @Override
+    public ObjectInputStream deserialize(ObjectName name, byte[] data) throws OperationsException {
+        return mbs.deserialize(name, data);
+    }
+
+    @Override
+    public ObjectInputStream deserialize(String className, byte[] data) throws OperationsException, ReflectionException {
+        return mbs.deserialize(className, data);
+    }
+
+    @Override
+    public ObjectInputStream deserialize(String className, ObjectName loaderName, byte[] data) throws OperationsException, ReflectionException {
+        return mbs.deserialize(className, loaderName, data);
+    }
+
+    @Override
+    public ClassLoader getClassLoaderFor(ObjectName mbeanName) throws InstanceNotFoundException {
+        return mbs.getClassLoaderFor(mbeanName);
+    }
+
+    @Override
+    public ClassLoader getClassLoader(ObjectName loaderName) throws InstanceNotFoundException {
+        return mbs.getClassLoaderFor(loaderName);
+    }
+
+    @Override
+    public ClassLoaderRepository getClassLoaderRepository() {
+        return mbs.getClassLoaderRepository();
+    }
+
+
+    private boolean isInExposedModelControllerDomains(ObjectName name) {
+        String domain = name.getDomain();
+
+        if (!name.isDomainPattern()) {
+            if (domain.equals(resolvedDomain) || domain.equals(expressionsDomain)) {
+                return true;
+            }
+        }
+        Pattern p = Pattern.compile(name.getDomain().replace("*", ".*"));
+        if (p.matcher(resolvedDomain).matches() || p.matcher(expressionsDomain).matches()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Block MBeanServerNotification corresponding to WildFly MBeans.
+     */
+    private class BlockingNotificationFilter implements NotificationFilter {
+        private final NotificationFilter filter;
+
+        private BlockingNotificationFilter(NotificationFilter filter) {
+            this.filter = filter;
+        }
+
+        @Override
+        public boolean isNotificationEnabled(Notification notification) {
+            if (notification instanceof MBeanServerNotification) {
+                MBeanServerNotification notif = (MBeanServerNotification) notification;
+                if (notif.getMBeanName().getDomain().equals(resolvedDomain) ||
+                        notif.getMBeanName().getDomain().equals(expressionsDomain)) {
+                    return false;
+                }
+            }
+            if (filter == null) {
+                return true;
+            } else {
+                return filter.isNotificationEnabled(notification);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            BlockingNotificationFilter that = (BlockingNotificationFilter) o;
+
+            if (filter != null ? !filter.equals(that.filter) : that.filter != null) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return filter != null ? filter.hashCode() : 0;
+        }
+    }
+
+    private static final class Association {
+        private final ObjectName name;
+        private final Object listener;
+        private final NotificationFilter filter;
+        private final Object handback;
+
+        /**
+         * @param name must not be {@code null}
+         * @param listener must not be {@code null}
+         * @param filter can be {@code null}
+         * @param handback can be {@code null}
+         */
+        private Association(ObjectName name, Object listener, NotificationFilter filter, Object handback) {
+            this.name = name;
+            this.filter = filter;
+            this.listener = listener;
+            this.handback = handback;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Association that = (Association) o;
+
+            if (filter != null ? !filter.equals(that.filter) : that.filter != null) return false;
+            if (handback != null ? !handback.equals(that.handback) : that.handback != null) return false;
+            if (!listener.equals(that.listener)) return false;
+            if (!name.equals(that.name)) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name.hashCode();
+            result = 31 * result + listener.hashCode();
+            result = 31 * result + (filter != null ? filter.hashCode() : 0);
+            result = 31 * result + (handback != null ? handback.hashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemAdd.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemAdd.java
@@ -83,7 +83,10 @@ class JMXSubsystemAdd extends AbstractAddStepHandler {
         }
     }
 
-    private static String getDomainName(OperationContext context, ModelNode model, String child) throws OperationFailedException {
+    /**
+     * return {@code null} if the {@code child} model is not exposed in JMX.
+     */
+    static String getDomainName(OperationContext context, ModelNode model, String child) throws OperationFailedException {
         if (!model.hasDefined(CommonAttributes.EXPOSE_MODEL)) {
             return null;
         }

--- a/jmx/src/main/java/org/jboss/as/jmx/PluggableMBeanServerBuilder.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/PluggableMBeanServerBuilder.java
@@ -44,6 +44,6 @@ public class PluggableMBeanServerBuilder extends MBeanServerBuilder {
 
     @Override
     public MBeanServer newMBeanServer(String defaultDomain, MBeanServer outer, MBeanServerDelegate delegate) {
-        return new PluggableMBeanServerImpl(super.newMBeanServer(defaultDomain, outer, delegate));
+        return new PluggableMBeanServerImpl(super.newMBeanServer(defaultDomain, outer, delegate), delegate);
     }
 }

--- a/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorRemove.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorRemove.java
@@ -22,10 +22,13 @@
 
 package org.jboss.as.jmx;
 
+import java.util.ArrayList;
+
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
 
 /**
  * @author Stuart Douglas
@@ -42,7 +45,6 @@ class RemotingConnectorRemove extends AbstractRemoveStepHandler {
     }
 
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        boolean useManagementEndpoint = RemotingConnectorResource.USE_MANAGEMENT_ENDPOINT.resolveModelAttribute(context, model).asBoolean();
-        RemotingConnectorAdd.INSTANCE.launchServices(context, null, null, useManagementEndpoint);
+        RemotingConnectorAdd.INSTANCE.performRuntime(context, operation, model, null, new ArrayList<ServiceController<?>>());
     }
 }

--- a/jmx/src/main/java/org/jboss/as/jmx/logging/JmxLogger.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/logging/JmxLogger.java
@@ -476,4 +476,16 @@ public interface JmxLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 47, value="An error happened unregistering the '%s' MBean registered in a reserved JMX domain")
     void errorUnregisteringMBeanWithBadCalculatedName(@Cause Exception e, ObjectName name);
+
+    @Message(id = 48, value = "Add notification listener using ObjectName %s is not supported")
+    UnsupportedOperationException addNotificationListerWithObjectNameNotSupported(ObjectName listener);
+
+    @Message(id = 49, value = "Remove notification listener using ObjectName %s is not supported")
+    UnsupportedOperationException removeNotificationListerWithObjectNameNotSupported(ObjectName listener);
+
+    @Message(id = 50, value = "Add notification listener using ObjectName %s is not supported")
+    UnsupportedOperationException addNotificationListenerNotAllowed(ObjectName name);
+
+    @Message(id = 51, value = "Remove notification listener using ObjectName %s is not supported")
+    UnsupportedOperationException removeNotificationListenerNotAllowed(ObjectName name);
 }

--- a/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
@@ -55,12 +55,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.management.AttributeChangeNotification;
 import javax.management.Descriptor;
 import javax.management.ImmutableDescriptor;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanInfo;
 import javax.management.MBeanNotificationInfo;
 import javax.management.MBeanOperationInfo;
+import javax.management.Notification;
 import javax.management.ObjectName;
 import javax.management.openmbean.OpenMBeanAttributeInfo;
 import javax.management.openmbean.OpenMBeanAttributeInfoSupport;
@@ -77,10 +79,12 @@ import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.AttributeAccess.AccessType;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.NotificationEntry;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.as.jmx.logging.JmxLogger;
@@ -342,8 +346,25 @@ public class MBeanInfoFactory {
     }
 
     private MBeanNotificationInfo[] getNotifications() {
-        //TODO handle notifications?
-        return null;
+        List<MBeanNotificationInfo> notifications = new ArrayList<>();
+        for (Map.Entry<String, NotificationEntry> entry : resourceRegistration.getNotificationDescriptions(PathAddress.EMPTY_ADDRESS, true).entrySet()) {
+            ModelNode descriptionModel = entry.getValue().getDescriptionProvider().getModelDescription(null);
+            String description = descriptionModel.get(DESCRIPTION).asString();
+            String notificationType = entry.getKey();
+            MBeanNotificationInfo info = null;
+            if (notificationType.equals(ModelDescriptionConstants.ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION)) {
+                info = new MBeanNotificationInfo(new String[]{AttributeChangeNotification.ATTRIBUTE_CHANGE}, AttributeChangeNotification.class.getName(), description);
+            } else if (notificationType.equals(ModelDescriptionConstants.RESOURCE_ADDED_NOTIFICATION)
+                    || notificationType.equals(ModelDescriptionConstants.RESOURCE_REMOVED_NOTIFICATION)) {
+                // do not expose these notifications as they are emitted by the JMImplementation:type=MBeanServerDelegate MBean.
+            } else {
+                info = new MBeanNotificationInfo(new String[]{notificationType}, Notification.class.getName(), description);
+            }
+            if (info != null) {
+                notifications.add(info);
+            }
+        }
+        return notifications.toArray(new MBeanNotificationInfo[notifications.size()]);
     }
 
     private Descriptor createMBeanDescriptor() {

--- a/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanHelper.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanHelper.java
@@ -180,6 +180,17 @@ public class ModelControllerMBeanHelper {
         return ObjectNameAddressUtil.resolvePathAddress(domain, reg.getResource(), name);
     }
 
+    /**
+     * Convert an ObjectName to a PathAddress.
+     *
+     * Patterns are supported: there may not be a resource at the returned PathAddress but a resource model <strong>MUST</strong>
+     * must be registered.
+     */
+
+    PathAddress toPathAddress(final ObjectName name) {
+        return ObjectNameAddressUtil.toPathAddress(domain, getRootResourceAndRegistration().getRegistration(), name);
+    }
+
     MBeanInfo getMBeanInfo(final ObjectName name) throws InstanceNotFoundException {
         final ResourceAndRegistration reg = getRootResourceAndRegistration();
         final PathAddress address = resolvePathAddress(name, reg);
@@ -511,6 +522,20 @@ public class ModelControllerMBeanHelper {
         } catch (MalformedObjectNameException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    String getDomain() {
+        return domain;
+    }
+
+    ImmutableManagementResourceRegistration getMBeanRegistration(ObjectName name) throws InstanceNotFoundException {
+        final ResourceAndRegistration reg = getRootResourceAndRegistration();
+        final PathAddress address = resolvePathAddress(name, reg);
+        return getMBeanRegistration(address, reg);
+    }
+
+    TypeConverters getConverters() {
+        return converters;
     }
 
     private abstract class ObjectNameMatchResourceAction<T> implements ResourceAction<T> {

--- a/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanServerPlugin.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanServerPlugin.java
@@ -21,11 +21,16 @@
 */
 package org.jboss.as.jmx.model;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_ADDED_NOTIFICATION;
+
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
 import javax.management.Attribute;
+import javax.management.AttributeChangeNotification;
 import javax.management.AttributeList;
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
@@ -34,16 +39,27 @@ import javax.management.InvalidAttributeValueException;
 import javax.management.ListenerNotFoundException;
 import javax.management.MBeanException;
 import javax.management.MBeanInfo;
-import javax.management.NotificationFilter;
+import javax.management.MBeanServerDelegate;
+import javax.management.MBeanServerNotification;
+import javax.management.NotificationBroadcaster;
 import javax.management.NotificationListener;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 import javax.management.QueryExp;
 import javax.management.ReflectionException;
+import javax.management.RuntimeOperationsException;
 
 import org.jboss.as.controller.ModelController;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.notification.Notification;
+import org.jboss.as.controller.notification.NotificationFilter;
+import org.jboss.as.controller.notification.NotificationHandler;
+import org.jboss.as.controller.notification.NotificationRegistry;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.jmx.BaseMBeanServerPlugin;
 import org.jboss.as.jmx.logging.JmxLogger;
+import org.jboss.dmr.ModelNode;
 
 /**
  * An MBeanServer wrapper that exposes the ModelController via JMX.
@@ -55,17 +71,32 @@ public class ModelControllerMBeanServerPlugin extends BaseMBeanServerPlugin {
     private final ConfiguredDomains configuredDomains;
     private final ModelControllerMBeanHelper legacyHelper;
     private final ModelControllerMBeanHelper exprHelper;
+    private final NotificationRegistry notificationRegistry;
+    private final AtomicLong notificationSequenceNumber = new AtomicLong(0);
 
-    public ModelControllerMBeanServerPlugin(ConfiguredDomains configuredDomains, ModelController controller,
+    public ModelControllerMBeanServerPlugin(final ConfiguredDomains configuredDomains, ModelController controller, final MBeanServerDelegate delegate,
                                             boolean legacyWithProperPropertyFormat, boolean forStandalone) {
         assert configuredDomains != null;
         this.configuredDomains = configuredDomains;
+        this.notificationRegistry = controller.getNotificationRegistry();
+
         legacyHelper = configuredDomains.getLegacyDomain() != null ?
                 new ModelControllerMBeanHelper(TypeConverters.createLegacyTypeConverters(legacyWithProperPropertyFormat),
                         configuredDomains, configuredDomains.getLegacyDomain(), controller, forStandalone) : null;
         exprHelper = configuredDomains.getExprDomain() != null ?
                 new ModelControllerMBeanHelper(TypeConverters.createExpressionTypeConverters(), configuredDomains,
                         configuredDomains.getExprDomain(), controller, forStandalone) : null;
+
+        // JMX notifications for MBean registration/unregistration are emitted by the MBeanServerDelegate and not by the
+        // MBeans itself. If we have a reference on the delegate, we add a listener for any WildFly resource address
+        // that converts the resource-added and resource-removed notifications to MBeanServerNotification and send them
+        // through the delegate.
+        if (delegate != null) {
+            for (String domain : configuredDomains.getDomains()) {
+                ResourceRegistrationNotificationHandler handler = new ResourceRegistrationNotificationHandler(delegate, domain);
+                notificationRegistry.registerNotificationHandler(NotificationRegistry.ANY_ADDRESS, handler, handler);
+            }
+        }
     }
 
     @Override
@@ -107,7 +138,7 @@ public class ModelControllerMBeanServerPlugin extends BaseMBeanServerPlugin {
     }
 
     public ClassLoader getClassLoaderFor(ObjectName mbeanName) throws InstanceNotFoundException {
-        if (getHelper(mbeanName).resolvePathAddress(mbeanName) != null) {
+        if (getHelper(mbeanName).toPathAddress(mbeanName) != null) {
             return SecurityActions.getClassLoader(this.getClass());
         }
         throw JmxLogger.ROOT_LOGGER.mbeanNotFound(mbeanName);
@@ -142,6 +173,11 @@ public class ModelControllerMBeanServerPlugin extends BaseMBeanServerPlugin {
     }
 
     public boolean isInstanceOf(ObjectName name, String className) throws InstanceNotFoundException {
+        // return true for NotificationBroadcaster so that client connected to the MBeanServer know
+        // that it can broadcast notifications.
+        if (NotificationBroadcaster.class.getName().equals(className)) {
+            return true;
+        }
         return false;
     }
 
@@ -188,33 +224,37 @@ public class ModelControllerMBeanServerPlugin extends BaseMBeanServerPlugin {
         return getHelper(name).setAttributes(name, attributes);
     }
 
-    public void addNotificationListener(ObjectName name, NotificationListener listener, NotificationFilter filter, Object handback)
+    public void addNotificationListener(final ObjectName name, final NotificationListener listener, final javax.management.NotificationFilter filter, final Object handback)
             throws InstanceNotFoundException {
-        //TODO handle notifications in model?
+        PathAddress pathAddress = getHelper(name).toPathAddress(name);
+        JMXNotificationHandler handler = new JMXNotificationHandler(getHelper(name).getDomain(), name, listener, filter, handback);
+        notificationRegistry.registerNotificationHandler(pathAddress, handler, handler);
     }
 
-    public void addNotificationListener(ObjectName name, ObjectName listener, NotificationFilter filter, Object handback)
+    public void addNotificationListener(ObjectName name, ObjectName listener, javax.management.NotificationFilter filter, Object handback)
             throws InstanceNotFoundException {
-        //TODO handle notifications in model?
+        throw new RuntimeOperationsException(JmxLogger.ROOT_LOGGER.addNotificationListerWithObjectNameNotSupported(listener));
     }
 
-    public void removeNotificationListener(ObjectName name, NotificationListener listener, NotificationFilter filter, Object handback)
+    public void removeNotificationListener(ObjectName name, NotificationListener listener, javax.management.NotificationFilter filter, Object handback)
             throws InstanceNotFoundException, ListenerNotFoundException {
-        //TODO handle notifications in model?
+        PathAddress pathAddress = getHelper(name).toPathAddress(name);
+        JMXNotificationHandler handler = new JMXNotificationHandler(getHelper(name).getDomain(), name, listener, filter, handback);
+        notificationRegistry.unregisterNotificationHandler(pathAddress, handler, handler);
     }
 
     public void removeNotificationListener(ObjectName name, NotificationListener listener) throws InstanceNotFoundException,
             ListenerNotFoundException {
-        //TODO handle notifications in model?
+        removeNotificationListener(name, listener, null, null);
     }
 
-    public void removeNotificationListener(ObjectName name, ObjectName listener, NotificationFilter filter, Object handback)
+    public void removeNotificationListener(ObjectName name, ObjectName listener, javax.management.NotificationFilter filter, Object handback)
             throws InstanceNotFoundException, ListenerNotFoundException {
-        //TODO handle notifications in model?
+        throw new RuntimeOperationsException(JmxLogger.ROOT_LOGGER.removeNotificationListerWithObjectNameNotSupported(listener));
     }
 
     public void removeNotificationListener(ObjectName name, ObjectName listener) throws InstanceNotFoundException, ListenerNotFoundException {
-        //TODO handle notifications in model?
+        throw new RuntimeOperationsException(JmxLogger.ROOT_LOGGER.removeNotificationListerWithObjectNameNotSupported(listener));
     }
 
     private ModelControllerMBeanHelper getHelper(ObjectName name) {
@@ -227,5 +267,145 @@ public class ModelControllerMBeanServerPlugin extends BaseMBeanServerPlugin {
         }
         //This should not happen
         throw JmxLogger.ROOT_LOGGER.unknownDomain(domain);
+    }
+
+    /**
+     * Handle WildFly notifications, convert them to JMX notifications and forward them to the JMX listener.
+     */
+    private class JMXNotificationHandler implements NotificationHandler, NotificationFilter {
+
+        private final String domain;
+        private final ObjectName name;
+        private final NotificationListener listener;
+        private final javax.management.NotificationFilter filter;
+        private final Object handback;
+
+        private JMXNotificationHandler(String domain, ObjectName name, NotificationListener listener, javax.management.NotificationFilter filter, Object handback) {
+            this.domain = domain;
+            this.name = name;
+            this.listener = listener;
+            this.filter = filter;
+            this.handback = handback;
+        }
+
+        @Override
+        public boolean isNotificationEnabled(Notification notification) {
+            if (isResourceAddedOrRemovedNotification(notification)) {
+                // filter outs resource-added and resource-removed notifications that are handled by the
+                // MBeanServerDelegate
+                return false;
+            }
+
+            if (filter == null) {
+                return true;
+            } else {
+                javax.management.Notification jmxNotification = convert(notification);
+                return filter.isNotificationEnabled(jmxNotification);
+            }
+        }
+
+        @Override
+        public void handleNotification(Notification notification) {
+            javax.management.Notification jmxNotification = convert(notification);
+            if (jmxNotification != null) {
+            listener.handleNotification(jmxNotification, handback);
+            }
+        }
+
+        private javax.management.Notification convert(Notification notification) {
+            long sequenceNumber = notificationSequenceNumber.incrementAndGet();
+            ObjectName source = ObjectNameAddressUtil.createObjectName(domain, notification.getSource());
+            String message = notification.getMessage();
+            long timestamp = notification.getTimestamp();
+            String notificationType = notification.getType();
+            javax.management.Notification jmxNotification;
+            if (notificationType.equals(ModelDescriptionConstants.ATTRIBUTE_VALUE_WRITTEN_NOTIFICATION)) {
+                ModelNode data = notification.getData();
+                String attributeName = data.get(ModelDescriptionConstants.NAME).asString();
+                String jmxAttributeName = NameConverter.convertToCamelCase(attributeName);
+                try {
+                    ModelNode modelDescription = getHelper(source).getMBeanRegistration(source).getModelDescription(PathAddress.EMPTY_ADDRESS).getModelDescription(null);
+                    ModelNode attributeDescription = modelDescription.get(ATTRIBUTES, attributeName);
+                    TypeConverters converters = getHelper(source).getConverters();
+                    Object oldValue = converters.fromModelNode(attributeDescription, data.get(GlobalNotifications.OLD_VALUE));
+                    Object newValue = converters.fromModelNode(attributeDescription, data.get(GlobalNotifications.NEW_VALUE));
+                    String attributeType = converters.convertToMBeanType(attributeDescription).getTypeName();
+                    jmxNotification = new AttributeChangeNotification(source, sequenceNumber, timestamp, message, jmxAttributeName, attributeType, oldValue, newValue);
+
+                } catch (InstanceNotFoundException e) {
+                    // fallback to a generic notification
+                    jmxNotification = new javax.management.Notification(notification.getType(), source, sequenceNumber, timestamp, message);
+
+                }
+            } else if (notificationType.equals(ModelDescriptionConstants.RESOURCE_ADDED_NOTIFICATION) ||
+                notificationType.equals(ModelDescriptionConstants.RESOURCE_REMOVED_NOTIFICATION)) {
+                // do not convert resource-added and resource-removed notifications: for JMX, they are not emitted by the MBean itself
+                // but by the MBeanServerDelegate (see ModelControllerMBeanServerPlugin constructor)
+                jmxNotification = null;
+            } else {
+                jmxNotification = new javax.management.Notification(notificationType, source, sequenceNumber, timestamp, message);
+                jmxNotification.setUserData(notification.getData());
+            }
+            return jmxNotification;
+        }
+
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            JMXNotificationHandler that = (JMXNotificationHandler) o;
+
+            if (filter != null ? !filter.equals(that.filter) : that.filter != null) return false;
+            if (handback != null ? !handback.equals(that.handback) : that.handback != null) return false;
+            if (!listener.equals(that.listener)) return false;
+            if (!name.equals(that.name)) return false;
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name.hashCode();
+            result = 31 * result + listener.hashCode();
+            result = 31 * result + (filter != null ? filter.hashCode() : 0);
+            result = 31 * result + (handback != null ? handback.hashCode() : 0);
+            return result;
+        }
+    }
+
+    /**
+     * Handle resource-added and resource-removed notifications that are converted to MBeanServerNotifcations
+     * emitted by the MBeanServerDelegate
+     */
+    private static class ResourceRegistrationNotificationHandler implements NotificationHandler, NotificationFilter {
+
+        private final MBeanServerDelegate delegate;
+        private final String domain;
+        private AtomicLong sequence = new AtomicLong(0);
+
+        private ResourceRegistrationNotificationHandler(MBeanServerDelegate delegate, String domain) {
+            this.delegate = delegate;
+            this.domain = domain;
+        }
+
+        @Override
+        public void handleNotification(Notification notification) {
+            String jmxType = notification.getType().equals(RESOURCE_ADDED_NOTIFICATION) ? MBeanServerNotification.REGISTRATION_NOTIFICATION : MBeanServerNotification.UNREGISTRATION_NOTIFICATION;
+            ObjectName mbeanName = ObjectNameAddressUtil.createObjectName(domain, notification.getSource());
+            javax.management.Notification jmxNotification = new MBeanServerNotification(jmxType, MBeanServerDelegate.DELEGATE_NAME, sequence.incrementAndGet(), mbeanName);
+            delegate.sendNotification(jmxNotification);
+        }
+
+        @Override
+        public boolean isNotificationEnabled(Notification notification) {
+            return isResourceAddedOrRemovedNotification(notification);
+        }
+    }
+
+    private static boolean isResourceAddedOrRemovedNotification(Notification notification) {
+        return notification.getType().equals(RESOURCE_ADDED_NOTIFICATION) ||
+                notification.getType().equals(ModelDescriptionConstants.RESOURCE_REMOVED_NOTIFICATION);
     }
 }

--- a/jmx/src/main/java/org/jboss/as/jmx/model/ObjectNameAddressUtil.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/ObjectNameAddressUtil.java
@@ -32,6 +32,7 @@ import javax.management.ObjectName;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.jmx.logging.JmxLogger;
 
@@ -114,6 +115,44 @@ class ObjectNameAddressUtil {
                 Map<String, String> childProps = new HashMap<String, String>(properties);
                 childProps.remove(entry.getKey());
                 PathAddress foundAddr = searchPathAddress(address.append(childElement), child, childProps);
+                if (foundAddr != null) {
+                    return foundAddr;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Straight conversion from an ObjectName to a PathAddress.
+     *
+     * There may not necessary be a Resource at this path address (if that correspond to a pattern) but it must
+     * match a model in the registry.
+     */
+    static PathAddress toPathAddress(String domain, ImmutableManagementResourceRegistration registry, ObjectName name) {
+        if (!name.getDomain().equals(domain)) {
+            return PathAddress.EMPTY_ADDRESS;
+        }
+        if (name.equals(ModelControllerMBeanHelper.createRootObjectName(domain))) {
+            return PathAddress.EMPTY_ADDRESS;
+        }
+        final Hashtable<String, String> properties = name.getKeyPropertyList();
+        return searchPathAddress(PathAddress.EMPTY_ADDRESS, registry, properties);
+    }
+
+    private static PathAddress searchPathAddress(PathAddress address, ImmutableManagementResourceRegistration registry, Map<String, String> properties) {
+        if (properties.size() == 0) {
+            return address;
+        }
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            PathAddress childAddress = PathAddress.pathAddress(
+                    replaceEscapedCharactersInKey(entry.getKey()),
+                    replaceEscapedCharactersInValue(entry.getValue()));
+            ImmutableManagementResourceRegistration subModel = registry.getSubModel(address);
+            if (subModel != null) {
+                Map<String, String> childProps = new HashMap<String, String>(properties);
+                childProps.remove(entry.getKey());
+                PathAddress foundAddr = searchPathAddress(address.append(childAddress), subModel, childProps);
                 if (foundAddr != null) {
                     return foundAddr;
                 }

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -23,6 +23,8 @@ package org.jboss.as.jmx;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -34,17 +36,30 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
 import javax.management.Attribute;
+import javax.management.AttributeChangeNotification;
 import javax.management.AttributeList;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
+import javax.management.MBeanNotificationInfo;
 import javax.management.MBeanOperationInfo;
 import javax.management.MBeanParameterInfo;
+import javax.management.MBeanServer;
 import javax.management.MBeanServerConnection;
+import javax.management.MBeanServerDelegate;
+import javax.management.MBeanServerNotification;
 import javax.management.MalformedObjectNameException;
+import javax.management.Notification;
+import javax.management.NotificationFilterSupport;
+import javax.management.NotificationListener;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
+import javax.management.RuntimeOperationsException;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.CompositeDataSupport;
 import javax.management.openmbean.CompositeType;
@@ -57,6 +72,8 @@ import javax.management.openmbean.TabularData;
 import javax.management.openmbean.TabularType;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXConnectorServer;
+import javax.management.remote.JMXConnectorServerFactory;
 import javax.management.remote.JMXServiceURL;
 
 import org.jboss.as.controller.Extension;
@@ -74,17 +91,27 @@ import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
+import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.staxmapper.XMLMapper;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xnio.IoUtils;
 import org.xnio.OptionMap;
 
 /**
+ *
+ * This test modifies the {@link java.lang.management.ManagementFactory#getPlatformMBeanServer()} by setting the
+ * @{code javax.management.builder.initial} system property.
+ *
+ * The jmx module runs its test target in Maven by always forking the JVM (and not reuse one) to ensure that the
+ * platform mbean server is not modified outside of this test case.
+ *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
@@ -111,6 +138,11 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
 
     public ModelControllerMBeanTestCase() {
         super(JMXExtension.SUBSYSTEM_NAME, new JMXExtension());
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        System.setProperty("javax.management.builder.initial", PluggableMBeanServerBuilder.class.getName());
     }
 
     @After
@@ -269,6 +301,21 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         checkComplexTypeInfo(assertCast(CompositeType.class, op.getReturnOpenType()), false, "complex.");
         Assert.assertEquals(1, op.getSignature().length);
         checkComplexTypeInfo(assertCast(CompositeType.class, assertCast(OpenMBeanParameterInfo.class, op.getSignature()[0]).getOpenType()), false, "param1.");
+
+        MBeanNotificationInfo[] notifications = info.getNotifications();
+        Set<String> notificationTypes = getNotificationTypes(notifications);
+        Assert.assertEquals(1, notificationTypes.size());
+        Assert.assertTrue(notificationTypes.contains(AttributeChangeNotification.ATTRIBUTE_CHANGE));
+    }
+
+    private Set<String> getNotificationTypes(MBeanNotificationInfo[] notifications) {
+        Set<String> notificationTypes = new HashSet<String>();
+        for (MBeanNotificationInfo notification : notifications) {
+            for (String notificationType : notification.getNotifTypes()) {
+                    notificationTypes.add(notificationType);
+            }
+        }
+        return notificationTypes;
     }
 
     @Test
@@ -1068,6 +1115,236 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
 
     }
 
+    @Test
+    public void testAttributeChangeNotificationUsingMSc() throws Exception {
+        KernelServices kernelServices = setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new TestExtension()));
+        ServiceController<?> service = kernelServices.getContainer().getService(MBeanServerService.SERVICE_NAME);
+        MBeanServer mbeanServer = MBeanServer.class.cast(service.getValue());
+
+        doTestAttributeChangeNotification(mbeanServer, true);
+    }
+
+    @Test
+    public void testAttributeChangeNotificationUsingManagementFactory() throws Exception {
+        setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new TestExtension()));
+        MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+
+        doTestAttributeChangeNotification(mbeanServer, true);
+    }
+
+    @Test
+    public void testAttributeChangeNotificationUsingRemoteJMXConnector() throws Exception {
+        setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new TestExtension()));
+
+        JMXConnectorServer connectorServer = startLocalConnectorServer(ManagementFactory.getPlatformMBeanServer());
+        JMXConnector connector = JMXConnectorFactory.connect(connectorServer.getAddress());
+
+        try {
+            doTestAttributeChangeNotification(connector.getMBeanServerConnection(), true);
+        } finally {
+            connector.close();
+            connectorServer.stop();
+        }
+    }
+
+    @Test
+    public void testAttributeChangeNotificationUsingRemotingConnector() throws Exception {
+        MBeanServerConnection connection = setupAndGetConnection(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new TestExtension()));
+
+        doTestAttributeChangeNotification(connection, false);
+    }
+
+    private void doTestAttributeChangeNotification(MBeanServerConnection connection, boolean notificationListenerOperationsMustSucceed) throws Exception {
+        ObjectName name = createObjectName(LEGACY_DOMAIN + ":subsystem=test");
+
+        final CountDownLatch notificationEmitted = new CountDownLatch(1);
+        final AtomicReference<Notification> notification = new AtomicReference<>();
+        NotificationListener listener = new NotificationListener() {
+            @Override
+            public void handleNotification(javax.management.Notification notif, Object handback) {
+                notification.set(notif);
+                notificationEmitted.countDown();
+
+            }
+        };
+        NotificationFilterSupport filter = new NotificationFilterSupport();
+        filter.enableType(AttributeChangeNotification.ATTRIBUTE_CHANGE);
+
+        try {
+            connection.addNotificationListener(name, listener, filter, null);
+            if (!notificationListenerOperationsMustSucceed) {
+                Assert.fail("Adding the notification listener must fail");
+            }
+        } catch (RuntimeOperationsException e) {
+            if (notificationListenerOperationsMustSucceed) {
+                Assert.fail("Unexpected exception when adding the notification listener");
+            } else {
+                RuntimeException exception = e.getTargetException();
+                Assert.assertTrue(exception instanceof UnsupportedOperationException);
+            }
+        }
+
+        connection.setAttribute(name, new Attribute("int", 102));
+
+        if (notificationListenerOperationsMustSucceed) {
+            Assert.assertTrue("Did not receive expected notification", notificationEmitted.await(1, TimeUnit.SECONDS));
+            Notification notif = notification.get();
+            Assert.assertTrue(notif instanceof AttributeChangeNotification);
+            AttributeChangeNotification attributeChangeNotification = (AttributeChangeNotification) notif;
+            Assert.assertEquals(AttributeChangeNotification.ATTRIBUTE_CHANGE, attributeChangeNotification.getType());
+            Assert.assertEquals(name, attributeChangeNotification.getSource());
+            Assert.assertEquals(Integer.class.getName(), attributeChangeNotification.getAttributeType());
+            Assert.assertEquals("int", attributeChangeNotification.getAttributeName());
+            Assert.assertEquals(2, attributeChangeNotification.getOldValue());
+            Assert.assertEquals(102, attributeChangeNotification.getNewValue());
+        } else {
+            Assert.assertFalse("Did receive unexpected notification", notificationEmitted.await(500, TimeUnit.MILLISECONDS));
+        }
+
+        connection.removeNotificationListener(name, listener, filter, null);
+    }
+
+    @Test
+    public void testMBeanServerNotification_REGISTRATION_NOTIFICATIONUsingMsc() throws Exception {
+        KernelServices kernelServices = setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new SubystemWithSingleFixedChildExtension()));
+        ServiceController<?> service = kernelServices.getContainer().getService(MBeanServerService.SERVICE_NAME);
+        MBeanServer mbeanServer = MBeanServer.class.cast(service.getValue());
+
+        doTestMBeanServerNotification_REGISTRATION_NOTIFICATION(mbeanServer, true);
+    }
+
+    @Test
+    public void testMBeanServerNotification_REGISTRATION_NOTIFICATIONUsingManagementFactory() throws Exception {
+        setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new SubystemWithSingleFixedChildExtension()));
+        MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+
+        doTestMBeanServerNotification_REGISTRATION_NOTIFICATION(mbeanServer, true);
+    }
+
+    @Test
+    public void testMBeanServerNotification_REGISTRATION_NOTIFICATIONUsingRemotingConnector() throws Exception {
+        MBeanServerConnection connection = setupAndGetConnection(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new SubystemWithSingleFixedChildExtension()));
+
+        doTestMBeanServerNotification_REGISTRATION_NOTIFICATION(connection, false);
+    }
+
+    @Test
+    public void testMBeanServerNotification_REGISTRATION_NOTIFICATIONUsingRemoteJMXConnector() throws Exception {
+        setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new SubystemWithSingleFixedChildExtension()));
+
+        JMXConnectorServer connectorServer = startLocalConnectorServer(ManagementFactory.getPlatformMBeanServer());
+        JMXConnector connector = JMXConnectorFactory.connect(connectorServer.getAddress());
+
+        try {
+            doTestMBeanServerNotification_REGISTRATION_NOTIFICATION(connector.getMBeanServerConnection(), true);
+        } finally {
+            connector.close();
+            connectorServer.stop();
+        }
+    }
+
+    public void doTestMBeanServerNotification_REGISTRATION_NOTIFICATION(MBeanServerConnection connection, boolean mustReceiveNotification) throws Exception {
+        final ObjectName testObjectName = createObjectName(LEGACY_DOMAIN + ":subsystem=test");
+        final ObjectName childObjectName = createObjectName(LEGACY_DOMAIN + ":subsystem=test,single=only");
+
+        final CountDownLatch notificationEmitted = new CountDownLatch(1);
+        final AtomicReference<Notification> notification = new AtomicReference<>();
+        NotificationListener listener = new MbeanServerNotificationListener(notification, notificationEmitted, LEGACY_DOMAIN);
+        NotificationFilterSupport filter = new NotificationFilterSupport();
+        filter.enableType(MBeanServerNotification.REGISTRATION_NOTIFICATION);
+
+        connection.addNotificationListener(MBeanServerDelegate.DELEGATE_NAME, listener, filter, null);
+
+        // add a management resource
+        connection.invoke(testObjectName, "addSingleOnly", new Object[]{123}, new String[]{String.class.getName()});
+
+        if (mustReceiveNotification) {
+            Assert.assertTrue("Did not receive expected notification", notificationEmitted.await(1, TimeUnit.SECONDS));
+            Notification notif = notification.get();
+            Assert.assertNotNull(notif);
+            Assert.assertTrue(notif instanceof MBeanServerNotification);
+            MBeanServerNotification mBeanServerNotification = (MBeanServerNotification) notif;
+            Assert.assertEquals(MBeanServerNotification.REGISTRATION_NOTIFICATION, notif.getType());
+            Assert.assertEquals(childObjectName, mBeanServerNotification.getMBeanName());
+        } else {
+            Assert.assertFalse("Did receive unexpected notification", notificationEmitted.await(500, TimeUnit.MILLISECONDS));
+        }
+
+        connection.removeNotificationListener(MBeanServerDelegate.DELEGATE_NAME, listener, filter, null);
+    }
+
+    @Test
+    public void testMBeanServerNotification_UNREGISTRATION_NOTIFICATIONUsingMsc() throws Exception {
+        KernelServices kernelServices = setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new SubystemWithSingleFixedChildExtension()));
+        ServiceController<?> service = kernelServices.getContainer().getService(MBeanServerService.SERVICE_NAME);
+        MBeanServer mBeanServer = MBeanServer.class.cast(service.getValue());
+
+        doTestMBeanServerNotification_UNREGISTRATION_NOTIFICATION(mBeanServer, true);
+    }
+
+    @Test
+    public void testMBeanServerNotification_UNREGISTRATION_NOTIFICATIONUsingManagementFactory() throws Exception {
+        setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new SubystemWithSingleFixedChildExtension()));
+        MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+
+        doTestMBeanServerNotification_UNREGISTRATION_NOTIFICATION(mbeanServer, true);
+    }
+
+    @Test
+    public void testMBeanServerNotification_UNREGISTRATION_NOTIFICATIONUsingRemotingConnector() throws Exception {
+        MBeanServerConnection connection = setupAndGetConnection(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new SubystemWithSingleFixedChildExtension()));
+
+        doTestMBeanServerNotification_UNREGISTRATION_NOTIFICATION(connection, false);
+    }
+
+    @Test
+    public void testMBeanServerNotification_UNREGISTRATION_NOTIFICATIONUsingRemoteJMXConnector() throws Exception {
+        setup(new MBeanInfoAdditionalInitialization(ProcessType.STANDALONE_SERVER, new SubystemWithSingleFixedChildExtension()));
+
+        JMXConnectorServer connectorServer = startLocalConnectorServer(ManagementFactory.getPlatformMBeanServer());
+        JMXConnector connector = JMXConnectorFactory.connect(connectorServer.getAddress());
+
+        try {
+            doTestMBeanServerNotification_UNREGISTRATION_NOTIFICATION(connector.getMBeanServerConnection(), true);
+        } finally {
+            connector.close();
+            connectorServer.stop();
+        }
+    }
+
+    private void doTestMBeanServerNotification_UNREGISTRATION_NOTIFICATION(MBeanServerConnection connection, boolean mustReceiveNotification) throws Exception {
+        final ObjectName testObjectName = createObjectName(LEGACY_DOMAIN + ":subsystem=test");
+        final ObjectName childObjectName = createObjectName(LEGACY_DOMAIN + ":subsystem=test,single=only");
+
+        final CountDownLatch notificationEmitted = new CountDownLatch(1);
+        final AtomicReference<Notification> notification = new AtomicReference<>();
+
+        NotificationListener listener = new MbeanServerNotificationListener(notification, notificationEmitted, LEGACY_DOMAIN);
+        NotificationFilterSupport filter = new NotificationFilterSupport();
+        filter.enableType(MBeanServerNotification.UNREGISTRATION_NOTIFICATION);
+
+        connection.addNotificationListener(MBeanServerDelegate.DELEGATE_NAME, listener, filter, null);
+
+        // add a management resource
+        connection.invoke(testObjectName, "addSingleOnly", new Object[]{123}, new String[]{String.class.getName()});
+        // and remove it
+        connection.invoke(childObjectName, "remove", new Object[0], new String[0]);
+
+        if (mustReceiveNotification) {
+            Assert.assertTrue("Did not receive expected notification", notificationEmitted.await(1, TimeUnit.SECONDS));
+            Notification notif = notification.get();
+            Assert.assertNotNull(notif);
+            Assert.assertTrue(notif instanceof MBeanServerNotification);
+            MBeanServerNotification mBeanServerNotification = (MBeanServerNotification) notif;
+            Assert.assertEquals(MBeanServerNotification.UNREGISTRATION_NOTIFICATION, mBeanServerNotification.getType());
+            Assert.assertEquals(childObjectName, mBeanServerNotification.getMBeanName());
+        } else {
+            Assert.assertFalse("Did receive unexpected notification", notificationEmitted.await(500, TimeUnit.MILLISECONDS));
+        }
+
+        connection.removeNotificationListener(MBeanServerDelegate.DELEGATE_NAME, listener, filter, null);
+    }
+
     private OpenMBeanOperationInfo findOperation(MBeanOperationInfo[] ops, String name) {
         for (MBeanOperationInfo op : ops) {
             Assert.assertNotNull(op.getName());
@@ -1188,16 +1465,53 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         }
     }
 
-    private MBeanServerConnection setupAndGetConnection(BaseAdditionalInitialization additionalInitialization) throws Exception {
-        Assert.assertNull(jmxConnector);
+    private static class MbeanServerNotificationListener implements NotificationListener {
 
+        private final AtomicReference<Notification> notification;
+        private final CountDownLatch latch;
+        private final String domain;
+
+        private MbeanServerNotificationListener(AtomicReference<Notification> notification, CountDownLatch latch, String domain) {
+            this.notification = notification;
+            this.latch = latch;
+            this.domain = domain;
+        }
+
+        @Override
+        public void handleNotification(Notification notification, Object handback) {
+            if (notification instanceof MBeanServerNotification) {
+                MBeanServerNotification notif = (MBeanServerNotification) notification;
+                if (notif.getMBeanName().getDomain().equals(domain)) {
+                    this.notification.set(notification);
+                    this.latch.countDown();
+                }
+            }
+        }
+    }
+
+    /*
+     * Start a local RMI Server (similar to what the Attach API does when connecting locally using jconsole)
+     */
+    private static JMXConnectorServer startLocalConnectorServer(MBeanServer mBeanServer) throws IOException {
+        JMXServiceURL serviceURL = new JMXServiceURL("service:jmx:rmi://localhost");
+        JMXConnectorServer connectorServer = JMXConnectorServerFactory.newJMXConnectorServer(serviceURL, new HashMap<String, String>(), mBeanServer);
+        connectorServer.start();
+        return connectorServer;
+    }
+
+    private KernelServices setup(BaseAdditionalInitialization additionalInitialization) throws Exception {
         // Parse the subsystem xml and install into the controller
         String subsystemXml = "<subsystem xmlns=\"" + Namespace.CURRENT.getUriString() + "\">"
                 + "<expose-resolved-model domain-name=\"jboss.resolved\"/>"
                 + "<expose-expression-model/>"
                 + "<remoting-connector/>" + "</subsystem>"
                 + additionalInitialization.getExtraXml();
-        createKernelServicesBuilder(additionalInitialization).setSubsystemXml(subsystemXml).build();
+        KernelServices kernelServices = createKernelServicesBuilder(additionalInitialization).setSubsystemXml(subsystemXml).build();
+        return kernelServices;
+    }
+
+    private MBeanServerConnection getRemoteConnection() throws Exception {
+        Assert.assertNull(jmxConnector);
 
         // Make sure that we can connect to the MBean server
         String host = "localhost";
@@ -1222,6 +1536,11 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
                 Thread.sleep(50);
             }
         }
+    }
+
+    private MBeanServerConnection setupAndGetConnection(BaseAdditionalInitialization additionalInitialization) throws Exception {
+        setup(additionalInitialization);
+        return getRemoteConnection();
     }
 
     private static ObjectName createObjectName(String s) {


### PR DESCRIPTION
- Emit JMX notifications based on WildFly's own notifications
- Notification is supported for JMX connections either in-vm (through
  ManagementFactory.getPlatformMBeanServer() or WildFly's
  MBeanServerService) and remotely if the JVM is started with the remote
  monitoring and management
- WildFly remoting-jmx does not support JMX notifications
- WildFLy notification are converted to their idiomatic JMX
  counterpart
  - WildFly's attribute-value-written is converted to JMX's
    AttibuteChangeNotification
  - WildFly's resource-added and resource-removed are converted to JMX's
    MBeanServerNotifications _and_ emitted by the
    MBeanServerDelegateMBean (like regular MBeans)

JIRA: https://issues.jboss.org/browse/WFLY-3169
