### PR TITLE
[WFCORE-536] : Sanitize origins ports in CORS.

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiCheckHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiCheckHandler.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ControlledProcessStateService;
 import org.jboss.as.controller.ModelController;
+import org.jboss.as.domain.http.server.cors.CorsUtil;
 import org.jboss.as.domain.http.server.security.SubjectDoAsHandler;
 
 /**
@@ -61,7 +62,9 @@ class DomainApiCheckHandler implements HttpHandler {
         addContentHandler = new BlockingHandler(new SubjectDoAsHandler(new DomainApiUploadHandler(modelController)));
         genericOperationHandler = new BlockingHandler(new SubjectDoAsHandler(new DomainApiGenericOperationHandler(modelController)));
         if (allowedOrigins != null) {
-            this.allowedOrigins.addAll(allowedOrigins);
+            for (String allowedOrigin : allowedOrigins) {
+                this.allowedOrigins.add(CorsUtil.sanitizeDefaultPort(allowedOrigin));
+            }
         }
     }
 

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/cors/CorsUtil.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/cors/CorsUtil.java
@@ -30,14 +30,14 @@ import io.undertow.server.handlers.ResponseCodeHandler;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.Headers;
 import io.undertow.util.Methods;
+import io.undertow.util.NetworkUtils;
 import java.util.Collection;
 
 /**
- *
+ * Utility class for CORS handling.
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
  */
 public class CorsUtil {
-
     public static boolean isCoreRequest(HeaderMap headers) {
         return headers.contains(ORIGIN)
                 || headers.contains(ACCESS_CONTROL_REQUEST_HEADERS)
@@ -45,33 +45,43 @@ public class CorsUtil {
     }
 
     /**
-     * Match the Origin header with the allowed origins. If it doesn't match then a 403 response code is set on the response.
+     * Match the Origin header with the allowed origins.
+     * If it doesn't match then a 403 response code is set on the response and it returns null.
      * @param exchange the current HttpExchange.
-     * @param allowedOrigins list of allowed origins.
-     * @return the matched origin, null otherwise.
+     * @param allowedOrigins list of sanitized allowed origins.
+     * @return the first matching origin, null otherwise.
      * @throws Exception
      */
     public static String matchOrigin(HttpServerExchange exchange, Collection<String> allowedOrigins) throws Exception {
         HeaderMap headers = exchange.getRequestHeaders();
-        String origin = headers.getFirst(Headers.ORIGIN);
+        String[] origins = headers.get(Headers.ORIGIN).toArray();
         if (allowedOrigins != null && !allowedOrigins.isEmpty()) {
             for (String allowedOrigin : allowedOrigins) {
-                if (allowedOrigin.equalsIgnoreCase(origin)) {
-                    return origin;
+                for (String origin : origins) {
+                    if (allowedOrigin.equalsIgnoreCase(sanitizeDefaultPort(origin))) {
+                        return allowedOrigin;
+                    }
                 }
             }
         }
         String allowedOrigin = defaultOrigin(exchange);
-        if (allowedOrigin.equalsIgnoreCase(origin)) {
-            return origin;
+        for (String origin : origins) {
+            if (allowedOrigin.equalsIgnoreCase(sanitizeDefaultPort(origin))) {
+                return allowedOrigin;
+            }
         }
         ROOT_LOGGER.debug("Request rejected due to HOST/ORIGIN mis-match.");
         ResponseCodeHandler.HANDLE_403.handleRequest(exchange);
         return null;
     }
 
+    /**
+     * Determine the default origin, to allow for local access.
+     * @param exchange the current HttpExchange.
+     * @return the default origin (aka current server).
+     */
     public static String defaultOrigin(HttpServerExchange exchange) {
-        String host = exchange.getRequestHeaders().getFirst(Headers.HOST);
+        String host = NetworkUtils.formatPossibleIpv6Address(exchange.getHostName());
         String protocol = exchange.getRequestScheme();
         int port = exchange.getHostPort();
         //This browser set header should not need IPv6 escaping
@@ -85,6 +95,33 @@ public class CorsUtil {
 
     private static boolean isDefaultPort(int port, String protocol) {
         return (("http".equals(protocol) && 80 == port) || ("https".equals(protocol) && 443 == port));
+    }
+
+    /**
+     * Removes the port from a URL if this port is the default one for the URL's scheme.
+     * @param url the url to be sanitized.
+     * @return  the sanitized url.
+     */
+    public static String sanitizeDefaultPort(String url) {
+        int afterSchemeIndex = url.indexOf("://");
+        if(afterSchemeIndex < 0) {
+            return url;
+        }
+        String scheme = url.substring(0, afterSchemeIndex);
+        int fromIndex = scheme.length() + 3;
+        //Let's see if it is an IPv6 Address
+        int ipv6StartIndex = url.indexOf('[', fromIndex);
+        if (ipv6StartIndex > 0) {
+            fromIndex = url.indexOf(']', ipv6StartIndex);
+        }
+        int portIndex = url.indexOf(':', fromIndex);
+        if(portIndex >= 0) {
+            int port = Integer.parseInt(url.substring(portIndex + 1));
+            if(isDefaultPort(port, scheme)) {
+                return url.substring(0, portIndex);
+            }
+        }
+        return url;
     }
 
     public static boolean isPreflightedRequest(HttpServerExchange exchange) {

--- a/domain-http/interface/src/test/java/org/jboss/as/domain/http/server/cors/CorsUtilTest.java
+++ b/domain-http/interface/src/test/java/org/jboss/as/domain/http/server/cors/CorsUtilTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.domain.http.server.cors;
+
+import static io.undertow.util.Headers.HOST;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.jboss.as.domain.http.server.cors.CorsHeaders.ACCESS_CONTROL_REQUEST_HEADERS;
+import static org.jboss.as.domain.http.server.cors.CorsHeaders.ACCESS_CONTROL_REQUEST_METHOD;
+import static org.jboss.as.domain.http.server.cors.CorsHeaders.ORIGIN;
+import static org.junit.Assert.assertThat;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Test;
+
+/**
+ * Testing CORS utility class.
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class CorsUtilTest {
+
+    public CorsUtilTest() {
+    }
+
+    /**
+     * Test of isCoreRequest method, of class CorsUtil.
+     */
+    @Test
+    public void testIsCoreRequest() {
+        HeaderMap headers = new HeaderMap();
+        assertThat(CorsUtil.isCoreRequest(headers), is(false));
+        headers = new HeaderMap();
+        headers.add(ORIGIN, "");
+        assertThat(CorsUtil.isCoreRequest(headers), is(true));
+        headers = new HeaderMap();
+        headers.add(ACCESS_CONTROL_REQUEST_HEADERS, "");
+        assertThat(CorsUtil.isCoreRequest(headers), is(true));
+        headers = new HeaderMap();
+        headers.add(ACCESS_CONTROL_REQUEST_METHOD, "");
+        assertThat(CorsUtil.isCoreRequest(headers), is(true));
+    }
+
+    /**
+     * Test of matchOrigin method, of class CorsUtil.
+     */
+    @Test
+    public void testMatchOrigin() throws Exception {
+        HeaderMap headerMap = new HeaderMap();
+        headerMap.add(HOST, "localhost:80");
+        headerMap.add(ORIGIN, "http://localhost");
+        HttpServerExchange exchange = new HttpServerExchange(null, headerMap, new HeaderMap(), 10);
+        exchange.setRequestScheme("http");
+        Collection<String> allowedOrigins = null;
+        assertThat(CorsUtil.matchOrigin(exchange, allowedOrigins), is("http://localhost"));
+        allowedOrigins = Collections.singletonList("http://www.example.com:9990");
+        //Default origin
+        assertThat(CorsUtil.matchOrigin(exchange, allowedOrigins), is("http://localhost"));
+        headerMap.clear();
+        headerMap.add(HOST, "localhost:80");
+        headerMap.add(ORIGIN, "http://www.example.com:9990");
+        assertThat(CorsUtil.matchOrigin(exchange, allowedOrigins), is("http://www.example.com:9990"));
+        headerMap.clear();
+        headerMap.add(HOST, "localhost:80");
+        headerMap.add(ORIGIN, "http://www.example.com");
+        assertThat(CorsUtil.matchOrigin(exchange, allowedOrigins), is(nullValue()));
+        headerMap.addAll(ORIGIN, Arrays.asList("http://localhost:8080", "http://www.example.com:9990", "http://localhost"));
+        allowedOrigins = Arrays.asList("http://localhost", "http://www.example.com:9990");
+        assertThat(CorsUtil.matchOrigin(exchange, allowedOrigins), is("http://localhost"));
+    }
+
+    /**
+     * Test of sanitizeDefaultPort method, of class CorsUtil.
+     */
+    @Test
+    public void testSanitizeDefaultPort() {
+        String url = "http://127.0.0.1:80";
+        assertThat(CorsUtil.sanitizeDefaultPort(url), is("http://127.0.0.1"));
+        url = "http://127.0.0.1";
+        assertThat(CorsUtil.sanitizeDefaultPort(url), is("http://127.0.0.1"));
+        url = "http://127.0.0.1:443";
+        assertThat(CorsUtil.sanitizeDefaultPort(url), is("http://127.0.0.1:443"));
+        url = "http://127.0.0.1:8080";
+        assertThat(CorsUtil.sanitizeDefaultPort(url), is("http://127.0.0.1:8080"));
+        url = "https://127.0.0.1:80";
+        assertThat(CorsUtil.sanitizeDefaultPort(url), is("https://127.0.0.1:80"));
+        url = "https://127.0.0.1:443";
+        assertThat(CorsUtil.sanitizeDefaultPort(url), is("https://127.0.0.1"));
+        url = "https://127.0.0.1";
+        assertThat(CorsUtil.sanitizeDefaultPort(url), is("https://127.0.0.1"));
+        url = "http://[::FFFF:129.144.52.38]:8080";
+        assertThat(CorsUtil.sanitizeDefaultPort(url), is("http://[::FFFF:129.144.52.38]:8080"));
+        url = "http://[::FFFF:129.144.52.38]:80";
+        assertThat(CorsUtil.sanitizeDefaultPort(url), is("http://[::FFFF:129.144.52.38]"));
+    }
+
+    /**
+     * Test of defaultOrigin method, of class CorsUtil.
+     */
+    @Test
+    public void testDefaultOrigin() {
+        HeaderMap headerMap = new HeaderMap();
+        headerMap.add(HOST, "localhost:80");
+        HttpServerExchange exchange = new HttpServerExchange(null, headerMap, new HeaderMap(), 10);
+        exchange.setRequestScheme("http");
+        assertThat(CorsUtil.defaultOrigin(exchange), is("http://localhost"));
+        headerMap.clear();
+        headerMap.add(HOST, "www.example.com:8080");
+        assertThat(CorsUtil.defaultOrigin(exchange), is("http://www.example.com:8080"));
+        headerMap.clear();
+        headerMap.add(HOST, "www.example.com:443");
+        exchange.setRequestScheme("https");
+        assertThat(CorsUtil.defaultOrigin(exchange), is("https://www.example.com"));
+        headerMap.clear();
+        exchange.setRequestScheme("http");
+        headerMap.add(HOST, "[::1]:80");
+        assertThat(CorsUtil.defaultOrigin(exchange), is("http://[::1]"));
+    }
+}


### PR DESCRIPTION
Sanitizing default port from urls.
Fixing double port issue when defining the default origin.

Jira: https://issues.jboss.org/browse/WFCORE-536