### PR TITLE
[WFCORE-279] Update JBoss Remoting from 4.0.5 to 4.0.7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <version.org.jboss.metadata.jboss-metadata-common>8.1.2.Final</version.org.jboss.metadata.jboss-metadata-common>
         <version.org.jboss.modules.jboss-modules>1.4.1.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.4.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>4.0.5.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>4.0.7.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>2.0.1.CR1</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.sasl>1.0.5.Final</version.org.jboss.sasl>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.1.2</version.org.jboss.shrinkwrap.shrinkwrap>


### PR DESCRIPTION
Intermediate step related to https://issues.jboss.org/browse/WFCORE-279.