### PR TITLE
WFLY-3705 read-resource recursive-depth has no effect

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationAttributes.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationAttributes.java
@@ -24,6 +24,7 @@ package org.jboss.as.controller.operations.global;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -34,14 +35,15 @@ import org.jboss.dmr.ModelType;
  */
 class GlobalOperationAttributes {
 
+    // WFLY-3705
     static final SimpleAttributeDefinition RECURSIVE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.RECURSIVE, ModelType.BOOLEAN)
     .setAllowNull(true)
-    .setDefaultValue(new ModelNode(false))
     .build();
 
+    // WFLY-3705
     static final SimpleAttributeDefinition RECURSIVE_DEPTH = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.RECURSIVE_DEPTH, ModelType.INT)
     .setAllowNull(true)
-    .setDefaultValue(new ModelNode(0))
+    .setValidator(new IntRangeValidator(0, true))
     .build();
 
     static final SimpleAttributeDefinition PROXIES = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PROXIES, ModelType.BOOLEAN)

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -24,6 +24,8 @@ package org.jboss.as.controller.operations.global;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_CONTROL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.operations.global.GlobalOperationAttributes.RECURSIVE;
+import static org.jboss.as.controller.operations.global.GlobalOperationAttributes.RECURSIVE_DEPTH;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -474,6 +476,41 @@ public class GlobalOperationHandlers {
             return null;
         }
         return new Locale(unparsed.substring(0, 2), unparsed.substring(3, 5), unparsed.substring(6));
+    }
+
+    static boolean getRecursive(OperationContext context, ModelNode op) throws OperationFailedException {
+        // -1 means UNDEFINED
+        ModelNode recursiveNode = RECURSIVE.resolveModelAttribute(context, op);
+        final int recursiveValue = recursiveNode.isDefined() ? (recursiveNode.asBoolean() ? 1 : 0) : -1;
+        final int recursiveDepthValue = RECURSIVE_DEPTH.resolveModelAttribute(context, op).asInt(-1);
+        // WFLY-3705: We are recursing in this round IFF:
+        //  Recursive is explicitly specified as TRUE and recursiveDepth is UNDEFINED
+        //  Recursive is either TRUE or UNDEFINED and recursiveDepth is >0
+        return recursiveValue > 0 && recursiveDepthValue == -1 || //
+                recursiveValue != 0 && recursiveDepthValue > 0;
+    }
+
+    static void setNextRecursive(OperationContext context, ModelNode op, ModelNode nextOp) throws OperationFailedException {
+        // -1 means UNDEFINED
+        final int recursiveDepthValue = RECURSIVE_DEPTH.resolveModelAttribute(context, op).asInt(-1);
+        // WFLY-3705: We are recursing in the next step IFF:
+        //  Recursive is explicitly specified as TRUE and recursiveDepth is UNDEFINED; or
+        //  Recursive is either TRUE or UNDEFINED and (recursiveDepth - 1) is >0
+
+        // Recursive value carries through unchanged
+        nextOp.get(RECURSIVE.getName()).set(op.get(RECURSIVE.getName()));
+        switch(recursiveDepthValue) {
+        case -1:
+            // Undefined stays undefined
+            nextOp.get(RECURSIVE_DEPTH.getName()).set(op.get(RECURSIVE_DEPTH.getName()));
+            break;
+        case 0:
+            nextOp.get(RECURSIVE_DEPTH.getName()).set(recursiveDepthValue);
+            break;
+        default:
+            nextOp.get(RECURSIVE_DEPTH.getName()).set(recursiveDepthValue - 1);
+            break;
+        }
     }
 
     private static String normalizeLocale(String toNormalize) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -181,8 +181,8 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
 
         final String opName = operation.require(OP).asString();
         PathAddress opAddr = PathAddress.pathAddress(operation.get(OP_ADDR));
