### PR TITLE
[WFCORE-122] Remove default usage for extended stack traces when logging

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli-logging.properties
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli-logging.properties
@@ -44,4 +44,4 @@ handler.FILE.formatter=PATTERN
 # Formatter pattern configuration
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%E%n
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%e%n

--- a/core-feature-pack/src/main/resources/content/domain/configuration/default-server-logging.properties
+++ b/core-feature-pack/src/main/resources/content/domain/configuration/default-server-logging.properties
@@ -63,8 +63,8 @@ handler.FILE.suffix=.yyyy-MM-dd
 
 formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.COLOR-PATTERN.properties=pattern
-formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
 
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n

--- a/core-feature-pack/src/main/resources/content/domain/configuration/logging.properties
+++ b/core-feature-pack/src/main/resources/content/domain/configuration/logging.properties
@@ -46,9 +46,9 @@ handler.BOOT_FILE.formatter=PATTERN
 # Color formatter pattern configuration
 formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.COLOR-PATTERN.properties=pattern
-formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
 
 # Formatter pattern configuration
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n

--- a/core-feature-pack/src/main/resources/content/standalone/configuration/logging.properties
+++ b/core-feature-pack/src/main/resources/content/standalone/configuration/logging.properties
@@ -63,8 +63,8 @@ handler.FILE.suffix=.yyyy-MM-dd
 
 formatter.COLOR-PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.COLOR-PATTERN.properties=pattern
-formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n
 
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%e%n

--- a/logging/src/main/java/org/jboss/as/logging/AbstractHandlerDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/AbstractHandlerDefinition.java
@@ -48,6 +48,7 @@ import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.transform.description.AttributeConverter;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
@@ -80,7 +81,7 @@ abstract class AbstractHandlerDefinition extends TransformerResourceDefinition {
                     }
                 }
             })
-            .setDefaultValue(new ModelNode("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"))
+            .setDefaultValue(new ModelNode("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"))
             .build();
 
     public static final SimpleAttributeDefinition NAMED_FORMATTER = SimpleAttributeDefinitionBuilder.create("named-formatter", ModelType.STRING, true)
@@ -274,6 +275,18 @@ abstract class AbstractHandlerDefinition extends TransformerResourceDefinition {
                             .getAttributeBuilder()
                             .setDiscard(DiscardAttributeChecker.UNDEFINED, NAMED_FORMATTER)
                             .addRejectCheck(RejectAttributeChecker.DEFINED, NAMED_FORMATTER)
+                            .end();
+                    break;
+                }
+                case VERSION_2_0_0: {
+                    final AttributeConverter attributeConverter = AttributeConverter.Factory
+                            .createHardCoded(FORMATTER.getDefaultValue(), true);
+                    resourceBuilder.getAttributeBuilder()
+                            .setValueConverter(attributeConverter, FORMATTER)
+                            .end();
+                    loggingProfileResourceBuilder = loggingProfileBuilder.addChildResource(pathElement);
+                    loggingProfileResourceBuilder.getAttributeBuilder()
+                            .setValueConverter(attributeConverter, FORMATTER)
                             .end();
                     break;
                 }

--- a/logging/src/main/java/org/jboss/as/logging/PatternFormatterResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PatternFormatterResourceDefinition.java
@@ -64,7 +64,7 @@ public class PatternFormatterResourceDefinition extends TransformerResourceDefin
     public static final PropertyAttributeDefinition PATTERN = PropertyAttributeDefinition.Builder.of("pattern", ModelType.STRING)
             .setAllowExpression(true)
             .setAllowNull(false)
-            .setDefaultValue(new ModelNode("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"))
+            .setDefaultValue(new ModelNode("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"))
             .build();
 
     public static final ObjectTypeAttributeDefinition PATTERN_FORMATTER = ObjectTypeAttributeDefinition.Builder.of("pattern-formatter", PATTERN, COLOR_MAP)

