### PR TITLE
[WFCORE-42] Stage 1 of cleaning up interactions with CommonXml

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -419,27 +419,7 @@ public class HostXml extends CommonXml {
             element = nextElement(reader, namespace);
         }
         if (element == Element.VAULT) {
-            switch (namespace) {
-                // Less than 1.1 does not end up in this method
-                case DOMAIN_1_1:
-                case DOMAIN_1_2:
-                case DOMAIN_1_3:
-                case DOMAIN_1_4:
-                case DOMAIN_1_5: {
-                    parseVault_1_1(reader, address, namespace, list);
-                    break;
-                }
-                default: {
-                    switch (namespace.getMajorVersion()) {
-                        case 2:
-                            parseVault_1_1(reader, address, namespace, list);
-                            break;
-                        default:
-                            parseVault_1_6_and_3_0(reader, address, namespace, list);
-                            break;
-                    }
-                }
-            }
+            parseVault(reader, address, namespace, list);
             element = nextElement(reader, namespace);
         }
         if (element == Element.MANAGEMENT) {

--- a/server/src/main/java/org/jboss/as/server/parsing/CommonXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/CommonXml.java
@@ -1168,6 +1168,27 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
 
     }
 
+    protected void parseVault(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs, final List<ModelNode> list) throws XMLStreamException {
+        switch (expectedNs) {
+            case DOMAIN_1_0:
+                throw unexpectedElement(reader);
+            case DOMAIN_1_1:
+            case DOMAIN_1_2:
+            case DOMAIN_1_3:
+            case DOMAIN_1_4:
+            case DOMAIN_1_5:
+                parseVault_1_1(reader, address, expectedNs, list);
+                break;
+            default:
+                if (expectedNs.getMajorVersion() == 2) {
+                    parseVault_1_1(reader, address, expectedNs, list);
+                } else {
+                    parseVault_1_6_and_3_0(reader, address, expectedNs, list);
+                }
+        }
+    }
+
+    // TODO - Once WFLY-3710 is committed make this method private.
     protected void parseVault_1_1(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs, final List<ModelNode> list) throws XMLStreamException {
         final int vaultAttribCount = reader.getAttributeCount();
 
@@ -1209,12 +1230,14 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
         list.add(vault);
     }
 
+    // TODO - Once WFLY-3710 is committed delete this method.
     /** @deprecated kept for compatibility purposes with AppClientXml */
     @Deprecated
     protected final void parseVault_3_0(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs, final List<ModelNode> list) throws XMLStreamException {
         parseVault_1_6_and_3_0(reader, address, expectedNs, list);
     }
 
+    // TODO - Once WFLY-3710 is committed make this method private.
     protected void parseVault_1_6_and_3_0(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs, final List<ModelNode> list) throws XMLStreamException {
         final int vaultAttribCount = reader.getAttributeCount();
 

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -335,8 +335,7 @@ public class StandaloneXml extends CommonXml {
         }
 
         if (element == Element.VAULT) {
-            //Only 1.1 to 1.3 end up here, all of which use the same version of the vault
-            parseVault_1_1(reader, address, namespace, list);
+            parseVault(reader, address, namespace, list);
             element = nextElement(reader, namespace);
         }
 
@@ -445,24 +444,7 @@ public class StandaloneXml extends CommonXml {
         }
 
         if (element == Element.VAULT) {
-            switch (namespace) {
-                // Less than 1.4 does not end up here
-                case DOMAIN_1_4:
-                case DOMAIN_1_5: {
-                    parseVault_1_1(reader, address, namespace, list);
-                    break;
-                }
-                default: {
-                    switch (namespace.getMajorVersion()) {
-                        case 2:
-                            parseVault_1_1(reader, address, namespace, list);
-                            break;
-                        default:
-                            parseVault_1_6_and_3_0(reader, address, namespace, list);
-                            break;
-                    }
-                }
-            }
+            parseVault(reader, address, namespace, list);
             element = nextElement(reader, namespace);
         }
         if (element == Element.MANAGEMENT) {


### PR DESCRIPTION
Subclasses of CommonXml should call version independent parse methods, where different versions of an element are supported CommonXml should handle it.
