### PR TITLE
WFLY-4239: Add support for Locale.forLanguageTag()

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/LocaleResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/LocaleResolver.java
@@ -35,51 +35,21 @@ public final class LocaleResolver {
     private LocaleResolver(){};
 
     static Locale resolveLocale(String unparsed) throws IllegalArgumentException {
-        int len = unparsed.length();
-        if ( len < 1 ) {
+        Locale locale = forLanguageTag(unparsed);
+
+        if ( "".equals(locale.getLanguage()) ) {
             throw new IllegalArgumentException(unparsed);
         }
 
-        if (len != 2 && len != 5 && len < 7) {
-            throw new IllegalArgumentException(unparsed);
-        }
-
-        char char0 = unparsed.charAt(0);
-        char char1 = unparsed.charAt(1);
-        if (char0 < 'a' || char0 > 'z' || char1 < 'a' || char1 > 'z') {
-            throw new IllegalArgumentException(unparsed);
-        }
-        if (len == 2) {
-            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed, ""));
-        }
-
-        if (!isLocaleSeparator(unparsed.charAt(2))) {
-            throw new IllegalArgumentException(unparsed);
-        }
-
-        char char3 = unparsed.charAt(3);
-        if (isLocaleSeparator(char3)) {
-            // no country
-            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), "", unparsed.substring(4)));
-        }
-
-        char char4 = unparsed.charAt(4);
-        if (char3 < 'A' || char3 > 'Z' || char4 < 'A' || char4 > 'Z') {
-            throw new IllegalArgumentException(unparsed);
-        }
-
-        if (len == 5) {
-            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3)));
-        }
-
-        if (!isLocaleSeparator(unparsed.charAt(5))) {
-            throw new IllegalArgumentException(unparsed);
-        }
-        return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3, 5), unparsed.substring(6)));
+        return replaceByRootLocaleIfLanguageIsEnglish(locale);
     }
 
-    private static boolean isLocaleSeparator(char ch) {
-        return ch == '-' || ch == '_';
+    private static Locale forLanguageTag(String unparsed) {
+        try {
+            return Locale.forLanguageTag(unparsed);
+        } catch ( StringIndexOutOfBoundsException  e ) {
+            throw new IllegalArgumentException(unparsed);
+        }
     }
 
     /**

--- a/controller/src/test/java/org/jboss/as/controller/operations/global/LocaleResolverTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/operations/global/LocaleResolverTest.java
@@ -1,20 +1,23 @@
 /*
- * JBoss, Home of Professional Open Source
- * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
- * as indicated by the @authors tag. All rights reserved.
- * See the copyright.txt in the distribution for a
- * full listing of individual contributors.
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
  *
- * This copyrighted material is made available to anyone wishing to use,
- * modify, copy, or redistribute it subject to the terms and conditions
- * of the GNU Lesser General Public License, v. 2.1.
- * This program is distributed in the hope that it will be useful, but WITHOUT A
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
- * You should have received a copy of the GNU Lesser General Public License,
- * v.2.1 along with this distribution; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
- * MA  02110-1301, USA.
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 package org.jboss.as.controller.operations.global;
 
@@ -24,8 +27,7 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 /**
- *
- * @author rpelisse
+ * @author Romain Pelisse <belaran@gredhat.com>
  */
 public class LocaleResolverTest {
 
@@ -45,7 +47,7 @@ public class LocaleResolverTest {
 
     @Test
     public void invalidLanguageTag() {
-        validLanguageOrCountry("en_EN_long_but_OK");
+        validLanguageOrCountry("en-US-x-lvariant-POSIX");
         invalidLanguageOrCountry("e"); // too short
         invalidLanguageOrCountry("e_U");
         invalidLanguageOrCountry("en_U");
@@ -54,7 +56,6 @@ public class LocaleResolverTest {
 
     @Test
     public void nonExistingLanguageOrCountry() {
-        invalidLanguageOrCountry("aW");
         invalidLanguageOrCountry("aW_AW");
     }
 
@@ -80,7 +81,7 @@ public class LocaleResolverTest {
             LocaleResolver.resolveLocale(unparsed);
         } catch ( IllegalArgumentException e) {
             assertEquals(unparsed,e.getMessage());
-            fail("Format " + unparsed + " is invalid, test should have failed.");
+            fail("Format " + unparsed + " is valid, test should not have failed.");
         }
     }
 


### PR DESCRIPTION
- uses Locale.forLanguageTag instead of custom code to parse locale string
- update unit test accordingly