### PR TITLE
Speed test execution by not being so patient waiting for output from CLI...

### DIFF
--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliScriptTestBase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliScriptTestBase.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import org.jboss.as.cli.Util;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.Assert;
 
 /**
  * @author Alexey Loubyansky
@@ -133,6 +134,7 @@ public class CliScriptTestBase {
             try {
                 Thread.sleep(STATUS_CHECK_INTERVAL);
             } catch (InterruptedException e) {
+                fail("Interrupted");
             }
             runningTime += STATUS_CHECK_INTERVAL;
             readStream(cliOutBuf, cliStream);


### PR DESCRIPTION
... process

On my machine this saves ~ 18 secs in testsuite/standalone execution time.
