### PR TITLE
[WFCORE-325] : Allow socket-binding-group-refType to override default-interface.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -401,10 +401,11 @@ public class ModelDescriptionConstants {
     public static final String SHUTDOWN = "shutdown";
     public static final String SKIP_MISSING_GROUPS = "skip-missing-groups";
     public static final String SOCKET_BINDING = "socket-binding";
-    public static final String SOCKET_BINDING_REF = "socket-binding-ref";
+    public static final String SOCKET_BINDING_DEFAULT_INTERFACE = "socket-binding-default-interface";
     public static final String SOCKET_BINDING_GROUP = "socket-binding-group";
     public static final String SOCKET_BINDING_GROUP_NAME = "socket-binding-group-name";
     public static final String SOCKET_BINDING_PORT_OFFSET = "socket-binding-port-offset";
+    public static final String SOCKET_BINDING_REF = "socket-binding-ref";
     public static final String SOURCE_INTERFACE = "source-interface";
     public static final String SOURCE_PORT = "source-port";
     public static final String SSL = "ssl";

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/host/HostModelTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/host/HostModelTestCase.java
@@ -36,6 +36,11 @@ public class HostModelTestCase extends AbstractCoreModelTest {
     }
 
     @Test
+    public void testSocketBindingDefaultInterface() throws Exception {
+        doHostXml("host-with-default-interface.xml");
+    }
+
+    @Test
     public void testWFLY75() throws Exception {
         doRemoteHostXml("host-remote-domain-manager.xml");
     }

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-default-interface.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-with-default-interface.xml
@@ -1,0 +1,90 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<host name="master" xmlns="urn:jboss:domain:3.0">
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true" />
+                    <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir"/>
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true" />
+                    <properties path="application-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+                <authorization>
+                    <properties path="application-roles.properties" relative-to="jboss.domain.config.dir"/>
+                </authorization>
+            </security-realm>
+        </security-realms>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="${jboss.management.native.port:9999}"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm">
+                <socket interface="management" port="${jboss.management.http.port:9990}"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+       <local/>
+       <!-- Alternative remote domain controller configuration with a host and port -->
+       <!-- <remote host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.bind.address.management:127.0.0.1}"/>
+        </interface>
+        <interface name="public">
+           <inet-address value="${jboss.bind.address:127.0.0.1}"/>
+        </interface>
+        <interface name="unsecure">
+            <!-- Used for IIOP sockets in the standard configuration.
+                 To secure JacORB you need to setup SSL -->
+            <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
+        </interface>
+    </interfaces>
+
+ 	<jvms>
+ 	   <jvm name="default">
+          <heap size="64m" max-size="256m"/>
+          <permgen size="256m" max-size="256m"/>
+            <jvm-options>
+                <option value="-server"/>
+            </jvm-options>
+       </jvm>
+ 	</jvms>
+
+    <servers>
+        <server name="server-one" group="main-server-group">
+            <!-- Remote JPDA debugging for a specific server
+            <jvm name="default">
+              <jvm-options>
+                <option value="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"/>
+              </jvm-options>
+           </jvm>
+           -->
+        </server>
+        <server name="server-two" group="main-server-group" auto-start="true">
+            <!-- server-two avoids port conflicts by incrementing the ports in
+                 the default socket-group declared in the server-group -->
+            <socket-bindings port-offset="150"/>
+        </server>
+        <server name="server-three" group="other-server-group" auto-start="false">
+            <!-- server-three avoids port conflicts by incrementing the ports in
+                 the default socket-group declared in the server-group -->
+            <socket-bindings port-offset="250"/>
+        </server>
+        <server name="server-four" group="other-server-group" auto-start="false">
+            <jvm name="default">
+                <heap size="64m" max-size="512m"/>
+            </jvm>
+            <socket-bindings socket-binding-group="full-ha-sockets" default-interface="public-two"/>
+        </server>
+    </servers>
+</host>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
@@ -33,7 +33,7 @@
                  </environment-variables>
             </jvm>
 
