### PR TITLE
[WFCORE-39] : Make KeepAliveTimeAttributeDefinition deal with both a sim...

### DIFF
--- a/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolResourceDefinition.java
+++ b/threads/src/main/java/org/jboss/as/threads/BoundedQueueThreadPoolResourceDefinition.java
@@ -104,4 +104,14 @@ public class BoundedQueueThreadPoolResourceDefinition extends SimpleResourceDefi
                 .addRejectCheck(KeepAliveTimeAttributeDefinition.TRANSFORMATION_CHECKER, PoolAttributeDefinitions.KEEPALIVE_TIME);
     }
 
+    public static void registerTransformers1_1(ResourceTransformationDescriptionBuilder parent) {
+        registerTransformers1_1(parent, CommonAttributes.BLOCKING_BOUNDED_QUEUE_THREAD_POOL);
+        registerTransformers1_1(parent, CommonAttributes.BOUNDED_QUEUE_THREAD_POOL);
+    }
+
+    public static void registerTransformers1_1(ResourceTransformationDescriptionBuilder parent, String type) {
+        parent.addChildResource(PathElement.pathElement(type)).getAttributeBuilder()
+                .setValueConverter(KeepAliveTimeAttributeDefinition.TIME_UNIT_TRANSFORMER, CommonAttributes.KEEPALIVE_TIME);
+    }
+
 }

--- a/threads/src/main/java/org/jboss/as/threads/Namespace.java
+++ b/threads/src/main/java/org/jboss/as/threads/Namespace.java
@@ -32,16 +32,18 @@ import java.util.Map;
  */
 public enum Namespace {
     // must be first
+// must be first
     UNKNOWN(null),
 
     THREADS_1_0("urn:jboss:domain:threads:1.0"),
     THREADS_1_1("urn:jboss:domain:threads:1.1"),
+    THREADS_2_0("urn:jboss:domain:threads:2.0"),
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = THREADS_1_1;
+    public static final Namespace CURRENT = THREADS_2_0;
 
     private final String name;
 

--- a/threads/src/main/java/org/jboss/as/threads/QueuelessThreadPoolResourceDefinition.java
+++ b/threads/src/main/java/org/jboss/as/threads/QueuelessThreadPoolResourceDefinition.java
@@ -103,4 +103,16 @@ public class QueuelessThreadPoolResourceDefinition extends SimpleResourceDefinit
         .getAttributeBuilder()
             .addRejectCheck(KeepAliveTimeAttributeDefinition.TRANSFORMATION_CHECKER, PoolAttributeDefinitions.KEEPALIVE_TIME);
     }
+
+    public static void registerTransformers1_1(ResourceTransformationDescriptionBuilder parent) {
+        registerTransformers1_1(parent, CommonAttributes.BLOCKING_QUEUELESS_THREAD_POOL);
+        registerTransformers1_1(parent, CommonAttributes.QUEUELESS_THREAD_POOL);
+    }
+
+    public static void registerTransformers1_1(ResourceTransformationDescriptionBuilder parent, String type) {
+        parent.addChildResource(PathElement.pathElement(type))
+                .getAttributeBuilder()
+                .setValueConverter(KeepAliveTimeAttributeDefinition.TIME_UNIT_TRANSFORMER, CommonAttributes.KEEPALIVE_TIME);
+    }
+
 }

--- a/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolResourceDefinition.java
+++ b/threads/src/main/java/org/jboss/as/threads/ScheduledThreadPoolResourceDefinition.java
@@ -76,4 +76,14 @@ public class ScheduledThreadPoolResourceDefinition extends SimpleResourceDefinit
         .getAttributeBuilder()
             .addRejectCheck(KeepAliveTimeAttributeDefinition.TRANSFORMATION_CHECKER, PoolAttributeDefinitions.KEEPALIVE_TIME);
     }
+
+    public static void registerTransformers1_1(ResourceTransformationDescriptionBuilder parent) {
+        registerTransformers1_1(parent, CommonAttributes.SCHEDULED_THREAD_POOL);
+    }
+
+    public static void registerTransformers1_1(ResourceTransformationDescriptionBuilder parent, String type) {
+        parent.addChildResource(PathElement.pathElement(type))
+                .getAttributeBuilder().setValueConverter(KeepAliveTimeAttributeDefinition.TIME_UNIT_TRANSFORMER, CommonAttributes.KEEPALIVE_TIME).end();
+    }
+
 }

