### PR TITLE
Add the ability to force begin requests to the ControlPoint

### DIFF
--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/ActiveRequestsReadHandler.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/ActiveRequestsReadHandler.java
@@ -26,6 +26,7 @@ import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
 
 /**
  * Reads handler for active requests
@@ -34,15 +35,15 @@ import org.jboss.dmr.ModelNode;
  */
 class ActiveRequestsReadHandler extends AbstractRuntimeOnlyHandler {
 
-    private final RequestController requestController;
-
-    ActiveRequestsReadHandler(final RequestController requestController) {
-        this.requestController = requestController;
-    }
-
     @Override
     protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
-        context.getResult().set(requestController.getActiveRequestCount());
+        ServiceController<?> service = context.getServiceRegistry(false).getService(RequestController.SERVICE_NAME);
+        if(service != null) {
+            RequestController requestController = (RequestController) service.getService().getValue();
+            context.getResult().set(requestController.getActiveRequestCount());
+        } else {
+            context.getResult().set(-1);
+        }
         context.stepCompleted();
     }
 }

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/Constants.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/Constants.java
@@ -30,4 +30,5 @@ package org.wildfly.extension.requestcontroller;
 interface Constants {
     String MAX_REQUESTS = "max-requests";
     String ACTIVE_REQUESTS = "active-requests";
+    String TRACK_INDIVIDUAL_ENDPOINTS = "track-individual-endpoints";
 }

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/MaxRequestsWriteHandler.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/MaxRequestsWriteHandler.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
 
 /**
  * Write handler for the max requests attribute
@@ -37,12 +38,10 @@ import org.jboss.dmr.ModelNode;
 class MaxRequestsWriteHandler extends AbstractWriteAttributeHandler<Void> {
 
     private final AttributeDefinition attributeDefinition;
-    private final RequestController requestController;
 
-    MaxRequestsWriteHandler(final AttributeDefinition attributeDefinition, final RequestController requestController) {
+    MaxRequestsWriteHandler(final AttributeDefinition attributeDefinition) {
         super(attributeDefinition);
         this.attributeDefinition = attributeDefinition;
-        this.requestController = requestController;
     }
 
     @Override
@@ -63,15 +62,16 @@ class MaxRequestsWriteHandler extends AbstractWriteAttributeHandler<Void> {
     }
 
     private void apply(final OperationContext context, final ModelNode model) throws OperationFailedException {
-
-        if (this.requestController == null) {
+        ServiceController<?> serviceController = context.getServiceRegistry(false).getService(RequestController.SERVICE_NAME);
+        if(serviceController == null) {
             return;
         }
+        RequestController requestController = (RequestController) serviceController.getService().getValue();
         final ModelNode modelNode = this.attributeDefinition.resolveModelAttribute(context, model);
         if(!modelNode.isDefined()) {
-            this.requestController.setMaxRequestCount(-1);
+            requestController.setMaxRequestCount(-1);
         } else {
-            this.requestController.setMaxRequestCount(modelNode.asInt());
+            requestController.setMaxRequestCount(modelNode.asInt());
         }
     }
 

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerExtension.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerExtension.java
@@ -61,7 +61,7 @@ public class RequestControllerExtension implements Extension {
     @Override
     public void initialize(ExtensionContext context) {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 1, 0);
-        final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(RequestControllerRootDefinition.INSTANCE);
+        final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new RequestControllerRootDefinition(context.isRuntimeOnlyRegistrationValid()));
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE, false);
         subsystem.registerXMLElementWriter(RequestControllerSubsystemParser_1_0.INSTANCE);
     }

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerSubsystemAdd.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerSubsystemAdd.java
@@ -25,6 +25,7 @@
 package org.wildfly.extension.requestcontroller;
 
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.registry.Resource;
@@ -34,6 +35,8 @@ import org.jboss.as.server.deployment.Phase;
 import org.jboss.as.server.suspend.SuspendController;
 import org.jboss.dmr.ModelNode;
 
+import java.util.Collection;
+
 
 /**
  * Handler responsible for adding the subsystem resource to the model
@@ -42,11 +45,8 @@ import org.jboss.dmr.ModelNode;
  */
 class RequestControllerSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
-    private final RequestController requestController;
-
-    RequestControllerSubsystemAdd(RequestController requestController) {
-        super(RequestControllerRootDefinition.ATTRIBUTES);
-        this.requestController = requestController;
+    RequestControllerSubsystemAdd(Collection<AttributeDefinition> attributeDefinitions) {
+        super(attributeDefinitions);
     }
 
     /**
@@ -65,6 +65,10 @@ class RequestControllerSubsystemAdd extends AbstractBoottimeAddStepHandler {
         }, OperationContext.Stage.RUNTIME);
 
         int maxRequests = RequestControllerRootDefinition.MAX_REQUESTS.resolveModelAttribute(context, resource.getModel()).asInt();
+        boolean trackIndividual = RequestControllerRootDefinition.TRACK_INDIVIDUAL_ENDPOINTS.resolveModelAttribute(context, resource.getModel()).asBoolean();
+
+        RequestController requestController = new RequestController(trackIndividual);
+
         requestController.setMaxRequestCount(maxRequests);
 
         context.getServiceTarget().addService(RequestController.SERVICE_NAME, requestController)

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerSubsystemParser_1_0.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerSubsystemParser_1_0.java
@@ -47,7 +47,7 @@ class RequestControllerSubsystemParser_1_0 implements XMLStreamConstants, XMLEle
 
     private RequestControllerSubsystemParser_1_0() {
         xmlDescription = builder(RequestControllerRootDefinition.INSTANCE)
-                .addAttribute(RequestControllerRootDefinition.MAX_REQUESTS)
+                .addAttributes(RequestControllerRootDefinition.MAX_REQUESTS, RequestControllerRootDefinition.TRACK_INDIVIDUAL_ENDPOINTS)
                 .build();
     }
 

--- a/request-controller/src/main/resources/org/wildfly/extension/requestcontroller/LocalDescriptions.properties
+++ b/request-controller/src/main/resources/org/wildfly/extension/requestcontroller/LocalDescriptions.properties
@@ -3,3 +3,4 @@ request-controller.add=Adds the request controller subsystem
 request-controller.remove=Removes the request controller subsystem
 request-controller.max-requests=The maximum number of all types of requests that can be running in a server at a time
 request-controller.active-requests=The number of requests that are currently running in the server
+request-controller.track-individual-endpoints=If this is true requests are tracked at an endpoint level, which will allow individual deployments to be suspended

--- a/request-controller/src/main/resources/schema/wildfly-request-controller_1_0.xsd
+++ b/request-controller/src/main/resources/schema/wildfly-request-controller_1_0.xsd
@@ -41,5 +41,6 @@
             </xs:documentation>
         </xs:annotation>
         <xs:attribute name="max-requests" type="xs:int" default="-1" />
+        <xs:attribute name="track-individual-endpoints" type="xs:boolean" default="false" />
     </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
This allows threads that are alredy running to use an
executor service or asyn method without it being rejected.