-        final int recursiveDepth = RECURSIVE_DEPTH.resolveModelAttribute(context, operation).asInt();
-        final boolean recursive = recursiveDepth > 0 || RECURSIVE.resolveModelAttribute(context, operation).asBoolean();
+        // WFLY-3705
+        final boolean recursive = GlobalOperationHandlers.getRecursive(context, operation);
         final boolean proxies = PROXIES.resolveModelAttribute(context, operation).asBoolean();
         final boolean ops = OPERATIONS.resolveModelAttribute(context, operation).asBoolean();
         final boolean nots = NOTIFICATIONS.resolveModelAttribute(context, operation).asBoolean();
@@ -281,7 +281,6 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
                 }
 
                 if (readChild) {
-                    final int newDepth = recursiveDepth > 0 ? recursiveDepth - 1 : 0;
                     final ModelNode rrOp = operation.clone();
                     final PathAddress address;
                     try {
@@ -290,7 +289,8 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
                         continue;
                     }
                     rrOp.get(OP_ADDR).set(address.toModelNode());
-                    rrOp.get(RECURSIVE_DEPTH.getName()).set(newDepth);
+                    // WFLY-3705
+                    GlobalOperationHandlers.setNextRecursive(context, operation, rrOp);
                     final ModelNode rrRsp = new ModelNode();
                     childResources.put(element, rrRsp);
 

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -47,7 +47,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.NoSuchResourceException;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
@@ -64,8 +64,8 @@ import org.jboss.as.controller.access.AuthorizationResult;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.operations.validation.ModelTypeValidator;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
@@ -104,6 +104,9 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
         @Override
         public void validate(ModelNode operation) throws OperationFailedException {
             super.validate(operation);
+            for (AttributeDefinition def : DEFINITION.getParameters()) {
+                def.validateOperation(operation);
+            }
             if (operation.hasDefined(ModelDescriptionConstants.ATTRIBUTES_ONLY)) {
                 if (operation.hasDefined(ModelDescriptionConstants.RECURSIVE)) {
                     throw ControllerLogger.ROOT_LOGGER.cannotHaveBothParameters(ModelDescriptionConstants.ATTRIBUTES_ONLY, ModelDescriptionConstants.RECURSIVE);
@@ -123,13 +126,6 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
 
     ReadResourceHandler(final FilteredData filteredData, OperationStepHandler overrideHandler) {
         super(filteredData);
-        //todo use AD for validation
-        validator.registerValidator(ModelDescriptionConstants.RECURSIVE, new ModelTypeValidator(ModelType.BOOLEAN, true));
-        validator.registerValidator(ModelDescriptionConstants.RECURSIVE_DEPTH, new ModelTypeValidator(ModelType.INT, true));
-        validator.registerValidator(ModelDescriptionConstants.INCLUDE_RUNTIME, new ModelTypeValidator(ModelType.BOOLEAN, true));
-        validator.registerValidator(ModelDescriptionConstants.PROXIES, new ModelTypeValidator(ModelType.BOOLEAN, true));
-        validator.registerValidator(ModelDescriptionConstants.INCLUDE_DEFAULTS, new ModelTypeValidator(ModelType.BOOLEAN, true));
-        validator.registerValidator(ModelDescriptionConstants.ATTRIBUTES_ONLY, new ModelTypeValidator(ModelType.BOOLEAN, true));
         this.overrideHandler = overrideHandler;
     }
 
@@ -170,9 +166,8 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
 
         final String opName = operation.require(OP).asString();
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
-
-        final int recursiveDepth = operation.get(ModelDescriptionConstants.RECURSIVE_DEPTH).asInt(0);
-        final boolean recursive = recursiveDepth > 0 || operation.get(ModelDescriptionConstants.RECURSIVE).asBoolean(false);
+        // WFLY-3705
+        final boolean recursive = GlobalOperationHandlers.getRecursive(context, operation);
         final boolean queryRuntime = operation.get(ModelDescriptionConstants.INCLUDE_RUNTIME).asBoolean(false);
         final boolean proxies = operation.get(ModelDescriptionConstants.PROXIES).asBoolean(false);
         final boolean aliases = operation.get(ModelDescriptionConstants.INCLUDE_ALIASES).asBoolean(false);
@@ -238,10 +233,8 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
                         }
                         if (getChild) {
                             nonExistentChildTypes.remove(childType);
-                            final int newDepth = recursiveDepth > 0 ? recursiveDepth - 1 : 0;
-                            // Add a step to read the child resource
-                            rrOp.get(ModelDescriptionConstants.RECURSIVE).set(operation.get(ModelDescriptionConstants.RECURSIVE));
-                            rrOp.get(ModelDescriptionConstants.RECURSIVE_DEPTH).set(newDepth);
+                            // WFLY-3705
+                            GlobalOperationHandlers.setNextRecursive(context, operation, rrOp);
                             rrOp.get(ModelDescriptionConstants.PROXIES).set(proxies);
                             rrOp.get(ModelDescriptionConstants.INCLUDE_RUNTIME).set(queryRuntime);
                             rrOp.get(ModelDescriptionConstants.INCLUDE_ALIASES).set(aliases);

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/mgmt/BasicOperationsUnitTestCase.java
@@ -1,0 +1,388 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.smoke.mgmt;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ANY_ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ANY_IPV4_ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ANY_IPV6_ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE_DEPTH;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Basic management operation unit test.
+ *
+ * @author Emanuel Muckenhuber
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class BasicOperationsUnitTestCase {
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    @Test
+    public void testSocketBindingsWildcards() throws IOException {
+
+        final ModelNode address = new ModelNode();
+        address.add("socket-binding-group", "*");
+        address.add("socket-binding", "*");
+        address.protect();
+
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertTrue(result.hasDefined(RESULT));
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        final Collection<ModelNode> steps = getSteps(result.get(RESULT));
+        Assert.assertFalse(steps.isEmpty());
+        for(final ModelNode step : steps) {
+            Assert.assertTrue(step.hasDefined(OP_ADDR));
+            Assert.assertTrue(step.hasDefined(RESULT));
+            Assert.assertEquals(SUCCESS, step.get(OUTCOME).asString());
+        }
+    }
+
+    @Test
+    public void testReadResourceRecursiveDepthRecursiveUndefined() throws IOException {
+        // WFLY-3705
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(RECURSIVE_DEPTH).set(1);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.hasDefined(RESULT));
+
+        final ModelNode web = result.get(RESULT, SUBSYSTEM, "io");
+        Assert.assertTrue(web.hasDefined("worker"));
+        final ModelNode worker = result.get(RESULT, SUBSYSTEM, "io", "worker");
+        Assert.assertFalse(worker.hasDefined("default"));
+    }
+
+    @Test
+    public void testReadResourceRecursiveDepthRecursiveTrue() throws IOException {
+        // WFLY-3705
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(RECURSIVE).set(true);
+        operation.get(RECURSIVE_DEPTH).set(1);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.hasDefined(RESULT));
+
+        final ModelNode web = result.get(RESULT, SUBSYSTEM, "io");
+        Assert.assertTrue(web.hasDefined("worker"));
+        final ModelNode worker = result.get(RESULT, SUBSYSTEM, "io", "worker");
+        Assert.assertFalse(worker.hasDefined("default"));
+    }
+
+    @Test
+    public void testReadResourceRecursiveDepthGt1RecursiveTrue() throws IOException {
+        // WFLY-3705
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(RECURSIVE).set(true);
+        operation.get(RECURSIVE_DEPTH).set(2);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.hasDefined(RESULT));
+
+        final ModelNode web = result.get(RESULT, SUBSYSTEM, "io");
+        Assert.assertTrue(web.hasDefined("worker"));
+        final ModelNode worker = result.get(RESULT, SUBSYSTEM, "io", "worker");
+        Assert.assertTrue(worker.hasDefined("default"));
+    }
+
+    @Test
+    public void testReadResourceRecursiveDepthRecursiveFalse() throws IOException {
+        // WFLY-3705
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(RECURSIVE).set(false);
+        operation.get(RECURSIVE_DEPTH).set(1);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.hasDefined(RESULT));
+
+        final ModelNode web = result.get(RESULT, SUBSYSTEM, "io");
+        Assert.assertFalse(web.hasDefined("worker"));
+    }
+
+    @Test
+    public void testReadResourceNoRecursiveDepthRecursiveTrue() throws IOException {
+        // WFLY-3705
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(RECURSIVE).set(true);
+        operation.get(RECURSIVE_DEPTH).set(0);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.hasDefined(RESULT));
+
+        final ModelNode web = result.get(RESULT, SUBSYSTEM, "io");
+        Assert.assertFalse(web.hasDefined("worker"));
+    }
+
+    @Test
+    public void testReadAttributeWildcards() throws IOException {
+
+        final ModelNode address = new ModelNode();
+        address.add("socket-binding-group", "*");
+        address.add("socket-binding", "*");
+        address.protect();
+
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+        operation.get(NAME).set(PORT);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertTrue(result.hasDefined(RESULT));
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        final Collection<ModelNode> steps = getSteps(result.get(RESULT));
+        Assert.assertFalse(steps.isEmpty());
+        for(final ModelNode step : steps) {
+            Assert.assertTrue(step.hasDefined(OP_ADDR));
+            Assert.assertTrue(step.hasDefined(RESULT));
+            final ModelNode stepResult = step.get(RESULT);
+            Assert.assertTrue(stepResult.getType() == ModelType.EXPRESSION || stepResult.asInt() >= 0);
+        }
+    }
+
+    @Test
+    public void testSocketBindingDescriptions() throws IOException {
+
+        final ModelNode address = new ModelNode();
+        address.add("socket-binding-group", "*");
+        address.add("socket-binding", "*");
+        address.protect();
+
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_DESCRIPTION_OPERATION);
+        operation.get(OP_ADDR).set(address);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertTrue(result.hasDefined(RESULT));
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        final Collection<ModelNode> steps = result.get(RESULT).asList();
+        Assert.assertFalse(steps.isEmpty());
+        Assert.assertEquals("should only contain a single type", 1, steps.size());
+        for(final ModelNode step : steps) {
+            Assert.assertTrue(step.hasDefined(OP_ADDR));
+            Assert.assertTrue(step.hasDefined(RESULT));
+            Assert.assertEquals(SUCCESS, step.get(OUTCOME).asString());
+            final ModelNode stepResult = step.get(RESULT);
+            Assert.assertTrue(stepResult.hasDefined(DESCRIPTION));
+            Assert.assertTrue(stepResult.hasDefined(ATTRIBUTES));
+            Assert.assertTrue(stepResult.get(ModelDescriptionConstants.ATTRIBUTES).hasDefined(ModelDescriptionConstants.NAME));
+            Assert.assertTrue(stepResult.get(ModelDescriptionConstants.ATTRIBUTES).hasDefined(ModelDescriptionConstants.INTERFACE));
+            Assert.assertTrue(stepResult.get(ModelDescriptionConstants.ATTRIBUTES).hasDefined(ModelDescriptionConstants.PORT));
+        }
+    }
+
+    @Test
+    public void testRecursiveReadIncludingRuntime() throws IOException {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(RECURSIVE).set(true);
+        operation.get(INCLUDE_RUNTIME).set(true);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(result.get(FAILURE_DESCRIPTION).isDefined() ? result.get(FAILURE_DESCRIPTION).asString() : "", SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.hasDefined(RESULT));
+    }
+
+    @Test
+    public void testHttpSocketBinding() throws IOException {
+        final ModelNode address = new ModelNode();
+        address.add("socket-binding-group", "*");
+        address.add("socket-binding", "http");
+        address.protect();
+
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertTrue(result.hasDefined(RESULT));
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        final List<ModelNode> steps = getSteps(result.get(RESULT));
+        Assert.assertEquals(1, steps.size());
+        final ModelNode httpBinding = steps.get(0);
+        Assert.assertEquals(8080, httpBinding.get(RESULT, "port").resolve().asInt());
+
+    }
+
+    @Test
+    public void testSimpleReadAttribute() throws IOException {
+        final ModelNode address = new ModelNode();
+        address.add("subsystem", "deployment-scanner");
+        address.add("scanner", "default");
+
+        final ModelNode operation = createReadAttributeOperation(address, "path");
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        assertSuccessful(result);
+
+        Assert.assertEquals("deployments", result.get(RESULT).asString());
+    }
+
+    @Test
+    @Ignore //TODO UNDERTOW reneable when we expose metrics from undertow
+    public void testMetricReadAttribute() throws IOException {
+        final ModelNode address = new ModelNode();
+        address.add("subsystem", "undertow");
+        address.add("connector", "http");
+
+        final ModelNode operation = createReadAttributeOperation(address, "bytesReceived");
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        assertSuccessful(result);
+        Assert.assertTrue(result.asInt() >= 0);
+    }
+
+    @Test
+    public void testReadAttributeChild() throws IOException {
+        final ModelNode address = new ModelNode();
+        address.add("subsystem", "deployment-scanner");
+
+        final ModelNode operation = createReadAttributeOperation(address, "scanner");
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+    }
+
+    @Test
+    public void testInterfaceAdd() throws IOException {
+
+        final ModelNode base = new ModelNode();
+        base.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+        base.get(OP_ADDR).add(INTERFACE, "test");
+        base.protect();
+
+        final ModelNode add = base.clone();
+        add.get(OP).set(ADD);
+        add.get(ANY_ADDRESS).set(true);
+        // Add interface
+        execute(add);
+
+        final ModelNode any = base.clone();
+        any.get(NAME).set(ANY_ADDRESS);
+        any.get(VALUE).set(false);
+
+        final ModelNode any6 = base.clone();
+        any6.get(NAME).set(ANY_IPV6_ADDRESS) ;
+        any6.get(VALUE).set(false);
+
+        final ModelNode any4 = base.clone();
+        any4.get(NAME).set(ANY_IPV4_ADDRESS);
+        any4.get(VALUE).set(true);
+
+        final ModelNode composite = new ModelNode();
+        composite.get(OP).set(COMPOSITE);
+        composite.get(OP_ADDR).setEmptyList();
+
+        composite.get(STEPS).add(any);
+        composite.get(STEPS).add(any6);
+        composite.get(STEPS).add(any4);
+
+        execute(composite);
+
+        // Remove interface
+        final ModelNode remove = base.clone();
+        remove.get(OP).set(REMOVE);
+        execute(remove);
+    }
+
+    protected ModelNode execute(final ModelNode operation) throws IOException {
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
+        return result;
+    }
+
+    static void assertSuccessful(final ModelNode result) {
+        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.hasDefined(RESULT));
+    }
+
+    static ModelNode createReadAttributeOperation(final ModelNode address, final String attributeName) {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+        operation.get(NAME).set(attributeName);
+        return operation;
+    }
+
+    protected static List<ModelNode> getSteps(final ModelNode result) {
+        Assert.assertTrue(result.isDefined());
+        return result.asList();
+    }
+}


### PR DESCRIPTION
Logic implemented according to bevavioral tables

1) Recursive decision and value propagation is isolated
2) Attribute validators changed
3) ReadResourceHandler no longer manipulates its own validators, but uses the ones in the definition
4) ReadResourceDescriptionHandler had yet another version of recursion logic - fix that one as well
5) Update testsuite to check for, hopefully, all conditions

This is a forward-port of https://github.com/wildfly/wildfly/pull/6591

Arcadiy, I hope you don't mind; I squashed this down to 1 commit. I tried to retain the most substantive part of the commit messages.
