### PR TITLE
[WFCORE-229] Do not provide ops registered with ProxyControllerRegistrat...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -666,6 +666,11 @@ public class ExtensionRegistry {
         }
 
         @Override
+        public PathAddress getPathAddress() {
+            return deployments.getPathAddress();
+        }
+
+        @Override
         public boolean isRuntimeOnly() {
             return deployments.isRuntimeOnly();
         }

--- a/controller/src/main/java/org/jboss/as/controller/registry/AbstractResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AbstractResourceRegistration.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -44,6 +43,7 @@ import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.OverrideDescriptionProvider;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.registry.OperationEntry.EntryType;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.dmr.ModelNode;
@@ -409,7 +409,7 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
         return getSubRegistration(address);
     }
 
-    final AbstractResourceRegistration getSubRegistration(PathAddress address) {
+    final ManagementResourceRegistration getSubRegistration(PathAddress address) {
 
 
         if (parent != null) {
@@ -421,18 +421,10 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
 
     }
 
-    abstract AbstractResourceRegistration getResourceRegistration(ListIterator<PathElement> iterator);
-
-    public final String getValueString() {
-        return valueString;
-    }
+    abstract ManagementResourceRegistration getResourceRegistration(ListIterator<PathElement> iterator);
 
     final String getLocationString() {
-        if (parent == null) {
-            return "";
-        } else {
-            return parent.getLocationString() + valueString + ")";
-        }
+        return getPathAddress().toCLIStyleString();
     }
 
     final void getInheritedOperations(final Map<String, OperationEntry> providers, boolean skipSelf) {
@@ -527,7 +519,8 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
         throw ControllerLogger.ROOT_LOGGER.resourceRegistrationIsNotAnAlias();
     }
 
-    PathAddress getPathAddress() {
+    @Override
+    public PathAddress getPathAddress() {
         return pathAddress;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/AliasResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AliasResourceRegistration.java
@@ -272,7 +272,7 @@ final class AliasResourceRegistration extends AbstractResourceRegistration imple
     }
 
     @Override
-    AbstractResourceRegistration getResourceRegistration(ListIterator<PathElement> iterator) {
+    ManagementResourceRegistration getResourceRegistration(ListIterator<PathElement> iterator) {
         if (!iterator.hasNext()) {
             return this;
         }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -145,9 +145,9 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         if (isRuntimeOnly()) {
             throw ControllerLogger.ROOT_LOGGER.cannotRegisterSubmodel();
         }
-        final AbstractResourceRegistration existing = getSubRegistration(PathAddress.pathAddress(address));
-        if (existing != null && existing.getValueString().equals(address.getValue())) {
-            throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(existing.getLocationString());
+        final ManagementResourceRegistration existing = getSubRegistration(PathAddress.pathAddress(address));
+        if (existing != null && existing.getPathAddress().getLastElement().getValue().equals(address.getValue())) {
+            throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(existing.getPathAddress().toCLIStyleString());
         }
         final String key = address.getKey();
         final NodeSubregistry child = getOrCreateSubregistry(key);
@@ -402,9 +402,9 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     @Override
     public void registerProxyController(final PathElement address, final ProxyController controller) throws IllegalArgumentException {
-        final AbstractResourceRegistration existing = getSubRegistration(PathAddress.pathAddress(address));
-        if (existing != null && existing.getValueString().equals(address.getValue())) {
-            throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(existing.getLocationString());
+        final ManagementResourceRegistration existing = getSubRegistration(PathAddress.pathAddress(address));
+        if (existing != null && existing.getPathAddress().getLastElement().getValue().equals(address.getValue())) {
+            throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(existing.getPathAddress().toCLIStyleString());
         }
         getOrCreateSubregistry(address.getKey()).registerProxyController(address.getValue(), controller);
     }
@@ -603,7 +603,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
     }
 
     @Override
-    AbstractResourceRegistration getResourceRegistration(ListIterator<PathElement> iterator) {
+    ManagementResourceRegistration getResourceRegistration(ListIterator<PathElement> iterator) {
         if (! iterator.hasNext()) {
             checkPermission();
             return this;

--- a/controller/src/main/java/org/jboss/as/controller/registry/DelegatingImmutableManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/DelegatingImmutableManagementResourceRegistration.java
@@ -54,6 +54,11 @@ public class DelegatingImmutableManagementResourceRegistration implements Immuta
     }
 
     @Override
+    public PathAddress getPathAddress() {
+        return delegate.getPathAddress();
+    }
+
+    @Override
     public boolean isRuntimeOnly() {
         return delegate.isRuntimeOnly();
     }

--- a/controller/src/main/java/org/jboss/as/controller/registry/DelegatingManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/DelegatingManagementResourceRegistration.java
@@ -91,6 +91,11 @@ public class DelegatingManagementResourceRegistration implements ManagementResou
     }
 
     @Override
+    public PathAddress getPathAddress() {
+        return getDelegate().getPathAddress();
+    }
+
+    @Override
     public boolean isRuntimeOnly() {
         return getDelegate().isRuntimeOnly();
     }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
@@ -47,6 +47,13 @@ public interface ImmutableManagementResourceRegistration {
     RuntimePermission ACCESS_PERMISSION = new RuntimePermission("canAccessManagementResourceRegistration");
 
     /**
+     * Gets the address under which we are registered.
+     *
+     * @return the address. Will not be {@code null}
+     */
+    PathAddress getPathAddress();
+
+    /**
      * Gets whether this model node only exists in the runtime and has no representation in the
      * persistent configuration model.
      *

--- a/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
@@ -82,7 +82,7 @@ final class NodeSubregistry {
         final AbstractResourceRegistration newRegistry = new ConcreteResourceRegistration(elementValue, this, provider, constraintUtilizationRegistry, runtimeOnly);
         final AbstractResourceRegistration existingRegistry = childRegistriesUpdater.putIfAbsent(this, elementValue, newRegistry);
         if (existingRegistry != null) {
-            throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(getLocationString(), elementValue);
+            throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(getLocationString(elementValue));
         }
         return newRegistry;
     }
@@ -91,7 +91,7 @@ final class NodeSubregistry {
         final ProxyControllerRegistration newRegistry = new ProxyControllerRegistration(elementValue, this, proxyController);
         final AbstractResourceRegistration appearingRegistry = childRegistriesUpdater.putIfAbsent(this, elementValue, newRegistry);
         if (appearingRegistry != null) {
-            throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(getLocationString(), elementValue);
+            throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(getLocationString(elementValue));
         }
         //register(elementValue, newRegistry);
         return newRegistry;
@@ -106,7 +106,7 @@ final class NodeSubregistry {
         final AliasResourceRegistration newRegistry = new AliasResourceRegistration(elementValue, this, aliasEntry, target);
         final AbstractResourceRegistration existingRegistry = childRegistriesUpdater.putIfAbsent(this, elementValue, newRegistry);
         if (existingRegistry != null) {
-            throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(getLocationString(), elementValue);
+            throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(getLocationString(elementValue));
         }
         return newRegistry;
     }
@@ -172,8 +172,8 @@ final class NodeSubregistry {
         }
     }
 
-    String getLocationString() {
-        return parent.getLocationString() + "(" + keyName + " => ";
+    private String getLocationString(String value) {
+        return parent.getPathAddress().append(keyName, value).toCLIStyleString();
     }
 
     DescriptionProvider getModelDescription(final ListIterator<PathElement> iterator, final String child) {
@@ -297,12 +297,12 @@ final class NodeSubregistry {
         return result;
     }
 
-    AbstractResourceRegistration getResourceRegistration(final ListIterator<PathElement> iterator, final String child) {
+    ManagementResourceRegistration getResourceRegistration(final ListIterator<PathElement> iterator, final String child) {
 
         final RegistrySearchControl searchControl = new RegistrySearchControl(iterator, child);
 
         // First search the non-wildcard child; if not found, search the wildcard child
-        AbstractResourceRegistration result = null;
+        ManagementResourceRegistration result = null;
 
         if (searchControl.getSpecifiedRegistry() != null) {
             result = searchControl.getSpecifiedRegistry().getResourceRegistration(searchControl.getIterator());

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -847,6 +847,11 @@ public abstract class AbstractOperationTestCase {
 
         }
 
+        @Override
+        public PathAddress getPathAddress() {
+            return PathAddress.EMPTY_ADDRESS;
+        }
+
         public boolean isRuntimeOnly() {
             return false;
         }

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -934,6 +934,11 @@ final class SubsystemTestDelegate {
     private final ManagementResourceRegistration MOCK_RESOURCE_REG = new ManagementResourceRegistration() {
 
         @Override
+        public PathAddress getPathAddress() {
+            return PathAddress.EMPTY_ADDRESS;
+        }
+
+        @Override
         public boolean isRuntimeOnly() {
             return false;
         }


### PR DESCRIPTION
...ion when the targeted address is a child address

The problem here is any call for a handler in an AbstractResourceRegistration ends up calling  AbstractResourceRegistration.getRootInvocation(). That builds a RootInvocation based on the address of the proxy registration, not of the virtual child. The result is the elements of the address below the proxy registration are lost and the lookup of the OperationEntry ends up thinking the request is for the proxy reg address, not a child, and returns handlers registered for the root address.
