### PR TITLE
[WFCORE-297] : HC should remember the 'run' state of the server instances after crash or shutdown

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -449,6 +449,7 @@ public class ModelDescriptionConstants {
     public static final String UPLOAD_DEPLOYMENT_URL = "upload-deployment-url";
     public static final String UPLOAD_DEPLOYMENT_STREAM = "upload-deployment-stream";
     public static final String UNIT = "unit";
+    public static final String UPDATE_AUTO_START_WITH_SERVER_STATUS = "update-auto-start-with-server-status";
     public static final String URI = "uri";
     public static final String URL = "url";
     public static final String USE_CURRENT_DOMAIN_CONFIG = "use-current-domain-config";

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -169,6 +169,7 @@ public enum Attribute {
     SYSLOG_FORMAT ("syslog-format"),
     TRUNCATE("truncate"),
     TYPE("type"),
+    UPDATE_AUTO_START_WITH_SERVER_STATUS("update-auto-start-with-server-status"),
     URL("url"),
     USER("user"),
     USER_DN("user-dn"),

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -49,6 +49,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -1215,4 +1216,11 @@ public interface HostControllerLogger extends BasicLogger {
 
     @Message(id = 156, value = "failed to resolve interface %s")
     OperationFailedException failedToResolveInterface(String name);
+
+    @Message( id = 157, value = "Could not create domain auto-start directory: %s")
+    IllegalStateException couldNotCreateDomainAutoStartDirectory(Path file, @Cause Throwable cause);
+
+    @LogMessage(level = Level.INFO)
+    @Message( id = 158, value = "Error persisting server autostart status")
+    void couldNotPersistAutoStartServerStatus(@Cause Throwable cause);
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -396,7 +396,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
         interfaces.registerOperationHandler(SpecifiedInterfaceResolveHandler.DEFINITION, SpecifiedInterfaceResolveHandler.INSTANCE);
 
         //server configurations
-        hostRegistration.registerSubModel(new ServerConfigResourceDefinition(hostControllerInfo, serverInventory, pathManager));
+        hostRegistration.registerSubModel(new ServerConfigResourceDefinition(hostControllerInfo, serverInventory, pathManager, processState, environment.getDomainDataDir()));
         hostRegistration.registerSubModel(new StoppedServerResource(serverInventory));
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerStopHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerStopHandler.java
@@ -19,6 +19,7 @@
 package org.jboss.as.host.controller.operations;
 
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 import java.util.EnumSet;
@@ -71,7 +72,7 @@ public class ServerStopHandler implements OperationStepHandler {
         final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
         final PathElement element = address.getLastElement();
         final String serverName = element.getValue();
-        final boolean blocking = operation.get("blocking").asBoolean(false);
+        final boolean blocking = operation.get(BLOCKING).asBoolean(false);
         final int timeout = TIMEOUT.resolveModelAttribute(context, operation).asInt();
         context.addStep(new OperationStepHandler() {
             @Override
@@ -86,6 +87,7 @@ public class ServerStopHandler implements OperationStepHandler {
                 context.authorize(operation, EnumSet.of(Action.ActionEffect.WRITE_RUNTIME));
 
                 final ServerStatus status = serverInventory.stopServer(serverName, timeout, blocking);
+                context.readResource(PathAddress.EMPTY_ADDRESS, false);
                 context.getResult().set(status.toString());
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -2004,6 +2004,10 @@ public class HostXml extends CommonXml {
                         ServerConfigResourceDefinition.AUTO_START.parseAndSetParameter(value, addUpdate, reader);
                         break;
                     }
+                    case UPDATE_AUTO_START_WITH_SERVER_STATUS: {
+                        ServerConfigResourceDefinition.UPDATE_AUTO_START_WITH_SERVER_STATUS.parseAndSetParameter(value, addUpdate, reader);
+                        break;
+                    }
                     default:
                         throw unexpectedAttribute(reader, i);
                 }
@@ -2168,6 +2172,7 @@ public class HostXml extends CommonXml {
             writeAttribute(writer, Attribute.NAME, prop.getName());
             ServerConfigResourceDefinition.GROUP.marshallAsAttribute(server, writer);
             ServerConfigResourceDefinition.AUTO_START.marshallAsAttribute(server, writer);
+            ServerConfigResourceDefinition.UPDATE_AUTO_START_WITH_SERVER_STATUS.marshallAsAttribute(server, writer);
             if (server.hasDefined(PATH)) {
                 writePaths(writer, server.get(PATH), false);
             }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResource.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResource.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.host.controller.resources;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTO_START;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UPDATE_AUTO_START_WITH_SERVER_STATUS;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.client.helpers.domain.ServerStatus;
+import org.jboss.as.controller.registry.DelegatingResource;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.host.controller.ServerInventory;
+import org.jboss.as.host.controller.logging.HostControllerLogger;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class ServerConfigResource extends DelegatingResource {
+
+    private final ServerInventory serverInventory;
+    private final String serverName;
+    private final ControlledProcessState processState;
+    private final Path autoStartDataDir;
+
+    private static final String STOPPED_EXT = ".stopped";
+    private static final String STARTED_EXT = ".started";
+
+    public ServerConfigResource(ServerInventory serverInventory, ControlledProcessState processState, String serverName, File domainDataDir, Resource delegate) {
+        super(delegate);
+        this.serverInventory = serverInventory;
+        this.serverName = serverName;
+        this.processState = processState;
+        this.autoStartDataDir = domainDataDir.toPath().resolve("auto-start");
+        try {
+            if (Files.notExists(autoStartDataDir)) {
+                Files.createDirectory(autoStartDataDir);
+            }
+        } catch (IOException ex) {
+            throw HostControllerLogger.ROOT_LOGGER.couldNotCreateDomainAutoStartDirectory(autoStartDataDir, ex);
+        }
+    }
+
+    @Override
+    public ModelNode getModel() {
+        assert serverName != null && !serverName.isEmpty() : "ServerName is null";
+
+        ModelNode model = super.getModel();
+        if (processState.getState() == ControlledProcessState.State.STARTING) {
+            getAutoStart(serverName, model);
+        } else if (processState.getState() == ControlledProcessState.State.RUNNING) {
+            persistAutoStart(serverName, model);
+        }
+        return model;
+    }
+
+    private void getAutoStart(String serverName, ModelNode model) {
+        Path startedFile = autoStartDataDir.resolve(serverName + STARTED_EXT);
+        Path stoppedFile = autoStartDataDir.resolve(serverName + STOPPED_EXT);
+        if (shouldUpdateAutoStart(model)) {
+            if (Files.exists(startedFile)) {
+                model.get(AUTO_START).set(true);
+            }
+            if (Files.exists(stoppedFile)) {
+                model.get(AUTO_START).set(false);
+            }
+        }
+    }
+
+    private void persistAutoStart(String serverName, ModelNode model) {
+        Path startedFile = autoStartDataDir.resolve(serverName + STARTED_EXT);
+        Path stoppedFile = autoStartDataDir.resolve(serverName + STOPPED_EXT);
+        if (serverInventory != null && shouldUpdateAutoStart(model)) {
+            ServerStatus status = serverInventory.determineServerStatus(serverName);
+            try {
+                if (status == ServerStatus.STARTED || status == ServerStatus.STARTING) {
+                    if (Files.notExists(startedFile)) {
+                        Files.createFile(startedFile);
+                    }
+                    Files.deleteIfExists(stoppedFile);
+                    model.get(AUTO_START).set(true);
+                } else if (status == ServerStatus.STOPPED || status == ServerStatus.STOPPING) {
+                    if (Files.notExists(stoppedFile)) {
+                        Files.createFile(stoppedFile);
+                    }
+                    Files.deleteIfExists(startedFile);
+                    model.get(AUTO_START).set(false);
+                }
+            } catch (IOException ex) {
+                HostControllerLogger.ROOT_LOGGER.couldNotPersistAutoStartServerStatus(ex);
+            }
+        }
+    }
+
+    private boolean shouldUpdateAutoStart(final ModelNode model) {
+        return model.hasDefined(UPDATE_AUTO_START_WITH_SERVER_STATUS)
+                && model.get(UPDATE_AUTO_START_WITH_SERVER_STATUS).asBoolean();
+    }
+
+    @Override
+    public Resource clone() {
+        Resource delegate = super.clone();
+        return new ServerConfigResource(serverInventory, processState, serverName, autoStartDataDir.getParent().toFile(), delegate);
+    }
+
+}

--- a/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
@@ -135,6 +135,7 @@ server-config.socket-binding-port-offset=An offset to be added to the port value
 server-config.auto-start=Whether or not this server should be started when the Host Controller starts.
 server-config.status=The current status of the server.
 server-config.system-property=A list of system properties to set on this server.
+server-config.update-auto-start-with-server-status=Update auto-start attribute with the status of the server.
 
 server=The managed server instance.
 server.launch-type=The manner in which the server process was launched. Either "DOMAIN" for a domain mode server launched by a Host Controller, "STANDALONE" for a standalone server launched from the command line, or "EMBEDDED" for a standalone server launched as an embedded part of an application running in the same virtual machine.

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -36,13 +36,18 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.security.auth.callback.CallbackHandler;
+import org.jboss.as.controller.ControlledProcessState;
 
 import org.jboss.as.controller.ControlledProcessState.State;
 import org.jboss.as.controller.OperationContext;
@@ -50,16 +55,22 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.OperationResponse;
+import org.jboss.as.controller.client.helpers.domain.ServerStatus;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.host.controller.MasterDomainControllerClient;
+import org.jboss.as.host.controller.ServerInventory;
 import org.jboss.as.host.controller.discovery.DiscoveryOption;
 import org.jboss.as.host.controller.operations.ServerAddHandler;
 import org.jboss.as.host.controller.operations.ServerRemoveHandler;
 import org.jboss.as.host.controller.operations.ServerRestartRequiredServerConfigWriteAttributeHandler;
+import org.jboss.as.process.ProcessInfo;
+import org.jboss.as.process.ProcessMessageHandler;
+import org.jboss.as.protocol.mgmt.ManagementChannelHandler;
 import org.jboss.as.repository.HostFileRepository;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.Service;
@@ -193,7 +204,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
             operation.get(SOCKET_BINDING_GROUP).set(socketBindingGroupName);
         }
 
-        ServerAddHandler.create(new MockHostControllerInfo(master)).execute(operationContext, operation);
+        ServerAddHandler.create(new MockHostControllerInfo(master), new ServerInventoryMock(), new ControlledProcessState(false), new File(System.getProperty("java.io.tmpdir"))).execute(operationContext, operation);
 
         if (master && (socketBindingGroupOverride == SocketBindingGroupOverrideType.BAD || badServerGroup)) {
             Assert.fail();
@@ -477,6 +488,177 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         @Override
         public Collection<String> getAllowedOrigins() {
             return Collections.EMPTY_LIST;
+        }
+    }
+
+    private static class ServerInventoryMock implements ServerInventory {
+
+        public ServerInventoryMock() {
+        }
+
+        @Override
+        public String getServerProcessName(String serverName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public String getProcessServerName(String processName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Map<String, ProcessInfo> determineRunningProcesses() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public Map<String, ProcessInfo> determineRunningProcesses(boolean serversOnly) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public ServerStatus determineServerStatus(String serverName) {
+            return ServerStatus.STARTED;
+        }
+
+        @Override
+        public ServerStatus startServer(String serverName, ModelNode domainModel) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public ServerStatus startServer(String serverName, ModelNode domainModel, boolean blocking) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public ServerStatus restartServer(String serverName, int gracefulTimeout, ModelNode domainModel) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public ServerStatus restartServer(String serverName, int gracefulTimeout, ModelNode domainModel, boolean blocking) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public ServerStatus stopServer(String serverName, int gracefulTimeout) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public ServerStatus stopServer(String serverName, int gracefulTimeout, boolean blocking) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void stopServers(int gracefulTimeout) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void stopServers(int gracefulTimeout, boolean blockUntilStopped) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void reconnectServer(String serverName, ModelNode domainModel, byte[] authKey, boolean running, boolean stopping) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public ServerStatus reloadServer(String serverName, boolean blocking) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void destroyServer(String serverName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void killServer(String serverName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallbackHandler getServerCallbackHandler() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public ProxyController serverCommunicationRegistered(String serverProcessName, ManagementChannelHandler channelHandler) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean serverReconnected(String serverProcessName, ManagementChannelHandler channelHandler) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void serverStarted(String serverProcessName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void serverStartFailed(String serverProcessName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void serverProcessStopped(String serverProcessName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void connectionFinished() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void serverProcessAdded(String processName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void serverProcessStarted(String processName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void serverProcessRemoved(String processName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void operationFailed(String processName, ProcessMessageHandler.OperationType type) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void processInventory(Map<String, ProcessInfo> processInfos) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void awaitServersState(Collection<String> serverNames, boolean started) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void suspendServer(String serverName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public void resumeServer(String serverName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean awaitServerSuspend(Set<String> waitForServers, int timeout) {
+            throw new UnsupportedOperationException("Not supported yet.");
         }
     }
 

--- a/server/src/main/resources/schema/wildfly-config_3_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_3_0.xsd
@@ -2442,6 +2442,13 @@
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="group" type="xs:string" use="required"/>
         <xs:attribute name="auto-start" type="xs:boolean" default="true"/>
+        <xs:attribute name="update-auto-start-with-server-status" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Iif the server last status (STARTED or STOPPED) is to be used to define the value of auto-start.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="server-socket-bindingsType">

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ServerAutoStartTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ServerAutoStartTestCase.java
@@ -1,0 +1,280 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.domain.management;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTO_START;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.START_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STOP_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.test.integration.domain.management.util.DomainTestUtils.waitUntilState;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Emanuel Muckenhuber
+ */
+public class ServerAutoStartTestCase {
+
+    private static final String STOPPED_EXT = ".stopped";
+    private static final String STARTED_EXT = ".started";
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainMasterLifecycleUtil;
+    private static DomainLifecycleUtil domainSlaveLifecycleUtil;
+    private static final ModelNode hostMaster = new ModelNode();
+    private static final ModelNode hostSlave = new ModelNode();
+    private static final ModelNode mainOne = new ModelNode();
+    private static final ModelNode mainTwo = new ModelNode();
+    private static final ModelNode mainThree = new ModelNode();
+    private static final ModelNode mainFour = new ModelNode();
+    private static final ModelNode otherOne = new ModelNode();
+    private static final ModelNode otherTwo = new ModelNode();
+    private static final ModelNode otherThree = new ModelNode();
+    private static final ModelNode otherFour = new ModelNode();
+    private static final Path autoStartMasterDataDir
+            = DomainTestSupport.getHostDir(ServerAutoStartTestCase.class.getSimpleName(), "master").toPath()
+            .resolve("data")
+            .resolve("auto-start");
+    private static final Path autoStartSlaveDataDir
+            = DomainTestSupport.getHostDir(ServerAutoStartTestCase.class.getSimpleName(), "slave").toPath()
+            .resolve("data")
+            .resolve("auto-start");
+
+    static {
+        // (host=master)
+        hostMaster.add("host", "master");
+        // (host=master),(server-config=main-one)
+        mainOne.add("host", "master");
+        mainOne.add("server-config", "main-one");
+        // (host=master),(server-config=main-two)
+        mainTwo.add("host", "master");
+        mainTwo.add("server-config", "main-two");
+        // (host=master),(server-config=other-one)
+        otherOne.add("host", "master");
+        otherOne.add("server-config", "other-one");
+        // (host=master),(server-config=other-two)
+        otherTwo.add("host", "master");
+        otherTwo.add("server-config", "other-two");
+
+        // (host=slave)
+        hostSlave.add("host", "slave");
+        // (host=slave),(server-config=main-three)
+        mainThree.add("host", "slave");
+        mainThree.add("server-config", "main-three");
+        // (host=slave),(server-config=main-four)
+        mainFour.add("host", "slave");
+        mainFour.add("server-config", "main-four");
+        // (host=slave),(server-config=other-three)
+        otherThree.add("host", "slave");
+        otherThree.add("server-config", "other-three");
+        // (host=slave),(server-config=other-four)
+        otherFour.add("host", "slave");
+        otherFour.add("server-config", "other-four");
+
+    }
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSupport.createAndStartSupport(DomainTestSupport.Configuration.create(ServerAutoStartTestCase.class.getSimpleName(),
+                "domain-configs/domain-minimal.xml", "host-configs/host-master-auto-start.xml", "host-configs/host-slave-auto-start.xml"));
+        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        testSupport.stop();
+        testSupport = null;
+        domainMasterLifecycleUtil = null;
+        domainSlaveLifecycleUtil = null;
+    }
+
+    @Test
+    public void testDomainLifecycleMethods() throws Throwable {
+
+        DomainClient client = domainMasterLifecycleUtil.getDomainClient();
+        executeLifecycleOperation(client, START_SERVERS);
+        waitUntilState(client, "master", "main-one", "STARTED");
+        waitUntilState(client, "master", "main-two", "STARTED");
+        waitUntilState(client, "master", "other-one", "STARTED");
+        waitUntilState(client, "master", "other-two", "STARTED");
+        waitUntilState(client, "slave", "main-three", "STARTED");
+        waitUntilState(client, "slave", "main-four", "STARTED");
+        waitUntilState(client, "slave", "other-three", "STARTED");
+        waitUntilState(client, "slave", "other-four", "STARTED");
+        assertAutoStartStatus(client, mainOne, true);
+        assertAutoStartStatus(client, mainTwo, true);
+        assertAutoStartStatus(client, otherOne, true);
+        assertAutoStartStatus(client, otherTwo, false);
+        assertAutoStartStatus(client, mainThree, true);
+        assertAutoStartStatus(client, mainFour, true);
+        assertAutoStartStatus(client, otherThree, true);
+        assertAutoStartStatus(client, otherFour, false);
+        assertAutoStartNotUpdated(autoStartMasterDataDir, "main-one");
+        assertAutoStartUpdated(autoStartMasterDataDir, "main-two", true);
+        assertAutoStartUpdated(autoStartMasterDataDir, "other-one", true);
+        assertAutoStartNotUpdated(autoStartMasterDataDir, "other-two");
+        assertAutoStartNotUpdated(autoStartSlaveDataDir, "main-three");
+        assertAutoStartUpdated(autoStartSlaveDataDir, "main-four", true);
+        assertAutoStartUpdated(autoStartSlaveDataDir, "other-three", true);
+        assertAutoStartNotUpdated(autoStartSlaveDataDir, "other-four");
+
+        executeLifecycleOperation(client, STOP_SERVERS);
+        //When stopped auto-start=true -> STOPPED, auto-start=false -> DISABLED
+        waitUntilState(client, "master", "main-one", "STOPPED");
+        waitUntilState(client, "master", "main-two", "DISABLED");
+        waitUntilState(client, "master", "other-one", "DISABLED");
+        waitUntilState(client, "master", "other-two", "DISABLED");
+        waitUntilState(client, "slave", "main-three", "STOPPED");
+        waitUntilState(client, "slave", "main-four", "DISABLED");
+        waitUntilState(client, "slave", "other-three", "DISABLED");
+        waitUntilState(client, "slave", "other-four", "DISABLED");
+        assertAutoStartStatus(client, mainOne, true);
+        assertAutoStartStatus(client, mainTwo, false);
+        assertAutoStartStatus(client, otherOne, false);
+        assertAutoStartStatus(client, otherTwo, false);
+        assertAutoStartStatus(client, mainThree, true);
+        assertAutoStartStatus(client, mainFour, false);
+        assertAutoStartStatus(client, otherThree, false);
+        assertAutoStartStatus(client, otherFour, false);
+        assertAutoStartNotUpdated(autoStartMasterDataDir, "main-one");
+        assertAutoStartUpdated(autoStartMasterDataDir, "main-two", false);
+        assertAutoStartUpdated(autoStartMasterDataDir, "other-one", false);
+        assertAutoStartNotUpdated(autoStartMasterDataDir, "other-two");
+        assertAutoStartNotUpdated(autoStartSlaveDataDir, "main-three");
+        assertAutoStartUpdated(autoStartSlaveDataDir, "main-four", false);
+        assertAutoStartUpdated(autoStartSlaveDataDir, "other-three", false);
+        assertAutoStartNotUpdated(autoStartSlaveDataDir, "other-four");
+
+        executeLifecycleOperation(client, START_SERVERS);
+        waitUntilState(client, "master", "main-one", "STARTED");
+        waitUntilState(client, "master", "main-two", "STARTED");
+        waitUntilState(client, "master", "other-one", "STARTED");
+        waitUntilState(client, "master", "other-two", "STARTED");
+        waitUntilState(client, "slave", "main-three", "STARTED");
+        waitUntilState(client, "slave", "main-four", "STARTED");
+        waitUntilState(client, "slave", "other-three", "STARTED");
+        waitUntilState(client, "slave", "other-four", "STARTED");
+        assertAutoStartStatus(client, mainOne, true);
+        assertAutoStartStatus(client, mainTwo, true);
+        assertAutoStartStatus(client, otherOne, true);
+        assertAutoStartStatus(client, otherTwo, false);
+        assertAutoStartNotUpdated(autoStartMasterDataDir, "main-one");
+        assertAutoStartUpdated(autoStartMasterDataDir, "main-two", true);
+        assertAutoStartUpdated(autoStartMasterDataDir, "other-one", true);
+        assertAutoStartNotUpdated(autoStartMasterDataDir, "other-two");
+        assertAutoStartNotUpdated(autoStartSlaveDataDir, "main-three");
+        assertAutoStartUpdated(autoStartSlaveDataDir, "main-four", true);
+        assertAutoStartUpdated(autoStartSlaveDataDir, "other-three", true);
+        assertAutoStartNotUpdated(autoStartSlaveDataDir, "other-four");
+
+        domainMasterLifecycleUtil.stop();
+        assertAutoStartNotUpdated(autoStartMasterDataDir, "main-one");
+        assertAutoStartUpdated(autoStartMasterDataDir, "main-two", true);
+        assertAutoStartUpdated(autoStartMasterDataDir, "other-one", true);
+        assertAutoStartNotUpdated(autoStartMasterDataDir, "other-two");
+
+        domainMasterLifecycleUtil.start();
+        client = domainMasterLifecycleUtil.getDomainClient();
+        waitUntilState(client, "master", "main-one", "STARTED");
+        waitUntilState(client, "master", "main-two", "STARTED");
+        waitUntilState(client, "master", "other-one", "STARTED");
+    }
+
+    private void assertAutoStartStatus(final ModelControllerClient client, ModelNode address, boolean autostart) throws IOException {
+        final ModelNode operation = Operations.createReadAttributeOperation(address, AUTO_START);
+        ModelNode result = validateResponse(client.execute(operation));
+        Assert.assertThat(result.asBoolean(), is(autostart));
+    }
+
+    private void assertAutoStartNotUpdated(Path dir, String serverName) throws IOException {
+        Path startedFile = dir.resolve(serverName + STARTED_EXT);
+        Path stoppedFile = dir.resolve(serverName + STOPPED_EXT);
+        Assert.assertThat(Files.exists(startedFile), is(false));
+        Assert.assertThat(Files.exists(stoppedFile), is(false));
+    }
+
+    private void assertAutoStartUpdated(Path dir, String serverName, boolean autostart) throws IOException {
+        Path startedFile = dir.resolve(serverName + STARTED_EXT);
+        Path stoppedFile = dir.resolve(serverName + STOPPED_EXT);
+        if (autostart) {
+            Assert.assertThat(Files.exists(startedFile), is(true));
+            Assert.assertThat(Files.exists(stoppedFile), is(false));
+        } else {
+            Assert.assertThat(Files.exists(startedFile), is(false));
+            Assert.assertThat(Files.exists(stoppedFile), is(true));
+        }
+    }
+
+    private void executeLifecycleOperation(final ModelControllerClient client, String opName) throws IOException {
+        executeLifecycleOperation(client, null, opName);
+    }
+
+    private void executeLifecycleOperation(final ModelControllerClient client, String groupName, String opName) throws IOException {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(opName);
+        if (groupName == null) {
+            operation.get(OP_ADDR).setEmptyList();
+        } else {
+            operation.get(OP_ADDR).add(SERVER_GROUP, groupName);
+        }
+        validateResponse(client.execute(operation));
+    }
+
+    private ModelNode validateResponse(ModelNode response) {
+        return validateResponse(response, true);
+    }
+
+    private ModelNode validateResponse(ModelNode response, boolean validateResult) {
+
+        if (!SUCCESS.equals(response.get(OUTCOME).asString())) {
+            System.out.println("Failed response:");
+            System.out.println(response);
+            Assert.fail(response.get(FAILURE_DESCRIPTION).toString());
+        }
+
+        if (validateResult) {
+            Assert.assertTrue("result exists", response.has(RESULT));
+        }
+        return response.get(RESULT);
+    }
+}

--- a/testsuite/domain/src/test/resources/host-configs/host-master-auto-start.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-auto-start.xml
@@ -1,0 +1,143 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<host xmlns="urn:jboss:domain:3.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:3.0 wildfly-config_3_0.xsd"
+      name="master">
+
+    <paths>
+        <path name="domainTestPath" path="/tmp" />
+    </paths>
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                     <local default-user="$local" skip-group-loading="true"/>
+                     <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                     <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="host-file" formatter="json-formatter" relative-to="jboss.domain.data.dir" path="audit-log.log"/>
+                <file-handler name="server-file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="host-file"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="server-file"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="9999"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm"  http-upgrade-enabled="true">
+                <socket interface="management" port="9990"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+       <local/>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.master.address}"/>
+        </interface>
+    </interfaces>
+
+	<jvms>
+	   <jvm name="default">
+          <heap size="64m" max-size="128m"/>
+          <environment-variables>
+              <variable name="DOMAIN_TEST_JVM" value="jvm"/>
+          </environment-variables>
+        </jvm>
+    </jvms>
+
+    <servers>
+        <server name="main-one" group="main-server-group">
+            <paths>
+                <path name="domainTestPath" path="main-one" relative-to="jboss.server.temp.dir" />
+            </paths>
+            <interfaces>
+                <interface name="public">
+                    <inet-address value="${jboss.test.host.master.address}"/>
+                </interface>
+            </interfaces>
+            <!-- server-one inherits the default socket-group declared in the server-group -->
+            <jvm name="default">
+                <environment-variables>
+                    <variable name="DOMAIN_TEST_SERVER" value="server"/>
+                </environment-variables>
+            </jvm>
+        </server>
+        <server name="main-two" group="main-server-group" auto-start="true" update-auto-start-with-server-status="true">
+            <interfaces>
+                <interface name="public">
+                    <inet-address value="${jboss.test.host.master.address}"/>
+                </interface>
+            </interfaces>
+            <!-- server-two avoids port conflicts by incrementing the ports in
+            the default socket-group declared in the server-group -->
+            <socket-bindings socket-binding-group="standard-sockets" port-offset="150"/>
+            <jvm name="default">
+                <heap size="64m" max-size="256m"/>
+            </jvm>
+        </server>
+        <server name="other-one" group="other-server-group" auto-start="false" update-auto-start-with-server-status="true">
+            <interfaces>
+                <interface name="public">
+                    <inet-address value="${jboss.test.host.master.address}"/>
+                </interface>
+            </interfaces>
+            <socket-bindings port-offset="250"/>
+        </server>
+        <server name="other-two" group="other-server-group" auto-start="false" update-auto-start-with-server-status="false">
+            <interfaces>
+                <interface name="public">
+                    <inet-address value="${jboss.test.host.master.address}"/>
+                </interface>
+            </interfaces>
+            <jvm name="default" />
+            <socket-bindings port-offset="350"/>
+        </server>
+    </servers>
+</host>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-auto-start.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-auto-start.xml
@@ -1,0 +1,141 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<host xmlns="urn:jboss:domain:3.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:3.0 wildfly-config_3_0.xsd"
+      name="slave">
+
+    <paths>
+        <path name="domainTestPath" path="/tmp" />
+    </paths>
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                     <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA==" />
+                </server-identities>
+                <authentication>
+                     <local default-user="$local" skip-group-loading="true" />
+                     <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true" />
+                    <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="host-file" formatter="json-formatter" relative-to="jboss.domain.data.dir" path="audit-log.log"/>
+                <file-handler name="server-file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="host-file"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="server-file"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="19999"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm" console-enabled="false"  http-upgrade-enabled="true">
+                <socket interface="management" port="19990"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+        <!-- Remote domain controller configuration with a host and port -->
+        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+            <ignored-resources type="extension">
+                <instance name="org.jboss.as.jsr77"/>
+            </ignored-resources>
+            <ignored-resources type="profile">
+                <instance name="ignored"/>
+            </ignored-resources>
+            <ignored-resources type="socket-binding-group">
+                <instance name="ignored"/>
+            </ignored-resources>
+            <ignored-resources type="foo" wildcard="true">
+                <instance name="ignored"/>
+            </ignored-resources>
+            <ignored-resources type="server-group">
+                <instance name="minimal" />
+            </ignored-resources>
+        </remote>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+
+	<jvms>
+	   <jvm name="default">
+          <heap size="64m" max-size="128m"/>
+       </jvm>
+	</jvms>
+
+    <servers directory-grouping="by-type">
+        <server name="main-three" group="main-server-group">
+            <socket-bindings socket-binding-group="standard-sockets" port-offset="450"/>
+            <jvm name="default"/>
+        </server>
+        <server name="main-four" group="main-server-group" auto-start="true" update-auto-start-with-server-status="true">
+            <socket-bindings port-offset="550"/>
+            <jvm name="default">
+                <heap size="64m" max-size="256m"/>
+            </jvm>
+        </server>
+        <server name="other-three" group="other-server-group" auto-start="false" update-auto-start-with-server-status="true">
+            <!--AS7-4177 override the host level config to smoke test that handling
+                Note we use the same values; this is just to check for obvious fatal errors -->
+            <interfaces>
+                <interface name="public">
+                    <inet-address value="${jboss.test.host.slave.address}"/>
+                </interface>
+            </interfaces>
+            <socket-bindings socket-binding-group="other-sockets" port-offset="650"/>
+        </server>
+        <server name="other-four" group="other-server-group" auto-start="false" update-auto-start-with-server-status="false">
+            <jvm name="default" />
+            <socket-bindings port-offset="750"/>
+        </server>
+    </servers>
+</host>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/ModelParserUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/ModelParserUtils.java
@@ -379,7 +379,7 @@ public class ModelParserUtils {
                 ));
 
                 //server configurations
-                hostRegistration.registerSubModel(new ServerConfigResourceDefinition(MOCK_HOST_CONTROLLER_INFO, null, MOCK_PATH_MANAGER));
+                hostRegistration.registerSubModel(new ServerConfigResourceDefinition(MOCK_HOST_CONTROLLER_INFO, null, MOCK_PATH_MANAGER, new ControlledProcessState(false), new File(System.getProperty("java.io.tmpdir"))));
             }
         });
 


### PR DESCRIPTION
Since starting or stopping a server is a read-only operation this can't be done as proposed.
When the update-auto-start-with-server-status attribute is set to true on the server declaration then when the server is started a file servername.started will be created in ${jboss.datahome}/auto-start.
When the server is stopped the servername.started will be deleted and a servername.stopped will be created.
Those files are used at startup to determine the auto-start value : if the  update-auto-start-with-server-status is set then the exisitng file will be used instead of the value of the auto-start attribute in the XML.

Jira: https://issues.jboss.org/browse/WFCORE-297