### PR TITLE
[WFCORE-237] : Use boot-completed notification to trigger deployment scanner "forced undeploy" scan.

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerAdd.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerAdd.java
@@ -49,6 +49,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import org.jboss.as.controller.ControlledProcessStateService;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -117,7 +118,8 @@ class DeploymentScannerAdd implements OperationStepHandler {
                     relativePath = new File(pathManager.getPathEntry(relativeTo).resolvePath());
                 }
 
-                bootTimeScanner = new FileSystemDeploymentService(relativeTo, new File(pathName), relativePath, null, scheduledExecutorService);
+                bootTimeScanner = new FileSystemDeploymentService(relativeTo, new File(pathName), relativePath, null, scheduledExecutorService,
+                        (ControlledProcessStateService) context.getServiceRegistry(false).getService(ControlledProcessStateService.SERVICE_NAME).getValue());
                 bootTimeScanner.setAutoDeployExplodedContent(autoDeployExp);
                 bootTimeScanner.setAutoDeployZippedContent(autoDeployZip);
                 bootTimeScanner.setAutoDeployXMLContent(autoDeployXml);

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerService.java
@@ -25,6 +25,7 @@ package org.jboss.as.server.deployment.scanner;
 import java.io.File;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import org.jboss.as.controller.ControlledProcessStateService;
 
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.services.path.PathManager;
@@ -67,6 +68,7 @@ public class DeploymentScannerService implements Service<DeploymentScanner> {
     private final InjectedValue<PathManager> pathManagerValue = new InjectedValue<PathManager>();
     private final InjectedValue<ModelController> controllerValue = new InjectedValue<ModelController>();
     private final InjectedValue<ScheduledExecutorService> scheduledExecutorValue = new InjectedValue<ScheduledExecutorService>();
+    private final InjectedValue<ControlledProcessStateService> controlledProcessStateServiceValue = new InjectedValue<ControlledProcessStateService>();
     private volatile PathManager.Callback.Handle callbackHandle;
 
     public static ServiceName getServiceName(String repositoryName) {
@@ -99,6 +101,7 @@ public class DeploymentScannerService implements Service<DeploymentScanner> {
                 .addDependency(PathManagerService.SERVICE_NAME, PathManager.class, service.pathManagerValue)
                 .addDependency(Services.JBOSS_SERVER_CONTROLLER, ModelController.class, service.controllerValue)
                 .addDependency(org.jboss.as.server.deployment.Services.JBOSS_DEPLOYMENT_CHAINS)
+                .addDependency(ControlledProcessStateService.SERVICE_NAME, ControlledProcessStateService.class, service.controlledProcessStateServiceValue)
                 .addInjection(service.scheduledExecutorValue, scheduledExecutorService)
                 .setInitialMode(Mode.ACTIVE)
                 .install();
@@ -146,7 +149,7 @@ public class DeploymentScannerService implements Service<DeploymentScanner> {
                 }
 
                 final FileSystemDeploymentService scanner = new FileSystemDeploymentService(relativeTo, new File(pathName),
-                        relativePath, factory, scheduledExecutorValue.getValue());
+                        relativePath, factory, scheduledExecutorValue.getValue(), controlledProcessStateServiceValue.getValue());
 
                 scanner.setScanInterval(unit.toMillis(interval));
                 scanner.setAutoDeployExplodedContent(autoDeployExploded);

--- a/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentServiceUnitTestCase.java
+++ b/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentServiceUnitTestCase.java
@@ -1763,7 +1763,7 @@ public class FileSystemDeploymentServiceUnitTestCase {
     }
 
     private TesteeSet createTestee(final MockServerController sc, final ScheduledExecutorService executor) throws OperationFailedException {
-        final FileSystemDeploymentService testee = new FileSystemDeploymentService(null, tmpDir, null, sc, executor);
+        final FileSystemDeploymentService testee = new FileSystemDeploymentService(null, tmpDir, null, sc, executor, null);
         testee.startScanner(new DefaultDeploymentOperations(sc));
         return new TesteeSet(testee, sc);
     }


### PR DESCRIPTION
Adding dependency on ControlledProcessStateService.
Adding a listener and running the forced undeploy if scan is enabled once the server is in "running" state.

Jira: https://issues.jboss.org/browse/WFCORE-237
