### PR TITLE
[WFCORE-492] fix ObjectNameAddressUtil.toPathAddress

### DIFF
--- a/jmx/src/main/java/org/jboss/as/jmx/model/ObjectNameAddressUtil.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/ObjectNameAddressUtil.java
@@ -148,7 +148,7 @@ class ObjectNameAddressUtil {
             PathAddress childAddress = PathAddress.pathAddress(
                     replaceEscapedCharactersInKey(entry.getKey()),
                     replaceEscapedCharactersInValue(entry.getValue()));
-            ImmutableManagementResourceRegistration subModel = registry.getSubModel(address);
+            ImmutableManagementResourceRegistration subModel = registry.getSubModel(childAddress);
             if (subModel != null) {
                 Map<String, String> childProps = new HashMap<String, String>(properties);
                 childProps.remove(entry.getKey());


### PR DESCRIPTION
The call to registry.getSubmodel() must be done on the childAddress, not
the address of the registry itself

JIRA: https://issues.jboss.org/browse/WFCORE-492