### PR TITLE
[WFCORE-208] : Expose 'singleton' type information in read-children-types

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -202,6 +202,7 @@ public class ModelDescriptionConstants {
     public static final String INCLUDE_DATE = "include-date";
     public static final String INCLUDE_DEFAULTS = "include-defaults";
     public static final String INCLUDE_RUNTIME = "include-runtime";
+    public static final String INCLUDE_SINGLETONS = "include-singletons";
     public static final String INET_ADDRESS = "inet-address";
     public static final String INHERITED = "inherited";
     public static final String INITIAL_SERVER_GROUPS = "initial-server-groups";

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationAttributes.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationAttributes.java
@@ -51,6 +51,11 @@ class GlobalOperationAttributes {
     .setDefaultValue(new ModelNode(false))
     .build();
 
+    static final SimpleAttributeDefinition INCLUDE_SINGLETONS = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.INCLUDE_SINGLETONS, ModelType.BOOLEAN)
+    .setAllowNull(true)
+    .setDefaultValue(new ModelNode(false))
+    .build();
+
     static final SimpleAttributeDefinition INCLUDE_RUNTIME = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.INCLUDE_RUNTIME, ModelType.BOOLEAN)
     .setAllowNull(true)
     .setDefaultValue(new ModelNode(false))

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -309,7 +309,7 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
                     //Add a "child" => undefined
                     nodeDescription.get(CHILDREN, element.getKey(), MODEL_DESCRIPTION, element.getValue());
                 } else if (childReg.isAlias() && !aliases) {
-                    if (isSquatterResource(registry, element.getKey())) {
+                    if (isSingletonResource(registry, element.getKey())) {
                         if (nodeDescription.get(CHILDREN).hasDefined(element.getKey())) {
                             nodeDescription.get(CHILDREN).get(element.getKey()).remove(element.getValue());
                         }
@@ -334,12 +334,12 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
         });
     }
 
