### PR TITLE
[WFCORE-123] Allow clear to be defined as a color-map attribute.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/PatternFormatterResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PatternFormatterResourceDefinition.java
@@ -51,7 +51,7 @@ import org.jboss.logmanager.formatters.PatternFormatter;
  */
 public class PatternFormatterResourceDefinition extends TransformerResourceDefinition {
 
-    static final String COLOR_MAP_VALIDATION_PATTERN = "^((severe|fatal|error|warn|warning|info|debug|trace|config|fine|finer|finest|):(black|green|red|yellow|blue|magenta|cyan|white|brightblack|brightred|brightgreen|brightblue|brightyellow|brightmagenta|brightcyan|brightwhite|)(,(?!$)|$))*$";
+    static final String COLOR_MAP_VALIDATION_PATTERN = "^((severe|fatal|error|warn|warning|info|debug|trace|config|fine|finer|finest|):(clear|black|green|red|yellow|blue|magenta|cyan|white|brightblack|brightred|brightgreen|brightblue|brightyellow|brightmagenta|brightcyan|brightwhite|)(,(?!$)|$))*$";
 
     // Pattern formatter options
     public static final PropertyAttributeDefinition COLOR_MAP = PropertyAttributeDefinition.Builder.of("color-map", ModelType.STRING)


### PR DESCRIPTION
The color attribute `clear` should be allowed in the `color-map` pattern.