--- a/threads/src/main/java/org/jboss/as/threads/ThreadPoolManagementUtils.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadPoolManagementUtils.java
@@ -175,12 +175,11 @@ class ThreadPoolManagementUtils {
             if (!keepaliveTime.hasDefined(TIME)) {
                 throw ThreadsLogger.ROOT_LOGGER.missingKeepAliveTime(TIME, KEEPALIVE_TIME);
             }
-            if (!keepaliveTime.hasDefined(UNIT)) {
-                throw ThreadsLogger.ROOT_LOGGER.missingKeepAliveUnit(UNIT, KEEPALIVE_TIME);
-            }
             long time = KeepAliveTimeAttributeDefinition.KEEPALIVE_TIME_TIME.resolveModelAttribute(context, keepaliveTime).asLong();
-            String unit = KeepAliveTimeAttributeDefinition.KEEPALIVE_TIME_UNIT.resolveModelAttribute(context, keepaliveTime).asString();
-            params.keepAliveTime = new TimeSpec(Enum.valueOf(TimeUnit.class, unit.toUpperCase(Locale.ENGLISH)), time);
+            if (keepaliveTime.hasDefined(UNIT)) {
+                time = TimeUnit.valueOf(KeepAliveTimeAttributeDefinition.KEEPALIVE_TIME_UNIT.resolveModelAttribute(context, keepaliveTime).asString().toUpperCase(Locale.ENGLISH)).toMillis(time);
+            }
+            params.keepAliveTime = new TimeSpec(TimeUnit.MILLISECONDS, time);
         }
 
         return params;

--- a/threads/src/main/java/org/jboss/as/threads/UnboundedQueueThreadPoolResourceDefinition.java
+++ b/threads/src/main/java/org/jboss/as/threads/UnboundedQueueThreadPoolResourceDefinition.java
@@ -81,4 +81,15 @@ public class UnboundedQueueThreadPoolResourceDefinition extends SimpleResourceDe
         .getAttributeBuilder()
             .addRejectCheck(KeepAliveTimeAttributeDefinition.TRANSFORMATION_CHECKER, PoolAttributeDefinitions.KEEPALIVE_TIME);
     }
+
+    public static void registerTransformers1_1(ResourceTransformationDescriptionBuilder parent) {
+        registerTransformers1_1(parent, CommonAttributes.UNBOUNDED_QUEUE_THREAD_POOL);
+    }
+
+    public static void registerTransformers1_1(ResourceTransformationDescriptionBuilder parent, String type) {
+        parent.addChildResource(PathElement.pathElement(type))
+                .getAttributeBuilder()
+                .setValueConverter(KeepAliveTimeAttributeDefinition.TIME_UNIT_TRANSFORMER, CommonAttributes.KEEPALIVE_TIME);
+    }
+
 }

