### PR TITLE
[WFCORE-371/WFCORE-419] : Expose mgmt client socket binding config through ModelControllerClient Factory.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
@@ -21,9 +21,11 @@
  */
 package org.jboss.as.cli;
 
+import org.jboss.as.cli.impl.CommandContextConfiguration;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
 import java.io.InputStream;
 import java.io.OutputStream;
-import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  *
@@ -56,14 +58,24 @@ public abstract class CommandContextFactory {
 
     public abstract CommandContext newCommandContext(String controller, String username, char[] password) throws CliInitializationException;
 
+    /**
+     * @deprecated Use {@link #newCommandContext(CommandContextConfiguration configuration)} instead.
+     */
+    @Deprecated
     public abstract CommandContext newCommandContext(String controller, String username, char[] password, boolean initConsole,
             final int connectionTimeout) throws CliInitializationException;
 
+    /**
+     * @deprecated Use {@link #newCommandContext(CommandContextConfiguration configuration)} instead.
+     */
+    @Deprecated
     public abstract CommandContext newCommandContext(String controller, String username, char[] password, boolean disableLocalAuth,
             boolean initConsole, final int connectionTimeout) throws CliInitializationException;
 
     public abstract CommandContext newCommandContext(String controller, String username, char[] password, InputStream consoleInput,
             OutputStream consoleOutput) throws CliInitializationException;
+
+    public abstract CommandContext newCommandContext(CommandContextConfiguration configuration) throws CliInitializationException;
 
     /**
      * @deprecated Use {@link #newCommandContext(String, String, char[])} instead.

--- a/cli/src/main/java/org/jboss/as/cli/gui/ConnectDialog.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/ConnectDialog.java
@@ -183,7 +183,7 @@ public class ConnectDialog extends JInternalFrame {
                     if (user == null) {
                         cmdCtx = CommandContextFactory.getInstance().newCommandContext();
                     } else {
-                        cmdCtx = CommandContextFactory.getInstance().newCommandContext(user, password.toCharArray());
+                        cmdCtx = CommandContextFactory.getInstance().newCommandContext(null, user, password.toCharArray());
                     }
                     cmdCtx.connectController(controller);
                     plugin.init(cmdCtx);

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -124,7 +124,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
 
     CLIModelControllerClient(final ControllerAddress address, CallbackHandler handler, int connectionTimeout,
             final ConnectionCloseHandler closeHandler, Map<String, String> saslOptions, SSLContext sslContext,
-            ProtocolTimeoutHandler timeoutHandler) throws IOException {
+            ProtocolTimeoutHandler timeoutHandler, String clientBindAddress) throws IOException {
         this.handler = handler;
         this.sslContext = sslContext;
         this.closeHandler = closeHandler;
@@ -141,6 +141,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
         }, executorService, this);
 
         channelConfig = new ProtocolChannelClient.Configuration();
+        channelConfig.setClientBindAddress(clientBindAddress);
         this.saslOptions = saslOptions;
         channelConfig.setSaslOptions(saslOptions);
         try {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextConfiguration.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2014 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.cli.impl;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class CommandContextConfiguration {
+    private final String controller;
+    private final String username;
+    private final char[] password;
+    private final String clientBindAddress;
+    private final InputStream consoleInput;
+    private final OutputStream consoleOutput;
+    private final boolean initConsole;
+    private final boolean disableLocalAuth;
+    private final int connectionTimeout;
+
+    private CommandContextConfiguration(String controller, String username, char[] password, String clientBindAddress, boolean disableLocalAuth, boolean initConsole, int connectionTimeout, InputStream consoleInput, OutputStream consoleOutput) {
+        this.controller = controller;
+        this.username = username;
+        this.password = password;
+        this.clientBindAddress = clientBindAddress;
+        this.consoleInput = consoleInput;
+        this.consoleOutput = consoleOutput;
+        this.initConsole = initConsole;
+        this.disableLocalAuth = disableLocalAuth || username != null;
+        this.connectionTimeout = connectionTimeout;
+    }
+
+    public String getController() {
+        return controller;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public char[] getPassword() {
+        return password;
+    }
+
+    public String getClientBindAddress() {
+        return clientBindAddress;
+    }
+
+    public InputStream getConsoleInput() {
+        return consoleInput;
+    }
+
+    public OutputStream getConsoleOutput() {
+        return consoleOutput;
+    }
+
+    public boolean isInitConsole() {
+        return initConsole;
+    }
+
+    public int getConnectionTimeout() {
+        return connectionTimeout;
+    }
+
+    public boolean isDisableLocalAuth() {
+        return disableLocalAuth;
+    }
+
+    public static class Builder {
+        private String controller;
+        private String username;
+        private char[] password;
+        private String clientBindAddress;
+        private InputStream consoleInput;
+        private OutputStream consoleOutput;
+        private boolean initConsole = false;
+        private boolean disableLocalAuth;
+        private int connectionTimeout = -1;
+        private boolean disableLocalAuthUnset = true;
+
+        public Builder() {
+        }
+
+        public CommandContextConfiguration build() {
+            if(disableLocalAuthUnset) {
+                this.disableLocalAuth = username != null;
+            }
+            return new CommandContextConfiguration(controller, username, password, clientBindAddress, disableLocalAuth,
+                    initConsole, connectionTimeout, consoleInput, consoleOutput);
+        }
+        public Builder setController(String controller) {
+            this.controller = controller;
+            return this;
+        }
+
+        public Builder setUsername(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder setPassword(char[] password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder setClientBindAddress(String clientBindAddress) {
+            this.clientBindAddress = clientBindAddress;
+            return this;
+        }
+
+        public Builder setConsoleInput(InputStream consoleInput) {
+            this.consoleInput = consoleInput;
+            return this;
+        }
+
+        public Builder setConsoleOutput(OutputStream consoleOutput) {
+            this.consoleOutput = consoleOutput;
+            return this;
+        }
+
+        public Builder setInitConsole(boolean initConsole) {
+            this.initConsole = initConsole;
+            return this;
+        }
+
+        public Builder setDisableLocalAuth(boolean disableLocalAuth) {
+            this.disableLocalAuth = disableLocalAuth;
+            this.disableLocalAuthUnset = false;
+            return this;
+        }
+
+        public Builder setConnectionTimeout(int connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
@@ -21,14 +21,14 @@
  */
 package org.jboss.as.cli.impl;
 
+import org.jboss.as.cli.CliInitializationException;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContextFactory;
+
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-
-import org.jboss.as.cli.CliInitializationException;
-import org.jboss.as.cli.CommandContext;
-import org.jboss.as.cli.CommandContextFactory;
 
 /**
  *
@@ -45,35 +45,60 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     }
 
     @Override
-    public CommandContext newCommandContext(String username, char[] password)
-            throws CliInitializationException {
-        return new CommandContextImpl(username, password, username != null);
+    public CommandContext newCommandContext(String username, char[] password) throws CliInitializationException {
+        return newCommandContext(new CommandContextConfiguration.Builder()
+                .setUsername(username)
+                .setPassword(password)
+                .setInitConsole(false)
+                .build());
     }
 
     @Override
-    public CommandContext newCommandContext(String controller, String username, char[] password)
-            throws CliInitializationException {
-        return newCommandContext(controller, username, password, false, -1);
+    public CommandContext newCommandContext(String controller, String username, char[] password) throws CliInitializationException {
+        return newCommandContext(new CommandContextConfiguration.Builder()
+                .setController(controller)
+                .setUsername(username)
+                .setPassword(password)
+                .setInitConsole(false)
+                .build());
     }
 
     @Override
-    public CommandContext newCommandContext(String controller, String username, char[] password,
-            boolean initConsole, final int connectionTimeout) throws CliInitializationException {
-        return new CommandContextImpl(controller, username, password, username != null, initConsole, connectionTimeout);
+    @Deprecated
+    public CommandContext newCommandContext(String controller, String username, char[] password, boolean initConsole, int connectionTimeout) throws CliInitializationException {
+        return newCommandContext(new CommandContextConfiguration.Builder()
+                .setController(controller)
+                .setUsername(username)
+                .setPassword(password)
+                .setInitConsole(initConsole)
+                .setConnectionTimeout(connectionTimeout)
+                .build());
     }
 
     @Override
-    public CommandContext newCommandContext(String controller,
-            String username, char[] password,
-            InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException {
-        return new CommandContextImpl(controller, username, password, username != null, consoleInput, consoleOutput);
+    @Deprecated
+    public CommandContext newCommandContext(String controller, String username, char[] password, boolean disableLocalAuth, boolean initConsole, int connectionTimeout) throws CliInitializationException {
+        return newCommandContext(new CommandContextConfiguration.Builder()
+                .setController(controller)
+                .setUsername(username)
+                .setPassword(password)
+                .setDisableLocalAuth(disableLocalAuth)
+                .setInitConsole(initConsole)
+                .setConnectionTimeout(connectionTimeout)
+                .build());
     }
 
     @Override
-    public CommandContext newCommandContext(String controller,
-            String username, char[] password, boolean disableLocalAuth, boolean initConsole, int connectionTimeout)
-            throws CliInitializationException {
-        return new CommandContextImpl(controller, username, password, disableLocalAuth || username != null, initConsole, connectionTimeout);
+    public CommandContext newCommandContext(String controller, String username, char[] password, InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException {
+        return newCommandContext(new CommandContextConfiguration.Builder()
+                .setController(controller)
+                .setUsername(username)
+                .setPassword(password)
+                .setConsoleInput(consoleInput)
+                .setConsoleOutput(consoleOutput)
+                .setDisableLocalAuth(false)
+                .setInitConsole(false)
+                .build());
     }
 
     @Override
@@ -81,8 +106,11 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     public CommandContext newCommandContext(String controllerHost, int controllerPort, String username, char[] password)
             throws CliInitializationException {
         try {
-            return newCommandContext(new URI(null, null, controllerHost, controllerPort, null, null, null).toString().substring(2),
-                    username, password);
+            return newCommandContext(new CommandContextConfiguration.Builder()
+                    .setController(new URI(null, null, controllerHost, controllerPort, null, null, null).toString().substring(2))
+                    .setUsername(username)
+                    .setPassword(password)
+                    .build());
         } catch (URISyntaxException e) {
             throw new CliInitializationException("Unable to construct URI for connection.", e);
         }
@@ -93,8 +121,13 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     public CommandContext newCommandContext(String controllerHost, int controllerPort, String username, char[] password,
             boolean initConsole, int connectionTimeout) throws CliInitializationException {
         try {
-            return newCommandContext(new URI(null, null, controllerHost, controllerPort, null, null, null).toString().substring(2),
-                    username, password, initConsole, connectionTimeout);
+            return newCommandContext(new CommandContextConfiguration.Builder()
+                .setController(new URI(null, null, controllerHost, controllerPort, null, null, null).toString().substring(2))
+                .setUsername(username)
+                .setPassword(password)
+                .setInitConsole(initConsole)
+                .setConnectionTimeout(connectionTimeout)
+                .build());
         } catch (URISyntaxException e) {
             throw new CliInitializationException("Unable to construct URI for connection.", e);
         }
@@ -105,10 +138,22 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     public CommandContext newCommandContext(String controllerHost, int controllerPort, String username, char[] password,
             InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException {
         try {
-            return newCommandContext(new URI(null, null, controllerHost, controllerPort, null, null, null).toString().substring(2),
-                    username, password, consoleInput, consoleOutput);
+            return newCommandContext(new CommandContextConfiguration.Builder()
+                    .setController(new URI(null, null, controllerHost, controllerPort, null, null, null).toString().substring(2))
+                    .setUsername(username)
+                    .setPassword(password)
+                    .setConsoleInput(consoleInput)
+                    .setConsoleOutput(consoleOutput)
+                    .setInitConsole(false)
+                    .setDisableLocalAuth(false)
+                    .build());
         } catch (URISyntaxException e) {
             throw new CliInitializationException("Unable to construct URI for connection.", e);
         }
+    }
+
+    @Override
+    public CommandContext newCommandContext(CommandContextConfiguration configuration) throws CliInitializationException {
+        return new CommandContextImpl(configuration);
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
@@ -50,16 +50,16 @@ public interface ModelControllerClientFactory {
 
     ModelControllerClient getClient(ControllerAddress address, CallbackHandler handler,
             boolean disableLocalAuth, SSLContext sslContext, int connectionTimeout,
-            ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler) throws IOException;
+            ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler, String clientBindAddress) throws IOException;
 
     ModelControllerClientFactory DEFAULT = new ModelControllerClientFactory() {
         @Override
         public ModelControllerClient getClient(ControllerAddress address, CallbackHandler handler,
                 boolean disableLocalAuth, SSLContext sslContext, int connectionTimeout,
-                ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler) throws IOException {
+                ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler, String clientBindAddress) throws IOException {
             // TODO - Make use of the ProtocolTimeoutHandler
             Map<String, String> saslOptions = disableLocalAuth ? DISABLED_LOCAL_AUTH : ENABLED_LOCAL_AUTH;
-            return ModelControllerClient.Factory.create(address.getProtocol(), address.getHost(), address.getPort(), handler, sslContext, connectionTimeout, saslOptions);
+            return ModelControllerClient.Factory.create(address.getProtocol(), address.getHost(), address.getPort(), handler, sslContext, connectionTimeout, saslOptions, clientBindAddress);
         }
     };
 
@@ -68,9 +68,9 @@ public interface ModelControllerClientFactory {
         @Override
         public ModelControllerClient getClient(ControllerAddress address,
                 final CallbackHandler handler, boolean disableLocalAuth, final SSLContext sslContext,
-                final int connectionTimeout, final ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler) throws IOException {
+                final int connectionTimeout, final ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler, String clientBindAddress) throws IOException {
             Map<String, String> saslOptions = disableLocalAuth ? DISABLED_LOCAL_AUTH : ENABLED_LOCAL_AUTH;
-            return new CLIModelControllerClient(address, handler, connectionTimeout, closeHandler, saslOptions, sslContext, timeoutHandler);
+            return new CLIModelControllerClient(address, handler, connectionTimeout, closeHandler, saslOptions, sslContext, timeoutHandler, clientBindAddress);
         }};
 
 }

--- a/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
+++ b/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
@@ -27,6 +27,7 @@ import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContextFactory;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.impl.CommandContextConfiguration;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -112,9 +113,26 @@ public class CLI {
      * @param password The password for logging in.
      */
     public void connect(String controller, String username, char[] password) {
+        connect(controller, username, password, null);
+    }
+
+    /**
+     * Connect to the server using a specified host and port.
+     *
+     * @param controller
+     * @param username The user name for logging in.
+     * @param clientBindAddress
+     * @param password The password for logging in.
+     */
+    public void connect(String controller, String username, char[] password, String clientBindAddress) {
         checkAlreadyConnected();
         try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(controller, username, password);
+            ctx = CommandContextFactory.getInstance().newCommandContext(new CommandContextConfiguration.Builder()
+                    .setController(controller)
+                    .setUsername(username)
+                    .setPassword(password)
+                    .setClientBindAddress(clientBindAddress)
+                    .build());
             ctx.connectController();
         } catch (CliInitializationException e) {
             throw new IllegalStateException("Unable to initialize command context.", e);
@@ -132,7 +150,20 @@ public class CLI {
      * @param password The password for logging in.
      */
     public void connect(String controllerHost, int controllerPort, String username, char[] password) {
-        connect("http-remoting", controllerHost, controllerPort, username, password);
+        connect("http-remoting", controllerHost, controllerPort, username, password, null);
+    }
+
+    /**
+     * Connect to the server using a specified host and port.
+     *
+     * @param controllerHost The host name.
+     * @param controllerPort The port.
+     * @param username The user name for logging in.
+     * @param password The password for logging in.
+     * @param clientBindAddress the client bind address.
+     */
+    public void connect(String controllerHost, int controllerPort, String username, char[] password, String clientBindAddress) {
+        connect("http-remoting", controllerHost, controllerPort, username, password, clientBindAddress);
     }
 
     /**
@@ -144,9 +175,26 @@ public class CLI {
      * @param password The password for logging in.
      */
     public void connect(String protocol, String controllerHost, int controllerPort, String username, char[] password) {
+        connect(protocol, controllerHost, controllerPort, username, password, null);
+    }
+
+    /**
+     * Connect to the server using a specified host and port.
+     * @param protocol The protocol
+     * @param controllerHost The host name.
+     * @param controllerPort The port.
+     * @param username The user name for logging in.
+     * @param password The password for logging in.
+     */
+    public void connect(String protocol, String controllerHost, int controllerPort, String username, char[] password, String clientBindAddress) {
         checkAlreadyConnected();
         try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(constructUri(protocol, controllerHost, controllerPort), username, password);
+            ctx = CommandContextFactory.getInstance().newCommandContext(
+                    new CommandContextConfiguration.Builder().setController(constructUri(protocol, controllerHost, controllerPort))
+                    .setUsername(username)
+                    .setPassword(password)
+                    .setClientBindAddress(clientBindAddress)
+                    .build());
             ctx.connectController();
         } catch (CliInitializationException e) {
             throw new IllegalStateException("Unable to initialize command context.", e);

--- a/cli/src/main/resources/help/help.txt
+++ b/cli/src/main/resources/help/help.txt
@@ -66,9 +66,12 @@ Usage:
                    to demonstrate that it is being executed locally to the server 
                    being managed through an exchange of tokens using the filesystem.                   
 
- --timeout       - specifies home many milliseconds to wait for a given command
+ --timeout       - specifies how many milliseconds to wait for a given command
                    to return. The value provided must be a positive integer.
                    Defaults to 5000 milliseconds when not provided.
+
+  --bind         - specifies to which address the CLI is going to be bound to.
+                   If none is provided then the CLI will choose one automatically as needed.
 
 
 For a list of available commands execute

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
+import org.jboss.as.controller.client.impl.ClientConfigurationImpl;
 
 import org.jboss.as.controller.client.impl.RemotingModelControllerClient;
 import org.jboss.dmr.ModelNode;
@@ -147,7 +148,10 @@ public interface ModelControllerClient extends Closeable {
          * @return A model controller client
          */
         public static ModelControllerClient create(final InetAddress address, final int port) {
-            return create(ModelControllerClientConfiguration.Factory.create(address, port));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHostName(address.getHostAddress())
+                    .setPort(port)
+                    .build());
         }
 
         /**
@@ -159,7 +163,11 @@ public interface ModelControllerClient extends Closeable {
          * @return A model controller client
          */
         public static ModelControllerClient create(final String protocol, final InetAddress address, final int port) {
-            return create(ModelControllerClientConfiguration.Factory.create(protocol, address, port));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHostName(address.getHostAddress())
+                    .setPort(port)
+                    .setProtocol(protocol)
+                    .build());
         }
 
         /**
@@ -171,7 +179,11 @@ public interface ModelControllerClient extends Closeable {
          * @return A model controller client
          */
         public static ModelControllerClient create(final InetAddress address, final int port, final CallbackHandler handler) {
-            return create(ModelControllerClientConfiguration.Factory.create(address, port, handler));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHandler(handler)
+                    .setHostName(address.getHostAddress())
+                    .setPort(port)
+                    .build());
         }
 
 
@@ -185,7 +197,12 @@ public interface ModelControllerClient extends Closeable {
          * @return A model controller client
          */
         public static ModelControllerClient create(final String protocol, final InetAddress address, final int port, final CallbackHandler handler) {
-            return create(ModelControllerClientConfiguration.Factory.create(protocol, address, port, handler));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHandler(handler)
+                    .setHostName(address.getHostAddress())
+                    .setPort(port)
+                    .setProtocol(protocol)
+                    .build());
         }
 
         /**
@@ -198,7 +215,11 @@ public interface ModelControllerClient extends Closeable {
          * @return A model controller client
          */
         public static ModelControllerClient create(final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) {
-            return create(ModelControllerClientConfiguration.Factory.create(address, port, handler, saslOptions));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHandler(handler)
+                    .setHostName(address.getHostAddress())
+                    .setPort(port)
+                    .build());
         }
 
         /**
@@ -212,7 +233,13 @@ public interface ModelControllerClient extends Closeable {
          * @return A model controller client
          */
         public static ModelControllerClient create(final String protocol, final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) {
-            return create(ModelControllerClientConfiguration.Factory.create(protocol, address, port, handler, saslOptions));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHandler(handler)
+                    .setHostName(address.getHostAddress())
+                    .setPort(port)
+                    .setProtocol(protocol)
+                    .setSaslOptions(saslOptions)
+                    .build());
         }
 
         /**
@@ -224,7 +251,10 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(hostName, port));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .build());
         }
 
         /**
@@ -237,7 +267,11 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String protocol, final String hostName, final int port) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(protocol, hostName, port));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setProtocol(protocol)
+                    .build());
         }
 
         /**
@@ -250,7 +284,11 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(hostName, port, handler));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .build());
         }
 
         /**
@@ -264,7 +302,12 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(protocol, hostName, port, handler));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setProtocol(protocol)
+                    .build());
         }
 
         /**
@@ -278,7 +321,12 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(hostName, port, handler, sslContext));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setSslContext(sslContext)
+                    .build());
         }
 
         /**
@@ -293,7 +341,13 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(protocol, hostName, port, handler, sslContext));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setProtocol(protocol)
+                    .setSslContext(sslContext)
+                    .build());
         }
 
         /**
@@ -303,11 +357,18 @@ public interface ModelControllerClient extends Closeable {
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
          * @param sslContext a pre-initialised SSLContext
+         * @param connectionTimeout
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(hostName, port, handler, sslContext, connectionTimeout));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setConnectionTimeout(connectionTimeout)
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setSslContext(sslContext)
+                    .build());
         }
 
         /**
@@ -322,7 +383,14 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(protocol, hostName, port, handler, sslContext, connectionTimeout));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setConnectionTimeout(connectionTimeout)
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setProtocol(protocol)
+                    .setSslContext(sslContext)
+                    .build());
         }
 
         /**
@@ -333,12 +401,47 @@ public interface ModelControllerClient extends Closeable {
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
          * @param sslContext a pre-initialised SSLContext
+         * @param connectionTimeout
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(protocol, hostName, port, handler, sslContext, connectionTimeout, saslOptions));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setConnectionTimeout(connectionTimeout)
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setProtocol(protocol)
+                    .setSaslOptions(saslOptions)
+                    .setSslContext(sslContext)
+                    .build());
+        }
+        /**
+         * Create a client instance for a remote address and port and CallbackHandler.
+         *
+         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param hostName   the remote host
+         * @param port       the port
+         * @param handler    CallbackHandler to obtain authentication information for the call.
+         * @param sslContext a pre-initialised SSLContext
+         * @param connectionTimeout
+         * @param saslOptions Additional options to be passed to the SASL mechanism.
+         * @param clientBindAddress the address to which the client will bind.
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions, final String clientBindAddress) throws UnknownHostException {
+            return create(new ClientConfigurationImpl.Builder()
+                    .setClientBindAddress(clientBindAddress)
+                    .setConnectionTimeout(connectionTimeout)
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setProtocol(protocol)
+                    .setSaslOptions(saslOptions)
+                    .setSslContext(sslContext)
+                    .build());
         }
 
         /**
@@ -352,7 +455,12 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(hostName, port, handler, saslOptions));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setSaslOptions(saslOptions)
+                    .build());
         }
 
         /**
@@ -367,7 +475,13 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
-            return create(ModelControllerClientConfiguration.Factory.create(protocol, hostName, port, handler, saslOptions));
+            return create(new ClientConfigurationImpl.Builder()
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setProtocol(protocol)
+                    .setSaslOptions(saslOptions)
+                    .build());
         }
 
         /**

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
@@ -37,6 +37,7 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
 
     private static final int DEFAULT_CONNECTION_TIMEOUT = 5000;
     private final String address;
+    private final String clientBindAddress;
     private final int port;
     private final CallbackHandler handler;
     private final Map<String, String> saslOptions;
@@ -46,7 +47,7 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
     private final boolean shutdownExecutor;
     private final int connectionTimeout;
 
-    public ClientConfigurationImpl(String address, int port, CallbackHandler handler, Map<String, String> saslOptions, SSLContext sslContext, ExecutorService executorService, boolean shutdownExecutor, final int connectionTimeout, final String protocol) {
+    public ClientConfigurationImpl(String address, int port, CallbackHandler handler, Map<String, String> saslOptions, SSLContext sslContext, ExecutorService executorService, boolean shutdownExecutor, final int connectionTimeout, final String protocol, String clientBindAddress) {
         this.address = address;
         this.port = port;
         this.handler = handler;
@@ -55,6 +56,7 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
         this.executorService = executorService;
         this.shutdownExecutor = shutdownExecutor;
         this.protocol = protocol;
+        this.clientBindAddress = clientBindAddress;
         this.connectionTimeout = connectionTimeout > 0 ? connectionTimeout : DEFAULT_CONNECTION_TIMEOUT;
     }
 
@@ -104,5 +106,10 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
         if(shutdownExecutor && executorService != null) {
             executorService.shutdown();
         }
+    }
+
+    @Override
+    public String getClientBindAddress() {
+        return clientBindAddress;
     }
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/ProtocolConfigurationFactory.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/ProtocolConfigurationFactory.java
@@ -49,6 +49,7 @@ class ProtocolConfigurationFactory {
         } else  {
             configuration.setUri(new URI(client.getProtocol() + "://" + formatPossibleIpv6Address(client.getHost()) +  ":" + client.getPort()));
         }
+        configuration.setClientBindAddress(client.getClientBindAddress());
         configuration.setOptionMap(DEFAULT_OPTIONS);
         final long timeout = client.getConnectionTimeout();
         if(timeout > 0) {

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
@@ -55,6 +55,9 @@ public class ProtocolConnectionConfiguration {
     protected ProtocolConnectionConfiguration() {
         // TODO AS7-6223 propagate clientBindAddress configuration up to end user level and get rid of this system property
         this.clientBindAddress = SecurityActions.getSystemProperty(JBOSS_CLIENT_SOCKET_BIND_ADDRESS);
+        if(this.clientBindAddress != null) {
+             ProtocolLogger.ROOT_LOGGER.deprecatedCLIConfiguration(JBOSS_CLIENT_SOCKET_BIND_ADDRESS);
+        }
     }
 
     protected void validate() {
@@ -137,7 +140,9 @@ public class ProtocolConnectionConfiguration {
     }
 
     public void setClientBindAddress(String clientBindAddress) {
-        this.clientBindAddress = clientBindAddress;
+        if(clientBindAddress != null || this.clientBindAddress == null) {
+            this.clientBindAddress = clientBindAddress;
+        }
     }
 
     public ProtocolTimeoutHandler getTimeoutHandler() {

--- a/protocol/src/main/java/org/jboss/as/protocol/logging/ProtocolLogger.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/logging/ProtocolLogger.java
@@ -345,4 +345,7 @@ public interface ProtocolLogger extends BasicLogger {
     @Message(id = 58, value = "%s cancelled task before execution began")
     void cancelledAsyncTaskBeforeRun(String asyncTaskRunner);
 
+    @LogMessage(level = INFO)
+    @Message(id = 59, value = "You are using a deprecated way to set the client bind address. Please use the \"--bind\" parameter on the CLI instead of the %s system property.")
+    void deprecatedCLIConfiguration(String systemPropName);
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/interfaces/CliManagementInterface.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/interfaces/CliManagementInterface.java
@@ -94,7 +94,7 @@ public class CliManagementInterface implements ManagementInterface {
 
     public static ManagementInterface create(String host, int port, String username, String password) {
         CLI client = CLI.newInstance();
-        client.connect(host, port, username, password.toCharArray());
+        client.connect(host, port, username, password.toCharArray(), null);
         return new CliManagementInterface(client);
     }
 }


### PR DESCRIPTION
Now you can specify the bind address for the ModelControllerClient.
You may set it using  client socket binding config through CLI connect with the --bind= param.

Jira: https://issues.jboss.org/browse/WFCORE-371 and https://issues.jboss.org/browse/WFCORE-419