-            <socket-binding-group ref="test-sockets" port-offset="10"/>
+            <socket-binding-group ref="test-sockets" port-offset="10" default-interface="public-two"/>
 
             <deployments>
                 <deployment name="test-deployment" runtime-name="bar.war" enabled="false"/>

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
@@ -73,6 +73,12 @@ public class ServerGroupResourceDefinition extends SimpleResourceDefinition {
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
             .build();
 
+    public static final SimpleAttributeDefinition SOCKET_BINDING_DEFAULT_INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE, ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setXmlName(Attribute.DEFAULT_INTERFACE.getLocalName())
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
+            .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_CONFIG).build();
+
     public static final SimpleAttributeDefinition SOCKET_BINDING_PORT_OFFSET = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET, ModelType.INT, true)
             .setDefaultValue(new ModelNode(0))
             .setXmlName(Attribute.PORT_OFFSET.getLocalName())
@@ -87,7 +93,7 @@ public class ServerGroupResourceDefinition extends SimpleResourceDefinition {
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES)
             .build();
 
-    public static final AttributeDefinition[] ADD_ATTRIBUTES = new AttributeDefinition[] {PROFILE, SOCKET_BINDING_GROUP, SOCKET_BINDING_PORT_OFFSET, MANAGEMENT_SUBSYSTEM_ENDPOINT};
+    public static final AttributeDefinition[] ADD_ATTRIBUTES = new AttributeDefinition[] {PROFILE, SOCKET_BINDING_GROUP, SOCKET_BINDING_DEFAULT_INTERFACE, SOCKET_BINDING_PORT_OFFSET, MANAGEMENT_SUBSYSTEM_ENDPOINT};
 
     private final boolean master;
     private final HostFileRepository fileRepository;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerOperationsFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerOperationsFactory.java