--- a/threads/src/main/resources/schema/wildfly-threads_2_0.xsd
+++ b/threads/src/main/resources/schema/wildfly-threads_2_0.xsd
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:domain:threads:2.0"
+            xmlns="urn:jboss:domain:threads:2.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.0">
+
+    <!-- The threads subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    The threading subsystem, used to declare manageable thread pools and resources.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="thread-factory" type="thread-factory"/>
+            <xs:element name="unbounded-queue-thread-pool" type="unbounded-queue-thread-pool"/>
+            <xs:element name="bounded-queue-thread-pool" type="bounded-queue-thread-pool"/>
+            <xs:element name="blocking-bounded-queue-thread-pool" type="blocking-bounded-queue-thread-pool"/>
+            <xs:element name="queueless-thread-pool" type="queueless-thread-pool"/>
+            <xs:element name="blocking-queueless-thread-pool" type="blocking-queueless-thread-pool"/>
+            <xs:element name="scheduled-thread-pool" type="scheduled-thread-pool"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="thread-factory">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A thread factory (implementing java.util.concurrent.ThreadFactory).  The "name" attribute is
+                the bean name of the created thread factory.  The optional "priority" attribute may be used to specify
+                the thread priority of created threads.  The optional "group-name" attribute specifies the name of a the
+                thread group to create for this thread factory.
+
+                The "thread-name-pattern" is the template used to create names for threads.  The following patterns
+                may be used:
+
+                 %% - emit a percent sign
+                 %t - emit the per-factory thread sequence number
+                 %g - emit the global thread sequence number
+                 %f - emit the factory sequence number
+                 %i - emit the thread ID
+                 %G - emit the thread group name
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="group-name" type="xs:string" use="optional"/>
+        <xs:attribute name="thread-name-pattern" type="xs:string" use="optional"/>
+        <xs:attribute name="priority" type="priority" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="unbounded-queue-thread-pool">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A thread pool executor with an unbounded queue.  Such a thread pool has a core size and a queue with no
+                upper bound.  When a task is submitted, if the number of running threads is less than the core size,
+                a new thread is created.  Otherwise, the task is placed in queue.  If too many tasks are allowed to be
+                submitted to this type of executor, an out of memory condition may occur.
+
+                The "name" attribute is the bean name of the created executor.
+
+                The "max-threads" attribute must be used to specify the thread pool size.  The nested
+                "keepalive-time" element may used to specify the amount of time that pool threads should
+                be kept running when idle; if not specified, threads will run until the executor is shut down.
+                The "thread-factory" element specifies the bean name of a specific thread factory to use to create worker
+                threads.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="max-threads" type="countType"/>
+            <xs:element name="keepalive-time" type="time" minOccurs="0"/>
+            <xs:element name="thread-factory" type="ref" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="bounded-queue-thread-pool">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A thread pool executor with a bounded queue, where threads attempting to submit tasks will not block.
+                Such a thread pool has a core and maximum size and a specified queue length.  When a task is submitted,
+                if the number of running threads is less than the core size, a new thread is created.  Otherwise, if
+                there is room in the queue, the task is enqueued. Otherwise, if the number of running threads is less
+                than the maximum size, a new thread is created. Otherwise, the task is handed off to the designated
+                handoff executor, if one is specified.  Otherwise, the task is discarded.
+
+                The "name" attribute is the bean name of the created executor.  The "allow-core-timeout" attribute
+                specifies whether core threads may time out; if false, only threads above the core size will time out.
+
+                The optional "core-threads" element may be used to specify the core thread pool size which is smaller
+                than the maximum pool size.  The required "max-threads" element specifies the maximum thread pool size.
+                The required "queue-length" element specifies the queue length.  The optional "keepalive-time" element may
+                used to specify the amount of time that threads beyond the core pool size should be kept running when idle.
+                The optional "thread-factory" element specifies the bean name of a specific thread factory to use to
+                create worker threads.  The optional "handoff-executor" element specifies an executor to delegate tasks
+                to in the event that a task cannot be accepted.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="core-threads" type="countType" minOccurs="0"/>
+            <xs:element name="queue-length" type="countType"/>
+            <xs:element name="max-threads" type="countType"/>
+            <xs:element name="keepalive-time" type="time" minOccurs="0"/>
+            <xs:element name="thread-factory" type="ref" minOccurs="0"/>
+            <xs:element name="handoff-executor" type="ref" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="allow-core-timeout" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="blocking" use="optional" type="xs:boolean" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="blocking-bounded-queue-thread-pool">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A thread pool executor with a bounded queue, where threads attempting to submit tasks may block.
+                Such a thread pool has a core and maximum size and a specified queue length.  When a task is submitted,
+                if the number of running threads is less than the core size, a new thread is created.  Otherwise, if
+                there is room in the queue, the task is enqueued. Otherwise, if the number of running threads is less
+                than the maximum size, a new thread is created.Otherwise, the caller blocks until room becomes available
+                in the queue.
+
+                The "name" attribute is the bean name of the created executor.  The "allow-core-timeout" attribute
+                specifies whether core threads may time out; if false, only threads above the core size will time out.
+
+                The optional "core-threads" element may be used to specify the core thread pool size which is smaller
+                than the maximum pool size.  The required "max-threads" element specifies the maximum thread pool size.
+                The required "queue-length" element specifies the queue length.  The optional "keepalive-time" element may
+                used to specify the amount of time that threads beyond the core pool size should be kept running when idle.
+                The optional "thread-factory" element specifies the bean name of a specific thread factory to use to
+                create worker threads.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="core-threads" type="countType" minOccurs="0"/>
+            <xs:element name="queue-length" type="countType"/>
+            <xs:element name="max-threads" type="countType"/>
+            <xs:element name="keepalive-time" type="time" minOccurs="0"/>
+            <xs:element name="thread-factory" type="ref" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="allow-core-timeout" use="optional" type="xs:boolean" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="queueless-thread-pool">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A thread pool executor with no queue, where threads attempting to submit tasks will not block.
+                When a task is submitted, if the number of running threads is less than the maximum size, a new thread
+                is created. Otherwise, the task is handed off to the designated handoff executor, if one is specified.
+                Otherwise, the task is discarded.
+
+                The "name" attribute is the bean name of the created executor.
+
+                The "max-threads" attribute specifies the number of threads to use for this executor before
+                tasks cannot be accepted anymore.  The optional "keepalive-time" is used to specify the amount of time
+                that threads should be kept running when idle; by default threads run indefinitely.  The optional
+                "thread-factory" element specifies the bean name of a specific thread factory to use to create worker
+                threads.  The optional "handoff-executor" element specifies an executor to delegate tasks to in the
+                event that a task cannot be accepted.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="max-threads" type="countType"/>
+            <xs:element name="keepalive-time" type="time" minOccurs="0"/>
+            <xs:element name="thread-factory" type="ref" minOccurs="0"/>
+            <xs:element name="handoff-executor" type="ref" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="blocking-queueless-thread-pool">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A thread pool executor with no queue, where threads attempting to submit tasks may block.
+                When a task is submitted, if the number of running threads is less than the maximum size, a new thread
+                is created.  Otherwise, the caller blocks until another thread completes its task and accepts the new one.
+
+                The "name" attribute is the bean name of the created executor.
+
+                The "max-threads" attribute specifies the number of threads to use for this executor before
+                tasks cannot be accepted anymore.  The optional "keepalive-time" is used to specify the amount of time
+                that threads should be kept running when idle; by default threads run indefinitely.  The optional
+                "thread-factory" element specifies the bean name of a specific thread factory to use to create worker
+                threads.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="max-threads" type="countType"/>
+            <xs:element name="keepalive-time" type="time" minOccurs="0"/>
+            <xs:element name="thread-factory" type="ref" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="scheduled-thread-pool">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A scheduled thread pool executor.  The "name" attribute is the bean name of the created executor.  The
+                "thread-factory" attribute specifies the bean name of the thread factory to use to create worker
+                threads.  The nested "max-threads" attribute may be used to specify the thread pool size.  The nested
+                "keepalive-time" element is used to specify the amount of time that threads should be kept running when idle.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="max-threads" type="countType"/>
+            <xs:element name="keepalive-time" type="time" minOccurs="0"/>
+            <xs:element name="thread-factory" type="ref" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:simpleType name="priority">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A priority which can range from 1 to 10 (inclusive).  See http://java.sun.com/javase/6/docs/api/java/lang/Thread.html#setPriority(int) for more information.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:integer">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="10"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="countType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A size designation.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="count" type="xs:int" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="ref">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A reference to another named service.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="time">
+        <xs:annotation>
+            <xs:documentation>
+                An amount of time in milliseconds.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="time" type="xs:long" use="required"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/threads/src/test/java/org/jboss/as/threads/ThreadsSubsystemParsingTestCase.java
+++ b/threads/src/test/java/org/jboss/as/threads/ThreadsSubsystemParsingTestCase.java
@@ -57,7 +57,6 @@ import static org.jboss.as.threads.CommonAttributes.THREAD_FACTORY;
 import static org.jboss.as.threads.CommonAttributes.THREAD_NAME_PATTERN;
 import static org.jboss.as.threads.CommonAttributes.TIME;
 import static org.jboss.as.threads.CommonAttributes.UNBOUNDED_QUEUE_THREAD_POOL;