--- a/logging/src/main/resources/subsystem-templates/logging.xml
+++ b/logging/src/main/resources/subsystem-templates/logging.xml
@@ -26,10 +26,10 @@
            </handlers>
        </root-logger>
        <formatter name="PATTERN">
-           <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+           <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
        </formatter>
        <formatter name="COLOR-PATTERN">
-           <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+           <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
        </formatter>
    </subsystem>
    <supplement name="default">

--- a/logging/src/test/java/org/jboss/as/logging/FormatterOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/FormatterOperationsTestCase.java
@@ -89,7 +89,7 @@ public class FormatterOperationsTestCase extends AbstractOperationsTestCase {
         executeOperation(kernelServices, addOp);
 
         // Write each attribute and check the value
-        testWrite(kernelServices, address, PatternFormatterResourceDefinition.PATTERN, "[test] %d{HH:mm:ss,SSS} %-5p [%c] %s%E%n");
+        testWrite(kernelServices, address, PatternFormatterResourceDefinition.PATTERN, "[test] %d{HH:mm:ss,SSS} %-5p [%c] %s%e%n");
         testWrite(kernelServices, address, PatternFormatterResourceDefinition.COLOR_MAP, "info:blue,warn:yellow,error:red,debug:cyan");
 
         // Undefine attributes

--- a/logging/src/test/java/org/jboss/as/logging/HandlerLegacyOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/HandlerLegacyOperationsTestCase.java
@@ -306,7 +306,7 @@ public class HandlerLegacyOperationsTestCase extends AbstractOperationsTestCase 
         testUpdateProperties(kernelServices, address, CommonAttributes.LEVEL, "TRACE");
         testUpdateProperties(kernelServices, address, CommonAttributes.ENABLED, false);
         testUpdateProperties(kernelServices, address, CommonAttributes.ENCODING, "utf-8");
-        testUpdateProperties(kernelServices, address, AbstractHandlerDefinition.FORMATTER, "[test] %d{HH:mm:ss,SSS} %-5p [%c] %s%E%n");
+        testUpdateProperties(kernelServices, address, AbstractHandlerDefinition.FORMATTER, "[test] %d{HH:mm:ss,SSS} %-5p [%c] %s%e%n");
         testUpdateProperties(kernelServices, address, CommonAttributes.FILTER_SPEC, "deny");
     }
 

--- a/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
@@ -504,7 +504,7 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
         testWrite(kernelServices, address, CommonAttributes.LEVEL, "INFO");
         testWrite(kernelServices, address, CommonAttributes.ENABLED, true);
         testWrite(kernelServices, address, CommonAttributes.ENCODING, ENCODING);
-        testWrite(kernelServices, address, AbstractHandlerDefinition.FORMATTER, "[test] %d{HH:mm:ss,SSS} %-5p [%c] %s%E%n");
+        testWrite(kernelServices, address, AbstractHandlerDefinition.FORMATTER, "[test] %d{HH:mm:ss,SSS} %-5p [%c] %s%e%n");
         testWrite(kernelServices, address, CommonAttributes.FILTER_SPEC, "deny");
 
         // Add a pattern-formatter
@@ -527,7 +527,7 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
     private void addPatternFormatter(final KernelServices kernelServices, final String profileName, final String name) throws Exception {
         final ModelNode address = createPatternFormatterAddress(profileName, name).toModelNode();
         final ModelNode op = createAddOperation(address);
-        op.get(PatternFormatterResourceDefinition.PATTERN.getName()).set("[test-pattern] %d{HH:mm:ss,SSS} %-5p [%c] %s%E%n");
+        op.get(PatternFormatterResourceDefinition.PATTERN.getName()).set("[test-pattern] %d{HH:mm:ss,SSS} %-5p [%c] %s%e%n");
         executeOperation(kernelServices, op);
     }
 

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemRollbackTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemRollbackTestCase.java
@@ -121,7 +121,7 @@ public class LoggingSubsystemRollbackTestCase extends AbstractLoggingSubsystemTe
         // Operation should fail based on byteman script
         ModelNode op = SubsystemOperations.createAddOperation(address.toModelNode());
         op.get(CommonAttributes.LEVEL.getName()).set("INFO");
