### PR TITLE
[WFCORE-57-fix-update] : Fix for WFCORE-57-fix

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -237,6 +237,11 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
 
                 // child type has no children until we add one
                 nonExistentChildTypes.add(childType);
+                if(!aliases && (entry.getValue() == null || entry.getValue().isEmpty())) {
+                    if(isGlobalAlias(registry, childType)) {
+                        nonExistentChildTypes.remove(childType);
+                    }
+                }
 
                 for (String child : entry.getValue()) {
                     PathElement childPE = PathElement.pathElement(childType, child);
@@ -349,6 +354,27 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
         }
 
         context.stepCompleted();
+    }
+
+    private boolean isSquatterResource(final ImmutableManagementResourceRegistration registry, final String key) {
+        return registry.getSubModel(PathAddress.pathAddress(PathElement.pathElement(key))) == null;
+    }
+
+    private boolean isGlobalAlias(final ImmutableManagementResourceRegistration registry, final String childName) {
+        if(isSquatterResource(registry, childName)) {
+            Set<PathElement> childrenPath = registry.getChildAddresses(PathAddress.EMPTY_ADDRESS);
+            boolean found = false;
+            boolean alias = true;
+            for(PathElement childPath : childrenPath) {
+                if(childPath.getKey().equals(childName)) {
+                    found = true;
+                    ImmutableManagementResourceRegistration squatterRegistration = registry.getSubModel(PathAddress.pathAddress(childPath));
+                    alias = alias && (squatterRegistration != null && squatterRegistration.isAlias());
+                }
+            }
+            return (found && alias);
+        }
+        return registry.getSubModel(PathAddress.pathAddress(PathElement.pathElement(childName))).isAlias();
     }
 
     private void addReadAttributeStep(OperationContext context, PathAddress address, boolean defaults, boolean resolve, FilteredData localFilteredData, ImmutableManagementResourceRegistration registry, String attributeName, Map<String, ModelNode> responseMap) {


### PR DESCRIPTION
The changes in the ReadResourceDescriptionHandler weren't in the ReadResourceHandler creating a difference in result :
  the read resource displaying aliases which were filtered out by the read resource description.

Jira : https://issues.jboss.org/browse/WFCORE-57
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1070214