-import static org.jboss.as.threads.CommonAttributes.UNIT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -161,9 +160,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
                 .asType());
         assertEquals(ModelType.LONG, blockingBoundedQueueThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE)
                 .require(TIME).require(TYPE).asType());
-        assertEquals(ModelType.STRING,
-                blockingBoundedQueueThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE).require(UNIT)
-                        .require(TYPE).asType());
         assertEquals(ModelType.BOOLEAN, blockingBoundedQueueThreadPoolDesc.require(ATTRIBUTES).require(ALLOW_CORE_TIMEOUT)
                 .require(TYPE).asType());
         assertFalse(blockingBoundedQueueThreadPoolDesc.require(ATTRIBUTES).has(HANDOFF_EXECUTOR));
@@ -183,9 +179,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
                 .asType());
         assertEquals(ModelType.LONG, boundedQueueThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE)
                 .require(TIME).require(TYPE).asType());
-        assertEquals(ModelType.STRING,
-                boundedQueueThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE).require(UNIT)
-                        .require(TYPE).asType());
         assertEquals(ModelType.BOOLEAN, boundedQueueThreadPoolDesc.require(ATTRIBUTES).require(ALLOW_CORE_TIMEOUT)
                 .require(TYPE).asType());
         assertEquals(ModelType.STRING, boundedQueueThreadPoolDesc.require(ATTRIBUTES).require(HANDOFF_EXECUTOR).require(TYPE)
@@ -198,9 +191,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
         assertEquals(ModelType.INT, blockingQueueLessThreadPoolDesc.require(ATTRIBUTES).require(MAX_THREADS).require(TYPE).asType());
         assertEquals(ModelType.LONG, blockingQueueLessThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE)
                 .require(TIME).require(TYPE).asType());