-        op.get(AbstractHandlerDefinition.FORMATTER.getName()).set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) CONSOLE2: %s%E%n");
+        op.get(AbstractHandlerDefinition.FORMATTER.getName()).set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) CONSOLE2: %s%e%n");
         ModelNode result = kernelServices.executeOperation(op);
         Assert.assertFalse("The add operation should have failed, but was successful: " + result, SubsystemOperations.isSuccessfulOutcome(result));
 
@@ -153,7 +153,7 @@ public class LoggingSubsystemRollbackTestCase extends AbstractLoggingSubsystemTe
         // Create a new handler
         ModelNode op = SubsystemOperations.createAddOperation(consoleHandler.toModelNode());
         op.get(CommonAttributes.LEVEL.getName()).set("INFO");
-        op.get(AbstractHandlerDefinition.FORMATTER.getName()).set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) CONSOLE2: %s%E%n");
+        op.get(AbstractHandlerDefinition.FORMATTER.getName()).set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) CONSOLE2: %s%e%n");
         ModelNode result = kernelServices.executeOperation(op);
         Assert.assertTrue(SubsystemOperations.getFailureDescriptionAsString(result), SubsystemOperations.isSuccessfulOutcome(result));
 
@@ -219,7 +219,7 @@ public class LoggingSubsystemRollbackTestCase extends AbstractLoggingSubsystemTe
         // Create a new handler
         ModelNode op = SubsystemOperations.createAddOperation(consoleHandler.toModelNode());
         op.get(CommonAttributes.LEVEL.getName()).set("INFO");
-        op.get(AbstractHandlerDefinition.FORMATTER.getName()).set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) CONSOLE2: %s%E%n");
+        op.get(AbstractHandlerDefinition.FORMATTER.getName()).set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) CONSOLE2: %s%e%n");
         ModelNode result = kernelServices.executeOperation(op);
         Assert.assertTrue(SubsystemOperations.getFailureDescriptionAsString(result), SubsystemOperations.isSuccessfulOutcome(result));
 
@@ -391,7 +391,7 @@ public class LoggingSubsystemRollbackTestCase extends AbstractLoggingSubsystemTe
         // Create a new handler
         ModelNode op = SubsystemOperations.createAddOperation(consoleHandler.toModelNode());
         op.get(CommonAttributes.LEVEL.getName()).set("INFO");
-        op.get(AbstractHandlerDefinition.FORMATTER.getName()).set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) CONSOLE2: %s%E%n");
+        op.get(AbstractHandlerDefinition.FORMATTER.getName()).set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) CONSOLE2: %s%e%n");
         ModelNode result = kernelServices.executeOperation(op);
         Assert.assertFalse("The add operation should have failed, but was successful: " + result, SubsystemOperations.isSuccessfulOutcome(result));
 

--- a/logging/src/test/resources/default-subsystem.xml
+++ b/logging/src/test/resources/default-subsystem.xml
@@ -24,12 +24,12 @@
     <console-handler name="CONSOLE">
         <level name="INFO"/>
         <formatter>
-            <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
         </formatter>
     </console-handler>
     <periodic-rotating-file-handler name="FILE" autoflush="true">
         <formatter>
-            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
         </formatter>
         <file relative-to="jboss.server.log.dir" path="server.log"/>
         <suffix value=".yyyy-MM-dd"/>

--- a/logging/src/test/resources/expressions.xml
+++ b/logging/src/test/resources/expressions.xml
@@ -37,7 +37,7 @@
         <encoding value="${test.encoding:UTF-8}"/>
         <filter-spec value="${test.console.filter:levelRange(TRACE,WARN)}" />
         <formatter>
