### PR TITLE
WFLY-3723: Ensure ROOT Locale (en) is loaded whenever user request for en_* locale

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -466,46 +466,12 @@ public class GlobalOperationHandlers {
             return null;
         }
         String unparsed = normalizeLocale(operation.get(GlobalOperationAttributes.LOCALE.getName()).asString());
-        int len = unparsed.length();
-        if (len != 2 && len != 5 && len < 7) {
-            reportInvalidLocaleFormat(context, unparsed);
+        try {
+            return LocaleResolver.resolveLocale(unparsed);
+        } catch (IllegalArgumentException e) {
+            reportInvalidLocaleFormat(context, e.getMessage());
             return null;
         }
-
-        char char0 = unparsed.charAt(0);
-        char char1 = unparsed.charAt(1);
-        if (char0 < 'a' || char0 > 'z' || char1 < 'a' || char1 > 'z') {
-            reportInvalidLocaleFormat(context, unparsed);
-            return null;
-        }
-        if (len == 2) {
-            return new Locale(unparsed, "");
-        }
-
-        if (!isLocaleSeparator(unparsed.charAt(2))) {
-            reportInvalidLocaleFormat(context, unparsed);
-            return null;
-        }
-        char char3 = unparsed.charAt(3);
-        if (isLocaleSeparator(char3)) {
-            // no country
-            return new Locale(unparsed.substring(0, 2), "", unparsed.substring(4));
-        }
-
-        char char4 = unparsed.charAt(4);
-        if (char3 < 'A' || char3 > 'Z' || char4 < 'A' || char4 > 'Z') {
-            reportInvalidLocaleFormat(context, unparsed);
-            return null;
-        }
-        if (len == 5) {
-            return new Locale(unparsed.substring(0, 2), unparsed.substring(3));
-        }
-
-        if (!isLocaleSeparator(unparsed.charAt(5))) {
-            reportInvalidLocaleFormat(context, unparsed);
-            return null;
-        }
-        return new Locale(unparsed.substring(0, 2), unparsed.substring(3, 5), unparsed.substring(6));
     }
 
     static boolean getRecursive(OperationContext context, ModelNode op) throws OperationFailedException