-        assertEquals(ModelType.STRING,
-                blockingQueueLessThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE).require(UNIT)
-                        .require(TYPE).asType());
         assertFalse(blockingQueueLessThreadPoolDesc.require(ATTRIBUTES).has(HANDOFF_EXECUTOR));
 
         ModelNode queueLessThreadPoolDesc = threadsDescription.get(CHILDREN, QUEUELESS_THREAD_POOL, MODEL_DESCRIPTION, "*");
@@ -210,9 +200,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
         assertEquals(ModelType.INT, queueLessThreadPoolDesc.require(ATTRIBUTES).require(MAX_THREADS).require(TYPE).asType());
         assertEquals(ModelType.LONG, queueLessThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE)
                 .require(TIME).require(TYPE).asType());
-        assertEquals(ModelType.STRING,
-                queueLessThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE).require(UNIT)
-                        .require(TYPE).asType());
         assertEquals(ModelType.STRING, queueLessThreadPoolDesc.require(ATTRIBUTES).require(HANDOFF_EXECUTOR).require(TYPE)
                 .asType());
 
@@ -223,9 +210,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
         assertEquals(ModelType.INT, scheduledThreadPoolDesc.require(ATTRIBUTES).require(MAX_THREADS).require(TYPE).asType());
         assertEquals(ModelType.LONG, scheduledThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE)
                 .require(TIME).require(TYPE).asType());
-        assertEquals(ModelType.STRING,
-                scheduledThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE).require(UNIT)
-                        .require(TYPE).asType());
 
         ModelNode unboundedThreadPoolDesc = threadsDescription.get(CHILDREN, UNBOUNDED_QUEUE_THREAD_POOL, MODEL_DESCRIPTION,
                 "*");
@@ -235,9 +219,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
         assertEquals(ModelType.INT, unboundedThreadPoolDesc.require(ATTRIBUTES).require(MAX_THREADS).require(TYPE).asType());
         assertEquals(ModelType.LONG, unboundedThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE)
                 .require(TIME).require(TYPE).asType());
-        assertEquals(ModelType.STRING,
-                unboundedThreadPoolDesc.require(ATTRIBUTES).require(KEEPALIVE_TIME).require(VALUE_TYPE).require(UNIT)
-                        .require(TYPE).asType());
 
     }
 
@@ -387,7 +368,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
         assertEquals(1, threadPool.keys().size());
         assertEquals(100, threadPool.require("test-pool").require(MAX_THREADS).asInt());
         assertEquals(1000L, threadPool.require("test-pool").require(KEEPALIVE_TIME).require(TIME).asLong());
-        assertEquals("MILLISECONDS", threadPool.require("test-pool").require(KEEPALIVE_TIME).require(UNIT).asString());
     }
 
     @Test