-            <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+            <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n}"/>
         </formatter>
         <target name="${test.console.target:System.out}"/>
     </console-handler>
@@ -57,7 +57,7 @@
         <encoding value="${test.encoding:UTF-8}"/>
         <filter-spec value="${test.file.filter:any(levels(INFO),not(levels(TRACE)))}"/>
         <formatter>
-            <pattern-formatter pattern="${test.console.pattern:%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+            <pattern-formatter pattern="${test.console.pattern:%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n}"/>
         </formatter>
         <file relative-to="jboss.server.log.dir" path="${test.server.log.file:server.log}"/>
         <suffix value="${test.file.suffix:.yyyy-MM-dd}"/>
@@ -67,7 +67,7 @@
         <level name="${test.file.level:INFO}"/>
         <encoding value="${test.encoding:UTF-8}"/>
         <formatter>
-            <pattern-formatter pattern="${test.file.pattern:%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+            <pattern-formatter pattern="${test.file.pattern:%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n}"/>
         </formatter>
         <file relative-to="jboss.server.log.dir" path="${test.periodic.size.log.file:ps.log}"/>
         <rotate-size value="${test.rotate.size:64m}"/>
@@ -80,7 +80,7 @@
         <level name="${test.file.level:INFO}"/>
         <encoding value="${test.encoding:UTF-8}"/>
         <formatter>
-            <pattern-formatter pattern="${test.console.pattern:%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+            <pattern-formatter pattern="${test.console.pattern:%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n}"/>
         </formatter>
         <file relative-to="jboss.server.log.dir" path="${test.size.log.file:sizeLogger.log}"/>
         <rotate-size value="${test.rotate.size:64m}"/>
@@ -119,7 +119,7 @@
     </root-logger>
 
     <formatter name="PATTERN">
-        <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}" color-map="${test.console.color:info:cyan,warn:yellow,error:red}"/>
+        <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n}" color-map="${test.console.color:info:cyan,warn:yellow,error:red}"/>
     </formatter>
 
     <logging-profiles>
@@ -130,7 +130,7 @@
                 <encoding value="${test.encoding:UTF-8}"/>
                 <filter-spec value="${test.console.filter:levelRange(TRACE,WARN)}" />
                 <formatter>
-                    <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+                    <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n}"/>
                 </formatter>
             </console-handler>
 
@@ -169,7 +169,7 @@
             </root-logger>
 
             <formatter name="PATTERN">
-                <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}" color-map="${test.console.color:info:cyan,warn:yellow,error:red}"/>
+                <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n}" color-map="${test.console.color:info:cyan,warn:yellow,error:red}"/>
             </formatter>
         </logging-profile>
     </logging-profiles>

--- a/logging/src/test/resources/logging.properties
+++ b/logging/src/test/resources/logging.properties
@@ -38,4 +38,4 @@ handler.CONSOLE.formatter=PATTERN
 # Formatter pattern configuration
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%E%n
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%e%n

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -37,7 +37,7 @@
         <level name="INFO"/>
         <filter-spec value="levelRange(TRACE,WARN)" />
         <formatter>
-            <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
         </formatter>
         <target name="console"/>
     </console-handler>
@@ -82,7 +82,7 @@
         <encoding value="UTF-8"/>
         <filter-spec value="any(levels(INFO),not(levels(TRACE)))"/>
         <formatter>
-            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
         </formatter>
         <file relative-to="jboss.server.log.dir" path="server.log"/>
         <suffix value=".yyyy-MM-dd"/>
@@ -107,7 +107,7 @@
         <encoding value="UTF-8"/>
         <filter-spec value="all(levelChange(DEBUG),match(&quot;JBAS+\\d&quot;))"/>
         <formatter>
-            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
         </formatter>
         <file relative-to="jboss.server.log.dir" path="sizeLogger.log"/>
         <rotate-size value="64m"/>
