### PR TITLE
[WFCORE-94] Facitilitate usage of -secmgr flag in startup scripts and propagate through domain

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/domain.conf
+++ b/core-feature-pack/src/main/resources/content/bin/domain.conf
@@ -51,6 +51,9 @@ fi
 # Use JBoss Modules lockless mode
 #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.lockless=true"
 
+# Uncomment this to run with a security manager enabled
+# SECMGR="true"
+
 # The ProcessController process uses its own set of java options
 if [ "x$PROCESS_CONTROLLER_JAVA_OPTS" = "x" ]; then
     PROCESS_CONTROLLER_JAVA_OPTS="$JAVA_OPTS"

--- a/core-feature-pack/src/main/resources/content/bin/domain.conf.bat
+++ b/core-feature-pack/src/main/resources/content/bin/domain.conf.bat
@@ -55,6 +55,9 @@ set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.system.pkgs=org.jboss.byteman"
 rem # Use JBoss Modules lockless mode
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.lockless=true"
 
+rem # Uncomment this to run with a security manager enabled
+rem set "SECMGR=true"
+
 rem The ProcessController process uses its own set of java options
 set "PROCESS_CONTROLLER_JAVA_OPTS=%JAVA_OPTS%"
 

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf
@@ -65,6 +65,9 @@ fi
 # Uncomment to gather JBoss Modules metrics
 #JAVA_OPTS="$JAVA_OPTS -Djboss.modules.metrics=true"
 
+# Uncomment this to run with a security manager enabled
+# SECMGR="true"
+
 # Uncomment this in order to be able to run WildFly on FreeBSD
 # when you get "epoll_create function not implemented" message in dmesg output
 #JAVA_OPTS="$JAVA_OPTS -Djava.nio.channels.spi.SelectorProvider=sun.nio.ch.PollSelectorProvider"

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf.bat
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf.bat
@@ -64,4 +64,7 @@ rem set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,address=jboss,s
 rem # Use JBoss Modules lockless mode
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.lockless=true"
 
+rem # Uncomment this to run with a security manager enabled
+rem set "SECMGR=true"
+
 :JAVA_OPTS_SET

--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -20,6 +20,16 @@ do
               SERVER_OPTS="$SERVER_OPTS '$1'"
           fi
           ;;
+      -secmgr)
+          SECMGR="true"
+          ;;
+      -Djava.security.manager)
+          SECMGR="true"
+          ;;
+      -Djava.security.manager=*)
+          echo "WARNING: Security manager enabled without custom security manager. Value"
+          SECMGR="true"
+          ;;
       --)
           shift
           break;;
@@ -283,6 +293,19 @@ if [ "x$JBOSS_MODULEPATH" = "x" ]; then
     JBOSS_MODULEPATH="$JBOSS_HOME/modules"
 fi
 
+# Process the JAVA_OPTS and fail the script of a java.security.manager was found
+SECURITY_MANAGER_SET=`echo $JAVA_OPTS | $GREP "java\.security\.manager"`
+if [ "x$SECURITY_MANAGER_SET" != "x" ]; then
+    echo "ERROR: Support for using -Djava.security.manager has been removed. Please use -secmgr or set the environment variable SECMGR=true"
+    exit 1
+fi
+
+# Set up the module arguments
+MODULE_OPTS=""
+if [ "$SECMGR" = "true" ]; then
+    MODULE_OPTS="$MODULE_OPTS -secmgr";
+fi
+
 # Display our environment
 echo "========================================================================="
 echo ""
