### PR TITLE
[WFCORE-309] : system properties are trim()'d and loose whitespace.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
@@ -24,13 +24,13 @@
 
 package org.jboss.as.controller;
 
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
 
 /**
  * @author Tomaz Cerar (c) 2014 Red Hat Inc.
@@ -86,44 +86,7 @@ public abstract class AttributeParser {
     }
 
     private ModelNode parse(final AttributeDefinition attribute, final String value) throws OperationFailedException {
-        final String trimmed = value == null ? null : value.trim();
-        ModelNode node;
-        if (trimmed != null) {
-            if (attribute.isAllowExpression()) {
-                node = ParseUtils.parsePossibleExpression(trimmed);
-            } else {
-                node = new ModelNode().set(trimmed);
-            }
-            if (node.getType() != ModelType.EXPRESSION) {
-                // Convert the string to the expected type
-                switch (attribute.getType()) {
-                    case BIG_DECIMAL:
-                        node.set(node.asBigDecimal());
-                        break;
-                    case BIG_INTEGER:
-                        node.set(node.asBigInteger());
-                        break;
-                    case BOOLEAN:
-                        node.set(node.asBoolean());
-                        break;
-                    case BYTES:
-                        node.set(node.asBytes());
-                        break;
-                    case DOUBLE:
-                        node.set(node.asDouble());
-                        break;
-                    case INT:
-                        node.set(node.asInt());
-                        break;
-                    case LONG:
-                        node.set(node.asLong());
-                        break;
-                }
-            }
-        } else {
-            node = new ModelNode();
-        }
-
+        ModelNode node = ParseUtils.parseAttributeValue(value, attribute.isAllowExpression(), attribute.getType());
         final ParameterValidator validator;
         // A bit yuck, but I didn't want to introduce a new type just for this
         if (attribute instanceof ListAttributeDefinition) {

--- a/controller/src/main/java/org/jboss/as/controller/MapAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/MapAttributeDefinition.java
@@ -22,14 +22,13 @@
 
 package org.jboss.as.controller;
 
+
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
-
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.validation.MapValidator;
@@ -82,47 +81,7 @@ public abstract class MapAttributeDefinition extends AttributeDefinition {
      * @throws XMLStreamException if {@code value} is not valid
      */
     public ModelNode parse(final String value, final Location location) throws XMLStreamException {
-
-        final String trimmed = value == null ? null : value.trim();
-        ModelNode node;
-        if (trimmed != null) {
-            if (isAllowExpression()) {
-                node = ParseUtils.parsePossibleExpression(trimmed);
-            } else {
-                node = new ModelNode().set(trimmed);
-            }
-            if (node.getType() != ModelType.EXPRESSION) {
-                // Convert the string to the expected type
-                switch (getType()) {
-                    case BIG_DECIMAL:
-                        node.set(node.asBigDecimal());
-                        break;
-                    case BIG_INTEGER:
-                        node.set(node.asBigInteger());
-                        break;
-                    case BOOLEAN:
-                        node.set(node.asBoolean());
-                        break;
-                    case BYTES:
-                        node.set(node.asBytes());
-                        break;
-                    case DOUBLE:
-                        node.set(node.asDouble());
-                        break;
-                    case INT:
-                        node.set(node.asInt());
-                        break;
-                    case LONG:
-                        node.set(node.asLong());
-                        break;
-                }
-            }
-        }
-        else {
-            node = new ModelNode();
-        }
-
-
+        ModelNode node = ParseUtils.parseAttributeValue(value, isAllowExpression(), getType());
         try {
             elementValidator.validateParameter(getXmlName(), node);
         } catch (OperationFailedException e) {

--- a/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinition.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.controller;
 
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
@@ -230,52 +231,17 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
      * {@inheritDoc}
      *
      * This implementation marshalls the attribute value as text content of the element.
+     * @param marshallDefault
+     * @throws javax.xml.stream.XMLStreamException
      */
+    @Override
     public void marshallAsElement(final ModelNode resourceModel, final boolean marshallDefault, final XMLStreamWriter writer) throws XMLStreamException {
         attributeMarshaller.marshallAsElement(this,resourceModel,marshallDefault,writer);
     }
 
     static ModelNode parse(AttributeDefinition attribute, ParameterValidator validator, final String value) throws OperationFailedException  {
-        final String trimmed = value == null ? null : value.trim();
-        ModelNode node;
-        if (trimmed != null ) {
-            if (attribute.isAllowExpression()) {
-                node = ParseUtils.parsePossibleExpression(trimmed);
-            } else {
-                node = new ModelNode().set(trimmed);
-            }
-            if (node.getType() != ModelType.EXPRESSION) {
-                // Convert the string to the expected type
-                switch (attribute.getType()) {
-                    case BIG_DECIMAL:
-                        node.set(node.asBigDecimal());
-                        break;
-                    case BIG_INTEGER:
-                        node.set(node.asBigInteger());
-                        break;
-                    case BOOLEAN:
-                        node.set(node.asBoolean());
-                        break;
-                    case BYTES:
-                        node.set(node.asBytes());
-                        break;
-                    case DOUBLE:
-                        node.set(node.asDouble());
-                        break;
-                    case INT:
-                        node.set(node.asInt());
-                        break;
-                    case LONG:
-                        node.set(node.asLong());
-                        break;
-                }
-            }
-        } else {
-            node = new ModelNode();
-        }
-
+        ModelNode node = ParseUtils.parseAttributeValue(value, attribute.isAllowExpression(), attribute.getType());
         validator.validateParameter(attribute.getXmlName(), node);
-
         return node;
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTest.java
@@ -50,6 +50,7 @@ public abstract class AbstractSystemPropertyTest extends AbstractCoreModelTest {
     static final String PROP_THREE = "sys.prop.test.three";
     static final String PROP_FOUR = "sys.prop.test.four";
     static final String PROP_FIVE = "sys.prop.test.five";
+    static final String PROP_SIX = "sys.prop.test.six";
 
     final boolean standalone;
     final boolean domain;
@@ -65,6 +66,8 @@ public abstract class AbstractSystemPropertyTest extends AbstractCoreModelTest {
         System.clearProperty(PROP_TWO);
         System.clearProperty(PROP_THREE);
         System.clearProperty(PROP_FOUR);
+        System.clearProperty(PROP_FIVE);
+        System.clearProperty(PROP_SIX);
     }
 
     @Test
@@ -326,11 +329,12 @@ public abstract class AbstractSystemPropertyTest extends AbstractCoreModelTest {
         ModelTestUtils.compareXml(xmlOriginal, marshalled);
 
         ModelNode props = readSystemPropertiesParentModel(kernelServices);
-        Assert.assertEquals(standalone || domain ? 4 : 5, props.keys().size());
+        Assert.assertEquals(standalone || domain ? 5 : 6, props.keys().size());
 
         Assert.assertEquals("1", props.get(PROP_ONE, VALUE).asString());
         Assert.assertEquals("2", props.get(PROP_TWO, VALUE).asString());
         Assert.assertEquals("3", props.get(PROP_THREE, VALUE).asString());
+        Assert.assertEquals(" six ", props.get(PROP_SIX, VALUE).asString());
         Assert.assertFalse(props.get(PROP_FOUR, VALUE).isDefined());
         if (!standalone) {
             Assert.assertTrue(props.get(PROP_ONE, BOOT_TIME).asBoolean());

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties-with-expressions.xml
@@ -1,18 +1,19 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <domain xmlns="urn:jboss:domain:3.0">
 
-   <server-groups>
-     <server-group name="test" profile="test">
+    <server-groups>
+        <server-group name="test" profile="test">
 
-          <!-- Needed for the add operation -->
-          <socket-binding-group ref="test-sockets"/>
+            <!-- Needed for the add operation -->
+            <socket-binding-group ref="test-sockets"/>
 
-		    <system-properties>
-            <property name="sys.prop.test.one" value="ONE"/>
-            <property name="sys.prop.test.two" value="${sys.prop.test.one:UNO}"/>
-            <property name="sys.prop.test.three" value="${sys.prop.test.one:UNO}" boot-time="${sys.prop.test.boot-time:true}"/>
-		    </system-properties>
+            <system-properties>
+                <property name="sys.prop.test.one" value="ONE"/>
+                <property name="sys.prop.test.two" value="${sys.prop.test.one:UNO}"/>
+                <property name="sys.prop.test.three" value="${sys.prop.test.one:UNO}" boot-time="${sys.prop.test.boot-time:true}"/>
+                <property name="sys.prop.test.six" value=" six "/>
+            </system-properties>
 
-      </server-group>
+        </server-group>
     </server-groups>
 </domain>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-servergroup-systemproperties.xml
@@ -1,19 +1,20 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <domain xmlns="urn:jboss:domain:3.0">
 
-   <server-groups>
-     <server-group name="test" profile="test">
+    <server-groups>
+        <server-group name="test" profile="test">
 
-          <!-- Needed for the add operation -->
-          <socket-binding-group ref="test-sockets"/>
+            <!-- Needed for the add operation -->
+            <socket-binding-group ref="test-sockets"/>
 
-		    <system-properties>
-		        <property name="sys.prop.test.one" value="1"/>
-		        <property name="sys.prop.test.two" value="2" boot-time="true"/>
-		        <property name="sys.prop.test.three" value="3" boot-time="false"/>
-		        <property name="sys.prop.test.four"/>
-		    </system-properties>
+            <system-properties>
+                <property name="sys.prop.test.one" value="1"/>
+                <property name="sys.prop.test.two" value="2" boot-time="true"/>
+                <property name="sys.prop.test.three" value="3" boot-time="false"/>
+                <property name="sys.prop.test.four"/>
+                <property name="sys.prop.test.six" value=" six "/>
+            </system-properties>
 
-      </server-group>
+        </server-group>
     </server-groups>
 </domain>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties-with-expressions.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties-with-expressions.xml
@@ -5,6 +5,7 @@
         <property name="sys.prop.test.one" value="ONE"/>
         <property name="sys.prop.test.two" value="${sys.prop.test.one:UNO}"/>
         <property name="sys.prop.test.three" value="${sys.prop.test.one:UNO}" boot-time="${sys.prop.test.boot-time:true}"/>
+        <property name="sys.prop.test.six" value=" six "/>
     </system-properties>
 
 </domain>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/domain-systemproperties.xml
@@ -6,6 +6,7 @@
         <property name="sys.prop.test.two" value="2" boot-time="true"/>
         <property name="sys.prop.test.three" value="3" boot-time="false"/>
         <property name="sys.prop.test.four"/>
+        <property name="sys.prop.test.six" value=" six "/>
     </system-properties>
 
 </domain>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-server-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-server-systemproperties.xml
@@ -13,13 +13,14 @@
 
     <servers>
         <server name="server-one" group="main-server-group">
-		    <system-properties>
-		        <property name="sys.prop.test.one" value="1"/>
-		        <property name="sys.prop.test.two" value="2" boot-time="true"/>
-		        <property name="sys.prop.test.three" value="3" boot-time="false"/>
+            <system-properties>
+                <property name="sys.prop.test.one" value="1"/>
+                <property name="sys.prop.test.two" value="2" boot-time="true"/>
+                <property name="sys.prop.test.three" value="3" boot-time="false"/>
                 <property name="sys.prop.test.four"/>
                 <property name="sys.prop.test.five" value="${sys.prop.test.three:5}" boot-time="${sys.prop.test.boot-time:false}"/>
-		    </system-properties>
+                <property name="sys.prop.test.six" value=" six "/>
+            </system-properties>
         </server>
     </servers>
 </host>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/host-systemproperties.xml
@@ -7,6 +7,7 @@
         <property name="sys.prop.test.three" value="3" boot-time="false"/>
         <property name="sys.prop.test.four"/>
         <property name="sys.prop.test.five" value="${sys.prop.test.three:5}" boot-time="${sys.prop.test.boot-time:false}"/>
+        <property name="sys.prop.test.six" value=" six "/>
     </system-properties>
 
     <!--  The native interface is always required by the parser -->

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/standalone-systemproperties.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/systemproperty/standalone-systemproperties.xml
@@ -6,6 +6,7 @@
         <property name="sys.prop.test.two" value="2"/>
         <property name="sys.prop.test.three" value="3"/>
         <property name="sys.prop.test.four"/>
+        <property name="sys.prop.test.six" value=" six "/>
     </system-properties>
     
 </server>        


### PR DESCRIPTION
When the ModelType is STRING or PROPERTY the attribute value is set without trimming.

Jira: https://issues.jboss.org/browse/WFCORE-309