### PR TITLE
[WFCORE-48] : EOFException when address of a mgmt operation is of a bad data type.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3293,4 +3293,7 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = 382, value="Illegal permission actions '%s'")
     IllegalArgumentException illegalPermissionActions(String actions);
+
+    @Message(id = 383, value = "No operation is defined %s")
+    String noOperationDefined(final ModelNode operation);
 }

--- a/controller/src/main/java/org/jboss/as/controller/remote/ModelControllerClientOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/ModelControllerClientOperationHandler.java
@@ -245,24 +245,28 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
      * @return {@code true} if the prepared result should be sent, {@code false} otherwise
      */
     private boolean sendPreparedResponse(final ModelNode operation) {
-        final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
-        final String op = operation.get(OP).asString();
-        final int size = address.size();
-        if (size == 0) {
-            if (op.equals("reload")) {
-                return true;
-            } else if (op.equals(COMPOSITE)) {
-                // TODO
-                return false;
-            } else {
-                return false;
+        try {
+            final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+            final String op = operation.get(OP).asString();
+            final int size = address.size();
+            if (size == 0) {
+                if ("reload".equals(op)) {
+                    return true;
+                } else if (COMPOSITE.equals(op)) {
+                    // TODO
+                    return false;
+                } else {
+                    return false;
+                }
+            } else if (size == 1) {
+                if (HOST.equals(address.getLastElement().getKey())) {
+                    return "reload".equals(op);
+                }
             }
-        } else if (size == 1) {
-            if (address.getLastElement().getKey().equals(HOST)) {
-                return op.equals("reload");
-            }
+            return false;
+        } catch(Exception ex) {
+            return false;
         }
-        return false;
     }
 
     private static class CompletedCallback {

--- a/controller/src/test/java/org/jboss/as/controller/ModelControllerClientTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModelControllerClientTestCase.java
@@ -193,10 +193,8 @@ public class ModelControllerClientTestCase {
         // Set the handler
         final ModelControllerClient client = setupTestClient(controller);
         try {
-            ModelNode operation = new ModelNode();
-            operation.get("test").set("123");
-
             ModelNode op = new ModelNode();
+            op.get("operation").set("fake");
             op.get("name").set(123);
             OperationBuilder builder = new OperationBuilder(op);
             builder.addInputStream(new ByteArrayInputStream(firstBytes));
@@ -235,6 +233,7 @@ public class ModelControllerClientTestCase {
 
             ModelNode operation = new ModelNode();
             operation.get("test").set("123");
+            operation.get("operation").set("fake");
 
             final BlockingQueue<String> messages = new LinkedBlockingQueue<String>();
 
@@ -287,6 +286,7 @@ public class ModelControllerClientTestCase {
         try {
             ModelNode operation = new ModelNode();
             operation.get("test").set("123");
+            operation.get("operation").set("fake");
 
             final BlockingQueue<String> messages = new LinkedBlockingQueue<String>();
 
@@ -322,6 +322,7 @@ public class ModelControllerClientTestCase {
         final ModelControllerClient client = setupTestClient(controller);
         try {
             final ModelNode op = new ModelNode();
+            op.get("operation").set("fake");
             final TestEntry entry = new TestEntry();
             final Operation operation = OperationBuilder.create(op)
                     .addInputStream(entry)

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/MainKernelServicesImpl.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/MainKernelServicesImpl.java
@@ -23,6 +23,7 @@ package org.jboss.as.core.model.test;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
@@ -120,7 +121,9 @@ public class MainKernelServicesImpl extends AbstractKernelServicesImpl {
 
         DomainControllerRuntimeIgnoreTransformationRegistry registry = new DomainControllerRuntimeIgnoreTransformationRegistry();
         registry.initializeHost("host");
-        ModelNode result = internalExecute(new ModelNode(), new ReadMasterDomainModelHandler("host", transformers, registry));
+        ModelNode fakeOP = new ModelNode();
+        fakeOP.get(OP).set("fake");
+        ModelNode result = internalExecute(fakeOP, new ReadMasterDomainModelHandler(HOST, transformers, registry));
         if (FAILED.equals(result.get(OUTCOME).asString())) {
             throw new RuntimeException(result.get(FAILURE_DESCRIPTION).asString());
         }

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -22,6 +22,7 @@
 package org.jboss.as.model.test;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 
 import java.util.Collections;
 import java.util.List;
@@ -321,7 +322,9 @@ public abstract class ModelTestModelControllerService extends AbstractController
      */
     public static Resource grabRootResource(ModelTestKernelServices<?> kernelServices) {
         final AtomicReference<Resource> resourceRef = new AtomicReference<Resource>();
-        ((ModelTestKernelServicesImpl<?>)kernelServices).internalExecute(new ModelNode(), new OperationStepHandler() {
+        ModelNode fakeOP = new ModelNode();
+        fakeOP.get(OP).set("fake");
+        ((ModelTestKernelServicesImpl<?>)kernelServices).internalExecute(fakeOP, new OperationStepHandler() {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 resourceRef.set(context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, true));

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementResponseHeader.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementResponseHeader.java
@@ -128,7 +128,7 @@ public class ManagementResponseHeader extends ManagementProtocolHeader {
 
     public static ManagementResponseHeader create(final ManagementRequestHeader header, Exception error) {
         final int workingVersion = Math.min(ManagementProtocol.VERSION, header.getVersion());
-        return new ManagementResponseHeader(workingVersion, header.getRequestId(), error != null ? error.getMessage() : null);
+        return new ManagementResponseHeader(workingVersion, header.getRequestId(), error != null ? error.getClass().getName() + ':' + error.getMessage() : null);
     }
 
     public static ManagementResponseHeader create(final ManagementProtocolHeader header, int responseId) {

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
@@ -359,6 +359,27 @@ public class BasicOperationsUnitTestCase {
         execute(remove);
     }
 
+    @Test
+    public void testEmptyAddress() throws IOException {
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("whoami");
+        operation.get(OP_ADDR).set("");
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.hasDefined(FAILURE_DESCRIPTION));
+        Assert.assertTrue(result.get(FAILURE_DESCRIPTION).asString() + "should contain WFLYCTL0378", result.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0378"));
+    }
+
+    @Test
+    public void testEmptyOperation() throws IOException {
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).setEmptyList();
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertTrue(result.hasDefined(FAILURE_DESCRIPTION));
+        Assert.assertTrue(result.get(FAILURE_DESCRIPTION).asString() + "should contain WFLYCTL0383", result.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0383"));
+    }
+
     protected ModelNode execute(final ModelNode operation) throws IOException {
         final ModelNode result = managementClient.getControllerClient().execute(operation);
         Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());


### PR DESCRIPTION
Adding some simple validation on operation before trying to execute it.
Fixing issue in ManagementResponseHeader when the exception has no message.

Jira: https://issues.jboss.org/browse/WFCORE-48