### PR TITLE
Add a new install phase priority for batch resources.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -568,6 +568,7 @@ public enum Phase {
     public static final int INSTALL_BUNDLE_ACTIVATE                     = 0x2040;
     public static final int INSTALL_WAB_SERVLETCONTEXT_SERVICE          = 0x2050;
     public static final int INSTALL_PERSISTENCE_SERVICES                = 0x2060;
+    public static final int INSTALL_BATCH_RESOURCES                     = 0x2070;
     public static final int INSTALL_DEPLOYMENT_COMPLETE_SERVICE         = 0x2100;
 
     // CLEANUP


### PR DESCRIPTION
As part of https://issues.jboss.org/browse/WFLY-3174 new runtime resources will be displayed on the deployment. A new priority on the install phase will be used to run the DUP that creates the dynamic resources and registers them on the deployment resource.