@@ -304,6 +327,7 @@ while true; do
          \"-Dorg.jboss.boot.log.file="$JBOSS_LOG_DIR"/server.log\" \
          \"-Dlogging.configuration=file:"$JBOSS_CONFIG_DIR"/logging.properties\" \
          -jar \""$JBOSS_HOME"/jboss-modules.jar\" \
+         $MODULE_OPTS \
          -mp \""${JBOSS_MODULEPATH}"\" \
          org.jboss.as.standalone \
          -Djboss.home.dir=\""$JBOSS_HOME"\" \
@@ -316,6 +340,7 @@ while true; do
          \"-Dorg.jboss.boot.log.file="$JBOSS_LOG_DIR"/server.log\" \
          \"-Dlogging.configuration=file:"$JBOSS_CONFIG_DIR"/logging.properties\" \
          -jar \""$JBOSS_HOME"/jboss-modules.jar\" \
+         $MODULE_OPTS \
          -mp \""${JBOSS_MODULEPATH}"\" \
          org.jboss.as.standalone \
          -Djboss.home.dir=\""$JBOSS_HOME"\" \

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -236,11 +236,20 @@ public class HostControllerEnvironment extends ProcessEnvironment {
 
     private volatile String hostControllerName;
     private final HostRunningModeControl runningModeControl;
+    private final boolean securityManagerEnabled;
 
     public HostControllerEnvironment(Map<String, String> hostSystemProperties, boolean isRestart, String modulePath,
                                      InetAddress processControllerAddress, Integer processControllerPort, InetAddress hostControllerAddress,
                                      Integer hostControllerPort, String defaultJVM, String domainConfig, String initialDomainConfig, String hostConfig,
                                      String initialHostConfig, RunningMode initialRunningMode, boolean backupDomainFiles, boolean useCachedDc, ProductConfig productConfig) {
+        this(hostSystemProperties, isRestart, modulePath, processControllerAddress, processControllerPort, hostControllerAddress, hostControllerPort, defaultJVM,
+                domainConfig, initialDomainConfig, hostConfig, initialHostConfig, initialRunningMode, backupDomainFiles, useCachedDc, productConfig, false);
+    }
+
+    public HostControllerEnvironment(Map<String, String> hostSystemProperties, boolean isRestart, String modulePath,
+                                     InetAddress processControllerAddress, Integer processControllerPort, InetAddress hostControllerAddress,
+                                     Integer hostControllerPort, String defaultJVM, String domainConfig, String initialDomainConfig, String hostConfig,
+                                     String initialHostConfig, RunningMode initialRunningMode, boolean backupDomainFiles, boolean useCachedDc, ProductConfig productConfig, boolean securityManagerEnabled) {
 
         if (hostSystemProperties == null) {
             throw HostControllerLogger.ROOT_LOGGER.nullVar("hostSystemProperties");
@@ -456,6 +465,7 @@ public class HostControllerEnvironment extends ProcessEnvironment {
         this.backupDomainFiles = backupDomainFiles;
         this.useCachedDc = useCachedDc;
         this.productConfig = productConfig;
+        this.securityManagerEnabled = securityManagerEnabled || hostSystemProperties.containsKey("java.security.manager");
     }
 
     /**
@@ -770,6 +780,10 @@ public class HostControllerEnvironment extends ProcessEnvironment {
 
     String getModulePath() {
         return modulePath;
+    }
+
+    boolean isSecurityManagerEnabled() {
+        return securityManagerEnabled;
     }
 
     /**

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
@@ -262,6 +262,10 @@ public class ManagedServerBootCmdFactory implements ManagedServerBootConfigurati
         command.add(getAbsolutePath(environment.getHomeDir(), "jboss-modules.jar"));
         command.add("-mp");
         command.add(environment.getModulePath());
+        // Enable the security manager if required
+        if (environment.isSecurityManagerEnabled()){
+            command.add("-secmgr");
+        }
         command.add("org.jboss.as.server");
 
         return command;

--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -43,6 +43,7 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
 
     static final String HOME_DIR = "jboss.home.dir";
     static final String SECURITY_MANAGER_ARG = "-secmgr";
+    static final String SECURITY_MANAGER_PROP = "java.security.manager";
     // TODO (jrp) should java.awt.headless=true be added?
     static final String[] DEFAULT_VM_ARGUMENTS = {
             "-Xms64m",

--- a/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
@@ -587,8 +587,13 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
      * @return the builder
      */
     public DomainCommandBuilder addProcessControllerJavaOption(final String arg) {
-        if (arg != null) {
-            processControllerJavaOpts.add(arg);
+        if (arg != null && !arg.trim().isEmpty()) {
+            final Argument argument = Arguments.parse(arg);
+            if (argument.getKey().equals(SECURITY_MANAGER_PROP)) {
+                setUseSecurityManager(true);
+            } else {
+                processControllerJavaOpts.add(argument);
+            }
         }
         return this;
     }

--- a/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
@@ -114,6 +114,8 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
                 if (argument.getValue() != null) {
                     setLogDirectory(argument.getValue());
                 }
+            } else if (argument.getKey().equals(SECURITY_MANAGER_PROP)) {
+                setUseSecurityManager(true);
             } else {
                 javaOpts.add(argument);
             }

--- a/launcher/src/test/java/org/wildfly/core/launcher/DomainCommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/DomainCommandBuilderTest.java
@@ -41,11 +41,11 @@ public class DomainCommandBuilderTest extends CommandBuilderTest {
                 .setMasterAddressHint("0.0.0.0")
                 .setDomainConfiguration("domain.xml")
                 .setHostConfiguration("host.xml")
+                .addProcessControllerJavaOption("-Djava.security.manager")
                 .setBindAddressHint("management", "0.0.0.0");
 
         // Get all the commands
         List<String> commands = commandBuilder.buildArguments();
-        System.out.println(commands);
 
         Assert.assertTrue("--admin-only is missing", commands.contains("--admin-only"));
 
@@ -56,6 +56,8 @@ public class DomainCommandBuilderTest extends CommandBuilderTest {
         Assert.assertTrue("Missing -b=0.0.0.0", commands.contains("-bmanagement=0.0.0.0"));
 
         Assert.assertTrue("Missing server configuration file override", commands.contains("-c=domain.xml"));
+
+        Assert.assertTrue("Missing -secmgr option", commands.contains("-secmgr"));
 
         // Rename the binding address
         commandBuilder.setBindAddressHint(null);

--- a/launcher/src/test/java/org/wildfly/core/launcher/StandaloneCommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/StandaloneCommandBuilderTest.java
@@ -40,11 +40,11 @@ public class StandaloneCommandBuilderTest extends CommandBuilderTest {
                 .setBindAddressHint("0.0.0.0")
                 .setDebug(true, 5005)
                 .setServerConfiguration("standalone-full.xml")
+                .addJavaOption("-Djava.security.manager")
                 .setBindAddressHint("management", "0.0.0.0");
 
         // Get all the commands
         List<String> commands = commandBuilder.buildArguments();
-        System.out.println(commands);
 
         Assert.assertTrue("--admin-only is missing", commands.contains("--admin-only"));
 
@@ -55,6 +55,8 @@ public class StandaloneCommandBuilderTest extends CommandBuilderTest {
         Assert.assertTrue("Missing debug argument", commands.contains(String.format(StandaloneCommandBuilder.DEBUG_FORMAT, "y", 5005)));
 
         Assert.assertTrue("Missing server configuration file override", commands.contains("-c=standalone-full.xml"));
+
+        Assert.assertTrue("Missing -secmgr option", commands.contains("-secmgr"));
 
         // Rename the binding address
         commandBuilder.setBindAddressHint(null);

--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineArgumentUsageImpl.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineArgumentUsageImpl.java
@@ -92,6 +92,9 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
 
         addArguments(CommandLineConstants.OLD_SHORT_VERSION, CommandLineConstants.SHORT_VERSION, CommandLineConstants.VERSION);
         instructions.add(ProcessLogger.ROOT_LOGGER.argVersion());
+
+        addArguments(CommandLineConstants.SECMGR);
+        instructions.add(ProcessLogger.ROOT_LOGGER.argSecMgr());
     }
 
     public static void printUsage(final PrintStream out) {

--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
@@ -119,6 +119,7 @@ public class CommandLineConstants {
     public static final String MASTER_PORT = "--master-port";
 
     public static final String MODULE_PATH = "-mp";
+    public static final String SECMGR = "-secmgr";
 
     // java.net properties
     public static final String PREFER_IPV4_STACK = "java.net.preferIPv4Stack";

--- a/process-controller/src/main/java/org/jboss/as/process/logging/ProcessLogger.java
+++ b/process-controller/src/main/java/org/jboss/as/process/logging/ProcessLogger.java
@@ -454,6 +454,14 @@ public interface ProcessLogger extends BasicLogger {
     String argMasterPort();
 
     /**
+     * Instructions for the {@link CommandLineConstants#SECMGR} command line argument.
+     *
+     * @return the message
+     */
+    @Message(id = Message.NONE, value = "Runs the server with a security manager installed.")
+    String argSecMgr();
+
+    /**
      * Error message indicating no value was provided for a command line argument.
      *
      * @param argument the name of the argument

--- a/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
+++ b/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
@@ -71,6 +71,9 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
         addArguments(CommandLineConstants.SHORT_VERSION, CommandLineConstants.OLD_SHORT_VERSION, CommandLineConstants.VERSION);
         instructions.add(ServerLogger.ROOT_LOGGER.argVersion());
 
+        addArguments(CommandLineConstants.SECMGR);
+        instructions.add(ServerLogger.ROOT_LOGGER.argSecMgr());
+
     }
 
     public static void printUsage(final PrintStream out) {

--- a/server/src/main/java/org/jboss/as/server/Main.java
+++ b/server/src/main/java/org/jboss/as/server/Main.java
@@ -243,6 +243,8 @@ public final class Main {
                             }
                         }
                     }
+                } else if (arg.equals(CommandLineConstants.SECMGR)) {
+                    // do nothing, just need to filter out as Windows batch scripts cannot filter it out
                 } else {
                     STDERR.println(ServerLogger.ROOT_LOGGER.invalidCommandLineOption(arg));
                     usage();

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -550,6 +550,14 @@ public interface ServerLogger extends BasicLogger {
     String argDebugPort();
 
     /**
+     * Instructions for the {@link CommandLineConstants#SECMGR} command line argument.
+     *
+     * @return the message
+     */
+    @Message(id = Message.NONE, value = "Runs the server with a security manager installed.")
+    String argSecMgr();
+
+    /**
      * Creates an error message indicating a value was expected for the given command line option.
      *
      * @param option the name of the command line option


### PR DESCRIPTION
Replacement for #169 @kabir needs to approve this and anyone with interest/knowledge of the security manager should have a look. Also a good look at the scripts could be useful. I tested only on Fedora 20 and Windows 7.
## General

Passing `-secmgr` or `-Djava.security.manager` to any of the startup scripts will activate the security manager by passing `-secmgr` to jboss-modules. Optionally in the `*.conf[.bat]` files you can set the `SECMGR=true` environment variable to turn on the security manager too. Finally passing `-Djava.security.manager=com.example.CustomSecurityManager` will turn on the security manager, but will not initialize it with the `com.example.CustomSecurityManager`.
## Linux

`JAVA_OPTS` and `PROCESS_CONTROLLER_JAVA_OPTS` will be processed and fail if `-Djava.security.manager[=class]` is found. The security manager will be turned on, but again if a custom security manager is defined the value is ignored. This essentially translates `-Djava.security.manager` command line argument to `-secmgr`.
## Windows

`JAVA_OPTS` and `PROCESS_CONTROLLER_JAVA_OPTS` will be processed looking for `-Djava.security.manager[=class]`. In this case if it's found the script will fail with an error message indicating the `SECMGR=true` environment variable should be used. I could not find a way to reliably rewrite the `JAVA_OPTS`. The other option would be to just ignore it, pass the `-Djava.security.manager` as was done before.

If anyone with better Windows scripting skills than me wants to look, please feel free :+1: 
