### PR TITLE
WFCORE 579 ProxyMetadataSource does not return JDK8 'default' methods fro minterfaces

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/reflect/InstallReflectionIndexProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/reflect/InstallReflectionIndexProcessor.java
@@ -56,14 +56,16 @@ public final class InstallReflectionIndexProcessor implements DeploymentUnitProc
 
         if(deploymentUnit.getParent() == null) {
             final DeploymentReflectionIndex index = DeploymentReflectionIndex.create();
+            final DeploymentClassIndex deploymentClassIndex = new DeploymentClassIndex(index, module);
             deploymentUnit.putAttachment(Attachments.REFLECTION_INDEX, index);
-            deploymentUnit.putAttachment(Attachments.PROXY_REFLECTION_INDEX, new ProxyMetadataSource(index));
-            deploymentUnit.putAttachment(Attachments.CLASS_INDEX, new DeploymentClassIndex(index, module));
+            deploymentUnit.putAttachment(Attachments.PROXY_REFLECTION_INDEX, new ProxyMetadataSource(index,deploymentClassIndex));
+            deploymentUnit.putAttachment(Attachments.CLASS_INDEX, deploymentClassIndex);
         } else {
             final DeploymentReflectionIndex index = deploymentUnit.getParent().getAttachment(Attachments.REFLECTION_INDEX);
+            final DeploymentClassIndex deploymentClassIndex = new DeploymentClassIndex(index, module);
             deploymentUnit.putAttachment(Attachments.REFLECTION_INDEX, index);
-            deploymentUnit.putAttachment(Attachments.PROXY_REFLECTION_INDEX, deploymentUnit.getParent().getAttachment(Attachments.PROXY_REFLECTION_INDEX));
-            deploymentUnit.putAttachment(Attachments.CLASS_INDEX, new DeploymentClassIndex(index, module));
+            deploymentUnit.putAttachment(Attachments.PROXY_REFLECTION_INDEX, new ProxyMetadataSource(index,deploymentClassIndex));
+            deploymentUnit.putAttachment(Attachments.CLASS_INDEX, deploymentClassIndex);
         }
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-579
https://issues.jboss.org/browse/WFLY-4404
https://bugzilla.redhat.com/show_bug.cgi?id=1196686


PRs
upstream: https://github.com/wildfly/wildfly-core/pull/541
6.4.x: https://github.com/jbossas/jboss-eap/pull/2339