### PR TITLE
Don't try to get service and to reconnect during server shutdown(HostCon...

### DIFF
--- a/server/src/main/java/org/jboss/as/server/DomainServerMain.java
+++ b/server/src/main/java/org/jboss/as/server/DomainServerMain.java
@@ -140,9 +140,13 @@ public final class DomainServerMain {
 
                 // Get the host-controller server client
                 final ServiceContainer container = containerFuture.get();
-                final HostControllerClient client = getRequiredService(container, HostControllerConnectionService.SERVICE_NAME, HostControllerClient.class);
-                // Reconnect to the host-controller
-                client.reconnect(hostControllerUri, asAuthKey, managementSubsystemEndpoint);
+                if (!container.isShutdown()) {
+                    // otherwise, ServiceNotFoundException or IllegalStateException is thrown because HostControllerClient is stopped
+                    final HostControllerClient client = getRequiredService(container,
+                            HostControllerConnectionService.SERVICE_NAME, HostControllerClient.class);
+                    // Reconnect to the host-controller
+                    client.reconnect(hostControllerUri, asAuthKey, managementSubsystemEndpoint);
+                }
 
             } catch (InterruptedIOException e) {
                 Thread.interrupted();


### PR DESCRIPTION
...trollerConnectionService is stopped)
upstream fix for IllegalStateException and ServiceNotFoundException  reported in  
https://bugzilla.redhat.com/show_bug.cgi?id=1121153