@@ -507,7 +487,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
         assertEquals(1, threadPool.keys().size());
         assertEquals(100, threadPool.require("test-pool").require(MAX_THREADS).asInt());
         assertEquals(1000L, threadPool.require("test-pool").require(KEEPALIVE_TIME).get(TIME).asLong());
-        assertEquals("MILLISECONDS", threadPool.require("test-pool").require(KEEPALIVE_TIME).get(UNIT).asString());
     }
 
     @Test
@@ -636,7 +615,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
         assertEquals(2, threadPool.keys().size());
         assertEquals(100, threadPool.require("test-pool").require(MAX_THREADS).asInt());
         assertEquals(1000L, threadPool.require("test-pool").require(KEEPALIVE_TIME).require(TIME).asLong());
-        assertEquals("MILLISECONDS", threadPool.require("test-pool").require(KEEPALIVE_TIME).require(UNIT).asString());
         assertEquals("other", threadPool.require("test-pool").require("handoff-executor").asString());
     }
 
@@ -741,7 +719,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
         assertEquals(1, threadPool.keys().size());
         assertEquals(100, threadPool.require("test-pool").require(MAX_THREADS).asInt());
         assertEquals(1000L, threadPool.require("test-pool").require(KEEPALIVE_TIME).require(TIME).asLong());
-        assertEquals("MILLISECONDS", threadPool.require("test-pool").require(KEEPALIVE_TIME).require(UNIT).asString());
         assertFalse(threadPool.has("handoff-executor"));
     }
 
@@ -878,7 +855,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
         assertEquals(300, threadPool.require("test-pool").require(QUEUE_LENGTH).asInt());
         assertEquals(100, threadPool.require("test-pool").require(MAX_THREADS).asInt());
         assertEquals(1000L, threadPool.require("test-pool").require(KEEPALIVE_TIME).require(TIME).asLong());
-        assertEquals("MILLISECONDS", threadPool.require("test-pool").require(KEEPALIVE_TIME).require(UNIT).asString());
         assertEquals("other", threadPool.require("test-pool").require("handoff-executor").asString());
     }
 
@@ -1010,7 +986,6 @@ public class ThreadsSubsystemParsingTestCase extends AbstractSubsystemTest {
         assertEquals(300, threadPool.require("test-pool").require(QUEUE_LENGTH).asInt());
         assertEquals(100, threadPool.require("test-pool").require(MAX_THREADS).asInt());
         assertEquals(1000L, threadPool.require("test-pool").require(KEEPALIVE_TIME).require(TIME).asLong());
-        assertEquals("MILLISECONDS", threadPool.require("test-pool").require(KEEPALIVE_TIME).require(UNIT).asString());
         assertFalse(threadPool.has(HANDOFF_EXECUTOR));
     }
 

--- a/threads/src/test/java/org/jboss/as/threads/ThreadsSubsystemTestCase.java
+++ b/threads/src/test/java/org/jboss/as/threads/ThreadsSubsystemTestCase.java
@@ -24,14 +24,22 @@
 
 package org.jboss.as.threads;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
 import java.io.IOException;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
 
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.model.test.ModelTestControllerVersion;
+import org.jboss.as.model.test.SingleClassFilter;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,18 +54,50 @@ public class ThreadsSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("threads-subsystem-1_1.xml");
+        return readResource("threads-subsystem-2_0.xml");
     }
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/jboss-as-threads_1_1.xsd";
+        return "schema/wildfly-threads_2_0.xsd";
     }
 
     @Test
     public void testExpressions() throws Exception {
         standardSubsystemTest("expressions.xml");
     }
