### PR TITLE
[WFCORE-506] : Incoherence in core dist between domain.xml and  host(-slave).xml

### DIFF
--- a/core-feature-pack/src/main/resources/configuration/domain/template.xml
+++ b/core-feature-pack/src/main/resources/configuration/domain/template.xml
@@ -80,6 +80,9 @@
             </jvm>
             <socket-binding-group ref="standard-sockets"/>
         </server-group>
+        <server-group name="other-server-group" profile="default">
+            <socket-binding-group ref="standard-sockets"/>
+        </server-group>
     </server-groups>
 
 </domain>


### PR DESCRIPTION
Updating domain.xml to be able to reference other-server-group.

Jira: https://issues.jboss.org/browse/WFCORE-506