### PR TITLE
WFLY-4084, add a regex to command completer to deal with multiple slashes in user input

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandCompleter.java
@@ -24,6 +24,7 @@ package org.jboss.as.cli;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.jboss.as.cli.impl.CommandCandidatesProvider;
 import org.jboss.as.cli.operation.OperationCandidatesProvider;
@@ -80,6 +81,8 @@ public class CommandCompleter implements CommandLineCompleter {
             candidates.add(OperationFormat.INSTANCE.getAddressOperationSeparator());
             return 0;
         }
+
+        buffer = Pattern.compile("/+").matcher(buffer).replaceAll("/");
 
         final DefaultCallbackHandler parsedCmd = (DefaultCallbackHandler) ctx.getParsedCommandLine();
         try {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-4084
Handle multiple slashes in the end of command for Tab press ([domain@localhost:9990 /] /host=master// It will display content under 'master' instead of root '/' ) 
