### PR TITLE
WFCORE-17 Add proper ResourceDefinition hooks for setting runtime only

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -116,7 +116,6 @@ public abstract class AbstractControllerService implements Service<ModelControll
     protected final ProcessType processType;
     protected final DelegatingConfigurableAuthorizer authorizer;
     private final RunningModeControl runningModeControl;
-    private final DescriptionProvider rootDescriptionProvider;
     private final ResourceDefinition rootResourceDefinition;
     private final ControlledProcessState processState;
     private final OperationStepHandler prepareStep;
@@ -208,6 +207,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
      *
      * @deprecated Here for backwards compatibility for ModelTestModelControllerService
      */
+    @Deprecated
     protected AbstractControllerService(final ProcessType processType, final RunningModeControl runningModeControl,
                                         final ConfigurationPersister configurationPersister,
                                         final ControlledProcessState processState, final ResourceDefinition rootResourceDefinition,
@@ -221,14 +221,14 @@ public abstract class AbstractControllerService implements Service<ModelControll
                                       final ResourceDefinition rootResourceDefinition, final DescriptionProvider rootDescriptionProvider,
                                       final OperationStepHandler prepareStep, final ExpressionResolver expressionResolver, final ManagedAuditLogger auditLogger,
                                       final DelegatingConfigurableAuthorizer authorizer) {
-        assert rootDescriptionProvider != null || rootResourceDefinition != null: rootDescriptionProvider == null ? "Null root description provider" : "Null root resource definition";
+        assert rootDescriptionProvider == null: "description provider cannot be used anymore";
+        assert rootResourceDefinition != null: "Null root resource definition";
         assert expressionResolver != null : "Null expressionResolver";
         assert auditLogger != null : "Null auditLogger";
         assert authorizer != null : "Null authorizer";
         this.processType = processType;
         this.runningModeControl = runningModeControl;
         this.configurationPersister = configurationPersister;
-        this.rootDescriptionProvider = rootDescriptionProvider;
         this.rootResourceDefinition = rootResourceDefinition;
         this.processState = processState;
         this.prepareStep = prepareStep;
@@ -252,9 +252,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
         final NotificationSupport notificationSupport = NotificationSupport.Factory.create(executorService);
         WritableAuthorizerConfiguration authorizerConfig = authorizer.getWritableAuthorizerConfiguration();
         authorizerConfig.reset();
-        ManagementResourceRegistration rootResourceRegistration = rootDescriptionProvider != null
-                ? ManagementResourceRegistration.Factory.create(rootDescriptionProvider, authorizerConfig)
-                : ManagementResourceRegistration.Factory.create(rootResourceDefinition, authorizerConfig);
+        ManagementResourceRegistration rootResourceRegistration = ManagementResourceRegistration.Factory.create(rootResourceDefinition, authorizerConfig);
         final ModelControllerImpl controller = new ModelControllerImpl(container, target,
                 rootResourceRegistration,
                 new ContainerStateMonitor(container),
@@ -469,7 +467,6 @@ public abstract class AbstractControllerService implements Service<ModelControll
      * a non {@code null} value from  {@link #getModelControllerServiceInitializationParams()}
      *
      * @param context the boot context
-     * @param the operation to trigger the initialization
      */
     protected final ModelNode registerModelControllerServiceInitializationBootStep(BootContext context) {
         ModelControllerServiceInitializationParams initParams = getModelControllerServiceInitializationParams();

--- a/controller/src/main/java/org/jboss/as/controller/DelegatingResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/DelegatingResourceDefinition.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
+/**
+* @author Tomaz Cerar (c) 2015 Red Hat Inc.
+*/
+public class DelegatingResourceDefinition implements ResourceDefinition {
+    protected volatile ResourceDefinition delegate;
+
+    public void setDelegate(ResourceDefinition delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+        delegate.registerOperations(resourceRegistration);
+    }
+
+    @Override
+    public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+        delegate.registerChildren(resourceRegistration);
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        delegate.registerAttributes(resourceRegistration);
+    }
+
+    @Override
+    public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+        delegate.registerNotifications(resourceRegistration);
+    }
+
+    @Override
+    public PathElement getPathElement() {
+        return delegate.getPathElement();
+    }
+
+    @Override
+    public DescriptionProvider getDescriptionProvider(ImmutableManagementResourceRegistration resourceRegistration) {
+        return delegate.getDescriptionProvider(resourceRegistration);
+    }
+
+    @Override
+    public List<AccessConstraintDefinition> getAccessConstraints() {
+        if (delegate == null) {
+            return Collections.emptyList();
+        }
+        return delegate.getAccessConstraints();
+    }
+
+    @Override
+    public boolean isRuntime() {
+        if (delegate!=null) {
+            return delegate.isRuntime();
+        }
+        return false;
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/DelegatingResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/DelegatingResourceDefinition.java
@@ -32,7 +32,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 public class DelegatingResourceDefinition implements ResourceDefinition {
     protected volatile ResourceDefinition delegate;
 
-    public void setDelegate(ResourceDefinition delegate) {
+    protected void setDelegate(ResourceDefinition delegate) {
         this.delegate = delegate;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceDefinition.java
@@ -28,6 +28,16 @@ public abstract class PersistentResourceDefinition extends SimpleResourceDefinit
         super(pathElement, descriptionResolver, addHandler, removeHandler, addRestartLevel, removeRestartLevel);
     }
 
+    protected PersistentResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, OperationStepHandler addHandler,
+                                           OperationStepHandler removeHandler, boolean isRuntime) {
+        super(pathElement, descriptionResolver, addHandler, removeHandler, isRuntime);
+    }
+
+    protected PersistentResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, OperationStepHandler addHandler,
+                                           OperationStepHandler removeHandler, OperationEntry.Flag addRestartLevel, OperationEntry.Flag removeRestartLevel, boolean isRuntime) {
+        super(pathElement, descriptionResolver, addHandler, removeHandler, addRestartLevel, removeRestartLevel, null, isRuntime);
+    }
+
 
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {

--- a/controller/src/main/java/org/jboss/as/controller/ResourceBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/ResourceBuilder.java
@@ -70,6 +70,8 @@ public interface ResourceBuilder {
 
     ResourceBuilder deprecated(ModelVersion since);
 
+    ResourceBuilder setRuntime();
+
     ResourceDefinition build();
 
     class Factory {

--- a/controller/src/main/java/org/jboss/as/controller/ResourceBuilderRoot.java
+++ b/controller/src/main/java/org/jboss/as/controller/ResourceBuilderRoot.java
@@ -46,6 +46,7 @@ class ResourceBuilderRoot implements ResourceBuilder {
     private DeprecationData deprecationData;
     private final List<ResourceBuilderRoot> children = new LinkedList<ResourceBuilderRoot>();
     private final ResourceBuilderRoot parent;
+    private boolean isRuntime = false;
 
 
     private ResourceBuilderRoot(PathElement pathElement, StandardResourceDescriptionResolver resourceResolver,
@@ -153,6 +154,12 @@ class ResourceBuilderRoot implements ResourceBuilder {
         return this;
     }
 
+    @Override
+    public ResourceBuilder setRuntime() {
+        this.isRuntime = true;
+        return this;
+    }
+
     public ResourceBuilder pushChild(final PathElement pathElement) {
         return pushChild(pathElement, resourceResolver.getChildResolver(pathElement.getKey()));
     }
@@ -213,7 +220,7 @@ class ResourceBuilderRoot implements ResourceBuilder {
         final ResourceBuilderRoot builder;
 
         private BuilderResourceDefinition(ResourceBuilderRoot builder) {
-            super(builder.pathElement, builder.resourceResolver, builder.addHandler, builder.removeHandler, builder.deprecationData);
+            super(builder.pathElement, builder.resourceResolver, builder.addHandler, builder.removeHandler, null, null, builder.deprecationData, builder.isRuntime);
             this.builder = builder;
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/ResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ResourceDefinition.java
@@ -86,4 +86,11 @@ public interface ResourceDefinition {
      * @return the access constraints or an empty list; will not return {@code null}.
      */
     List<AccessConstraintDefinition> getAccessConstraints();
+
+    /**
+     *
+     * @return true if resource is runtime
+     * @since WildFly Core 1.0, WildFly 9.0
+     */
+    boolean isRuntime();
 }

--- a/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
@@ -261,10 +261,9 @@ public class SimpleResourceDefinition implements ResourceDefinition {
      * @param handler      operation handler to register
      * @param flags        with flags
      */
-    @SuppressWarnings("deprecation")
     protected void registerAddOperation(final ManagementResourceRegistration registration, final AbstractAddStepHandler handler,
                                         OperationEntry.Flag... flags) {
-        this.registerAddOperation(registration, (OperationStepHandler) handler, flags);
+        registration.registerOperationHandler(ModelDescriptionConstants.ADD, handler, new DefaultResourceAddDescriptionProvider(registration, descriptionResolver), getFlagsSet(flags));
     }
 
     @Deprecated

--- a/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
@@ -54,6 +54,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
     private final OperationStepHandler removeHandler;
     private final OperationEntry.Flag addRestartLevel;
     private final OperationEntry.Flag removeRestartLevel;
+    private final boolean runtime;
     private volatile DeprecationData deprecationData;
 
     /**
@@ -77,6 +78,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
         this.addRestartLevel = null;
         this.removeRestartLevel = null;
         this.deprecationData = null;
+        this.runtime = false;
     }
 
     /**
@@ -97,6 +99,20 @@ public class SimpleResourceDefinition implements ResourceDefinition {
      * {@link DefaultResourceDescriptionProvider} to describe the resource.
      *
      * @param pathElement         the path. Cannot be {@code null}.
+     * @param descriptionResolver the description resolver to use in the description provider. Cannot be {@code null}
+     * @param isRuntime tells if resource is runtime
+     * @throws IllegalArgumentException if any parameter is {@code null}.
+     */
+    public SimpleResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver, boolean isRuntime) {
+        this(pathElement, descriptionResolver, null, null, OperationEntry.Flag.RESTART_NONE,
+                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, null, isRuntime);
+    }
+
+    /**
+     * {@link ResourceDefinition} that uses the given {code descriptionResolver} to configure a
+     * {@link DefaultResourceDescriptionProvider} to describe the resource.
+     *
+     * @param pathElement         the path. Cannot be {@code null}.
      * @param descriptionResolver the description resolver to use in the description provider. Cannot be {@code null}      *
      * @param addHandler          a handler to {@link #registerOperations(ManagementResourceRegistration) register} for the resource "add" operation.
      *                            Can be {null}
@@ -108,6 +124,25 @@ public class SimpleResourceDefinition implements ResourceDefinition {
                                     final OperationStepHandler addHandler, final OperationStepHandler removeHandler) {
         this(pathElement, descriptionResolver, addHandler, removeHandler, OperationEntry.Flag.RESTART_NONE,
                 OperationEntry.Flag.RESTART_RESOURCE_SERVICES, null);
+    }
+
+    /**
+     * {@link ResourceDefinition} that uses the given {code descriptionResolver} to configure a
+     * {@link DefaultResourceDescriptionProvider} to describe the resource.
+     *
+     * @param pathElement         the path. Cannot be {@code null}.
+     * @param descriptionResolver the description resolver to use in the description provider. Cannot be {@code null}      *
+     * @param addHandler          a handler to {@link #registerOperations(ManagementResourceRegistration) register} for the resource "add" operation.
+     *                            Can be {null}
+     * @param removeHandler       a handler to {@link #registerOperations(ManagementResourceRegistration) register} for the resource "remove" operation.
+     *                            Can be {null}
+     * @param isRuntime tells is resources is runtime or not
+     * @throws IllegalArgumentException if any parameter is {@code null}
+     */
+    public SimpleResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver,
+                                    final OperationStepHandler addHandler, final OperationStepHandler removeHandler, boolean isRuntime) {
+        this(pathElement, descriptionResolver, addHandler, removeHandler, OperationEntry.Flag.RESTART_NONE,
+                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, null, isRuntime);
     }
 
     /**
@@ -167,6 +202,27 @@ public class SimpleResourceDefinition implements ResourceDefinition {
                                     final OperationStepHandler addHandler, final OperationStepHandler removeHandler,
                                     final OperationEntry.Flag addRestartLevel, final OperationEntry.Flag removeRestartLevel,
                                     final DeprecationData deprecationData) {
+        this(pathElement, descriptionResolver, addHandler, removeHandler, addRestartLevel, removeRestartLevel, deprecationData, false);
+    }
+
+
+    /**
+     * {@link ResourceDefinition} that uses the given {code descriptionResolver} to configure a
+     * {@link DefaultResourceDescriptionProvider} to describe the resource.
+     *
+     * @param pathElement         the path. Can be {@code null}.
+     * @param descriptionResolver the description resolver to use in the description provider. Cannot be {@code null}      *
+     * @param addHandler          a handler to {@link #registerOperations(ManagementResourceRegistration) register} for the resource "add" operation.
+     *                            Can be {null}
+     * @param removeHandler       a handler to {@link #registerOperations(ManagementResourceRegistration) register} for the resource "remove" operation.
+     *                            Can be {null}
+     * @param deprecationData     Information describing deprecation of this resource. Can be {@code null} if the resource isn't deprecated.
+     * @throws IllegalArgumentException if {@code descriptionResolver} is {@code null}.
+     */
+    public SimpleResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver,
+                                    final OperationStepHandler addHandler, final OperationStepHandler removeHandler,
+                                    final OperationEntry.Flag addRestartLevel, final OperationEntry.Flag removeRestartLevel,
+                                    final DeprecationData deprecationData, final boolean runtime) {
         if (descriptionResolver == null) {
             throw ControllerLogger.ROOT_LOGGER.nullVar("descriptionProvider");
         }
@@ -180,6 +236,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
                 ? OperationEntry.Flag.RESTART_ALL_SERVICES
                 : validateRestartLevel("removeRestartLevel", removeRestartLevel);
         this.deprecationData = deprecationData;
+        this.runtime = runtime;
     }
 
     @Override
@@ -314,5 +371,10 @@ public class SimpleResourceDefinition implements ResourceDefinition {
 
     protected DeprecationData getDeprecationData(){
         return this.deprecationData;
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return runtime;
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultResourceDescriptionProvider.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultResourceDescriptionProvider.java
@@ -80,7 +80,9 @@ public class DefaultResourceDescriptionProvider implements DescriptionProvider {
             ModelNode deprecated = addDeprecatedInfo(result);
             deprecated.get(ModelDescriptionConstants.REASON).set(descriptionResolver.getResourceDeprecatedDescription(locale, bundle));
         }
-
+        if (registration.isRuntimeOnly()){
+            result.get(ModelDescriptionConstants.STORAGE).set(ModelDescriptionConstants.RUNTIME_ONLY);
+        }
         AccessConstraintDescriptionProviderUtil.addAccessConstraints(result, registration.getAccessConstraints(), locale);
 
         // Sort the attribute descriptions based on attribute group and then attribute name

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/NonResolvingResourceDescriptionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/NonResolvingResourceDescriptionResolver.java
@@ -34,6 +34,8 @@ import java.util.ResourceBundle;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public class NonResolvingResourceDescriptionResolver extends StandardResourceDescriptionResolver {
+    public static NonResolvingResourceDescriptionResolver INSTANCE = new NonResolvingResourceDescriptionResolver();
+
     public NonResolvingResourceDescriptionResolver() {
         super("", "", NonResolvingResourceDescriptionResolver.class.getClassLoader());
     }

--- a/controller/src/main/java/org/jboss/as/controller/registry/LegacyResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/LegacyResourceDefinition.java
@@ -148,5 +148,10 @@ public class LegacyResourceDefinition implements ResourceDefinition {
     public List<AccessConstraintDefinition> getAccessConstraints() {
         return Collections.emptyList();
     }
+
+    @Override
+    public boolean isRuntime() {
+        return false; //maybe read it from model description
+    }
 }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
@@ -460,8 +460,13 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
                 public List<AccessConstraintDefinition> getAccessConstraints() {
                     return Collections.emptyList();
                 }
+
+                @Override
+                public boolean isRuntime() {
+                    return false;
+                }
             };
-            return new ConcreteResourceRegistration(null, null, rootResourceDefinition, constraintUtilizationRegistry, false);
+            return new ConcreteResourceRegistration(null, null, rootResourceDefinition, constraintUtilizationRegistry, rootResourceDefinition.isRuntime());
         }
 
         /**
@@ -491,7 +496,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
             if (resourceDefinition == null) {
                 throw ControllerLogger.ROOT_LOGGER.nullVar("rootModelDescriptionProviderFactory");
             }
-            ConcreteResourceRegistration resourceRegistration = new ConcreteResourceRegistration(null, null, resourceDefinition, constraintUtilizationRegistry, false);
+            ConcreteResourceRegistration resourceRegistration = new ConcreteResourceRegistration(null, null, resourceDefinition, constraintUtilizationRegistry, resourceDefinition.isRuntime());
             resourceDefinition.registerAttributes(resourceRegistration);
             resourceDefinition.registerOperations(resourceRegistration);
             resourceDefinition.registerChildren(resourceRegistration);

--- a/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
@@ -400,7 +400,9 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
          * @return the new root model node registration
          *
          * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
+         * @deprecated DescriptionProvider shouldn't be used anymore, use ResourceDefinition variant
          */
+        @Deprecated
         public static ManagementResourceRegistration create(final DescriptionProvider rootModelDescriptionProvider) {
             return create(rootModelDescriptionProvider, null);
         }
@@ -414,7 +416,9 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
          * @return the new root model node registration
          *
          * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
+         * @deprecated DescriptionProvider shouldn't be used anymore, use ResourceDefinition variant
          */
+        @Deprecated
         public static ManagementResourceRegistration create(final DescriptionProvider rootModelDescriptionProvider,
                                                             AccessConstraintUtilizationRegistry constraintUtilizationRegistry) {
             if (rootModelDescriptionProvider == null) {

--- a/controller/src/test/java/org/jboss/as/controller/ListAttributeDefinitionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ListAttributeDefinitionTestCase.java
@@ -72,6 +72,11 @@ public class ListAttributeDefinitionTestCase {
             public List<AccessConstraintDefinition> getAccessConstraints() {
                 return Collections.emptyList();
             }
+
+            @Override
+            public boolean isRuntime() {
+                return false;
+            }
         };
 
         ImmutableManagementResourceRegistration registration = ManagementResourceRegistration.Factory.create(resource);
@@ -123,6 +128,11 @@ public class ListAttributeDefinitionTestCase {
             @Override
             public List<AccessConstraintDefinition> getAccessConstraints() {
                 return Collections.emptyList();
+            }
+
+            @Override
+            public boolean isRuntime() {
+                return false;
             }
         };
 

--- a/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
+++ b/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.controller;
 
-import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,11 +29,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.jboss.as.controller.ControlledProcessState.State;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
 import org.jboss.as.controller.audit.AuditLogger;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.persistence.ConfigurationPersister;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
-import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 
@@ -61,12 +58,6 @@ public abstract class TestModelControllerService extends AbstractControllerServi
     protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
                                          final ResourceDefinition rootResourceDefinition) {
         super(processType, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState, rootResourceDefinition, null, ExpressionResolver.TEST_RESOLVER, AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer());
-        this.processState = processState;
-    }
-    @SuppressWarnings("deprecation")
-    protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
-                                         final DescriptionProvider rootDescriptionProvider) {
-        super(processType, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState, rootDescriptionProvider, null, ExpressionResolver.TEST_RESOLVER, AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer());
         this.processState = processState;
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/AddResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/AddResourceTestCase.java
@@ -35,7 +35,6 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
@@ -388,17 +387,17 @@ public class AddResourceTestCase extends AbstractControllerTestBase {
     }
 
     private static class TestResourceDefinition extends SimpleResourceDefinition {
-        TestResourceDefinition(PathElement pathElement) {
+        TestResourceDefinition(PathElement pathElement,AbstractAddStepHandler addStepHandler) {
             super(pathElement,
                     new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
+                    addStepHandler,
                     new AbstractRemoveStepHandler() {});
         }
     }
 
     private static class RootResourceDefinition extends TestResourceDefinition {
         RootResourceDefinition() {
-            super(PathElement.pathElement("root"));
+            super(PathElement.pathElement("root"),new AbstractAddStepHandler());
         }
 
         @Override
@@ -413,7 +412,7 @@ public class AddResourceTestCase extends AbstractControllerTestBase {
         private final List<AttributeDefinition> attributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
 
         ChildResourceDefinition(PathElement element, AccessConstraintDefinition...constraints){
-            super(element);
+            super(element, null);
             this.constraints = Collections.unmodifiableList(Arrays.asList(constraints));
         }
 
@@ -444,10 +443,9 @@ public class AddResourceTestCase extends AbstractControllerTestBase {
         }
 
         @Override
-        protected void registerAddOperation(ManagementResourceRegistration registration, OperationStepHandler handler, OperationEntry.Flag... flags) {
-            // Use an add handler that knows about our attributes
-            OperationStepHandler addHandler = new AbstractAddStepHandler(attributes){};
-            super.registerAddOperation(registration, addHandler, flags);
+        public void registerOperations(ManagementResourceRegistration registration) {
+            super.registerOperations(registration);
+            super.registerAddOperation(registration, new AbstractAddStepHandler(attributes), OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
         }
 
         @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/RegistryProxyControllerTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/RegistryProxyControllerTestCase.java
@@ -28,16 +28,16 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Set;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProxyController;
+import org.jboss.as.controller.ResourceBuilder;
+import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
@@ -61,15 +61,11 @@ public class RegistryProxyControllerTestCase {
     ManagementResourceRegistration profileBReg;
     ManagementResourceRegistration profileAChildAReg;
 
+    final ResourceDefinition rootResource = ResourceBuilder.Factory.create(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE).build();
+
     @Before
     public void setup() {
-        DescriptionProvider rootDescriptionProvider = new DescriptionProvider() {
-            @Override
-            public ModelNode getModelDescription(final Locale locale) {
-                return new ModelNode();
-            }
-        };
-        root = ManagementResourceRegistration.Factory.create(rootDescriptionProvider);
+        root = ManagementResourceRegistration.Factory.create(rootResource);
         assertNotNull(root);
 
         profileAReg = registerSubModel(root, profileA);

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -51,6 +51,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ProxyController;
+import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
@@ -618,6 +619,11 @@ class TestModelControllerService extends ModelTestModelControllerService {
 
         public TestDelegatingResourceDefinition(TestModelType type) {
             this.type = type;
+        }
+
+        @Override
+        public void setDelegate(ResourceDefinition delegate) {
+            super.setDelegate(delegate);
         }
 
         @Override

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -651,6 +651,11 @@ class TestModelControllerService extends ModelTestModelControllerService {
             }
             super.registerNotifications(resourceRegistration);
         }
+
+        @Override
+        public boolean isRuntime() {
+            return false;
+        }
     }
 
 

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -41,6 +41,7 @@ import java.util.Properties;
 import java.util.concurrent.Executors;
 
 import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.DelegatingResourceDefinition;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
@@ -116,14 +117,14 @@ class TestModelControllerService extends ModelTestModelControllerService {
     private final RunningModeControl runningModeControl;
     private final PathManagerService pathManagerService;
     private final ModelInitializer modelInitializer;
-    private final DelegatingResourceDefinition rootResourceDefinition;
+    private final TestDelegatingResourceDefinition rootResourceDefinition;
     private final ControlledProcessState processState;
     private final ExtensionRegistry extensionRegistry;
     private final AbstractVaultReader vaultReader;
     private volatile Initializer initializer;
 
     TestModelControllerService(ProcessType processType, RunningModeControl runningModeControl, StringConfigurationPersister persister, ModelTestOperationValidatorFilter validateOpsFilter,
-            TestModelType type, ModelInitializer modelInitializer, DelegatingResourceDefinition rootResourceDefinition, ControlledProcessState processState, ExtensionRegistry extensionRegistry,
+            TestModelType type, ModelInitializer modelInitializer, TestDelegatingResourceDefinition rootResourceDefinition, ControlledProcessState processState, ExtensionRegistry extensionRegistry,
             AbstractVaultReader vaultReader) {
         super(processType, runningModeControl, null, persister, validateOpsFilter, rootResourceDefinition, processState,
                 new RuntimeExpressionResolver(vaultReader), Controller80x.INSTANCE);
@@ -149,7 +150,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
     static TestModelControllerService create(ProcessType processType, RunningModeControl runningModeControl, StringConfigurationPersister persister, ModelTestOperationValidatorFilter validateOpsFilter,
             TestModelType type, ModelInitializer modelInitializer, ExtensionRegistry extensionRegistry) {
         return new TestModelControllerService(processType, runningModeControl, persister, validateOpsFilter, type, modelInitializer,
-                new DelegatingResourceDefinition(type), new ControlledProcessState(true), extensionRegistry, new TestVaultReader());
+                new TestDelegatingResourceDefinition(type), new ControlledProcessState(true), extensionRegistry, new TestVaultReader());
     }
 
     InjectedValue<ContentRepository> getContentRepositoryInjector(){
@@ -497,7 +498,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
                             hostName,
                             persister,
                             env,
-                            (HostRunningModeControl)runningModeControl,
+                            (HostRunningModeControl) runningModeControl,
                             hostFileRepository,
                             info,
                             null /*serverInventory*/,
@@ -612,10 +613,10 @@ class TestModelControllerService extends ModelTestModelControllerService {
 
     }
 
-    private static class DelegatingResourceDefinition extends ModelTestModelControllerService.DelegatingResourceDefinition {
+    private static class TestDelegatingResourceDefinition extends DelegatingResourceDefinition {
         private final TestModelType type;
 
-        public DelegatingResourceDefinition(TestModelType type) {
+        public TestDelegatingResourceDefinition(TestModelType type) {
             this.type = type;
         }
 

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -62,31 +62,30 @@ public class TransformersTestParameter extends ClassloaderParameter {
 
         List<TransformersTestParameter> data = new ArrayList<TransformersTestParameter>();
         //AS releases
-        if (includeLegacy) {
+        /*if (includeLegacy) {
             data.add(new TransformersTestParameter(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.V7_1_2_FINAL));
             data.add(new TransformersTestParameter(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.V7_1_3_FINAL));
-        }
-        data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.V7_2_0_FINAL));
+            data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.V7_2_0_FINAL));
+        }*/
         data.add(new TransformersTestParameter(ModelVersion.create(2, 0, 0), ModelTestControllerVersion.MASTER));
 
         //EAP releases - these will only get tested if the EAPRepositoryReachableUtil.TEST_TRANSFORMERS_EAP system property is set AND the EAP repostitory is available
         if (EAPRepositoryReachableUtil.isReachable()) {
-            if (includeLegacy) {
+            /*if (includeLegacy) {
                 data.add(new TransformersTestParameter(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.EAP_6_0_0));
                 data.add(new TransformersTestParameter(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.EAP_6_0_1));
-            }
-            data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_0));
-            data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_1));
+                data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_0));
+                data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_1));
+            }*/
             data.add(new TransformersTestParameter(ModelVersion.create(1, 5, 0), ModelTestControllerVersion.EAP_6_2_0));
             data.add(new TransformersTestParameter(ModelVersion.create(1, 6, 0), ModelTestControllerVersion.EAP_6_3_0));
-
         }
 
 
-        for (int i = 0 ; i < data.size() ; i++) {
+       /* for (int i = 0 ; i < data.size() ; i++) {
             Object entry = data.get(i);
             System.out.println("Parameter " + i + ": " + entry);
-        }
+        }*/
         return data;
     }
 

--- a/jmx/src/test/java/org/jboss/as/jmx/model/ObjectNameAddressUtilTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/model/ObjectNameAddressUtilTestCase.java
@@ -24,7 +24,6 @@ package org.jboss.as.jmx.model;
 import static org.jboss.as.controller.PathElement.pathElement;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -32,8 +31,9 @@ import javax.management.ObjectName;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ResourceBuilder;
+import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -57,6 +57,7 @@ public class ObjectNameAddressUtilTestCase {
     static final PathElement BOTTOM_TWO = pathElement(BOTTOM, TWO);
     static final PathElement TOP_COMPLEX_VALUE = pathElement(TOP, COMPLEX_VALUE);
     static final PathElement COMPLEX_KEY_ONE = pathElement(COMPLEX_KEY, ONE);
+    static final ResourceDefinition rootResourceDef = ResourceBuilder.Factory.create(PathElement.pathElement("test"), NonResolvingResourceDescriptionResolver.INSTANCE).build();
 
     static final Resource rootResource;
     static{
@@ -99,13 +100,7 @@ public class ObjectNameAddressUtilTestCase {
 
         NonResolvingResourceDescriptionResolver resolver = new NonResolvingResourceDescriptionResolver();
 
-        DescriptionProvider provider = new DescriptionProvider() {
-            @Override
-            public ModelNode getModelDescription(Locale locale) {
-                return new ModelNode();
-            }
-        };
-        ManagementResourceRegistration rootRegistration = ManagementResourceRegistration.Factory.create(provider);
+        ManagementResourceRegistration rootRegistration = ManagementResourceRegistration.Factory.create(rootResourceDef);
         ManagementResourceRegistration subsystemRegistration = rootRegistration.registerSubModel(new SimpleResourceDefinition(pathElement("subsystem", "foo"), resolver));
         ManagementResourceRegistration resourceRegistration = subsystemRegistration.registerSubModel(new SimpleResourceDefinition(pathElement("resource", "resourceA"), resolver));
         ManagementResourceRegistration subresourceRegistration = resourceRegistration.registerSubModel(new SimpleResourceDefinition(pathElement("subresource", "resourceB"), resolver));

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -71,6 +71,7 @@ import org.junit.Assert;
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
+//TODO find better way to support legacy ModelTestModelControllerService without need for having all old methods still present on AbstractControllerService
 public abstract class ModelTestModelControllerService extends AbstractControllerService {
 
     private final CountDownLatch latch = new CountDownLatch(1);
@@ -212,10 +213,10 @@ public abstract class ModelTestModelControllerService extends AbstractController
      */
     protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
             final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
-            final DescriptionProvider rootDescriptionProvider, ControlledProcessState processState, Controller80x version) {
+            final ResourceDefinition resourceDefinition, ControlledProcessState processState, Controller80x version) {
         // Fails in core-model-test transformation testing if ExpressionResolver.TEST_RESOLVER is used because not present in 7.1.x
         super(processType, runningModeControl, persister,
-         processState == null ? new ControlledProcessState(true) : processState, rootDescriptionProvider, null, ExpressionResolver.TEST_RESOLVER);
+         processState == null ? new ControlledProcessState(true) : processState, resourceDefinition, null, ExpressionResolver.TEST_RESOLVER);
         this.persister = persister;
         this.transformerRegistry = transformerRegistry;
         this.validateOpsFilter = validateOpsFilter;
@@ -243,9 +244,9 @@ public abstract class ModelTestModelControllerService extends AbstractController
      */
     protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
             final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
-            final DescriptionProvider rootDescriptionProvider, ControlledProcessState processState, Controller90x version) {
+            final ResourceDefinition resourceDefinition, ControlledProcessState processState, Controller90x version) {
         super(processType, runningModeControl, persister,
-         processState == null ? new ControlledProcessState(true) : processState, rootDescriptionProvider, null, ExpressionResolver.TEST_RESOLVER);
+         processState == null ? new ControlledProcessState(true) : processState, resourceDefinition, null, ExpressionResolver.TEST_RESOLVER);
         this.persister = persister;
         this.transformerRegistry = transformerRegistry;
         this.validateOpsFilter = validateOpsFilter;

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -21,19 +21,17 @@
 */
 package org.jboss.as.model.test;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.DelegatingResourceDefinition;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelController;
@@ -41,12 +39,10 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.RunningModeControl;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
 import org.jboss.as.controller.audit.AuditLogger;
 import org.jboss.as.controller.client.OperationAttachments;
@@ -55,7 +51,6 @@ import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.operations.validation.OperationValidator;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
-import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.transform.TransformerRegistry;
@@ -408,61 +403,6 @@ public abstract class ModelTestModelControllerService extends AbstractController
                                         final ModelController.OperationTransactionControl control,
                                         final OperationAttachments attachments, final OperationStepHandler prepareStep) {
         return super.internalExecute(operation, handler, control, attachments, prepareStep);
-    }
-
-    public static final DescriptionProvider DESC_PROVIDER = new DescriptionProvider() {
-        @Override
-        public ModelNode getModelDescription(Locale locale) {
-            ModelNode model = new ModelNode();
-            model.get(DESCRIPTION).set("The test model controller");
-            return model;
-        }
-    };
-
-    public static class DelegatingResourceDefinition implements ResourceDefinition {
-        private volatile ResourceDefinition delegate;
-
-        public void setDelegate(ResourceDefinition delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public void registerOperations(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerOperations(resourceRegistration);
-        }
-
-        @Override
-        public void registerChildren(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerChildren(resourceRegistration);
-        }
-
-        @Override
-        public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerAttributes(resourceRegistration);
-        }
-
-        @Override
-        public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerNotifications(resourceRegistration);
-        }
-
-        @Override
-        public PathElement getPathElement() {
-            return delegate.getPathElement();
-        }
-
-        @Override
-        public DescriptionProvider getDescriptionProvider(ImmutableManagementResourceRegistration resourceRegistration) {
-            return delegate.getDescriptionProvider(resourceRegistration);
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            if (delegate == null) {
-                return Collections.emptyList();
-            }
-            return delegate.getAccessConstraints();
-        }
     }
 
     //These are here to overload the constuctor used for the different legacy controllers

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelDescriptionValidator.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelDescriptionValidator.java
@@ -99,6 +99,7 @@ public class ModelTestModelDescriptionValidator {
         validResourceKeys.put(CHILDREN, NullDescriptorValidator.INSTANCE);
         validResourceKeys.put(DEPRECATED, DeprecatedDescriptorValidator.INSTANCE);
         validResourceKeys.put(ACCESS_CONSTRAINTS, AccessConstraintValidator.INSTANCE);
+        validResourceKeys.put(STORAGE, NullDescriptorValidator.INSTANCE);
         VALID_RESOURCE_KEYS = Collections.unmodifiableMap(validResourceKeys);
 
         Map<String, ArbitraryDescriptorValidator> validChildTypeKeys = new HashMap<String, ModelTestModelDescriptionValidator.ArbitraryDescriptorValidator>();

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -27,7 +27,6 @@ import static java.security.AccessController.doPrivileged;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.ExecutorService;
@@ -42,22 +41,18 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.BootContext;
 import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.DelegatingResourceDefinition;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelControllerServiceInitialization;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
-import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.RunningModeControl;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
 import org.jboss.as.controller.audit.ManagedAuditLogger;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
-import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.PlaceholderResource;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.PathManager;
@@ -503,52 +498,6 @@ public final class ServerService extends AbstractControllerService {
         @Override
         public synchronized ScheduledExecutorService getValue() throws IllegalStateException {
             return scheduledExecutorService;
-        }
-    }
-
-    private static class DelegatingResourceDefinition implements ResourceDefinition {
-        private volatile ResourceDefinition delegate;
-
-        void setDelegate(ResourceDefinition delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public void registerOperations(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerOperations(resourceRegistration);
-        }
-
-        @Override
-        public void registerChildren(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerChildren(resourceRegistration);
-        }
-
-        @Override
-        public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerAttributes(resourceRegistration);
-        }
-
-        @Override
-        public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerNotifications(resourceRegistration);
-        }
-
-        @Override
-        public PathElement getPathElement() {
-            return delegate.getPathElement();
-        }
-
-        @Override
-        public DescriptionProvider getDescriptionProvider(ImmutableManagementResourceRegistration resourceRegistration) {
-            return delegate.getDescriptionProvider(resourceRegistration);
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            if (delegate == null) {
-                return Collections.emptyList();
-            }
-            return delegate.getAccessConstraints();
         }
     }
 }

--- a/server/src/test/java/org/jboss/as/server/test/InterfaceManagementUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/test/InterfaceManagementUnitTestCase.java
@@ -50,6 +50,7 @@ import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
@@ -111,7 +112,7 @@ public class InterfaceManagementUnitTestCase {
         final StringConfigurationPersister persister = new StringConfigurationPersister(Collections.<ModelNode>emptyList(), new StandaloneXml(null, null, extensionRegistry));
         extensionRegistry.setWriterRegistry(persister);
         final ControlledProcessState processState = new ControlledProcessState(true);
-        final ModelControllerService svc = new ModelControllerService(processState, persister, new DelegatingResourceDefinition());
+        final ModelControllerService svc = new ModelControllerService(processState, persister, new ServerDelegatingResourceDefinition());
         final ServiceBuilder<ModelController> builder = target.addService(Services.JBOSS_SERVER_CONTROLLER, svc);
         builder.install();
 
@@ -279,14 +280,14 @@ public class InterfaceManagementUnitTestCase {
         final CountDownLatch latch = new CountDownLatch(1);
         final StringConfigurationPersister persister;
         final ControlledProcessState processState;
-        final DelegatingResourceDefinition rootResourceDefinition;
+        final ServerDelegatingResourceDefinition rootResourceDefinition;
         final ServerEnvironment environment;
         final ExtensionRegistry extensionRegistry;
         volatile ManagementResourceRegistration rootRegistration;
         volatile Exception error;
 
 
-        ModelControllerService(final ControlledProcessState processState, final StringConfigurationPersister persister, final DelegatingResourceDefinition rootResourceDefinition) {
+        ModelControllerService(final ControlledProcessState processState, final StringConfigurationPersister persister, final ServerDelegatingResourceDefinition rootResourceDefinition) {
             super(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.ADMIN_ONLY), persister, processState, rootResourceDefinition, null, ExpressionResolver.TEST_RESOLVER,
                     AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer());
             this.persister = persister;
@@ -327,6 +328,13 @@ public class InterfaceManagementUnitTestCase {
                     persister, environment, processState, null, null, extensionRegistry, false, MOCK_PATH_MANAGER, null,
                     authorizer, AuditLogger.NO_OP_LOGGER, getMutableRootResourceRegistrationProvider(), getBootErrorCollector()));
             super.start(context);
+        }
+    }
+
+    static final class ServerDelegatingResourceDefinition extends DelegatingResourceDefinition {
+        @Override
+        public void setDelegate(ResourceDefinition delegate) {
+            super.setDelegate(delegate);
         }
     }
 

--- a/server/src/test/java/org/jboss/as/server/test/InterfaceManagementUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/test/InterfaceManagementUnitTestCase.java
@@ -44,20 +44,17 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.DelegatingResourceDefinition;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
-import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.RunningModeControl;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
 import org.jboss.as.controller.audit.AuditLogger;
 import org.jboss.as.controller.client.ModelControllerClient;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.extension.RuntimeHostControllerInfoAccessor;
@@ -65,7 +62,6 @@ import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.persistence.AbstractConfigurationPersister;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.ModelMarshallingContext;
-import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.resource.InterfaceDefinition;
@@ -331,52 +327,6 @@ public class InterfaceManagementUnitTestCase {
                     persister, environment, processState, null, null, extensionRegistry, false, MOCK_PATH_MANAGER, null,
                     authorizer, AuditLogger.NO_OP_LOGGER, getMutableRootResourceRegistrationProvider(), getBootErrorCollector()));
             super.start(context);
-        }
-    }
-
-    private static class DelegatingResourceDefinition implements ResourceDefinition {
-        private volatile ResourceDefinition delegate;
-
-        void setDelegate(ResourceDefinition delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public void registerOperations(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerOperations(resourceRegistration);
-        }
-
-        @Override
-        public void registerChildren(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerChildren(resourceRegistration);
-        }
-
-        @Override
-        public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerAttributes(resourceRegistration);
-        }
-
-        @Override
-        public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
-            delegate.registerNotifications(resourceRegistration);
-        }
-
-        @Override
-        public PathElement getPathElement() {
-            return delegate.getPathElement();
-        }
-
-        @Override
-        public DescriptionProvider getDescriptionProvider(ImmutableManagementResourceRegistration resourceRegistration) {
-            return delegate.getDescriptionProvider(resourceRegistration);
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            if (delegate == null) {
-                return Collections.emptyList();
-            }
-            return delegate.getAccessConstraints();
         }
     }
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
@@ -38,6 +38,8 @@ import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelControllerServiceInitialization;
 import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistryType;
 import org.jboss.as.controller.operations.global.GlobalNotifications;
@@ -72,7 +74,7 @@ class TestModelControllerService extends ModelTestModelControllerService impleme
                                          final AdditionalInitialization additionalInit, final RunningModeControl runningModeControl, final ExtensionRegistry extensionRegistry,
                                          final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter, final boolean registerTransformers) {
         super(additionalInit.getProcessType(), runningModeControl, extensionRegistry.getTransformerRegistry(), persister, validateOpsFilter,
-                ModelTestModelControllerService.DESC_PROVIDER, new ControlledProcessState(true), Controller80x.INSTANCE);
+                new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE) , new ControlledProcessState(true), Controller90x.INSTANCE);
         this.mainExtension = mainExtension;
         this.additionalInit = additionalInit;
         this.controllerInitializer = controllerInitializer;


### PR DESCRIPTION
- stop testing for core model transformers for  version <= EAP 6.2
- remove some deprecated APIs
- consolidate DelegatingResourceDefinition

needs https://github.com/wildfly/wildfly/pull/7232 merged otherwise full wont compile with this change in core.