### PR TITLE
[WFCORE-95] fix PrimitiveListAttributeDefinition.Builder copy constructor

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PrimitiveListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PrimitiveListAttributeDefinition.java
@@ -103,7 +103,6 @@ public class PrimitiveListAttributeDefinition extends ListAttributeDefinition {
         public Builder(final PrimitiveListAttributeDefinition basis) {
             super(basis);
             this.valueType = basis.getValueType();
-            setElementValidator(basis.getElementValidator());
         }
 
         public static Builder of(final String name, final ModelType valueType) {

--- a/controller/src/main/java/org/jboss/as/controller/SimpleListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleListAttributeDefinition.java
@@ -130,7 +130,6 @@ public class SimpleListAttributeDefinition extends ListAttributeDefinition {
         public Builder(final SimpleListAttributeDefinition basis) {
             super(basis);
             valueType = basis.getValueType();
-            setElementValidator(valueType.getValidator());
         }
 
         public static Builder of(final String name, final AttributeDefinition valueType) {


### PR DESCRIPTION
do not call setElementValidator() from the copy constructor as it
invalidates the validator of the attribute definition (corresponding to
the listValidator)

JIRA: https://issues.jboss.org/browse/WFCORE-95
