### PR TITLE
[WFCORE-60] Support multiple registration points for the same capability...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -272,7 +272,7 @@ final class OperationContextImpl extends AbstractOperationContext {
                         msg = msg.append(ControllerLogger.ROOT_LOGGER.cannotRemoveRequiredCapabilityInContext(required.getName(), required.getContext().getName()));
                     }
                     for (RuntimeRequirementRegistration reg : entry.getValue()) {
-                        RegistrationPoint rp = reg.getRegistrationPoint();
+                        RegistrationPoint rp = reg.getOldestRegistrationPoint();
                         if (rp.getAttribute() == null) {
                             msg = msg.append('\n').append(ControllerLogger.ROOT_LOGGER.requirementPointSimple(reg.getDependentName(), rp.getAddress().toCLIStyleString()));
                         } else {
@@ -1337,7 +1337,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         assertStageModel(currentStage);
         ensureLocalCapabilityRegistry();
         CapabilityContext context = createCapabilityContext(step);
-        RuntimeCapabilityRegistration capReg = managementModel.getCapabilityRegistry().removeCapability(capabilityName, context);
+        RuntimeCapabilityRegistration capReg = managementModel.getCapabilityRegistry().removeCapability(capabilityName, context, step.address);
         if (capReg != null) {
             RuntimeCapability capability = capReg.getCapability();
             for (String required : capability.getRequirements()) {

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityRegistry.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.controller.capability.registry;
 
+import org.jboss.as.controller.PathAddress;
+
 /**
  * Registry of {@link org.jboss.as.controller.capability.AbstractCapability capabilities} available in the system.
  *
@@ -60,17 +62,19 @@ public interface CapabilityRegistry<C extends CapabilityRegistration, R extends 
      *
      * @see #registerAdditionalCapabilityRequirement(org.jboss.as.controller.capability.registry.RequirementRegistration)
      */
-    void removeCapabilityRequirement(RequirementRegistration requirement);
+    void removeCapabilityRequirement(R requirement);
 
     /**
-     * Remove a previously registered capability.
+     * Remove a previously registered capability if all registration points for it have been removed.
      *
      *
      * @param capabilityName the name of the capability. Cannot be {@code null}
      * @param context the context in which the capability is registered. Cannot be {@code null}
-     * @return the capability that was removed, or {@code null} if no matching capability was registered
+     * @param registrationPoint the specific registration point that is being removed
+     * @return the capability that was removed, or {@code null} if no matching capability was registered or other
+     *         registration points for the capability still exist
      */
-    C removeCapability(String capabilityName, CapabilityContext context);
+    C removeCapability(String capabilityName, CapabilityContext context, PathAddress registrationPoint);
 
     /**
      * Gets whether a capability with the given name is registered.

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/DelegatingRuntimeCapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/DelegatingRuntimeCapabilityRegistry.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.controller.capability.registry;
 
+import org.jboss.as.controller.PathAddress;
+
 /**
  * {@link RuntimeCapabilityRegistry} implementation that simply delegates to another
  * {@link RuntimeCapabilityRegistry}. Intended as a convenience class to allow overriding
@@ -81,13 +83,13 @@ public class DelegatingRuntimeCapabilityRegistry implements RuntimeCapabilityReg
     }
 
     @Override
-    public void removeCapabilityRequirement(RequirementRegistration requirementRegistration) {
+    public void removeCapabilityRequirement(RuntimeRequirementRegistration requirementRegistration) {
         getDelegate().removeCapabilityRequirement(requirementRegistration);
     }
 
     @Override
-    public RuntimeCapabilityRegistration removeCapability(String capability, CapabilityContext context) {
-        return getDelegate().removeCapability(capability, context);
+    public RuntimeCapabilityRegistration removeCapability(String capability, CapabilityContext context, PathAddress registrationPoint) {
+        return getDelegate().removeCapability(capability, context, registrationPoint);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistration.java
@@ -22,25 +22,67 @@
 
 package org.jboss.as.controller.capability.registry;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.capability.RuntimeCapability;
 
 /**
  * Registration information for a {@link org.jboss.as.controller.capability.RuntimeCapability}. As a runtime capability is
- * associated with an actual management model, the registration exposes the {@link #getRegistrationPoint() point in the model}
+ * associated with an actual management model, the registration exposes the {@link #getOldestRegistrationPoint() point in the model}
  * that triggered the registration.
  *
  * @author Brian Stansberry (c) 2014 Red Hat Inc.
  */
 public class RuntimeCapabilityRegistration extends CapabilityRegistration<RuntimeCapability> {
 
-    private final RegistrationPoint registrationPoint;
+    private final Map<PathAddress, RegistrationPoint> registrationPoints = new LinkedHashMap<>();
 
     public RuntimeCapabilityRegistration(RuntimeCapability capability, CapabilityContext context, RegistrationPoint registrationPoint) {
         super(capability, context);
-        this.registrationPoint = registrationPoint;
+        this.registrationPoints.put(registrationPoint.getAddress(), registrationPoint);
     }
 
-    public RegistrationPoint getRegistrationPoint() {
-        return registrationPoint;
+    /**
+     * Gets the registration point that been associated with the registration for the longest period.
+     * @return the initial registration point, or {@code null} if there are no longer any registration points
+     */
+    public synchronized RegistrationPoint getOldestRegistrationPoint() {
+        return registrationPoints.size() == 0 ? null : registrationPoints.values().iterator().next();
+    }
+
+    /**
+     * Get all registration points associated with this registration.
+     *
+     * @return all registration points. Will not be {@code null} but may be empty
+     */
+    public synchronized Set<RegistrationPoint> getRegistrationPoints() {
+        return Collections.unmodifiableSet(new HashSet<>(registrationPoints.values()));
+    }
+
+    public synchronized boolean addRegistrationPoint(RegistrationPoint toAdd) {
+        PathAddress addedAddress = toAdd.getAddress();
+        if (registrationPoints.containsKey(addedAddress)) {
+            return false;
+        }
+        registrationPoints.put(addedAddress, toAdd);
+        return true;
+    }
+
+    public synchronized boolean removeRegistrationPoint(RegistrationPoint toAdd) {
+        PathAddress addedAddress = toAdd.getAddress();
+        if (!registrationPoints.containsKey(addedAddress)) {
+            return false;
+        }
+        registrationPoints.remove(addedAddress);
+        return true;
+    }
+
+    public synchronized int getRegistrationPointCount() {
+        return registrationPoints.size();
     }
 }


### PR DESCRIPTION
... or requirement

Ease of use thing for cases where the add/remove handler for a type=\* resource is the logical place to register/deregister a capability or requirement. We allow multiple registration points to account for the fact that the handler may be executed multiple times for different concrete addresses. Otherwise the subsystem author needs to track how many registration points exist and only register once and only deregister when the last registration point is removed.
