### PR TITLE
[WFCORE-539] Set recursive to false for non-runtime only resources.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -436,7 +436,7 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
             //instead of the recursive check
 
             // BES 2015/02/12 -- So, back to 'false'
-            result = context.readResource(PathAddress.EMPTY_ADDRESS, true);
+            result = context.readResource(PathAddress.EMPTY_ADDRESS, false);
         }
         return result;
     }


### PR DESCRIPTION
The comment from PR https://github.com/wildfly/wildfly-core/pull/490 indicated the value should be `false`. Changed to `true` so deployment resources are recursively cloned.