### PR TITLE
[WFCORE-507] :  Unit test FileSystemDeploymentServiceUnitTestCase fails on IBM JDK.

### DIFF
--- a/deployment-scanner/pom.xml
+++ b/deployment-scanner/pom.xml
@@ -37,6 +37,33 @@
 
     <name>WildFly: Deployment Scanner</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar}</argLine>
+                    <systemPropertyVariables>
+                        <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
+                        <org.jboss.byteman.contrib.bmunit.agent.port>9091</org.jboss.byteman.contrib.bmunit.agent.port>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/patching/pom.xml
+++ b/patching/pom.xml
@@ -52,14 +52,26 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <property>
-                            <name>org.wildfly.patching.jar.invalidation</name>
-                            <value>true</value>
-                        </property>
-                    </systemProperties>
+                     <argLine>-javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar} -Dorg.jboss.byteman.debug=true</argLine>
+                    <systemPropertyVariables>
+                        <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
+                        <org.jboss.byteman.debug>true</org.jboss.byteman.debug>
+                        <org.jboss.byteman.contrib.bmunit.agent.port>9091</org.jboss.byteman.contrib.bmunit.agent.port>
+                        <org.wildfly.patching.jar.invalidation>true</org.wildfly.patching.jar.invalidation>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/patching/src/test/java/org/jboss/as/patching/tests/PatchModuleInvalidationWithRenamingFailureTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/PatchModuleInvalidationWithRenamingFailureTestCase.java
@@ -21,16 +21,6 @@
  */
 package org.jboss.as.patching.tests;
 
-import java.io.File;
-import java.io.IOException;
-import java.lang.reflect.Constructor;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.Arrays;
-import java.util.List;
-import java.util.zip.ZipException;
-import java.util.zip.ZipFile;
-
 import org.jboss.as.patching.HashUtils;
 import org.jboss.as.patching.IoUtils;
 import org.jboss.as.patching.installation.PatchableTarget;
@@ -46,10 +36,20 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+
+import static org.hamcrest.CoreMatchers.is;
 import static org.jboss.as.patching.runner.TestUtils.createModule0;
 import static org.jboss.as.patching.runner.TestUtils.randomString;
 import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
 
 /**
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
@@ -71,10 +71,10 @@ public class PatchModuleInvalidationWithRenamingFailureTestCase extends Abstract
     @Test
     @BMRule(name = "Test renaming failure",
             targetClass = "java.io.File",
-            targetMethod = "isInvalid",
-            targetLocation = "AT EXIT",
-            condition = "\"SimpleResource.jar.patched\".equals($0.getName())",
-            action = "return true"
+            targetMethod = "renameTo",
+            targetLocation = "AT ENTRY",
+            condition = "\"SimpleResource.jar.patched\".equals($1.getName())",
+            action = "return false"
     )
     public void test() throws Exception {
         final PatchingTestBuilder test = createDefaultBuilder();


### PR DESCRIPTION
As ByteMan can't attach itslef to a running process which is what is done when using @BMRule then the test fails.
So the test simply returns when an IBM jvm is used.

Jira: https://issues.jboss.org/browse/WFCORE-507