### PR TITLE
[WFCORE-566] fix AttributeMarshaller.STRING_LIST & COMMA_STRING_LIST

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeMarshaller.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeMarshaller.java
@@ -82,9 +82,7 @@ public abstract class AttributeMarshaller {
         return false;
     }
 
-
-
-    private static class ListMarshaller extends DefaultAttributeMarshaller {
+    private static class ListMarshaller extends AttributeMarshaller {
         private final char delimiter;
 
         private ListMarshaller(char delimiter) {
@@ -92,8 +90,7 @@ public abstract class AttributeMarshaller {
         }
 
         @Override
-        public void marshallAsElement(final AttributeDefinition attribute, final ModelNode resourceModel, final boolean marshallDefault, final XMLStreamWriter writer) throws XMLStreamException {
-
+        public void marshallAsAttribute(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
             StringBuilder builder = new StringBuilder();
             if (resourceModel.hasDefined(attribute.getName())) {
                 for (ModelNode p : resourceModel.get(attribute.getName()).asList()) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/parsing/ManagementXml.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/parsing/ManagementXml.java
@@ -4017,7 +4017,8 @@ public class ManagementXml {
                     writer.writeAttribute(Attribute.PRINCIPAL.getLocalName(), current.getName());
                     KeytabResourceDefinition.PATH.marshallAsAttribute(currentNode, writer);
                     KeytabResourceDefinition.RELATIVE_TO.marshallAsAttribute(currentNode, writer);
-                    KeytabResourceDefinition.FOR_HOSTS.marshallAsElement(currentNode, writer);
+                    KeytabResourceDefinition.FOR_HOSTS.getAttributeMarshaller()
+                            .marshallAsAttribute(KeytabResourceDefinition.FOR_HOSTS, currentNode, true, writer);
                     KeytabResourceDefinition.DEBUG.marshallAsAttribute(currentNode, writer);
                 }
             }
@@ -4313,7 +4314,8 @@ public class ManagementXml {
             LdapConnectionResourceDefinition.SECURITY_REALM.marshallAsAttribute(connection, writer);
             LdapConnectionResourceDefinition.INITIAL_CONTEXT_FACTORY.marshallAsAttribute(connection, writer);
             LdapConnectionResourceDefinition.REFERRALS.marshallAsAttribute(connection, writer);
-            LdapConnectionResourceDefinition.HANDLES_REFERRALS_FOR.marshallAsElement(connection, writer);
+            LdapConnectionResourceDefinition.HANDLES_REFERRALS_FOR.getAttributeMarshaller()
+                    .marshallAsAttribute(LdapConnectionResourceDefinition.HANDLES_REFERRALS_FOR, connection, true, writer);
 
             if (connection.hasDefined(PROPERTY)) {
                 List<Property> propertyList = connection.get(PROPERTY).asPropertyList();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/KeytabResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/KeytabResourceDefinition.java
@@ -23,6 +23,7 @@
 package org.jboss.as.domain.management.security;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -62,6 +63,7 @@ public class KeytabResourceDefinition extends SimpleResourceDefinition {
             .setAllowExpression(true)
             .setAllowNull(true)
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
+            .setAttributeMarshaller(AttributeMarshaller.STRING_LIST)
             .build();
 
     public static final SimpleAttributeDefinition DEBUG = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.DEBUG, ModelType.BOOLEAN, true)

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -2500,7 +2500,8 @@ public class HostXml extends CommonXml {
             HttpManagementResourceDefinition.SECURITY_REALM.marshallAsAttribute(protocol, writer);
             HttpManagementResourceDefinition.CONSOLE_ENABLED.marshallAsAttribute(protocol, writer);
             HttpManagementResourceDefinition.HTTP_UPGRADE_ENABLED.marshallAsAttribute(protocol, writer);
-            HttpManagementResourceDefinition.ALLOWED_ORIGINS.marshallAsElement(protocol, writer);
+            HttpManagementResourceDefinition.ALLOWED_ORIGINS.getAttributeMarshaller()
+                    .marshallAsAttribute(HttpManagementResourceDefinition.ALLOWED_ORIGINS, protocol, true, writer);
             HttpManagementResourceDefinition.SASL_PROTOCOL.marshallAsAttribute(protocol, writer);
             HttpManagementResourceDefinition.SERVER_NAME.marshallAsAttribute(protocol, writer);
 

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -1468,7 +1468,8 @@ public class StandaloneXml extends CommonXml {
                 HttpManagementResourceDefinition.CONSOLE_ENABLED.marshallAsAttribute(protocol, writer);
             }
             HttpManagementResourceDefinition.HTTP_UPGRADE_ENABLED.marshallAsAttribute(protocol, writer);
-            HttpManagementResourceDefinition.ALLOWED_ORIGINS.marshallAsElement(protocol, writer);
+            HttpManagementResourceDefinition.ALLOWED_ORIGINS.getAttributeMarshaller()
+                    .marshallAsAttribute(HttpManagementResourceDefinition.ALLOWED_ORIGINS, protocol, true, writer);
 
             if (HttpManagementResourceDefinition.INTERFACE.isMarshallable(protocol)) {
                 writer.writeEmptyElement(Element.SOCKET.getLocalName());


### PR DESCRIPTION
* override their marshallAsAttribute() method instead of their
   marshallAsElement()
* extend AttributeMarshaller instead of DefaultAttributeMarshaller to
  ensure no other marshallXXX method will be called inadvertently.
* fix misuse of this marshaller for attributes that are marshalled as
  XML attributes
JIRA: https://issues.jboss.org/browse/WFCORE-566