### PR TITLE
[WFCORE-443] When an overridable directory is defined in the system prop...

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerBootCmdFactory.java
@@ -410,7 +410,7 @@ public class ManagedServerBootCmdFactory implements ManagedServerBootConfigurati
                     break;
                 case BY_SERVER:
                 default:
-                    result = dir.getAbsolutePath();
+                    result = getAbsolutePath(dir, serverName);
                     break;
             }
         }


### PR DESCRIPTION
...erties and the directory grouping is set to by-server (the default) ensure the server name is appended to the directory.
