### PR TITLE
WFLY-3892

### DIFF
--- a/testsuite-core/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
+++ b/testsuite-core/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
@@ -297,7 +297,6 @@ public class DomainLifecycleUtil {
                     }
                 }
             }
-            domainClient = null;
         }
 
         if (toThrow != null) {
@@ -516,6 +515,7 @@ public class DomainLifecycleUtil {
     private synchronized void closeConnection() {
         if (connection != null) {
             try {
+                domainClient = null;
                 connection.close();
             } catch (Exception e) {
                 log.log(Level.SEVERE, "Caught exception closing DomainTestConnection", e);


### PR DESCRIPTION
DomainLifecycleUtil.start() does not work if DomainLifecycleUtil.stop() is used to stop the host.

Addition of parameter closeConnectionBeforeStop that the user can reset during the tests in order not to close the Connection when stopping the host.
