### PR TITLE
[WFCORE-64] : Filesystem deployment scanner deployment failure removes unrelated deployments

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
@@ -423,8 +423,10 @@ class FileSystemDeploymentService implements DeploymentScanner {
                 }
 
                 if (forcedUndeployScan) {
-                    for (Map.Entry<String, Boolean> toUndeploy : scanContext.registeredDeployments.entrySet()) {
-                        scannerTasks.add(new UndeployTask(toUndeploy.getKey(), deploymentDir, scanContext.scanStartTime, true));
+                    Set<String> scannedDeployments = new HashSet<String>(scanContext.registeredDeployments.keySet());
+                    scannedDeployments.removeAll(scanContext.persistentDeployments);
+                    for (String toUndeploy : scannedDeployments) {
+                        scannerTasks.add(new UndeployTask(toUndeploy, deploymentDir, scanContext.scanStartTime, true));
                     }
                 }
                 // Process the tasks

--- a/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentServiceUnitTestCase.java
+++ b/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentServiceUnitTestCase.java
@@ -40,6 +40,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CANCELLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
@@ -62,6 +64,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEPLOY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -1673,6 +1676,20 @@ public class FileSystemDeploymentServiceUnitTestCase {
         Assert.assertTrue(removed.exists());
         Assert.assertTrue(nestedRemoved.exists());
         Assert.assertEquals(0, sc.deployed.size());
+    }
+    
+    
+    /** WFCORE-64 */
+    @Test
+    public void testForcedUndeployment() throws Exception {
+        MockServerController sc = new MockServerController("foo.war", "failure.ear");
+        TesteeSet ts = createTestee(sc);
+        ts.controller.externallyDeployed.add("foo.war");
+        ts.controller.addCompositeSuccessResponse(1);
+        assertThat(ts.controller.deployed.size() , is(2));
+        ts.testee.scan(true, new DefaultDeploymentOperations(sc), true);
+        assertThat(ts.controller.deployed.size() , is(1)); //Only non persistent deployments should be undeployed.
+        assertThat(ts.controller.deployed.keySet(), hasItems("foo.war"));
     }
 
     @Test


### PR DESCRIPTION
Only deployments marked as PERSITENT=false (which means deployments made by the scanner) will be undeployed instead of all of them.
Since we don't have a simple way to link a deployment to a scanner this fix won't be enough for a multiple scanners case which is traced by WFCORE-65.
Jira: https://issues.jboss.org/browse/WFCORE-64