+
+
+    @Test
+    public void testTransformerWFY80() throws Exception {
+        testTransformer_1_1(ModelTestControllerVersion.WILDFLY_8_0_0_FINAL);
+    }
+
+    /**
+     * Tests transformation of model from 2.0.0 version into 1.1.0 version.
+     *
+     * @throws Exception
+     */
+    private void testTransformer_1_1(ModelTestControllerVersion controllerVersion) throws Exception {
+        String subsystemXml = "threads-transform-1_1.xml";
+        ModelVersion modelVersion = ModelVersion.create(1, 1, 0); //The old model version
+        //Use the non-runtime version of the extension which will happen on the HC
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+                .setSubsystemXmlResource(subsystemXml);
+
+        final PathAddress subsystemAddress = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName()));
+        // Add legacy subsystems
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
+                .addOperationValidationResolve("add", subsystemAddress.append(PathElement.pathElement(CommonAttributes.THREAD_FACTORY)))
+                .addMavenResourceURL("org.wildfly:wildfly-threads:" + controllerVersion.getMavenGavVersion())
+                .excludeFromParent(SingleClassFilter.createFilter(ThreadsLogger.class));
+
+        KernelServices mainServices = builder.build();
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertNotNull(legacyServices);
+        checkSubsystemModelTransformation(mainServices, modelVersion);
+    }
+
     @Override
     protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
         final ModelNode operation = createDescribeOperation();

--- a/threads/src/test/resources/org/jboss/as/threads/threads-subsystem-2_0.xml
+++ b/threads/src/test/resources/org/jboss/as/threads/threads-subsystem-2_0.xml
@@ -1,57 +1,57 @@
-<subsystem xmlns="urn:jboss:domain:threads:1.1">
+<subsystem xmlns="urn:jboss:domain:threads:2.0">
     <thread-factory name="test-factory"/>
     <thread-factory name="factory1" group-name="factory1-threads" thread-name-pattern="%G %i" priority="5"/>
     <thread-factory name="factory2"/>
     <unbounded-queue-thread-pool name="unbounded-1">
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
     </unbounded-queue-thread-pool>
     <unbounded-queue-thread-pool name="unbounded-2">
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
         <thread-factory name="factory1"/>
     </unbounded-queue-thread-pool>
     <bounded-queue-thread-pool name="bounded-1" allow-core-timeout="true">
         <core-threads count="5"/>
         <queue-length count="100"/>
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
         <handoff-executor name="unbounded-1"/>
     </bounded-queue-thread-pool>
     <bounded-queue-thread-pool name="bounded-2">
         <core-threads count="5"/>
         <queue-length count="100"/>
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
         <thread-factory name="factory1"/>
     </bounded-queue-thread-pool>
     <blocking-bounded-queue-thread-pool name="blocking-bounded-1" allow-core-timeout="true">
         <core-threads count="5"/>
         <queue-length count="100"/>
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
     </blocking-bounded-queue-thread-pool>
     <blocking-bounded-queue-thread-pool name="blocking-bounded-2">
         <core-threads count="5"/>
         <queue-length count="100"/>
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
         <thread-factory name="factory1"/>
     </blocking-bounded-queue-thread-pool>
     <queueless-thread-pool name="test-pool">
         <max-threads count="${prop.max-thread-count:100}"/>
-        <keepalive-time time="1000" unit="milliseconds"/>
+        <keepalive-time time="1000"/>
         <thread-factory name="test-factory"/>
         <handoff-executor name="other"/>
     </queueless-thread-pool>
     <queueless-thread-pool name="queueless-1">
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
         <handoff-executor name="unbounded-1"/>
     </queueless-thread-pool>
     <queueless-thread-pool name="queueless-2">
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
         <thread-factory name="factory1"/>
     </queueless-thread-pool>
     <queueless-thread-pool name="other">
@@ -59,25 +59,25 @@
     </queueless-thread-pool>
     <blocking-queueless-thread-pool name="blocking-queueless-1">
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
     </blocking-queueless-thread-pool>
     <blocking-queueless-thread-pool name="blocking-queueless-2">
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
         <thread-factory name="factory1"/>
     </blocking-queueless-thread-pool>
     <scheduled-thread-pool name="test-pool">
         <max-threads count="${prop.max-thread-count:10}"/>
-        <keepalive-time time="${prop.keep-alive-time:1000}" unit="milliseconds"/>
+        <keepalive-time time="${prop.keep-alive-time:1000}"/>
         <thread-factory name="test-factory"/>
     </scheduled-thread-pool>
     <scheduled-thread-pool name="scheduled-1">
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
     </scheduled-thread-pool>
     <scheduled-thread-pool name="scheduled-2">
         <max-threads count="10"/>
-        <keepalive-time time="10" unit="seconds"/>
+        <keepalive-time time="10000"/>
         <thread-factory name="factory1"/>
     </scheduled-thread-pool>
 </subsystem>

