### PR TITLE
[WFCORE-158] Don't allow handlers to be removed if assigned to a logger or another handler.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -456,7 +456,7 @@ public interface LoggingLogger extends BasicLogger {
      * @return the message.
      */
     @Message(id = 44, value = "Handler %s is attached to the following handlers and cannot be removed; %s")
-    String handlerAttachedToHandlers(String handlerName, Collection<String> handlers);
+    OperationFailedException handlerAttachedToHandlers(String handlerName, Collection<String> handlers);
 
     /**
      * A message indicating the handler is attached to the loggers.
@@ -467,7 +467,7 @@ public interface LoggingLogger extends BasicLogger {
      * @return the message.
      */
     @Message(id = 45, value = "Handler %s is attached to the following loggers and cannot be removed; %s")
-    String handlerAttachedToLoggers(String handlerName, Collection<String> loggers);
+    OperationFailedException handlerAttachedToLoggers(String handlerName, Collection<String> loggers);
 
     /**
      * A message indicating the handler cannot be attached to itself.

--- a/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
+++ b/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
@@ -582,18 +582,26 @@ public abstract class AbstractLoggingSubsystemTest extends AbstractSubsystemBase
                 result = LESS;
             } else if (CommonAttributes.LOGGING_PROFILE.equals(key2)) {
                 result = GREATER;
+            } else if (PatternFormatterResourceDefinition.PATTERN_FORMATTER.getName().equals(key1)) {
+                result = LESS;
+            } else if (PatternFormatterResourceDefinition.PATTERN_FORMATTER.getName().equals(key2)) {
+                result = GREATER;
+            } else if (CustomFormatterResourceDefinition.CUSTOM_FORMATTER.getName().equals(key1)) {
+                result = LESS;
+            } else if (CustomFormatterResourceDefinition.CUSTOM_FORMATTER.getName().equals(key2)) {
+                result = GREATER;
             } else if (RootLoggerResourceDefinition.ROOT_LOGGER_PATH_NAME.equals(key1)) {
-                result = LESS;
+                result = GREATER;
             } else if (RootLoggerResourceDefinition.ROOT_LOGGER_PATH_NAME.equals(key2)) {
-                result = GREATER;
+                result = LESS;
             } else if (LoggerResourceDefinition.LOGGER.equals(key1)) {
-                result = LESS;
+                result = GREATER;
             } else if (LoggerResourceDefinition.LOGGER.equals(key2)) {
-                result = GREATER;
-            } else if (AsyncHandlerResourceDefinition.ASYNC_HANDLER.equals(key1) && !(LoggerResourceDefinition.LOGGER.equals(key2) || RootLoggerResourceDefinition.ROOT_LOGGER_PATH_NAME.equals(key2))) {
                 result = LESS;
-            } else if (AsyncHandlerResourceDefinition.ASYNC_HANDLER.equals(key2) && !(LoggerResourceDefinition.LOGGER.equals(key1) || RootLoggerResourceDefinition.ROOT_LOGGER_PATH_NAME.equals(key1))) {
+            } else if (AsyncHandlerResourceDefinition.ASYNC_HANDLER.equals(key1)) {
                 result = GREATER;
+            } else if (AsyncHandlerResourceDefinition.ASYNC_HANDLER.equals(key2)) {
+                result = LESS;
             }
             return result;
         }

--- a/logging/src/test/java/org/jboss/as/logging/HandlerLegacyOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/HandlerLegacyOperationsTestCase.java
@@ -121,6 +121,12 @@ public class HandlerLegacyOperationsTestCase extends AbstractOperationsTestCase 
         testUpdateProperties(kernelServices, address, AsyncHandlerResourceDefinition.QUEUE_LENGTH, 20);
 
         // Clean-up
+
+        // Remove the console handler from the async-handler before the handler is removed
+        final ModelNode removeHandlerOp = SubsystemOperations.createOperation("remove-handler", address);
+        removeHandlerOp.get("name").set("CONSOLE");
+        executeOperation(kernelServices, removeHandlerOp);
+
         executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(consoleAddress));
         verifyRemoved(kernelServices, consoleAddress);
         executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(address));

--- a/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
@@ -37,6 +37,7 @@ import java.util.logging.Level;
 
 import org.apache.commons.io.FileUtils;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.SubsystemOperations;
@@ -257,8 +258,13 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
         // Second line will start with the clear string, followed by the color string
         assertTrue("Line logged does not match expected: 4", Arrays.equals("[changed-pattern] Test message 4".getBytes(ENCODING), lines.get(3).getBytes(ENCODING)));
 
+        // Remove the handler operation
+        final ModelNode removeHandlerOp = SubsystemOperations.createOperation("remove-handler", loggerAddress);
+        removeHandlerOp.get("name").set(fileHandlerName);
+
         // Finally clean everything up
         op = SubsystemOperations.CompositeOperationBuilder.create()
+                .addStep(removeHandlerOp)
                 .addStep(SubsystemOperations.createRemoveOperation(handlerAddress))
                 .addStep(SubsystemOperations.createRemoveOperation(patternFormatterAddress))
                 .addStep(SubsystemOperations.createRemoveOperation(loggerAddress))
@@ -322,6 +328,24 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
         validateResourceAttributes(asyncHandlerResource, Logging.join(AsyncHandlerResourceDefinition.ATTRIBUTES, CommonAttributes.NAME, CommonAttributes.FILTER));
         // The name attribute should be the same as the last path element of the address
         assertEquals(asyncHandlerResource.get(CommonAttributes.NAME.getName()).asString(), PathAddress.pathAddress(address).getLastElement().getValue());
+
+        // Clean-up
+        executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(consoleAddress));
+        verifyRemoved(kernelServices, consoleAddress);
+        executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(address));
+        verifyRemoved(kernelServices, address);
+
+        // Add an async-handler with the console-handler assigned, then attempt to remove the async-handler which should
+        // result in a failure
+        executeOperation(kernelServices, CompositeOperationBuilder.create()
+                .addStep(SubsystemOperations.createAddOperation(consoleAddress))
+                .addStep(addOp)
+                .build().getOperation());
+
+        // Attempt to remove the CONSOLE handler
+        final ModelNode removeHandlerOp = SubsystemOperations.createOperation("remove-handler", address);
+        removeHandlerOp.get("name").set("CONSOLE");
+        executeOperationForFailure(kernelServices, removeHandlerOp);
 
         // Clean-up
         executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(consoleAddress));

--- a/logging/src/test/java/org/jboss/as/logging/LoggerLegacyOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggerLegacyOperationsTestCase.java
@@ -110,6 +110,12 @@ public class LoggerLegacyOperationsTestCase extends AbstractOperationsTestCase {
         assertEquals(handlers, SubsystemOperations.readResult(result));
 
         // Clean-up
+
+        // Remove the console handler from the root logger before the handler is removed
+        final ModelNode removeHandlerOp = SubsystemOperations.createOperation("remove-handler", address);
+        removeHandlerOp.get("name").set("CONSOLE");
+        executeOperation(kernelServices, removeHandlerOp);
+
         executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(consoleAddress));
         verifyRemoved(kernelServices, consoleAddress);
         executeOperation(kernelServices, SubsystemOperations.createOperation(

--- a/logging/src/test/java/org/jboss/as/logging/LoggerOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggerOperationsTestCase.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.SubsystemOperations;
 import org.jboss.dmr.ModelNode;
@@ -100,6 +101,24 @@ public class LoggerOperationsTestCase extends AbstractOperationsTestCase {
         verifyRemoved(kernelServices, consoleAddress);
         executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(address));
         verifyRemoved(kernelServices, address);
+
+        // Add logger with the console-handler assigned, then attempt to remove the async-handler which should
+        // result in a failure
+        executeOperation(kernelServices, CompositeOperationBuilder.create()
+                .addStep(SubsystemOperations.createAddOperation(consoleAddress))
+                .addStep(addOp)
+                .build().getOperation());
+
+        // Attempt to remove the CONSOLE handler
+        final ModelNode removeHandlerOp = SubsystemOperations.createOperation("remove-handler", address);
+        removeHandlerOp.get("name").set("CONSOLE");
+        executeOperationForFailure(kernelServices, removeHandlerOp);
+
+        // Clean-up
+        executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(consoleAddress));
+        verifyRemoved(kernelServices, consoleAddress);
+        executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(address));
+        verifyRemoved(kernelServices, address);
     }
 
     private void testLogger(final KernelServices kernelServices, final String profileName) throws Exception {
@@ -140,6 +159,24 @@ public class LoggerOperationsTestCase extends AbstractOperationsTestCase {
         assertTrue("Handler CONSOLE should have been removed: " + result, SubsystemOperations.readResult(result)
                 .asList()
                 .isEmpty());
+
+        // Clean-up
+        executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(consoleAddress));
+        verifyRemoved(kernelServices, consoleAddress);
+        executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(address));
+        verifyRemoved(kernelServices, address);
+
+        // Add a logger with the console-handler assigned, then attempt to remove the async-handler which should
+        // result in a failure
+        executeOperation(kernelServices, CompositeOperationBuilder.create()
+                .addStep(SubsystemOperations.createAddOperation(consoleAddress))
+                .addStep(addOp)
+                .build().getOperation());
+
+        // Attempt to remove the CONSOLE handler
+        final ModelNode removeHandlerOp = SubsystemOperations.createOperation("remove-handler", address);
+        removeHandlerOp.get("name").set("CONSOLE");
+        executeOperationForFailure(kernelServices, removeHandlerOp);
 
         // Clean-up
         executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(consoleAddress));


### PR DESCRIPTION
Added checks when removing handlers to assure they are not assigned to another handler or a logger.