-    private boolean isSquatterResource(final ImmutableManagementResourceRegistration registry, final String key) {
+    private boolean isSingletonResource(final ImmutableManagementResourceRegistration registry, final String key) {
         return registry.getSubModel(PathAddress.pathAddress(PathElement.pathElement(key))) == null;
     }
 
     private boolean isGlobalAlias(final ImmutableManagementResourceRegistration registry, final Property child) {
-        if(isSquatterResource(registry, child.getName())) {
+        if(isSingletonResource(registry, child.getName())) {
             Set<PathElement> childrenPath = registry.getChildAddresses(PathAddress.EMPTY_ADDRESS);
             boolean found = false;
             boolean alias = true;

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -356,12 +356,12 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
         context.stepCompleted();
     }
 
-    private boolean isSquatterResource(final ImmutableManagementResourceRegistration registry, final String key) {
+    private boolean isSingletonResource(final ImmutableManagementResourceRegistration registry, final String key) {
         return registry.getSubModel(PathAddress.pathAddress(PathElement.pathElement(key))) == null;
     }
 
     private boolean isGlobalAlias(final ImmutableManagementResourceRegistration registry, final String childName) {
-        if(isSquatterResource(registry, childName)) {
+        if(isSingletonResource(registry, childName)) {
             Set<PathElement> childrenPath = registry.getChildAddresses(PathAddress.EMPTY_ADDRESS);
             boolean found = false;
             boolean alias = true;

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -424,6 +424,7 @@ global.read-children-names.reply=The children names
 global.read-children-types=Gets the type names of all the children under the selected resource
 global.read-children-types.reply=The children types
 global.read-children-types.include-aliases=If 'true' include children which are aliases.
+global.read-children-types.include-singletons=If 'true' include the full key/value pair for any singleton registration.
 global.read-children-resources=Reads information about all of a resource's children that are of a given type
 global.read-children-resources.child-type=The name of the resource under which to get the child resources
 global.read-children-resources.recursive=Whether to get the children recursively. If absent, false is the default

--- a/controller/src/test/java/org/jboss/as/controller/test/AliasResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AliasResourceTestCase.java
@@ -219,7 +219,8 @@ public class AliasResourceTestCase extends AbstractControllerTestBase {
 
     @Test
     public void readChildrenTypes() throws Exception {
-        ModelNode op = createOperation(READ_CHILDREN_TYPES_OPERATION);
+        ModelNode op = createOperation(READ_CHILDREN_TYPES_OPERATION);        
+        op.get(INCLUDE_ALIASES).set(true);
         ModelNode result = executeForResult(op);
         List<ModelNode> list = result.asList();
         Assert.assertEquals(2, list.size());

--- a/controller/src/test/java/org/jboss/as/controller/test/SingletonResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/SingletonResourceTestCase.java
@@ -1,0 +1,160 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.controller.test;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_SINGLETONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_TYPES_OPERATION;
+
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.ResourceBundle;
+
+import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class SingletonResourceTestCase extends AbstractControllerTestBase {
+
+    private static final String CORE = "core";
+    static final String MODEL = "model";
+    private static final String CHILD = "child";
+    private static final String SERVICE = "service";
+    private static final String DATASOURCE = "data-source";
+    private static final String DS = "exampleDS";
+    private static final String REMOTE = "remote";
+    private static final String ASYNC = "async";
+
+    @Test
+    public void readChildrenTypes() throws Exception {
+        ModelNode op = createOperation(READ_CHILDREN_TYPES_OPERATION);
+        ModelNode result = executeForResult(op);
+        List<ModelNode> list = result.asList();
+        Assert.assertEquals(1, list.size());
+        Assert.assertTrue(list.contains(new ModelNode(CORE)));
+
+        op.get(OP_ADDR).setEmptyList().add(CORE, MODEL);
+        result = executeForResult(op);
+        list = result.asList();
+        Assert.assertEquals(3, list.size());
+        Assert.assertTrue(list.contains(new ModelNode(CHILD)));
+        Assert.assertTrue(list.contains(new ModelNode(SERVICE)));
+        Assert.assertTrue(list.contains(new ModelNode(DATASOURCE)));
+
+        op.get(OP_ADDR).setEmptyList().add(CORE, MODEL);
+        op.get(INCLUDE_SINGLETONS).set(true);
+        result = executeForResult(op);
+        list = result.asList();
+        Assert.assertEquals(5, list.size());
+        Assert.assertTrue(list.contains(new ModelNode(CHILD)));
+        Assert.assertTrue(list.contains(new ModelNode(DATASOURCE)));
+        Assert.assertTrue(list.contains(new ModelNode(DATASOURCE + '=' + DS)));
+        Assert.assertTrue(list.contains(new ModelNode(SERVICE + '=' + ASYNC)));
+        Assert.assertTrue(list.contains(new ModelNode(SERVICE + '=' + REMOTE)));
+    }
+
+    @Override
+    protected void initModel(ManagementModel managementModel) {
+        ManagementResourceRegistration registration = managementModel.getRootResourceRegistration();
+        GlobalOperationHandlers.registerGlobalOperations(registration, processType);
+
+        registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+
+        GlobalNotifications.registerGlobalNotifications(registration, processType);
+
+        ManagementResourceRegistration coreResourceRegistration = registration.registerSubModel(new CoreResourceDefinition());
+        coreResourceRegistration.registerSubModel(new ChildResourceDefinition(CHILD));
+        coreResourceRegistration.registerSubModel(new SingletonResourceDefinition(SERVICE, ASYNC));
+        coreResourceRegistration.registerSubModel(new SingletonResourceDefinition(SERVICE, REMOTE));
+        
+        coreResourceRegistration.registerSubModel(new ChildResourceDefinition(DATASOURCE));
+        coreResourceRegistration.registerSubModel(new SingletonResourceDefinition(DATASOURCE, DS));
+    }
+
+    private PathElement getCoreModelElement() {
+        return PathElement.pathElement(CORE, MODEL);
+    }
+
+    private class CoreResourceDefinition extends SimpleResourceDefinition {
+
+        public CoreResourceDefinition() {
+            super(getCoreModelElement(), createResourceDescriptionResolver());
+        }
+    }
+
+    private class ChildResourceDefinition extends SimpleResourceDefinition {
+
+        public ChildResourceDefinition(String name) {
+            super(PathElement.pathElement(name), createResourceDescriptionResolver());
+        }
+    }
+
+    private class SingletonResourceDefinition extends SimpleResourceDefinition {
+
+        public SingletonResourceDefinition(String parent, String name) {
+            super(PathElement.pathElement(parent, name), createResourceDescriptionResolver());
+        }
+    }
+
+    static ResourceDescriptionResolver createResourceDescriptionResolver() {
+        final Map<String, String> strings = new HashMap<String, String>();
+        strings.put("test", "The test resource");
+        strings.put("test.child", "Child test resource");
+        strings.put("test.data-source", "Override singleton test resource");
+        strings.put("test.service", "Pure singleton test resource");
+
+        return new StandardResourceDescriptionResolver("test", SingletonResourceTestCase.class.getName() + ".properties", SingletonResourceTestCase.class.getClassLoader(), true, false) {
+
+            @Override
+            public ResourceBundle getResourceBundle(Locale locale) {
+                return new ResourceBundle() {
+
+                    @Override
+                    protected Object handleGetObject(String key) {
+                        return strings.get(key);
+                    }
+
+                    @Override
+                    public Enumeration<String> getKeys() {
+                        return null;
+                    }
+                };
+            }
+
+        };
+    }
+}


### PR DESCRIPTION
If the "include-singletons" parameter is set to "true", the operation result will include the full key/value pair for any singleton registration.
If "include-singletons" is "true" a non-fully-qualified type (i.e. just key instead of key=value) will only appear in the result if there is a wildcard registration for that key.

Jira: https://issues.jboss.org/browse/WFCORE-208
