### PR TITLE
[WFCORE-502] Remove the need to call completeStep/stepCompleted

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
@@ -137,7 +137,6 @@ public class AbstractAddStepHandler implements OperationStepHandler {
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.stepCompleted();
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/AbstractModelUpdateHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractModelUpdateHandler.java
@@ -51,7 +51,6 @@ public abstract class AbstractModelUpdateHandler implements OperationStepHandler
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.stepCompleted();
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -741,6 +741,10 @@ abstract class AbstractOperationContext implements OperationContext {
                 ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(step.handler.getClass());
                 try {
                     step.handler.execute(this, step.operation);
+                    if (step.resultHandler == null) {
+                        // Add a default one
+                        completeStep(ResultHandler.NOOP_RESULT_HANDLER);
+                    }
                     // AS7-6046
                     if (isErrorLoggingNecessary() && step.hasFailed()) {
                         MGMT_OP_LOGGER.operationFailed(step.operation.get(OP), step.operation.get(OP_ADDR),
@@ -776,7 +780,7 @@ abstract class AbstractOperationContext implements OperationContext {
                                 step.response.get(FAILURE_DESCRIPTION));
                     }
 
-                    stepCompleted();
+                    completeStep(ResultHandler.NOOP_RESULT_HANDLER);
                 } else {
                     // Handler threw OCE after calling completeStep()
                     // Throw it on and let standard error handling deal with it

--- a/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
@@ -86,7 +86,6 @@ public abstract class AbstractRemoveStepHandler implements OperationStepHandler 
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.stepCompleted();
     }
 
     protected void performRemove(OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {

--- a/controller/src/main/java/org/jboss/as/controller/AbstractRuntimeOnlyHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractRuntimeOnlyHandler.java
@@ -53,8 +53,6 @@ public abstract class AbstractRuntimeOnlyHandler implements OperationStepHandler
                 executeRuntimeStep(context, operation);
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/AbstractWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractWriteAttributeHandler.java
@@ -138,8 +138,6 @@ public abstract class AbstractWriteAttributeHandler<T> implements OperationStepH
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-
-        context.stepCompleted();
     }
 
 

--- a/controller/src/main/java/org/jboss/as/controller/BootErrorCollector.java
+++ b/controller/src/main/java/org/jboss/as/controller/BootErrorCollector.java
@@ -157,10 +157,8 @@ public class BootErrorCollector {
                         bootErrors.add(bootError);
                     }
                     context.getResult().set(bootErrors);
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.RUNTIME);
-            context.stepCompleted();
         }
 
         private void secureOperationAddress(OperationContext context, ModelNode bootError) throws OperationFailedException {

--- a/controller/src/main/java/org/jboss/as/controller/NoopOperationStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/NoopOperationStepHandler.java
@@ -55,6 +55,5 @@ public class NoopOperationStepHandler implements OperationStepHandler {
         if (setResult) {
             context.getResult();
         }
-        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -249,7 +249,12 @@ public interface OperationContext extends ExpressionResolver {
      * So a {@link Stage#MODEL} handler typically can be uninterested in the result of the overall operation and can
      * use this method.
      * </p>
+     *
+     * @deprecated invoking this method is unnecessary since if an {@code OperationStepHandler} does not call one of
+     *             the {@link #completeStep(org.jboss.as.controller.OperationContext.ResultHandler) variants} from its
+     *             {@code execute} method, a no-op {@code ResultHandler} will automatically be registered
      */
+    @Deprecated
     void stepCompleted();
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/OperationStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationStepHandler.java
@@ -25,19 +25,28 @@ package org.jboss.as.controller;
 import org.jboss.dmr.ModelNode;
 
 /**
+ * Handler for an individual step in the overall execution of a management operation.
+ * <p>
+ * A handler is associated with a single {@link org.jboss.as.controller.OperationContext.Stage stage} of operation execution
+ * and should only perform functions appropriate for that stage.
+ * <p>
+ * A handler {@link org.jboss.as.controller.registry.ManagementResourceRegistration#registerOperationHandler(OperationDefinition, OperationStepHandler) registered with a ManagementResourceRegistration}
+ * will execute in {@link org.jboss.as.controller.OperationContext.Stage#MODEL}; otherwise the step will execute in the
+ * stage passed to {@link org.jboss.as.controller.OperationContext#addStep(OperationStepHandler, org.jboss.as.controller.OperationContext.Stage)}
+ * when it was added.
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public interface OperationStepHandler {
 
     /**
      * Execute this step.  If the operation fails, {@link OperationContext#getFailureDescription() context.getFailureDescription()}
-     * must be called, before calling one of the
-     * {@link org.jboss.as.controller.OperationContext#completeStep(OperationContext.ResultHandler) context.completeStep variants},
-     * or an {@link OperationFailedException} must be thrown.
-     * If the operation succeeded, {@link OperationContext#getResult() context.getResult()} should
-     * be called and the result populated with the outcome, after which one of the
+     * must be called, or an {@link OperationFailedException} must be thrown.
+     * If the operation succeeded and the operation provides a return value, {@link OperationContext#getResult() context.getResult()} should
+     * be called and the result populated with the outcome. If the handler wishes to take further action once the result
+     * of the overall operation execution is known, one of the
      * {@link org.jboss.as.controller.OperationContext#completeStep(OperationContext.ResultHandler) context.completeStep variants}
-     * must be called.
+     * should be called to register a callback. The callback will not be invoked if this method throws an exception.
      * <p>When this method is invoked the {@link Thread#getContextClassLoader() thread context classloader} will
      * be set to be the defining class loader of the class that implements this interface.</p>
      *

--- a/controller/src/main/java/org/jboss/as/controller/ReadResourceNameOperationStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadResourceNameOperationStepHandler.java
@@ -44,7 +44,5 @@ public class ReadResourceNameOperationStepHandler implements OperationStepHandle
         final String name = context.getCurrentAddressValue();
 
         context.getResult().set(name);
-
-        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/RestartParentResourceHandlerBase.java
+++ b/controller/src/main/java/org/jboss/as/controller/RestartParentResourceHandlerBase.java
@@ -90,7 +90,6 @@ public abstract class RestartParentResourceHandlerBase implements OperationStepH
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.stepCompleted();
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/ServiceVerificationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ServiceVerificationHandler.java
@@ -46,6 +46,5 @@ public final class ServiceVerificationHandler extends AbstractServiceListener<Ob
 
     public void execute(final OperationContext context, final ModelNode operation) {
         // no-op
-        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/ServiceVerificationHelper.java
+++ b/controller/src/main/java/org/jboss/as/controller/ServiceVerificationHelper.java
@@ -145,7 +145,6 @@ class ServiceVerificationHelper extends AbstractServiceListener<Object> implemen
                 context.setRollbackOnly();
             }
         }
-        context.stepCompleted();
     }
 
     private static ModelNode getServiceFailureDescription(final StartException exception) {

--- a/controller/src/main/java/org/jboss/as/controller/extension/ParallelExtensionAddHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ParallelExtensionAddHandler.java
@@ -84,8 +84,6 @@ public class ParallelExtensionAddHandler implements OperationStepHandler {
             ParsedBootOp op = extensionAdds.get(i);
             context.addStep(op.response, op.operation, op.handler, OperationContext.Stage.MODEL, true);
         }
-
-        context.stepCompleted();
     }
 
     private OperationStepHandler getParallelExtensionInitializeStep() {
@@ -122,8 +120,6 @@ public class ParallelExtensionAddHandler implements OperationStepHandler {
                     long elapsed = System.currentTimeMillis() - start;
                     MGMT_OP_LOGGER.debugf("Initialized extensions in [%d] ms", elapsed);
                 }
-
-                context.stepCompleted();
             }
         };
     }

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/GenericSubsystemDescribeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/GenericSubsystemDescribeHandler.java
@@ -127,7 +127,6 @@ public class GenericSubsystemDescribeHandler implements OperationStepHandler, De
         final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
         final ModelNode result = context.getResult();
         describe(resource, address, result, context.getResourceRegistration());
-        context.stepCompleted();
     }
 
     protected void describe(final Resource resource, final ModelNode address, ModelNode result, final ImmutableManagementResourceRegistration registration) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/NamespaceRemoveHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/NamespaceRemoveHandler.java
@@ -88,6 +88,5 @@ public class NamespaceRemoveHandler implements OperationStepHandler {
         } else {
             throw new OperationFailedException(ControllerLogger.ROOT_LOGGER.namespaceNotFound(prefix));
         }
-        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessEnvironment.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessEnvironment.java
@@ -184,8 +184,6 @@ public abstract class ProcessEnvironment {
             } else {
                 context.getResult().set(ProcessEnvironment.this.getProcessName());
             }
-
-            context.stepCompleted();
         }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessReloadHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessReloadHandler.java
@@ -96,8 +96,6 @@ public abstract class ProcessReloadHandler<T extends RunningModeControl> impleme
                 });
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 
     protected abstract ReloadContext<T> initializeReloadContext(OperationContext context, ModelNode operation) throws OperationFailedException;

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessStateAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessStateAttributeHandler.java
@@ -48,7 +48,6 @@ public class ProcessStateAttributeHandler implements OperationStepHandler {
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
 
         context.getResult().set(processState.getState().toString());
-        context.stepCompleted();
     }
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ResolveExpressionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ResolveExpressionHandler.java
@@ -89,7 +89,5 @@ public class ResolveExpressionHandler implements OperationStepHandler {
                 }
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/SchemaLocationRemoveHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/SchemaLocationRemoveHandler.java
@@ -93,8 +93,6 @@ public class SchemaLocationRemoveHandler implements OperationStepHandler {
         } else {
             throw new OperationFailedException(ControllerLogger.ROOT_LOGGER.schemaNotFound(uri));
         }
-
-        context.stepCompleted();
     }
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ValidateAddressOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ValidateAddressOperationHandler.java
@@ -104,7 +104,6 @@ public class ValidateAddressOperationHandler implements OperationStepHandler {
                 final OperationStepHandler proxyHandler = registration.getOperationHandler(PathAddress.EMPTY_ADDRESS, OPERATION_NAME);
                 if(proxyHandler != null) {
                     context.addStep(newOperation, proxyHandler, OperationContext.Stage.MODEL, true);
-                    context.stepCompleted();
                     return;
                 }
 
@@ -114,7 +113,6 @@ public class ValidateAddressOperationHandler implements OperationStepHandler {
                 // Invalid
                 context.getResult().get(VALID).set(false);
                 context.getResult().get(PROBLEM).set(ControllerLogger.ROOT_LOGGER.childResourceNotFound(next));
-                context.stepCompleted();
                 return;
             }
         }
@@ -125,7 +123,6 @@ public class ValidateAddressOperationHandler implements OperationStepHandler {
         } else {
             context.getResult().get(VALID).set(true);
         }
-        context.stepCompleted();
     }
 
     private AuthorizationResult authorize(OperationContext context, PathAddress address, ModelNode operation) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/XmlMarshallingHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/XmlMarshallingHandler.java
@@ -104,7 +104,6 @@ public class XmlMarshallingHandler implements OperationStepHandler{
             MGMT_OP_LOGGER.failedExecutingOperation(e, operation.require(ModelDescriptionConstants.OP), pa);
             context.getFailureDescription().set(e.toString());
         }
-        context.stepCompleted();
     }
 
     protected PathAddress getBaseAddress() {

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/AbstractCollectionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/AbstractCollectionHandler.java
@@ -87,7 +87,6 @@ abstract class AbstractCollectionHandler implements OperationStepHandler {
             writeOperation.get(ModelDescriptionConstants.VALUE).set(model);
             context.addStep(writeOperation, WriteAttributeHandler.INSTANCE, OperationContext.Stage.MODEL);
         }
-        context.stepCompleted();
     }
 
     abstract void updateModel(final OperationContext context, ModelNode model, AttributeDefinition attributeDefinition, ModelNode attribute) throws OperationFailedException;

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -335,7 +335,6 @@ public class GlobalOperationHandlers {
                             resultAddress.set(base.toModelNode());
                         } catch (NoSuchResourceException e) {
                             // just discard the result to avoid leaking the inaccessible address
-                            context.stepCompleted();
                         }
                     }
                 };
@@ -361,7 +360,6 @@ public class GlobalOperationHandlers {
         public void execute(final OperationContext context, final ModelNode ignored) throws OperationFailedException {
             final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
             execute(address, PathAddress.EMPTY_ADDRESS, context);
-            context.stepCompleted();
         }
 
         void execute(final PathAddress address, PathAddress base, final OperationContext context) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeHandler.java
@@ -147,7 +147,6 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
                 PathAddress pa = context.getCurrentAddress();
                 filteredData.addReadRestrictedAttribute(pa, operation.get(NAME).asString());
                 context.getResult().set(new ModelNode());
-                context.stepCompleted();
             }
         }
     }
@@ -188,8 +187,6 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
                     }
                 }
             }
-            // Complete the step for the unregistered attribute case
-            context.stepCompleted();
         } else if (attributeAccess.getReadHandler() == null) {
             final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS, false);
             final ModelNode subModel = resource.getModel();
@@ -208,8 +205,6 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
                     context.getResult(); // this initializes the "result" to ModelType.UNDEFINED
                 }
             }
-            // Complete the step for the "registered attribute but default read handler" case
-            context.stepCompleted();
         } else {
             OperationStepHandler handler = attributeAccess.getReadHandler();
             ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(handler.getClass());
@@ -218,7 +213,6 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
             } finally {
                 WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
             }
-            // no context.completeStep() here as that's the read handler's job
         }
     }
 
@@ -251,7 +245,6 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
                     PathAddress pa = context.getCurrentAddress();
                     filteredData.addReadRestrictedAttribute(pa, operation.get(NAME).asString());
                     context.getResult().set(new ModelNode());
-                    context.stepCompleted();
                 }
             }
         }
@@ -263,8 +256,6 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
                 context.getResult().clear();
                 throw ControllerLogger.ROOT_LOGGER.unauthorized(operation.require(OP).asString(), context.getCurrentAddress(), authorizationResult.getExplanation());
             }
-
-            context.stepCompleted();
         }
     }
 
@@ -292,7 +283,6 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
             // simply returning them unresolved.
             ModelNode resolved = ExpressionResolver.SIMPLE_LENIENT.resolveExpressions(result);
             context.getResult().set(resolved);
-            context.stepCompleted();
         }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenNamesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenNamesHandler.java
@@ -106,7 +106,5 @@ public class ReadChildrenNamesHandler implements OperationStepHandler {
         if (fd != null) {
             context.getResponseHeaders().get(ACCESS_CONTROL).set(fd.toModelNode());
         }
-
-        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenResourcesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenResourcesHandler.java
@@ -128,8 +128,6 @@ public class ReadChildrenResourcesHandler implements OperationStepHandler {
             resources.put(childPath, rrRsp);
             context.addStep(rrRsp, readResOp, rrHandler, OperationContext.Stage.MODEL, true);
         }
-
-        context.stepCompleted();
     }
 
     /**
@@ -195,12 +193,8 @@ public class ReadChildrenResourcesHandler implements OperationStepHandler {
                             context.getResponseHeaders().get(ACCESS_CONTROL).set(filteredData.toModelNode());
                         }
                     }
-
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.VERIFY);
-
-            context.stepCompleted();
         }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenTypesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenTypesHandler.java
@@ -93,6 +93,5 @@ public class ReadChildrenTypesHandler implements OperationStepHandler {
         for(String child : children) {
            result.add(child);
         }
-        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadOperationDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadOperationDescriptionHandler.java
@@ -116,7 +116,6 @@ public class ReadOperationDescriptionHandler implements OperationStepHandler {
 
             context.getResult().set(result);
         }
-        context.stepCompleted();
     }
 
     private static DescribedOp getDescribedOp(OperationContext context, String operationName, ModelNode operation, boolean lenient) throws OperationFailedException {

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadOperationNamesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadOperationNamesHandler.java
@@ -109,6 +109,5 @@ public class ReadOperationNamesHandler implements OperationStepHandler {
             result.setEmptyList();
         }
         context.getResult().set(result);
-        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -163,12 +163,8 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
         } else {
             try {
                 doExecuteInternal(context, operation, accessControlContext);
-            } catch (NoSuchResourceException nsre) {
+            } catch (NoSuchResourceException | UnauthorizedException nsre) {
                 context.getResult().set(new ModelNode());
-                context.stepCompleted();
-            } catch (UnauthorizedException ue) {
-                context.getResult().set(new ModelNode());
-                context.stepCompleted();
             }
         }
     }
@@ -526,7 +522,6 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
                 }
             }
             accessControlResult.set(result);
-            context.stepCompleted();
         }
 
         private void addResourceAuthorizationResults(ModelNode result, ResourceAuthorization authResp) {
@@ -687,7 +682,6 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
                 }
             }
             context.getResult().set(nodeDescription);
-            context.stepCompleted();
         }
     }
 
@@ -838,11 +832,9 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
                 } catch (NoSuchResourceException e){
                     //Mark it as not accessible so that the assembly handler can remove it
                     context.getResult().set(PROXY_NO_SUCH_RESOURCE);
-                    context.stepCompleted();
                 } catch (UnauthorizedException e) {
                     //We were not allowed to read it, the assembly handler should still allow people to see it
                     context.getResult().set(new ModelNode());
-                    context.stepCompleted();
                 }
             }
         }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -174,13 +174,11 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
                 PathAddress pa = PathAddress.pathAddress(operation.get(OP_ADDR));
                 filteredData.addAccessRestrictedResource(pa);
                 context.getResult().set(new ModelNode());
-                context.stepCompleted();
             } catch (UnauthorizedException ue) {
                 // Just report the failure to the filter and complete normally
                 PathAddress pa = PathAddress.pathAddress(operation.get(OP_ADDR));
                 filteredData.addReadRestrictedResource(pa);
                 context.getResult().set(new ModelNode());
-                context.stepCompleted();
             }
         }
     }
@@ -357,8 +355,6 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
                 }
             }
         }
-
-        context.stepCompleted();
     }
 
     private boolean isSingletonResource(final ImmutableManagementResourceRegistration registry, final String key) {
@@ -550,8 +546,6 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
                     context.getResponseHeaders().get(ACCESS_CONTROL).set(filteredData.toModelNode());
                 }
             }
-
-            context.stepCompleted();
         }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/WriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/WriteAttributeHandler.java
@@ -150,11 +150,8 @@ public class WriteAttributeHandler implements OperationStepHandler {
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                         // aggregate data from the 2 read-attribute operations
                         emitAttributeValueWrittenNotification(context, address, attributeName, oldValue.get(RESULT), newValue.get(RESULT));
-                        context.stepCompleted();
                     }
                 }, currentStage);
-
-                context.stepCompleted();
             }
         }
     }

--- a/controller/src/main/java/org/jboss/as/controller/registry/AliasStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AliasStepHandler.java
@@ -61,6 +61,5 @@ public class AliasStepHandler implements OperationStepHandler {
         ModelNode copy = operation.clone();
         copy.get(OP_ADDR).set(mapped.toModelNode());
         context.addStep(copy, targetHandler, Stage.MODEL, true);
-        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/services/path/PathRemoveHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/PathRemoveHandler.java
@@ -120,7 +120,5 @@ public class PathRemoveHandler implements OperationStepHandler {
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-
-        context.stepCompleted();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/transform/SubsystemDescriptionDump.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/SubsystemDescriptionDump.java
@@ -66,7 +66,6 @@ public class SubsystemDescriptionDump implements OperationStepHandler {
         PathAddress profileAddress = PathAddress.pathAddress(PathElement.pathElement(ModelDescriptionConstants.PROFILE));
         ImmutableManagementResourceRegistration profileRegistration = context.getResourceRegistration().getSubModel(profileAddress);
         dumpManagementResourceRegistration(profileRegistration, extensionRegistry, path);
-        context.stepCompleted();
     }
 
     public static void dumpManagementResourceRegistration(final ImmutableManagementResourceRegistration profileRegistration,

--- a/controller/src/test/java/org/jboss/as/controller/InterleavedSubsystemTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/InterleavedSubsystemTestCase.java
@@ -181,8 +181,6 @@ public class InterleavedSubsystemTestCase {
                     ReloadRequiredRemoveStepHandler.INSTANCE
             );
             rootRegistration.registerSubModel(subsystemResource);
-
-            context.stepCompleted();
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
@@ -676,8 +676,6 @@ public class ModelControllerImplUnitTestCase {
 
             context.createResource(CHILD_ONE).getModel().set(child1);
             context.createResource(CHILD_TWO).getModel().set(child2);
-
-            context.stepCompleted();
         }
     }
 
@@ -962,8 +960,6 @@ public class ModelControllerImplUnitTestCase {
                     });
                 }
             }, OperationContext.Stage.RUNTIME);
-
-            context.stepCompleted();
         }
     }
 
@@ -1091,7 +1087,6 @@ public class ModelControllerImplUnitTestCase {
             final String type = operation.require("type").asString();
             final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement(type)));
             context.getResult().set(Resource.Tools.readModel(resource));
-            context.stepCompleted();
         }
 
     }

--- a/controller/src/test/java/org/jboss/as/controller/OperationCancellationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationCancellationUnitTestCase.java
@@ -381,8 +381,6 @@ public class OperationCancellationUnitTestCase {
 
             context.createResource(PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement("child", "one"))).getModel().set(child1);
             context.createResource(PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement("child", "two"))).getModel().set(child2);
-
-            context.stepCompleted();
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
@@ -266,8 +266,6 @@ public class OperationTimeoutUnitTestCase {
 
             context.createResource(PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement("child", "one"))).getModel().set(child1);
             context.createResource(PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement("child", "two"))).getModel().set(child2);
-
-            context.stepCompleted();
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
@@ -541,7 +541,6 @@ public class BasicRbacTestCase extends AbstractRbacTestBase {
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             context.getServiceRegistry(modify); // causes read-runtime/write-runtime auth, otherwise ignored
             context.getResult().set(new Random().nextInt());
-            context.stepCompleted();
         }
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
@@ -696,7 +696,6 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
             }
 
             context.getResult().set(new Random().nextInt());
-            context.stepCompleted();
         }
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadAttributeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadAttributeTestCase.java
@@ -362,7 +362,6 @@ public class ReadAttributeTestCase extends AbstractRbacTestBase {
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             context.getResult().set(value);
-            context.stepCompleted();
         }
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationDescriptionAccessControlTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationDescriptionAccessControlTestCase.java
@@ -338,7 +338,7 @@ public class ReadOperationDescriptionAccessControlTestCase extends AbstractContr
 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.stepCompleted();
+            // no-op
         }
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationNamesRbacTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationNamesRbacTestCase.java
@@ -357,7 +357,7 @@ public class ReadOperationNamesRbacTestCase extends AbstractControllerTestBase {
 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.stepCompleted();
+            // no-op
         }
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessConstraintDefinitionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessConstraintDefinitionTestCase.java
@@ -282,7 +282,7 @@ public class ReadResourceDescriptionAccessConstraintDefinitionTestCase extends A
             resourceRegistration.registerOperationHandler(CUSTOM_OPERATION, new OperationStepHandler() {
                 @Override
                 public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                    context.stepCompleted();
+                    // no-op
                 }
             });
         }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
@@ -2111,7 +2111,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.stepCompleted();
+            // no-op
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/notification/GlobalNotificationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/GlobalNotificationsTestCase.java
@@ -147,15 +147,11 @@ public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
                     @Override
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                         context.getResult().set(runtimeAttributeValue);
-
-                        context.stepCompleted();
                     }
                 },  new OperationStepHandler() {
                     @Override
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                         runtimeAttributeValue = operation.get(VALUE).asLong();
-
-                        context.stepCompleted();
                     }
                 })
                 .build();

--- a/controller/src/test/java/org/jboss/as/controller/notification/NotificationCompositeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/NotificationCompositeOperationTestCase.java
@@ -79,7 +79,6 @@ public class NotificationCompositeOperationTestCase extends AbstractControllerTe
                         if (failOperation) {
                             throw new OperationFailedException("failed operation");
                         }
-                        context.stepCompleted();
                     }
                 }
         );

--- a/controller/src/test/java/org/jboss/as/controller/notification/OperationWithManyStepsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/OperationWithManyStepsTestCase.java
@@ -102,8 +102,6 @@ public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
                                 if (failSecondStep) {
                                     throw new OperationFailedException("2nd step failed");
                                 }
-
-                                context.stepCompleted();
                             }
                         }, RUNTIME);
 
@@ -111,7 +109,6 @@ public class OperationWithManyStepsTestCase extends AbstractControllerTestBase {
                             context.getFailureDescription().set("rolled back");
                             context.setRollbackOnly();
                         }
-                        context.stepCompleted();
                     }
                 }
         );

--- a/controller/src/test/java/org/jboss/as/controller/notification/OperationWithNotificationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/OperationWithNotificationTestCase.java
@@ -65,7 +65,6 @@ public class OperationWithNotificationTestCase extends AbstractControllerTestBas
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                         Notification notification = new Notification(MY_NOTIFICATION_TYPE, PathAddress.pathAddress(operation.get(OP_ADDR)), "notification message");
                         context.emit(notification);
-                        context.stepCompleted();
                     }
                 }
         );

--- a/controller/src/test/java/org/jboss/as/controller/operation/global/CollectionOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/operation/global/CollectionOperationsTestCase.java
@@ -92,7 +92,6 @@ public class CollectionOperationsTestCase extends AbstractControllerTestBase {
                     @Override
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                         context.getResult().set(runtimeMapAttributeValue);
-                        context.stepCompleted();
                     }
                 }, new AbstractWriteAttributeHandler() {
                     @Override
@@ -110,7 +109,6 @@ public class CollectionOperationsTestCase extends AbstractControllerTestBase {
                     @Override
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                         context.getResult().set(runtimeMapAttributeValue);
-                        context.stepCompleted();
                     }
                 }, new AbstractWriteAttributeHandler() {
                     @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
@@ -150,8 +150,6 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
                         model.get("profile", "profileC", "subsystem", "subsystem5", "name").set("Test");
 
                         createModel(context, model);
-
-                        context.stepCompleted();
                     }
                 }
         );
@@ -212,7 +210,6 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
             @Override
             public void execute(OperationContext context, ModelNode operation) {
                 context.getResult().set("Overridden by special read handler");
-                context.stepCompleted();
             }
         });
 
@@ -253,7 +250,6 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
         @Override
         public void execute(final OperationContext context, final ModelNode operation) {
             context.getResult().set(random.nextInt());
-            context.stepCompleted();
         }
 
     }

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
@@ -93,7 +93,6 @@ import org.jboss.as.controller.TestModelControllerService;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationBuilder;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.ValidateOperationHandler;
 import org.jboss.as.controller.operations.global.GlobalNotifications;
@@ -650,7 +649,6 @@ public abstract class AbstractProxyControllerTest {
                     mainModel.get("profile", "profileA").get(NAME).set("Profile A");
 
                     AbstractControllerTestBase.createModel(context, mainModel);
-                    context.stepCompleted();
                 }
             });
 
@@ -678,7 +676,7 @@ public abstract class AbstractProxyControllerTest {
                     new OperationStepHandler() {
                         @Override
                         public void execute(OperationContext context, ModelNode operation) {
-                            context.stepCompleted();
+                            // no-op
                         }
                     },
                     true
@@ -694,7 +692,6 @@ public abstract class AbstractProxyControllerTest {
                             proxyModel.get("serverchild", "svrA", "child", "childA", "value").set("childValue");
 
                             AbstractControllerTestBase.createModel(context, proxyModel);
-                            context.stepCompleted();
                         }
                     }
             );

--- a/controller/src/test/java/org/jboss/as/controller/test/AliasResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AliasResourceTestCase.java
@@ -219,7 +219,7 @@ public class AliasResourceTestCase extends AbstractControllerTestBase {
 
     @Test
     public void readChildrenTypes() throws Exception {
-        ModelNode op = createOperation(READ_CHILDREN_TYPES_OPERATION);        
+        ModelNode op = createOperation(READ_CHILDREN_TYPES_OPERATION);
         op.get(INCLUDE_ALIASES).set(true);
         ModelNode result = executeForResult(op);
         List<ModelNode> list = result.asList();
@@ -776,7 +776,6 @@ public class AliasResourceTestCase extends AbstractControllerTestBase {
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             context.getResult().set("runtime");
-            context.stepCompleted();
         }
     }
 
@@ -804,7 +803,6 @@ public class AliasResourceTestCase extends AbstractControllerTestBase {
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             context.getResult().set(value);
-            context.stepCompleted();
         }
     }
 
@@ -843,7 +841,6 @@ public class AliasResourceTestCase extends AbstractControllerTestBase {
             ModelNode aliasOp = operation.clone();
             aliasOp.get(NAME).set(targetAttribute);
             context.addStep(aliasOp, step, Stage.MODEL, true);
-            context.stepCompleted();
         }
 
 

--- a/controller/src/test/java/org/jboss/as/controller/test/CastAttributeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/CastAttributeOperationTestCase.java
@@ -168,7 +168,6 @@ public class CastAttributeOperationTestCase extends AbstractControllerTestBase {
                 model.get("profile", "profilType", "subsystem", "subsystem1", BIGINT_ATT_NAME).set(new BigInteger("100"));
                 model.get("profile", "profilType", "subsystem", "subsystem1", BIGDEC_ATT_NAME).set(new BigDecimal("10.0"));
                 createModel(context, model);
-                context.stepCompleted();
             }
         }
         );

--- a/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsAliasesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsAliasesTestCase.java
@@ -116,8 +116,6 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
                 model.get("profile", "profileD", "subsystem", "subsystem3", "service", "squatter3", "thing3").set("squatter");
 
                 createModel(context, model);
-
-                context.stepCompleted();
             }
         }
         );
@@ -258,7 +256,6 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
             @Override
             public void execute(OperationContext context, ModelNode operation) {
                 context.getResult().set("Overridden by special read handler");
-                context.stepCompleted();
             }
         });
 

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadResourceChildOrderingTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadResourceChildOrderingTestCase.java
@@ -78,7 +78,6 @@ public class ReadResourceChildOrderingTestCase extends AbstractControllerTestBas
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 createModel(context, model);
-                context.stepCompleted();
             }
         });
 

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadResourceWithRuntimeResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadResourceWithRuntimeResourceTestCase.java
@@ -105,7 +105,6 @@ public class ReadResourceWithRuntimeResourceTestCase extends AbstractControllerT
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 context.getResult().set(-1);
-                context.stepCompleted();
             }
         });
         runtimeResource.setRuntimeOnly(true);
@@ -120,8 +119,6 @@ public class ReadResourceWithRuntimeResourceTestCase extends AbstractControllerT
                 model.get("subsystem", "mysubsystem", "resource", "A").setEmptyObject();
 
                 createModel(context, model);
-
-                context.stepCompleted();
             }
         });
     }

--- a/controller/src/test/java/org/jboss/as/controller/test/WildcardUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WildcardUnitTestCase.java
@@ -101,8 +101,6 @@ public class WildcardUnitTestCase extends AbstractControllerTestBase {
                     model.get("host", "B", "server", "three", "subsystem", "web", "connector", "default", "6").setEmptyObject();
 
                     createModel(context, model);
-
-                    context.stepCompleted();
                 }
             });
 

--- a/controller/src/test/java/org/jboss/as/controller/test/WriteAttributeOperationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WriteAttributeOperationTestCase.java
@@ -168,7 +168,6 @@ public class WriteAttributeOperationTestCase extends AbstractControllerTestBase 
                 model.get("profile", "profilType", "subsystem", "subsystem1", BIGINT_ATT_NAME).set(new BigInteger("100"));
                 model.get("profile", "profilType", "subsystem", "subsystem1", BIGDEC_ATT_NAME).set(new BigDecimal("10.0"));
                 createModel(context, model);
-                context.stepCompleted();
             }
         }
         );

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationDomainSlaveConfigHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationDomainSlaveConfigHandler.java
@@ -73,7 +73,5 @@ public class AccessAuthorizationDomainSlaveConfigHandler implements OperationSte
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationRolesHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationRolesHandler.java
@@ -59,7 +59,6 @@ abstract class AccessAuthorizationRolesHandler implements OperationStepHandler {
         for (String role : list) {
             result.add(role);
         }
-        context.stepCompleted();
     }
 
     abstract Set<String> getRolesList();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessConstraintAppliesToResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessConstraintAppliesToResourceDefinition.java
@@ -108,7 +108,6 @@ public class AccessConstraintAppliesToResourceDefinition extends SimpleResourceD
             AccessConstraintAppliesToResource resource =
                     (AccessConstraintAppliesToResource) context.readResource(PathAddress.EMPTY_ADDRESS);
             setResult(context, resource.constraintUtilization);
-            context.stepCompleted();
         }
 
         abstract void setResult(OperationContext context, AccessConstraintUtilization constraintUtilization);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/ApplicationClassificationConfigResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/ApplicationClassificationConfigResourceDefinition.java
@@ -111,7 +111,6 @@ public class ApplicationClassificationConfigResourceDefinition extends SimpleRes
             if (result != null) {
                 context.getResult().set(result);
             }
-            context.stepCompleted();
         }
     }
 
@@ -132,7 +131,6 @@ public class ApplicationClassificationConfigResourceDefinition extends SimpleRes
                 //TODO i18n
                 throw new IllegalStateException();
             }
-            context.stepCompleted();
         }
 
         private Boolean readValue(OperationContext context, ModelNode value, AttributeDefinition definition) throws OperationFailedException {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/HostScopedRoleRemove.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/HostScopedRoleRemove.java
@@ -80,8 +80,6 @@ class HostScopedRoleRemove implements OperationStepHandler {
                 });
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/IsCallerInRoleOperation.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/IsCallerInRoleOperation.java
@@ -69,8 +69,6 @@ public class IsCallerInRoleOperation implements OperationStepHandler {
             Set<String> operationHeaderRoles = RunAsRoleMapper.getOperationHeaderRoles(operation);
             result.set(isCallerInRole(roleName, context.getCaller(), context.getCallEnvironment(), operationHeaderRoles));
         }
-
-        context.stepCompleted();
     }
 
     private boolean isCallerInRole(String roleName, Caller caller, Environment callEnvironment, Set<String> operationHeaderRoles) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/PrincipalAdd.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/PrincipalAdd.java
@@ -84,8 +84,6 @@ public class PrincipalAdd implements OperationStepHandler {
         validateUniqueness(context, roleName, roleAddress, principalType, realm, name);
 
         registerRuntimeAdd(context, roleName.toUpperCase(Locale.ENGLISH), principalType, name, realm);
-
-        context.stepCompleted();
     }
 
     private void validateUniqueness(final OperationContext context, final String roleName, final PathAddress roleAddress,

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/PrincipalRemove.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/PrincipalRemove.java
@@ -74,8 +74,6 @@ public class PrincipalRemove implements OperationStepHandler {
         }
 
         registerRuntimeRemove(context, roleName.toUpperCase(Locale.ENGLISH), principalType, name, realm);
-
-        context.stepCompleted();
     }
 
     private void registerRuntimeRemove(final OperationContext context, final String roleName,

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/RbacSanityCheckOperation.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/RbacSanityCheckOperation.java
@@ -90,8 +90,6 @@ public class RbacSanityCheckOperation implements OperationStepHandler {
                         throw DomainManagementLogger.ROOT_LOGGER.inconsistentRbacConfiguration();
                     }
 
-                    context.stepCompleted();
-
                     return null;
                 }
             });

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/RoleMappingAdd.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/RoleMappingAdd.java
@@ -77,8 +77,6 @@ public class RoleMappingAdd implements OperationStepHandler {
         RoleMappingResourceDefinition.INCLUDE_ALL.validateAndSet(operation, model);
 
         registerRuntimeAdd(context, roleName.toUpperCase(Locale.ENGLISH));
-
-        context.stepCompleted();
     }
 
     private void registerRuntimeAdd(final OperationContext context, final String roleName) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/RoleMappingNotRequiredHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/RoleMappingNotRequiredHandler.java
@@ -59,8 +59,6 @@ public class RoleMappingNotRequiredHandler implements OperationStepHandler {
         if (roleMappings.contains(roleName)) {
             throw DomainManagementLogger.ROOT_LOGGER.roleMappingRemaining(roleName);
         }
-
-        context.stepCompleted();
     }
 
     static void addOperation(OperationContext context, String roleName) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/RoleMappingRemove.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/RoleMappingRemove.java
@@ -65,8 +65,6 @@ public class RoleMappingRemove implements OperationStepHandler {
         RbacSanityCheckOperation.addOperation(context);
 
         registerRuntimeRemove(context, roleName.toUpperCase(Locale.ENGLISH));
-
-        context.stepCompleted();
     }
 
     private void registerRuntimeRemove(final OperationContext context, final String roleName) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/ScopedRoleRequiredHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/ScopedRoleRequiredHandler.java
@@ -63,8 +63,6 @@ public class ScopedRoleRequiredHandler implements OperationStepHandler {
         if (hostScopedRoles.contains(roleName) == false && serverGroupScopedRoles.contains(roleName) == false) {
             throw DomainManagementLogger.ROOT_LOGGER.invalidRoleNameDomain(roleName);
         }
-
-        context.stepCompleted();
     }
 
     static void addOperation(OperationContext context, String roleName) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/SensitivityResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/SensitivityResourceDefinition.java
@@ -191,7 +191,6 @@ public class SensitivityResourceDefinition extends SimpleResourceDefinition {
             if (result != null) {
                 context.getResult().set(result);
             }
-            context.stepCompleted();
         }
     }
 
@@ -221,7 +220,6 @@ public class SensitivityResourceDefinition extends SimpleResourceDefinition {
                 //TODO i18n
                 throw new IllegalStateException();
             }
-            context.stepCompleted();
         }
 
         private Boolean readValue(OperationContext context, ModelNode value, AttributeDefinition definition) throws OperationFailedException {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/ServerGroupScopedRoleRemove.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/ServerGroupScopedRoleRemove.java
@@ -78,7 +78,5 @@ class ServerGroupScopedRoleRemove implements OperationStepHandler {
                 });
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/AuditLogHandlerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/AuditLogHandlerResourceDefinition.java
@@ -124,7 +124,6 @@ public class AuditLogHandlerResourceDefinition extends SimpleResourceDefinition 
             } else if (attr.equals(DISABLED_DUE_TO_FAILURE.getName())) {
                 context.getResult().set(auditLogger.getHandlerDisabledDueToFailure(handlerName));
             }
-            context.stepCompleted();
         }
     }
 
@@ -138,7 +137,6 @@ public class AuditLogHandlerResourceDefinition extends SimpleResourceDefinition 
         @Override
         protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
             auditLogger.recycleHandler(Util.getNameFromAddress(operation.require(OP_ADDR)));
-            context.stepCompleted();
         }
     }
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/FileAuditLogHandlerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/FileAuditLogHandlerResourceDefinition.java
@@ -131,7 +131,6 @@ public class FileAuditLogHandlerResourceDefinition extends AuditLogHandlerResour
                     if (!HandlerUtil.lookForFormatter(context, context.getCurrentAddress(), formatterName)) {
                         throw DomainManagementLogger.ROOT_LOGGER.noFormatterCalled(formatterName);
                     }
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.MODEL);
         }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogHandlerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogHandlerResourceDefinition.java
@@ -293,7 +293,6 @@ public class SyslogAuditLogHandlerResourceDefinition extends AuditLogHandlerReso
                     if (!HandlerUtil.lookForFormatter(context, context.getCurrentAddress(), formatterName)) {
                         throw DomainManagementLogger.ROOT_LOGGER.noFormatterCalled(formatterName);
                     }
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.MODEL);
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelActiveOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelActiveOperationHandler.java
@@ -82,7 +82,5 @@ public class CancelActiveOperationHandler implements OperationStepHandler {
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelNonProgressingOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelNonProgressingOperationHandler.java
@@ -109,7 +109,6 @@ public class CancelNonProgressingOperationHandler implements OperationStepHandle
             });
         } else {
             context.getFailureDescription().set(DomainManagementLogger.ROOT_LOGGER.noNonProgressingOperationFound(TimeUnit.NANOSECONDS.toSeconds(timeout)));
-            context.stepCompleted();
         }
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/FindNonProgressingOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/FindNonProgressingOperationHandler.java
@@ -85,6 +85,5 @@ public class FindNonProgressingOperationHandler implements OperationStepHandler 
                 break;
             }
         }
-        context.stepCompleted();
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/SecureOperationReadHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/SecureOperationReadHandler.java
@@ -71,7 +71,5 @@ public class SecureOperationReadHandler implements OperationStepHandler {
             // Programming error
             throw new IllegalStateException();
         }
-
-        context.stepCompleted();
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/AuthorizationValidatingHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/AuthorizationValidatingHandler.java
@@ -79,6 +79,5 @@ public class AuthorizationValidatingHandler implements OperationStepHandler {
             Set<String> invalid = new HashSet<String>(children);
             throw DomainManagementLogger.ROOT_LOGGER.multipleAuthorizationConfigurationsDefined(realmName, invalid);
         }
-        context.stepCompleted();
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthenticationResourceDefinition.java
@@ -146,8 +146,6 @@ public class LdapAuthenticationResourceDefinition extends LdapResourceDefinition
                     final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
                     final ModelNode model = resource.getModel();
                     validateAttributeCombination(model);
-
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.MODEL);
             super.execute(context, operation);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthorizationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthorizationResourceDefinition.java
@@ -149,8 +149,6 @@ public class LdapAuthorizationResourceDefinition extends LdapResourceDefinition 
                 throw DomainManagementLogger.ROOT_LOGGER.multipleGroupSearchConfigurationsDefined(realmName, invalid);
             }
 
-            context.stepCompleted();
-
         }
     }
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapCacheResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapCacheResourceDefinition.java
@@ -267,13 +267,9 @@ public class LdapCacheResourceDefinition extends SimpleResourceDefinition {
                         } else if (CONTAINS.equals(operationName)) {
                             contains(context, operation);
                         }
-
-                        context.stepCompleted();
                     }
                 }, Stage.RUNTIME);
             }
-
-            context.stepCompleted();
         }
 
         public abstract void flushCache(OperationContext context, ModelNode operation) throws OperationFailedException;
@@ -453,8 +449,6 @@ public class LdapCacheResourceDefinition extends SimpleResourceDefinition {
                 String realmName = ManagementUtil.getSecurityRealmName(operation);
                 throw DomainManagementLogger.ROOT_LOGGER.multipleCacheConfigurationsDefined(realmName);
             }
-
-            context.stepCompleted();
 
         }
     }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandler.java
@@ -248,9 +248,6 @@ public class ApplyRemoteMasterDomainModelHandler implements OperationStepHandler
             }
             context.addStep(subOperation, stepHandler, OperationContext.Stage.MODEL, true);
         }
-
-
-        context.stepCompleted();
     }
 
     private void clearDomain(final Resource rootResource) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
@@ -206,8 +206,6 @@ public class DomainServerLifecycleHandlers {
                     context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }
             }, Stage.RUNTIME);
-
-            context.stepCompleted();
         }
     }
 
@@ -251,8 +249,6 @@ public class DomainServerLifecycleHandlers {
                     context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }
             }, Stage.RUNTIME);
-
-            context.stepCompleted();
         }
     }
 
@@ -289,7 +285,6 @@ public class DomainServerLifecycleHandlers {
                     context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }
             }, Stage.RUNTIME);
-            context.stepCompleted();
         }
 
     }
@@ -326,7 +321,6 @@ public class DomainServerLifecycleHandlers {
                     context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }
             }, Stage.RUNTIME);
-            context.stepCompleted();
         }
 
     }
@@ -363,7 +357,6 @@ public class DomainServerLifecycleHandlers {
                     context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }
             }, Stage.RUNTIME);
-            context.stepCompleted();
         }
     }
 
@@ -395,7 +388,6 @@ public class DomainServerLifecycleHandlers {
                     context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }
             }, Stage.RUNTIME);
-            context.stepCompleted();
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainSocketBindingGroupRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainSocketBindingGroupRemoveHandler.java
@@ -111,7 +111,6 @@ public class DomainSocketBindingGroupRemoveHandler extends AbstractRemoveStepHan
                     if (!runningServers.isEmpty()) {
                         throw new OperationFailedException("Could not remove socket-binding-group since the following servers are running: " + runningServers);
                     }
-                    context.stepCompleted();
                 }
             }, Stage.MODEL);
         }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/LocalHostNameOperationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/LocalHostNameOperationHandler.java
@@ -42,7 +42,6 @@ public class LocalHostNameOperationHandler implements OperationStepHandler {
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         context.getResult().set(info.getLocalHostName());
-        context.stepCompleted();
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProcessTypeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProcessTypeHandler.java
@@ -48,6 +48,5 @@ public class ProcessTypeHandler implements OperationStepHandler {
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         context.getResult().set(master ? DOMAIN_CONTROLLER_TYPE : HOST_CONTROLLER_TYPE);
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileDescribeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileDescribeHandler.java
@@ -114,7 +114,6 @@ public class ProfileDescribeHandler implements OperationStepHandler {
                     }
                     context.getResult().set(result);
                 }
-                context.stepCompleted();
             }
         }, OperationContext.Stage.MODEL, true);
 
@@ -152,7 +151,6 @@ public class ProfileDescribeHandler implements OperationStepHandler {
                                 }
                             }
                         }
-                        context.stepCompleted();
                     }
                 }, OperationContext.Stage.MODEL, true);
 
@@ -176,7 +174,5 @@ public class ProfileDescribeHandler implements OperationStepHandler {
                 context.addStep(includeRsp, newOp, INSTANCE, OperationContext.Stage.MODEL, true);
             }
         }
-
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ResolveExpressionOnDomainHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ResolveExpressionOnDomainHandler.java
@@ -63,7 +63,5 @@ public class ResolveExpressionOnDomainHandler implements OperationStepHandler {
 
         // Just validate. The real work happens on the servers
         ResolveExpressionHandler.EXPRESSION.validateOperation(operation);
-
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ServerGroupRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ServerGroupRemoveHandler.java
@@ -78,7 +78,6 @@ public class ServerGroupRemoveHandler extends AbstractRemoveStepHandler {
                     if (!foundServer.isEmpty()) {
                         throw DomainControllerLogger.ROOT_LOGGER.cannotRemoveUsedServerGroup(serverGroup, foundServer);
                     }
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.VERIFY);
         }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainRolloutStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainRolloutStepHandler.java
@@ -108,7 +108,6 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
         if (context.hasFailureDescription()) {
             // abort
             context.setRollbackOnly();
-            context.stepCompleted();
             return;
         }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
@@ -82,7 +82,6 @@ public class DomainSlaveHandler implements OperationStepHandler {
         if (context.hasFailureDescription()) {
             // abort
             context.setRollbackOnly();
-            context.stepCompleted();
             return;
         }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationCoordinatorStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationCoordinatorStepHandler.java
@@ -125,7 +125,6 @@ public class OperationCoordinatorStepHandler {
         // the ability to do this is being disabled until it's clear that it's
         // not a problem
         context.getFailureDescription().set(DomainControllerLogger.ROOT_LOGGER.masterDomainControllerOnlyOperation(operation.get(OP).asString(), PathAddress.pathAddress(operation.get(OP_ADDR))));
-        context.stepCompleted();
     }
 
     /**
@@ -201,8 +200,6 @@ public class OperationCoordinatorStepHandler {
 
         // Finally, the step to formulate and execute the 2nd phase rollout plan
         context.addStep(new DomainRolloutStepHandler(hostProxies, serverProxies, overallContext, rolloutPlan, getExecutorService()), OperationContext.Stage.DOMAIN);
-
-        context.stepCompleted();
     }
 
     static void configureDomainUUID(ModelNode operation) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/PrepareStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/PrepareStepHandler.java
@@ -150,7 +150,6 @@ public class PrepareStepHandler  implements OperationStepHandler {
                 context.getFailureDescription().set(ControllerLogger.ROOT_LOGGER.noHandlerForOperation(operationName, pathAddress));
             }
         }
-        context.stepCompleted();
     }
 
     private static OperationStepHandler resolveWildcardOperationHandler(final PathAddress address, final String operationName,

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
@@ -132,8 +132,6 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
                 HOST_CONTROLLER_LOGGER.tracef("%s responseNode is %s", getClass().getSimpleName(), overallResult);
             }
         }
-
-        context.stepCompleted();
     }
 
     private Map<Set<ServerIdentity>, ModelNode> getServerOperations(OperationContext context, ModelNode domainOp, PathAddress domainOpAddress, boolean pushToServers) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/AbstractDeploymentUploadHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/AbstractDeploymentUploadHandler.java
@@ -82,8 +82,6 @@ public abstract class AbstractDeploymentUploadHandler implements OperationStepHa
             }
         }
         // else this is a slave domain controller and we should ignore this operation
-
-        context.stepCompleted();
     }
 
     protected abstract InputStream getContentInputStream(OperationContext context, ModelNode operation) throws OperationFailedException;

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
@@ -150,8 +150,6 @@ public class DeploymentAddHandler implements OperationStepHandler {
                     }
                 }
             });
-        } else {
-            context.stepCompleted();
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentRemoveHandler.java
@@ -89,7 +89,7 @@ public abstract class DeploymentRemoveHandler implements OperationStepHandler {
                             try {
                                 newHashes = DeploymentUtils.getDeploymentHexHash(context.readResource(PathAddress.EMPTY_ADDRESS, false).getModel());
                             } catch (NoSuchResourceException ex) {
-                                newHashes = Collections.EMPTY_SET;
+                                newHashes = Collections.emptySet();
                             }
                             removeContent(address, newHashes, deploymentHashes);
                         }
@@ -97,8 +97,6 @@ public abstract class DeploymentRemoveHandler implements OperationStepHandler {
                 });
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 
     protected void checkCanRemove(OperationContext context, ModelNode operation) throws OperationFailedException {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentAddHandler.java
@@ -99,8 +99,6 @@ public class ServerGroupDeploymentAddHandler implements OperationStepHandler {
                 validateRuntimeNames(name, context, address);
             }
         }, OperationContext.Stage.MODEL);
-
-        context.stepCompleted();
     }
 
     private void validateRuntimeNames(String deploymentName, OperationContext context, PathAddress address) throws OperationFailedException {
@@ -126,8 +124,6 @@ public class ServerGroupDeploymentAddHandler implements OperationStepHandler {
                 }
             }
         }
-
-        context.stepCompleted();
     }
 
     private static String getRuntimeName(String name, ModelNode deployment, ModelNode domainDeployment) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentDeployHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentDeployHandler.java
@@ -42,6 +42,5 @@ public class ServerGroupDeploymentDeployHandler implements OperationStepHandler 
 
     public void execute(OperationContext context, ModelNode operation) {
         context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel().get(ENABLED.getName()).set(true);
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentRedeployHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentRedeployHandler.java
@@ -45,6 +45,5 @@ public class ServerGroupDeploymentRedeployHandler implements OperationStepHandle
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         // We do nothing. This operation is really handled at the server level.
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentUndeployHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentUndeployHandler.java
@@ -42,6 +42,5 @@ public class ServerGroupDeploymentUndeployHandler implements OperationStepHandle
 
     public void execute(OperationContext context, ModelNode operation) {
         context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel().get(ENABLED).set(false);
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostConnectionResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostConnectionResourceDefinition.java
@@ -108,14 +108,12 @@ public class HostConnectionResourceDefinition extends SimpleResourceDefinition {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 slaveHosts.pruneExpired();
-                context.stepCompleted();
             }
         });
         resourceRegistration.registerOperationHandler(PRUNE_DISCONNECTED_DEF, new OperationStepHandler() {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 slaveHosts.pruneDisconnected();
-                context.stepCompleted();
             }
         });
 
@@ -140,7 +138,6 @@ public class HostConnectionResourceDefinition extends SimpleResourceDefinition {
                         break;
                 }
             }
-            context.stepCompleted();
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
@@ -720,7 +720,6 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             resource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
-            context.stepCompleted();
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/descriptions/HostEnvironmentResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/descriptions/HostEnvironmentResourceDefinition.java
@@ -214,7 +214,6 @@ public class HostEnvironmentResourceDefinition extends SimpleResourceDefinition 
             } else if (equals(name, HOST_NAME)) {
                 set(result, environment.getHostName());
             }
-            context.stepCompleted();
         }
 
         private void set(final ModelNode node, final int value) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
@@ -252,7 +252,6 @@ public class HostControllerRegistrationHandler implements ManagementRequestHandl
                 final String failureDescription = DomainControllerLogger.ROOT_LOGGER.slaveAlreadyRegistered(registrationContext.hostName);
                 registrationContext.failed(SlaveRegistrationException.ErrorCode.HOST_ALREADY_EXISTS, failureDescription);
                 context.getFailureDescription().set(failureDescription);
-                context.stepCompleted();
                 return;
             }
             // Read the extensions (with recursive true, otherwise the entries are runtime=true - which are going to be ignored for transformation)
@@ -293,8 +292,6 @@ public class HostControllerRegistrationHandler implements ManagementRequestHandl
             // Now run the read-domain model operation
             final ReadMasterDomainModelHandler handler = new ReadMasterDomainModelHandler(hostInfo.getHostName(), transformers, runtimeIgnoreTransformationRegistry);
             context.addStep(READ_DOMAIN_MODEL.getOperation(), handler, OperationContext.Stage.MODEL);
-            // Complete
-            context.stepCompleted();
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
@@ -167,7 +167,6 @@ public class MasterDomainControllerOperationHandlerService extends AbstractModel
                                 activeSlaveRequest = new SlaveRequest(domainControllerLockId);
                             }
                             context.addStep(operation, handler, OperationContext.Stage.MODEL);
-                            context.stepCompleted();
                         }
                     });
                 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/ServerToHostProtocolHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/ServerToHostProtocolHandler.java
@@ -233,7 +233,6 @@ public class ServerToHostProtocolHandler implements ManagementRequestHandlerFact
                 }
             } catch (IOException e) {
                 context.getFailureDescription().set(e.getMessage());
-                context.stepCompleted();
                 return;
             }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JVMOptionAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JVMOptionAddHandler.java
@@ -70,7 +70,5 @@ final class JVMOptionAddHandler implements OperationStepHandler {
             }
         }
         model.get(JvmAttributes.JVM_OPTIONS).add(option);
-
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JVMOptionRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JVMOptionRemoveHandler.java
@@ -70,7 +70,5 @@ final class JVMOptionRemoveHandler implements OperationStepHandler {
                 }
             }
         }
-
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HostModelRegistrationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HostModelRegistrationHandler.java
@@ -129,8 +129,6 @@ public class HostModelRegistrationHandler implements OperationStepHandler {
 
         // Create the empty discovery options resource
         context.createResource(hostAddress.append(PathElement.pathElement(CORE_SERVICE, DISCOVERY_OPTIONS)));
-
-        context.stepCompleted();
     }
 
     private static void initCoreModel(final ModelNode root, HostControllerEnvironment environment) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HostShutdownHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HostShutdownHandler.java
@@ -91,6 +91,5 @@ public class HostShutdownHandler implements OperationStepHandler {
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }
         }, OperationContext.Stage.RUNTIME);
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/IsMasterHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/IsMasterHandler.java
@@ -49,6 +49,5 @@ public class IsMasterHandler implements OperationStepHandler {
         final ModelNode subModel = context.readResource(PathAddress.EMPTY_ADDRESS, false).getModel();
         boolean master = subModel.get(ModelDescriptionConstants.DOMAIN_CONTROLLER).hasDefined(ModelDescriptionConstants.LOCAL);
         context.getResult().set(master);
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalDomainControllerRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalDomainControllerRemoveHandler.java
@@ -57,6 +57,5 @@ public class LocalDomainControllerRemoveHandler implements OperationStepHandler 
         final Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
         final ModelNode model = resource.getModel();
         model.get(DOMAIN_CONTROLLER).setEmptyObject();
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ResolveExpressionOnHostHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ResolveExpressionOnHostHandler.java
@@ -62,7 +62,5 @@ public class ResolveExpressionOnHostHandler implements OperationStepHandler {
 
         // Just validate. The real work happens on the servers
         ResolveExpressionHandler.EXPRESSION.validateOperation(operation);
-
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerAddHandler.java
@@ -85,7 +85,6 @@ public class ServerAddHandler extends AbstractAddStepHandler {
             @Override
             public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
                 context.addResource(PathAddress.EMPTY_ADDRESS, PlaceholderResource.INSTANCE);
-                context.stepCompleted();
             }
         }, OperationContext.Stage.MODEL, true);
 
@@ -145,10 +144,8 @@ public class ServerAddHandler extends AbstractAddStepHandler {
                                 throw HostControllerLogger.ROOT_LOGGER.noSocketBindingGroupCalled(socketBindingGroupName);
                             }
                         }
-                        context.stepCompleted();
                     }
                 }, Stage.MODEL);
-                context.stepCompleted();
             }
         }, Stage.MODEL);
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerProcessHandlers.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerProcessHandlers.java
@@ -75,8 +75,6 @@ public abstract class ServerProcessHandlers implements OperationStepHandler {
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 
     abstract void doExecute(String serverName);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerReloadHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerReloadHandler.java
@@ -70,10 +70,7 @@ public class ServerReloadHandler implements OperationStepHandler {
 
                 final ServerStatus status = serverInventory.reloadServer(serverName, blocking);
                 context.getResult().set(status.toString());
-                context.stepCompleted();
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRemoveHandler.java
@@ -76,7 +76,6 @@ public class ServerRemoveHandler extends AbstractRemoveStepHandler {
             @Override
             public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
                 context.removeResource(PathAddress.EMPTY_ADDRESS);
-                context.stepCompleted();
             }
         }, OperationContext.Stage.MODEL, true);
 
@@ -92,7 +91,6 @@ public class ServerRemoveHandler extends AbstractRemoveStepHandler {
                 if (controller != null) {
                     context.getFailureDescription().set(HostControllerLogger.ROOT_LOGGER.serverStillRunning(serverName));
                 }
-                context.stepCompleted();
             }
         }, OperationContext.Stage.RUNTIME);
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRestartHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRestartHandler.java
@@ -84,7 +84,5 @@ public class ServerRestartHandler implements OperationStepHandler {
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRestartRequiredServerConfigWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRestartRequiredServerConfigWriteAttributeHandler.java
@@ -175,10 +175,8 @@ public abstract class ServerRestartRequiredServerConfigWriteAttributeHandler ext
                                 throw HostControllerLogger.ROOT_LOGGER.noSocketBindingGroupCalled(socketBindingGroupName);
                             }
                         }
-                        context.stepCompleted();
                     }
                 }, Stage.MODEL);
-                context.stepCompleted();
             }
         }, Stage.MODEL);
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerResumeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerResumeHandler.java
@@ -71,11 +71,8 @@ public class ServerResumeHandler implements OperationStepHandler {
                 context.getServiceRegistry(true);
 
                 serverInventory.resumeServer(serverName);
-                context.stepCompleted();
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 
     static OperationDefinition getOperationDefinition() {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerStartHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerStartHandler.java
@@ -123,7 +123,5 @@ public class ServerStartHandler implements OperationStepHandler {
                 });
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerStatusHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerStatusHandler.java
@@ -71,7 +71,6 @@ public class ServerStatusHandler implements OperationStepHandler {
 
         if(status != null) {
             context.getResult().set(status.toString());
-            context.stepCompleted();
         } else {
             throw new OperationFailedException(HostControllerLogger.ROOT_LOGGER.failedToGetServerStatus());
         }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerStopHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerStopHandler.java
@@ -90,6 +90,5 @@ public class ServerStopHandler implements OperationStepHandler {
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }
         }, OperationContext.Stage.RUNTIME);
-        context.stepCompleted();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerSuspendHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerSuspendHandler.java
@@ -84,11 +84,8 @@ public class ServerSuspendHandler implements OperationStepHandler {
                 if(timeout!= 0) {
                     serverInventory.awaitServerSuspend(Collections.singleton(serverName), timeout > 0 ? timeout * 1000 : timeout);
                 }
-                context.stepCompleted();
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 
     static OperationDefinition getOperationDefinition() {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/StartServersHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/StartServersHandler.java
@@ -105,8 +105,6 @@ public class StartServersHandler implements OperationStepHandler {
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 
     private void cleanStartServers(final ModelNode servers, final ModelNode domainModel, OperationContext context) throws OperationFailedException {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
@@ -166,8 +166,6 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
             if (model.hasDefined(SECURITY_REALM.getName()) == false && model.hasDefined(HTTPS_PORT.getName())) {
                 throw ROOT_LOGGER.noSecurityRealmForSsl();
             }
-
-            context.stepCompleted();
         }
 
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/StoppedServerResource.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/StoppedServerResource.java
@@ -69,7 +69,6 @@ public class StoppedServerResource extends SimpleResourceDefinition {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 context.getResult().set("STOPPED");
-                context.stepCompleted();
             }
         });
 

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -483,15 +483,21 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
             this.rollback = rollback;
         }
 
+        @Override
         public void completeStep(ResultHandler resultHandler) {
             if (nextStep != null) {
-                stepCompleted();
+                completed();
             } else if (rollback) {
                 resultHandler.handleResult(ResultAction.ROLLBACK, this, null);
             }
         }
 
+        @Override
         public void stepCompleted() {
+            completed();
+        }
+
+        private void completed() {
             if (nextStep != null) {
                 try {
                     OperationStepHandler step = nextStep;

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
@@ -230,7 +230,7 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         operation.get(NAME).set(PROFILE);
         operation.get(VALUE).set(profileName);
 
-        new ServerGroupProfileWriteAttributeHandler(master, null).execute(operationContext, operation);
+        operationContext.executeStep(new ServerGroupProfileWriteAttributeHandler(master, null), operation);
 
         if (master && badProfile) {
             //master will throw an exception
@@ -304,7 +304,7 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         operation.get(NAME).set(SOCKET_BINDING_GROUP);
         operation.get(VALUE).set(socketBindingGroupName);
 
-        new ServerGroupSocketBindingGroupWriteAttributeHandler(master, null).execute(operationContext, operation);
+        operationContext.executeStep(new ServerGroupSocketBindingGroupWriteAttributeHandler(master, null), operation);
 
         if (master && badSocketBindingGroup) {
             //master will throw an exception
@@ -335,6 +335,14 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         protected MockOperationContext(final Resource root, final boolean booting, final PathAddress operationAddress, final boolean rollback) {
             super(root, booting, operationAddress);
             this.rollback = rollback;
+        }
+
+        void executeStep(OperationStepHandler handler, ModelNode operation) throws OperationFailedException {
+            OperationStepHandler next = nextStep;
+            handler.execute(this, operation);
+            if (nextStep != null) {
+                stepCompleted();
+            }
         }
 
         public void completeStep(ResultHandler resultHandler) {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
@@ -338,22 +338,27 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         }
 
         void executeStep(OperationStepHandler handler, ModelNode operation) throws OperationFailedException {
-            OperationStepHandler next = nextStep;
             handler.execute(this, operation);
             if (nextStep != null) {
-                stepCompleted();
+                completed();
             }
         }
 
+        @Override
         public void completeStep(ResultHandler resultHandler) {
             if (nextStep != null) {
-                stepCompleted();
+                completed();
             } else if (rollback) {
                 resultHandler.handleResult(ResultAction.ROLLBACK, this, null);
             }
         }
 
+        @Override
         public void stepCompleted() {
+            completed();
+        }
+
+        private void completed() {
             if (nextStep != null) {
                 try {
                     OperationStepHandler step = nextStep;

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemRootResource.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemRootResource.java
@@ -137,7 +137,6 @@ public class JMXSubsystemRootResource extends SimpleResourceDefinition {
                     context.addStep(addOp, handler, Stage.MODEL, true);
                 }
             }
-            context.stepCompleted();
         }
     }
 
@@ -148,7 +147,6 @@ public class JMXSubsystemRootResource extends SimpleResourceDefinition {
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
             context.getResult().set(resource.hasChild(PathElement.pathElement(CommonAttributes.EXPOSE_MODEL, CommonAttributes.RESOLVED)));
-            context.stepCompleted();
         }
 
     }

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerResourceDefinition.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerResourceDefinition.java
@@ -197,7 +197,6 @@ public class ModelControllerResourceDefinition extends SimpleResourceDefinition 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             invoked = true;
-            context.stepCompleted();
         }
     }
 
@@ -247,7 +246,6 @@ public class ModelControllerResourceDefinition extends SimpleResourceDefinition 
             invoked = true;
             long l = operation.get("param1").resolve().asLong() + context.readResource(PathAddress.EMPTY_ADDRESS).getModel().get("int").asInt() + operation.get("param3", "test").resolve().asInt();
             context.getResult().set(operation.get("param2").resolve().asList().get(0).asString() + l);
-            context.stepCompleted();
         }
 
         private static class IntAllowedValuesValidator extends ModelTypeValidator implements AllowedValuesValidator{
@@ -279,7 +277,6 @@ public class ModelControllerResourceDefinition extends SimpleResourceDefinition 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             context.getResult().set(operation.get("param1"));
-            context.stepCompleted();
         }
 
     }

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
@@ -910,7 +910,6 @@ public class JmxFacadeRbacEnabledTestCase extends AbstractControllerTestBase {
             } else {
                 context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
             }
-            context.stepCompleted();
         }
     }
 

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
@@ -547,7 +547,6 @@ public abstract class JmxRbacTestCase extends AbstractControllerTestBase {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 context.getResult().set(TYPE_STANDALONE);
-                context.stepCompleted();
             }
         }, AttributeAccess.Storage.RUNTIME);
 

--- a/logging/src/main/java/org/jboss/as/logging/LogFileResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/LogFileResourceDefinition.java
@@ -171,7 +171,6 @@ class LogFileResourceDefinition extends SimpleResourceDefinition {
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
-                context.stepCompleted();
             }
         };
         resourceRegistration.registerReadOnlyAttribute(STREAM, streamHandler);

--- a/logging/src/main/java/org/jboss/as/logging/LoggingOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingOperations.java
@@ -132,7 +132,6 @@ final class LoggingOperations {
             if (filter.isDefined()) {
                 context.getResult().set(Filters.filterSpecToFilter(filter.asString()));
             }
-            context.stepCompleted();
         }
     }
 
@@ -168,8 +167,6 @@ final class LoggingOperations {
                         configurationPersistence.rollback();
                     }
                 });
-            } else {
-                context.stepCompleted();
             }
         }
 
@@ -205,7 +202,6 @@ final class LoggingOperations {
                     @Override
                     public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
                         performRuntime(context, operation, logContextConfiguration, name, model);
-                        context.stepCompleted();
                     }
                 }, Stage.RUNTIME);
             }
@@ -239,7 +235,6 @@ final class LoggingOperations {
                     @Override
                     public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
                         performRuntime(context, operation, logContextConfiguration, name, model);
-                        context.stepCompleted();
                     }
                 }, Stage.RUNTIME);
             }
@@ -274,7 +269,6 @@ final class LoggingOperations {
                     @Override
                     public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
                         performRuntime(context, operation, logContextConfiguration, name, model);
-                        context.stepCompleted();
                     }
                 }, Stage.RUNTIME);
             }

--- a/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentAddHandler.java
+++ b/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentAddHandler.java
@@ -57,7 +57,5 @@ public class ManagedDMRContentAddHandler extends AbstractAddStepHandler {
         context.addResource(PathAddress.EMPTY_ADDRESS, resource);
         // IMPORTANT: Use writeModel, as this is what causes the content to be flushed to the content repo!
         resource.writeModel(model);
-
-        context.stepCompleted();
     }
 }

--- a/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentStoreHandler.java
+++ b/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentStoreHandler.java
@@ -74,7 +74,5 @@ public class ManagedDMRContentStoreHandler implements OperationStepHandler {
 
         // IMPORTANT: Use writeModel, as this is what causes the content to be flushed to the content repo!
         resource.writeModel(model);
-
-        context.stepCompleted();
     }
 }

--- a/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentTypeAddHandler.java
+++ b/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentTypeAddHandler.java
@@ -57,7 +57,5 @@ public class ManagedDMRContentTypeAddHandler implements OperationStepHandler {
         // Create and add the specialized resource type we use for this resource tree
         ManagedDMRContentTypeResource resource = new ManagedDMRContentTypeResource(address, childType, hash, contentRepository);
         context.addResource(PathAddress.EMPTY_ADDRESS, resource);
-
-        context.stepCompleted();
     }
 }

--- a/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentWriteAttributeHandler.java
+++ b/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentWriteAttributeHandler.java
@@ -55,7 +55,5 @@ public class ManagedDMRContentWriteAttributeHandler implements OperationStepHand
         final Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
         // IMPORTANT: Use writeModel, as this is what causes the content to be flushed to the content repo!
         resource.writeModel(model);
-
-        context.stepCompleted();
     }
 }

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -326,7 +326,6 @@ public abstract class ModelTestModelControllerService extends AbstractController
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 resourceRef.set(context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, true));
                 context.getResult().setEmptyObject();
-                context.stepCompleted();
             }
         });
         Resource rootResource = resourceRef.get();

--- a/patching/src/main/java/org/jboss/as/patching/management/LocalPatchOperationStepHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/LocalPatchOperationStepHandler.java
@@ -83,7 +83,6 @@ public final class LocalPatchOperationStepHandler implements OperationStepHandle
             final ModelNode failureDescription = context.getFailureDescription();
             PatchOperationTarget.formatFailedResponse(e, failureDescription);
             installationManager.clearRestartRequired();
-            context.stepCompleted();
         }
     }
 

--- a/patching/src/main/java/org/jboss/as/patching/management/LocalPatchRollbackHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/LocalPatchRollbackHandler.java
@@ -82,7 +82,6 @@ public class LocalPatchRollbackHandler implements OperationStepHandler {
             final ModelNode failureDescription = context.getFailureDescription();
             PatchOperationTarget.formatFailedResponse(e, failureDescription);
             installationManager.clearRestartRequired();
-            context.stepCompleted();
         } finally {
             //
         }

--- a/patching/src/main/java/org/jboss/as/patching/management/LocalPatchRollbackLastHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/LocalPatchRollbackLastHandler.java
@@ -80,7 +80,6 @@ public class LocalPatchRollbackLastHandler implements OperationStepHandler {
             final ModelNode failureDescription = context.getFailureDescription();
             PatchOperationTarget.formatFailedResponse(e, failureDescription);
             installationManager.clearRestartRequired();
-            context.stepCompleted();
         } finally {
             //
         }

--- a/patching/src/main/java/org/jboss/as/patching/management/LocalShowHistoryHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/LocalShowHistoryHandler.java
@@ -52,7 +52,6 @@ public final class LocalShowHistoryHandler implements OperationStepHandler {
             final PatchableTarget.TargetInfo info = installationManager.getIdentity().loadTargetInfo();
             final ModelNode result =  PatchingHistory.Factory.getHistory(installationManager, info);
             context.getResult().set(result);
-            context.stepCompleted();
         } catch (Throwable t) {
             PatchLogger.ROOT_LOGGER.debugf(t, "failed to get history");
             throw PatchLogger.ROOT_LOGGER.failedToShowHistory(t);

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CompilationMXBeanReadResourceHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CompilationMXBeanReadResourceHandler.java
@@ -64,7 +64,5 @@ public class CompilationMXBeanReadResourceHandler implements OperationStepHandle
 
         final ModelNode store = result.get(PlatformMBeanConstants.OBJECT_NAME.getName());
         CompilationMXBeanAttributeHandler.storeResult(PlatformMBeanConstants.OBJECT_NAME.getName(), store);
-
-        context.stepCompleted();
     }
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryMXBeanGCHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryMXBeanGCHandler.java
@@ -61,6 +61,5 @@ public class MemoryMXBeanGCHandler implements OperationStepHandler {
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }
         }, OperationContext.Stage.RUNTIME);
-        context.stepCompleted();
     }
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolMXBeanReadResourceHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolMXBeanReadResourceHandler.java
@@ -80,8 +80,5 @@ public class MemoryPoolMXBeanReadResourceHandler implements OperationStepHandler
         }
         final ModelNode store = result.get(PlatformMBeanConstants.OBJECT_NAME.getName());
         MemoryPoolMXBeanAttributeHandler.storeResult(PlatformMBeanConstants.OBJECT_NAME.getName(), store, memoryPoolMXBean, memPoolName);
-
-
-        context.stepCompleted();
     }
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/OperatingSystemMXBeanReadResourceHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/OperatingSystemMXBeanReadResourceHandler.java
@@ -68,7 +68,5 @@ public class OperatingSystemMXBeanReadResourceHandler implements OperationStepHa
 
         final ModelNode store = result.get(PlatformMBeanConstants.OBJECT_NAME.getName());
         OperatingSystemMXBeanAttributeHandler.storeResult(PlatformMBeanConstants.OBJECT_NAME.getName(), store);
-
-        context.stepCompleted();
     }
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/PlatformLoggingMXBeanGetLoggerLevelHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/PlatformLoggingMXBeanGetLoggerLevelHandler.java
@@ -82,8 +82,6 @@ public class PlatformLoggingMXBeanGetLoggerLevelHandler implements OperationStep
         } catch (JMException e) {
             throw new RuntimeException(e);
         }
-
-        context.stepCompleted();
     }
 
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/PlatformLoggingMXBeanGetParentLoggerNameHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/PlatformLoggingMXBeanGetParentLoggerNameHandler.java
@@ -83,8 +83,6 @@ public class PlatformLoggingMXBeanGetParentLoggerNameHandler implements Operatio
         } catch (JMException e) {
             throw new RuntimeException(e);
         }
-
-        context.stepCompleted();
     }
 
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/RuntimeMXBeanReadResourceHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/RuntimeMXBeanReadResourceHandler.java
@@ -63,7 +63,5 @@ public class RuntimeMXBeanReadResourceHandler implements OperationStepHandler {
         }
         final ModelNode store = result.get(PlatformMBeanConstants.OBJECT_NAME.getName());
         RuntimeMXBeanAttributeHandler.storeResult(PlatformMBeanConstants.OBJECT_NAME.getName(), store);
-
-        context.stepCompleted();
     }
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanCpuTimeHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanCpuTimeHandler.java
@@ -67,7 +67,5 @@ public class ThreadMXBeanCpuTimeHandler implements OperationStepHandler {
         } catch (UnsupportedOperationException e) {
             throw new OperationFailedException(e.toString());
         }
-
-        context.stepCompleted();
     }
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanDumpAllThreadsHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanDumpAllThreadsHandler.java
@@ -85,8 +85,6 @@ public class ThreadMXBeanDumpAllThreadsHandler implements OperationStepHandler {
         } catch (UnsupportedOperationException e) {
             throw new OperationFailedException(e.toString());
         }
-
-        context.stepCompleted();
     }
 
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanFindDeadlockedThreadsHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanFindDeadlockedThreadsHandler.java
@@ -68,8 +68,6 @@ public class ThreadMXBeanFindDeadlockedThreadsHandler implements OperationStepHa
         } catch (SecurityException e) {
             throw new OperationFailedException(e.toString());
         }
-
-        context.stepCompleted();
     }
 
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanFindMonitorDeadlockedThreadsHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanFindMonitorDeadlockedThreadsHandler.java
@@ -68,8 +68,6 @@ public class ThreadMXBeanFindMonitorDeadlockedThreadsHandler implements Operatio
         } catch (SecurityException e) {
             throw new OperationFailedException(e.toString());
         }
-
-        context.stepCompleted();
     }
 
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanReadResourceHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanReadResourceHandler.java
@@ -79,7 +79,5 @@ public class ThreadMXBeanReadResourceHandler implements OperationStepHandler {
 
         final ModelNode store = result.get(PlatformMBeanConstants.OBJECT_NAME.getName());
         ThreadMXBeanAttributeHandler.storeResult(PlatformMBeanConstants.OBJECT_NAME.getName(), store);
-
-        context.stepCompleted();
     }
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanThreadInfoHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanThreadInfoHandler.java
@@ -83,8 +83,6 @@ public class ThreadMXBeanThreadInfoHandler implements OperationStepHandler {
         } catch (SecurityException e) {
             throw new OperationFailedException(e.toString());
         }
-
-        context.stepCompleted();
     }
 
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanThreadInfosHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanThreadInfosHandler.java
@@ -103,8 +103,6 @@ public class ThreadMXBeanThreadInfosHandler implements OperationStepHandler {
         } catch (SecurityException e) {
             throw new OperationFailedException(e.toString());
         }
-
-        context.stepCompleted();
     }
 
     private long[] getIds(final ModelNode operation) throws OperationFailedException {

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanUserTimeHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadMXBeanUserTimeHandler.java
@@ -67,7 +67,5 @@ public class ThreadMXBeanUserTimeHandler implements OperationStepHandler {
         } catch (UnsupportedOperationException e) {
             throw new OperationFailedException(e.toString());
         }
-
-        context.stepCompleted();
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/WorkerThreadPoolVsEndpointHandler.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/WorkerThreadPoolVsEndpointHandler.java
@@ -86,7 +86,5 @@ class WorkerThreadPoolVsEndpointHandler implements OperationStepHandler {
             // users can read the default config attribute values
             context.addResource(PathAddress.pathAddress(RemotingEndpointResource.ENDPOINT_PATH), Resource.Factory.create());
         }
-
-        context.stepCompleted();
     }
 }

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/ActiveRequestsReadHandler.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/ActiveRequestsReadHandler.java
@@ -44,6 +44,5 @@ class ActiveRequestsReadHandler extends AbstractRuntimeOnlyHandler {
         } else {
             context.getResult().set(-1);
         }
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/AbstractDeploymentChainStep.java
+++ b/server/src/main/java/org/jboss/as/server/AbstractDeploymentChainStep.java
@@ -48,7 +48,6 @@ public abstract class AbstractDeploymentChainStep implements OperationStepHandle
 
     public final void execute(final OperationContext context, final ModelNode operation) {
         execute(TARGET);
-        context.stepCompleted();
     }
 
     /**

--- a/server/src/main/java/org/jboss/as/server/DeployerChainAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/DeployerChainAddHandler.java
@@ -107,12 +107,9 @@ public class DeployerChainAddHandler implements OperationStepHandler {
                 public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
 
                     context.addStep(new FinalRuntimeStepHandler(), OperationContext.Stage.RUNTIME);
-
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.stepCompleted();
     }
 
 

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironmentResourceDescription.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironmentResourceDescription.java
@@ -181,8 +181,6 @@ public class ServerEnvironmentResourceDescription extends SimpleResourceDefiniti
             if (equals(name, TEMP_DIR)) {
                 set(result, environment.getServerTempDir());
             }
-
-            context.stepCompleted();
         }
 
         private void set(final ModelNode node, final String value) {

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ModuleLoadingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ModuleLoadingResourceDefinition.java
@@ -136,8 +136,6 @@ public class ModuleLoadingResourceDefinition extends SimpleResourceDefinition {
             } catch (PrivilegedActionException e) {
                 throw new IllegalStateException(e.getCause());
             }
-
-            context.stepCompleted();
         }
 
         private static void storeRepoRoots(final ModelNode list) throws NoSuchFieldException, IllegalAccessException {
@@ -198,11 +196,8 @@ public class ModuleLoadingResourceDefinition extends SimpleResourceDefinition {
                     } catch (PrivilegedActionException e) {
                         throw new OperationFailedException(e.getCause());
                     }
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.RUNTIME);
-
-            context.stepCompleted();
         }
     }
 

--- a/server/src/main/java/org/jboss/as/server/deployment/AbstractDeploymentUploadHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/AbstractDeploymentUploadHandler.java
@@ -80,8 +80,6 @@ public abstract class AbstractDeploymentUploadHandler implements OperationStepHa
         catch (IOException e) {
             throw ServerLogger.ROOT_LOGGER.caughtIOExceptionUploadingContent(e);
         }
-
-        context.stepCompleted();
     }
 
     protected abstract InputStream getContentInputStream(OperationContext context, ModelNode operation) throws IOException, OperationFailedException;

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
@@ -150,8 +150,6 @@ public class DeploymentAddHandler implements OperationStepHandler {
                     }
                 }
             });
-        } else {
-            context.stepCompleted();
         }
     }
 
@@ -174,8 +172,6 @@ public class DeploymentAddHandler implements OperationStepHandler {
                 }
             }
         }
-
-        context.stepCompleted();
     }
 
     private static String getRuntimeName(String name, ModelNode deployment) {

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentDeployHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentDeployHandler.java
@@ -60,7 +60,5 @@ public class DeploymentDeployHandler implements OperationStepHandler {
         final DeploymentHandlerUtil.ContentItem[] contents = getContents(CONTENT_ALL.resolveModelAttribute(context, model));
         DeploymentHandlerUtil.deploy(context, runtimeName, name, vaultReader, contents);
         DeploymentUtils.enableAttribute(model);
-
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentRedeployHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentRedeployHandler.java
@@ -59,7 +59,5 @@ public class DeploymentRedeployHandler implements OperationStepHandler {
         final String runtimeName = RUNTIME_NAME.resolveModelAttribute(context, model).asString();
         final DeploymentHandlerUtil.ContentItem[] contents = getContents(CONTENT_ALL.resolveModelAttribute(context, model));
         redeploy(context, runtimeName, name, vaultReader, contents);
-
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentRemoveHandler.java
@@ -131,8 +131,6 @@ public class DeploymentRemoveHandler implements OperationStepHandler {
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-
-        context.stepCompleted();
     }
 
     private void recoverServices(OperationContext context, ModelNode model, Resource deployment, String runtimeName,

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentReplaceHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentReplaceHandler.java
@@ -130,8 +130,6 @@ public class DeploymentReplaceHandler implements OperationStepHandler {
 
         final DeploymentHandlerUtil.ContentItem[] contents = getContents(deployNode.require(CONTENT));
         DeploymentHandlerUtil.replace(context, replaceNode, runtimeName, name, replacedName, vaultReader, contents);
-
-        context.stepCompleted();
     }
 
     protected void addFromHash(ContentReference reference) throws OperationFailedException {

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentStatusHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentStatusHandler.java
@@ -64,10 +64,7 @@ public class DeploymentStatusHandler implements OperationStepHandler {
                         result.set(NO_METRICS);
                     }
                 }
-                context.stepCompleted();
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentUndeployHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentUndeployHandler.java
@@ -55,7 +55,5 @@ public class DeploymentUndeployHandler implements OperationStepHandler {
 
         DeploymentHandlerUtil.undeploy(context, managementName, deploymentUnitName, vaultReader);
         DeploymentUtils.disableAttribute(model);
-
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/ReadContentHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/ReadContentHandler.java
@@ -65,8 +65,6 @@ public class ReadContentHandler implements OperationStepHandler {
         } catch (IOException e) {
             throw ServerLogger.ROOT_LOGGER.failedToLoadFile(file, e);
         }
-
-        context.stepCompleted();
     }
 
 

--- a/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
@@ -203,8 +203,6 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
                     && (model.hasDefined(SECURE_SOCKET_BINDING.getName()) || model.hasDefined(HTTPS_PORT.getName()))) {
                 throw ROOT_LOGGER.noSecurityRealmForSsl();
             }
-
-            context.stepCompleted();
         }
 
     }

--- a/server/src/main/java/org/jboss/as/server/operations/CleanObsoleteContentHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/CleanObsoleteContentHandler.java
@@ -84,7 +84,6 @@ public class CleanObsoleteContentHandler implements OperationStepHandler {
                 context.getResult().get(ContentRepository.DELETED_CONTENT).add(obsoleteContent);
             }
         }
-        context.stepCompleted();
     }
 
 }

--- a/server/src/main/java/org/jboss/as/server/operations/DumpServicesHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/DumpServicesHandler.java
@@ -65,10 +65,8 @@ public class DumpServicesHandler implements OperationStepHandler {
                 service.getServiceContainer().dumpServices(print);
                 print.flush();
                 context.getResult().set(new String(out.toByteArray()));
-                context.stepCompleted();
             }
         }, OperationContext.Stage.RUNTIME);
-        context.stepCompleted();
     }
 
 }

--- a/server/src/main/java/org/jboss/as/server/operations/LaunchTypeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/LaunchTypeHandler.java
@@ -44,6 +44,5 @@ public class LaunchTypeHandler implements OperationStepHandler {
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         context.getResult().set(launchType.toString());
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementWriteAttributeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementWriteAttributeHandler.java
@@ -58,7 +58,6 @@ public class NativeManagementWriteAttributeHandler extends ReloadRequiredWriteAt
                     throw ServerLogger.ROOT_LOGGER.conflictingConfigs(NativeManagementResourceDefinition.INTERFACE.getName(),
                             NativeManagementResourceDefinition.SOCKET_BINDING.getName());
                 }
-                context.stepCompleted();
             }
         }, OperationContext.Stage.MODEL);
 

--- a/server/src/main/java/org/jboss/as/server/operations/ProcessTypeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ProcessTypeHandler.java
@@ -43,6 +43,5 @@ public class ProcessTypeHandler implements OperationStepHandler {
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         context.getResult().set("Server");
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/operations/RunningModeReadHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/RunningModeReadHandler.java
@@ -44,7 +44,6 @@ public class RunningModeReadHandler implements OperationStepHandler {
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         context.getResult().set(runningModeControl.getRunningMode().name());
-        context.stepCompleted();
     }
 
 

--- a/server/src/main/java/org/jboss/as/server/operations/ServerDomainProcessShutdownHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerDomainProcessShutdownHandler.java
@@ -110,7 +110,5 @@ public class ServerDomainProcessShutdownHandler implements OperationStepHandler 
                 });
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/operations/ServerResumeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerResumeHandler.java
@@ -82,7 +82,5 @@ public class ServerResumeHandler implements OperationStepHandler {
                 });
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/operations/ServerShutdownHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerShutdownHandler.java
@@ -140,8 +140,6 @@ public class ServerShutdownHandler implements OperationStepHandler {
                 });
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 
     private final class ShutdownAction extends AtomicBoolean {

--- a/server/src/main/java/org/jboss/as/server/operations/ServerVersionOperations.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerVersionOperations.java
@@ -46,8 +46,6 @@ public class ServerVersionOperations {
             } else if (attr.equals(ModelDescriptionConstants.SCHEMA_LOCATIONS)) {
                 getAttributeValueOrDefault(ServerRootResourceDefinition.SCHEMA_LOCATIONS, context);
             }
-
-            context.stepCompleted();
         }
 
         private void getAttributeValueOrDefault(AttributeDefinition def, OperationContext context) throws OperationFailedException {

--- a/server/src/main/java/org/jboss/as/server/operations/SetServerGroupHostHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/SetServerGroupHostHandler.java
@@ -59,6 +59,5 @@ public class SetServerGroupHostHandler implements OperationStepHandler {
 
         ServerRootResourceDefinition.SERVER_GROUP.validateAndSet(operation, model);
         ServerRootResourceDefinition.HOST.validateAndSet(operation, model);
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/operations/SuspendStateReadHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/SuspendStateReadHandler.java
@@ -46,7 +46,6 @@ public class SuspendStateReadHandler implements OperationStepHandler {
         if(sc != null) {
             context.getResult().set(sc.getValue().getState().name());
         }
-        context.stepCompleted();
     }
 
 

--- a/server/src/main/java/org/jboss/as/server/operations/SystemPropertyAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/SystemPropertyAddHandler.java
@@ -166,7 +166,6 @@ public class SystemPropertyAddHandler implements OperationStepHandler{
                     // Should not be possible -- see initial assert
                     throw new RuntimeException(resolutionFailure);
                 }
-                context.stepCompleted();
             }
         }, OperationContext.Stage.VERIFY);
     }

--- a/server/src/main/java/org/jboss/as/server/services/net/BindingGroupAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingGroupAddHandler.java
@@ -92,8 +92,6 @@ public class BindingGroupAddHandler extends AbstractSocketBindingGroupAddHandler
                 }
 
                 SocketBindingGroupResourceDefinition.validateDefaultInterfaceReference(context, model);
-
-                context.stepCompleted();
             }
         }, OperationContext.Stage.MODEL);
     }

--- a/server/src/main/java/org/jboss/as/server/services/net/BindingMetricHandlers.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingMetricHandlers.java
@@ -71,12 +71,8 @@ public final class BindingMetricHandlers {
                     } else {
                         result.set(getNoMetrics());
                     }
-
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.RUNTIME);
-
-            context.stepCompleted();
         }
 
         abstract void execute(ModelNode operation, SocketBinding binding, ModelNode result);

--- a/server/src/main/java/org/jboss/as/server/services/net/NetworkInterfaceRuntimeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/NetworkInterfaceRuntimeHandler.java
@@ -72,10 +72,7 @@ public class NetworkInterfaceRuntimeHandler implements OperationStepHandler {
                     }
                     context.getResult().set(result);
                 }
-                context.stepCompleted();
             }
         }, OperationContext.Stage.RUNTIME);
-
-        context.stepCompleted();
     }
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/SpecifiedInterfaceResolveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SpecifiedInterfaceResolveHandler.java
@@ -90,8 +90,6 @@ public class SpecifiedInterfaceResolveHandler implements OperationStepHandler {
         } catch (UnknownHostException e) {
             throw ServerLogger.ROOT_LOGGER.cannotResolveInterface(e, e);
         }
-
-        context.stepCompleted();
     }
 
     private void validateAndSet(final AttributeDefinition definition, final ModelNode operation, final ModelNode subModel) throws OperationFailedException {

--- a/server/src/test/java/org/jboss/as/server/deployment/DeploymentAddHandlerTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/deployment/DeploymentAddHandlerTestCase.java
@@ -74,7 +74,7 @@ public class DeploymentAddHandlerTestCase {
         operation.get("content").get(0).get("path").set("test.war");
         handler.execute(context, operation);
         Mockito.verify(context).addStep(Mockito.any(OperationStepHandler.class), OperationContext.Stage.RUNTIME);
-        Mockito.verify(context).stepCompleted();
+        //Mockito.verify(context).stepCompleted();
 
     }
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ReadTransformedResourceOperation.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ReadTransformedResourceOperation.java
@@ -97,7 +97,6 @@ class ReadTransformedResourceOperation implements OperationStepHandler {
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 ModelNode transformed = transformReadResourceResult(context, readResourceResult, subsystem);
                 context.getResult().set(transformed);
-                context.stepCompleted();
             }
         }, OperationContext.Stage.MODEL, true);
 
@@ -108,6 +107,5 @@ class ReadTransformedResourceOperation implements OperationStepHandler {
         op.get(RECURSIVE).set(true);
         op.get(INCLUDE_DEFAULTS).set(includeDefaults);
         context.addStep(readResourceResult, op, ReadResourceHandler.INSTANCE, OperationContext.Stage.MODEL, true);
-        context.stepCompleted();
     }
 }

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/VersionedExtension2.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/VersionedExtension2.java
@@ -82,7 +82,6 @@ public class VersionedExtension2 extends VersionedExtensionCommon {
                 final ModelNode model = resource.getModel();
                 model.get("test-attribute").set("test");
                 context.getResult().set(model);
-                context.stepCompleted();
             }
         });
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/VersionedExtension1.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/VersionedExtension1.java
@@ -56,7 +56,6 @@ public class VersionedExtension1 extends VersionedExtensionCommon {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 context.getResult().set(true);
-                context.stepCompleted();
             }
         });
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/VersionedExtension2.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/VersionedExtension2.java
@@ -81,7 +81,6 @@ public class VersionedExtension2 extends VersionedExtensionCommon {
                 final ModelNode model = resource.getModel();
                 model.get("test-attribute").set("test");
                 context.getResult().set(model);
-                context.stepCompleted();
             }
         });
 
@@ -94,7 +93,6 @@ public class VersionedExtension2 extends VersionedExtensionCommon {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 context.getResult().set(true);
-                context.stepCompleted();
             }
         });
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/vault/module/TestVaultResolveExpressionHandler.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/vault/module/TestVaultResolveExpressionHandler.java
@@ -52,10 +52,8 @@ public class TestVaultResolveExpressionHandler implements OperationStepHandler {
             public void execute(OperationContext context, ModelNode operation)
                     throws OperationFailedException {
                 context.getResult().set(context.resolveExpressions(operation.get(TestVaultResolveExpressionHandler.PARAM_EXPRESSION.getName())));
-                context.stepCompleted();
             }
         }, Stage.RUNTIME);
-        context.stepCompleted();
     }
 
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -218,7 +218,6 @@ public class BlockerExtension implements Extension {
                             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                                 context.getFailureDescription().set("rollback");
                                 context.setRollbackOnly();
-                                context.stepCompleted();
                             }
                         }, OperationContext.Stage.MODEL);
                         break;
@@ -236,9 +235,6 @@ public class BlockerExtension implements Extension {
                         }
                     }
                 });
-            } else {
-
-                context.stepCompleted();
             }
         }
 
@@ -262,7 +258,6 @@ public class BlockerExtension implements Extension {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 block(blockTime);
-                context.stepCompleted();
             }
         }
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/streams/LogStreamExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/streams/LogStreamExtension.java
@@ -145,7 +145,6 @@ public class LogStreamExtension implements Extension {
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-            context.stepCompleted();
         }
 
         private void logPropValue(OperationContext context) {


### PR DESCRIPTION
Also remove all OperationContext.stepCompleted() calls from core.


This eliminates some unintuitive boilerplate from management development.