@@ -547,10 +513,6 @@ public class GlobalOperationHandlers {
 
     private static String normalizeLocale(String toNormalize) {
         return ("zh_Hans".equalsIgnoreCase(toNormalize) || "zh-Hans".equalsIgnoreCase(toNormalize)) ? "zh_CN" : toNormalize;
-    }
-
-    private static boolean isLocaleSeparator(char ch) {
-        return ch == '-' || ch == '_';
     }
 
     private static void reportInvalidLocaleFormat(OperationContext context, String format) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/LocaleResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/LocaleResolver.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.controller.operations.global;
+
+import java.util.Locale;
+
+/**
+ * Utility class handling low-level parsing of Locale string tag.
+ *
+ * @author Romain Pelisse - <romain@redhat.com>
+ */
+public final class LocaleResolver {
+
+    private static final String ENGLISH = new Locale("en").getLanguage();
+
+    private LocaleResolver(){};
+
+    static Locale resolveLocale(String unparsed) throws IllegalArgumentException {
+        int len = unparsed.length();
+        if ( len < 1 ) {
+            throw new IllegalArgumentException(unparsed);
+        }
+
+        if (len != 2 && len != 5 && len < 7) {
+            throw new IllegalArgumentException(unparsed);
+        }
+
+        char char0 = unparsed.charAt(0);
+        char char1 = unparsed.charAt(1);
+        if (char0 < 'a' || char0 > 'z' || char1 < 'a' || char1 > 'z') {
+            throw new IllegalArgumentException(unparsed);
+        }
+        if (len == 2) {
+            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed, ""));
+        }
+
+        if (!isLocaleSeparator(unparsed.charAt(2))) {
+            throw new IllegalArgumentException(unparsed);
+        }
+
+        char char3 = unparsed.charAt(3);
+        if (isLocaleSeparator(char3)) {
+            // no country
+            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), "", unparsed.substring(4)));
+        }
+
+        char char4 = unparsed.charAt(4);
+        if (char3 < 'A' || char3 > 'Z' || char4 < 'A' || char4 > 'Z') {
+            throw new IllegalArgumentException(unparsed);
+        }
+
+        if (len == 5) {
+            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3)));
+        }
+
+        if (!isLocaleSeparator(unparsed.charAt(5))) {
+            throw new IllegalArgumentException(unparsed);
+        }
+        return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3, 5), unparsed.substring(6)));
+    }
+
+    private static boolean isLocaleSeparator(char ch) {
+        return ch == '-' || ch == '_';
+    }
+
+    /**
+     * <p>By substituting Locale.ROOT for any locale that includes English, we're counting on the fact that the locale is in the end
+     * used in a call to {@link java.util.ResourceBundle#getBundle(java.lang.String, java.util.Locale, java.lang.ClassLoader) }.</p>
+     *
+     * <p>Note that Locale.ROOT bypasses the default locale (which could be French or German). It relies on the convention we used for
+     *    naming bundles files in Wildfly (LocalDescriptions.properties, not LocalDescriptions_en.properties).</p>
+     */
+    static Locale replaceByRootLocaleIfLanguageIsEnglish(Locale locale) {
+        return (locale.getLanguage().equals(ENGLISH) ? Locale.ROOT : locale);
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/operations/global/LocaleResolverTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/operations/global/LocaleResolverTest.java
@@ -1,0 +1,80 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jboss.as.controller.operations.global;
+
+import java.util.Locale;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+/**
+ *
+ * @author rpelisse
+ */
+public class LocaleResolverTest {
+
+    Locale french = Locale.FRENCH;
+    Locale english = Locale.ENGLISH;
+    Locale german = Locale.GERMAN;
+
+    @Test
+    public void invalidLanguageNotUsingAlphanumericCharacters() {
+        invalidLanguageOrCountry("1#");
+    }
+
+    @Test
+    public void invalidCountryNotUsingAlphanumericCharacters() {
+        invalidLanguageOrCountry("en_1€");
+    }
+
+    @Test
+    public void invalidLanguageTag() {
+        validLanguageOrCountry("en_EN_long_but_OK");
+        invalidLanguageOrCountry("e"); // too short
+        invalidLanguageOrCountry("e_U");
+        invalidLanguageOrCountry("en_U");
+        invalidLanguageOrCountry("en_US_"); // incomplete
+    }
+
+    @Test
+    public void nonExistingLanguageOrCountry() {
+        invalidLanguageOrCountry("aW");
+        invalidLanguageOrCountry("aW_AW");
+    }
+
+    @Test
+    public void invalidLocaleSeparator() {
+        invalidLanguageOrCountry("*");
+        invalidLanguageOrCountry("de_DE8");
+        invalidLanguageOrCountry("en_#");
+    }
+
+    public void invalidLanguageOrCountry(String unparsed) {
+        try {
+            LocaleResolver.resolveLocale(unparsed);
+        } catch ( IllegalArgumentException e) {
+            assertEquals(unparsed,e.getMessage());
+            return; // pass...
+        }
+        fail("Format " + unparsed + " is invalid, test should have failed.");
+    }
+
+    public void validLanguageOrCountry(String unparsed) {
+        try {
+            LocaleResolver.resolveLocale(unparsed);
+        } catch ( IllegalArgumentException e) {
+            assertEquals(unparsed,e.getMessage());
+            fail("Format " + unparsed + " is invalid, test should have failed.");
+        }
+    }
+
+    @Test
+    public void wfly3723() {
+        assertEquals("",french, LocaleResolver.resolveLocale(french.toLanguageTag()));
+        assertEquals("",german, LocaleResolver.resolveLocale(german.toLanguageTag()));
+        assertEquals("",Locale.ROOT, LocaleResolver.resolveLocale(english.toLanguageTag()));
+    }
+}


### PR DESCRIPTION
Also,
    - add extra test to ensure provided locale tag string is neither too small or too big
    - code cleanup to allow unit test
    - create a protected static method implementing the desired Locale resolution, but separated from Wildfly data model
    - methods throw exception to be catched by wfly specific code, which handle proper logging/display of format error
    - this ultimately allowed to add test case to ensure LocaleResolution behave as desired
    - cleanup, extract Locale, low-level parsing to separate utility class