### PR TITLE
[WFCORE-57-fix] : Fixing issue with squatrter resources aliases.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -310,7 +310,7 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
                     nodeDescription.get(CHILDREN, element.getKey(), MODEL_DESCRIPTION, element.getValue());
                 } else if (childReg.isAlias() && !aliases) {
                     if (isSquatterResource(registry, element.getKey())) {
-                        if (!nodeDescription.get(CHILDREN, element.getKey()).isDefined()) {
+                        if (nodeDescription.get(CHILDREN).hasDefined(element.getKey())) {
                             nodeDescription.get(CHILDREN).get(element.getKey()).remove(element.getValue());
                         }
                     }
@@ -340,6 +340,19 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
 
     private boolean isGlobalAlias(final ImmutableManagementResourceRegistration registry, final Property child) {
         if(isSquatterResource(registry, child.getName())) {
+            Set<PathElement> childrenPath = registry.getChildAddresses(PathAddress.EMPTY_ADDRESS);
+            boolean found = false;
+            boolean alias = true;
+            for(PathElement childPath : childrenPath) {
+                if(childPath.getKey().equals(child.getName())) {
+                    found = true;
+                    ImmutableManagementResourceRegistration squatterRegistration = registry.getSubModel(PathAddress.pathAddress(childPath));
+                    alias = alias && (squatterRegistration != null && squatterRegistration.isAlias());
+                }
+            }
+            if(found && alias) {
+                return true;
+            }
             ImmutableManagementResourceRegistration squatterRegistration = registry.getSubModel(PathAddress.pathAddress(PathElement.pathElement(child.getName(), child.getValue().asString())));
             return squatterRegistration != null && squatterRegistration.isAlias();
         }


### PR DESCRIPTION
When the alias isn't on the child name but on multiple PathElements then we don't detect it properly.
Fixing this case.

Jira : https://issues.jboss.org/browse/WFCORE-57
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1070214
