### PR TITLE
[WFCORE-156] Defer validation of any-ipv6-address/java.net.IPv4Stack com...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/interfaces/ParsedInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/ParsedInterfaceCriteria.java
@@ -23,10 +23,10 @@
 package org.jboss.as.controller.interfaces;
 
 
-import static org.jboss.as.controller.logging.ControllerLogger.SERVER_LOGGER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ANY_ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ANY_IPV4_ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ANY_IPV6_ADDRESS;
+import static org.jboss.as.controller.logging.ControllerLogger.SERVER_LOGGER;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -36,16 +36,15 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.parsing.Element;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
-import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * Utility class to create an interface criteria based on a {@link ModelNode} description
@@ -118,12 +117,7 @@ public final class ParsedInterfaceCriteria {
         } else if(subModel.hasDefined(ANY_IPV4_ADDRESS) && subModel.get(ANY_IPV4_ADDRESS).asBoolean(false)) {
             parsed = ParsedInterfaceCriteria.V4;
         } else if(subModel.hasDefined(ANY_IPV6_ADDRESS) && subModel.get(ANY_IPV6_ADDRESS).asBoolean(false)) {
-            // AS7-5360 Reject this setting if java.net.preferIPv4Stack=true
-            if (Boolean.parseBoolean(WildFlySecurityManager.getEnvPropertyPrivileged("java.net.preferIPv4Stack", "false"))) {
-                parsed = new ParsedInterfaceCriteria(ControllerLogger.ROOT_LOGGER.invalidAnyIPv6());
-            } else {
-                parsed = ParsedInterfaceCriteria.V6;
-            }
+            parsed = ParsedInterfaceCriteria.V6;
         } else {
             try {
                 final List<Property> nodes = subModel.asPropertyList();

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3046,7 +3046,7 @@ public interface ControllerLogger extends BasicLogger {
     String cannotGetControllerLock();
 
     @Message(id = 308, value = "Cannot configure an interface to use 'any-ipv6-address' when system property java.net.preferIPv4Stack is true")
-    String invalidAnyIPv6();
+    StartException invalidAnyIPv6();
 
     @Message(id = 309, value = "Legacy extension '%s' is not supported on servers running this version. The extension " +
             "is only supported for use by hosts running a previous release in a mixed-version managed domain")

--- a/server/src/main/java/org/jboss/as/server/services/net/NetworkInterfaceService.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/NetworkInterfaceService.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import org.jboss.as.controller.interfaces.InterfaceCriteria;
 import org.jboss.as.controller.interfaces.OverallInterfaceCriteria;
 import org.jboss.as.controller.interfaces.ParsedInterfaceCriteria;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.network.NetworkInterfaceBinding;
 import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.msc.service.Service;
@@ -86,6 +87,11 @@ public class NetworkInterfaceService implements Service<NetworkInterfaceBinding>
 
     public synchronized void start(StartContext arg0) throws StartException {
         log.debug("Starting NetworkInterfaceService\n");
+        // WFLY-184 Reject any-ipv6-address config if java.net.preferIPv4Stack=true
+        if (anyLocalV6 && Boolean.parseBoolean(WildFlySecurityManager.getEnvPropertyPrivileged("java.net.preferIPv4Stack", "false"))) {
+            throw ControllerLogger.ROOT_LOGGER.invalidAnyIPv6();
+        }
+
         try {
             this.interfaceBinding = createBinding(anyLocalV4, anyLocalV6, anyLocal, criteria);
         } catch (Exception e) {

--- a/server/src/main/java/org/jboss/as/server/services/net/SpecifiedInterfaceAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SpecifiedInterfaceAddHandler.java
@@ -24,6 +24,7 @@ import org.jboss.as.controller.operations.common.InterfaceAddHandler;
 import org.jboss.as.network.NetworkInterfaceBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceController;
 
 /**
  * Handler for adding a fully specified interface.
@@ -46,6 +47,7 @@ public class SpecifiedInterfaceAddHandler extends InterfaceAddHandler {
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, String name, ParsedInterfaceCriteria criteria) {
         context.getServiceTarget().addService(NetworkInterfaceService.JBOSS_NETWORK_INTERFACE.append(name), createInterfaceService(name, criteria))
+            .setInitialMode(ServiceController.Mode.ON_DEMAND)
             .install();
     }
 


### PR DESCRIPTION
...bo until interface service is actually needed

Note this PR also fixes a bug introduced in my WFCORE-102 patch which inadvertently changed the interface services from ON_DEMAND to ACTIVE.
