### PR TITLE
[WFCORE-438] The CLI freezes in phase of requesting username/password

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -36,6 +36,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.sasl.SaslException;
 
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.ControllerAddress;
@@ -258,6 +259,10 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
             }
 
             if (ioe != null) {
+                if (ioe.getCause() != null && ioe.getCause() instanceof SaslException) {
+                    throw new CommandLineException("Failed to establish connection", ioe);
+                }
+
                 if (System.currentTimeMillis() - start > timeoutMillis) {
                     throw new CommandLineException("Failed to establish connection in " + (System.currentTimeMillis() - start)
                             + "ms", ioe);


### PR DESCRIPTION
- solves repetitive authentication attempts during reload command when incorrect credentials are given
