### PR TITLE
[WFCORE-488] Better domain rollout failure reporting

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CompositeOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/CompositeOperationHandler.java
@@ -57,6 +57,11 @@ public final class CompositeOperationHandler implements OperationStepHandler {
     public static final CompositeOperationHandler INSTANCE = new CompositeOperationHandler();
     public static final String NAME = ModelDescriptionConstants.COMPOSITE;
 
+    /** Gets the failure message used for reporting a rollback with no failure message in a step */
+    public static String getUnexplainedFailureMessage() {
+        return ControllerLogger.ROOT_LOGGER.compositeOperationRolledBack();
+    }
+
     private static final AttributeDefinition STEPS = new PrimitiveListAttributeDefinition.Builder(ModelDescriptionConstants.STEPS, ModelType.OBJECT)
             .build();
 
@@ -122,7 +127,7 @@ public final class CompositeOperationHandler implements OperationStepHandler {
                     }
                 }
                 if (!failureMsg.isDefined()) {
-                    failureMsg.set(ControllerLogger.ROOT_LOGGER.compositeOperationRolledBack());
+                    failureMsg.set(getUnexplainedFailureMessage());
                 }
                 context.getFailureDescription().set(failureMsg);
             }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
@@ -731,4 +731,12 @@ public interface DomainControllerLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 73, value = "%s deployment has been re-deployed, its content will not be removed. You will need to restart it.")
     void undeployingDeploymentHasBeenRedeployed(String deploymentName);
+
+    /**
+     * A message indicating the operation failed or was rolled back on all servers,.
+     *
+     * @return the message.
+     */
+    @Message(id = 74, value = "Operation failed or was rolled back on all servers. Server failures:")
+    String operationFailedOrRolledBackWithCause();
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
@@ -35,6 +35,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 
@@ -46,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -111,7 +113,9 @@ public class DomainFinalResultHandler implements OperationStepHandler {
             domainFailure = coordinator.hasDefined(FAILURE_DESCRIPTION) ? coordinator.get(FAILURE_DESCRIPTION) : new ModelNode(DomainControllerLogger.ROOT_LOGGER.unexplainedFailure());
         }
         if (domainFailure != null) {
-            context.getFailureDescription().get(DOMAIN_FAILURE_DESCRIPTION).set(domainFailure);
+            ModelNode fullFailure = new ModelNode();
+            fullFailure.get(DOMAIN_FAILURE_DESCRIPTION).set(domainFailure);
+            context.getFailureDescription().set(fullFailure);
             return false;
         }
         return true;
