### PR TITLE
create properties files if missing

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesFileLoader.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesFileLoader.java
@@ -102,6 +102,7 @@ public class PropertiesFileLoader {
 
         propertiesFile = new File(file);
         try {
+            propertiesFile.createNewFile();
             getProperties();
         } catch (IOException ioe) {
             throw DomainManagementLogger.ROOT_LOGGER.unableToLoadProperties(ioe);


### PR DESCRIPTION
When managing several wildfly installations on the servers of the delivery pipeline from a central repository, the contents of the files like mgmt-users.properties or mgmt-groups.properties differ from server to server. So far, wildfly does not start if the files do not exist. This patch creates empty ones if they not exist and wildfly starts fine.
