### PR TITLE
[WFCORE-498] Ensure the server has been started before executing operations

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/Log4jAppenderTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/Log4jAppenderTestCase.java
@@ -55,12 +55,14 @@ public class Log4jAppenderTestCase extends AbstractLoggingTestCase {
     private static final ModelNode CUSTOM_HANDLER_ADDRESS = createAddress("custom-handler", CUSTOM_HANDLER_NAME);
     private static final ModelNode ROOT_LOGGER_ADDRESS = createAddress("root-logger", "ROOT");
 
-    private final Path logFile = getAbsoluteLogFilePath(FILE_NAME);
+    private Path logFile;
 
     @Before
     public void startContainer() throws Exception {
         // Start the server
         container.start();
+
+        logFile = getAbsoluteLogFilePath(FILE_NAME);
 
         final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
 

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
@@ -125,7 +125,7 @@ public class HTTPSConnectionWithCLITestCase {
     @Test
     public void testDefaultCLIConfiguration() throws InterruptedException, IOException {
 
-        String cliOutput = CustomCLIExecutor.execute(null, TESTING_OPERATION, HTTPS_CONTROLLER);
+        String cliOutput = CustomCLIExecutor.execute(null, TESTING_OPERATION, HTTPS_CONTROLLER, true, "N");
         assertThat("Untrusted client should not be authenticated.", cliOutput, not(containsString("\"outcome\" => \"success\"")));
 
     }

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -357,7 +357,6 @@
             </activation>
             <modules>
                 <module>domain</module>
-                <module>manualmode</module>
             </modules>
         </profile>
 
@@ -384,6 +383,7 @@
             <modules>
                 <module>rbac</module>
                 <module>domain</module>
+                <module>manualmode</module>
             </modules>
         </profile>
 


### PR DESCRIPTION
Fix broken logging manual mode test. The test was attempting to use the `ModelControllerClient` before the server has been started.

Moved the `manualmode` module to run with the `allTests` property.

[WFCORE-524] Send a response to the hanging CLI processes to ensure it terminates.