### PR TITLE
[WFCORE-293] : Add EAP 6.2 and 6.3 to versions tested in core-model-test.

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -77,6 +77,9 @@ public class TransformersTestParameter extends ClassloaderParameter {
             }
             data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_0));
             data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_1));
+            data.add(new TransformersTestParameter(ModelVersion.create(1, 5, 0), ModelTestControllerVersion.EAP_6_2_0));
+            data.add(new TransformersTestParameter(ModelVersion.create(1, 6, 0), ModelTestControllerVersion.EAP_6_3_0));
+
         }
 
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -103,7 +103,7 @@ public class DomainTransformers {
 
     private static void registerChainedManagementTransformers(TransformerRegistry registry, ModelVersion currentVersion) {
         ChainedTransformationDescriptionBuilder builder = ManagementTransformers.buildTransformerChain(currentVersion);
-        registerChainedTransformer(registry, builder, VERSION_1_2, VERSION_1_3, VERSION_1_4);
+        registerChainedTransformer(registry, builder, VERSION_1_2, VERSION_1_3, VERSION_1_4, VERSION_1_5, VERSION_1_6);
     }
 
     private static void registerChainedPathsTransformers(TransformerRegistry registry, ModelVersion currentVersion) {
@@ -118,7 +118,7 @@ public class DomainTransformers {
 
     private static void registerChainedServerGroupTransformers(TransformerRegistry registry, ModelVersion currentVersion) {
         ChainedTransformationDescriptionBuilder builder = ServerGroupTransformers.buildTransformerChain(currentVersion);
-        registerChainedTransformer(registry, builder, VERSION_1_2, VERSION_1_3, VERSION_1_4);
+        registerChainedTransformer(registry, builder, VERSION_1_2, VERSION_1_3, VERSION_1_4, VERSION_1_5, VERSION_1_6);
 
         registerChainedTransformer(registry, builder, VERSION_2_0, VERSION_2_1);
     }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ManagementTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ManagementTransformers.java
@@ -58,7 +58,7 @@ class ManagementTransformers {
         // Discard the domain level core-service=management resource and its children unless RBAC is enabled
         // Configuring rbac details is OK (i.e. discarable), so long as the provider is not enabled
         ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedInstance(CoreManagementResourceDefinition.PATH_ELEMENT, currentVersion);
-        ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(currentVersion, DomainTransformers.VERSION_1_4);
+        ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(currentVersion, DomainTransformers.VERSION_1_6);
         builder.setCustomResourceTransformer(new ResourceTransformer() {
             @Override
             public void transformResource(ResourceTransformationContext context, PathAddress address, Resource resource) throws OperationFailedException {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ServerGroupTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ServerGroupTransformers.java
@@ -46,7 +46,7 @@ class ServerGroupTransformers {
 
         //////////////////////////////////
         //The EAP/AS 7.x chains
-        ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(currentVersion, DomainTransformers.VERSION_1_4);
+        ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(currentVersion, DomainTransformers.VERSION_1_6);
         JvmTransformers.registerTransformers2_1_AndBelow(builder);
 
         builder = chainedBuilder.createBuilder(DomainTransformers.VERSION_1_4, DomainTransformers.VERSION_1_3)

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -41,8 +41,8 @@ public enum ModelTestControllerVersion {
     EAP_6_1_0 ("7.2.0.Final-redhat-8", true, "7.2.0"),
     EAP_6_1_1 ("7.2.1.Final-redhat-10", true, "7.2.0"),
     //TODO might eventually need EAP 6.2.0+ controllers since 7.2.0 does not have the RBAC classes, which could be used by subsystems
-    EAP_6_2_0 ("7.3.0.Final-redhat-14", true, "7.2.0"),
-    EAP_6_3_0 ("7.4.0.Final-redhat-19", true, "7.2.0"),
+    EAP_6_2_0 ("7.3.0.Final-redhat-14", true, "7.3.0"),
+    EAP_6_3_0 ("7.4.0.Final-redhat-19", true, "7.4.0"),
     ;
 
     private final String mavenGavVersion;

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -123,6 +123,59 @@ public abstract class ModelTestModelControllerService extends AbstractController
         this.runningModeControl = runningModeControl;
     }
 
+    /**
+     * This is the constructor to use for core-model/test-controller-7.3.x
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+            final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+            final DelegatingResourceDefinition rootResourceDefinition, ControlledProcessState processState, Controller73x version) {
+        super(processType, runningModeControl, persister,
+                processState == null ? new ControlledProcessState(true) : processState, rootResourceDefinition, null, ExpressionResolver.TEST_RESOLVER);
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+    /**
+     * This is the constructor to use for subsystem-test/test-controller-7.3.x
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+            final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+            final DescriptionProvider rootDescriptionProvider, ControlledProcessState processState, Controller73x version) {
+        super(processType, runningModeControl, persister,
+                processState == null ? new ControlledProcessState(true) : processState, rootDescriptionProvider, null, ExpressionResolver.TEST_RESOLVER);
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
+/**
+     * This is the constructor to use for core-model/test-controller-7.4.x
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+            final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+            final DelegatingResourceDefinition rootResourceDefinition, ControlledProcessState processState, Controller74x version) {
+        super(processType, runningModeControl, persister,
+                processState == null ? new ControlledProcessState(true) : processState, rootResourceDefinition, null, ExpressionResolver.TEST_RESOLVER);
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+    /**
+     * This is the constructor to use for subsystem-test/test-controller-7.4.x
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+            final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+            final DescriptionProvider rootDescriptionProvider, ControlledProcessState processState, Controller74x version) {
+        super(processType, runningModeControl, persister,
+                processState == null ? new ControlledProcessState(true) : processState, rootDescriptionProvider, null, ExpressionResolver.TEST_RESOLVER);
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
 
     /**
      * This is the constructor to use for 8.0.x core model tests
@@ -407,6 +460,18 @@ public abstract class ModelTestModelControllerService extends AbstractController
     public static class Controller72x {
         public static Controller72x INSTANCE = new Controller72x();
         private Controller72x() {
+        }
+    }
+
+    public static class Controller73x {
+        public static Controller73x INSTANCE = new Controller73x();
+        private Controller73x() {
+        }
+    }
+
+    public static class Controller74x {
+        public static Controller74x INSTANCE = new Controller74x();
+        private Controller74x() {
         }
     }
 

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestUtils.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestUtils.java
@@ -518,7 +518,8 @@ public class ModelTestUtils {
     private static void checkFailedTransformedAddOperation(ModelTestKernelServices<?> mainServices, ModelVersion modelVersion, ModelNode operation, FailedOperationTransformationConfig config) throws OperationFailedException {
         TransformedOperation transformedOperation = mainServices.transformOperation(modelVersion, operation.clone());
         if (config.expectFailed(operation)) {
-            Assert.assertNotNull("Expected transformation to get rejected " + operation, transformedOperation.getFailureDescription());
+            System.out.println("For version " + modelVersion + " we have the following error : " + transformedOperation.getFailureDescription());
+            Assert.assertNotNull("Expected transformation to get rejected " + operation + " for version " + modelVersion , transformedOperation.getFailureDescription());
             if (config.canCorrectMore(operation)) {
                 checkFailedTransformedAddOperation(mainServices, modelVersion, config.correctOperation(operation), config);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.eclipse.aether>1.0.0.v20140518</version.org.eclipse.aether>
         <version.org.wildfly.build-tools>1.0.0.Alpha3</version.org.wildfly.build-tools>
-        <version.org.wildfly.legacy.test>1.0.0.Alpha2</version.org.wildfly.legacy.test>
+        <version.org.wildfly.legacy.test>1.0.0.Alpha4-SNAPSHOT</version.org.wildfly.legacy.test>
         <version.org.wildfly.security.manager>1.1.2.Final</version.org.wildfly.security.manager>
         <version.org.wildfly.checkstyle-config>1.0.0.Final</version.org.wildfly.checkstyle-config>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->


### PR DESCRIPTION
Updating wildfly-legacy-test version.
Updating transformers for new versions.

Jira: https://issues.jboss.org/browse/WFCORE-293
PR needed before https://github.com/wildfly/wildfly-legacy-test/pull/2
