### PR TITLE
[WFCORE-136] Fix error messages to indicate what is actually incorrect about the suffix

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -422,7 +422,7 @@ public interface LoggingLogger extends BasicLogger {
      *
      * @return the message.
      */
-    @Message(id = 41, value = "The suffix (%s) is invalid. A suffix must be a valid date format and not contain seconds or milliseconds.")
+    @Message(id = 41, value = "The suffix (%s) is invalid. A suffix must be a valid date format.")
     String invalidSuffix(String suffix);
 
     /**
@@ -860,4 +860,14 @@ public interface LoggingLogger extends BasicLogger {
      */
     @Message(id = 81, value = "File '%s' is not allowed to be read.")
     OperationFailedException readNotAllowed(String name);
+
+    /**
+     * A message indicating a suffix contains seconds or milliseconds and the handler does not allow it.
+     *
+     * @param suffix the suffix.
+     *
+     * @return the message.
+     */
+    @Message(id = 82, value = "The suffix (%s) can not contain seconds or milliseconds.")
+    String suffixContainsMillis(String suffix);
 }

--- a/logging/src/main/java/org/jboss/as/logging/validators/SuffixValidator.java
+++ b/logging/src/main/java/org/jboss/as/logging/validators/SuffixValidator.java
@@ -54,7 +54,7 @@ public class SuffixValidator extends ModelTypeValidator {
             final String suffix = value.asString();
             try {
                 if (denySeconds && (suffix.contains("s") || suffix.contains("S"))) {
-                    throw createOperationFailure(LoggingLogger.ROOT_LOGGER.invalidSuffix(suffix));
+                    throw createOperationFailure(LoggingLogger.ROOT_LOGGER.suffixContainsMillis(suffix));
                 }
                 new SimpleDateFormat(suffix);
             } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Uses better error messages now that the `size-rotating-file-handler` also uses a suffix, but allows for seconds and milliseconds to be used.
