### PR TITLE
Minor fixes in WrapperSSLContext

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/WrapperSSLContext.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/WrapperSSLContext.java
@@ -161,7 +161,7 @@ class WrapperSSLContext extends SSLContext {
             @Override
             public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
                     throws IOException {
-                Socket socket = createSocket(address, port, localAddress, localPort);
+                Socket socket = wrapped.createSocket(address, port, localAddress, localPort);
                 setSslParams(socket);
                 return socket;
             }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/WrapperSSLContext.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/WrapperSSLContext.java
@@ -122,7 +122,9 @@ class WrapperSSLContext extends SSLContext {
 
             @Override
             public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
-                return wrapped.createSocket(s, host, port, autoClose);
+                Socket socket = wrapped.createSocket(s, host, port, autoClose);
+                setSslParams(socket);
+                return socket;
             }
 
             @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/WrapperSSLContext.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/WrapperSSLContext.java
@@ -122,8 +122,7 @@ class WrapperSSLContext extends SSLContext {
 
             @Override
             public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
-                // TODO Auto-generated method stub
-                return null;
+                return wrapped.createSocket(s, host, port, autoClose);
             }
 
             @Override


### PR DESCRIPTION
`HttpsURLConnection` invokes `createSocket(Socket, String, int, boolean)`. Extension modules that use `SSLContextService` to inject an `SSLContext` get an NPE when trying to use the socket factory from the
injected context to open a connection to a URL.

The fix here simply invokes the corresponding method on the wrapped socket factory.