### PR TITLE
Avoid NPE if shutdown Runnable detects exit and nulls process before mai...

### DIFF
--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -168,8 +168,10 @@ public class Server {
                     //ignore as this can only fail if shutdown is already in progress
                 }
 
-                process.waitFor();
-                process = null;
+                if (process != null) {
+                    process.waitFor();
+                    process = null;
+                }
 
                 shutdown.interrupt();
             }


### PR DESCRIPTION
...n thread tries to wait for process exit

Avoid http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=35186&buildTypeId=WildFlyCore_PullRequestWindows&tab=buildLog#_focus=11342