### PR TITLE
[WFCORE-498] Moved logging integration tests from WildFly to WildFly Core

### DIFF
--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>wildfly-model-test</artifactId>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.syslog4j</groupId>
             <artifactId>syslog4j</artifactId>
         </dependency>

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractLoggingTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractLoggingTestCase.java
@@ -1,0 +1,330 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.logging;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+import javax.inject.Inject;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper.ServerDeploymentException;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.wildfly.core.testrunner.ServerController;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public abstract class AbstractLoggingTestCase {
+
+    public static final String DEPLOYMENT_NAME = "logging-test.jar";
+
+    public static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "logging");
+
+    public static final PathAddress SUBSYSTEM_ADDRESS = PathAddress.pathAddress(SUBSYSTEM_PATH);
+
+    @Inject
+    protected ServerController container;
+
+    protected static ModelControllerClient client;
+
+    @BeforeClass
+    public static void configureClient() {
+        client = TestSuiteEnvironment.getModelControllerClient();
+    }
+
+    static JavaArchive createDeployment() {
+        return createDeployment(LoggingServiceActivator.class, LoggingServiceActivator.DEPENDENCIES);
+    }
+
+    static JavaArchive createDeployment(final Map<String, String> manifestEntries) {
+        return createDeployment(LoggingServiceActivator.class, manifestEntries, LoggingServiceActivator.DEPENDENCIES);
+    }
+
+    static JavaArchive createDeployment(final Class<? extends ServiceActivator> serviceActivator, final Class<?>... classes) {
+        return createDeployment(serviceActivator, Collections.<String, String>emptyMap(), classes);
+    }
+
+    static JavaArchive createDeployment(final Class<? extends ServiceActivator> serviceActivator,
+                                        final Map<String, String> manifestEntries, final Class<?>... classes) {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, DEPLOYMENT_NAME);
+        archive.addClasses(classes);
+        archive.addAsServiceProviderAndClasses(ServiceActivator.class, serviceActivator);
+        boolean addDeps = true;
+        final StringBuilder manifest = new StringBuilder();
+        for (String key : manifestEntries.keySet()) {
+            if ("Dependencies".equals(key)) {
+                addDeps = false;
+                manifest.append(key)
+                        .append(": ")
+                        .append("io.undertow.core,")
+                        .append(manifestEntries.get(key))
+                        .append('\n');
+            } else {
+                manifest.append(key)
+                        .append(": ")
+                        .append(manifestEntries.get(key))
+                        .append('\n');
+            }
+        }
+        if (addDeps) {
+            manifest.append("Dependencies: io.undertow.core");
+        }
+        archive.addAsResource(new StringAsset(manifest.toString()), "META-INF/MANIFEST.MF");
+        return archive;
+    }
+
+    public static ModelNode executeOperation(final ModelNode op) throws IOException {
+        ModelNode result = client.execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.assertTrue(Operations.getFailureDescription(result).toString(), false);
+        }
+        return result;
+    }
+
+    public static ModelNode executeOperation(final Operation op) throws IOException {
+        ModelNode result = client.execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.assertTrue(Operations.getFailureDescription(result).toString(), false);
+        }
+        return result;
+    }
+
+    public static String resolveRelativePath(final String relativePath) {
+        final ModelNode address = PathAddress.pathAddress(
+                PathElement.pathElement(ModelDescriptionConstants.PATH, relativePath)
+        ).toModelNode();
+        final ModelNode result;
+        try {
+            final ModelNode op = Operations.createReadAttributeOperation(address, ModelDescriptionConstants.PATH);
+            result = client.execute(op);
+            if (Operations.isSuccessfulOutcome(result)) {
+                return Operations.readResult(result).asString();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        throw new RuntimeException(Operations.getFailureDescription(result).asString());
+    }
+
+    public static Path getAbsoluteLogFilePath(final String filename) {
+        return Paths.get(resolveRelativePath("jboss.server.log.dir"), filename);
+    }
+
+    /**
+     * Deploys the {@link #createDeployment() default} archive to the running server.
+     *
+     * @throws ServerDeploymentException if an error occurs deploying the archive
+     */
+    public static void deploy() throws ServerDeploymentException {
+        deploy(createDeployment(), DEPLOYMENT_NAME);
+    }
+
+    /**
+     * Deploys the {@link #createDeployment() default} archive to the running server.
+     *
+     * @param runtimeName the runtime name for the deployment
+     *
+     * @throws ServerDeploymentException if an error occurs deploying the archive
+     */
+    public static void deploy(final String runtimeName) throws ServerDeploymentException {
+        deploy(createDeployment(), runtimeName);
+    }
+
+    /**
+     * Deploys the archive to the running server.
+     *
+     * @param archive the archive to deploy
+     *
+     * @throws ServerDeploymentException if an error occurs deploying the archive
+     */
+    public static void deploy(final Archive<?> archive) throws ServerDeploymentException {
+        deploy(archive, DEPLOYMENT_NAME);
+    }
+
+    /**
+     * Deploys the archive to the running server.
+     *
+     * @param archive     the archive to deploy
+     * @param runtimeName the runtime name for the deployment
+     *
+     * @throws ServerDeploymentException if an error occurs deploying the archive
+     */
+    public static void deploy(final Archive<?> archive, final String runtimeName) throws ServerDeploymentException {
+        final ServerDeploymentHelper helper = new ServerDeploymentHelper(client);
+        helper.deploy(runtimeName, archive.as(ZipExporter.class).exportAsInputStream());
+    }
+
+    /**
+     * Undeploys the default application from the running server.
+     *
+     * @throws ServerDeploymentException if an error occurs undeploying the application
+     */
+    public static void undeploy() throws ServerDeploymentException {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    /**
+     * Undeploys the application from the running server.
+     *
+     * @param runtimeName the runtime name
+     *
+     * @throws ServerDeploymentException if an error occurs undeploying the application
+     */
+    public static void undeploy(final String runtimeName) throws ServerDeploymentException {
+        final ServerDeploymentHelper helper = new ServerDeploymentHelper(client);
+        helper.undeploy(runtimeName);
+    }
+
+    public static ModelNode createAddress(final String resourceKey, final String resourceName) {
+        return PathAddress.pathAddress(
+                SUBSYSTEM_PATH,
+                PathElement.pathElement(resourceKey, resourceName)
+        ).toModelNode();
+    }
+
+    public static ModelNode createAddress(final String... paths) {
+        PathAddress address = SUBSYSTEM_ADDRESS;
+        for (int i = 0; i < paths.length; i++) {
+            final String key = paths[i];
+            if (++i < paths.length) {
+                address = address.append(PathElement.pathElement(key, paths[i]));
+            } else {
+                address = address.append(PathElement.pathElement(key));
+            }
+        }
+        return address.toModelNode();
+    }
+
+    /**
+     * Creates a new URL with the default context from {@link org.jboss.as.test.shared.TestSuiteEnvironment#getHttpUrl()}
+     * and a query parameter of {@code msg} with a value of the argument. The argument will be encoded in UTF-8.
+     *
+     * @param msg    the non-encoded message to send
+     * @param params an optional list of extra parameters to add to the URL.
+     *
+     * @return a URL to send to the server
+     *
+     * @throws java.io.UnsupportedEncodingException if the UTF-8 encoding is not supported
+     * @throws java.net.MalformedURLException       if the URL is malformed
+     */
+    public static URL createUrl(final String msg, final Map<String, String> params) throws UnsupportedEncodingException, MalformedURLException {
+        final StringBuilder spec = new StringBuilder("?msg=").append(URLEncoder.encode(msg, "utf-8"));
+        for (String key : params.keySet()) {
+            spec.append('&').append(key);
+            final String value = params.get(URLEncoder.encode(key, "utf-8"));
+            if (value != null) {
+                spec.append('=').append(URLEncoder.encode(value, "utf-8"));
+            }
+        }
+        return new URL(TestSuiteEnvironment.getHttpUrl(), spec.toString());
+    }
+
+    /**
+     * {@link AbstractLoggingTestCase#createUrl(String, java.util.Map) Creates} a URL with the message provided and
+     * opens a connection
+     * to the sever returning the response code.
+     *
+     * @param msg the non-encoded message to send
+     *
+     * @return the response code from the server
+     *
+     * @throws java.io.IOException if there was an error creating the URL or connecting to he server
+     * @see #createUrl(String, java.util.Map)
+     * @see #getResponse(java.net.URL)
+     */
+    public static int getResponse(final String msg) throws IOException {
+        return getResponse(createUrl(msg, Collections.<String, String>emptyMap()));
+    }
+
+    /**
+     * {@link AbstractLoggingTestCase#createUrl(String, java.util.Map) Creates} a URL with the message provided and
+     * opens a connection
+     * to the sever returning the response code.
+     *
+     * @param msg the non-encoded message to send
+     *
+     * @return the response code from the server
+     *
+     * @throws java.io.IOException if there was an error creating the URL or connecting to he server
+     * @see #createUrl(String, java.util.Map)
+     * @see #getResponse(java.net.URL)
+     */
+    public static int getResponse(final String msg, final Map<String, String> params) throws IOException {
+        return getResponse(createUrl(msg, params));
+    }
+
+    /**
+     * Opens a connection to the server and returns the response code.
+     *
+     * @param url the URL to connect to
+     *
+     * @return the response code from the server
+     *
+     * @throws java.io.IOException if an error occurs connecting to the server
+     */
+    public static int getResponse(final URL url) throws IOException {
+        return ((HttpURLConnection) url.openConnection()).getResponseCode();
+    }
+
+    static void checkLogs(final String msg, final Path file, final boolean expected) throws Exception {
+        boolean logFound = false;
+        if (Files.exists(file)) {
+            try (final BufferedReader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (line.contains(msg)) {
+                        logFound = true;
+                        break;
+                    }
+                }
+            }
+        }
+        Assert.assertEquals(String.format("Message '%s' found in %s", msg, file), expected, logFound);
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/Log4jAppenderTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/Log4jAppenderTestCase.java
@@ -1,0 +1,139 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.logging;
+
+import java.io.BufferedReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * This test ensures that log4j appenders weren't replaced and still log correctly after the server has been restarted.
+ * Confirms the logging.properties file was wrote log4j appenders properly as well. See WFLY-1379 for further details.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class Log4jAppenderTestCase extends AbstractLoggingTestCase {
+
+    private static final String FILE_NAME = "log4j-appender-file.log";
+    private static final String CUSTOM_HANDLER_NAME = "customFileAppender";
+    private static final ModelNode CUSTOM_HANDLER_ADDRESS = createAddress("custom-handler", CUSTOM_HANDLER_NAME);
+    private static final ModelNode ROOT_LOGGER_ADDRESS = createAddress("root-logger", "ROOT");
+
+    private final Path logFile = getAbsoluteLogFilePath(FILE_NAME);
+
+    @Before
+    public void startContainer() throws Exception {
+        // Start the server
+        container.start();
+
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+        // Create the custom handler
+        ModelNode op = Operations.createAddOperation(CUSTOM_HANDLER_ADDRESS);
+        op.get("class").set("org.apache.log4j.FileAppender");
+        op.get("module").set("org.apache.log4j");
+        ModelNode opProperties = op.get("properties").setEmptyObject();
+        opProperties.get("file").set(logFile.normalize().toString());
+        opProperties.get("immediateFlush").set(true);
+        builder.addStep(op);
+
+        // Add the handler to the root-logger
+        op = Operations.createOperation("add-handler", ROOT_LOGGER_ADDRESS);
+        op.get(ModelDescriptionConstants.NAME).set(CUSTOM_HANDLER_NAME);
+        builder.addStep(op);
+
+        executeOperation(builder.build());
+
+        // Stop the container
+        container.stop();
+        // Start the server again
+        container.start();
+
+        Assert.assertTrue("Container is not started", container.isStarted());
+
+        // Deploy the servlet
+        deploy(createDeployment(Log4jServiceActivator.class, Log4jServiceActivator.DEPENDENCIES), DEPLOYMENT_NAME);
+    }
+
+    @After
+    public void stopContainer() throws Exception {
+        // Remove the servlet
+        undeploy();
+
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        // Remove the handler from the root-logger
+        ModelNode op = Operations.createOperation("remove-handler", ROOT_LOGGER_ADDRESS);
+        op.get(ModelDescriptionConstants.NAME).set(CUSTOM_HANDLER_NAME);
+        builder.addStep(op);
+
+        // Remove the custom handler
+        builder.addStep(Operations.createRemoveOperation(CUSTOM_HANDLER_ADDRESS));
+
+        executeOperation(builder.build());
+
+        Files.deleteIfExists(logFile);
+
+        // Stop the container
+        container.stop();
+    }
+
+    @Test
+    public void logAfterReload() throws Exception {
+        // Write the message to the server
+        final String msg = "Logging test: Log4jCustomHandlerTestCase.logAfterReload";
+        searchLog(msg, true);
+    }
+
+    private void searchLog(final String msg, final boolean expected) throws Exception {
+        final int statusCode = getResponse(msg);
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            boolean logFound = false;
+
+            while ((line = reader.readLine()) != null) {
+                if (line.contains(msg)) {
+                    logFound = true;
+                    break;
+                }
+            }
+            Assert.assertTrue(logFound == expected);
+        }
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/Log4jServiceActivator.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/Log4jServiceActivator.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.logging;
+
+import java.util.Deque;
+import java.util.Map;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import org.apache.log4j.Logger;
+import org.wildfly.test.undertow.UndertowServiceActivator;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Log4jServiceActivator extends UndertowServiceActivator {
+    public static final String DEFAULT_MESSAGE = "Default log message";
+    private static final Logger LOGGER = Logger.getLogger(Log4jServiceActivator.class);
+
+    @Override
+    protected HttpHandler getHttpHandler() {
+        return new HttpHandler() {
+            @Override
+            public void handleRequest(final HttpServerExchange exchange) throws Exception {
+                final Map<String, Deque<String>> params = exchange.getQueryParameters();
+                String msg = DEFAULT_MESSAGE;
+                if (params.containsKey("msg")) {
+                    msg = getFirstValue(params, "msg");
+                }
+                LOGGER.info(msg);
+                exchange.getResponseSender().send("Response sent");
+            }
+        };
+    }
+
+    private String getFirstValue(final Map<String, Deque<String>> params, final String key) {
+        if (params.containsKey(key)) {
+            final Deque<String> values = params.get(key);
+            if (values != null && !values.isEmpty()) {
+                return values.getFirst();
+            }
+        }
+        return null;
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingDependenciesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingDependenciesTestCase.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.logging;
+
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper.ServerDeploymentException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Create a deployment with dependency to log4j module.
+ * Verify, that it can be deployed (server logging modules should be used by default).
+ * Disable the server logging modules (add-logging-api-dependencies=false).
+ * Verify, that exception is thrown during deployment.
+ *
+ * @author <a href="mailto:pkremens@redhat.com">Petr Kremensky</a>
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class LoggingDependenciesTestCase extends AbstractLoggingTestCase {
+    private static final Logger log = Logger.getLogger(LoggingDependenciesTestCase.class.getName());
+    private static final String API_DEPENDENCIES = "add-logging-api-dependencies";
+
+    @Before
+    public void startContainer() throws Exception {
+        // Start the container
+        container.start();
+    }
+
+    @After
+    public void stopContainer() throws Exception {
+        // No need to undeploy the deployment should be in error, but check the deployments and undeploy if necessary,
+        // for example if the test failed
+        final ModelNode op = Operations.createReadResourceOperation(PathAddress.pathAddress("deployment", "*").toModelNode());
+        final List<ModelNode> result = Operations.readResult(executeOperation(op)).asList();
+        if (!result.isEmpty()) {
+            try {
+                undeploy();
+            } catch (ServerDeploymentException e) {
+                log.warn("Error undeploying", e);
+            }
+        }
+
+        executeOperation(Operations.createWriteAttributeOperation(createAddress(), API_DEPENDENCIES, true));
+        container.stop();
+    }
+
+    @Test(expected = ServerDeploymentException.class)
+    public void disableLoggingDependencies() throws Exception {
+        final JavaArchive archive = createDeployment(Log4jServiceActivator.class, Log4jServiceActivator.DEPENDENCIES);
+        // Ensure the log4j deployment can be deployed
+        deploy(archive);
+        undeploy();
+
+        // Set add-logging-api-dependencies to false
+        executeOperation(Operations.createWriteAttributeOperation(createAddress(), API_DEPENDENCIES, false));
+        // Restart the container, expect the exception during deployment
+        container.stop();
+        container.start();
+        deploy(archive);
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingPreferencesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingPreferencesTestCase.java
@@ -1,0 +1,150 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.logging;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILE_HANDLER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Create a deployment with both per-deploy logging configuration file and logging profile.
+ * Verify that per-deploy logging has preference to logging profile.
+ * Set use-deployment-logging-config=false and verify that profile is used.
+ *
+ * @author <a href="mailto:pkremens@redhat.com">Petr Kremensky</a>
+ */
+@RunWith(WildflyTestRunner.class)
+public class LoggingPreferencesTestCase extends AbstractLoggingTestCase {
+
+    private static final String DEPLOYMENT_LOG_MESSAGE = "Deployment logging configuration message.";
+    private static final String LOGGING_PROFILE_MESSAGE = "Logging subsystem profile message.";
+    private static final String PER_DEPLOY_ATTRIBUTE = "use-deployment-logging-config";
+
+    private static final String PROFILE_NAME = "logging-preferences-profile";
+    private static final String FILE_HANDLER_NAME = "customFileAppender";
+    private static final String FILE_HANDLER_FILE_NAME = "custom-file-logger.log";
+    private static final String PER_DEPLOY_FILE_NAME = "per-deploy-logging.log";
+
+    private static final Path profileLog = getAbsoluteLogFilePath(FILE_HANDLER_FILE_NAME);
+    private static final Path perDeployLog = getAbsoluteLogFilePath(PER_DEPLOY_FILE_NAME);
+
+    private static final ModelNode PROFILE_ADDRESS = createAddress("logging-profile", PROFILE_NAME);
+    private static final ModelNode ROOT_LOGGER_ADDRESS = createAddress("logging-profile", PROFILE_NAME, "root-logger", "ROOT");
+    private static final ModelNode FILE_HANDLER_ADDRESS = createAddress("logging-profile", PROFILE_NAME, FILE_HANDLER, FILE_HANDLER_NAME);
+
+    @Before
+    public void prepareContainer() throws Exception {
+        // Start the container
+        container.start();
+
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        // Create a new logging profile
+        builder.addStep(Operations.createAddOperation(PROFILE_ADDRESS));
+
+        // Add root logger to the profile
+        builder.addStep(Operations.createAddOperation(ROOT_LOGGER_ADDRESS));
+
+        // Add file handler to the profile
+        ModelNode op = Operations.createAddOperation(FILE_HANDLER_ADDRESS);
+        ModelNode file = new ModelNode();
+        file.get(PATH).set(profileLog.normalize().toString());
+        op.get(FILE).set(file);
+        builder.addStep(op);
+
+        executeOperation(builder.build());
+
+        // Register file logger to root
+        op = Operations.createOperation("add-handler", ROOT_LOGGER_ADDRESS);
+        op.get(NAME).set(FILE_HANDLER_NAME);
+        executeOperation(op);
+
+        final JavaArchive archive = createDeployment(Collections.singletonMap("Logging-Profile", PROFILE_NAME))
+                .addAsResource(LoggingPreferencesTestCase.class.getPackage(), "per-deploy-logging.properties", "META-INF/logging.properties");
+        deploy(archive);
+    }
+
+    @After
+    public void stopContainer() throws Exception {
+        // Remove the servlet
+        undeploy();
+
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        // Set use-deployment-logging-config to true
+        builder.addStep(Operations.createWriteAttributeOperation(createAddress(), PER_DEPLOY_ATTRIBUTE, true));
+
+        // Remove the logging profile
+        builder.addStep(Operations.createRemoveOperation(PROFILE_ADDRESS));
+
+        executeOperation(builder.build());
+
+        // Stop the container
+        container.stop();
+        clearLogFiles();
+    }
+
+    @Test
+    public void loggingPreferences() throws Exception {
+        // Per-deploy logging test
+        int statusCode = getResponse(DEPLOYMENT_LOG_MESSAGE);
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        checkLogs(DEPLOYMENT_LOG_MESSAGE, perDeployLog, true);
+        checkLogs(DEPLOYMENT_LOG_MESSAGE, profileLog, false);
+
+        // Set use-deployment-logging-config to false
+        executeOperation(Operations.createWriteAttributeOperation(createAddress(), PER_DEPLOY_ATTRIBUTE, false));
+
+        // Restart the container and clean the logs
+        container.stop();
+        clearLogFiles();
+        container.start();
+
+        // Per-deploy logging disabled test
+        statusCode = getResponse(LOGGING_PROFILE_MESSAGE);
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        checkLogs(LOGGING_PROFILE_MESSAGE, perDeployLog, false);
+        checkLogs(LOGGING_PROFILE_MESSAGE, profileLog, true);
+    }
+
+    private void clearLogFiles() throws IOException {
+        Files.deleteIfExists(profileLog);
+        Files.deleteIfExists(perDeployLog);
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingServiceActivator.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingServiceActivator.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.logging;
+
+import java.util.Deque;
+import java.util.Map;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import org.jboss.logging.Logger;
+import org.wildfly.test.undertow.UndertowServiceActivator;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LoggingServiceActivator extends UndertowServiceActivator {
+    public static final String DEFAULT_MESSAGE = "Default log message";
+    private static final Logger LOGGER = Logger.getLogger(LoggingServiceActivator.class);
+
+    @Override
+    protected HttpHandler getHttpHandler() {
+        return new HttpHandler() {
+            @Override
+            public void handleRequest(final HttpServerExchange exchange) throws Exception {
+                final Map<String, Deque<String>> params = exchange.getQueryParameters();
+                String msg = DEFAULT_MESSAGE;
+                if (params.containsKey("msg")) {
+                    msg = getFirstValue(params, "msg");
+                }
+                LOGGER.info(msg);
+                exchange.getResponseSender().send("Response sent");
+            }
+        };
+    }
+
+    private String getFirstValue(final Map<String, Deque<String>> params, final String key) {
+        if (params.containsKey(key)) {
+            final Deque<String> values = params.get(key);
+            if (values != null && !values.isEmpty()) {
+                return values.getFirst();
+            }
+        }
+        return null;
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/PerDeployLoggingTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/PerDeployLoggingTestCase.java
@@ -1,0 +1,147 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.logging;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILE_HANDLER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Create a deployment with per-deploy logging configuration file.
+ * Verify that per-deploy logging has preference to logging subsystem (use-deployment-logging-config=true).
+ * Set use-deployment-logging-config=false and verify that per-deploy configuration is no longer used.
+ *
+ * @author <a href="mailto:pkremens@redhat.com">Petr Kremensky</a>
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class PerDeployLoggingTestCase extends AbstractLoggingTestCase {
+
+    private static final String DEPLOYMENT_LOG_MESSAGE = "Deployment logging configuration message.";
+    private static final String LOGGING_SUBSYSTEM_MESSAGE = "Per deploy logging disabled message.";
+    private static final String PER_DEPLOY_ATTRIBUTE = "use-deployment-logging-config";
+    private static final String FILE_HANDLER_NAME = "customFileAppender";
+    private static final String FILE_HANDLER_FILE_NAME = "custom-file-logger.log";
+    private static final String PER_DEPLOY_FILE_NAME = "per-deploy-logging.log";
+
+    private static final ModelNode ROOT_LOGGER_ADDRESS = createAddress("root-logger", "ROOT");
+    private static final ModelNode FILE_HANDLER_ADDRESS = createAddress(FILE_HANDLER, FILE_HANDLER_NAME);
+
+    private Path customLog;
+    private Path perDeployLog;
+
+    @Before
+    public void prepareContainer() throws Exception {
+        // Start the container
+        container.start();
+
+        customLog = getAbsoluteLogFilePath(FILE_HANDLER_FILE_NAME);
+        perDeployLog = getAbsoluteLogFilePath(PER_DEPLOY_FILE_NAME);
+
+        // Create the custom file handler
+        ModelNode op = Operations.createAddOperation(FILE_HANDLER_ADDRESS);
+        ModelNode file = new ModelNode();
+        file.get(PATH).set(customLog.normalize().toString());
+        op.get(FILE).set(file);
+        executeOperation(op);
+
+        // Add the handler to the root-logger
+        op = Operations.createOperation("add-handler", ROOT_LOGGER_ADDRESS);
+        op.get(NAME).set(FILE_HANDLER_NAME);
+        executeOperation(op);
+
+        final JavaArchive archive = createDeployment()
+                .addAsResource(PerDeployLoggingTestCase.class.getPackage(), "per-deploy-logging.properties", "META-INF/logging.properties");
+        deploy(archive);
+    }
+
+    @After
+    public void stopContainer() throws Exception {
+        // Remove the servlet
+        undeploy();
+
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        // Set use-deployment-logging-config to true
+        builder.addStep(Operations.createWriteAttributeOperation(createAddress(), PER_DEPLOY_ATTRIBUTE, true));
+
+        // Remove the custom handler from the root-logger
+        final ModelNode op = Operations.createOperation("remove-handler", ROOT_LOGGER_ADDRESS);
+        op.get(NAME).set(FILE_HANDLER_NAME);
+        builder.addStep(op);
+
+        // Remove the custom file handler
+        builder.addStep(Operations.createRemoveOperation(FILE_HANDLER_ADDRESS));
+
+        executeOperation(builder.build());
+
+        // Stop the container
+        container.stop();
+        clearLogFiles();
+    }
+
+    @Test
+    public void disablePerDeployLogging() throws Exception {
+        // Per-deploy logging test
+        int statusCode = getResponse(DEPLOYMENT_LOG_MESSAGE);
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        checkLogs(DEPLOYMENT_LOG_MESSAGE, perDeployLog, true);
+        checkLogs(DEPLOYMENT_LOG_MESSAGE, customLog, false);
+
+        // Set use-deployment-logging-config to false
+        executeOperation(Operations.createWriteAttributeOperation(createAddress(), PER_DEPLOY_ATTRIBUTE, false));
+
+        // Restart the container and clean the logs
+        container.stop();
+        clearLogFiles();
+        container.start();
+
+        // Per-deploy logging disabled test
+        statusCode = getResponse(LOGGING_SUBSYSTEM_MESSAGE);
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        checkLogs(LOGGING_SUBSYSTEM_MESSAGE, perDeployLog, false);
+        checkLogs(LOGGING_SUBSYSTEM_MESSAGE, customLog, true);
+    }
+
+    private void clearLogFiles() throws IOException {
+        Files.deleteIfExists(customLog);
+        Files.deleteIfExists(perDeployLog);
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SizeAppenderRestartTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SizeAppenderRestartTestCase.java
@@ -1,0 +1,185 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.logging;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Test to confirm rotate-on-boot works.
+ *
+ * @author <a href="mailto:pkremens@redhat.com">Petr Kremensky</a>
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class SizeAppenderRestartTestCase extends AbstractLoggingTestCase {
+    private static final String FILE_NAME = "sizeAppenderRestartTestCase.log";
+    private static final String SIZE_HANDLER_NAME = "sizeAppenderRestartTestCase";
+    private static final ModelNode SIZE_HANDLER_ADDRESS = createAddress("size-rotating-file-handler", SIZE_HANDLER_NAME);
+    private static final ModelNode ROOT_LOGGER_ADDRESS = createAddress("root-logger", "ROOT");
+    private Path logFile;
+
+    @Before
+    public void startContainer() throws Exception {
+        // Start the server
+        container.start();
+        Assert.assertTrue("Container is not started", container.isStarted());
+        logFile = getAbsoluteLogFilePath(FILE_NAME);
+        // Deploy the servlet
+        deploy();
+
+        // Create the size-rotating handler
+        ModelNode op = Operations.createAddOperation(SIZE_HANDLER_ADDRESS);
+        ModelNode file = new ModelNode();
+        file.get("path").set(logFile.normalize().toString());
+        op.get(FILE).set(file);
+        executeOperation(op);
+
+        // Add the handler to the root-logger
+        op = Operations.createOperation("add-handler", ROOT_LOGGER_ADDRESS);
+        op.get(NAME).set(SIZE_HANDLER_NAME);
+        executeOperation(op);
+    }
+
+    @After
+    public void stopContainer() throws Exception {
+        // Remove the servlet
+        undeploy();
+
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        // Remove the handler from the root-logger
+        ModelNode op = Operations.createOperation("remove-handler", ROOT_LOGGER_ADDRESS);
+        op.get(NAME).set(SIZE_HANDLER_NAME);
+        builder.addStep(op);
+
+        // Remove the size-rotating handler
+        builder.addStep(Operations.createRemoveOperation(SIZE_HANDLER_ADDRESS));
+
+        executeOperation(builder.build());
+
+        // Stop the container
+        container.stop();
+
+        // Remove log files
+        clearLogs(logFile);
+    }
+
+    /*
+     * rotate-on-boot = true:   restart -> log file is rotated, logs are written to new file
+     */
+    @Test
+    public void rotateFileOnRestartTest() throws Exception {
+        final String oldMessage = "SizeAppenderRestartTestCase - This is old message";
+        final String newMessage = "SizeAppenderRestartTestCase - This is new message";
+        executeOperation(Operations.createWriteAttributeOperation(SIZE_HANDLER_ADDRESS, "rotate-on-boot", true));
+        restartServer(true);
+
+        // make some logs, remember file size, restart
+        makeLog(oldMessage);
+        checkLogs(oldMessage, logFile, true);
+        restartServer(false);
+
+        // make log to new rotated log file
+        makeLog(newMessage);
+        checkLogs(newMessage, logFile, true);
+
+        // verify that file was rotated
+        int count = 0;
+        for (Path path : listLogFiles()) {
+            final String logFileName = logFile.getFileName().toString();
+            final String fileName = path.getFileName().toString();
+            if (fileName.startsWith(logFileName)) {
+                count++;
+                if (fileName.equals(logFileName + ".1")) {
+                    checkLogs(newMessage, path, false);
+                    checkLogs(oldMessage, path, true);
+                }
+            }
+        }
+        Assert.assertEquals("There should be two log files", 2, count);
+    }
+
+    private void restartServer(final boolean deleteLogs) throws IOException {
+        Assert.assertTrue("Container is not running", container.isStarted());
+        // Stop the container
+        container.stop();
+        if (deleteLogs) {
+            clearLogs(logFile);
+        }
+        // Start the server again
+        container.start();
+        Assert.assertTrue("Container is not started", container.isStarted());
+    }
+
+    private void makeLog(final String msg) throws Exception {
+        int statusCode = getResponse(msg);
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+    }
+
+    private Iterable<Path> listLogFiles() throws IOException {
+        final Collection<Path> names = new ArrayList<>();
+        Files.walkFileTree(logFile.getParent(), new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                names.add(file);
+                return super.visitFile(file, attrs);
+            }
+        });
+        return names;
+    }
+
+    private void clearLogs(final Path path) throws IOException {
+        final String expectedName = path.getFileName().toString();
+        Files.walkFileTree(path.getParent(), new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                final String currentName = file.getFileName().toString();
+                if (currentName.startsWith(expectedName)) {
+                    Files.delete(file);
+                }
+                return super.visitFile(file, attrs);
+            }
+        });
+    }
+}

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/logging/per-deploy-logging.properties
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/logging/per-deploy-logging.properties
@@ -1,0 +1,14 @@
+# Root logger level
+logger.level=INFO
+# Root logger handlers
+logger.handlers=FILE
+
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.level=INFO
+handler.FILE.properties=autoFlush,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=${jboss.server.log.dir}/per-deploy-logging.log
+handler.FILE.formatter=PATTERN
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%E%n

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -98,6 +98,9 @@
         <!-- IP address defaults. -->
         <node0>127.0.0.1</node0>
         <management.address>${node0}</management.address>
+        <!-- HTTP binding settings -->
+        <jboss.http.port>8080</jboss.http.port>
+        <jboss.bind.address>${management.address}</jboss.bind.address>
         <!-- Default multicast address. -->
         <mcast>230.0.0.4</mcast>
 
@@ -116,7 +119,8 @@
         <jvm.args.other>-server</jvm.args.other>
 
         <!-- Standalone server arguments -->
-        <jboss.args></jboss.args>
+        <jboss.http.bind.args>-Djboss.http.port=${jboss.http.port} -Djboss.bind.address=${jboss.bind.address}</jboss.http.bind.args>
+        <jboss.args>${jboss.http.bind.args}</jboss.args>
         <!-- Domain server argument -->
         <jboss.domain.server.args></jboss.domain.server.args>
 
@@ -292,6 +296,12 @@
                             <jboss.home>${basedir}/target/wildfly-core</jboss.home>
                             <org.wildfly.test.kill-servers-before-test>${org.wildfly.test.kill-servers-before-test}</org.wildfly.test.kill-servers-before-test>
                             <management.address>${management.address}</management.address>
+
+                            <!-- jboss.http.port and jboss.bind.address are by the UndertowService and the
+                            TestSuiteEnvironment to determine where to bind Undertow -->
+                            <jboss.http.port>${jboss.http.port}</jboss.http.port>
+                            <jboss.bind.address>${jboss.bind.address}</jboss.bind.address>
+
                             <jboss.args>${jboss.args}</jboss.args>
                             <jboss.domain.server.args>${jboss.domain.server.args}</jboss.domain.server.args>
                         </systemPropertyVariables>
@@ -420,7 +430,7 @@
             </activation>
             <properties>
                 <!-- Standalone security manager argument -->
-                <jboss.args>-secmgr</jboss.args>
+                <jboss.args>${jboss.http.bind.args} -secmgr</jboss.args>
                 <!-- Domain security manager argument -->
                 <jboss.domain.server.args>-secmgr</jboss.domain.server.args>
             </properties>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
@@ -1,6 +1,8 @@
 package org.jboss.as.test.shared;
 
 import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.List;
 
@@ -127,5 +129,54 @@ public class TestSuiteEnvironment {
             address = StringUtils.strip(address, "[]");
         }
         return address;
+    }
+
+    /**
+     * Creates an HTTP url with the {@link TestSuiteEnvironment#getHttpAddress() address} and {@link
+     * TestSuiteEnvironment#getHttpPort() port}.
+     *
+     * @return the URL
+     *
+     * @throws java.net.MalformedURLException if an unknown protocol is specified
+     * @see java.net.URL#URL(String, String, int, String)
+     */
+    public static URL getHttpUrl() throws MalformedURLException {
+        return new URL("http", getHttpAddress(), getHttpPort(), "");
+    }
+
+    /**
+     * Gets the address used as the binding address for HTTP.
+     * <p/>
+     * The system properties are checked in the following order:
+     * <ul>
+     * <li>{@code jboss.bind.address}</li>
+     * <li>{@code management.address}</li>
+     * <li>{@code node0</li>
+     * </ul>
+     * <p/>
+     * If neither system property is set {@code 0.0.0.0} is returned.
+     *
+     * @return the address for HTTP to bind to
+     */
+    public static String getHttpAddress() {
+        String address = getSystemProperty("jboss.bind.address");
+        if (address == null) {
+            address = getSystemProperty("management.address");
+            if (address == null) {
+                address = getSystemProperty("node0");
+            }
+        }
+        return address == null ? "0.0.0.0" : formatPossibleIpv6Address(address);
+    }
+
+    /**
+     * Gets the port used to bind to.
+     * <p/>
+     * Checks the system property {@code jboss.http.port} returning {@code 8080} by default.
+     *
+     * @return the binding port
+     */
+    public static int getHttpPort() {
+        return Integer.parseInt(getSystemProperty("jboss.http.port", "8080"));
     }
 }

--- a/testsuite/shared/src/main/java/org/wildfly/test/undertow/UndertowService.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/undertow/UndertowService.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.undertow;
+
+import io.undertow.Undertow;
+import io.undertow.server.HttpHandler;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class UndertowService implements Service<UndertowService> {
+    public static final ServiceName DEFAULT_SERVICE_NAME = ServiceName.JBOSS.append("undertow-test-server");
+
+    private Undertow undertow;
+    private final String address;
+    private final int port;
+    private final HttpHandler handler;
+
+    public UndertowService(final String address, final int port, final HttpHandler handler) {
+        this.address = address;
+        this.port = port;
+        this.handler = handler;
+    }
+
+    @Override
+    public synchronized void start(final StartContext context) throws StartException {
+        undertow = Undertow.builder().addHttpListener(port, address).setHandler(handler).build();
+        undertow.start();
+        Logger.getLogger(UndertowService.class).infof("Started Undertow on %s:%d", address, port);
+    }
+
+    @Override
+    public synchronized void stop(final StopContext context) {
+        undertow.stop();
+        undertow = null;
+    }
+
+    @Override
+    public UndertowService getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/undertow/UndertowServiceActivator.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/undertow/UndertowServiceActivator.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.undertow;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistryException;
+
+/**
+ * A default service activator which will create an Undertow service and send a default response to 0.0.0.0 port
+ * 8080.
+ * <p/>
+ * You can override the address with the {@code jboss.bind.address} or {@code management.address} system properties.
+ * <p/>
+ * To override  the port use the {@code jboss.http.port} system property.
+ * <p/>
+ * Override any of the getter methods to customize the desired behavior.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class UndertowServiceActivator implements ServiceActivator {
+
+    /**
+     * Class dependencies required to use the {@link org.wildfly.test.undertow.UndertowService}.
+     */
+    public static final Class<?>[] DEPENDENCIES = {
+            UndertowService.class,
+            UndertowServiceActivator.class,
+            TestSuiteEnvironment.class
+    };
+
+    public static final String DEFAULT_RESPONSE = "Response sent";
+    private static final HttpHandler DEFAULT_HANDLER = new HttpHandler() {
+        @Override
+        public void handleRequest(final HttpServerExchange exchange) throws Exception {
+            exchange.getResponseSender().send(DEFAULT_RESPONSE);
+        }
+    };
+
+    @Override
+    public final void activate(final ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        final String address = getAddress();
+        assert address != null : "address cannot be null";
+        final int port = getPort();
+        assert port > 0 : "port must be greater than 0";
+        final HttpHandler handler = getHttpHandler();
+        assert handler != null : "A handler is required";
+        final UndertowService service = new UndertowService(address, port, handler);
+        serviceActivatorContext.getServiceTarget().addService(getServiceName(), service).install();
+    }
+
+    /**
+     * Returns the service name to use when adding the UndertowService.
+     *
+     * @return the undertow service name
+     */
+    protected ServiceName getServiceName() {
+        return UndertowService.DEFAULT_SERVICE_NAME;
+    }
+
+    /**
+     * Returns the {@link io.undertow.server.HttpHandler handler} used to process the request
+     *
+     * @return the handler to use
+     */
+    protected HttpHandler getHttpHandler() {
+        return DEFAULT_HANDLER;
+    }
+
+    /**
+     * Returns the address for Undertow to bind to.
+     *
+     * @return the address
+     */
+    protected String getAddress() {
+        return TestSuiteEnvironment.getHttpAddress();
+    }
+
+    /**
+     * Returns the port for Undertow to bind to.
+     *
+     * @return the port
+     */
+    protected int getPort() {
+        return TestSuiteEnvironment.getHttpPort();
+    }
+}

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -51,6 +51,10 @@
             <artifactId>wildfly-threads</artifactId>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/AbstractLoggingTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/AbstractLoggingTestCase.java
@@ -1,0 +1,271 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+import javax.inject.Inject;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper.ServerDeploymentException;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.wildfly.core.testrunner.ManagementClient;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public abstract class AbstractLoggingTestCase {
+
+    public static final String DEPLOYMENT_NAME = "logging-test.jar";
+
+    public static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "logging");
+
+    public static final PathAddress SUBSYSTEM_ADDRESS = PathAddress.pathAddress(SUBSYSTEM_PATH);
+
+    @Inject
+    protected static ManagementClient client;
+
+    public static JavaArchive createDeployment() {
+        return createDeployment(LoggingServiceActivator.class, LoggingServiceActivator.DEPENDENCIES);
+    }
+
+    public static JavaArchive createDeployment(final Map<String, String> manifestEntries) {
+        return createDeployment(LoggingServiceActivator.class, manifestEntries, LoggingServiceActivator.DEPENDENCIES);
+    }
+
+    public static JavaArchive createDeployment(final Class<? extends ServiceActivator> serviceActivator, final Class<?>... classes) {
+        return createDeployment(serviceActivator, Collections.<String, String>emptyMap(), classes);
+    }
+
+    public static JavaArchive createDeployment(final Class<? extends ServiceActivator> serviceActivator,
+                                               final Map<String, String> manifestEntries, final Class<?>... classes) {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, DEPLOYMENT_NAME);
+        archive.addClasses(classes);
+        archive.addAsServiceProviderAndClasses(ServiceActivator.class, serviceActivator);
+        boolean addDeps = true;
+        final StringBuilder manifest = new StringBuilder();
+        for (String key : manifestEntries.keySet()) {
+            if ("Dependencies".equals(key)) {
+                addDeps = false;
+                manifest.append(key)
+                        .append(": ")
+                        .append("io.undertow.core,")
+                        .append(manifestEntries.get(key))
+                        .append('\n');
+            } else {
+                manifest.append(key)
+                        .append(": ")
+                        .append(manifestEntries.get(key))
+                        .append('\n');
+            }
+        }
+        if (addDeps) {
+            manifest.append("Dependencies: io.undertow.core");
+        }
+        archive.addAsResource(new StringAsset(manifest.toString()), "META-INF/MANIFEST.MF");
+        return archive;
+    }
+
+    public static ModelNode executeOperation(final ModelNode op) throws IOException {
+        ModelNode result = client.getControllerClient().execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.assertTrue(Operations.getFailureDescription(result).toString(), false);
+        }
+        return result;
+    }
+
+    public static ModelNode executeOperation(final Operation op) throws IOException {
+        ModelNode result = client.getControllerClient().execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.assertTrue(Operations.getFailureDescription(result).toString(), false);
+        }
+        return result;
+    }
+
+    public static String resolveRelativePath(final String relativePath) {
+        final ModelNode address = PathAddress.pathAddress(
+                PathElement.pathElement(ModelDescriptionConstants.PATH, relativePath)
+        ).toModelNode();
+        final ModelNode result;
+        try {
+            final ModelNode op = Operations.createReadAttributeOperation(address, ModelDescriptionConstants.PATH);
+            result = client.getControllerClient().execute(op);
+            if (Operations.isSuccessfulOutcome(result)) {
+                return Operations.readResult(result).asString();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        throw new RuntimeException(Operations.getFailureDescription(result).asString());
+    }
+
+    public static Path getAbsoluteLogFilePath(final String filename) {
+        return Paths.get(resolveRelativePath("jboss.server.log.dir"), filename);
+    }
+
+    public static void setEnabled(final ModelNode address, final boolean enabled) throws IOException {
+        final ModelNode op = Operations.createWriteAttributeOperation(address, ModelDescriptionConstants.ENABLED, enabled);
+        executeOperation(op);
+    }
+
+    /**
+     * Deploys the archive to the running server.
+     *
+     * @param archive     the archive to deploy
+     * @param runtimeName the runtime name for the deployment
+     *
+     * @throws ServerDeploymentException if an error occurs deploying the archive
+     */
+    public static void deploy(final Archive<?> archive, final String runtimeName) throws ServerDeploymentException {
+        final ServerDeploymentHelper helper = new ServerDeploymentHelper(client.getControllerClient());
+        helper.deploy(runtimeName, archive.as(ZipExporter.class).exportAsInputStream());
+    }
+
+    /**
+     * Undeploys the application from the running server.
+     *
+     * @param runtimeName the runtime name
+     *
+     * @throws ServerDeploymentException if an error occurs undeploying the application
+     */
+    public static void undeploy(final String runtimeName) throws ServerDeploymentException {
+        final ServerDeploymentHelper helper = new ServerDeploymentHelper(client.getControllerClient());
+        helper.undeploy(runtimeName);
+    }
+
+    public static ModelNode createAddress(final String resourceKey, final String resourceName) {
+        return PathAddress.pathAddress(
+                SUBSYSTEM_PATH,
+                PathElement.pathElement(resourceKey, resourceName)
+        ).toModelNode();
+    }
+
+    public static ModelNode createAddress(final String... paths) {
+        PathAddress address = SUBSYSTEM_ADDRESS;
+        for (int i = 0; i < paths.length; i++) {
+            final String key = paths[i];
+            if (++i < paths.length) {
+                address = address.append(PathElement.pathElement(key, paths[i]));
+            } else {
+                address = address.append(PathElement.pathElement(key));
+            }
+        }
+        return address.toModelNode();
+    }
+
+    /**
+     * Creates a new URL with the default context from {@link org.jboss.as.test.shared.TestSuiteEnvironment#getHttpUrl()}
+     * and a query parameter of {@code msg} with a value of the argument. The argument will be encoded in UTF-8.
+     *
+     * @param msg    the non-encoded message to send
+     * @param params an optional list of extra parameters to add to the URL.
+     *
+     * @return a URL to send to the server
+     *
+     * @throws UnsupportedEncodingException if the UTF-8 encoding is not supported
+     * @throws MalformedURLException        if the URL is malformed
+     */
+    public static URL createUrl(final String msg, final Map<String, String> params) throws UnsupportedEncodingException, MalformedURLException {
+        final StringBuilder spec = new StringBuilder()
+                .append('?')
+                .append(LoggingServiceActivator.MSG_KEY)
+                .append('=')
+                .append(URLEncoder.encode(msg, "utf-8"));
+        for (String key : params.keySet()) {
+            spec.append('&').append(key);
+            final String value = params.get(URLEncoder.encode(key, "utf-8"));
+            if (value != null) {
+                spec.append('=').append(URLEncoder.encode(value, "utf-8"));
+            }
+        }
+        return new URL(TestSuiteEnvironment.getHttpUrl(), spec.toString());
+    }
+
+    /**
+     * {@link AbstractLoggingTestCase#createUrl(String, java.util.Map) Creates} a URL with the message provided and
+     * opens a connection
+     * to the sever returning the response code.
+     *
+     * @param msg the non-encoded message to send
+     *
+     * @return the response code from the server
+     *
+     * @throws IOException if there was an error creating the URL or connecting to he server
+     * @see #createUrl(String, java.util.Map)
+     * @see #getResponse(java.net.URL)
+     */
+    public static int getResponse(final String msg) throws IOException {
+        return getResponse(createUrl(msg, Collections.<String, String>emptyMap()));
+    }
+
+    /**
+     * {@link AbstractLoggingTestCase#createUrl(String, java.util.Map) Creates} a URL with the message provided and
+     * opens a connection
+     * to the sever returning the response code.
+     *
+     * @param msg the non-encoded message to send
+     *
+     * @return the response code from the server
+     *
+     * @throws IOException if there was an error creating the URL or connecting to he server
+     * @see #createUrl(String, java.util.Map)
+     * @see #getResponse(java.net.URL)
+     */
+    public static int getResponse(final String msg, final Map<String, String> params) throws IOException {
+        return getResponse(createUrl(msg, params));
+    }
+
+    /**
+     * Opens a connection to the server and returns the response code.
+     *
+     * @param url the URL to connect to
+     *
+     * @return the response code from the server
+     *
+     * @throws IOException if an error occurs connecting to the server
+     */
+    public static int getResponse(final URL url) throws IOException {
+        return ((HttpURLConnection) url.openConnection()).getResponseCode();
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/Log4jServiceActivator.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/Log4jServiceActivator.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging;
+
+import static org.apache.log4j.Level.DEBUG;
+import static org.apache.log4j.Level.ERROR;
+import static org.apache.log4j.Level.FATAL;
+import static org.apache.log4j.Level.INFO;
+import static org.apache.log4j.Level.TRACE;
+import static org.apache.log4j.Level.WARN;
+
+import java.util.Deque;
+import java.util.Locale;
+import java.util.Map;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.wildfly.test.undertow.UndertowServiceActivator;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Log4jServiceActivator extends UndertowServiceActivator {
+    public static final String DEFAULT_MESSAGE = "Default log message";
+    public static final Level[] LOG_LEVELS = {DEBUG, TRACE, INFO, WARN, ERROR, FATAL};
+    private static final Logger LOGGER = Logger.getLogger(Log4jServiceActivator.class);
+
+    @Override
+    protected HttpHandler getHttpHandler() {
+        return new HttpHandler() {
+            @Override
+            public void handleRequest(final HttpServerExchange exchange) throws Exception {
+                final Map<String, Deque<String>> params = exchange.getQueryParameters();
+                String msg = DEFAULT_MESSAGE;
+                if (params.containsKey("msg")) {
+                    msg = getFirstValue(params, "msg");
+                }
+                boolean includeLevel = false;
+                if (params.containsKey("includeLevel")) {
+                    includeLevel = Boolean.parseBoolean(getFirstValue(params, "includeLevel"));
+                }
+                for (Level level : LOG_LEVELS) {
+                    if (includeLevel) {
+                        LOGGER.log(level, formatMessage(msg, level));
+                    } else {
+                        LOGGER.log(level, msg);
+                    }
+                }
+                exchange.getResponseSender().send("Response sent");
+            }
+        };
+    }
+
+    private String getFirstValue(final Map<String, Deque<String>> params, final String key) {
+        if (params.containsKey(key)) {
+            final Deque<String> values = params.get(key);
+            if (values != null && !values.isEmpty()) {
+                return values.getFirst();
+            }
+        }
+        return null;
+    }
+
+    public static String formatMessage(final String msg, final Level level) {
+        return msg + " - " + level.toString().toLowerCase(Locale.ROOT);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/LoggingServiceActivator.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/LoggingServiceActivator.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging;
+
+import static org.jboss.logging.Logger.Level.DEBUG;
+import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.FATAL;
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.TRACE;
+import static org.jboss.logging.Logger.Level.WARN;
+
+import java.util.Deque;
+import java.util.Locale;
+import java.util.Map;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import org.jboss.logging.Logger;
+import org.wildfly.test.undertow.UndertowServiceActivator;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LoggingServiceActivator extends UndertowServiceActivator {
+    public static final String DEFAULT_MESSAGE = "Default log message";
+    public static final Logger.Level[] LOG_LEVELS = {DEBUG, TRACE, INFO, WARN, ERROR, FATAL};
+    public static final String MSG_KEY = "msg";
+    public static final String INCLUDE_LEVEL_KEY = "includeLevel";
+    public static final String LOG_INFO_ONLY_KEY = "logInfoOnly";
+    private static final Logger LOGGER = Logger.getLogger(LoggingServiceActivator.class);
+
+    @Override
+    protected HttpHandler getHttpHandler() {
+        return new HttpHandler() {
+            @Override
+            public void handleRequest(final HttpServerExchange exchange) throws Exception {
+                final Map<String, Deque<String>> params = exchange.getQueryParameters();
+                String msg = DEFAULT_MESSAGE;
+                if (params.containsKey(MSG_KEY)) {
+                    msg = getFirstValue(params, MSG_KEY);
+                }
+                boolean includeLevel = false;
+                if (params.containsKey(INCLUDE_LEVEL_KEY)) {
+                    includeLevel = Boolean.parseBoolean(getFirstValue(params, INCLUDE_LEVEL_KEY));
+                }
+                boolean logInfoOnly = false;
+                if (params.containsKey(LOG_INFO_ONLY_KEY)) {
+                    logInfoOnly = Boolean.parseBoolean(getFirstValue(params, LOG_INFO_ONLY_KEY));
+                }
+                if (logInfoOnly) {
+                    LOGGER.info(msg);
+                } else {
+                    for (Logger.Level level : LOG_LEVELS) {
+                        if (includeLevel) {
+                            LOGGER.log(level, formatMessage(msg, level));
+                        } else {
+                            LOGGER.log(level, msg);
+                        }
+                    }
+                }
+                exchange.getResponseSender().send("Response sent");
+            }
+        };
+    }
+
+    private String getFirstValue(final Map<String, Deque<String>> params, final String key) {
+        if (params.containsKey(key)) {
+            final Deque<String> values = params.get(key);
+            if (values != null && !values.isEmpty()) {
+                return values.getFirst();
+            }
+        }
+        return null;
+    }
+
+    public static String formatMessage(final String msg, final Logger.Level level) {
+        return msg + " - " + level.name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/AbstractLoggingOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/AbstractLoggingOperationsTestCase.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging.operations;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public abstract class AbstractLoggingOperationsTestCase extends AbstractLoggingTestCase {
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        deploy(createDeployment(), DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    static ModelNode createRootLoggerAddress() {
+        return createAddress("root-logger", "ROOT");
+    }
+
+    static ModelNode createCustomHandlerAddress(final String name) {
+        return createAddress("custom-handler", name);
+    }
+
+    protected ModelNode testWrite(final ModelNode address, final String attribute, final String value) throws IOException {
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        builder.addStep(Operations.createWriteAttributeOperation(address, attribute, value));
+        // Create the read operation
+        builder.addStep(Operations.createReadAttributeOperation(address, attribute));
+        final ModelNode result = executeOperation(builder.build());
+        assertEquals(value, Operations.readResult(Operations.readResult(result).get("step-2")).asString());
+        return result;
+    }
+
+    protected ModelNode testWrite(final ModelNode address, final String attribute, final boolean value) throws IOException {
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        builder.addStep(Operations.createWriteAttributeOperation(address, attribute, value));
+        // Create the read operation
+        builder.addStep(Operations.createReadAttributeOperation(address, attribute));
+        final ModelNode result = executeOperation(builder.build());
+        assertEquals(value, Operations.readResult(Operations.readResult(result).get("step-2")).asBoolean());
+        return result;
+    }
+
+    protected ModelNode testWrite(final ModelNode address, final String attribute, final ModelNode value) throws IOException {
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        builder.addStep(Operations.createWriteAttributeOperation(address, attribute, value));
+        // Create the read operation
+        builder.addStep(Operations.createReadAttributeOperation(address, attribute));
+        final ModelNode result = executeOperation(builder.build());
+        assertEquals(value, Operations.readResult(Operations.readResult(result).get("step-2")));
+        return result;
+    }
+
+    protected ModelNode testUndefine(final ModelNode address, final String attribute) throws IOException {
+        return testUndefine(address, attribute, false);
+    }
+
+    protected ModelNode testUndefine(final ModelNode address, final String attribute, final boolean expectFailure) throws IOException {
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        builder.addStep(Operations.createUndefineAttributeOperation(address, attribute));
+        // Create the read operation
+        final ModelNode readOp = Operations.createReadAttributeOperation(address, attribute);
+        readOp.get("include-defaults").set(false);
+        builder.addStep(readOp);
+        final ModelNode result = client.getControllerClient().execute(builder.build());
+        if (expectFailure) {
+            assertFalse("Undefining attribute " + attribute + " should have failed.", Operations.isSuccessfulOutcome(result));
+        } else {
+            if (!Operations.isSuccessfulOutcome(result)) {
+                Assert.fail(Operations.getFailureDescription(result).toString());
+            }
+            assertFalse("Attribute '" + attribute + "' was not undefined.", Operations.readResult(Operations.readResult(result).get("step-2"))
+                    .isDefined());
+        }
+        return result;
+    }
+
+    protected void verifyRemoved(final ModelNode address) throws IOException {
+        final ModelNode op = Operations.createReadResourceOperation(address);
+        final ModelNode result = client.getControllerClient().execute(op);
+        assertFalse("Resource not removed: " + address, Operations.isSuccessfulOutcome(result));
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomFormattersTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomFormattersTestCase.java
@@ -1,0 +1,208 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging.operations;
+
+import java.io.BufferedReader;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(WildflyTestRunner.class)
+public class CustomFormattersTestCase extends AbstractLoggingOperationsTestCase {
+
+    private static final String CUSTOM_FORMATTER_NAME = "customFormatter";
+    private static final String FILE_NAME = "cf-log.xml";
+    private static final String HANDLER_NAME = "xmlFile";
+    private static final ModelNode CUSTOM_FORMATTER_ADDRESS = createAddress("custom-formatter", CUSTOM_FORMATTER_NAME);
+    private static final ModelNode HANDLER_ADDRESS = createAddress("file-handler", HANDLER_NAME);
+    private static final ModelNode ROOT_LOGGER_ADDRESS = createAddress("root-logger", "ROOT");
+
+    @Test
+    public void testOperations() throws Exception {
+        // Create the custom formatter
+        ModelNode op = Operations.createAddOperation(CUSTOM_FORMATTER_ADDRESS);
+        op.get("class").set("org.jboss.logmanager.formatters.PatternFormatter");
+        op.get("module").set("org.jboss.logmanager");
+        executeOperation(op);
+
+        // Write some properties
+        final ModelNode properties = new ModelNode().setEmptyList();
+        properties.add("pattern", "%s%E%n");
+        testWrite(CUSTOM_FORMATTER_ADDRESS, "properties", properties);
+
+        // Undefine the properties
+        testUndefine(CUSTOM_FORMATTER_ADDRESS, "properties");
+
+        // Write a new class attribute, should leave in restart state
+        ModelNode result = testWrite(CUSTOM_FORMATTER_ADDRESS, "class", "java.util.logging.XMLFormatter");
+        // Check the state
+        ModelNode step1 = Operations.readResult(result).get("step-1");
+        Assert.assertTrue("Should be in reload-required state: " + result, step1.get("response-headers").get("operation-requires-reload").asBoolean());
+
+        // Undefining the class should fail
+        testUndefine(CUSTOM_FORMATTER_ADDRESS, "class", true);
+
+        // Change the module which should require a restart
+        result = testWrite(CUSTOM_FORMATTER_ADDRESS, "module", "sun.jdk");
+        // Check the state
+        step1 = Operations.readResult(result).get("step-1");
+        Assert.assertTrue("Should be in reload-required state: " + result, step1.get("response-headers").get("operation-requires-reload").asBoolean());
+
+        // Undefining the module should fail
+        testUndefine(CUSTOM_FORMATTER_ADDRESS, "module", true);
+
+        // Remove the custom formatter
+        op = Operations.createRemoveOperation(CUSTOM_FORMATTER_ADDRESS);
+        executeOperation(op);
+
+        // Verify it's been removed
+        verifyRemoved(CUSTOM_FORMATTER_ADDRESS);
+    }
+
+    @Test
+    public void testUsage() throws Exception {
+
+        // Create the custom formatter
+        CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        ModelNode op = Operations.createAddOperation(CUSTOM_FORMATTER_ADDRESS);
+        op.get("class").set("java.util.logging.XMLFormatter");
+        // the module doesn't really matter since it's a JDK, so we'll just use the jboss-logmanager.
+        op.get("module").set("org.jboss.logmanager");
+        builder.addStep(op);
+
+        // Create the handler
+        op = Operations.createAddOperation(HANDLER_ADDRESS);
+        final ModelNode file = op.get("file");
+        file.get("relative-to").set("jboss.server.log.dir");
+        file.get("path").set(FILE_NAME);
+        op.get("append").set(false);
+        op.get("autoflush").set(true);
+        op.get("named-formatter").set(CUSTOM_FORMATTER_NAME);
+        builder.addStep(op);
+
+        // Add the handler to the root logger
+        op = Operations.createOperation("add-handler", ROOT_LOGGER_ADDRESS);
+        op.get(ModelDescriptionConstants.NAME).set(HANDLER_NAME);
+        builder.addStep(op);
+
+        executeOperation(builder.build());
+
+        // Get the log file
+        op = Operations.createOperation("resolve-path", HANDLER_ADDRESS);
+        ModelNode result = executeOperation(op);
+        final Path logFile = Paths.get(Operations.readResult(result).asString());
+
+        // The file should exist
+        Assert.assertTrue("The log file was not created.", Files.exists(logFile));
+
+        // Log 5 records
+        doLog("Test message: ", 5);
+
+        // Read the log file
+        try (BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            final Pattern pattern = Pattern.compile("^(<message>)+(Test message: \\d)+(</message>)$");
+            final List<String> messages = new ArrayList<>(5);
+            String line;
+            while ((line = reader.readLine()) != null) {
+                final String trimmedLine = line.trim();
+                final Matcher m = pattern.matcher(trimmedLine);
+                // Very simple xml parsing
+                if (m.matches()) {
+                    messages.add(m.group(2));
+                }
+            }
+
+            // Should be 5 messages
+            Assert.assertEquals(5, messages.size());
+            // Check each message
+            int count = 0;
+            for (String msg : messages) {
+                Assert.assertEquals("Test message: " + count++, msg);
+            }
+        }
+
+        builder = CompositeOperationBuilder.create();
+        // Remove the handler from the root-logger
+        op = Operations.createOperation("remove-handler", ROOT_LOGGER_ADDRESS);
+        op.get(ModelDescriptionConstants.NAME).set(HANDLER_NAME);
+        builder.addStep(op);
+
+
+        // Remove the custom formatter
+        op = Operations.createRemoveOperation(CUSTOM_FORMATTER_ADDRESS);
+        builder.addStep(op);
+
+        // Remove the handler
+        op = Operations.createRemoveOperation(HANDLER_ADDRESS);
+        builder.addStep(op);
+
+        executeOperation(builder.build());
+
+        // So we don't pollute other, verify the formatter and handler have been removed
+        op = Operations.createReadAttributeOperation(ROOT_LOGGER_ADDRESS, "handlers");
+        result = executeOperation(op);
+        // Should be a list type
+        final List<ModelNode> handlers = Operations.readResult(result).asList();
+        for (ModelNode handler : handlers) {
+            Assert.assertNotEquals(CUSTOM_FORMATTER_NAME, handler.asString());
+        }
+        verifyRemoved(CUSTOM_FORMATTER_ADDRESS);
+        verifyRemoved(HANDLER_ADDRESS);
+
+        // Delete the log file
+        Files.delete(logFile);
+        // Ensure it's been deleted
+        Assert.assertFalse(Files.exists(logFile));
+    }
+
+    private void doLog(final String msg, final int count) throws Exception {
+        final URL url = TestSuiteEnvironment.getHttpUrl();
+        for (int i = 0; i < count; i++) {
+            final String s = msg + i;
+            final int statusCode = getResponse(s, Collections.singletonMap(LoggingServiceActivator.LOG_INFO_ONLY_KEY, "true"));
+            Assert.assertTrue("Invalid response statusCode: " + statusCode + " URL: " + url, statusCode == HttpStatus.SC_OK);
+        }
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging.operations;
+
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logmanager.handlers.ConsoleHandler;
+import org.jboss.logmanager.handlers.QueueHandler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(WildflyTestRunner.class)
+public class CustomHandlerOperationsTestCase extends AbstractLoggingOperationsTestCase {
+
+    @Test
+    public void testCustomHandler() throws Exception {
+
+        testCustomHandler(null);
+
+        // Create the profile
+        final String profileName = "test-profile";
+        final ModelNode profileAddress = createAddress("logging-profile", profileName);
+        final ModelNode addOp = Operations.createAddOperation(profileAddress);
+        executeOperation(addOp);
+
+        testCustomHandler(profileName);
+
+        // Remove the profile
+        executeOperation(Operations.createRemoveOperation(profileAddress));
+        verifyRemoved(profileAddress);
+    }
+
+    private void testCustomHandler(final String profileName) throws Exception {
+        final ModelNode address = createCustomHandlerAddress(profileName, "CONSOLE2");
+
+        // Add the handler
+        final ModelNode addOp = Operations.createAddOperation(address);
+        addOp.get("module").set("org.jboss.logmanager");
+        addOp.get("class").set(ConsoleHandler.class.getName());
+        executeOperation(addOp);
+
+        // Write each attribute and check the value
+        testWrite(address, "level", "INFO");
+        testWrite(address, "enabled", true);
+        testWrite(address, "encoding", "utf-8");
+        testWrite(address, "formatter", "[test] %d{HH:mm:ss,SSS} %-5p [%c] %s%E%n");
+        testWrite(address, "filter-spec", "deny");
+        testWrite(address, "class", QueueHandler.class.getName());
+        testWrite(address, "module", "org.jboss.logmanager");
+        // Create a properties value
+        final ModelNode properties = new ModelNode().setEmptyObject();
+        properties.get("autoFlush").set(true);
+        properties.get("target").set("SYSTEM_OUT");
+        testWrite(address, "properties", properties);
+
+        // Undefine attributes
+        testUndefine(address, "level");
+        testUndefine(address, "enabled");
+        testUndefine(address, "encoding");
+        testUndefine(address, "formatter");
+        testUndefine(address, "filter-spec");
+        testUndefine(address, "properties");
+
+        // Clean-up
+        executeOperation(Operations.createRemoveOperation(address));
+        verifyRemoved(address);
+    }
+
+    private static ModelNode createCustomHandlerAddress(final String profileName, final String name) {
+        if (profileName == null) {
+            return createAddress("custom-handler", name);
+        }
+        return createAddress("logging-profile", profileName, "custom-handler", name);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerTestCase.java
@@ -1,0 +1,141 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging.operations;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logmanager.handlers.FileHandler;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ServerSetup(CustomHandlerTestCase.CustomHandlerSetUp.class)
+@RunWith(WildflyTestRunner.class)
+public class CustomHandlerTestCase extends AbstractLoggingOperationsTestCase {
+
+    private static final String FILE_NAME = "custom-handler-file.log";
+    private static final String CUSTOM_HANDLER_NAME = "customFileHandler";
+    private static final ModelNode CUSTOM_HANDLER_ADDRESS = createCustomHandlerAddress(CUSTOM_HANDLER_NAME);
+    private Path logFile = null;
+
+    @Before
+    public void setLogFile() throws Exception {
+        if (logFile == null) {
+            logFile = getAbsoluteLogFilePath(FILE_NAME);
+        }
+    }
+
+    @Test
+    public void defaultLoggingTest() throws Exception {
+        final String msg = "Logging test: CustomHandlerTestCase.defaultLoggingTest";
+        searchLog(msg, true);
+    }
+
+    @Test
+    public void disabledLoggerTest() throws Exception {
+        setEnabled(CUSTOM_HANDLER_ADDRESS, false);
+
+        try {
+            final String msg = "Logging Test: CustomHandlerTestCase.disabledLoggerTest";
+            searchLog(msg, false);
+        } finally {
+            setEnabled(CUSTOM_HANDLER_ADDRESS, true);
+        }
+    }
+
+    private void searchLog(final String msg, final boolean expected) throws Exception {
+        int statusCode = getResponse(msg);
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        boolean logFound = false;
+        for (String s : Files.readAllLines(logFile, StandardCharsets.UTF_8)) {
+            if (s.contains(msg)) {
+                logFound = true;
+                break;
+            }
+        }
+        Assert.assertTrue(msg + " not found in " + logFile, logFound == expected);
+    }
+
+    static class CustomHandlerSetUp implements ServerSetupTask {
+
+        private Path logFile;
+
+        @Override
+        public void setup(final ManagementClient managementClient) throws Exception {
+            logFile = getAbsoluteLogFilePath(FILE_NAME);
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            // Create the custom handler
+            ModelNode op = Operations.createAddOperation(CUSTOM_HANDLER_ADDRESS);
+            op.get("class").set(FileHandler.class.getName());
+            op.get("module").set("org.jboss.logmanager");
+            ModelNode opProperties = op.get("properties").setEmptyObject();
+            opProperties.get("fileName").set(logFile.normalize().toString());
+            opProperties.get("autoFlush").set(true);
+            builder.addStep(op);
+
+            // Add the handler to the root-logger
+            op = Operations.createOperation("add-handler", createRootLoggerAddress());
+            op.get(ModelDescriptionConstants.NAME).set(CUSTOM_HANDLER_NAME);
+            builder.addStep(op);
+
+            executeOperation(builder.build());
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient) throws Exception {
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            // Remove the handler from the root-logger
+            ModelNode op = Operations.createOperation("remove-handler", createRootLoggerAddress());
+            op.get(ModelDescriptionConstants.NAME).set(CUSTOM_HANDLER_NAME);
+            builder.addStep(op);
+
+            // Remove the custom handler
+            op = Operations.createRemoveOperation(CUSTOM_HANDLER_ADDRESS);
+            builder.addStep(op);
+
+            executeOperation(builder.build());
+
+            if (logFile != null) Files.deleteIfExists(logFile);
+
+        }
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/Log4jCustomHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/Log4jCustomHandlerTestCase.java
@@ -1,0 +1,148 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging.operations;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
+import org.jboss.as.test.integration.logging.Log4jServiceActivator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ServerSetup(Log4jCustomHandlerTestCase.Log4jCustomHandlerSetUp.class)
+@RunWith(WildflyTestRunner.class)
+public class Log4jCustomHandlerTestCase extends AbstractLoggingTestCase {
+
+    private static final String FILE_NAME = "log4j-appender-file.log";
+    private static final String CUSTOM_HANDLER_NAME = "customFileAppender";
+    private static final ModelNode CUSTOM_HANDLER_ADDRESS = createAddress("custom-handler", CUSTOM_HANDLER_NAME);
+    private final Path logFile = getAbsoluteLogFilePath(FILE_NAME);
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        final JavaArchive archive = createDeployment(Log4jServiceActivator.class, Log4jServiceActivator.DEPENDENCIES);
+        deploy(archive, DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    @Test
+    public void defaultLoggingTest() throws Exception {
+        final String msg = "Logging test: Log4jCustomHandlerTestCase.defaultLoggingTest";
+        searchLog(msg, true);
+    }
+
+    @Test
+    public void disabledLoggerTest() throws Exception {
+        setEnabled(CUSTOM_HANDLER_ADDRESS, false);
+
+        try {
+            final String msg = "Logging Test: Log4jCustomHandlerTestCase.disabledLoggerTest";
+            searchLog(msg, false);
+        } finally {
+            setEnabled(CUSTOM_HANDLER_ADDRESS, true);
+        }
+    }
+
+    private void searchLog(final String msg, final boolean expected) throws Exception {
+        int statusCode = getResponse(msg);
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        boolean logFound = false;
+        for (String s : Files.readAllLines(logFile, StandardCharsets.UTF_8)) {
+            if (s.contains(msg)) {
+                logFound = true;
+                break;
+            }
+        }
+        Assert.assertTrue(msg + " not found in " + logFile, logFound == expected);
+    }
+
+    static class Log4jCustomHandlerSetUp implements ServerSetupTask {
+
+        private Path logFile;
+
+        @Override
+        public void setup(final ManagementClient managementClient) throws Exception {
+            logFile = getAbsoluteLogFilePath(FILE_NAME);
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            // Create the custom handler
+            ModelNode op = Operations.createAddOperation(CUSTOM_HANDLER_ADDRESS);
+            op.get("class").set("org.apache.log4j.FileAppender");
+            op.get("module").set("org.apache.log4j");
+            ModelNode opProperties = op.get("properties").setEmptyObject();
+            opProperties.get("file").set(logFile.normalize().toString());
+            opProperties.get("immediateFlush").set(true);
+            builder.addStep(op);
+
+            // Add the handler to the root-logger
+            op = Operations.createOperation("add-handler", createAddress("root-logger", "ROOT"));
+            op.get(ModelDescriptionConstants.NAME).set(CUSTOM_HANDLER_NAME);
+            builder.addStep(op);
+
+            executeOperation(builder.build());
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient) throws Exception {
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            // Remove the handler from the root-logger
+            final ModelNode op = Operations.createOperation("remove-handler", createAddress("root-logger", "ROOT"));
+            op.get(ModelDescriptionConstants.NAME).set(CUSTOM_HANDLER_NAME);
+            builder.addStep(op);
+
+            // Remove the custom handler
+            builder.addStep(Operations.createRemoveOperation(CUSTOM_HANDLER_ADDRESS));
+
+            executeOperation(builder.build());
+
+            if (logFile != null) Files.deleteIfExists(logFile);
+
+        }
+
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/DeploymentBaseTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/DeploymentBaseTestCase.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging.perdeploy;
+
+import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DeploymentBaseTestCase extends AbstractLoggingTestCase {
+
+    static JavaArchive createDeployment(final String fileName) {
+        return createDeployment().addAsResource(DeploymentBaseTestCase.class.getPackage(), fileName, "META-INF/" + fileName);
+    }
+
+    static JavaArchive createDeployment(final Class<? extends ServiceActivator> serviceActivator, final String fileName, final Class<?>... classes) {
+        final JavaArchive archive = createDeployment(serviceActivator, classes);
+        archive.addAsResource(DeploymentBaseTestCase.class.getPackage(), fileName, "META-INF/" + fileName);
+        return archive;
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLog4jXmlTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLog4jXmlTestCase.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.logging.perdeploy;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.http.HttpStatus;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author Petr Křemenský <pkremens@redhat.com>
+ */
+@RunWith(WildflyTestRunner.class)
+public class JBossLog4jXmlTestCase extends DeploymentBaseTestCase {
+
+    private static final Path logFile = getAbsoluteLogFilePath("jboss-log4j-xml-test.log");
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        deploy(createDeployment("jboss-log4j.xml"), DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    @Test
+    public void logsTest() throws IOException {
+        final String msg = "logTest: jboss-log4j message";
+        final int statusCode = getResponse(msg, Collections.singletonMap("includeLevel", "true"));
+        assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        boolean trace = false;
+        boolean fatal = false;
+        String traceLine = msg + " - trace";
+        String fatalLine = msg + " - fatal";
+        try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains(traceLine)) {
+                    trace = true;
+                }
+                if (line.contains(fatalLine)) {
+                    fatal = true;
+                }
+            }
+        }
+        Assert.assertTrue("Log file should contain line: " + traceLine, trace);
+        Assert.assertTrue("Log file should contain line: " + fatalLine, fatal);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLoggingPropertiesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLoggingPropertiesTestCase.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.logging.perdeploy;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.http.HttpStatus;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author Petr Křemenský <pkremens@redhat.com>
+ */
+@RunWith(WildflyTestRunner.class)
+public class JBossLoggingPropertiesTestCase extends DeploymentBaseTestCase {
+
+    private static final Path logFile = getAbsoluteLogFilePath("jboss-logging-properties-test.log");
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        deploy(createDeployment("jboss-logging.properties"), DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    @Test
+    public void logsTest() throws IOException {
+        final String msg = "logTest: jboss-logging.properties message";
+        final int statusCode = getResponse(msg, Collections.singletonMap("includeLevel", "true"));
+        assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        boolean trace = false;
+        boolean fatal = false;
+        String traceLine = msg + " - trace";
+        String fatalLine = msg + " - fatal";
+        try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains(traceLine)) {
+                    trace = true;
+                }
+                if (line.contains(fatalLine)) {
+                    fatal = true;
+                }
+            }
+        }
+        Assert.assertTrue("Log file should contain line: " + traceLine, trace);
+        Assert.assertTrue("Log file should contain line: " + fatalLine, fatal);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/Log4jPropertiesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/Log4jPropertiesTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.logging.perdeploy;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.test.integration.logging.Log4jServiceActivator;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author Petr Křemenský <pkremens@redhat.com>
+ */
+@RunWith(WildflyTestRunner.class)
+public class Log4jPropertiesTestCase extends DeploymentBaseTestCase {
+
+    private static final Path logFile = getAbsoluteLogFilePath("log4j-properties-test.log");
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        deploy(createDeployment(Log4jServiceActivator.class, "log4j.properties", Log4jServiceActivator.DEPENDENCIES), DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    @Test
+    public void logsTest() throws IOException {
+        final String msg = "logTest: log4j.properties message";
+        final int statusCode = getResponse(msg, Collections.singletonMap("includeLevel", "true"));
+        assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        boolean trace = false;
+        boolean fatal = false;
+        String traceLine = msg + " - trace";
+        String fatalLine = msg + " - fatal";
+        try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains(traceLine)) {
+                    trace = true;
+                }
+                if (line.contains(fatalLine)) {
+                    fatal = true;
+                }
+            }
+        }
+        Assert.assertTrue("Log file should contain line: " + traceLine, trace);
+        Assert.assertTrue("Log file should contain line: " + fatalLine, fatal);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/Log4jXmlTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/Log4jXmlTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.logging.perdeploy;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.test.integration.logging.Log4jServiceActivator;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author Petr Křemenský <pkremens@redhat.com>
+ */
+@RunWith(WildflyTestRunner.class)
+public class Log4jXmlTestCase extends DeploymentBaseTestCase {
+
+    private static final Path logFile = getAbsoluteLogFilePath("log4j-xml-test.log");
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        deploy(createDeployment(Log4jServiceActivator.class, "log4j.xml", Log4jServiceActivator.DEPENDENCIES), DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    @Test
+    public void logsTest() throws IOException {
+        final String msg = "logTest: log4j.xml message";
+        final int statusCode = getResponse(msg, Collections.singletonMap("includeLevel", "true"));
+        assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        boolean trace = false;
+        boolean fatal = false;
+        String traceLine = msg + " - trace";
+        String fatalLine = msg + " - fatal";
+        try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains(traceLine)) {
+                    trace = true;
+                }
+                if (line.contains(fatalLine)) {
+                    fatal = true;
+                }
+            }
+        }
+        Assert.assertTrue("Log file should contain line: " + traceLine, trace);
+        Assert.assertTrue("Log file should contain line: " + fatalLine, fatal);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/LoggingPropertiesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/LoggingPropertiesTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.logging.perdeploy;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import org.apache.http.HttpStatus;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author Petr Křemenský <pkremens@redhat.com>
+ */
+@RunWith(WildflyTestRunner.class)
+public class LoggingPropertiesTestCase extends DeploymentBaseTestCase {
+
+    private static final Path logFile = getAbsoluteLogFilePath("logging-properties-test.log");
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        deploy(createDeployment("logging.properties"), DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    @Test
+    public void logsTest() throws IOException {
+        final String msg = "logTest: logging.properties message";
+        final int statusCode = getResponse(msg, Collections.singletonMap("includeLevel", "true"));
+        assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        boolean trace = false;
+        boolean fatal = false;
+        String traceLine = msg + " - trace";
+        String fatalLine = msg + " - fatal";
+        try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains(traceLine)) {
+                    trace = true;
+                }
+                if (line.contains(fatalLine)) {
+                    fatal = true;
+                }
+            }
+        }
+        Assert.assertTrue("Log file should contain line: " + traceLine, trace);
+        Assert.assertTrue("Log file should contain line: " + fatalLine, fatal);
+    }
+
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/LoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/LoggingProfilesTestCase.java
@@ -1,0 +1,314 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging.profiles;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper.ServerDeploymentException;
+import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
+import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author Petr Křemenský <pkremens@redhat.com>
+ */
+@ServerSetup(LoggingProfilesTestCase.LoggingProfilesTestCaseSetup.class)
+@RunWith(WildflyTestRunner.class)
+public class LoggingProfilesTestCase extends AbstractLoggingTestCase {
+    private static Logger log = Logger.getLogger(LoggingProfilesTestCase.class);
+
+    private static final String PROFILE1 = "dummy-profile1";
+    private static final String PROFILE2 = "dummy-profile2";
+    private static final String RUNTIME_NAME1 = "logging1.jar";
+    private static final String RUNTIME_NAME2 = "logging2.jar";
+
+    private static final String LOG_FILE_NAME = "profiles-test.log";
+    private static final String PROFILE1_LOG_NAME = "dummy-profile1.log";
+    private static final String PROFILE2_LOG_NAME = "dummy-profile2.log";
+    private static final String CHANGED_LOG_NAME = "dummy-profile1-changed.log";
+    private static final String LOG_DIR = resolveRelativePath("jboss.server.log.dir");
+    private static final Path logFile = Paths.get(LOG_DIR, LOG_FILE_NAME);
+    private static final Path dummyLog1 = Paths.get(LOG_DIR, PROFILE1_LOG_NAME);
+    private static final Path dummyLog2 = Paths.get(LOG_DIR, PROFILE2_LOG_NAME);
+    private static final Path dummyLog1Changed = Paths.get(LOG_DIR, CHANGED_LOG_NAME);
+
+    static class LoggingProfilesTestCaseSetup implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient) throws Exception {
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            ModelNode op = Operations.createAddOperation(createAddress("periodic-rotating-file-handler", "LOGGING_TEST"));
+            op.get("append").set("true");
+            op.get("suffix").set(".yyyy-MM-dd");
+            ModelNode file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(LOG_FILE_NAME);
+            op.get("file").set(file);
+            op.get("formatter").set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n");
+            builder.addStep(op);
+
+            op = Operations.createOperation("add-handler", createAddress("root-logger", "ROOT"));
+            op.get("name").set("LOGGING_TEST");
+            builder.addStep(op);
+
+            // create dummy-profile1
+            builder.addStep(Operations.createAddOperation(createAddress("logging-profile", "dummy-profile1")));
+
+            // add file handler
+            op = Operations.createAddOperation(createAddress("logging-profile", "dummy-profile1", "periodic-rotating-file-handler", "DUMMY1"));
+            op.get("level").set("FATAL");
+            op.get("append").set("true");
+            op.get("suffix").set(".yyyy-MM-dd");
+            file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(PROFILE1_LOG_NAME);
+            op.get("file").set(file);
+            op.get("formatter").set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n");
+            builder.addStep(op);
+
+            // add root logger
+            op = Operations.createAddOperation(createAddress("logging-profile", "dummy-profile1", "root-logger", "ROOT"));
+            op.get("level").set("INFO");
+            ModelNode handlers = op.get("handlers");
+            handlers.add("DUMMY1");
+            op.get("handlers").set(handlers);
+            builder.addStep(op);
+
+            // create dummy-profile2
+            builder.addStep(Operations.createAddOperation(createAddress("logging-profile", "dummy-profile2")));
+
+            // add file handler
+            op = Operations.createAddOperation(createAddress("logging-profile", "dummy-profile2", "periodic-rotating-file-handler", "DUMMY2"));
+            op.get("level").set("INFO");
+            op.get("append").set("true");
+            op.get("suffix").set(".yyyy-MM-dd");
+            file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(PROFILE2_LOG_NAME);
+            op.get("file").set(file);
+            op.get("formatter").set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n");
+            builder.addStep(op);
+
+            // add root logger
+            op = Operations.createAddOperation(createAddress("logging-profile", "dummy-profile2", "root-logger", "ROOT"));
+            op.get("level").set("INFO");
+            handlers = op.get("handlers");
+            handlers.add("DUMMY2");
+            op.get("handlers").set(handlers);
+            builder.addStep(op);
+
+            executeOperation(builder.build());
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient) throws Exception {
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            // remove LOGGING_TEST from root-logger
+            ModelNode op = Operations.createOperation("remove-handler", createAddress("root-logger", "ROOT"));
+            op.get("name").set("LOGGING_TEST");
+            builder.addStep(op);
+
+            // remove custom file handler
+            builder.addStep(Operations.createRemoveOperation(createAddress("periodic-rotating-file-handler", "LOGGING_TEST")));
+
+            // remove dummy-profile1
+            builder.addStep(Operations.createRemoveOperation(createAddress("logging-profile", "dummy-profile1")));
+
+            // remove dummy-profile2
+            builder.addStep(Operations.createRemoveOperation(createAddress("logging-profile", "dummy-profile2")));
+
+            executeOperation(builder.build());
+
+            // delete log files only if this did not fail
+            Files.deleteIfExists(logFile);
+            Files.deleteIfExists(dummyLog1);
+            Files.deleteIfExists(dummyLog2);
+            Files.deleteIfExists(dummyLog1Changed);
+        }
+    }
+
+    @Test
+    public void noWarningTest() throws Exception {
+        try {
+            deploy(RUNTIME_NAME1, PROFILE1, false);
+            deploy(RUNTIME_NAME2, PROFILE2, false);
+            try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    // Look for message id in order to support all languages.
+                    if (line.contains(PROFILE1) || line.contains(PROFILE2)) {
+                        Assert.fail("Every deployment should have defined its own logging profile. But found this line in logs: "
+                                + line);
+                    }
+                }
+            }
+        } finally {
+            undeploy(RUNTIME_NAME1, RUNTIME_NAME2);
+        }
+    }
+
+    @Test
+    public void testProfiles() throws Exception {
+        // Test the first profile
+        try {
+            deploy(RUNTIME_NAME1, PROFILE1);
+            // make some logs
+            int statusCode = getResponse("DummyProfile1: Test log message from 1");
+            assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        } finally {
+            undeploy(RUNTIME_NAME1);
+        }
+
+        // Test the next profile
+        try {
+            deploy(RUNTIME_NAME2, PROFILE2);
+            // make some logs
+            int statusCode = getResponse("DummyProfile2: Test log message from 2");
+            assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        } finally {
+            undeploy(RUNTIME_NAME2);
+        }
+
+        // Check that only one log record is in the first file
+        Assert.assertTrue("dummy-profile1.log was not created", Files.exists(dummyLog1));
+        try (final BufferedReader reader = Files.newBufferedReader(dummyLog1, StandardCharsets.UTF_8)) {
+            String line = reader.readLine();
+            Assert.assertTrue(
+                    "\"LoggingServlet is logging fatal message\" should be presented in dummy-profile1.log",
+                    line.contains("DummyProfile1: Test log message from 1"));
+            Assert.assertTrue("Only one log should be found in dummy-profile1.log",
+                    reader.readLine() == null);
+        }
+
+        // Check that only one log record is in the second file
+        Assert.assertTrue("dummy-profile2.log was not created", Files.exists(dummyLog2));
+        try (final BufferedReader reader = Files.newBufferedReader(dummyLog2, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                // The UndertowService also logs one line, this line should be ignored
+                if (line.contains("UndertowService")) continue;
+                if (!line.contains("DummyProfile2: Test log message from 2")) {
+                    Assert.fail("dummy-profile2 should not contains this line: "
+                            + line);
+                }
+            }
+        }
+
+        // Check a file that should not have been written to
+        try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains("Test log message from")) {
+                    Assert.fail("LoggingServlet messages should be presented only in files specified in profiles, but found: "
+                            + line);
+                }
+            }
+        }
+
+        // Change the file for the first profile
+        try {
+            deploy(RUNTIME_NAME1, PROFILE1);
+            // Change logging level of file handler on dummy-profile1 from FATAL to
+            // INFO
+            final ModelNode address = createAddress("logging-profile", PROFILE1, "periodic-rotating-file-handler", "DUMMY1");
+            final ModelNode file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(CHANGED_LOG_NAME);
+            ModelNode op = Operations.createWriteAttributeOperation(address, "file", file);
+            executeOperation(op);
+
+            // make some logs
+            int statusCode = getResponse("DummyProfile1: Changed test message 1");
+            assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+
+            // check logs, after logging level change we should see also INFO and
+            // ... messages
+            try (final BufferedReader reader = Files.newBufferedReader(dummyLog1Changed, StandardCharsets.UTF_8)) {
+                String line = reader.readLine();
+                Assert.assertTrue(
+                        "\"LoggingServlet is logging fatal message\" should be presented in dummy-profile1.log",
+                        line.contains("DummyProfile1: Changed test message 1"));
+                Assert.assertTrue("Only one log should be found in " + CHANGED_LOG_NAME, reader.readLine() == null);
+            }
+        } finally {
+            undeploy(RUNTIME_NAME1);
+        }
+    }
+
+    private static void deploy(final String name, final String profileName) throws ServerDeploymentException {
+        deploy(name, profileName, true);
+    }
+
+    private static void deploy(final String name, final String profileName, final boolean useServiceActivator) throws ServerDeploymentException {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, name);
+        if (useServiceActivator) {
+            archive.addClasses(LoggingServiceActivator.DEPENDENCIES);
+            archive.addAsServiceProviderAndClasses(ServiceActivator.class, LoggingServiceActivator.class);
+        }
+        archive.addAsResource(new StringAsset("Dependencies: io.undertow.core\nLogging-Profile: " + profileName), "META-INF/MANIFEST.MF");
+        deploy(archive, name);
+    }
+
+    private static void undeploy(final String... deployments) throws Exception {
+        // Safely undeploy each deployment only logging deployment errors and throwing and exception at the end
+        boolean error = false;
+        final StringWriter stringWriter = new StringWriter();
+        final PrintWriter writer = new PrintWriter(stringWriter);
+        for (String name : deployments) {
+            try {
+                undeploy(name);
+            } catch (Exception e) {
+                error = true;
+                e.printStackTrace(writer);
+            }
+        }
+        Assert.assertFalse(stringWriter.toString(), error);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/NonExistingProfileTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/NonExistingProfileTestCase.java
@@ -1,0 +1,145 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.logging.profiles;
+
+import static org.junit.Assert.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * @author Petr Křemenský <pkremens@redhat.com>
+ */
+@ServerSetup(NonExistingProfileTestCase.NonExistingProfileTestCaseSetup.class)
+@RunWith(WildflyTestRunner.class)
+public class NonExistingProfileTestCase extends AbstractLoggingTestCase {
+
+    private static final String LOG_FILE_NAME = "non-existing-profile-test.log";
+    private static final Path loggingTestLog = Paths.get(resolveRelativePath("jboss.server.log.dir"), LOG_FILE_NAME);
+
+    static class NonExistingProfileTestCaseSetup implements ServerSetupTask {
+        @Override
+        public void setup(final ManagementClient managementClient) throws Exception {
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            // add custom file-handler
+            ModelNode op = Operations.createAddOperation(createAddress("periodic-rotating-file-handler", "LOGGING_TEST"));
+            op.get("append").set("true");
+            op.get("suffix").set(".yyyy-MM-dd");
+            ModelNode file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(LOG_FILE_NAME);
+            op.get("file").set(file);
+            op.get("formatter").set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n");
+            builder.addStep(op);
+
+            // add handler to root-logger
+            op = Operations.createOperation("add-handler", createAddress("root-logger", "ROOT"));
+            op.get("name").set("LOGGING_TEST");
+            builder.addStep(op);
+
+            executeOperation(builder.build());
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient) throws Exception {
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            // remove LOGGING_TEST from root-logger
+            ModelNode op = Operations.createOperation("remove-handler", createAddress("root-logger", "ROOT"));
+            op.get("name").set("LOGGING_TEST");
+            builder.addStep(op);
+
+            // remove custom file handler
+            builder.addStep(Operations.createRemoveOperation(createAddress("periodic-rotating-file-handler", "LOGGING_TEST")));
+
+            executeOperation(builder.build());
+
+            Files.deleteIfExists(loggingTestLog);
+        }
+    }
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        deploy(createDeployment(Collections.singletonMap("Logging-Profile", "non-existing-profile")), "test-logging.jar");
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy("test-logging.jar");
+    }
+
+    @Test
+    public void warningMessageTest() throws IOException {
+        boolean warningFound = false;
+        try (final BufferedReader reader = Files.newBufferedReader(loggingTestLog, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                // Look for profile id
+                if (line.contains("non-existing-profile")) {
+                    warningFound = true;
+                    break;
+                }
+            }
+        }
+        Assert.assertTrue(warningFound);
+    }
+
+    @Test
+    public void defaultLoggingTest() throws IOException {
+        final String msg = "defaultLoggingTest: This is a test message";
+        final int statusCode = getResponse(msg);
+        assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        // check logs
+        boolean logFound = false;
+        try (final BufferedReader br = Files.newBufferedReader(loggingTestLog, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.contains(msg)) {
+                    logFound = true;
+                    break;
+                }
+            }
+        }
+        Assert.assertTrue(logFound);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
@@ -1,0 +1,237 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.logging.syslog;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.junit.Assert.*;
+import static org.productivity.java.syslog4j.SyslogConstants.UDP;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
+import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.as.test.syslogserver.BlockedSyslogServerEventHandler;
+import org.jboss.as.test.syslogserver.UDPSyslogServerConfig;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.logging.Logger.Level;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.productivity.java.syslog4j.SyslogConstants;
+import org.productivity.java.syslog4j.server.SyslogServer;
+import org.productivity.java.syslog4j.server.SyslogServerEventIF;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * A SyslogHandlerTestCase for testing that logs are logged to syslog
+ * <p/>
+ * <b>This test is not thread safe and should never be run with other tests the use the {@link
+ * org.jboss.as.test.syslogserver.BlockedSyslogServerEventHandler}</b>
+ *
+ * @author Ondrej Lukas
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerSetup(SyslogHandlerTestCase.SyslogHandlerTestCaseSetup.class)
+public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
+
+    private static final Logger LOGGER = Logger.getLogger(SyslogHandlerTestCase.class);
+
+    private static final String MSG = "syslog test log message";
+
+    private static final ModelNode SYSLOG_PROFILE_ADDR = createAddress("logging-profile", "syslog-profile");
+    private static final ModelNode SYSLOG_HANDLER_ADDR = createAddress("logging-profile", "syslog-profile", "syslog-handler", "SYSLOG");
+    private static final ModelNode SYSLOG_PROFILE_ROOT_LOGGER_ADDR = createAddress("logging-profile", "syslog-profile", "root-logger", "ROOT");
+
+    /**
+     * Syslog server port.
+     */
+    private static final int PORT = 10514;
+
+    private static final int ADJUSTED_SECOND = TimeoutUtil.adjust(1000);
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        deploy(createDeployment(Collections.singletonMap("Logging-Profile", "syslog-profile")), DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    /**
+     * Tests that messages on all levels are logged, when level="TRACE" in syslog handler.
+     */
+    @Test
+    public void testAllLevelLogs() throws Exception {
+        final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();
+        executeOperation(Operations.createWriteAttributeOperation(SYSLOG_HANDLER_ADDR, "level", "TRACE"));
+        queue.clear();
+        makeLogs();
+        for (Level level : LoggingServiceActivator.LOG_LEVELS) {
+            testLog(queue, level);
+        }
+        Assert.assertTrue("No other message was expected in syslog.", queue.isEmpty());
+    }
+
+    /**
+     * Tests that only messages on specific level or higher level are logged to syslog.
+     */
+    @Test
+    public void testLogOnSpecificLevel() throws Exception {
+        final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();
+        executeOperation(Operations.createWriteAttributeOperation(SYSLOG_HANDLER_ADDR, "level", "ERROR"));
+        queue.clear();
+        makeLogs();
+        testLog(queue, Level.ERROR);
+        testLog(queue, Level.FATAL);
+        Assert.assertTrue("No other message was expected in syslog.", queue.isEmpty());
+    }
+
+    /**
+     * Tests if the next message in the syslog is the expected one with the given log-level.
+     *
+     * @param expectedLevel
+     *
+     * @throws Exception
+     */
+    private void testLog(final BlockingQueue<SyslogServerEventIF> queue, final Level expectedLevel) throws Exception {
+        SyslogServerEventIF log = queue.poll(15L * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
+        assertNotNull(log);
+        assertEquals("Message with unexpected Syslog event level received.", getSyslogLevel(expectedLevel), log.getLevel());
+        final String expectedMsg = LoggingServiceActivator.formatMessage(MSG, expectedLevel);
+        String msg = log.getMessage();
+        assertEquals("Message with unexpected Syslog event text received.", expectedMsg, msg);
+    }
+
+    /**
+     * Convert JBoss Logger.Level to Syslog log level.
+     *
+     * @param jbossLogLevel
+     *
+     * @return
+     */
+    private int getSyslogLevel(Level jbossLogLevel) {
+        final int result;
+        switch (jbossLogLevel) {
+            case TRACE:
+            case DEBUG:
+                result = SyslogConstants.LEVEL_DEBUG;
+                break;
+            case INFO:
+                result = SyslogConstants.LEVEL_INFO;
+                break;
+            case WARN:
+                result = SyslogConstants.LEVEL_WARN;
+                break;
+            case ERROR:
+                result = SyslogConstants.LEVEL_ERROR;
+                break;
+            case FATAL:
+                result = SyslogConstants.LEVEL_EMERGENCY;
+                break;
+            default:
+                // unexpected
+                result = SyslogConstants.LEVEL_CRITICAL;
+                break;
+        }
+        return result;
+    }
+
+    private void makeLogs() throws IOException {
+        final int statusCode = getResponse(MSG, Collections.singletonMap("includeLevel", "true"));
+        assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+    }
+
+    static class SyslogHandlerTestCaseSetup implements ServerSetupTask {
+
+        @Override
+        public void setup(final ManagementClient managementClient) throws Exception {
+            LOGGER.info("starting syslog server on port " + PORT);
+
+            // clear created server instances (TCP/UDP)
+            SyslogServer.shutdown();
+            // create a new UDP instance
+            final String host = CoreUtils.stripSquareBrackets(managementClient.getMgmtAddress());
+            final UDPSyslogServerConfig config = new UDPSyslogServerConfig();
+            config.setPort(PORT);
+            config.setHost(host);
+            config.setUseStructuredData(true);
+            config.addEventHandler(new BlockedSyslogServerEventHandler());
+            SyslogServer.createInstance(UDP, config);
+            // start syslog server
+            SyslogServer.getThreadedInstance(SyslogConstants.UDP);
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            // create syslog-profile
+            builder.addStep(Operations.createAddOperation(SYSLOG_PROFILE_ADDR));
+
+            ModelNode op = Operations.createAddOperation(SYSLOG_HANDLER_ADDR);
+            op.get("level").set("TRACE");
+            op.get("port").set(PORT);
+            op.get("server-address").set(host);
+            op.get("enabled").set("true");
+            builder.addStep(op);
+
+            op = Operations.createAddOperation(SYSLOG_PROFILE_ROOT_LOGGER_ADDR);
+            op.get("level").set("TRACE");
+            op.get("handlers").add("SYSLOG");
+            builder.addStep(op);
+
+            executeOperation(builder.build());
+
+            LOGGER.info("syslog server setup complete");
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient) throws Exception {
+            // stop syslog server
+            LOGGER.info("stopping syslog server");
+            SyslogServer.shutdown();
+            LOGGER.info("syslog server stopped");
+
+            // remove syslog-profile
+            final ModelNode op = Operations.createRemoveOperation(SYSLOG_PROFILE_ADDR);
+            op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+            op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            executeOperation(op);
+            LOGGER.info("syslog server logging profile removed");
+        }
+    }
+}

--- a/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/perdeploy/jboss-log4j.xml
+++ b/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/perdeploy/jboss-log4j.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+  <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+     <appender name="AppLogAppender" class="org.apache.log4j.DailyRollingFileAppender">
+         <param name="DatePattern" value="'.'yyyy-MM-dd"/>
+	 <param name="File" value="${jboss.server.log.dir}/jboss-log4j-xml-test.log" />
+	 <param name="Append" value="false"/>
+         <layout class="org.apache.log4j.PatternLayout">
+	     <param name="ConversionPattern" value="%d [%t] %p - %m%n"/>
+	 </layout>
+     </appender>
+
+     <!-- The "category" represents the package names of your Application APIs which we want to log -->
+     <category name="servlets">
+         <priority value="TRACE"/>
+     </category>
+
+     <root>
+         <priority value ="TRACE"/>
+         <appender-ref ref="AppLogAppender"/>
+     </root>
+ </log4j:configuration>

--- a/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/perdeploy/jboss-logging.properties
+++ b/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/perdeploy/jboss-logging.properties
@@ -1,0 +1,24 @@
+# Additional logger names to configure (root logger is always configured)
+loggers=jboss.as
+
+# Dump system environment at boot by default
+# logger.org.jboss.as.config.level=WARN
+
+# Root logger level
+logger.level=${jboss.boot.server.log.level:ALL}
+# Root logger handlers
+logger.handlers=FILE
+
+handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+handler.FILE.level=${jboss.boot.server.log.console.level:ALL}
+handler.FILE.properties=autoFlush,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=${jboss.server.log.dir}/jboss-logging-properties-test.log
+handler.FILE.formatter=PATTERN
+
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+#formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%E%n
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %C.%M:%L (%t) %5p %c{1}:%L - %m%n

--- a/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/perdeploy/log4j.properties
+++ b/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/perdeploy/log4j.properties
@@ -1,0 +1,14 @@
+log4j.rootLogger=ALL, dummy
+
+
+
+
+# My Application Log
+log4j.appender.dummy=org.apache.log4j.RollingFileAppender
+log4j.appender.dummy.File=${jboss.server.log.dir}/log4j-properties-test.log
+log4j.appender.dummy.logfile.Threshold=ALL
+log4j.appender.dummy.MaxBackupIndex=100
+log4j.appender.dummy.MaxFileSize=1Gb
+log4j.appender.dummy.encoding=UTF8
+log4j.appender.dummy.layout=org.apache.log4j.PatternLayout
+log4j.appender.dummy.layout.ConversionPattern=%p %t %c - %m%n

--- a/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/perdeploy/log4j.xml
+++ b/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/perdeploy/log4j.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+  <log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+     <appender name="AppLogAppender" class="org.apache.log4j.DailyRollingFileAppender">
+         <param name="DatePattern" value="'.'yyyy-MM-dd"/>
+	 <param name="File" value="${jboss.server.log.dir}/log4j-xml-test.log" />
+	 <param name="Append" value="false"/>
+         <layout class="org.apache.log4j.PatternLayout">
+	     <param name="ConversionPattern" value="%d [%t] %p - %m%n"/>
+	 </layout>
+     </appender>
+
+     <!-- The "category" represents the package names of your Application APIs which we want to log -->
+     <category name="servlets">
+         <priority value="TRACE"/>
+     </category>
+
+     <root>
+         <priority value ="TRACE"/>
+         <appender-ref ref="AppLogAppender"/>
+     </root>
+ </log4j:configuration>

--- a/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/perdeploy/logging.properties
+++ b/testsuite/standalone/src/test/resources/org/jboss/as/test/integration/logging/perdeploy/logging.properties
@@ -1,0 +1,24 @@
+# Additional logger names to configure (root logger is always configured)
+loggers=jboss.as
+
+# Dump system environment at boot by default
+logger.org.jboss.as.config.level=WARN
+
+# Root logger level
+logger.level=${jboss.boot.server.log.level:ALL}
+# Root logger handlers
+logger.handlers=CONSOLE
+logger.handlers=FILE
+
+handler.FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler
+handler.FILE.level=${jboss.boot.server.log.console.level:ALL}
+handler.FILE.properties=autoFlush,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=${jboss.server.log.dir}/logging-properties-test.log
+handler.FILE.formatter=PATTERN
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+#formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%E%n
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %C.%M:%L (%t) %5p %c{1}:%L - %m%n


### PR DESCRIPTION
First commit adds a generic `ServiceActivator` to start an Undertow server.

The second commit is the large commit which moves the logging integration tests from WildFly. A couple tests from WildFly were removed as they shouldn't be needed here or are tested via the normal subsystem tests.