### PR TITLE
[WFCORE-92] cli deploy command with unpaired quotation mark causes Strin...

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/WindowsFilenameTabCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/WindowsFilenameTabCompleter.java
@@ -49,7 +49,7 @@ public class WindowsFilenameTabCompleter extends FilenameTabCompleter {
        boolean dontCloseQuote = false;
        if(buffer.length() >= 2 && buffer.charAt(0) == '"') {
            int lastQuote = buffer.lastIndexOf('"');
-           if(lastQuote >= 0) {
+           if(lastQuote > 0) {
                StringBuilder buf = new StringBuilder();
                buf.append(buffer.substring(1, lastQuote));
                if(lastQuote != buffer.length() - 1) {


### PR DESCRIPTION
...gIndexOutOfBoundsException

https://issues.jboss.org/browse/WFCORE-92
