### PR TITLE
[WFCORE-207] write- and undefine-attribute are not runtime-only ops

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/UndefineAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/UndefineAttributeHandler.java
@@ -41,7 +41,6 @@ public class UndefineAttributeHandler extends WriteAttributeHandler {
 
     static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(NAME)
-            .setRuntimeOnly()
             .build();
 
     public static final OperationStepHandler INSTANCE = new UndefineAttributeHandler();

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/WriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/WriteAttributeHandler.java
@@ -58,7 +58,6 @@ public class WriteAttributeHandler implements OperationStepHandler {
 
     public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(NAME, VALUE)
-            .setRuntimeOnly()
             .build();
 
     public static final OperationStepHandler INSTANCE = new WriteAttributeHandler();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-207
