### PR TITLE
WFLY-3468 handle reconnection failing by re-trying several times

### DIFF
--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1052,4 +1052,8 @@ public interface ServerLogger extends BasicLogger {
     @LogMessage(level = INFO)
     @Message(id = 212, value = "Resuming server")
     void resumingServer();
+
+    @LogMessage(level = ERROR)
+    @Message(id = 213, value = "Failed to reconnect to host controller on attempt %d")
+    void hostControllerReconnectFailed(int attempt, @Cause IOException e);
 }


### PR DESCRIPTION
Initial version of a patch which works for me to solve this, at least against the reproduction steps I posted on WFLY-3468.

It should probably use proper logging messages rather then a hard-coded message printed to System.err. Most of the logging messages have disappeared from WF-core after the split - should I add a new Messages file to the server project, or add a new message to one of the existing ones?