@@ -173,7 +177,9 @@ public class DomainFinalResultHandler implements OperationStepHandler {
             //DomainRolloutStepHandler.pushToServers() puts in a simple string into the failure description, but that might be a red herring.
             //If there is a failure description and it is not of type OBJECT, then let's not set it for now
             if (!context.getFailureDescription().isDefined() || context.getFailureDescription().getType() == ModelType.OBJECT) {
-                context.getFailureDescription().get(HOST_FAILURE_DESCRIPTIONS).set(hostFailureResults);
+                ModelNode fullFailure = new ModelNode();
+                fullFailure.get(HOST_FAILURE_DESCRIPTIONS).set(hostFailureResults);
+                context.getFailureDescription().set(fullFailure);
             } else {
                 DomainControllerLogger.CONTROLLER_LOGGER.debugf("Failure description is not of type OBJECT '%s'", context.getFailureDescription());
             }
@@ -241,9 +247,11 @@ public class DomainFinalResultHandler implements OperationStepHandler {
         }
 
         boolean serverGroupSuccess = false;
+        ModelNode failureReport = new ModelNode();
         for (String groupName : groupNames) {
             final ModelNode groupNode = new ModelNode();
-            if (domainOperationContext.isServerGroupRollback(groupName)) {
+            boolean groupFailure = domainOperationContext.isServerGroupRollback(groupName);
+            if (groupFailure) {
                 // TODO revisit if we should report this for the whole group, since the result might not be accurate
                 // groupNode.get(ROLLED_BACK).set(true);
             } else {
@@ -251,12 +259,27 @@ public class DomainFinalResultHandler implements OperationStepHandler {
             }
             for (HostServer hostServer : groupToServerMap.get(groupName)) {
                 groupNode.get(HOST, hostServer.hostName, hostServer.serverName, RESPONSE).set(hostServer.result);
+                if (groupFailure && hostServer.result.hasDefined(OUTCOME)
+                        && FAILED.equals(hostServer.result.get(OUTCOME).asString())
+                        && hostServer.result.hasDefined(FAILURE_DESCRIPTION)) {
+                    ModelNode failDesc = hostServer.result.get(FAILURE_DESCRIPTION);
+                    if (!CompositeOperationHandler.getUnexplainedFailureMessage().equals(failDesc.asString())) {
+                        failureReport.get(SERVER_GROUP, groupName, HOST, hostServer.hostName, hostServer.serverName).set(failDesc);
+                    } // else the server just reported an unexplained composite failure.
+                      // We assume it's due to domain-wide rollback, which is not useful information
+                      // so don't include this server in the top level failure description
+                }
             }
             context.getServerResults().get(groupName).set(groupNode);
         }
         if (!serverGroupSuccess) {
-            // TODO see if we can extract more information from the server details
-            context.getFailureDescription().set(DomainControllerLogger.ROOT_LOGGER.operationFailedOrRolledBack());
+            if (failureReport.isDefined()) {
+                ModelNode fullFailure = new ModelNode();
+                fullFailure.get(DomainControllerLogger.ROOT_LOGGER.operationFailedOrRolledBackWithCause()).set(failureReport);
+                context.getFailureDescription().set(fullFailure);
+            } else {
+                context.getFailureDescription().set(DomainControllerLogger.ROOT_LOGGER.operationFailedOrRolledBack());
+            }
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
@@ -41,7 +41,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.CurrentOperationIdHolder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -84,9 +83,6 @@ public class DomainSlaveHandler implements OperationStepHandler {
             context.setRollbackOnly();
             return;
         }
-
-        // Temporary hack to prevent CompositeOperationHandler throwing away domain failure data
-        context.attachIfAbsent(CompositeOperationHandler.DOMAIN_EXECUTION_KEY, Boolean.TRUE);
 
         final Set<String> outstanding = new HashSet<String>(hostProxies.keySet());
         final List<TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation>> results = new ArrayList<TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation>>();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -95,6 +96,10 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
             // We do not allow failures on the host controllers
             context.setRollbackOnly();
         } else {
+
+            // Temporary hack to prevent CompositeOperationHandler throwing away domain failure data
+            context.attachIfAbsent(CompositeOperationHandler.DOMAIN_EXECUTION_KEY, Boolean.TRUE);
+
             boolean nullDomainOp = hostControllerExecutionSupport.getDomainOperation() == null;
 
             // Transformed operations might need to simulate certain behavior, so allow read-only operations to be pushed as well

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/deployment/broken/ServiceActivatorDeployment.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/deployment/broken/ServiceActivatorDeployment.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.deployment.broken;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistryException;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * ServiceActivator that installs itself as a service and sets a set of system
+ * properties read from a "service-activator-deployment.properties" resource in the deployment.
+ * If no resource is available, sets a default property.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class ServiceActivatorDeployment implements ServiceActivator, Service<Void> {
+
+    public static final ServiceName SERVICE_NAME = ServiceName.of("test", "deployment", "broken");
+    public static final String FAIL_SYS_PROP = "test.deployment.broken.fail";
+
+    @Override
+    public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        serviceActivatorContext.getServiceTarget().addService(SERVICE_NAME, this).install();
+    }
+
+    @Override
+    public synchronized void start(StartContext context) throws StartException {
+        Boolean fail = Boolean.getBoolean(FAIL_SYS_PROP);
+        if (fail) {
+            throw new StartException("configured to fail");
+        }
+    }
+
+    @Override
+    public void stop(StopContext context) {
+    }
+
+    @Override
+    public Void getValue() throws IllegalStateException, IllegalArgumentException {
+        return null;
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/deployment/broken/ServiceActivatorDeployment.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/deployment/broken/ServiceActivatorDeployment.java
@@ -42,6 +42,7 @@ public class ServiceActivatorDeployment implements ServiceActivator, Service<Voi
 
     public static final ServiceName SERVICE_NAME = ServiceName.of("test", "deployment", "broken");
     public static final String FAIL_SYS_PROP = "test.deployment.broken.fail";
+    public static final String FAILURE_MESSAGE = "configured to fail";
 
     @Override
     public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
@@ -52,7 +53,7 @@ public class ServiceActivatorDeployment implements ServiceActivator, Service<Voi
     public synchronized void start(StartContext context) throws StartException {
         Boolean fail = Boolean.getBoolean(FAIL_SYS_PROP);
         if (fail) {
-            throw new StartException("configured to fail");
+            throw new StartException(FAILURE_MESSAGE);
         }
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentRolloutFailureTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentRolloutFailureTestCase.java
@@ -27,15 +27,18 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CON
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IN_SERIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX_FAILED_SERVERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLOUT_PLAN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEPLOY;
@@ -63,6 +66,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -74,6 +78,7 @@ import org.junit.Test;
 public class DeploymentRolloutFailureTestCase {
 
     private static final String BROKEN_DEPLOYMENT = "broken.jar";
+    private static final String MSG = "main-server-group";
     private static final PathElement DEPLOYMENT_PATH = PathElement.pathElement(DEPLOYMENT, BROKEN_DEPLOYMENT);
     private static final PathElement MAIN_SERVER_GROUP = PathElement.pathElement(SERVER_GROUP, "main-server-group");
     private static final PathAddress SYS_PROP_ADDR = PathAddress.pathAddress(PathElement.pathElement(HOST, "slave"),
@@ -160,6 +165,12 @@ public class DeploymentRolloutFailureTestCase {
         if (! FAILED.equals(ret.get(OUTCOME).asString())) {
             throw new MgmtOperationException("Management operation succeeded.", op, ret);
         }
+        // Validate the server results are included
+        ModelNode m3Resp = ret.get(SERVER_GROUPS, MSG, HOST, "slave", "main-three", RESPONSE);
+        Assert.assertTrue(ret.toString(), m3Resp.isDefined());
+        Assert.assertEquals(m3Resp.toString(), FAILED, m3Resp.get(OUTCOME).asString());
+        Assert.assertTrue(m3Resp.toString(), m3Resp.get(FAILURE_DESCRIPTION).asString().contains(ServiceActivatorDeployment.FAILURE_MESSAGE));
+
     }
 
     private ModelNode getDeploymentCompositeOp() throws MalformedURLException {
@@ -202,6 +213,12 @@ public class DeploymentRolloutFailureTestCase {
         if (! FAILED.equals(ret.get(OUTCOME).asString())) {
             throw new MgmtOperationException("Management operation succeeded.", op, ret);
         }
+        // Validate the server results are included
+        ModelNode m3Resp = ret.get(SERVER_GROUPS, MSG, HOST, "slave", "main-three", RESPONSE);
+        Assert.assertTrue(ret.toString(), m3Resp.isDefined());
+        Assert.assertEquals(m3Resp.toString(), FAILED, m3Resp.get(OUTCOME).asString());
+        Assert.assertTrue(m3Resp.toString(), m3Resp.get(FAILURE_DESCRIPTION).isDefined());
+
     }
 
     private ModelNode getUndeployCompositeOp() throws MalformedURLException {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentRolloutFailureTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentRolloutFailureTestCase.java
@@ -1,0 +1,242 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IN_SERIES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX_FAILED_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLOUT_PLAN;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEPLOY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.URL;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.deployment.broken.ServiceActivatorDeployment;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests handling of a failed deployment rollout and the removal thereof.
+ *
+ * @author Brian Stansberry (c) 2015 Red Hat Inc.
+ */
+public class DeploymentRolloutFailureTestCase {
+
+    private static final String BROKEN_DEPLOYMENT = "broken.jar";
+    private static final PathElement DEPLOYMENT_PATH = PathElement.pathElement(DEPLOYMENT, BROKEN_DEPLOYMENT);
+    private static final PathElement MAIN_SERVER_GROUP = PathElement.pathElement(SERVER_GROUP, "main-server-group");
+    private static final PathAddress SYS_PROP_ADDR = PathAddress.pathAddress(PathElement.pathElement(HOST, "slave"),
+            PathElement.pathElement(SERVER_CONFIG, "main-three"), PathElement.pathElement(SYSTEM_PROPERTY, ServiceActivatorDeployment.FAIL_SYS_PROP));
+    private static DomainTestSupport testSupport;
+    private static DomainClient masterClient;
+    private static File tmpDir;
+    private static File deployment;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(DeploymentRolloutFailureTestCase.class.getSimpleName());
+        masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+
+        File tmpRoot = new File(System.getProperty("java.io.tmpdir"));
+        tmpDir = new File(tmpRoot, DeploymentRolloutFailureTestCase.class.getSimpleName() + System.currentTimeMillis());
+        Files.createDirectory(tmpDir.toPath());
+        deployment = new File(tmpDir, BROKEN_DEPLOYMENT);
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, BROKEN_DEPLOYMENT);
+        archive.addClass(ServiceActivatorDeployment.class);
+        archive.addAsServiceProvider(ServiceActivator.class, ServiceActivatorDeployment.class);
+        archive.addAsManifestResource(new StringAsset("Dependencies: org.jboss.msc\n"), "MANIFEST.MF");
+        archive.as(ZipExporter.class).exportTo(deployment);
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        testSupport = null;
+        masterClient = null;
+        DomainTestSuite.stopSupport();
+
+        if (deployment != null && !deployment.delete() && deployment.exists()) {
+            deployment.deleteOnExit();
+        }
+        if (tmpDir != null && !tmpDir.delete() && tmpDir.exists()) {
+            tmpDir.deleteOnExit();
+        }
+
+    }
+
+    @After
+    public void cleanup() throws IOException {
+        try {
+            cleanDeploymentFromServerGroup();
+        } catch (MgmtOperationException e) {
+            // ignored
+        } finally {
+            try {
+                cleanDeployment();
+            }  catch (MgmtOperationException e) {
+                // ignored
+            } finally {
+                try {
+                    cleanSystemProperty();
+                }  catch (MgmtOperationException e1) {
+                    // ignored
+                }
+
+            }
+        }
+    }
+
+    @Test
+    public void test() throws IOException, MgmtOperationException {
+        configureDeploymentFailure();
+        failInstallFailedDeployment();
+        succeedInstallFailedDeployment();
+        failRemoveFailedDeployment();
+        succeedRemoveFailedDeployment();
+    }
+
+    private void configureDeploymentFailure() throws IOException, MgmtOperationException {
+        ModelNode op = Util.createAddOperation(SYS_PROP_ADDR);
+        op.get(VALUE).set("true");
+        DomainTestUtils.executeForResult(op, masterClient);
+    }
+
+    private void failInstallFailedDeployment() throws IOException, MgmtOperationException {
+        ModelNode op = getDeploymentCompositeOp();
+        System.out.println("Deploy op expected to fail:");
+        System.out.println(op);
+        final ModelNode ret = masterClient.execute(op);
+        System.out.println(ret);
+        if (! FAILED.equals(ret.get(OUTCOME).asString())) {
+            throw new MgmtOperationException("Management operation succeeded.", op, ret);
+        }
+    }
+
+    private ModelNode getDeploymentCompositeOp() throws MalformedURLException {
+        ModelNode op = new ModelNode();
+        op.get(OP).set(COMPOSITE);
+        ModelNode steps = op.get(STEPS);
+
+        ModelNode depAdd = Util.createAddOperation(PathAddress.pathAddress(DEPLOYMENT_PATH));
+        ModelNode content = new ModelNode();
+        content.get(URL).set(deployment.toURI().toURL().toString());
+        depAdd.get(CONTENT).add(content);
+
+        steps.add(depAdd);
+
+        ModelNode sgAdd = Util.createAddOperation(PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_PATH));
+        sgAdd.get(ENABLED).set(true);
+        steps.add(sgAdd);
+        return op;
+    }
+
+    private void succeedInstallFailedDeployment() throws IOException, MgmtOperationException {
+        ModelNode op = getDeploymentCompositeOp();
+        op.get(OPERATION_HEADERS, ROLLOUT_PLAN).set(getRolloutPlanO());
+        DomainTestUtils.executeForResult(op, masterClient);
+    }
+
+    private ModelNode getRolloutPlanO() {
+        ModelNode plan = new ModelNode();
+        ModelNode sg = plan.get(IN_SERIES).add().get(SERVER_GROUP, "main-server-group");
+        sg.get(MAX_FAILED_SERVERS).set(1);
+        return plan;
+    }
+
+    private void failRemoveFailedDeployment() throws IOException, MgmtOperationException {
+        System.out.println("Undeploy op expected to fail:");
+        ModelNode op = getUndeployCompositeOp();
+        System.out.println(op);
+        final ModelNode ret = masterClient.execute(op);
+        System.out.println(ret);
+        if (! FAILED.equals(ret.get(OUTCOME).asString())) {
+            throw new MgmtOperationException("Management operation succeeded.", op, ret);
+        }
+    }
+
+    private ModelNode getUndeployCompositeOp() throws MalformedURLException {
+        ModelNode op = new ModelNode();
+        op.get(OP).set(COMPOSITE);
+        ModelNode steps = op.get(STEPS);
+
+        PathAddress sgDep = PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_PATH);
+        steps.add(Util.createEmptyOperation(UNDEPLOY, sgDep));
+        steps.add(Util.createRemoveOperation(sgDep));
+        steps.add(Util.createRemoveOperation(PathAddress.pathAddress(DEPLOYMENT_PATH)));
+
+        return op;
+    }
+
+    private void succeedRemoveFailedDeployment() throws IOException, MgmtOperationException {
+        ModelNode op = getUndeployCompositeOp();
+        op.get(OPERATION_HEADERS, ROLLOUT_PLAN).set(getRolloutPlanO());
+        DomainTestUtils.executeForResult(op, masterClient);
+    }
+
+    private void cleanDeploymentFromServerGroup() throws IOException, MgmtOperationException {
+        ModelNode op = Util.createRemoveOperation(PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_PATH));
+        op.get(ENABLED).set(true);
+        op.get(OPERATION_HEADERS, ROLLOUT_PLAN).set(getRolloutPlanO());
+        DomainTestUtils.executeForResult(op, masterClient);
+    }
+
+    private void cleanDeployment() throws IOException, MgmtOperationException {
+        ModelNode op = Util.createRemoveOperation(PathAddress.pathAddress(DEPLOYMENT_PATH));
+        DomainTestUtils.executeForResult(op, masterClient);
+    }
+
+    private void cleanSystemProperty() throws IOException, MgmtOperationException {
+        ModelNode op = Util.createRemoveOperation(SYS_PROP_ADDR);
+        DomainTestUtils.executeForResult(op, masterClient);
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentRolloutFailureTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentRolloutFailureTestCase.java
@@ -80,7 +80,7 @@ public class DeploymentRolloutFailureTestCase {
     private static final String BROKEN_DEPLOYMENT = "broken.jar";
     private static final String MSG = "main-server-group";
     private static final PathElement DEPLOYMENT_PATH = PathElement.pathElement(DEPLOYMENT, BROKEN_DEPLOYMENT);
-    private static final PathElement MAIN_SERVER_GROUP = PathElement.pathElement(SERVER_GROUP, "main-server-group");
+    private static final PathElement MAIN_SERVER_GROUP = PathElement.pathElement(SERVER_GROUP, MSG);
     private static final PathAddress SYS_PROP_ADDR = PathAddress.pathAddress(PathElement.pathElement(HOST, "slave"),
             PathElement.pathElement(SERVER_CONFIG, "main-three"), PathElement.pathElement(SYSTEM_PROPERTY, ServiceActivatorDeployment.FAIL_SYS_PROP));
     private static DomainTestSupport testSupport;
@@ -158,10 +158,7 @@ public class DeploymentRolloutFailureTestCase {
 
     private void failInstallFailedDeployment() throws IOException, MgmtOperationException {
         ModelNode op = getDeploymentCompositeOp();
-        System.out.println("Deploy op expected to fail:");
-        System.out.println(op);
         final ModelNode ret = masterClient.execute(op);
-        System.out.println(ret);
         if (! FAILED.equals(ret.get(OUTCOME).asString())) {
             throw new MgmtOperationException("Management operation succeeded.", op, ret);
         }
@@ -171,6 +168,13 @@ public class DeploymentRolloutFailureTestCase {
         Assert.assertEquals(m3Resp.toString(), FAILED, m3Resp.get(OUTCOME).asString());
         Assert.assertTrue(m3Resp.toString(), m3Resp.get(FAILURE_DESCRIPTION).asString().contains(ServiceActivatorDeployment.FAILURE_MESSAGE));
 
+        ModelNode failDesc = ret.get(FAILURE_DESCRIPTION);
+        Assert.assertTrue(failDesc.toString(), failDesc.isDefined());
+        ModelNode servers = failDesc.asProperty().getValue();
+        Assert.assertTrue(failDesc.toString(), servers.isDefined());
+        ModelNode serverFail = servers.get(SERVER_GROUP, MSG, HOST, "slave", "main-three");
+        Assert.assertTrue(failDesc.toString(), serverFail.isDefined());
+        Assert.assertTrue(failDesc.toString(), serverFail.toString().contains(ServiceActivatorDeployment.FAILURE_MESSAGE));
     }
 
     private ModelNode getDeploymentCompositeOp() throws MalformedURLException {
@@ -205,11 +209,8 @@ public class DeploymentRolloutFailureTestCase {
     }
 
     private void failRemoveFailedDeployment() throws IOException, MgmtOperationException {
-        System.out.println("Undeploy op expected to fail:");
         ModelNode op = getUndeployCompositeOp();
-        System.out.println(op);
         final ModelNode ret = masterClient.execute(op);
-        System.out.println(ret);
         if (! FAILED.equals(ret.get(OUTCOME).asString())) {
             throw new MgmtOperationException("Management operation succeeded.", op, ret);
         }
@@ -219,6 +220,12 @@ public class DeploymentRolloutFailureTestCase {
         Assert.assertEquals(m3Resp.toString(), FAILED, m3Resp.get(OUTCOME).asString());
         Assert.assertTrue(m3Resp.toString(), m3Resp.get(FAILURE_DESCRIPTION).isDefined());
 
+        ModelNode failDesc = ret.get(FAILURE_DESCRIPTION);
+        Assert.assertTrue(failDesc.toString(), failDesc.isDefined());
+        ModelNode servers = failDesc.asProperty().getValue();
+        Assert.assertTrue(failDesc.toString(), servers.isDefined());
+        ModelNode serverFail = servers.get(SERVER_GROUP, MSG, HOST, "slave", "main-three");
+        Assert.assertTrue(failDesc.toString(), serverFail.isDefined());
     }
 
     private ModelNode getUndeployCompositeOp() throws MalformedURLException {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -40,6 +40,7 @@ import org.junit.runners.Suite;
         CoreResourceManagementTestCase.class,
         //DeploymentManagementTestCase.class,
         //DeploymentOverlayTestCase.class,
+        DeploymentRolloutFailureTestCase.class,
         DirectoryGroupingByTypeTestCase.class,
         ExtensionManagementTestCase.class,
         HcExtensionAndSubsystemManagementTestCase.class,


### PR DESCRIPTION
1) Adds a test of deliberately introducing an inconsistent domain (by using a rollout plan that allows a failure on one server) and then of reverting that change (requiring an equivalent rollout plan.)

2) Fixes a bug that resulted in server results not being included in the overall response when a domain rollout is rolled back.

3) Improved the top level failure description when a domain rollout fails by identifying relevant server-level failure descriptions and incorporating them in the top level message. Clients (e.g. CLI high level commands, or perhaps web console error reporting) may not provide the detail server results to users when a failure occurs, so including the data in the top level failure description is important.