### PR TITLE
[WFCORE-293] : Add EAP 6.2 and 6.3 to versions tested in core-model-test...

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -77,6 +77,9 @@ public class TransformersTestParameter extends ClassloaderParameter {
             }
             data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_0));
             data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_1));
+            data.add(new TransformersTestParameter(ModelVersion.create(1, 5, 0), ModelTestControllerVersion.EAP_6_2_0));
+            data.add(new TransformersTestParameter(ModelVersion.create(1, 6, 0), ModelTestControllerVersion.EAP_6_3_0));
+
         }
 
 


### PR DESCRIPTION
Fixing constructor issue between upstream and EAP 6.2

Jira: https://issues.jboss.org/browse/WFCORE-293
