### PR TITLE
WFCORE-194 Improve Debian/Ubuntu init.d shutdown process

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-debian.sh
+++ b/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-debian.sh
@@ -210,29 +210,21 @@ case "$1" in
 	if [ $status_stop -eq 0 ]; then
 		read kpid < "$JBOSS_PIDFILE"
 		log_daemon_msg "Stopping $DESC" "$NAME"
+		
+		children_pids=$(pgrep -P $kpid)
 
-		start-stop-daemon --start --chuid "$JBOSS_USER" \
-		--exec "$JBOSS_CLI" -- --connect --command=:shutdown \
+		start-stop-daemon --stop --quiet --pidfile "$JBOSS_PIDFILE" \
+		--user "$JBOSS_USER" --retry=TERM/$SHUTDOWN_WAIT/KILL/5 \
 		>/dev/null 2>&1
-
-		if [ $? -eq 1 ]; then
-			kill -15 $kpid
+		
+		if [ $? -eq 2 ]; then
+			log_failure_msg "$DESC can't be stopped"
+			exit 1
 		fi
-
-		count=0
-		until [ $count -gt $SHUTDOWN_WAIT ]
-		do
-			check_status
-			if [ $? -eq 3 ]; then
-				break
-			fi
-			sleep 1
-			count=$((count + 1));
+		
+		for child in $children_pids; do
+			/bin/kill -9 $child >/dev/null 2>&1
 		done
-
-		if [ $count -gt $SHUTDOWN_WAIT ]; then
-			kill -9 $kpid
-		fi
 		
 		log_end_msg 0
 	elif [ $status_stop -eq 1 ]; then


### PR DESCRIPTION
The init.d script for Debian/Ubuntu can be improved in the way it shutdown the server...

If some process hang up, the actual script don't handle that scenario.
