### PR TITLE
[WFCORE-274] : The CLI command "read-boot-errors" does not include the timestamp of the error event.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/BootErrorCollector.java
+++ b/controller/src/main/java/org/jboss/as/controller/BootErrorCollector.java
@@ -23,6 +23,7 @@ package org.jboss.as.controller;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED_SERVICES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_TIMESTAMP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MISSING_TRANSITIVE_DEPENDENCY_PROBLEMS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -60,6 +61,7 @@ public class BootErrorCollector {
         // for security reasons failure.get(FAILED).set(operation.clone());
         ModelNode failedOperation = error.get(FAILED_OPERATION);
         failedOperation.get(OP).set(operation.get(OP));
+        error.get(FAILURE_TIMESTAMP).set(System.currentTimeMillis());
         ModelNode opAddr = operation.get(OP_ADDR);
         if (!opAddr.isDefined()) {
             opAddr.setEmptyList();
@@ -102,6 +104,7 @@ public class BootErrorCollector {
 
         private static final AttributeDefinition OP_DEFINITION = ObjectTypeAttributeDefinition.Builder.of(FAILED_OPERATION,
                     SimpleAttributeDefinitionBuilder.create(OP, ModelType.STRING, false).build(),
+                    SimpleAttributeDefinitionBuilder.create(FAILURE_TIMESTAMP, ModelType.LONG, false).build(),
                     SimpleListAttributeDefinition.Builder.of(OP_ADDR,
                             SimpleAttributeDefinitionBuilder.create("element", ModelType.PROPERTY, false).build())
                             .build())

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -155,6 +155,7 @@ public class ModelDescriptionConstants {
     public static final String FAILED_SERVICES = "failed-services";
     public static final String FAILURE_COUNT = "failure-count";
     public static final String FAILURE_DESCRIPTION = "failure-description";
+    public static final String FAILURE_TIMESTAMP = "failure-timestamp";
     public static final String FILE = "file";
     public static final String FILE_HANDLER = "file-handler";
     public static final String FILTER = "filter";

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -567,6 +567,7 @@ errors.read-boot-errors.failed-operation=Operation that caused the failure.
 #errors.failed-operation=Operation that caused the failure.
 errors.failed-operation.address=Address of the failing operation.
 errors.failed-operation.operation=Name of the failing operation.
+errors.failed-operation.failure-timestamp=Timestamp of the failing operation.
 errors.read-boot-errors.failure-description=String representation of the failure description associated with the operation.
 #errors.failure-description=String representation of the failure description associated with the operation.
 errors.read-boot-errors.failed-services=Services that failed during execution of the operation.

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/HostBootErrorsTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/HostBootErrorsTestCase.java
@@ -29,6 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COR
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED_SERVICES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_TIMESTAMP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICES_MISSING_DEPENDENCIES;
@@ -84,6 +85,7 @@ public class HostBootErrorsTestCase extends AbstractBootErrorTestCase {
         ModelNode error = errors.get(0);
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(OP).asString(), is(ADD));
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(ADDRESS).asString(), is("[(\"host\" => \"master\"),(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-udp\")]"));
+        Assert.assertThat(error.asString(), error.get(FAILURE_TIMESTAMP).isDefined(), is(true));
         Assert.assertThat(error.asString(), error.hasDefined(FAILURE_DESCRIPTION), is(true));
         Assert.assertThat(error.asString(), error.get(FAILURE_DESCRIPTION).asString(), containsString("testhost"));
         Assert.assertThat(error.asString(), error.hasDefined(FAILED_SERVICES), is(false));
@@ -91,6 +93,7 @@ public class HostBootErrorsTestCase extends AbstractBootErrorTestCase {
         error = errors.get(1);
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(OP).asString(), is(ADD));
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(ADDRESS).asString(), is("[(\"host\" => \"master\"),(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-tcp\")]"));
+        Assert.assertThat(error.asString(), error.get(FAILURE_TIMESTAMP).isDefined(), is(true));
         Assert.assertThat(error.asString(), error.hasDefined(FAILURE_DESCRIPTION), is(true));
         Assert.assertThat(error.asString(), error.get(FAILURE_DESCRIPTION).asString(), containsString("testhost"));
         Assert.assertThat(error.asString(), error.hasDefined(FAILED_SERVICES), is(false));
@@ -98,6 +101,7 @@ public class HostBootErrorsTestCase extends AbstractBootErrorTestCase {
         error = errors.get(2);
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(OP).asString(), is(ADD));
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(ADDRESS).asString(), is("[(\"host\" => \"master\"),(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-tls\")]"));
+        Assert.assertThat(error.asString(), error.get(FAILURE_TIMESTAMP).isDefined(), is(true));
         Assert.assertThat(error.asString(), error.hasDefined(FAILURE_DESCRIPTION), is(true));
         Assert.assertThat(error.asString(), error.get(FAILURE_DESCRIPTION).asString(), containsString("testhost"));
         Assert.assertThat(error.asString(), error.hasDefined(FAILED_SERVICES), is(false));
@@ -105,6 +109,7 @@ public class HostBootErrorsTestCase extends AbstractBootErrorTestCase {
         error = errors.get(3);
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(OP).asString(), is(ADD));
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(ADDRESS).asString(), is("[(\"host\" => \"master\"),(\"core-service\" => \"management\"),(\"management-interface\" => \"native-interface\")]"));
+        Assert.assertThat(error.asString(), error.get(FAILURE_TIMESTAMP).isDefined(), is(true));
         Assert.assertThat(error.asString(), error.hasDefined(FAILURE_DESCRIPTION), is(true));
         Assert.assertThat(error.asString(), error.hasDefined(FAILED_SERVICES), is(false));
         Assert.assertThat(error.asString(), error.hasDefined(SERVICES_MISSING_DEPENDENCIES), is(true));

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/StandaloneBootErrorsTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/StandaloneBootErrorsTestCase.java
@@ -29,6 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COR
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED_SERVICES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_TIMESTAMP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 
@@ -83,18 +84,21 @@ public class StandaloneBootErrorsTestCase extends AbstractBootErrorTestCase {
         ModelNode error = errors.get(0);
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(OP).asString(), is(ADD));
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(ADDRESS).asString(), is("[(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-udp\")]"));
+        Assert.assertThat(error.asString(), error.get(FAILURE_TIMESTAMP).isDefined(), is(true));
         Assert.assertThat(error.asString(), error.hasDefined(FAILURE_DESCRIPTION), is(true));
         Assert.assertThat(error.asString(), error.get(FAILURE_DESCRIPTION).asString(), containsString("testhost"));
         Assert.assertThat(error.asString(), error.hasDefined(FAILED_SERVICES), is(false));
         error = errors.get(1);
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(OP).asString(), is(ADD));
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(ADDRESS).asString(), is("[(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-tcp\")]"));
+        Assert.assertThat(error.asString(), error.hasDefined(FAILURE_TIMESTAMP), is(true));
         Assert.assertThat(error.asString(), error.hasDefined(FAILURE_DESCRIPTION), is(true));
         Assert.assertThat(error.asString(), error.get(FAILURE_DESCRIPTION).asString(), containsString("testhost"));
         Assert.assertThat(error.asString(), error.hasDefined(FAILED_SERVICES), is(false));
         error = errors.get(2);
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(OP).asString(), is(ADD));
         Assert.assertThat(error.asString(), error.get(FAILED_OPERATION).get(ADDRESS).asString(), is("[(\"core-service\" => \"management\"),(\"access\" => \"audit\"),(\"syslog-handler\" => \"syslog-tls\")]"));
+        Assert.assertThat(error.asString(), error.hasDefined(FAILURE_TIMESTAMP), is(true));
         Assert.assertThat(error.asString(), error.hasDefined(FAILURE_DESCRIPTION), is(true));
         Assert.assertThat(error.asString(), error.get(FAILURE_DESCRIPTION).asString(), containsString("testhost"));
         Assert.assertThat(error.asString(), error.hasDefined(FAILED_SERVICES), is(false));


### PR DESCRIPTION
Adding a new attribute to store the timestamp when the error was reported.

Jira: https://issues.jboss.org/browse/WFCORE-274