--- a/threads/src/test/resources/org/jboss/as/threads/threads-transform-1_1.xml
+++ b/threads/src/test/resources/org/jboss/as/threads/threads-transform-1_1.xml
@@ -1,42 +1,42 @@
-<subsystem xmlns="urn:jboss:domain:threads:2.0">
-    <thread-factory name="test-factory" group-name="${test.exp:Thread Group}" thread-name-pattern="${test.exp:%G - %t}" priority="${test.exp:6}"/>
+<subsystem xmlns="urn:jboss:domain:threads:1.1">
+    <thread-factory name="test-factory" group-name="Thread Group" thread-name-pattern="%G - %t" priority="${test.exp:6}"/>
     <unbounded-queue-thread-pool name="test-pool">
-       <max-threads count="${prop.max-thread-count:100}"/>
-        <keepalive-time time="${test.exp:1000}"/>
-       <thread-factory name="test-factory"/>
+        <max-threads count="${prop.max-thread-count:100}"/>
+        <keepalive-time time="1000" unit="milliseconds"/>
+        <thread-factory name="test-factory"/>
     </unbounded-queue-thread-pool>
-    <bounded-queue-thread-pool name="test-pool" allow-core-timeout="${test.exp:true}">
+    <bounded-queue-thread-pool name="test-bounded-pool" allow-core-timeout="true">
         <core-threads count="${test.exp:200}"/>
         <queue-length count="${test.exp:300}"/>
         <max-threads count="${test.exp:100}"/>
-        <keepalive-time time="${test.exp:1000}"/>
+        <keepalive-time time="1000" unit="milliseconds"/>
         <thread-factory name="test-factory"/>
         <handoff-executor name="other"/>
     </bounded-queue-thread-pool>
-    <blocking-bounded-queue-thread-pool name="test-pool" allow-core-timeout="${test.exp:true}">
+    <blocking-bounded-queue-thread-pool name="test-blocking-bounded-pool" allow-core-timeout="true">
         <core-threads count="${test.exp:200}"/>
         <queue-length count="${test.exp:300}"/>
         <max-threads count="${test.exp:100}"/>
-        <keepalive-time time="${test.exp:1000}"/>
+        <keepalive-time time="1000" unit="milliseconds"/>
         <thread-factory name="test-factory"/>
     </blocking-bounded-queue-thread-pool>
     <queueless-thread-pool name="other">
         <max-threads count="${test.exp:1}"/>
     </queueless-thread-pool>
-    <queueless-thread-pool name="test-pool">
+    <queueless-thread-pool name="test-queueless-pool">
         <max-threads count="${prop.max-thread-count:100}"/>
-        <keepalive-time time="${test.exp:1000}"/>
+        <keepalive-time time="1000" unit="milliseconds"/>
         <thread-factory name="test-factory"/>
         <handoff-executor name="other"/>
     </queueless-thread-pool>
-    <blocking-queueless-thread-pool name="test-pool">
+    <blocking-queueless-thread-pool name="test-blocking-queueless-pool">
         <max-threads count="${prop.max-thread-count:100}"/>
-        <keepalive-time time="${test.exp:1000}"/>
+        <keepalive-time time="1000" unit="milliseconds"/>
         <thread-factory name="test-factory"/>
     </blocking-queueless-thread-pool>
-    <scheduled-thread-pool name="test-pool">
+    <scheduled-thread-pool name="test-scheduled-pool">
         <max-threads count="${prop.max-thread-count:10}"/>
-        <keepalive-time time="${prop.keep-alive-time:1000}"/>
+        <keepalive-time time="1000" unit="milliseconds"/>
         <thread-factory name="test-factory"/>
     </scheduled-thread-pool>
 </subsystem>


### PR DESCRIPTION
...ple long and a complex attribute.

Transforming KeepAliveTimeAttributeDefinition in Model from a complex Object to a Long.
All keep-alive now are expressed as long in milliseconds.
This will affects all subsystems using the "threads" subsystem in wildfly which will be treated in another PR once this one is integrated and released.
Jira: https://issues.jboss.org/browse/WFCORE-39
Replace : https://github.com/wildfly/wildfly-core/pull/64
Requires : https://github.com/wildfly/wildfly/pull/7850 in full for integration tests