@@ -151,7 +151,7 @@
     </root-logger>
 
     <formatter name="PATTERN">
-        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n" color-map="info:cyan,warn:yellow,error:red"/>
+        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n" color-map="info:cyan,warn:yellow,error:red"/>
     </formatter>
 
     <logging-profiles>
@@ -161,7 +161,7 @@
                 <level name="ALL"/>
                 <filter-spec value="levelRange(TRACE,WARN)"/>
                 <formatter>
-                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
                 </formatter>
             </console-handler>
 
@@ -201,7 +201,7 @@
             </root-logger>
 
             <formatter name="PATTERN">
-                <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n" color-map="info:cyan"/>
+                <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n" color-map="info:cyan"/>
             </formatter>
         </logging-profile>
     </logging-profiles>

--- a/logging/src/test/resources/operations.xml
+++ b/logging/src/test/resources/operations.xml
@@ -2,12 +2,12 @@
     <console-handler name="CONSOLE">
         <level name="INFO"/>
         <formatter>
-            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
         </formatter>
     </console-handler>
     <periodic-rotating-file-handler name="FILE">
         <formatter>
-            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
         </formatter>
         <file relative-to="jboss.server.log.dir" path="server.log"/>
         <suffix value=".yyyy-MM-dd"/>
@@ -27,12 +27,12 @@
             <console-handler name="CONSOLE">
                 <level name="INFO"/>
                 <formatter>
-                    <pattern-formatter pattern="[profile] %d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    <pattern-formatter pattern="[profile] %d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
                 </formatter>
             </console-handler>
             <periodic-rotating-file-handler name="FILE">
                 <formatter>
-                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
                 </formatter>
                 <file relative-to="jboss.server.log.dir" path="server-profile.log"/>
                 <suffix value=".yyyy-MM-dd"/>

--- a/logging/src/test/resources/rollback-logging.xml
+++ b/logging/src/test/resources/rollback-logging.xml
@@ -31,7 +31,7 @@
 
     <file-handler name="FILE" autoflush="true">
         <formatter>
-            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
         </formatter>
         <file relative-to="jboss.server.log.dir" path="rollback-server.log"/>
         <append value="true"/>
@@ -50,7 +50,7 @@
     </root-logger>
 
     <formatter name="CONSOLE-PATTERN">
-        <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n" color-map="info:cyan"/>
+        <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n" color-map="info:cyan"/>
     </formatter>
 
     <logging-profiles>
@@ -60,7 +60,7 @@
                 <level name="ALL"/>
                 <filter-spec value="levelRange(TRACE,WARN)"/>
                 <formatter>
-                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
                 </formatter>
             </console-handler>
 

--- a/logging/src/test/resources/simple-subsystem.xml
+++ b/logging/src/test/resources/simple-subsystem.xml
@@ -49,7 +49,7 @@
     </root-logger>
 
     <formatter name="PATTERN">
-        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
     </formatter>
 
     <logging-profiles>
@@ -78,7 +78,7 @@
             </root-logger>
 
             <formatter name="PATTERN">
-                <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
             </formatter>
         </logging-profile>
     </logging-profiles>

--- a/patching/src/main/resources/logging.properties
+++ b/patching/src/main/resources/logging.properties
@@ -35,4 +35,4 @@ handler.CONSOLE.target=SYSTEM_OUT
 
 formatter.CONSOLE=org.jboss.logmanager.formatters.PatternFormatter
 formatter.CONSOLE.properties=pattern
-formatter.CONSOLE.pattern= %-5p [%c] %s%E%n
+formatter.CONSOLE.pattern= %-5p [%c] %s%e%n


### PR DESCRIPTION
Switch the default pattern for log formatting to use `%e` instead of `%E`. Both patterns print a stack trace `%e` is a more proficient version as it leaves off the JAR name which can be expensive to determine. 