@@ -81,6 +81,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_IDENTITY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_LOGGER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSLOG_HANDLER;
@@ -195,6 +196,7 @@ public final class ManagedServerOperationsFactory {
 
         int portOffSet = 0;
         String socketBindingRef = null;
+        String defaultInterface = null;
 
         if (serverGroup.hasDefined(SOCKET_BINDING_GROUP)) {
             socketBindingRef = serverGroup.get(SOCKET_BINDING_GROUP).asString();
@@ -207,6 +209,12 @@ public final class ManagedServerOperationsFactory {
         }
         if (serverModel.hasDefined(SOCKET_BINDING_PORT_OFFSET)) {
             portOffSet = serverModel.get(SOCKET_BINDING_PORT_OFFSET).asInt();
+        }
+        if (serverGroup.hasDefined(SOCKET_BINDING_DEFAULT_INTERFACE)) {
+            defaultInterface = serverGroup.get(SOCKET_BINDING_DEFAULT_INTERFACE).asString();
+        }
+        if (serverModel.hasDefined(SOCKET_BINDING_DEFAULT_INTERFACE)) {
+            defaultInterface = serverModel.get(SOCKET_BINDING_DEFAULT_INTERFACE).asString();
         }
         if (socketBindingRef == null) {
             throw HostControllerLogger.ROOT_LOGGER.undefinedSocketBinding(serverName);
@@ -227,7 +235,7 @@ public final class ManagedServerOperationsFactory {
         addManagementConnections(updates);
         addManagementAuthorization(updates);
         addInterfaces(updates);
-        addSocketBindings(updates, portOffSet, socketBindingRef);
+        addSocketBindings(updates, portOffSet, socketBindingRef, defaultInterface);
         addSubsystems(updates);
         addDeployments(updates);
         addDeploymentOverlays(updates);
@@ -589,7 +597,7 @@ public final class ManagedServerOperationsFactory {
         }
     }
 
-    private void addSocketBindings(List<ModelNode> updates, int portOffSet, String bindingRef) {
+    private void addSocketBindings(List<ModelNode> updates, int portOffSet, String bindingRef, String defaultInterface) {
         final Set<String> processed = new HashSet<String>();
         final Map<String, ModelNode> groups = new LinkedHashMap<String, ModelNode>();
         if (domainModel.hasDefined(SOCKET_BINDING_GROUP)) {
@@ -608,6 +616,9 @@ public final class ManagedServerOperationsFactory {
         final PathAddress groupAddress = PathAddress.pathAddress(PathElement.pathElement(SOCKET_BINDING_GROUP, bindingRef));
         final ModelNode groupAdd = BindingGroupAddHandler.getOperation(groupAddress, group);
         groupAdd.get(PORT_OFFSET).set(portOffSet);
+        if(defaultInterface != null) {
+            groupAdd.get(DEFAULT_INTERFACE).set(defaultInterface);
+        }
         updates.add(groupAdd);
         mergeBindingGroups(updates, groups, bindingRef, group, processed);
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerAddHandler.java
@@ -25,6 +25,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -91,6 +92,7 @@ public class ServerAddHandler extends AbstractAddStepHandler {
 
         final String group = model.require(GROUP).asString();
         final String socketBindingGroup = model.hasDefined(SOCKET_BINDING_GROUP) ? model.get(SOCKET_BINDING_GROUP).asString() : null;
+        final String defaultInterface = model.hasDefined(SOCKET_BINDING_DEFAULT_INTERFACE) ? model.get(SOCKET_BINDING_DEFAULT_INTERFACE).asString() : null;
         final Resource root = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, false);
 
         //Check for missing data and pull it down if necessary
@@ -115,6 +117,9 @@ public class ServerAddHandler extends AbstractAddStepHandler {
         if (missingData) {
             String serverName = PathAddress.pathAddress(operation.require(OP_ADDR)).getLastElement().getValue();
             pullDownMissingDataFromDc(context, serverName, group, socketBindingGroup);
+        }
+        if(defaultInterface != null) {
+            System.out.println("We a an overiden default interface");
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRestartRequiredServerConfigWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRestartRequiredServerConfigWriteAttributeHandler.java
@@ -51,6 +51,7 @@ import org.jboss.dmr.ModelNode;
 public abstract class ServerRestartRequiredServerConfigWriteAttributeHandler extends ModelOnlyWriteAttributeHandler {
 
     public static final ServerRestartRequiredServerConfigWriteAttributeHandler SOCKET_BINDING_PORT_OFFSET_INSTANCE = new SocketBindingPortOffsetHandler();
+    public static final ServerRestartRequiredServerConfigWriteAttributeHandler SOCKET_BINDING_DEFAULT_INTERFACE_INSTANCE = new SocketBindingDefaultInterfaceHandler();
 
     private final AttributeDefinition attributeDefinition;
 
@@ -144,6 +145,17 @@ public abstract class ServerRestartRequiredServerConfigWriteAttributeHandler ext
         }
     }
 
+    private static class SocketBindingDefaultInterfaceHandler extends ServerRestartRequiredServerConfigWriteAttributeHandler {
+
+        public SocketBindingDefaultInterfaceHandler() {
+            super(ServerConfigResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE);
+        }
+
+        @Override
+        protected void validateReferencedNewValueExists(OperationContext context, ModelNode operation, ModelNode currentValue, ModelNode resolvedValue) throws OperationFailedException {
+            // our attribute is not a model reference
+        }
+    }
 
     private static class SocketBindingPortOffsetHandler extends ServerRestartRequiredServerConfigWriteAttributeHandler {
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
@@ -805,8 +805,14 @@ public class DomainXml extends CommonXml {
                         break;
                     }
                     case SOCKET_BINDING_GROUP: {
-                        parseSocketBindingGroupRef(reader, groupAddOp, ServerGroupResourceDefinition.SOCKET_BINDING_GROUP,
-                                ServerGroupResourceDefinition.SOCKET_BINDING_PORT_OFFSET);
+                        if(expectedNs.compareTo(Namespace.DOMAIN_3_0) >= 0) {
+                            parseSocketBindingGroupRef(reader, groupAddOp, ServerGroupResourceDefinition.SOCKET_BINDING_GROUP,
+                                ServerGroupResourceDefinition.SOCKET_BINDING_PORT_OFFSET,
+                                ServerGroupResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE);
+                        } else {
+                             parseSocketBindingGroupRef(reader, groupAddOp, ServerGroupResourceDefinition.SOCKET_BINDING_GROUP,
+                                ServerGroupResourceDefinition.SOCKET_BINDING_PORT_OFFSET, null);
+                        }
                         break;
                     }
                     case DEPLOYMENTS: {
@@ -1078,6 +1084,7 @@ public class DomainXml extends CommonXml {
             writer.writeStartElement(Element.SOCKET_BINDING_GROUP.getLocalName());
             ServerGroupResourceDefinition.SOCKET_BINDING_GROUP.marshallAsAttribute(group, writer);
             ServerGroupResourceDefinition.SOCKET_BINDING_PORT_OFFSET.marshallAsAttribute(group, writer);
+            ServerGroupResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE.marshallAsAttribute(group, writer);
             writer.writeEndElement();
         }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -49,6 +49,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRO
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SECURITY_REALM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STATIC_DISCOVERY;
@@ -1894,7 +1895,8 @@ public class HostXml extends CommonXml {
                         throw ControllerLogger.ROOT_LOGGER.alreadyDefined(element.getLocalName(), reader.getLocation());
                     }
                     parseSocketBindingGroupRef(reader, serverAddOperation, ServerConfigResourceDefinition.SOCKET_BINDING_GROUP,
-                            ServerConfigResourceDefinition.SOCKET_BINDING_PORT_OFFSET);
+                            ServerConfigResourceDefinition.SOCKET_BINDING_PORT_OFFSET,
+                            ServerConfigResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE);
                     sawSocketBinding = true;
                     break;
                 }
@@ -2022,6 +2024,10 @@ public class HostXml extends CommonXml {
                 switch (attribute) {
                     case SOCKET_BINDING_GROUP: {
                         ServerConfigResourceDefinition.SOCKET_BINDING_GROUP.parseAndSetParameter(value, serverAddOperation, reader);
+                        break;
+                    }
+                    case DEFAULT_INTERFACE: {
+                        ServerConfigResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE.parseAndSetParameter(value, serverAddOperation, reader);
                         break;
                     }
                     case PORT_OFFSET: {
@@ -2171,10 +2177,11 @@ public class HostXml extends CommonXml {
                     break; // TODO just write the first !?
                 }
             }
-            if (server.hasDefined(SOCKET_BINDING_GROUP) || server.hasDefined(SOCKET_BINDING_PORT_OFFSET)) {
+            if (server.hasDefined(SOCKET_BINDING_GROUP) || server.hasDefined(SOCKET_BINDING_PORT_OFFSET) || server.hasDefined(SOCKET_BINDING_DEFAULT_INTERFACE)) {
                 writer.writeStartElement(Element.SOCKET_BINDINGS.getLocalName());
                 ServerConfigResourceDefinition.SOCKET_BINDING_GROUP.marshallAsAttribute(server, writer);
                 ServerConfigResourceDefinition.SOCKET_BINDING_PORT_OFFSET.marshallAsAttribute(server, writer);
+                ServerConfigResourceDefinition.SOCKET_BINDING_DEFAULT_INTERFACE.marshallAsAttribute(server, writer);
                 writer.writeEndElement();
             }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
@@ -40,6 +40,7 @@ import org.jboss.as.controller.client.helpers.domain.ServerStatus;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.parsing.Attribute;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.resource.InterfaceDefinition;
@@ -83,6 +84,12 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition SOCKET_BINDING_GROUP = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SOCKET_BINDING_GROUP, ModelType.STRING, true)
             .build();
 
+    public static final SimpleAttributeDefinition SOCKET_BINDING_DEFAULT_INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE, ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setXmlName(Attribute.DEFAULT_INTERFACE.getLocalName())
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
+            .build();
+
     public static final SimpleAttributeDefinition SOCKET_BINDING_PORT_OFFSET = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET, ModelType.INT, true)
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(0))
@@ -115,7 +122,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     /** The attributes that can be written by the {@code add} operation */
-    public static final List<SimpleAttributeDefinition> WRITABLE_ATTRIBUTES = Arrays.asList(AUTO_START, SOCKET_BINDING_GROUP, SOCKET_BINDING_PORT_OFFSET, GROUP);
+    public static final List<SimpleAttributeDefinition> WRITABLE_ATTRIBUTES = Arrays.asList(AUTO_START, SOCKET_BINDING_GROUP, SOCKET_BINDING_DEFAULT_INTERFACE, SOCKET_BINDING_PORT_OFFSET, GROUP);
 
     private final ServerInventory serverInventory;
     private final PathManagerService pathManager;
@@ -145,6 +152,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
 
         resourceRegistration.registerReadWriteAttribute(AUTO_START, null, new ModelOnlyWriteAttributeHandler(AUTO_START));
         resourceRegistration.registerReadWriteAttribute(SOCKET_BINDING_GROUP, null, ServerRestartRequiredServerConfigWriteAttributeHandler.createSocketBindingGroupInstance(hostControllerInfo));
+        resourceRegistration.registerReadWriteAttribute(SOCKET_BINDING_DEFAULT_INTERFACE, null, ServerRestartRequiredServerConfigWriteAttributeHandler.SOCKET_BINDING_DEFAULT_INTERFACE_INSTANCE);
         resourceRegistration.registerReadWriteAttribute(SOCKET_BINDING_PORT_OFFSET, null, ServerRestartRequiredServerConfigWriteAttributeHandler.SOCKET_BINDING_PORT_OFFSET_INSTANCE);
         resourceRegistration.registerReadWriteAttribute(GROUP, null, ServerRestartRequiredServerConfigWriteAttributeHandler.createGroupInstance(hostControllerInfo));
 

--- a/host-controller/src/main/resources/org/jboss/as/domain/controller/resources/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/domain/controller/resources/LocalDescriptions.properties
@@ -68,6 +68,7 @@ server-group.remove=Remove an existing new server group.
 server-group.profile=The profile name.
 server-group.jvm=The named jvm.
 server-group.socket-binding-group=The default socket binding group used for servers associated with this group.
+server-group.socket-binding-default-interface=The socket binding group default interface for this server.
 server-group.socket-binding-port-offset=The default offset to be added to the port values given by the socket binding group.
 server-group.management-subsystem-endpoint=Set to true to have servers belonging to the server group connect back to the host controller using the endpoint from their remoting subsystem. The subsystem must be present for this to work.
 server-group.deployment=A list of deployments available for use in the server group.

--- a/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
@@ -130,6 +130,7 @@ server-config.priority.deprecated=Unused.
 server-config.cpu-affinity=Deprecated. Unused.
 server-config.cpu-affinity.deprecated=Unused.
 server-config.socket-binding-group=The socket binding group to which this server belongs.
+server-config.socket-binding-default-interface=The socket binding group default interface for this server.
 server-config.socket-binding-port-offset=An offset to be added to the port values given by the socket binding group for this server.
 server-config.auto-start=Whether or not this server should be started when the Host Controller starts.
 server-config.status=The current status of the server.

--- a/server/src/main/java/org/jboss/as/server/parsing/CommonXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/CommonXml.java
@@ -638,7 +638,8 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
 
     protected void parseSocketBindingGroupRef(final XMLExtendedStreamReader reader, final ModelNode addOperation,
                                               final SimpleAttributeDefinition socketBindingGroup,
-                                              final SimpleAttributeDefinition portOffset) throws XMLStreamException {
+                                              final SimpleAttributeDefinition portOffset,
+                                              final SimpleAttributeDefinition defaultInterface) throws XMLStreamException {
         // Handle attributes
         boolean gotRef = false;
         final int count = reader.getAttributeCount();
@@ -656,6 +657,13 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
                     }
                     case PORT_OFFSET: {
                         portOffset.parseAndSetParameter(value, addOperation, reader);
+                        break;
+                    }
+                    case DEFAULT_INTERFACE: {
+                        if(defaultInterface == null) {
+                            throw unexpectedAttribute(reader, i);
+                        }
+                        defaultInterface.parseAndSetParameter(value, addOperation, reader);
                         break;
                     }
                     default:

--- a/server/src/main/resources/schema/wildfly-config_3_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_3_0.xsd
@@ -2464,6 +2464,17 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="default-interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one, overiding the one defined
+                    in the socket-binding-group referenced.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="extensionsType">
@@ -3016,6 +3027,17 @@
                     Increment to apply to the base port values defined in the
                     referenced socket group to derive the values to use on this
                     server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="default-interface" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Name of an interface that should be used as the interface for
+                    any sockets that do not explicitly declare one, overiding the one defined
+                    in the socket-binding-group referenced.
+                ]]>
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultInterfaceOveridingDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultInterfaceOveridingDomainTestCase.java
@@ -1,0 +1,157 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.domain;
+
+
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT_INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.util.Set;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.domain.management.util.DomainControllerClientConfig;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.WildFlyManagedConfiguration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.logging.Logger;
+import org.jboss.sasl.util.UsernamePasswordHashUtil;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test of migration of the domain controller from one host to another
+ *
+ * @author <a href="dpospisi@redhat.com">Dominik Pospisil</a>
+ */
+public class DefaultInterfaceOveridingDomainTestCase {
+
+    private static final Logger log = Logger.getLogger(DefaultInterfaceOveridingDomainTestCase.class.getName());
+
+    private static String[] SERVERS = new String[] {"main-one", "other-two"};
+    private static String masterAddress = System.getProperty("jboss.test.host.master.address");
+    private static String slaveAddress = System.getProperty("jboss.test.host.slave.address");
+
+    private static DomainControllerClientConfig domainControllerClientConfig;
+    private static DomainLifecycleUtil hostUtils;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        domainControllerClientConfig = DomainControllerClientConfig.create();
+        hostUtils = new DomainLifecycleUtil(getHostConfiguration(), domainControllerClientConfig);
+        hostUtils.start();
+    }
+
+    @AfterClass
+    public static void shutdownDomain() throws IOException {
+        try {
+            hostUtils.stop();
+        } catch (Exception e) {
+            log.error("Failed closing host util", e);
+        } finally {
+            if (domainControllerClientConfig != null) {
+                domainControllerClientConfig.close();
+            }
+        }
+    }
+
+    private static WildFlyManagedConfiguration getHostConfiguration() throws Exception {
+
+        final String testName = DefaultInterfaceOveridingDomainTestCase.class.getSimpleName();
+        File domains = new File("target" + File.separator + "domains" + File.separator + testName);
+        final File hostDir = new File(domains, "default-interface");
+        final File hostConfigDir = new File(hostDir, "configuration");
+        assert hostConfigDir.mkdirs() || hostConfigDir.isDirectory();
+
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        final WildFlyManagedConfiguration hostConfig = new WildFlyManagedConfiguration();
+        hostConfig.setHostControllerManagementAddress(masterAddress);
+        hostConfig.setHostCommandLineProperties("-Djboss.test.host.master.address=" + masterAddress + " -Djboss.test.host.slave.address=" + slaveAddress);
+        URL url = tccl.getResource("domain-configs/domain-default-interface.xml");
+        assert url != null;
+        hostConfig.setDomainConfigFile(new File(url.toURI()).getAbsolutePath());
+        System.out.println(hostConfig.getDomainConfigFile());
+        url = tccl.getResource("host-configs/host-default-interface.xml");
+        assert url != null;
+        hostConfig.setHostConfigFile(new File(url.toURI()).getAbsolutePath());
+        System.out.println(hostConfig.getHostConfigFile());
+        hostConfig.setDomainDirectory(hostDir.getAbsolutePath());
+        hostConfig.setHostName("slave");
+        hostConfig.setHostControllerManagementPort(9999);
+        hostConfig.setStartupTimeoutInSeconds(120);
+        hostConfig.setBackupDC(true);
+        File usersFile = new File(hostConfigDir, "mgmt-users.properties");
+        FileOutputStream fos = new FileOutputStream(usersFile);
+        PrintWriter pw = new PrintWriter(fos);
+        pw.println("slave=" + new UsernamePasswordHashUtil().generateHashedHexURP("slave", "ManagementRealm", "slave_user_password".toCharArray()));
+        pw.close();
+        fos.close();
+
+
+        return hostConfig;
+    }
+
+    @Test
+    /**
+     * Test setup: 2 servers in 2 server-groups using the same socket-binding-group.
+     * One is overriding the default-interface of the socket-binding-group.
+     */
+    public void testInterfaceOverriden() throws Exception {
+        // check that the failover-h1 is acting as domain controller and all three servers are registered
+        Set<String> hosts = getHosts(hostUtils);
+        Assert.assertTrue(hosts.contains("slave"));
+        Assert.assertThat(getServerDefaultInterface(hostUtils, "main-one"), is("public"));
+        Assert.assertThat(getServerDefaultInterface(hostUtils, "other-two"), is("public-two"));
+    }
+
+    private String getServerDefaultInterface(DomainLifecycleUtil hostUtil, String serverName) throws IOException {
+        ModelNode opAdress = PathAddress.pathAddress(PathElement.pathElement(HOST, "slave"), PathElement.pathElement(SERVER, serverName)).toModelNode();
+        ModelNode readOp = Operations.createReadResourceOperation(opAdress, true);
+        ModelNode domain = hostUtil.executeForResult(readOp);
+        Assert.assertThat(domain.get(SOCKET_BINDING_GROUP).isDefined(), is(true));
+        Property socketBindingGroup = domain.get(SOCKET_BINDING_GROUP).asProperty();
+        Assert.assertThat(socketBindingGroup.getName(), is("standard-sockets"));
+        Assert.assertThat(socketBindingGroup.getValue().hasDefined(DEFAULT_INTERFACE), is(true));
+        return socketBindingGroup.getValue().get(DEFAULT_INTERFACE).asString();
+    }
+
+    private Set<String> getHosts(DomainLifecycleUtil hostUtil) throws IOException {
+        ModelNode readOp = new ModelNode();
+        readOp.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.READ_RESOURCE_OPERATION);
+        ModelNode domain = hostUtil.executeForResult(readOp);
+        Assert.assertTrue(domain.get(HOST).isDefined());
+        return domain.get(HOST).keys();
+    }
+}

--- a/testsuite/domain/src/test/resources/domain-configs/domain-default-interface.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-default-interface.xml
@@ -1,0 +1,109 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<domain xmlns="urn:jboss:domain:3.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <extensions>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.threads"/>
+    </extensions>
+
+    <system-properties>
+    </system-properties>
+
+    <paths>
+        <path name="domainTestPath" />
+    </paths>
+
+    <profiles>
+
+        <profile name="default">
+
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                </console-handler>
+
+                <periodic-rotating-file-handler name="FILE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                </periodic-rotating-file-handler>
+
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+            </subsystem>
+        </profile>
+
+    </profiles>
+
+    <!--
+         Named interfaces that can be referenced elsewhere. Different
+         mechanisms for associating an IP address with the interface
+         are shown.
+    -->
+    <interfaces>
+        <interface name="management"/>
+        <interface name="public"/>
+        <interface name="public-two"/>
+    </interfaces>
+
+    <socket-binding-groups>
+         <socket-binding-group name="standard-sockets" default-interface="public">
+            <socket-binding name="jmx-connector-registry" interface="management" port="1090"/>
+            <socket-binding name="jmx-connector-server" interface="management" port="1091"/>
+            <socket-binding name="remoting" port="4447"/>
+            <socket-binding name="txn-recovery-environment" port="4712"/>
+            <socket-binding name="txn-status-manager" port="4713"/>
+            <socket-binding name="messaging" port="5445" />
+            <socket-binding name="messaging-throughput" port="5455"/>
+             <socket-binding name="http" port="8080"/>
+             <socket-binding name="https" port="8443"/>
+            <outbound-socket-binding name="mail-smtp">
+                <remote-destination host="localhost" port="25"/>
+            </outbound-socket-binding>
+        </socket-binding-group>
+    </socket-binding-groups>
+
+    <server-groups>
+        <server-group name="main-server-group" profile="default">
+            <socket-binding-group ref="standard-sockets"/>
+        </server-group>
+        <server-group name="other-server-group" profile="default">
+            <socket-binding-group ref="standard-sockets"/>
+        </server-group>
+    </server-groups>
+
+
+</domain>

--- a/testsuite/domain/src/test/resources/host-configs/host-default-interface.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-default-interface.xml
@@ -1,0 +1,88 @@
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2014, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<host xmlns="urn:jboss:domain:3.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:3.0 wildfly-config_3_0.xsd"
+      name="slave">
+
+    <paths>
+        <path name="domainTestPath" path="/tmp" />
+    </paths>
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                    <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA==" />
+                </server-identities>
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true" />
+                    <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true" />
+                    <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="9999"/>
+            </native-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+        <local/>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.master.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.master.address}"/>
+        </interface>
+        <interface name="public-two">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="128m"/>
+        </jvm>
+    </jvms>
+
+    <servers directory-grouping="by-type">
+        <server name="main-one" group="main-server-group">
+            <socket-bindings socket-binding-group="standard-sockets"/>
+            <jvm name="default"/>
+        </server>
+        <server name="other-two" group="other-server-group">
+            <socket-bindings socket-binding-group="standard-sockets" default-interface="public-two"/>
+        </server>
+    </servers>
+</host>


### PR DESCRIPTION
Now you can redefine the default-interface in the socket-bindings element of a server definition in the host.xml like this :
<socket-bindings socket-binding-group="full-ha-sockets" default-interface="public-two"/>
Or in the domain.xml you may redefine the default-interface of a socket-binding-group like this:
<socket-binding-group ref="full-sockets" default-interface="public-two" />

Jira: https://issues.jboss.org/browse/WFCORE-325