### PR TITLE
[WFCORE-171] Validate the file is not an existing directory

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -870,4 +870,14 @@ public interface LoggingLogger extends BasicLogger {
      */
     @Message(id = 82, value = "The suffix (%s) can not contain seconds or milliseconds.")
     String suffixContainsMillis(String suffix);
+
+    /**
+     * Creates an exception indicating the path is a directory and cannot be used as a log file.
+     *
+     * @param path the path attempting to be used as a log file
+     *
+     * @return an {@link org.jboss.as.controller.OperationFailedException} for the error.
+     */
+    @Message(id = 83, value = "Path '%s' is a directory and cannot be used as a log file.")
+    OperationFailedException invalidLogFile(String path);
 }

--- a/logging/src/main/java/org/jboss/as/logging/resolvers/FileResolver.java
+++ b/logging/src/main/java/org/jboss/as/logging/resolvers/FileResolver.java
@@ -25,6 +25,10 @@ package org.jboss.as.logging.resolvers;
 import static org.jboss.as.controller.services.path.PathResourceDefinition.PATH;
 import static org.jboss.as.controller.services.path.PathResourceDefinition.RELATIVE_TO;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.services.path.PathManager;
@@ -56,6 +60,10 @@ public class FileResolver implements ModelNodeResolver<String> {
         }
         if (result == null) {
             throw new IllegalStateException(LoggingLogger.ROOT_LOGGER.pathManagerServiceNotStarted());
+        }
+        final Path file = Paths.get(result);
+        if (Files.exists(file) && Files.isDirectory(file)) {
+            throw LoggingLogger.ROOT_LOGGER.invalidLogFile(file.normalize().toString());
         }
         return result;
     }

--- a/logging/src/test/java/org/jboss/as/logging/AbstractOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/AbstractOperationsTestCase.java
@@ -121,9 +121,17 @@ public abstract class AbstractOperationsTestCase extends AbstractLoggingSubsyste
         return result;
     }
 
+    protected ModelNode executeOperationForFailure(final KernelServices kernelServices, final ModelNode op) {
+        final ModelNode result = kernelServices.executeOperation(op);
+        assertFalse("Operation was expected to fail: " + op, SubsystemOperations.isSuccessfulOutcome(result));
+        return result;
+    }
+
     protected ModelNode createFileValue(final String relativeTo, final String path) {
         final ModelNode file = new ModelNode().setEmptyObject();
-        file.get(PathResourceDefinition.RELATIVE_TO.getName()).set(relativeTo);
+        if (relativeTo != null) {
+            file.get(PathResourceDefinition.RELATIVE_TO.getName()).set(relativeTo);
+        }
         file.get(PathResourceDefinition.PATH.getName()).set(path);
         return file;
     }

--- a/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
@@ -28,6 +28,9 @@ import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
@@ -382,6 +385,8 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
         verifyRemoved(kernelServices, address);
         removeFile(filename);
         removeFile(newFilename);
+
+        testCommonFileOperations(kernelServices, address);
     }
 
     private void testPeriodicRotatingFileHandler(final KernelServices kernelServices, final String profileName) throws Exception {
@@ -418,6 +423,8 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
         verifyRemoved(kernelServices, address);
         removeFile(filename);
         removeFile(newFilename);
+
+        testCommonFileOperations(kernelServices, address);
     }
 
     private void testPeriodicSizeRotatingFileHandler(final KernelServices kernelServices, final String profileName) throws Exception {
@@ -457,6 +464,8 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
         verifyRemoved(kernelServices, address);
         removeFile(filename);
         removeFile(newFilename);
+
+        testCommonFileOperations(kernelServices, address);
     }
 
     private void testSizeRotatingFileHandler(final KernelServices kernelServices, final String profileName) throws Exception {
@@ -496,6 +505,8 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
         verifyRemoved(kernelServices, address);
         removeFile(filename);
         removeFile(newFilename);
+
+        testCommonFileOperations(kernelServices, address);
     }
 
     // TODO (jrp) do syslog? only concern is will it active it
@@ -535,5 +546,20 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
         final ModelNode address = createPatternFormatterAddress(profileName, name).toModelNode();
         final ModelNode op = createRemoveOperation(address);
         executeOperation(kernelServices, op);
+    }
+
+    private void testCommonFileOperations(final KernelServices kernelServices, final ModelNode address) throws Exception {
+        // Create a directory a new directory
+        final LoggingTestEnvironment env = LoggingTestEnvironment.get();
+        final Path dir = Paths.get(env.getLogDir().getAbsolutePath(), "file-dir");
+        Files.createDirectories(dir);
+        // Attempt to add a file-handler with the dir for the path
+        ModelNode op = OperationBuilder.createAddOperation(address)
+                .addAttribute(CommonAttributes.FILE, createFileValue(null, dir.toString()))
+                .build();
+        executeOperationForFailure(kernelServices, op);
+
+        // Clean-up
+        Files.deleteIfExists(dir);
     }
 }


### PR DESCRIPTION
Checks that the file name used for a file handler is not an existing directory. Previously the file handler in the log manager would fail, but the operation would succeed. This validates the path passed in and fails if it's an existing directory.
