### PR TITLE
[WFCORE-439] : Wrong format of IPv6 addresses in log entries

### DIFF
--- a/network/src/main/java/org/jboss/as/network/NetworkUtils.java
+++ b/network/src/main/java/org/jboss/as/network/NetworkUtils.java
@@ -289,6 +289,26 @@ public class NetworkUtils {
 
     /**
      * Formats input address. For IPV4 returns simply host address, for IPV6 formats address according to <a
+     * href="http://tools.ietf.org/html/rfc5952">RFC5952</a> rules. It embeds IPV6 address in '[', ']'.
+     *
+     * @param inet
+     * @return
+     */
+    public static String formatIPAddressForURI(InetAddress inet){
+        if(inet == null){
+            throw new IllegalArgumentException();
+        }
+        if(inet instanceof Inet4Address){
+            return inet.getHostAddress();
+        } else if (inet instanceof Inet6Address){
+            return '[' + formatAddress(inet) + ']';
+        } else {
+            return inet.getHostAddress();
+        }
+    }
+
+    /**
+     * Formats input address. For IPV4 returns simply host address, for IPV6 formats address according to <a
      * href="http://tools.ietf.org/html/rfc5952">RFC5952</a> rules. It does not embed IPV6 address in '[', ']', since those are part of IPV6 URI literal.
      *
      * @param inet
@@ -296,7 +316,7 @@ public class NetworkUtils {
      */
     public static String formatAddress(InetAddress inet){
         if(inet == null){
-            throw new NullPointerException();
+            throw new IllegalArgumentException();
         }
         if(inet instanceof Inet4Address){
             return inet.getHostAddress();

--- a/network/src/test/java/org/jboss/as/network/NetworkUtilsTestCase.java
+++ b/network/src/test/java/org/jboss/as/network/NetworkUtilsTestCase.java
@@ -63,6 +63,24 @@ public class NetworkUtilsTestCase {
     }
 
     @Test
+    public void testFormatIPAddressForURI() throws Exception{
+        InetAddress inetAddress = InetAddress.getByName("127.0.0.1");
+        Assert.assertEquals("127.0.0.1", NetworkUtils.formatIPAddressForURI(inetAddress));
+        
+        inetAddress = InetAddress.getByName("0:0:0:0:0:0:0:1");
+        Assert.assertEquals("[::1]", NetworkUtils.formatIPAddressForURI(inetAddress));
+        
+        inetAddress = InetAddress.getByName("fe80:0:0:0:f24d:a2ff:fe63:5766");
+        Assert.assertEquals("[fe80::f24d:a2ff:fe63:5766]", NetworkUtils.formatIPAddressForURI(inetAddress));
+        
+        inetAddress = InetAddress.getByName("1:0:0:1:0:0:0:1");
+        Assert.assertEquals("[1:0:0:1::1]", NetworkUtils.formatIPAddressForURI(inetAddress));
+        
+        inetAddress = InetAddress.getByName("1:0:0:1:1:0:0:1");
+        Assert.assertEquals("[1::1:1:0:0:1]", NetworkUtils.formatIPAddressForURI(inetAddress));
+    }
+    
+    @Test
     public void testFormatSocketAddress() throws Exception {
         InetAddress inetAddress = InetAddress.getByName("127.0.0.1");
         InetSocketAddress socketAddress = new InetSocketAddress(inetAddress,8000);

--- a/server/src/main/java/org/jboss/as/server/BootstrapListener.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapListener.java
@@ -105,23 +105,23 @@ public final class BootstrapListener {
             boolean hasHttp = mgmt.getHttpNetworkInterfaceBinding() != null && mgmt.getHttpPort() > 0;
             boolean hasHttps = mgmt.getHttpsNetworkInterfaceBinding() != null && mgmt.getHttpsPort() > 0;
             if (hasHttp && hasHttps) {
-                ServerLogger.AS_ROOT_LOGGER.logHttpAndHttpsManagement(NetworkUtils.formatAddress(mgmt.getHttpNetworkInterfaceBinding().getAddress()), mgmt.getHttpPort(), NetworkUtils.formatAddress(mgmt.getHttpsNetworkInterfaceBinding().getAddress()), mgmt.getHttpsPort());
+                ServerLogger.AS_ROOT_LOGGER.logHttpAndHttpsManagement(NetworkUtils.formatIPAddressForURI(mgmt.getHttpNetworkInterfaceBinding().getAddress()), mgmt.getHttpPort(), NetworkUtils.formatIPAddressForURI(mgmt.getHttpsNetworkInterfaceBinding().getAddress()), mgmt.getHttpsPort());
                 if (mgmt.hasConsole()) {
-                    ServerLogger.AS_ROOT_LOGGER.logHttpAndHttpsConsole(NetworkUtils.formatAddress(mgmt.getHttpNetworkInterfaceBinding().getAddress()), mgmt.getHttpPort(), NetworkUtils.formatAddress(mgmt.getHttpsNetworkInterfaceBinding().getAddress()), mgmt.getHttpsPort());
+                    ServerLogger.AS_ROOT_LOGGER.logHttpAndHttpsConsole(NetworkUtils.formatIPAddressForURI(mgmt.getHttpNetworkInterfaceBinding().getAddress()), mgmt.getHttpPort(), NetworkUtils.formatIPAddressForURI(mgmt.getHttpsNetworkInterfaceBinding().getAddress()), mgmt.getHttpsPort());
                 } else {
                     ServerLogger.AS_ROOT_LOGGER.logNoConsole();
                 }
             } else if (hasHttp) {
-                ServerLogger.AS_ROOT_LOGGER.logHttpManagement(NetworkUtils.formatAddress(mgmt.getHttpNetworkInterfaceBinding().getAddress()), mgmt.getHttpPort());
+                ServerLogger.AS_ROOT_LOGGER.logHttpManagement(NetworkUtils.formatIPAddressForURI(mgmt.getHttpNetworkInterfaceBinding().getAddress()), mgmt.getHttpPort());
                 if (mgmt.hasConsole()) {
-                    ServerLogger.AS_ROOT_LOGGER.logHttpConsole(NetworkUtils.formatAddress(mgmt.getHttpNetworkInterfaceBinding().getAddress()), mgmt.getHttpPort());
+                    ServerLogger.AS_ROOT_LOGGER.logHttpConsole(NetworkUtils.formatIPAddressForURI(mgmt.getHttpNetworkInterfaceBinding().getAddress()), mgmt.getHttpPort());
                 } else {
                     ServerLogger.AS_ROOT_LOGGER.logNoConsole();
                 }
             } else if (hasHttps) {
-                ServerLogger.AS_ROOT_LOGGER.logHttpsManagement(NetworkUtils.formatAddress(mgmt.getHttpsNetworkInterfaceBinding().getAddress()), mgmt.getHttpsPort());
+                ServerLogger.AS_ROOT_LOGGER.logHttpsManagement(NetworkUtils.formatIPAddressForURI(mgmt.getHttpsNetworkInterfaceBinding().getAddress()), mgmt.getHttpsPort());
                 if (mgmt.hasConsole()) {
-                    ServerLogger.AS_ROOT_LOGGER.logHttpsConsole(NetworkUtils.formatAddress(mgmt.getHttpsNetworkInterfaceBinding().getAddress()), mgmt.getHttpsPort());
+                    ServerLogger.AS_ROOT_LOGGER.logHttpsConsole(NetworkUtils.formatIPAddressForURI(mgmt.getHttpsNetworkInterfaceBinding().getAddress()), mgmt.getHttpsPort());
                 } else {
                     ServerLogger.AS_ROOT_LOGGER.logNoConsole();
                 }


### PR DESCRIPTION
Log entries now have URI formatted addresses.

Jira: https://issues.jboss.org/browse/WFCORE-439
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=900564
