### PR TITLE
Update WildFly Security Manager to 1.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <version.org.eclipse.aether>1.0.0.v20140518</version.org.eclipse.aether>
         <version.org.wildfly.build-tools>1.0.0.Alpha3</version.org.wildfly.build-tools>
         <version.org.wildfly.legacy.test>1.0.0.Alpha2</version.org.wildfly.legacy.test>
-        <version.org.wildfly.security.manager>1.0.0.Final</version.org.wildfly.security.manager>
+        <version.org.wildfly.security.manager>1.0.1.Final</version.org.wildfly.security.manager>
         <version.org.wildfly.checkstyle-config>1.0.0.Final</version.org.wildfly.checkstyle-config>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
         <!-- Non-default maven plugin versions and configuration -->


### PR DESCRIPTION
Produces better messages for permission failures which should make diagnosing access problems a bit simpler.
