### PR TITLE
[WFCORE-150] Known attributes that have been undefined need to remove the property

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
@@ -674,10 +674,16 @@ final class HandlerOperations {
                     // Get the resolver
                     final ModelNodeResolver<String> resolver = configurationProperty.resolver();
                     // Resolve the value
-                    final String resolvedValue = (resolver == null ? model.asString() : resolver.resolveValue(context, model));
-                    // Set the string value
-                    configuration.setPropertyValueString(configurationProperty.getPropertyName(),
-                            (resolvedValue == null ? null : resolvedValue));
+                    final String resolvedValue = (resolver == null ? (model.isDefined() ? model.asString() : null) : resolver.resolveValue(context, model));
+                    if (resolvedValue == null) {
+                        // The value must be set to null and then the property removed,
+                        // Note that primitive attributes should use a default value as null is invalid
+                        configuration.setPropertyValueString(configurationProperty.getPropertyName(), null);
+                        configuration.removeProperty(configurationProperty.getPropertyName());
+                    } else {
+                        // Set the string value
+                        configuration.setPropertyValueString(configurationProperty.getPropertyName(), resolvedValue);
+                    }
                 }
             } else {
                 LoggingLogger.ROOT_LOGGER.invalidPropertyAttribute(attribute.getName());


### PR DESCRIPTION
If an attribute is `undefined` via a `undefine-attribute` operation the value on the handler needs to be set to `null` and the property needs to be removed from the configuration.
