### PR TITLE
[WFCORE-28] Add Global Resource Notifications

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/InterleavedSubsystemTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/InterleavedSubsystemTestCase.java
@@ -45,6 +45,7 @@ import org.jboss.as.controller.extension.ExtensionAddHandler;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.extension.MutableRootResourceRegistrationProvider;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.persistence.AbstractConfigurationPersister;
 import org.jboss.as.controller.persistence.ConfigurationPersister;
@@ -137,6 +138,8 @@ public class InterleavedSubsystemTestCase {
         @Override
         protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+
+            GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
 
             /*ManagementResourceRegistration extensions = rootRegistration.registerSubModel(PathElement.pathElement(EXTENSION), ModelControllerImplUnitTestCase.DESC_PROVIDER);
             extensions.registerOperationHandler("add", new FakeExtensionAddHandler(rootRegistration), ModelControllerImplUnitTestCase.DESC_PROVIDER);*/

--- a/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
@@ -27,6 +27,7 @@ package org.jboss.as.controller;
 
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -622,6 +623,9 @@ public class ModelControllerImplUnitTestCase {
             rootRegistration.registerOperationHandler(getOD("read-wildcards"), new ModelControllerImplUnitTestCase.WildcardReadHandler(),true);
 
             GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+
+            GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
+
             SimpleResourceDefinition childResource = new SimpleResourceDefinition(
                     PathElement.pathElement("child"),
                     new NonResolvingResourceDescriptionResolver()

--- a/controller/src/test/java/org/jboss/as/controller/OperationCancellationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationCancellationUnitTestCase.java
@@ -52,6 +52,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -171,6 +172,8 @@ public class OperationCancellationUnitTestCase {
             rootRegistration.registerOperationHandler(getOD("block-verify"), new BlockingServiceHandler());
 
             GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+
+            GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
 
             rootRegistration.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement("child"), new NonResolvingResourceDescriptionResolver()));
             this.managementControllerResource = modelControllerResource;

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/AddResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/AddResourceTestCase.java
@@ -45,6 +45,7 @@ import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -291,6 +292,8 @@ public class AddResourceTestCase extends AbstractControllerTestBase {
     protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
         this.rootResource = rootResource;
         this.rootRegistration = registration;
+
+        GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
     }
 
     private static class TestResourceDefinition extends SimpleResourceDefinition {

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
@@ -53,6 +53,7 @@ import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraint
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -468,6 +469,8 @@ public class BasicRbacTestCase extends AbstractRbacTestBase {
     @Override
     protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
         GlobalOperationHandlers.registerGlobalOperations(registration, ProcessType.EMBEDDED_SERVER);
+
+        GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
         registration.registerSubModel(new TestResourceDefinition(UNCONSTRAINED_RESOURCE));
         registration.registerSubModel(new TestResourceDefinition(SENSITIVE_NON_ADDRESSABLE_RESOURCE,

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
@@ -52,6 +52,7 @@ import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraint
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -579,6 +580,8 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
     @Override
     protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
         GlobalOperationHandlers.registerGlobalOperations(registration, ProcessType.EMBEDDED_SERVER);
+
+        GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
         registration.registerSubModel(new TestResourceDefinition(UNCONSTRAINED_RESOURCE));
         registration.registerSubModel(new TestResourceDefinition(SENSITIVE_CONSTRAINED_RESOURCE,

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenNamesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenNamesTestCase.java
@@ -49,6 +49,7 @@ import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -165,6 +166,8 @@ public class FilteredReadChildrenNamesTestCase extends AbstractRbacTestBase {
     @Override
     protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
         GlobalOperationHandlers.registerGlobalOperations(registration, ProcessType.EMBEDDED_SERVER);
+
+        GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
         registration.registerSubModel(new TestResourceDefinition(UNCONSTRAINED_RESOURCE));
         registration.registerSubModel(new TestResourceDefinition(SENSITIVE_CONSTRAINED_RESOURCE,

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenResourcesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenResourcesTestCase.java
@@ -49,6 +49,7 @@ import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -156,6 +157,8 @@ public class FilteredReadChildrenResourcesTestCase extends AbstractRbacTestBase 
     @Override
     protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
         GlobalOperationHandlers.registerGlobalOperations(registration, ProcessType.EMBEDDED_SERVER);
+
+        GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
         registration.registerSubModel(new TestResourceDefinition(UNCONSTRAINED_RESOURCE));
         registration.registerSubModel(new TestResourceDefinition(SENSITIVE_CONSTRAINED_RESOURCE,

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadResourceTestCase.java
@@ -55,6 +55,7 @@ import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -202,6 +203,8 @@ public class FilteredReadResourceTestCase extends AbstractRbacTestBase {
     @Override
     protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
         GlobalOperationHandlers.registerGlobalOperations(registration, ProcessType.EMBEDDED_SERVER);
+
+        GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
         registration.registerSubModel(new TestResourceDefinition(UNCONSTRAINED_RESOURCE));
         registration.registerSubModel(new TestResourceDefinition(SENSITIVE_CONSTRAINED_RESOURCE,

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadAttributeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadAttributeTestCase.java
@@ -51,6 +51,7 @@ import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraint
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -274,6 +275,8 @@ public class ReadAttributeTestCase extends AbstractRbacTestBase {
     @Override
     protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
         GlobalOperationHandlers.registerGlobalOperations(registration, ProcessType.EMBEDDED_SERVER);
+
+        GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
         registration.registerSubModel(new TestResourceDefinition(UNCONSTRAINED_RESOURCE_1, true));
         registration.registerSubModel(new TestResourceDefinition(SENSITIVE_CONSTRAINED_RESOURCE_1, true,

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/RemoveResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/RemoveResourceTestCase.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -200,6 +201,9 @@ public class RemoveResourceTestCase extends AbstractControllerTestBase {
     protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
         this.rootResource = rootResource;
         this.rootRegistration = registration;
+
+        GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
+
     }
 
     private static class TestResourceDefinition extends SimpleResourceDefinition {

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/WriteAttributeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/WriteAttributeTestCase.java
@@ -50,6 +50,7 @@ import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraint
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -300,6 +301,8 @@ public class WriteAttributeTestCase extends AbstractRbacTestBase {
     @Override
     protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
         GlobalOperationHandlers.registerGlobalOperations(registration, ProcessType.EMBEDDED_SERVER);
+
+        GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
         registration.registerSubModel(new TestResourceDefinition(UNCONSTRAINED_RESOURCE));
         registration.registerSubModel(new TestResourceDefinition(SENSITIVE_CONSTRAINED_RESOURCE,

--- a/controller/src/test/java/org/jboss/as/controller/notification/NotificationCompositeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/NotificationCompositeOperationTestCase.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.as.controller.CompositeOperationHandler;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -81,6 +82,7 @@ public class NotificationCompositeOperationTestCase extends AbstractControllerTe
                     }
                 }
         );
+        registration.registerNotification(NotificationDefinition.Builder.create(MY_NOTIFICATION_TYPE, new NonResolvingResourceDescriptionResolver()).build());
     }
 
     @Test

--- a/controller/src/test/java/org/jboss/as/controller/notification/OperationWithManyStepsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/OperationWithManyStepsTestCase.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -113,6 +114,7 @@ public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
                     }
                 }
         );
+        registration.registerNotification(NotificationDefinition.Builder.create(MY_NOTIFICATION_TYPE, new NonResolvingResourceDescriptionResolver()).build());
     }
 
     @Test

--- a/controller/src/test/java/org/jboss/as/controller/notification/OperationWithNotificationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/OperationWithNotificationTestCase.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -67,6 +68,7 @@ public class OperationWithNotificationTestCase extends AbstractControllerTestBas
                     }
                 }
         );
+        registration.registerNotification(NotificationDefinition.Builder.create(MY_NOTIFICATION_TYPE, new NonResolvingResourceDescriptionResolver()).build());
     }
 
     @Test

--- a/controller/src/test/java/org/jboss/as/controller/services/path/PathsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/services/path/PathsTestCase.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -808,6 +809,8 @@ public class PathsTestCase extends AbstractControllerTestBase {
             }
         };
         GlobalOperationHandlers.registerGlobalOperations(registration, processType);
+
+        GlobalNotifications.registerGlobalNotifications(registration, processType);
 
         TestServiceListener listener = new TestServiceListener();
         listener.reset(1);

--- a/controller/src/test/java/org/jboss/as/controller/test/AliasResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AliasResourceTestCase.java
@@ -75,6 +75,7 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.operations.global.ReadAttributeHandler;
 import org.jboss.as.controller.operations.global.WriteAttributeHandler;
@@ -642,6 +643,8 @@ public class AliasResourceTestCase extends AbstractControllerTestBase {
         GlobalOperationHandlers.registerGlobalOperations(registration, processType);
 
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+
+        GlobalNotifications.registerGlobalNotifications(registration, processType);
 
         ManagementResourceRegistration coreResourceRegistration = registration.registerSubModel(new CoreResourceDefinition());
         registration.registerAlias(getAliasedModelElement(),

--- a/controller/src/test/java/org/jboss/as/controller/test/CastAttributeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/CastAttributeOperationTestCase.java
@@ -46,6 +46,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -174,6 +175,8 @@ public class CastAttributeOperationTestCase extends AbstractControllerTestBase {
             }
         }
         );
+
+        GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
 
         ResourceDefinition profileDef = ResourceBuilder.Factory.create(PathElement.pathElement("profile", "*"),
                 new NonResolvingResourceDescriptionResolver())

--- a/controller/src/test/java/org/jboss/as/controller/test/DefaultAttributeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/DefaultAttributeTestCase.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.ReadAttributeHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -68,6 +69,9 @@ public class DefaultAttributeTestCase extends AbstractControllerTestBase {
     @Override
     protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
         registration.registerOperationHandler(ReadAttributeHandler.DEFINITION, ReadAttributeHandler.INSTANCE, true);
+
+        GlobalNotifications.registerGlobalNotifications(registration, processType);
+
         registration.registerSubModel(new TestResource());
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadResourceChildOrderingTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadResourceChildOrderingTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -79,6 +80,8 @@ public class ReadResourceChildOrderingTestCase extends AbstractControllerTestBas
                 context.stepCompleted();
             }
         });
+
+        GlobalNotifications.registerGlobalNotifications(registration, processType);
 
         registration.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver()));
 

--- a/controller/src/test/java/org/jboss/as/controller/test/WildcardUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WildcardUnitTestCase.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -104,6 +105,7 @@ public class WildcardUnitTestCase extends AbstractControllerTestBase {
                 }
             });
 
+            GlobalNotifications.registerGlobalNotifications(root, processType);
 
 
             final ManagementResourceRegistration hosts = root.registerSubModel(new SimpleResourceDefinition(host, new NonResolvingResourceDescriptionResolver()));

--- a/controller/src/test/java/org/jboss/as/controller/test/WriteAttributeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WriteAttributeOperationTestCase.java
@@ -45,6 +45,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -168,6 +169,8 @@ public class WriteAttributeOperationTestCase extends AbstractControllerTestBase 
             }
         }
         );
+
+        GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
 
         ResourceDefinition profileDef = ResourceBuilder.Factory.create(PathElement.pathElement("profile", "*"),
                 new NonResolvingResourceDescriptionResolver())

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/util/ManagementControllerTestBase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/util/ManagementControllerTestBase.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
 import org.jboss.as.controller.audit.ManagedAuditLogger;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -70,6 +71,8 @@ public class ManagementControllerTestBase extends AbstractControllerTestBase {
         };
         GlobalOperationHandlers.registerGlobalOperations(registration, processType);
         registration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
+
+        GlobalNotifications.registerGlobalNotifications(registration, processType);
 
         TestServiceListener listener = new TestServiceListener();
         listener.reset(1);

--- a/jmx/src/test/java/org/jboss/as/jmx/auditlog/JmxAuditLogHandlerTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/auditlog/JmxAuditLogHandlerTestCase.java
@@ -54,6 +54,7 @@ import org.jboss.as.controller.audit.ManagedAuditLoggerImpl;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -740,6 +741,8 @@ public class JmxAuditLogHandlerTestCase extends AbstractControllerTestBase {
         };
         GlobalOperationHandlers.registerGlobalOperations(registration, processType);
         registration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
+
+        GlobalNotifications.registerGlobalNotifications(registration, processType);
 
         TestServiceListener listener = new TestServiceListener();
         listener.reset(1);

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
@@ -72,6 +72,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -763,6 +764,8 @@ public class JmxFacadeRbacEnabledTestCase extends AbstractControllerTestBase {
         GlobalOperationHandlers.registerGlobalOperations(registration, processType);
         registration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
         registration.registerOperationHandler(RootResourceHack.DEFINITION, RootResourceHack.INSTANCE);
+
+        GlobalNotifications.registerGlobalNotifications(registration, processType);
 
         TestServiceListener listener = new TestServiceListener();
         listener.reset(1);

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
@@ -60,6 +60,7 @@ import org.jboss.as.controller.audit.AuditLogger;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -535,6 +536,8 @@ public abstract class JmxRbacTestCase extends AbstractControllerTestBase {
         };
         GlobalOperationHandlers.registerGlobalOperations(registration, processType);
         registration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
+
+        GlobalNotifications.registerGlobalNotifications(registration, processType);
 
         registration.registerReadOnlyAttribute(LAUNCH_TYPE, new OperationStepHandler() {
 

--- a/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanTestModelControllerService.java
+++ b/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanTestModelControllerService.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorize
 import org.jboss.as.controller.audit.AuditLogger;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -67,6 +68,8 @@ public class PlatformMBeanTestModelControllerService extends AbstractControllerS
 
         GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
         rootRegistration.registerOperationHandler(ValidateAddressOperationHandler.DEFINITION, ValidateAddressOperationHandler.INSTANCE);
+
+        GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
 
         // Platform mbeans
         PlatformMBeanResourceRegistrar.registerPlatformMBeanResources(rootRegistration);


### PR DESCRIPTION
Add the global notification handlers to all tests
that modify resources to remove the warnings about the
emitted notifications not being defined

JIRA: https://issues.jboss.org/browse/WFCORE-28
