### PR TITLE
[WFCORE-232] : Unclean shutdown of deployment scanner

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerService.java
@@ -49,16 +49,16 @@ import org.jboss.msc.value.InjectedValue;
  */
 public class DeploymentScannerService implements Service<DeploymentScanner> {
 
-    private long interval;
+    private final long interval;
     private TimeUnit unit = TimeUnit.MILLISECONDS;
-    private boolean enabled;
-    private boolean autoDeployZipped;
-    private boolean autoDeployExploded;
-    private boolean autoDeployXml;
-    private Long deploymentTimeout;
+    private final boolean enabled;
+    private final boolean autoDeployZipped;
+    private final boolean autoDeployExploded;
+    private final boolean autoDeployXml;
+    private final Long deploymentTimeout;
     private final String relativeTo;
     private final String path;
-    private boolean rollbackOnRuntimeFailure;
+    private final boolean rollbackOnRuntimeFailure;
 
     /**
      * The created scanner.
@@ -83,10 +83,15 @@ public class DeploymentScannerService implements Service<DeploymentScanner> {
      * @param relativeTo        the relative to
      * @param path              the path
      * @param scanInterval      the scan interval
+     * @param unit
+     * @param autoDeployZip
+     * @param autoDeployExploded
+     * @param autoDeployXml
      * @param scanEnabled       scan enabled
      * @param deploymentTimeout the deployment timeout
      * @param rollbackOnRuntimeFailure rollback on runtime failures
      * @param bootTimeService   the deployment scanner used in the boot time scan
+     * @param scheduledExecutorService
      * @return the controller for the deployment scanner service
      */
     public static ServiceController<DeploymentScanner> addService(final ServiceTarget serviceTarget, final String name, final String relativeTo, final String path,

--- a/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/ShutdownFileSystemDeploymentServiceUnitTestCase.java
+++ b/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/ShutdownFileSystemDeploymentServiceUnitTestCase.java
@@ -1,0 +1,668 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.server.deployment.scanner;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CANCELLED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FULL_REPLACE_DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PERSISTENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLED_BACK;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEPLOY;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.RunnableScheduledFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.client.OperationResponse;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.threads.AsyncFuture;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Unit tests of {@link FileSystemDeploymentService}.
+ *
+ * @author Brian Stansberry (c) 2011 Red Hat Inc.
+ */
+public class ShutdownFileSystemDeploymentServiceUnitTestCase {
+
+    private static Logger logger = Logger.getLogger(ShutdownFileSystemDeploymentServiceUnitTestCase.class);
+
+    private static long count = System.currentTimeMillis();
+
+    private static final Random random = new Random(System.currentTimeMillis());
+
+    private static final DiscardTaskExecutor executor = new DiscardTaskExecutor();
+
+    private static AutoDeployTestSupport testSupport;
+    private File tmpDir;
+
+    @BeforeClass
+    public static void createTestSupport() throws Exception {
+        testSupport = new AutoDeployTestSupport(ShutdownFileSystemDeploymentServiceUnitTestCase.class.getSimpleName());
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        if (testSupport != null) {
+            testSupport.cleanupFiles();
+        }
+    }
+
+    @Before
+    public void setup() throws Exception {
+        executor.clear();
+
+        File root = testSupport.getTempDir();
+        for (int i = 0; i < 200; i++) {
+            tmpDir = new File(root, String.valueOf(count++));
+            if (!tmpDir.exists() && tmpDir.mkdirs()) {
+                break;
+            }
+        }
+
+        if (!tmpDir.exists()) {
+            throw new RuntimeException("cannot create tmpDir");
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        testSupport.cleanupChannels();
+    }
+
+    @Test
+    public void testUncleanShutdown() throws Exception {
+        File deployment = new File(tmpDir, "foo.war");
+        final DiscardTaskExecutor myExecutor = new DiscardTaskExecutor();
+        MockServerController sc = new MockServerController(myExecutor);
+        final BlockingDeploymentOperations ops = new BlockingDeploymentOperations(sc);
+        final FileSystemDeploymentService testee = new FileSystemDeploymentService(null, tmpDir, null, sc, myExecutor, null);
+        testee.setAutoDeployZippedContent(true);
+        sc.addCompositeSuccessResponse(1);
+        testSupport.createZip(deployment, 0, false, false, true, true);
+        Future<Boolean> lockDone = Executors.newSingleThreadExecutor().submit(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                try {
+                    synchronized (ops.lock) {
+                        logger.info("Executor service should be locked");
+                        while (!ops.ready) {//Waiting for deployment to start.
+                            Thread.sleep(100);
+                        }
+                        logger.info("About to stop the scanner");
+                        testee.stopScanner();
+                        logger.info("Closing executor service " + myExecutor);
+                        myExecutor.shutdown();
+                        logger.info("Executor service should be closed");
+                    }
+                    return true;
+                } catch (InterruptedException ex) {
+                    ex.printStackTrace();
+                    throw new RuntimeException(ex);
+                }
+            }
+        });
+        final File dodeploy = new File(tmpDir, "foo.war" + FileSystemDeploymentService.DO_DEPLOY);
+        Files.createFile(dodeploy.toPath());
+        testee.startScanner(ops);
+        testee.scan();
+        lockDone.get(100000, TimeUnit.MILLISECONDS);
+    }
+
+    private static class MockServerController implements ModelControllerClient, DeploymentOperations.Factory {
+
+        private final DiscardTaskExecutor executorService;
+        private final List<ModelNode> requests = new ArrayList<ModelNode>(1);
+        private final List<Response> responses = new ArrayList<Response>(1);
+        private final Map<String, byte[]> added = new HashMap<String, byte[]>();
+        private final Map<String, byte[]> deployed = new HashMap<String, byte[]>();
+        private final Set<String> externallyDeployed = new HashSet<String>();
+
+        @Override
+        public ModelNode execute(ModelNode operation) throws IOException {
+            requests.add(operation);
+            return processOp(operation);
+        }
+
+        @Override
+        public ModelNode execute(Operation operation) throws IOException {
+            return execute(operation.getOperation());
+        }
+
+        @Override
+        public ModelNode execute(ModelNode operation, OperationMessageHandler messageHandler) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ModelNode execute(Operation operation, OperationMessageHandler messageHandler) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public OperationResponse executeOperation(Operation operation, OperationMessageHandler messageHandler) throws IOException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncFuture<ModelNode> executeAsync(final ModelNode operation, OperationMessageHandler messageHandler) {
+            logger.info("Executing deploy command from MockServerController, its executor service should be closed");
+            return executorService.submit(new Callable<ModelNode>() {
+                @Override
+                public ModelNode call() throws Exception {
+                    return execute(operation);
+                }
+            });
+        }
+
+        @Override
+        public AsyncFuture<ModelNode> executeAsync(Operation operation, OperationMessageHandler messageHandler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncFuture<OperationResponse> executeOperationAsync(Operation operation, OperationMessageHandler messageHandler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+
+        @Override
+        public DeploymentOperations create() {
+            return new DefaultDeploymentOperations(this);
+        }
+
+        private static class Response {
+
+            private final boolean ok;
+            private final ModelNode rsp;
+
+            Response(boolean ok, ModelNode rsp) {
+                this.ok = ok;
+                this.rsp = rsp;
+            }
+        }
+
+        MockServerController(String... existingDeployments) {
+            this(executor, existingDeployments);
+        }
+
+        MockServerController(DiscardTaskExecutor executorService, String... existingDeployments) {
+            for (String dep : existingDeployments) {
+                added.put(dep, randomHash());
+                deployed.put(dep, added.get(dep));
+            }
+            this.executorService = executorService;
+        }
+
+        public void addCompositeSuccessResponse(int count) {
+            ModelNode rsp = new ModelNode();
+            rsp.get(OUTCOME).set(SUCCESS);
+            ModelNode result = rsp.get(RESULT);
+            for (int i = 1; i <= count; i++) {
+                result.get("step-" + i, OUTCOME).set(SUCCESS);
+                result.get("step-" + i, RESULT);
+            }
+
+            responses.add(new Response(true, rsp));
+        }
+
+        public void addCompositeFailureResponse(int count, int failureStep) {
+
+            if (count < failureStep) {
+                throw new IllegalArgumentException("failureStep must be > count");
+            }
+
+            ModelNode rsp = new ModelNode();
+            rsp.get(OUTCOME).set(FAILED);
+            ModelNode result = rsp.get(RESULT);
+            for (int i = 1; i <= count; i++) {
+                String step = "step-" + i;
+                if (i < failureStep) {
+                    result.get(step, OUTCOME).set(FAILED);
+                    result.get(step, RESULT);
+                    result.get(step, ROLLED_BACK).set(true);
+                } else if (i == failureStep) {
+                    result.get(step, OUTCOME).set(FAILED);
+                    result.get(step, FAILURE_DESCRIPTION).set(new ModelNode().set("badness happened"));
+                    result.get(step, ROLLED_BACK).set(true);
+                } else {
+                    result.get(step, OUTCOME).set(CANCELLED);
+                }
+            }
+            rsp.get(FAILURE_DESCRIPTION).set(new ModelNode().set("badness happened"));
+            rsp.get(ROLLED_BACK).set(true);
+
+            responses.add(new Response(true, rsp));
+        }
+
+        public void addCompositeFailureResultResponse(int count, int failureStep) {
+
+            if (count < failureStep) {
+                throw new IllegalArgumentException("failureStep must be > count");
+            }
+
+            ModelNode rsp = new ModelNode();
+            rsp.get(OUTCOME).set(SUCCESS);
+            ModelNode result = rsp.get(RESULT);
+            ModelNode failedStep = result.get("step-" + failureStep);
+            failedStep.get(OUTCOME).set(SUCCESS);
+            ModelNode stepResult = failedStep.get(RESULT);
+            for (int i = 1; i <= count; i++) {
+                String step = "step-" + i;
+                if (i < failureStep) {
+                    stepResult.get(step, OUTCOME).set(SUCCESS);
+                    stepResult.get(step, RESULT);
+                    stepResult.get(step, ROLLED_BACK).set(true);
+                } else if (i == failureStep) {
+                    stepResult.get(step, OUTCOME).set(FAILED);
+                    stepResult.get(step, FAILURE_DESCRIPTION).set(new ModelNode().set("true failed step"));
+                    stepResult.get(step, ROLLED_BACK).set(true);
+                } else {
+                    stepResult.get(step, OUTCOME).set(CANCELLED);
+                }
+            }
+            rsp.get(FAILURE_DESCRIPTION).set(new ModelNode().set("badness happened"));
+            rsp.get(ROLLED_BACK).set(true);
+
+            responses.add(new Response(true, rsp));
+        }
+
+        public void addPartialCompositeFailureResultResponse(int count, int failureStep) {
+
+            if (count < failureStep) {
+                throw new IllegalArgumentException("failureStep must be > count");
+            }
+
+            ModelNode rsp = new ModelNode();
+            rsp.get(OUTCOME).set(SUCCESS);
+            ModelNode result = rsp.get(RESULT);
+            for (int i = 1; i <= count; i++) {
+                String step = "step-" + i;
+                if (i < failureStep) {
+                    result.get(step, OUTCOME).set(SUCCESS);
+                    result.get(step, RESULT);
+                    result.get(step, RESULT, "step-1", OUTCOME).set(SUCCESS);
+                    result.get(step, RESULT, "step-1", RESULT);
+                    result.get(step, RESULT, "step-2", OUTCOME).set(SUCCESS);
+                    result.get(step, RESULT, "step-2", RESULT);
+                } else if (i == failureStep) {
+                    result.get(step, OUTCOME).set(SUCCESS);
+                    result.get(step, RESULT);
+                    result.get(step, RESULT, "step-1", OUTCOME).set(SUCCESS);
+                    result.get(step, RESULT, "step-1", RESULT);
+                    result.get(step, RESULT, "step-2", OUTCOME).set(FAILED);
+                    result.get(step, RESULT, "step-2", FAILURE_DESCRIPTION).set(new ModelNode().set("badness happened"));
+                } else {
+                    result.get(step, OUTCOME).set(CANCELLED);
+                }
+            }
+
+            responses.add(new Response(true, rsp));
+        }
+
+        private ModelNode getDeploymentNamesResponse() {
+            ModelNode content = new ModelNode();
+            content.get(OUTCOME).set(SUCCESS);
+            ModelNode result = content.get(RESULT);
+            result.setEmptyObject();
+            for (String deployment : added.keySet()) {
+                result.get(deployment, ENABLED).set(deployed.containsKey(deployment));
+                result.get(deployment, PERSISTENT).set(externallyDeployed.contains(deployment));
+            }
+            return content;
+        }
+
+        private ModelNode processOp(ModelNode op) {
+
+            String opName = op.require(OP).asString();
+            if (READ_CHILDREN_RESOURCES_OPERATION.equals(opName)) {
+                return getDeploymentNamesResponse();
+            } else if (COMPOSITE.equals(opName)) {
+                for (ModelNode child : op.require(STEPS).asList()) {
+                    opName = child.require(OP).asString();
+                    if (COMPOSITE.equals(opName)) {
+                        return processOp(child);
+                    }
+
+                    if (responses.isEmpty()) {
+                        Assert.fail("unexpected request " + op);
+                        return null; // unreachable
+                    }
+
+                    if (!responses.get(0).ok) {
+                        // don't change state for a failed response
+                        continue;
+                    }
+
+                    PathAddress address = PathAddress.pathAddress(child.require(OP_ADDR));
+                    if (ADD.equals(opName)) {
+                        // Since AS7-431 the content is no longer managed
+                        //added.put(address.getLastElement().getValue(), child.require(CONTENT).require(0).require(HASH).asBytes());
+                        added.put(address.getLastElement().getValue(), randomHash());
+                    } else if (REMOVE.equals(opName)) {
+                        added.remove(address.getLastElement().getValue());
+                    } else if (DEPLOY.equals(opName)) {
+                        String name = address.getLastElement().getValue();
+                        deployed.put(name, added.get(name));
+                    } else if (UNDEPLOY.equals(opName)) {
+                        deployed.remove(address.getLastElement().getValue());
+                    } else if (FULL_REPLACE_DEPLOYMENT.equals(opName)) {
+                        String name = child.require(NAME).asString();
+                        // Since AS7-431 the content is no longer managed
+                        //byte[] hash = child.require(CONTENT).require(0).require(HASH).asBytes();
+                        final byte[] hash = randomHash();
+                        added.put(name, hash);
+                        deployed.put(name, hash);
+                    } else {
+                        throw new IllegalArgumentException("unexpected step " + opName);
+                    }
+                }
+                return responses.remove(0).rsp;
+            } else {
+                throw new IllegalArgumentException("unexpected operation " + opName);
+            }
+        }
+
+    }
+
+    private static class DiscardTaskExecutor extends ScheduledThreadPoolExecutor {
+
+        private final List<Runnable> tasks = new ArrayList<Runnable>();
+        private final Set<CallOnGetFuture<?>> futures = new HashSet<CallOnGetFuture<?>>();
+        private DiscardTaskExecutor() {
+            super(0);
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(final Runnable command, final long delay, final TimeUnit delayUnit) {
+            tasks.add(command);
+            return new RunnableScheduledFuture() {
+                private FutureTask<?> task = new FutureTask<>(command, new Object());
+
+                @Override
+                public boolean isPeriodic() {
+                    return false;
+                }
+
+                @Override
+                public void run() {
+                    task.run();
+                }
+
+                @Override
+                public boolean cancel(boolean mayInterruptIfRunning) {
+                    logger.info("Task is being cancelled " +  mayInterruptIfRunning);
+                    return task.cancel(mayInterruptIfRunning);
+                }
+
+                @Override
+                public boolean isCancelled() {
+                    return task.isCancelled();
+                }
+
+                @Override
+                public boolean isDone() {
+                    return task.isDone();
+                }
+
+                @Override
+                public Object get() throws InterruptedException, ExecutionException {
+                    return task.get();
+                }
+
+                @Override
+                public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+                   return task.get(timeout, unit);
+                }
+
+                @Override
+                public long getDelay(TimeUnit unit) {
+                    return delayUnit.convert(delay, unit);
+                }
+
+                @Override
+                public int compareTo(Object o) {
+                    throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                }
+            };
+        }
+
+        @Override
+        public <T> AsyncFuture<T> submit(Callable<T> tCallable) {
+            if (isShutdown() || isTerminating()) {
+                throw new RejectedExecutionException("DiscardTaskExecutor has shutdown we can't run " + tCallable);
+            }
+            CallOnGetFuture<T> future = new CallOnGetFuture<>(tCallable);
+            futures.add(future);
+            return future;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            List<Runnable> superList = super.shutdownNow();
+            for(CallOnGetFuture<?> future : futures) {
+                future.cancel(true);
+            }
+            superList.addAll(tasks);
+            return superList;
+        }
+
+        @Override
+        public void shutdown() {
+            super.shutdown();
+            for(CallOnGetFuture<?> future : futures) {
+                future.cancel(false);
+            }
+        }
+
+
+
+        void clear() {
+            tasks.clear();
+        }
+    }
+
+    private static class CallOnGetFuture<T> implements AsyncFuture<T> {
+
+        final Callable<T> callable;
+        private boolean cancelled = false;
+
+        private CallOnGetFuture(Callable<T> callable) {
+            this.callable = callable;
+        }
+
+        @Override
+        public boolean cancel(boolean interrupt) {
+            this.cancelled = true;
+            logger.info("CallOnGetFuture is to be cancelled " + callable);
+            if (interrupt) {
+                logger.info("CallOnGetFuture interrupted " + callable);
+                Thread.currentThread().interrupt();
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
+
+        @Override
+        public boolean isDone() {
+            return false;
+        }
+
+        @Override
+        public T get() throws InterruptedException, ExecutionException {
+            try {
+                logger.info("CallOnGetFuture get " + callable);
+                return callable.call();
+            } catch (InterruptedException | ExecutionException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public T get(long l, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+            return get();
+        }
+
+        @Override
+        public AsyncFuture.Status await() throws InterruptedException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncFuture.Status await(long timeout, TimeUnit unit) throws InterruptedException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public T getUninterruptibly() throws CancellationException, ExecutionException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public T getUninterruptibly(long timeout, TimeUnit unit) throws CancellationException, ExecutionException, TimeoutException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncFuture.Status awaitUninterruptibly() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncFuture.Status awaitUninterruptibly(long timeout, TimeUnit unit) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public AsyncFuture.Status getStatus() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <A> void addListener(AsyncFuture.Listener<? super T, A> listener, A attachment) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void asyncCancel(boolean interruptionDesired) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class BlockingDeploymentOperations implements DeploymentOperations {
+
+        private volatile boolean ready = false;
+        private final DefaultDeploymentOperations delegate;
+        private final Object lock = new Object();
+
+        BlockingDeploymentOperations(final ModelControllerClient controllerClient) {
+            delegate = new DefaultDeploymentOperations(controllerClient);
+        }
+
+        @Override
+        public Future<ModelNode> deploy(final ModelNode operation, ScheduledExecutorService scheduledExecutor) {
+            ready = true;
+            logger.info("Ready to deploy");
+            synchronized(lock) {
+                logger.info("Deploying on delegate.");
+                return delegate.deploy(operation, null);
+            }
+        }
+
+        @Override
+        public Map<String, Boolean> getDeploymentsStatus() {
+            return delegate.getDeploymentsStatus();
+        }
+
+        @Override
+        public void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public Set<String> getPersistentDeployments() {
+            return delegate.getPersistentDeployments();
+        }
+
+    }
+
+    private static byte[] randomHash() {
+        final byte[] hash = new byte[20];
+        random.nextBytes(hash);
+        return hash;
+    }
+}

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -63,8 +63,33 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-deployment-scanner</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.syslog4j</groupId>
             <artifactId>syslog4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-submit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-install</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-bmunit</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -121,9 +146,11 @@
                             <!-- Parameters to test cases. -->
                             <systemPropertyVariables combine.children="append">
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <byteman.server.ipaddress>${node0}</byteman.server.ipaddress>
+                                <byteman.server.port>9091</byteman.server.port>
                                 <jboss.home>${wildfly.home}</jboss.home>
                                 <module.path>${wildfly.home}/modules/</module.path>
-                                <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
+                                <jvm.args>-javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar},sys:${org.wildfly.core:wildfly-core-testsuite-shared:jar} -Dorg.jboss.byteman.transform.all -Dorg.jboss.byteman.verbose=true -Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
                                 <cli.args>-Dmaven.repo.local=${settings.localRepository}</cli.args>
                                 <javax.net.ssl.trustStore>${basedir}/src/test/resources/ssl/jbossClient.truststore</javax.net.ssl.trustStore>
                                 <javax.net.ssl.keyStore>${basedir}/src/test/resources/ssl/jbossClient.keystore</javax.net.ssl.keyStore>
@@ -131,7 +158,17 @@
                                 <javax.net.ssl.keyStorePassword>clientPassword</javax.net.ssl.keyStorePassword>
                             </systemPropertyVariables>
                         </configuration>
-
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>properties</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
 
                     <plugin>

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerShutdownTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerShutdownTestCase.java
@@ -1,0 +1,380 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.deployment;
+
+import static org.jboss.as.controller.ControlledProcessState.State.RUNNING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.protocol.StreamUtils;
+import org.jboss.as.test.deployment.trivial.ServiceActivatorDeploymentUtil;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.byteman.agent.submit.Submit;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Tests server reload during a deployment or undeployment to a wildfly core server by the filesystem scanner.
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+@Ignore
+public class DeploymentScannerShutdownTestCase {
+
+    // Max time to wait for some action to complete, in ms
+    private static final int TIMEOUT = TimeoutUtil.adjust(20000);
+    // Pause time between checks whether some action has completed, in ms
+    private static final int BACKOFF = 10;
+    private static final String DEPLOYMENT_SCANNER_EXTENSION = "org.jboss.as.deployment-scanner";
+    private static final String DEPLOYMENT_SCANNER_SUBSYSTEM = "deployment-scanner";
+    private static final String DEPLOYMENT_NAME = "test-deployment.jar";
+
+    @Inject
+    private ServerController container;
+
+    private ModelControllerClient client;
+    private File deployDir;
+    private final String scannerName = "autoZips";
+    private static final Map<String, String> properties = new HashMap<>();
+
+    private final Submit bytemanSubmit = new Submit(
+            System.getProperty("byteman.server.ipaddress", Submit.DEFAULT_ADDRESS),
+            Integer.getInteger("byteman.server.port", Submit.DEFAULT_PORT));
+
+    @BeforeClass
+    public static void addDeploymentScanner() throws Exception {
+        properties.clear();
+        properties.put("service", "is new");
+        properties.clear();
+        properties.put("service", "is replaced");
+    }
+
+    @After
+    public void cleanAll() throws Exception {
+        removeRules();
+        removeDeploymentScanner(client, scannerName);
+        removeDeploymentScannerExtension();
+        cleanFile(deployDir);
+        deployDir.delete();
+        client.close();
+        container.stop();
+    }
+
+    @Before
+    public void prepareServer() throws Exception {
+        container.start();
+        client = TestSuiteEnvironment.getModelControllerClient();
+        addDeploymentScannerExtension();
+        deployDir = createDeploymentDir("auto-deployments");
+        addDeploymentScanner(deployDir, client, scannerName, true);
+    }
+
+    private void deployRules() throws Exception {
+        bytemanSubmit.addRulesFromResources(Collections.singletonList(
+                DeploymentScannerShutdownTestCase.class.getClassLoader().getResourceAsStream("byteman/DeploymentScannerShutdownTestCase.btm")));
+    }
+
+    private void removeRules() {
+        try {
+            bytemanSubmit.deleteAllRules();
+        } catch (Exception ex) {
+
+        }
+    }
+
+    @Test
+    public void testFilesystemDeployment() throws Exception {
+        deployRules();
+        final JavaArchive archive = ServiceActivatorDeploymentUtil.createServiceActivatorDeploymentArchive(DEPLOYMENT_NAME, properties);
+        final File dir = new File("target/archives");
+        dir.mkdirs();
+        final File deployed = new File(deployDir, DEPLOYMENT_NAME + ".deployed");
+        final File target = new File(deployDir, DEPLOYMENT_NAME);
+        final File file = new File(dir, DEPLOYMENT_NAME);
+        archive.as(ZipExporter.class).exportTo(file, true);
+        deploy(file, target, deployed);
+        client.close();
+        waitForServerToReload(TIMEOUT);
+        Assert.assertTrue("We should have the deployed marker", deployed.exists());
+        Assert.assertTrue(container.isStarted());
+        Path serverLog = getAbsoluteLogFilePath("jboss.server.log.dir", "server.log");
+        assertLogContains(serverLog, "rejected from java.util.concurrent.ScheduledThreadPoolExecutor", false);
+        container.stop();
+        deployed.delete();
+        target.delete();
+        container.start();
+        removeRules();
+    }
+
+    @Test
+    public void testFileSystemUndeployment() throws Exception {
+        final JavaArchive archive = ServiceActivatorDeploymentUtil.createServiceActivatorDeploymentArchive("test-deployment.jar", properties);
+        final File dir = new File("target/archives");
+        dir.mkdirs();
+        final File deployed = new File(deployDir, DEPLOYMENT_NAME + ".deployed");
+        final File undeployed = new File(deployDir, DEPLOYMENT_NAME + ".undeployed");
+        if (undeployed.exists()) {
+            undeployed.delete();
+        }
+        final File target = new File(deployDir, DEPLOYMENT_NAME);
+        final File file = new File(dir,DEPLOYMENT_NAME);
+        archive.as(ZipExporter.class).exportTo(file, true);
+        removeRules();
+        deploy(file, target, deployed);
+        deployRules();
+        undeploy(target, undeployed);
+        client.close();
+        waitForServerToReload(TIMEOUT);
+        Assert.assertTrue("We should have the undeployed marker", undeployed.exists());
+        Assert.assertTrue(container.isStarted());
+        Path serverLog = getAbsoluteLogFilePath("jboss.server.log.dir", "server.log");
+        assertLogContains(serverLog, "rejected from java.util.concurrent.ScheduledThreadPoolExecutor", false);
+        container.start();
+    }
+
+    private void assertLogContains(final Path logFile, final String msg, final boolean expected) throws Exception {
+        try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            boolean logFound = false;
+
+            while ((line = reader.readLine()) != null) {
+                if (line.contains(msg)) {
+                    logFound = true;
+                    break;
+                }
+            }
+            Assert.assertTrue(logFound == expected);
+        }
+    }
+
+    private void deploy(final File file, final File target, final File deployed) throws IOException {
+        Assert.assertFalse(target.exists());
+        // Copy file to deploy directory
+        final InputStream in = new BufferedInputStream(new FileInputStream(file));
+        try {
+            final OutputStream out = new BufferedOutputStream(new FileOutputStream(target));
+            try {
+                int i = in.read();
+                while (i != -1) {
+                    out.write(i);
+                    i = in.read();
+                }
+            } finally {
+                StreamUtils.safeClose(out);
+            }
+        } finally {
+            StreamUtils.safeClose(in);
+        }
+        Assert.assertTrue(file.exists());
+        waitForMarkerFile(deployed);
+    }
+
+    private void undeploy(final File target, final File undeployed) throws IOException {
+        // Delete file from deploy directory
+        target.delete();
+        waitForMarkerFile(undeployed);
+    }
+
+    private void waitForMarkerFile(File marker) {
+        for (int i = 0; i < TIMEOUT / BACKOFF; i++) {
+            if (marker.exists()) {
+                break;
+            }
+            try {
+                Thread.sleep(BACKOFF);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private ModelNode addDeploymentScanner(final File deployDir, final ModelControllerClient client, final String scannerName, final boolean autoDeployZipped)
+            throws IOException {
+        ModelNode add = new ModelNode();
+        add.get(OP).set(ADD);
+        ModelNode addr = new ModelNode();
+        addr.add("subsystem", "deployment-scanner");
+        addr.add("scanner", scannerName);
+        add.get(OP_ADDR).set(addr);
+        add.get("path").set(deployDir.getAbsolutePath());
+        add.get("scan-enabled").set(true);
+        add.get("scan-interval").set(1000);
+        if (autoDeployZipped == false) {
+            add.get("auto-deploy-zipped").set(false);
+        }
+        ModelNode result = client.execute(add);
+        Assert.assertEquals(result.toString(), ModelDescriptionConstants.SUCCESS, result.require(ModelDescriptionConstants.OUTCOME).asString());
+        return result;
+    }
+
+    private void removeDeploymentScanner(final ModelControllerClient client, final String scannerName) throws IOException {
+        ModelNode addr = new ModelNode();
+        addr.add("subsystem", "deployment-scanner");
+        addr.add("scanner", scannerName);
+        ModelNode remove = new ModelNode();
+        remove.get(OP).set(REMOVE);
+        remove.get(OP_ADDR).set(addr);
+        ModelNode result = client.execute(remove);
+        Assert.assertEquals(result.toString(), ModelDescriptionConstants.SUCCESS, result.require(ModelDescriptionConstants.OUTCOME).asString());
+    }
+
+    private File createDeploymentDir(String dir) {
+        deployDir = new File("target", dir);
+        cleanFile(deployDir);
+        deployDir.mkdirs();
+        Assert.assertTrue(deployDir.exists());
+        return deployDir;
+    }
+
+    private static void cleanFile(File toClean) {
+        if (toClean.isDirectory()) {
+            for (File child : toClean.listFiles()) {
+                cleanFile(child);
+            }
+        }
+        toClean.delete();
+    }
+
+    private void waitForServerToReload(int timeout) throws Exception {
+        // FIXME use the CLI high-level reload operation that blocks instead of
+        // fiddling with timeouts...
+        // leave some time to have the server starts its reload process and change
+        // its server-starte from running.
+        Thread.sleep(TimeoutUtil.adjust(500));
+        ModelControllerClient liveClient = null;
+        long start = System.currentTimeMillis();
+        long now;
+        do {
+            if (liveClient != null) {
+                liveClient.close();
+            }
+            liveClient = TestSuiteEnvironment.getModelControllerClient();
+            ModelNode operation = new ModelNode();
+            operation.get(OP_ADDR).setEmptyList();
+            operation.get(OP).set(READ_ATTRIBUTE_OPERATION);
+            operation.get(NAME).set("server-state");
+            try {
+                ModelNode result = liveClient.execute(operation);
+                boolean normal = RUNNING.toString().equals(result.get(RESULT).asString());
+                if (normal) {
+                    client = liveClient;
+                    return;
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            try {
+                Thread.sleep(TimeoutUtil.adjust(100));
+            } catch (InterruptedException e) {
+            }
+            now = System.currentTimeMillis();
+        } while (now - start < timeout);
+
+        fail("Server did not reload in the imparted time.");
+    }
+
+    private Path getAbsoluteLogFilePath(final String relativePath, final String fileName) {
+        final ModelNode address = PathAddress.pathAddress(
+                PathElement.pathElement(ModelDescriptionConstants.PATH, relativePath)).toModelNode();
+        final ModelNode result;
+        try {
+            final ModelNode op = Operations.createReadAttributeOperation(address, ModelDescriptionConstants.PATH);
+            result = client.execute(op);
+            if (Operations.isSuccessfulOutcome(result)) {
+                return Paths.get(Operations.readResult(result).asString(), fileName);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        throw new RuntimeException(Operations.getFailureDescription(result).asString());
+    }
+
+
+    private void addDeploymentScannerExtension() throws Exception {
+        ModelNode addOp = Util.createAddOperation(PathAddress.pathAddress(PathElement.pathElement(EXTENSION, DEPLOYMENT_SCANNER_EXTENSION)));
+        ModelNode result = client.execute(addOp);
+        assertEquals("Unexpected outcome of adding the test deployment scanner extension: " + addOp, SUCCESS, result.get(OUTCOME).asString());
+        addOp = Util.createAddOperation(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, DEPLOYMENT_SCANNER_SUBSYSTEM)));
+        result = client.execute(addOp);
+        assertEquals("Unexpected outcome of adding the test deployment scanner subsystem: " + addOp, SUCCESS, result.get(OUTCOME).asString());
+    }
+
+    private void removeDeploymentScannerExtension() throws Exception {
+        try {
+            ModelNode removeOp = Util.createRemoveOperation(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, DEPLOYMENT_SCANNER_SUBSYSTEM)));
+            client.execute(removeOp);
+        } finally {
+            ModelNode removeOp = Util.createRemoveOperation(PathAddress.pathAddress(PathElement.pathElement(EXTENSION, DEPLOYMENT_SCANNER_EXTENSION)));
+            client.execute(removeOp);
+        }
+    }
+}

--- a/testsuite/manualmode/src/test/resources/byteman/DeploymentScannerShutdownTestCase.btm
+++ b/testsuite/manualmode/src/test/resources/byteman/DeploymentScannerShutdownTestCase.btm
@@ -1,0 +1,10 @@
+RULE Reload server when deploying files
+CLASS org.jboss.as.server.deployment.scanner.FileSystemDeploymentService
+METHOD executeScannerTasks
+HELPER org.jboss.byteman.ServerReloadHelper
+AT LINE 545
+BIND NOTHING
+IF TRUE
+DO
+reloadServer($2)
+ENDRULE

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -130,6 +130,16 @@
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-test-runner</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-deployment-scanner</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/deployment/trivial/ServiceActivatorDeployment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/deployment/trivial/ServiceActivatorDeployment.java
@@ -76,8 +76,6 @@ public class ServiceActivatorDeployment implements ServiceActivator, Service<Voi
         } else {
             properties.setProperty(DEFAULT_SYS_PROP_NAME, DEFAULT_SYS_PROP_VALUE);
         }
-
-
         for (String name : properties.stringPropertyNames()) {
             System.setProperty(name, properties.getProperty(name));
         }

--- a/testsuite/shared/src/main/java/org/jboss/byteman/ServerReloadHelper.java
+++ b/testsuite/shared/src/main/java/org/jboss/byteman/ServerReloadHelper.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.byteman;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import org.jboss.byteman.rule.Rule;
+import org.jboss.byteman.rule.helper.Helper;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleClassLoader;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * Byteman Helper to inject the reload of a server on a deployment scanner.
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
+ */
+public class ServerReloadHelper extends Helper {
+
+    public ServerReloadHelper(Rule rule) {
+        super(rule);
+        openTrace("ServerLoaderhelper", "target" + File.separatorChar + " byteman.log");
+        traceln("ServerLoaderhelper", "ServerReloadHelper loaded.");
+        System.out.println("ServerReloadHelper loaded.");
+    }
+
+    public void shutdownServer(Object deploymentOperations) {
+        System.out.println("Trying to shutdown server.");
+        traceln("ServerLoaderhelper", "Trying to shutdown server.");
+        try {
+            executeOperation(deploymentOperations, "shutdown");
+        } catch (Exception ex) {
+            trace(ex.getMessage());
+            ex.printStackTrace();
+        }
+    }
+
+    public void reloadServer(Object deploymentOperations) {
+        System.out.println("Trying to reload server.");
+        traceln("ServerLoaderhelper", "Trying to reload server.");
+        try {
+            traceln("ServerLoaderhelper", "deploymentOperations are " + deploymentOperations);
+            if (deploymentOperations != null) {
+                traceln("ServerLoaderhelper", "deploymentOperations class is " + deploymentOperations.getClass().getSimpleName());
+                if ("DefaultDeploymentOperations".equals(deploymentOperations.getClass().getSimpleName())) {
+                    executeOperation(deploymentOperations, "reload");
+                }
+            }
+            delay(100);
+        } catch (Exception ex) {
+            traceln("ServerLoaderhelper", ex.getMessage());
+            ex.printStackTrace();
+        }
+
+    }
+
+    private void executeOperation(Object deploymentOperations, String operation) throws Exception {
+        Class defaultBootModuleLoaderHolder = this.getClass().getClassLoader().loadClass("org.jboss.modules.DefaultBootModuleLoaderHolder");
+        Field instance = defaultBootModuleLoaderHolder.getDeclaredField("INSTANCE");
+        instance.setAccessible(true);
+        ModuleLoader loader = (ModuleLoader) instance.get(null);
+        Module module = loader.loadModule(ModuleIdentifier.fromString("org.jboss.as.deployment-scanner"));
+        traceln("ServerLoaderhelper", "Module " + module.toString() + " loaded.");
+        ModuleClassLoader cl = module.getClassLoader();
+        Class modelNodeClass = cl.loadClassLocal("org.jboss.dmr.ModelNode");
+        traceln("ServerLoaderhelper", "org.jboss.dmr.ModelNode class loaded.");
+        Object modelNode = modelNodeClass.newInstance();
+        Method getMethod = modelNodeClass.getDeclaredMethod("get", String.class);
+        Method setMethod = modelNodeClass.getDeclaredMethod("set", String.class);
+        Method setAddressMethod = modelNodeClass.getDeclaredMethod("set", modelNodeClass);
+        Method setEmptyListMethod = modelNodeClass.getDeclaredMethod("setEmptyList");
+        Object operationNode = getMethod.invoke(modelNode, "operation");
+        setMethod.invoke(operationNode, operation);
+        Object operationAddressNode = getMethod.invoke(modelNode, "address");
+        Object addressNode = modelNodeClass.newInstance();
+        setEmptyListMethod.invoke(addressNode);
+        setAddressMethod.invoke(operationAddressNode, addressNode);
+        traceln("ServerLoaderhelper", "We have computed the following operation " + modelNode.toString());
+        for (Method deployMethod : deploymentOperations.getClass().getDeclaredMethods()) {
+            if ("deploy".equals(deployMethod.getName())) {
+                deployMethod.setAccessible(true);
+                traceln("ServerLoaderhelper", "We have found the execution method.");
+                deployMethod.invoke(deploymentOperations, modelNode, null);
+                traceln("ServerLoaderhelper", "We have executed the following operation: " + modelNode.toString());
+            }
+        }
+    }
+}

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -83,8 +83,11 @@ public class Server {
             if (JBOSS_ARGS != null) {
                 commandBuilder.addServerArguments(JBOSS_ARGS.split("\\s+"));
             }
-
-            log.infof("Starting container with: {0}", commandBuilder.build());
+            StringBuilder builder = new StringBuilder("Starting container with: ");
+            for(String arg : commandBuilder.build()) {
+                builder.append(arg).append(" ");
+            }
+            log.info(builder.toString());
             process = Launcher.of(commandBuilder)
                     // Redirect the output and error stream to a file
                     .setRedirectErrorStream(true)


### PR DESCRIPTION
Avoiding tracing the exception when the Executor is shutting down.
Adding a test to check that reload does occurs without blocking.

Jira: https://issues.jboss.org/browse/WFCORE-232