### PR TITLE
WELD-1853 Add path com/sun/org/apache/bcel/internal/classfile to sun-jdk system dependency

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
@@ -52,6 +52,7 @@
                 <path name="com/sun/jndi/url/rmi"/>
                 <path name="com/sun/media/sound"/>
                 <path name="com/sun/crypto/provider"/>
+                <path name="com/sun/org/apache/bcel/internal/classfile"/>
                 <path name="com/sun/org/apache/xml/internal/security/transforms/implementations"/>
                 <path name="com/sun/rowset"/>
                 <path name="com/sun/rowset/providers"/>


### PR DESCRIPTION
To improve some error messages Weld attempts to get the line number
associated with a particular class member. Reflection API does not
expose such an info so Weld is analysing the bytecode using the
Apache BCEL inluded in Oracle JDK and OpenJDK.