### PR TITLE
Don't log system prop or env var values at boot if their name contains '...

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -27,6 +27,7 @@ import static java.security.AccessController.doPrivileged;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeSet;
@@ -106,7 +107,8 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
             final StringBuilder b = new StringBuilder(8192);
             b.append("Configured system properties:");
             for (String property : new TreeSet<String>(properties.stringPropertyNames())) {
-                b.append("\n\t").append(property).append(" = ").append(properties.getProperty(property, "<undefined>"));
+                String propVal = property.toLowerCase(Locale.getDefault()).contains("password") ? "<redacted>" : properties.getProperty(property, "<undefined>");
+                b.append("\n\t").append(property).append(" = ").append(propVal);
             }
             ServerLogger.CONFIG_LOGGER.debug(b);
             ServerLogger.CONFIG_LOGGER.debugf("VM Arguments: %s", getVMArguments());
@@ -115,7 +117,8 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
                 final Map<String, String> env = System.getenv();
                 b.append("Configured system environment:");
                 for (String key : new TreeSet<String>(env.keySet())) {
-                    b.append("\n\t").append(key).append(" = ").append(env.get(key));
+                    String envVal = key.toLowerCase(Locale.getDefault()).contains("password") ? "<redacted>" : env.get(key);
+                    b.append("\n\t").append(key).append(" = ").append(envVal);
                 }
                 ServerLogger.CONFIG_LOGGER.trace(b);
             }

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -26,6 +26,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -99,7 +100,8 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
             final StringBuilder b = new StringBuilder(8192);
             b.append(ServerLogger.ROOT_LOGGER.configuredSystemPropertiesLabel());
             for (String property : new TreeSet<String>(properties.stringPropertyNames())) {
-                b.append("\n\t").append(property).append(" = ").append(properties.getProperty(property, "<undefined>"));
+                String propVal = property.toLowerCase(Locale.getDefault()).contains("password") ? "<redacted>" : properties.getProperty(property, "<undefined>");
+                b.append("\n\t").append(property).append(" = ").append(propVal);
             }
             ServerLogger.CONFIG_LOGGER.debug(b);
             ServerLogger.CONFIG_LOGGER.debugf(ServerLogger.ROOT_LOGGER.vmArgumentsLabel(getVMArguments()));
@@ -108,7 +110,8 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
                 final Map<String,String> env = System.getenv();
                 b.append(ServerLogger.ROOT_LOGGER.configuredSystemEnvironmentLabel());
                 for (String key : new TreeSet<String>(env.keySet())) {
-                    b.append("\n\t").append(key).append(" = ").append(env.get(key));
+                    String envVal = key.toLowerCase(Locale.getDefault()).contains("password") ? "<redacted>" : env.get(key);
+                    b.append("\n\t").append(key).append(" = ").append(envVal);
                 }
                 ServerLogger.CONFIG_LOGGER.trace(b);
             }


### PR DESCRIPTION
...password'

https://issues.jboss.org/browse/EAP6-341
