### PR TITLE
Update MavenUtil to use the new location for the EAP repository

### DIFF
--- a/model-test/src/main/java/org/jboss/as/model/test/MavenUtil.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/MavenUtil.java
@@ -209,7 +209,7 @@ class MavenUtil {
         List<RemoteRepository> remoteRepositories = new ArrayList<RemoteRepository>();
         if (remoteReposFromSysProp == null || remoteReposFromSysProp.trim().length() == 0 || remoteReposFromSysProp.startsWith("${")) {
             if (useEapRepository) {
-                remoteRepositories.add(new RemoteRepository.Builder("jboss-product-repository", "default", "http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6-rhel-6-build/latest/maven/").build());
+                remoteRepositories.add(new RemoteRepository.Builder("jboss-product-repository", "default", "http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6.4-rhel-6-build/latest/maven/").build());
             }
             //always add jboss developer repository
             remoteRepositories.add(new RemoteRepository.Builder("jboss-developer", "default", "http://repository.jboss.org/nexus/content/groups/developer/").build());


### PR DESCRIPTION
The EAP repository has moved from the folder jb-eap-6-rhel-6-build to jb-eap-6.4-rhel-6-build. There are several sibling repositories to jb-eap-6.4-rhel-6-build for previous versions, but jb-eap-6.4-rhel-6-build seems to have all the ones we need.

This is only really apparent if you blow away your local copy of the maven repository.
