### PR TITLE
Change the test suite to provision a server directly instead of copying ...

### DIFF
--- a/testsuite-core/domain/pom.xml
+++ b/testsuite-core/domain/pom.xml
@@ -41,8 +41,7 @@
     <properties>
 
         <!-- used to provide an absolute location for the distribution under test -->
-        <!-- this value is overridden in modules with the correct relative pathname -->
-        <jboss.dist>${project.basedir}/../../${wildfly.core.build.output.dir}</jboss.dist>
+        <jboss.dist>${project.basedir}/target/wildfly-core</jboss.dist>
         <!-- This really should be ${project.basedir}/target/wildfly-core but the parent pom's
              ts.copy-jbossas.groups execution assumes it's the same as jboss.dist -->
         <jboss.home>${jboss.dist}</jboss.home>
@@ -65,10 +64,32 @@
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-testsuite-shared</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-feature-pack</artifactId>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.wildfly.build</groupId>
+                <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>server-provisioning</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <config-file>server-provisioning.xml</config-file>
+                            <server-name>wildfly-core</server-name>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>

--- a/testsuite-core/domain/server-provisioning.xml
+++ b/testsuite-core/domain/server-provisioning.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
+    <feature-packs>
+        <artifact name="org.wildfly.core:wildfly-core-feature-pack" />
+    </feature-packs>
+</server-provisioning>

--- a/testsuite-core/patching/pom.xml
+++ b/testsuite-core/patching/pom.xml
@@ -64,42 +64,19 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <groupId>org.wildfly.build</groupId>
+                <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>unpack-wildfly</id>
-                        <phase>generate-test-resources</phase>
+                        <id>server-provisioning</id>
                         <goals>
-                            <goal>unpack-dependencies</goal>
+                            <goal>build</goal>
                         </goals>
+                        <phase>compile</phase>
                         <configuration>
-                            <includeGroupIds>org.wildfly</includeGroupIds>
-                            <includeArtifactIds>wildfly-core-build</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <config-file>server-provisioning.xml</config-file>
+                            <server-name>wildfly-core</server-name>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>${version.antrun.plugin}</version>
-                <executions>
-                    <execution>
-                        <phase>process-test-resources</phase>
-                        <configuration>
-                            <target>
-                                <delete dir="${project.build.directory}/dependency-maven-plugin-markers"/>
-                                <move file="${project.build.directory}/wildfly-core-${project.version}"
-                                      tofile="${project.build.directory}/wildfly-core" overwrite="true" force="true"/>
-                                <!--<copy file="${project.build.testOutputDirectory}/mgmt-users.properties"
-                                      todir="${project.build.directory}/wildfly-core/standalone/configuration" overwrite="true"/>-->
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/testsuite-core/patching/server-provisioning.xml
+++ b/testsuite-core/patching/server-provisioning.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
+    <feature-packs>
+        <artifact name="org.wildfly.core:wildfly-core-feature-pack" />
+    </feature-packs>
+</server-provisioning>

--- a/testsuite-core/pom.xml
+++ b/testsuite-core/pom.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ /*
-  ~ * JBoss, Home of Professional Open Source.
-  ~ * Copyright 2014, Red Hat, Inc., and individual contributors
-  ~ * as indicated by the @author tags. See the copyright.txt file in the
-  ~ * distribution for a full listing of individual contributors.
-  ~ *
-  ~ * This is free software; you can redistribute it and/or modify it
-  ~ * under the terms of the GNU Lesser General Public License as
-  ~ * published by the Free Software Foundation; either version 2.1 of
-  ~ * the License, or (at your option) any later version.
-  ~ *
-  ~ * This software is distributed in the hope that it will be useful,
-  ~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~ * Lesser General Public License for more details.
-  ~ *
-  ~ * You should have received a copy of the GNU Lesser General Public
-  ~ * License along with this software; if not, write to the Free
-  ~ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  ~ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-  ~ */
+  ~
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~
   -->
 
 
@@ -191,42 +191,6 @@
 
         <pluginManagement>
             <plugins>
-
-                <!--
-                    A build of target/wildfly-core which is shared by all modules.
-                    Modules and bundles are not copied as they are read-only (see surefire props).
-                -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <executions combine.children="append">
-                        <!-- Copy the AS into current_submodule/target/wildfly-core . This is executed recursively in submodules. -->
-                        <execution>
-                            <id>ts.copy-jbossas.groups</id>
-                            <inherited>true</inherited>
-                            <phase>generate-test-resources</phase>
-                            <goals>
-                                <goal>copy-resources</goal>
-                            </goals>
-                            <configuration>
-                                <outputDirectory>${basedir}/target/wildfly-core</outputDirectory>
-                                <overwrite>true</overwrite>
-                                <resources>
-                                    <resource>
-                                        <directory>${jboss.home}</directory>
-                                        <excludes>
-                                            <exclude>modules/</exclude>
-                                            <exclude>standalone/data</exclude>
-                                            <exclude>standalone/log</exclude>
-                                            <exclude>standalone/tmp</exclude>
-                                        </excludes>
-                                    </resource>
-                                </resources>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-
                 <!--
                     Adjust IP addresses used in server config files.
                  -->

--- a/testsuite-core/server-provisioning.xml
+++ b/testsuite-core/server-provisioning.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
+    <feature-packs>
+        <artifact name="org.wildfly.core:wildfly-core-feature-pack" />
+    </feature-packs>
+</server-provisioning>

--- a/testsuite-core/standalone/pom.xml
+++ b/testsuite-core/standalone/pom.xml
@@ -66,19 +66,18 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <groupId>org.wildfly.build</groupId>
+                <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>unpack-wildfly</id>
-                        <phase>generate-resources</phase>
+                        <id>server-provisioning</id>
                         <goals>
-                            <goal>unpack-dependencies</goal>
+                            <goal>build</goal>
                         </goals>
+                        <phase>compile</phase>
                         <configuration>
-                            <includeGroupIds>org.wildfly</includeGroupIds>
-                            <includeArtifactIds>wildfly-core-build</includeArtifactIds>
-                            <outputDirectory>${project.build.directory}</outputDirectory>
+                            <config-file>server-provisioning.xml</config-file>
+                            <server-name>wildfly-core</server-name>
                         </configuration>
                     </execution>
                 </executions>
@@ -93,9 +92,6 @@
                         <phase>process-test-resources</phase>
                         <configuration>
                             <target>
-                                <delete dir="${project.build.directory}/dependency-maven-plugin-markers" />
-                                <move file="${project.build.directory}/wildfly-core-${project.version}"
-                                      tofile="${project.build.directory}/wildfly-core" overwrite="true" force="true"/>
                                 <copy file="${project.build.testOutputDirectory}/mgmt-users.properties" todir="${project.build.directory}/wildfly-core/standalone/configuration" overwrite="true" />
                             </target>
                         </configuration>

--- a/testsuite-core/standalone/server-provisioning.xml
+++ b/testsuite-core/standalone/server-provisioning.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
+    <feature-packs>
+        <artifact name="org.wildfly.core:wildfly-core-feature-pack" />
+    </feature-packs>
+</server-provisioning>


### PR DESCRIPTION
...the server from the build dir

This means that only the feature-pack artifact must be re-build to test with a different version.
