### PR TITLE
[WFCORE-134] : Make sure CLIWrapper doesn't use default encoding

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/RuntimeApplicationTypeReconfigurationTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/RuntimeApplicationTypeReconfigurationTestCase.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.core.model.test.access;
 
+
 import static org.jboss.as.controller.PathAddress.pathAddress;
 import static org.jboss.as.controller.PathElement.pathElement;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS;
@@ -50,6 +51,7 @@ import static org.junit.Assert.assertTrue;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
 import org.jboss.as.controller.access.rbac.StandardRole;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
@@ -195,11 +197,6 @@ public class RuntimeApplicationTypeReconfigurationTestCase extends AbstractCoreM
 
     protected static void assertDenied(ModelNode operationResult) {
         assertEquals(FAILED, operationResult.get(OUTCOME).asString());
-        assertTrue(operationResult.get(FAILURE_DESCRIPTION).asString().contains("Permission denied"));
-    }
-
-    protected static void assertNoAccess(ModelNode operationResult) {
-        assertEquals(FAILED, operationResult.get(OUTCOME).asString());
-        assertTrue(operationResult.get(FAILURE_DESCRIPTION).asString().contains("not found"));
+        assertTrue(operationResult.get(FAILURE_DESCRIPTION).asString().contains(ControllerLogger.ACCESS_LOGGER.permissionDenied()));
     }
 }

--- a/patching/src/test/java/org/jboss/as/patching/cli/ContentConflictsUnitTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/cli/ContentConflictsUnitTestCase.java
@@ -43,6 +43,7 @@ import java.io.File;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContextFactory;
 import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.patching.logging.PatchLogger;
 import org.jboss.as.patching.metadata.ContentModification;
 import org.jboss.as.patching.metadata.Patch;
 import org.jboss.as.patching.metadata.PatchBuilder;
@@ -277,7 +278,7 @@ public class ContentConflictsUnitTestCase extends AbstractTaskTestCase {
 
     protected void assertConflicts(CommandLineException e, String... conflicts) {
         final StringBuilder buf = new StringBuilder();
-        buf.append("Conflicts detected: ");
+        buf.append(PatchLogger.ROOT_LOGGER.detectedConflicts()).append(": ");
         int i = 0;
         while(i < conflicts.length) {
             buf.append(conflicts[i++].replace('\\', '/')); // fix paths on windows

--- a/testsuite-core/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
+++ b/testsuite-core/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
@@ -22,6 +22,7 @@
 package org.jboss.as.test.integration.management.util;
 
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -186,12 +187,12 @@ public class CLIWrapper {
      * @return array of CLI output lines
      */
     public CLIOpResult readAllAsOpResult() throws IOException {
-        final String response = readOutput();
-        if(response == null) {
+        if(consoleOut.size() <= 0) {
             return new CLIOpResult();
         }
-        final ModelNode node = ModelNode.fromString(response);
+        final ModelNode node = ModelNode.fromStream(new ByteArrayInputStream(consoleOut.toByteArray()));
         return new CLIOpResult(node);
+
     }
 
     /**


### PR DESCRIPTION
Fixing issue in CLIWrapper that uses the default encoding instead of UTF-8
Fixing some hard coded string in tests.

Jira: https://issues.jboss.org/browse/WFCORE-134
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=980923
