### PR TITLE
[WFCORE-490] Do not create SecureRandom instance per operation

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -49,7 +49,6 @@ import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
 import java.io.IOException;
 import java.security.AccessControlContext;
 import java.security.PrivilegedAction;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -138,6 +137,7 @@ class ModelControllerImpl implements ModelController {
     private final Authorizer authorizer;
 
     private final ConcurrentMap<Integer, OperationContextImpl> activeOperations = new ConcurrentHashMap<>();
+    private final Random random = new Random();
     private final ManagedAuditLogger auditLogger;
     private final BootErrorCollector bootErrorCollector;
 
@@ -334,7 +334,7 @@ class ModelControllerImpl implements ModelController {
         for (;;) {
             responseStreams = null;
             // Create a random operation-id
-            final Integer operationID = new Random(new SecureRandom().nextLong()).nextInt();
+            final Integer operationID = random.nextInt();
             final OperationContextImpl context = new OperationContextImpl(operationID, operation.get(OP).asString(),
                     operation.get(OP_ADDR), this, processType, runningModeControl.getRunningMode(),
                     contextFlags, handler, attachments, managementModel.get(), originalResultTxControl, processState, auditLogger,
@@ -397,8 +397,7 @@ class ModelControllerImpl implements ModelController {
 
     boolean boot(final List<ModelNode> bootList, final OperationMessageHandler handler, final OperationTransactionControl control,
               final boolean rollbackOnRuntimeFailure) {
-
-        final Integer operationID = new Random(new SecureRandom().nextLong()).nextInt();
+        final Integer operationID = random.nextInt();
 
         EnumSet<OperationContextImpl.ContextFlag> contextFlags = rollbackOnRuntimeFailure
                 ? EnumSet.of(OperationContextImpl.ContextFlag.ROLLBACK_ON_FAIL)


### PR DESCRIPTION
This removes the use of SecureRandom and constructs the Random once per instance rather than once (or more) per internalExecute() call, which uses less entropy from /dev/random. As per the jira discussion, I cannot think of a reason why the operation id needs to be secure-random rather than merely pseudo-random, however that should be checked. In JDK 7+ java.util.Random is thread safe, with a small penalty for concurrent use, but that penalty is likely lower than repeatedly constructing SecureRandom instances.

The code was added in https://github.com/wildfly/wildfly-core/commit/d971a7a75bb8196731453c0ecbfa49029c9fec1c (for https://issues.jboss.org/browse/WFLY-4), which has no discussion of why SecureRandom is useful/needed.


On my test server, having 10 threads perform 1000 no-op operations each takes around 9 seconds before the change and 7.5 after. Concurrently draining the entry pool with "cat /dev/random > /dev/null" slows it down to 12 seconds without the patch (and still ~7.5 with it). Obviously that high a management operation rate is not usual so the throughput is not the main aim, but on a virtual machine with even less entropy being created, it could help reduce the usage of the limited resource.