### PR TITLE
[WFCORE-542] Added a new utility to work with registering resources and ...

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
@@ -203,6 +203,11 @@ public final class Attachments {
 
     public static final AttachmentKey<Map<String, MountedDeploymentOverlay>> DEPLOYMENT_OVERLAY_LOCATIONS = AttachmentKey.create(Map.class);
 
+    /**
+     * Support for getting and creating resource models on a deployments resource.
+     */
+    public static final AttachmentKey<DeploymentResourceSupport> DEPLOYMENT_RESOURCE_SUPPORT = AttachmentKey.create(DeploymentResourceSupport.class);
+
 
 
     //

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentHandlerUtil.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentHandlerUtil.java
@@ -93,7 +93,7 @@ public class DeploymentHandlerUtil {
             final ImmutableManagementResourceRegistration registration = context.getResourceRegistration();
             final ManagementResourceRegistration mutableRegistration = context.getResourceRegistrationForUpdate();
 
-            DeploymentModelUtils.cleanup(deployment);
+            DeploymentResourceSupport.cleanup(deployment);
 
             context.addStep(new OperationStepHandler() {
                 public void execute(OperationContext context, ModelNode operation) {
@@ -178,7 +178,7 @@ public class DeploymentHandlerUtil {
             final ImmutableManagementResourceRegistration registration = context.getResourceRegistration();
             final ManagementResourceRegistration mutableRegistration = context.getResourceRegistrationForUpdate();
 
-            DeploymentModelUtils.cleanup(deployment);
+            DeploymentResourceSupport.cleanup(deployment);
 
             context.addStep(new OperationStepHandler() {
                 public void execute(final OperationContext context, ModelNode operation) throws OperationFailedException {
@@ -239,7 +239,7 @@ public class DeploymentHandlerUtil {
             final ImmutableManagementResourceRegistration registration = context.getResourceRegistration().getSubModel(PathAddress.EMPTY_ADDRESS.append(path));
             final ManagementResourceRegistration mutableRegistration = context.getResourceRegistrationForUpdate().getSubModel(PathAddress.EMPTY_ADDRESS.append(path));
 
-            DeploymentModelUtils.cleanup(deployment);
+            DeploymentResourceSupport.cleanup(deployment);
 
             context.addStep(new OperationStepHandler() {
                 public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
@@ -255,7 +255,7 @@ public class DeploymentHandlerUtil {
                         public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
                             if (resultAction == OperationContext.ResultAction.ROLLBACK) {
 
-                                DeploymentModelUtils.cleanup(deployment);
+                                DeploymentResourceSupport.cleanup(deployment);
                                 final String name = originalDeployment.require(NAME).asString();
                                 final String runtimeName = originalDeployment.require(RUNTIME_NAME).asString();
                                 final DeploymentHandlerUtil.ContentItem[] contents = getContents(originalDeployment.require(CONTENT));
@@ -281,7 +281,7 @@ public class DeploymentHandlerUtil {
             final Resource deployment = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
             final ImmutableManagementResourceRegistration registration = context.getResourceRegistration();
             final ManagementResourceRegistration mutableRegistration = context.getResourceRegistrationForUpdate();
-            DeploymentModelUtils.cleanup(deployment);
+            DeploymentResourceSupport.cleanup(deployment);
 
             context.addStep(new OperationStepHandler() {
                 public void execute(OperationContext context, ModelNode operation) {

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentModelUtils.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentModelUtils.java
@@ -22,115 +22,16 @@
 
 package org.jboss.as.server.deployment;
 
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.logging.ControllerLogger;
-import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
-import org.jboss.dmr.ModelNode;
 
 /**
  * @author Emanuel Muckenhuber
- * TODO:  make this package protected again instead of public
+ * @deprecated Use {@link org.jboss.as.server.deployment.DeploymentResourceSupport} from an {@link Attachments#DEPLOYMENT_RESOURCE_SUPPORT attachment} on the {@link org.jboss.as.server.deployment.DeploymentUnit}
  */
+@Deprecated
 public class DeploymentModelUtils {
 
-    // TODO:  make this package protected again instead of public
-    public static final AttachmentKey<Resource> DEPLOYMENT_RESOURCE = AttachmentKey.create(Resource.class);
-    static final AttachmentKey<ImmutableManagementResourceRegistration> REGISTRATION_ATTACHMENT = AttachmentKey.create(ImmutableManagementResourceRegistration.class);
-    public static final AttachmentKey<ManagementResourceRegistration> MUTABLE_REGISTRATION_ATTACHMENT = AttachmentKey.create(ManagementResourceRegistration.class);
-
-    static final String SUBSYSTEM = ModelDescriptionConstants.SUBSYSTEM;
-    static final String SUB_DEPLOYMENT = "subdeployment";
-
-    static ModelNode getSubsystemRoot(final String subsystemName, final DeploymentUnit unit) {
-        final Resource root = unit.getAttachment(DEPLOYMENT_RESOURCE);
-        synchronized (root) {
-            return getOrCreate(root, PathElement.pathElement(SUBSYSTEM, subsystemName)).getModel();
-        }
-    }
-
-    static ModelNode createDeploymentSubModel(final String subsystemName, final PathElement address, final DeploymentUnit unit) {
-        final Resource root = unit.getAttachment(DEPLOYMENT_RESOURCE);
-        synchronized (root) {
-            final ImmutableManagementResourceRegistration registration = unit.getAttachment(REGISTRATION_ATTACHMENT);
-            final Resource subsystem = getOrCreate(root, PathElement.pathElement(SUBSYSTEM, subsystemName));
-            final ImmutableManagementResourceRegistration subModel = registration.getSubModel(getExtensionAddress(subsystemName, address));
-            if(subModel == null) {
-                throw new IllegalStateException(address.toString());
-            }
-            return getOrCreate(subsystem, address).getModel();
-        }
-    }
-
-    static ModelNode createDeploymentSubModel(final String subsystemName, final PathAddress address, final Resource resource,final DeploymentUnit unit) {
-        final Resource root = unit.getAttachment(DEPLOYMENT_RESOURCE);
-        synchronized (root) {
-            final ImmutableManagementResourceRegistration registration = unit.getAttachment(REGISTRATION_ATTACHMENT);
-            final Resource subsystem = getOrCreate(root, PathElement.pathElement(SUBSYSTEM, subsystemName));
-            Resource parent = subsystem;
-            int count = address.size()-1;
-            for(int index = 0; index<count;index++){
-                parent = getOrCreate(parent, address.getElement(index));
-            }
-            final ImmutableManagementResourceRegistration subModel = registration.getSubModel(getExtensionAddress(subsystemName, address));
-            if(subModel == null) {
-                throw new IllegalStateException(address.toString());
-            }
-            return getOrCreate(parent, address.getLastElement(),resource).getModel();
-        }
-    }
-
-    static Resource createSubDeployment(final String deploymentName, DeploymentUnit parent) {
-        final Resource root = parent.getAttachment(DEPLOYMENT_RESOURCE);
-        return getOrCreate(root, PathElement.pathElement(SUB_DEPLOYMENT, deploymentName));
-    }
-
-    static Resource getOrCreate(final Resource parent, final PathElement element) {
-       return getOrCreate(parent, element, null);
-    }
-
-    static Resource getOrCreate(final Resource parent, final PathElement element, final Resource desired) {
-        synchronized(parent) {
-            if(parent.hasChild(element)) {
-                if(desired==null){
-                    return parent.requireChild(element);
-                } else {
-                    throw new IllegalStateException();
-                }
-            } else {
-                Resource toRegister = desired;
-                if(toRegister == null){
-                    toRegister = Resource.Factory.create(true);
-                }else if (!toRegister.isRuntime()){
-                    throw ControllerLogger.ROOT_LOGGER.deploymentResourceMustBeRuntimeOnly();
-                }
-                parent.registerChild(element, toRegister);
-                return toRegister;
-            }
-        }
-    }
-
-    static void cleanup(final Resource resource) {
-        synchronized (resource) {
-            for(final Resource.ResourceEntry entry : resource.getChildren(SUBSYSTEM)) {
-                resource.removeChild(entry.getPathElement());
-            }
-            for(final Resource.ResourceEntry entry : resource.getChildren(SUB_DEPLOYMENT)) {
-                resource.removeChild(entry.getPathElement());
-            }
-        }
-    }
-
-    static PathAddress getExtensionAddress(final String subsystemName, final PathElement element) {
-        return PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, subsystemName), element);
-    }
-
-    static PathAddress getExtensionAddress(final String subsystemName, final PathAddress elements) {
-        PathAddress address = PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, subsystemName));
-        address = address.append(elements);
-        return address;
-    }
+    public static final AttachmentKey<Resource> DEPLOYMENT_RESOURCE = DeploymentResourceSupport.DEPLOYMENT_RESOURCE;
+    public static final AttachmentKey<ManagementResourceRegistration> MUTABLE_REGISTRATION_ATTACHMENT = DeploymentResourceSupport.MUTABLE_REGISTRATION_ATTACHMENT;
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentResourceSupport.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentResourceSupport.java
@@ -1,0 +1,276 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.server.deployment;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Support for creation of resources on deployments or retrieving the model of a resource on deployments.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public final class DeploymentResourceSupport {
+    static final AttachmentKey<Resource> DEPLOYMENT_RESOURCE = AttachmentKey.create(Resource.class);
+    static final AttachmentKey<ImmutableManagementResourceRegistration> REGISTRATION_ATTACHMENT = AttachmentKey.create(ImmutableManagementResourceRegistration.class);
+    static final AttachmentKey<ManagementResourceRegistration> MUTABLE_REGISTRATION_ATTACHMENT = AttachmentKey.create(ManagementResourceRegistration.class);
+
+    private final DeploymentUnit deploymentUnit;
+
+    protected DeploymentResourceSupport(final DeploymentUnit deploymentUnit) {
+        this.deploymentUnit = deploymentUnit;
+    }
+
+    /**
+     * Get the subsystem deployment model root.
+     *
+     * <p>
+     * If the subsystem resource does not exist one will be created.
+     * </p>
+     *
+     * @param subsystemName the subsystem name.
+     *
+     * @return the model
+     */
+    public ModelNode getDeploymentSubsystemModel(final String subsystemName) {
+        assert subsystemName != null : "The subsystemName cannot be null";
+        return getDeploymentSubModel(subsystemName, PathAddress.EMPTY_ADDRESS, null, deploymentUnit);
+    }
+
+    /**
+     * Registers the resource to the parent deployment resource. The model returned is that of the resource parameter.
+     *
+     * @param subsystemName the subsystem name
+     * @param resource      the resource to be used for the subsystem on the deployment
+     *
+     * @return the model
+     *
+     * @throws java.lang.IllegalStateException if the subsystem resource already exists
+     */
+    public ModelNode registerDeploymentSubsystemResource(final String subsystemName, final Resource resource) {
+        assert subsystemName != null : "The subsystemName cannot be null";
+        assert resource != null : "The resource cannot be null";
+        return registerDeploymentSubResource(subsystemName, PathAddress.EMPTY_ADDRESS, resource);
+    }
+
+    /**
+     * Gets the sub-model for a components from the deployment itself. Operations, metrics and descriptions have to be
+     * registered as part of the subsystem registration {@link org.jboss.as.controller.ExtensionContext} and
+     * {@link org.jboss.as.controller.SubsystemRegistration#registerDeploymentModel(org.jboss.as.controller.ResourceDefinition)}.
+     *
+     * <p>
+     * If the subsystem resource does not exist it will be created. If no resource exists for the address parameter on
+     * the resource it also be created.
+     * </p>
+     *
+     * @param subsystemName the name of the subsystem
+     * @param address       the path address this sub-model should return the model for
+     *
+     * @return the model for the resource
+     */
+    public ModelNode getDeploymentSubModel(final String subsystemName, final PathElement address) {
+        assert subsystemName != null : "The subsystemName cannot be null";
+        return getDeploymentSubModel(subsystemName, address, deploymentUnit);
+    }
+
+    /**
+     * Gets the sub-model for a components from the deployment itself. Operations, metrics and descriptions have to be
+     * registered as part of the subsystem registration {@link org.jboss.as.controller.ExtensionContext} and
+     * {@link org.jboss.as.controller.SubsystemRegistration#registerDeploymentModel(org.jboss.as.controller.ResourceDefinition)}.
+     *
+     * <p>
+     * The subsystem resource as well as each {@link org.jboss.as.controller.PathAddress#getParent()} parent element}
+     * from the address will be created if it does not already exist.
+     * </p>
+     *
+     * @param subsystemName the name of the subsystem
+     * @param address       the path address this sub-model should return the model for
+     *
+     * @return the model for the resource
+     */
+    public ModelNode getDeploymentSubModel(final String subsystemName, final PathAddress address) {
+        assert subsystemName != null : "The subsystemName cannot be null";
+        assert address != null : "The address cannot be null";
+        return getDeploymentSubModel(subsystemName, address, null, deploymentUnit);
+    }
+
+    /**
+     * Registers the provided resource as the resource for the {@link org.jboss.as.controller.PathAddress#getLastElement()
+     * last element} of the address. Operations, metrics and descriptions have to be registered as part of the
+     * subsystem registration {@link org.jboss.as.controller.ExtensionContext} and {@link
+     * org.jboss.as.controller.SubsystemRegistration#registerDeploymentModel(org.jboss.as.controller.ResourceDefinition)}.
+     *
+     * <p>
+     * The subsystem resource as well as each {@link org.jboss.as.controller.PathAddress#getParent()} parent element}
+     * from the address will be created if it does not already exist.
+     * </p>
+     *
+     * @param subsystemName the subsystem name the model was registered
+     * @param address       the path address this sub-model should be created in
+     * @param resource      the resource to be registered as sub-module
+     *
+     * @return the {@link org.jboss.as.controller.registry.Resource#getModel() model} from the resource parameter
+     *
+     * @throws java.lang.IllegalStateException if the {@link org.jboss.as.controller.PathAddress#getLastElement() last}
+     *                                         resource already exists
+     */
+    public ModelNode registerDeploymentSubResource(final String subsystemName, final PathAddress address, final Resource resource) {
+        final Resource root = deploymentUnit.getAttachment(DEPLOYMENT_RESOURCE);
+        synchronized (root) {
+            final ImmutableManagementResourceRegistration registration = deploymentUnit.getAttachment(REGISTRATION_ATTACHMENT);
+            final PathElement subsystemPath = PathElement.pathElement(SUBSYSTEM, subsystemName);
+            if (address == PathAddress.EMPTY_ADDRESS) {
+                return register(root, subsystemPath, resource).getModel();
+            }
+            Resource parent = getOrCreate(root, subsystemPath);
+            int count = address.size() - 1;
+            for (int index = 0; index < count; index++) {
+                parent = getOrCreate(parent, address.getElement(index));
+            }
+            final ImmutableManagementResourceRegistration subModel = registration.getSubModel(getSubsystemAddress(subsystemName, address));
+            if (subModel == null) {
+                throw new IllegalStateException(address.toString());
+            }
+            return register(parent, address.getLastElement(), resource).getModel();
+        }
+    }
+
+    /**
+     * Gets or creates the a resource for the sub-deployment on the parent deployments resource.
+     *
+     * @param deploymentName the name of the deployment
+     * @param parent         the parent deployment used to find the parent resource
+     *
+     * @return the already registered resource or a newly created resource
+     */
+    static Resource getOrCreateSubDeployment(final String deploymentName, final DeploymentUnit parent) {
+        final Resource root = parent.getAttachment(DEPLOYMENT_RESOURCE);
+        return getOrCreate(root, PathElement.pathElement(SUBDEPLOYMENT, deploymentName));
+    }
+
+    /**
+     * Cleans up the subsystem children for the deployment and each sub-deployment resource.
+     *
+     * @param resource the subsystem resource to clean up
+     */
+    static void cleanup(final Resource resource) {
+        synchronized (resource) {
+            for (final Resource.ResourceEntry entry : resource.getChildren(SUBSYSTEM)) {
+                resource.removeChild(entry.getPathElement());
+            }
+            for (final Resource.ResourceEntry entry : resource.getChildren(SUBDEPLOYMENT)) {
+                resource.removeChild(entry.getPathElement());
+            }
+        }
+    }
+
+    /**
+     * @see #getDeploymentSubModel(String, org.jboss.as.controller.PathElement, DeploymentUnit)
+     */
+    static ModelNode getDeploymentSubModel(final String subsystemName, final PathElement address, final DeploymentUnit unit) {
+        final Resource root = unit.getAttachment(DEPLOYMENT_RESOURCE);
+        synchronized (root) {
+            final ImmutableManagementResourceRegistration registration = unit.getAttachment(REGISTRATION_ATTACHMENT);
+            final PathElement subsystemPath = PathElement.pathElement(SUBSYSTEM, subsystemName);
+            if (address == null) {
+                return getOrCreate(root, subsystemPath, null).getModel();
+            }
+            Resource parent = getOrCreate(root, subsystemPath);
+            final ImmutableManagementResourceRegistration subModel = registration.getSubModel(PathAddress.pathAddress(subsystemPath, address));
+            if (subModel == null) {
+                throw new IllegalStateException(address.toString());
+            }
+            return getOrCreate(parent, address, null).getModel();
+        }
+    }
+
+    /**
+     * @see #getDeploymentSubModel(String, org.jboss.as.controller.PathAddress)
+     */
+    static ModelNode getDeploymentSubModel(final String subsystemName, final PathAddress address, final Resource resource, final DeploymentUnit unit) {
+        final Resource root = unit.getAttachment(DEPLOYMENT_RESOURCE);
+        synchronized (root) {
+            final ImmutableManagementResourceRegistration registration = unit.getAttachment(REGISTRATION_ATTACHMENT);
+            final PathElement subsystemPath = PathElement.pathElement(SUBSYSTEM, subsystemName);
+            if (address == PathAddress.EMPTY_ADDRESS) {
+                return getOrCreate(root, subsystemPath, resource).getModel();
+            }
+            Resource parent = getOrCreate(root, subsystemPath);
+            int count = address.size() - 1;
+            for (int index = 0; index < count; index++) {
+                parent = getOrCreate(parent, address.getElement(index));
+            }
+            final ImmutableManagementResourceRegistration subModel = registration.getSubModel(getSubsystemAddress(subsystemName, address));
+            if (subModel == null) {
+                throw new IllegalStateException(address.toString());
+            }
+            return getOrCreate(parent, address.getLastElement(), resource).getModel();
+        }
+    }
+
+    private static Resource getOrCreate(final Resource parent, final PathElement element) {
+        return getOrCreate(parent, element, null);
+    }
+
+    private static Resource getOrCreate(final Resource parent, final PathElement element, final Resource desired) {
+        synchronized (parent) {
+            if (parent.hasChild(element)) {
+                if (desired == null) {
+                    return parent.requireChild(element);
+                } else {
+                    throw new IllegalStateException();
+                }
+            } else {
+                return register(parent, element, desired);
+            }
+        }
+    }
+
+    private static Resource register(final Resource parent, final PathElement element, final Resource desired) {
+        synchronized (parent) {
+            Resource toRegister = desired;
+            if (toRegister == null) {
+                toRegister = Resource.Factory.create(true);
+            } else if (!toRegister.isRuntime()) {
+                throw ControllerLogger.ROOT_LOGGER.deploymentResourceMustBeRuntimeOnly();
+            }
+            parent.registerChild(element, toRegister);
+            return toRegister;
+        }
+    }
+
+    private static PathAddress getSubsystemAddress(final String subsystemName, final PathAddress elements) {
+        PathAddress address = PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement(SUBSYSTEM, subsystemName));
+        address = address.append(elements);
+        return address;
+    }
+
+}

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnit.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnit.java
@@ -68,18 +68,24 @@ public interface DeploymentUnit extends Attachable {
      *
      * @param subsystemName the subsystem name.
      * @return the model
+     *
+     * @deprecated Use {@link org.jboss.as.server.deployment.DeploymentResourceSupport#getDeploymentSubsystemModel(String)}
      */
+    @Deprecated
     ModelNode getDeploymentSubsystemModel(final String subsystemName);
 
     /**
      * Create a management sub-model for components from the deployment itself. Operations, metrics and descriptions
      * have to be registered as part of the subsystem registration {@link org.jboss.as.controller.ExtensionContext} and
-     * {@linkplain org.jboss.as.controller.SubsystemRegistration.registerDeploymentModel}.
+     * {@linkplain org.jboss.as.controller.SubsystemRegistration#registerDeploymentModel(org.jboss.as.controller.ResourceDefinition)}.
      *
      * @param subsystemName the subsystem name the model was registered
      * @param address the path address this sub-model should be created in
      * @return the model node
+     *
+     * @deprecated Use {@link org.jboss.as.server.deployment.DeploymentResourceSupport#getDeploymentSubModel(String, org.jboss.as.controller.PathElement)}
      */
+    @Deprecated
     ModelNode createDeploymentSubModel(final String subsystemName, final PathElement address);
 
     /**
@@ -90,7 +96,10 @@ public interface DeploymentUnit extends Attachable {
      * @param subsystemName the subsystem name the model was registered
      * @param address the path address this sub-model should be created in
      * @return the model node
+     *
+     * @deprecated Use {@link org.jboss.as.server.deployment.DeploymentResourceSupport#getDeploymentSubModel(String, org.jboss.as.controller.PathAddress)}
      */
+    @Deprecated
     ModelNode createDeploymentSubModel(final String subsystemName, final PathAddress address);
 
     /**
@@ -102,7 +111,10 @@ public interface DeploymentUnit extends Attachable {
      * @param address the path address this sub-model should be created in
      * @param resource the resource that needs to be registered as submodule
      * @return the model node
+     *
+     * @deprecated Use {@link org.jboss.as.server.deployment.DeploymentResourceSupport#registerDeploymentSubResource(String, org.jboss.as.controller.PathAddress, org.jboss.as.controller.registry.Resource)}
      */
+    @Deprecated
     ModelNode createDeploymentSubModel(final String subsystemName, final PathAddress address, final Resource resource);
 
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnitImpl.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnitImpl.java
@@ -86,12 +86,13 @@ class DeploymentUnitImpl extends SimpleAttachable implements DeploymentUnit {
 
     @Override
     public ModelNode getDeploymentSubsystemModel(final String subsystemName) {
-        return DeploymentModelUtils.getSubsystemRoot(subsystemName, this);
+        return DeploymentResourceSupport.getDeploymentSubModel(subsystemName, null, this);
     }
 
     @Override
     public ModelNode createDeploymentSubModel(final String subsystemName, final PathElement address) {
-        return DeploymentModelUtils.createDeploymentSubModel(subsystemName, address, this);
+        // Using the getDeploymentSubModel results in the previous behavior
+        return DeploymentResourceSupport.getDeploymentSubModel(subsystemName, address, this);
     }
 
     @Override
@@ -101,6 +102,7 @@ class DeploymentUnitImpl extends SimpleAttachable implements DeploymentUnit {
 
     @Override
     public ModelNode createDeploymentSubModel(String subsystemName, PathAddress address, Resource resource) {
-        return DeploymentModelUtils.createDeploymentSubModel(subsystemName, address, resource,this);
+        // Using the getDeploymentSubModel results in the previous behavior
+        return DeploymentResourceSupport.getDeploymentSubModel(subsystemName, address, resource, this);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/RootDeploymentUnitService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/RootDeploymentUnitService.java
@@ -81,9 +81,10 @@ final class RootDeploymentUnitService extends AbstractDeploymentUnitService {
         deploymentUnit.putAttachment(Attachments.RUNTIME_NAME, name);
         deploymentUnit.putAttachment(Attachments.MANAGEMENT_NAME, managementName);
         deploymentUnit.putAttachment(Attachments.DEPLOYMENT_CONTENTS, contentsInjector.getValue());
-        deploymentUnit.putAttachment(DeploymentModelUtils.REGISTRATION_ATTACHMENT, registration);
-        deploymentUnit.putAttachment(DeploymentModelUtils.MUTABLE_REGISTRATION_ATTACHMENT, mutableRegistration);
-        deploymentUnit.putAttachment(DeploymentModelUtils.DEPLOYMENT_RESOURCE, resource);
+        deploymentUnit.putAttachment(DeploymentResourceSupport.REGISTRATION_ATTACHMENT, registration);
+        deploymentUnit.putAttachment(DeploymentResourceSupport.MUTABLE_REGISTRATION_ATTACHMENT, mutableRegistration);
+        deploymentUnit.putAttachment(DeploymentResourceSupport.DEPLOYMENT_RESOURCE, resource);
+        deploymentUnit.putAttachment(Attachments.DEPLOYMENT_RESOURCE_SUPPORT, new DeploymentResourceSupport(deploymentUnit));
         deploymentUnit.putAttachment(Attachments.VAULT_READER_ATTACHMENT_KEY, vaultReader);
         deploymentUnit.putAttachment(Attachments.DEPLOYMENT_OVERLAY_INDEX, deploymentOverlays);
         deploymentUnit.putAttachment(Attachments.PATH_MANAGER, pathManagerInjector.getValue());

--- a/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentProcessor.java
@@ -57,9 +57,9 @@ public class SubDeploymentProcessor implements DeploymentUnitProcessor {
             if (childRoot == deploymentResourceRoot || !SubDeploymentMarker.isSubDeployment(childRoot)) {
                 continue;
             }
-            final Resource resource = DeploymentModelUtils.createSubDeployment(childRoot.getRootName(), deploymentUnit);
-            final ImmutableManagementResourceRegistration registration = deploymentUnit.getAttachment(DeploymentModelUtils.REGISTRATION_ATTACHMENT);
-            final ManagementResourceRegistration mutableRegistration =  deploymentUnit.getAttachment(DeploymentModelUtils.MUTABLE_REGISTRATION_ATTACHMENT);
+            final Resource resource = DeploymentResourceSupport.getOrCreateSubDeployment(childRoot.getRootName(), deploymentUnit);
+            final ImmutableManagementResourceRegistration registration = deploymentUnit.getAttachment(DeploymentResourceSupport.REGISTRATION_ATTACHMENT);
+            final ManagementResourceRegistration mutableRegistration =  deploymentUnit.getAttachment(DeploymentResourceSupport.MUTABLE_REGISTRATION_ATTACHMENT);
             final AbstractVaultReader vaultReader = deploymentUnit.getAttachment(Attachments.VAULT_READER_ATTACHMENT_KEY);
             final PathManager pathManager = deploymentUnit.getAttachment(Attachments.PATH_MANAGER);
             final SubDeploymentUnitService service = new SubDeploymentUnitService(childRoot, deploymentUnit, registration, mutableRegistration, resource, vaultReader, pathManager);

--- a/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentUnitService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentUnitService.java
@@ -64,9 +64,10 @@ public class SubDeploymentUnitService extends AbstractDeploymentUnitService {
         final DeploymentUnit deploymentUnit = new DeploymentUnitImpl(parent, deploymentName, registry);
         deploymentUnit.putAttachment(Attachments.DEPLOYMENT_ROOT, deploymentRoot);
         deploymentUnit.putAttachment(Attachments.MODULE_SPECIFICATION, new ModuleSpecification());
-        deploymentUnit.putAttachment(DeploymentModelUtils.REGISTRATION_ATTACHMENT, registration);
-        deploymentUnit.putAttachment(DeploymentModelUtils.MUTABLE_REGISTRATION_ATTACHMENT, mutableRegistration);
-        deploymentUnit.putAttachment(DeploymentModelUtils.DEPLOYMENT_RESOURCE, resource);
+        deploymentUnit.putAttachment(DeploymentResourceSupport.REGISTRATION_ATTACHMENT, registration);
+        deploymentUnit.putAttachment(DeploymentResourceSupport.MUTABLE_REGISTRATION_ATTACHMENT, mutableRegistration);
+        deploymentUnit.putAttachment(DeploymentResourceSupport.DEPLOYMENT_RESOURCE, resource);
+        deploymentUnit.putAttachment(Attachments.DEPLOYMENT_RESOURCE_SUPPORT, new DeploymentResourceSupport(deploymentUnit));
         deploymentUnit.putAttachment(Attachments.VAULT_READER_ATTACHMENT_KEY, vaultReader);
         deploymentUnit.putAttachment(Attachments.DEPLOYMENT_OVERLAY_INDEX, parent.getAttachment(Attachments.DEPLOYMENT_OVERLAY_INDEX));
         deploymentUnit.putAttachment(Attachments.PATH_MANAGER, pathManager);


### PR DESCRIPTION
...retrieving models from a deployment resource. Deprecated the previous methods on the DeploymentUtil.

Added a new API to assist with registering and creating resources for a deployments subsystem model. The new API was added as an attachment to the `DeploymentUnit` and the old `DeploymentUnit` methods were deprecated.

Deprecated the `DeploymentModelUtils` as there was a `TODO` to make it package private. Moved the needed methods within the package to the `DeploymentResourceSupport`.