### PR TITLE
WFCORE-564 Fix PersistentResourceXMLDescription parser

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -6,10 +6,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAM
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
@@ -41,11 +42,15 @@ public class PersistentResourceXMLDescription {
     protected final boolean noAddOperation;
     protected final AdditionalOperationsGenerator additionalOperationsGenerator;
     private boolean flushRequired = true;
-    private final Map<String,AttributeParser> attributeParsers;
+    private final Map<String, AttributeParser> attributeParsers;
+    private final Map<String, AttributeMarshaller> attributeMarshallers;
     private final boolean useElementsForGroups;
     private final String namespaceURI;
+    private final Set<String> attributeGroups;
 
-    /** @deprecated use a {@link org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder builder} */
+    /**
+     * @deprecated use a {@link org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder builder}
+     */
     @Deprecated
     protected PersistentResourceXMLDescription(final PersistentResourceDefinition resourceDefinition, final String xmlElementName, final String xmlWrapperElement, final LinkedHashMap<String, AttributeDefinition> attributes, final List<PersistentResourceXMLDescription> children, final boolean useValueAsElementName, final boolean noAddOperation, final AdditionalOperationsGenerator additionalOperationsGenerator, Map<String, AttributeParser> attributeParsers) {
         this.resourceDefinition = resourceDefinition;
@@ -61,6 +66,8 @@ public class PersistentResourceXMLDescription {
         this.additionalOperationsGenerator = additionalOperationsGenerator;
         this.attributeParsers = attributeParsers;
         this.namespaceURI = null;
+        this.attributeGroups = null;
+        this.attributeMarshallers = null;
     }
 
     private PersistentResourceXMLDescription(PersistentResourceXMLBuilder builder) {
@@ -74,7 +81,7 @@ public class PersistentResourceXMLDescription {
         if (useElementsForGroups) {
             // Ensure we have a map for the default group even if there are no attributes so we don't NPE later
             this.attributesByGroup.put(null, new LinkedHashMap<String, AttributeDefinition>());
-
+            this.attributeGroups = new HashSet<>();
             // Segregate attributes by group
             for (Map.Entry<String, AttributeDefinition> entry : builder.attributes.entrySet()) {
                 AttributeDefinition ad = entry.getValue();
@@ -82,12 +89,14 @@ public class PersistentResourceXMLDescription {
                 if (forGroup == null) {
                     forGroup = new LinkedHashMap<>();
                     this.attributesByGroup.put(ad.getAttributeGroup(), forGroup);
+                    this.attributeGroups.add(ad.getAttributeGroup());
                 }
                 forGroup.put(entry.getKey(), ad);
             }
         } else {
             // Ignore attribute-group, treat all as if they are in the default group
             this.attributesByGroup.put(null, builder.attributes);
+            this.attributeGroups = null;
         }
         this.children = new ArrayList<>();
         for (PersistentResourceXMLBuilder b : builder.children) {
@@ -97,46 +106,49 @@ public class PersistentResourceXMLDescription {
         this.noAddOperation = builder.noAddOperation;
         this.additionalOperationsGenerator = builder.additionalOperationsGenerator;
         this.attributeParsers = builder.attributeParsers;
+        this.attributeMarshallers = builder.attributeMarshallers;
     }
 
-    public PathElement getPathElement(){
+    public PathElement getPathElement() {
         return resourceDefinition.getPathElement();
     }
 
     public void parse(final XMLExtendedStreamReader reader, PathAddress parentAddress, List<ModelNode> list) throws XMLStreamException {
-        if (xmlWrapperElement != null) {
-            if (reader.getLocalName().equals(xmlWrapperElement)) {
-                if (reader.hasNext()) {
-                    if (reader.nextTag() == END_ELEMENT) {
-                        return;
-                    }
-                }
-            } else {
-                throw ParseUtils.unexpectedElement(reader);
-            }
-
-        }
         ModelNode op = Util.createAddOperation();
-
         boolean wildcard = resourceDefinition.getPathElement().isWildcard();
-        String name = parseAttributes(reader, op, attributesByGroup.get(null), wildcard);
+        String name = parseAttributeGroups(reader, op, wildcard);
         if (wildcard && name == null) {
             throw ControllerLogger.ROOT_LOGGER.missingRequiredAttributes(new StringBuilder(NAME), reader.getLocation());
         }
-
         PathElement path = wildcard ? PathElement.pathElement(resourceDefinition.getPathElement().getKey(), name) : resourceDefinition.getPathElement();
         PathAddress address = parentAddress.append(path);
-        if(!noAddOperation) {
+        if (!noAddOperation) {
             op.get(ADDRESS).set(address.toModelNode());
             list.add(op);
         }
-        if(additionalOperationsGenerator != null) {
+        if (additionalOperationsGenerator != null) {
             additionalOperationsGenerator.additionalOperations(address, op, list);
         }
-        parseChildren(reader, address, list, op);
-        if (xmlWrapperElement != null) {
-            ParseUtils.requireNoContent(reader);
+        parseChildren(reader, address, list);
+    }
+
+    private String parseAttributeGroups(final XMLExtendedStreamReader reader, ModelNode op, boolean wildcard) throws XMLStreamException {
+        String name;
+        if (useElementsForGroups && !attributeGroups.isEmpty()) {
+            name = parseAttributes(reader, op, attributesByGroup.get(null), wildcard); //parse attributes not belonging to a group
+            while (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT) {
+                if (attributeGroups.contains(reader.getLocalName())) {
+                    parseAttributes(reader, op, attributesByGroup.get(reader.getLocalName()), wildcard);
+                    ParseUtils.requireNoContent(reader);
+                } else {
+                    throw ParseUtils.unexpectedElement(reader);
+                }
+            }
+            flushRequired = false;
+        } else {
+            name =  parseAttributes(reader, op, attributesByGroup.get(null), wildcard);
         }
+        return name;
     }
 
     private String parseAttributes(final XMLExtendedStreamReader reader, ModelNode op, Map<String, AttributeDefinition> attributes, boolean wildcard) throws XMLStreamException {
@@ -148,18 +160,18 @@ public class PersistentResourceXMLDescription {
                 name = value;
             } else if (attributes.containsKey(attributeName)) {
                 AttributeDefinition def = attributes.get(attributeName);
-                AttributeParser parser = attributeParsers.containsKey(attributeName)? attributeParsers.get(attributeName) : def.getParser();
+                AttributeParser parser = attributeParsers.containsKey(attributeName) ? attributeParsers.get(attributeName) : def.getParser();
                 assert parser != null;
-                parser.parseAndSetParameter(def,value,op,reader);
+                parser.parseAndSetParameter(def, value, op, reader);
             } else {
                 throw ParseUtils.unexpectedAttribute(reader, i, attributes.keySet());
             }
         }
-        for (AttributeDefinition attributeDefinition: attributes.values()){
-            if (attributeDefinition instanceof PropertiesAttributeDefinition){
+        for (AttributeDefinition attributeDefinition : attributes.values()) {
+            if (attributeDefinition instanceof PropertiesAttributeDefinition) {
                 PropertiesAttributeDefinition attribute = (PropertiesAttributeDefinition) attributeDefinition;
                 // TODO what if this attribute isn't required and isn't in the xml?
-                attribute.parse(reader,op);
+                attribute.parse(reader, op);
                 flushRequired = false;
             }
         }
@@ -178,33 +190,32 @@ public class PersistentResourceXMLDescription {
         return res;
     }
 
-    private void parseChildren(final XMLExtendedStreamReader reader, PathAddress parentAddress, List<ModelNode> list, ModelNode parentAddOp) throws XMLStreamException {
-        if (children.size() == 0 && (!useElementsForGroups || attributesByGroup.size() == 1)) {
-            if (flushRequired){
+    private void parseChildren(final XMLExtendedStreamReader reader, PathAddress parentAddress, List<ModelNode> list) throws XMLStreamException {
+        if (children.size() == 0) {
+            if (flushRequired && attributeGroups.isEmpty()) {
                 ParseUtils.requireNoContent(reader);
             }
         } else {
-            String parentName = reader.getLocalName();
             Map<String, PersistentResourceXMLDescription> children = getChildrenMap();
-            while (reader.hasNext()) {
-                if (reader.nextTag() == XMLStreamConstants.END_ELEMENT) {
-                    // break the loop at the end of the parent element
-                    if (parentName.equals(reader.getLocalName())) {
-                        break;
-                    }
-                    // else continue to the next children
-                    continue;
-                }
+            while (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT) {
                 PersistentResourceXMLDescription child = children.get(reader.getLocalName());
                 if (child != null) {
-                    child.parse(reader, parentAddress, list);
-                } else {
-                    Map<String, AttributeDefinition> groupAttributes = useElementsForGroups ? attributesByGroup.get(reader.getLocalName()) : null;
-                    if (groupAttributes != null) {
-                        parseAttributes(reader, parentAddOp, groupAttributes, false);
+                    if (child.xmlWrapperElement != null) {
+                        if (reader.getLocalName().equals(child.xmlWrapperElement)) {
+                            if (reader.hasNext() && reader.nextTag() == END_ELEMENT) { return; }
+                        } else {
+                            throw ParseUtils.unexpectedElement(reader);
+                        }
+                        child.parse(reader, parentAddress, list);
+                        while (reader.nextTag() != END_ELEMENT && !reader.getLocalName().equals(child.xmlWrapperElement)) {
+                            child.parse(reader, parentAddress, list);
+                        }
                     } else {
-                        throw ParseUtils.unexpectedElement(reader, children.keySet());
+                        child.parse(reader, parentAddress, list);
                     }
+
+                } else {
+                    throw ParseUtils.unexpectedElement(reader, children.keySet());
                 }
             }
         }
@@ -223,8 +234,7 @@ public class PersistentResourceXMLDescription {
         }
     }
 
-    public void startSubsystemElement(XMLExtendedStreamWriter writer, String namespaceURI, boolean empty) throws XMLStreamException {
-
+    private void startSubsystemElement(XMLExtendedStreamWriter writer, String namespaceURI, boolean empty) throws XMLStreamException {
         if (writer.getNamespaceContext().getPrefix(namespaceURI) == null) {
             // Unknown namespace; it becomes default
             writer.setDefaultNamespace(namespaceURI);
@@ -265,9 +275,7 @@ public class PersistentResourceXMLDescription {
                     writeStartElement(writer, namespaceURI, xmlElementName);
                     writer.writeAttribute(NAME, p.getName());
                 }
-
                 persistAttributes(writer, p.getValue(), false);
-
                 persistChildren(writer, p.getValue());
                 writer.writeEndElement();
             }
@@ -295,12 +303,11 @@ public class PersistentResourceXMLDescription {
     }
 
     private void persistAttributes(XMLExtendedStreamWriter writer, ModelNode model, boolean marshalDefault) throws XMLStreamException {
-
         // Persist all attributes in the 'null' group
-        for (Map.Entry<String, AttributeDefinition> def : attributesByGroup.get(null).entrySet()) {
-            def.getValue().getAttributeMarshaller().marshallAsAttribute(def.getValue(), model, marshalDefault, writer);
+        for (AttributeDefinition def : attributesByGroup.get(null).values()) {
+            AttributeMarshaller marshaller = attributeMarshallers.containsKey(def.getName()) ? attributeMarshallers.get(def.getName()) : def.getAttributeMarshaller();
+            marshaller.marshallAsAttribute(def, model, marshalDefault, writer);
         }
-
         if (useElementsForGroups) {
             for (Map.Entry<String, LinkedHashMap<String, AttributeDefinition>> entry : attributesByGroup.entrySet()) {
                 if (entry.getKey() == null) {
@@ -309,7 +316,7 @@ public class PersistentResourceXMLDescription {
                 boolean started = false;
                 for (Map.Entry<String, AttributeDefinition> def : entry.getValue().entrySet()) {
                     AttributeDefinition ad = def.getValue();
-                    AttributeMarshaller marshaller = ad.getAttributeMarshaller();
+                    AttributeMarshaller marshaller = attributeMarshallers.containsKey(ad.getName()) ? attributeMarshallers.get(ad.getName()) : ad.getAttributeMarshaller();
                     if (marshaller.isMarshallable(ad, model, marshalDefault)) {
                         if (!started) {
                             writer.writeEmptyElement(entry.getKey());
@@ -337,8 +344,6 @@ public class PersistentResourceXMLDescription {
     }
 
     public static class PersistentResourceXMLBuilder {
-
-
         protected final PersistentResourceDefinition resourceDefinition;
         private final String namespaceURI;
         protected String xmlElementName;
@@ -349,6 +354,7 @@ public class PersistentResourceXMLDescription {
         protected final LinkedHashMap<String, AttributeDefinition> attributes = new LinkedHashMap<>();
         protected final List<PersistentResourceXMLBuilder> children = new ArrayList<>();
         protected final LinkedHashMap<String, AttributeParser> attributeParsers = new LinkedHashMap<>();
+        protected final LinkedHashMap<String, AttributeMarshaller> attributeMarshallers = new LinkedHashMap<>();
         protected boolean useElementsForGroups = true;
 
         protected PersistentResourceXMLBuilder(final PersistentResourceDefinition resourceDefinition) {
@@ -372,9 +378,17 @@ public class PersistentResourceXMLDescription {
             this.attributes.put(attribute.getXmlName(), attribute);
             return this;
         }
+
         public PersistentResourceXMLBuilder addAttribute(AttributeDefinition attribute, AttributeParser attributeParser) {
             this.attributes.put(attribute.getXmlName(), attribute);
-            this.attributeParsers.put(attribute.getXmlName(),attributeParser);
+            this.attributeParsers.put(attribute.getXmlName(), attributeParser);
+            return this;
+        }
+
+        public PersistentResourceXMLBuilder addAttribute(AttributeDefinition attribute, AttributeParser attributeParser, AttributeMarshaller attributeMarshaller) {
+            this.attributes.put(attribute.getXmlName(), attribute);
+            this.attributeParsers.put(attribute.getXmlName(), attributeParser);
+            this.attributeMarshallers.put(attribute.getXmlName(), attributeMarshaller);
             return this;
         }
 
@@ -437,9 +451,10 @@ public class PersistentResourceXMLDescription {
 
         /**
          * Generates any additional operations required by the resource
-         * @param address The address of the resource
+         *
+         * @param address      The address of the resource
          * @param addOperation The add operation for the resource
-         * @param operations The operation list
+         * @param operations   The operation list
          */
         void additionalOperations(final PathAddress address, final ModelNode addOperation, final List<ModelNode> operations);
 

--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -5,9 +5,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -35,7 +38,7 @@ public class PersistentResourceXMLDescription {
     protected final PersistentResourceDefinition resourceDefinition;
     protected final String xmlElementName;
     protected final String xmlWrapperElement;
-    protected final LinkedHashMap<String, AttributeDefinition> attributes;
+    protected final Collection<AttributeDefinition> attributes;
     protected final LinkedHashMap<String, LinkedHashMap<String, AttributeDefinition>> attributesByGroup;
     protected final List<PersistentResourceXMLDescription> children;
     protected final boolean useValueAsElementName;
@@ -57,7 +60,7 @@ public class PersistentResourceXMLDescription {
         this.xmlElementName = xmlElementName;
         this.xmlWrapperElement = xmlWrapperElement;
         this.useElementsForGroups = true;
-        this.attributes = attributes;
+        this.attributes = attributes.values();
         this.attributesByGroup = new LinkedHashMap<>();
         this.attributesByGroup.put(null, attributes);
         this.children = children;
@@ -83,19 +86,22 @@ public class PersistentResourceXMLDescription {
             this.attributesByGroup.put(null, new LinkedHashMap<String, AttributeDefinition>());
             this.attributeGroups = new HashSet<>();
             // Segregate attributes by group
-            for (Map.Entry<String, AttributeDefinition> entry : builder.attributes.entrySet()) {
-                AttributeDefinition ad = entry.getValue();
+            for (AttributeDefinition ad : builder.attributes) {
                 LinkedHashMap<String, AttributeDefinition> forGroup = this.attributesByGroup.get(ad.getAttributeGroup());
                 if (forGroup == null) {
                     forGroup = new LinkedHashMap<>();
                     this.attributesByGroup.put(ad.getAttributeGroup(), forGroup);
                     this.attributeGroups.add(ad.getAttributeGroup());
                 }
-                forGroup.put(entry.getKey(), ad);
+                forGroup.put(ad.getXmlName(), ad);
             }
         } else {
+            LinkedHashMap<String,AttributeDefinition> attrs = new LinkedHashMap<>();
+            for (AttributeDefinition ad : builder.attributes) {
+                attrs.put(ad.getXmlName(), ad);
+            }
             // Ignore attribute-group, treat all as if they are in the default group
-            this.attributesByGroup.put(null, builder.attributes);
+            this.attributesByGroup.put(null, attrs);
             this.attributeGroups = null;
         }
         this.children = new ArrayList<>();
@@ -351,7 +357,7 @@ public class PersistentResourceXMLDescription {
         protected boolean useValueAsElementName;
         protected boolean noAddOperation;
         protected AdditionalOperationsGenerator additionalOperationsGenerator;
-        protected final LinkedHashMap<String, AttributeDefinition> attributes = new LinkedHashMap<>();
+        protected final LinkedList<AttributeDefinition> attributes = new LinkedList<>();
         protected final List<PersistentResourceXMLBuilder> children = new ArrayList<>();
         protected final LinkedHashMap<String, AttributeParser> attributeParsers = new LinkedHashMap<>();
         protected final LinkedHashMap<String, AttributeMarshaller> attributeMarshallers = new LinkedHashMap<>();
@@ -375,27 +381,25 @@ public class PersistentResourceXMLDescription {
         }
 
         public PersistentResourceXMLBuilder addAttribute(AttributeDefinition attribute) {
-            this.attributes.put(attribute.getXmlName(), attribute);
+            this.attributes.add(attribute);
             return this;
         }
 
         public PersistentResourceXMLBuilder addAttribute(AttributeDefinition attribute, AttributeParser attributeParser) {
-            this.attributes.put(attribute.getXmlName(), attribute);
+            this.attributes.add(attribute);
             this.attributeParsers.put(attribute.getXmlName(), attributeParser);
             return this;
         }
 
         public PersistentResourceXMLBuilder addAttribute(AttributeDefinition attribute, AttributeParser attributeParser, AttributeMarshaller attributeMarshaller) {
-            this.attributes.put(attribute.getXmlName(), attribute);
+            this.attributes.add(attribute);
             this.attributeParsers.put(attribute.getXmlName(), attributeParser);
             this.attributeMarshallers.put(attribute.getXmlName(), attributeMarshaller);
             return this;
         }
 
         public PersistentResourceXMLBuilder addAttributes(AttributeDefinition... attributes) {
-            for (final AttributeDefinition at : attributes) {
-                this.attributes.put(at.getXmlName(), at);
-            }
+            Collections.addAll(this.attributes, attributes);
             return this;
         }
 

--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
@@ -26,73 +26,97 @@ import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.junit.Assert.assertEquals;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.lang.reflect.Constructor;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLOutputFactory;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.stream.StreamSource;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
 import org.jboss.staxmapper.XMLMapper;
+import org.junit.Assert;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.bootstrap.DOMImplementationRegistry;
+import org.w3c.dom.ls.DOMImplementationLS;
+import org.w3c.dom.ls.LSInput;
+import org.w3c.dom.ls.LSParser;
+import org.w3c.dom.ls.LSSerializer;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
  */
 public class PersistentResourceXMLParserTestCase {
 
+
+    static String readResource(final String name) throws IOException {
+
+        URL configURL = PersistentResourceXMLParserTestCase.class.getResource(name);
+        Assert.assertNotNull(name + " url is null", configURL);
+
+        StringWriter writer = new StringWriter();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(configURL.openStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                writer.write(line + "\n");
+            }
+        }
+        return writer.toString();
+    }
+
+    public static XMLExtendedStreamWriter createXMLStreamWriter(XMLStreamWriter writer) throws Exception {
+        // Use reflection to access package protected class FormattingXMLStreamWriter
+        // TODO: at some point the staxmapper API could be enhanced to make this unnecessary
+        Class clazz = Class.forName("org.jboss.staxmapper.FormattingXMLStreamWriter");
+        Object[] args = new Object[1];
+        args[0] = writer;
+        Constructor ctr = clazz.getConstructor(XMLStreamWriter.class);
+        ctr.setAccessible(true);
+        return (XMLExtendedStreamWriter) ctr.newInstance(args);
+    }
+
     @Test
-    public void testParse() throws XMLStreamException {
-
+    public void testWrappersAndGroups() throws Exception {
         MyParser parser = new MyParser();
-
-        String xml = "<subsystem xmlns=\"" + parser.NAMESPACE + "\">\n" +
-                "  <resource name=\"foo\">\n" +
-                "    <cluster attr1='bar'\n" +
-                "             attr2='baz' />\n" +
-                "    <security my-attr1='alice'\n" +
-                "             my-attr2='bob' />\n" +
-                "   </resource>\n" +
-                "  <resource name=\"foo2\">\n" +
-                "    <cluster attr1='bar2'\n" +
-                "             attr2='baz2' />\n" +
-                "   </resource>\n" +
-                "</subsystem>";
-        System.out.println(xml);
+        String xml = readResource("groups-wrappers-subsystem.xml");
         StringReader strReader = new StringReader(xml);
 
         XMLMapper mapper = XMLMapper.Factory.create();
-        mapper.registerRootElement(new QName(parser.NAMESPACE, "subsystem"), parser);
+        mapper.registerRootElement(new QName(MyParser.NAMESPACE, "subsystem"), parser);
 
         XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(new StreamSource(strReader));
-        List<ModelNode> operations = new ArrayList<ModelNode>();
+        List<ModelNode> operations = new ArrayList<>();
         mapper.parseDocument(operations, reader);
 
-        System.out.println(operations);
-
-        ModelNode subsystem = createSubystemModelNode(operations);
+        ModelNode subsystem = opsToModel(operations);
 
         assertEquals("bar", subsystem.get("resource", "foo", "cluster-attr1").asString());
         assertEquals("baz", subsystem.get("resource", "foo", "cluster-attr2").asString());
@@ -102,97 +126,235 @@ public class PersistentResourceXMLParserTestCase {
         assertEquals("baz2", subsystem.get("resource", "foo2", "cluster-attr2").asString());
 
         StringWriter stringWriter = new StringWriter();
-        XMLStreamWriter xmlStreamWriter = XMLOutputFactory.newInstance().createXMLStreamWriter(stringWriter);
-        mapper.deparseDocument(parser, subsystem, xmlStreamWriter);
+        XMLExtendedStreamWriter xmlStreamWriter = createXMLStreamWriter(XMLOutputFactory.newInstance()
+                .createXMLStreamWriter(stringWriter));
+        SubsystemMarshallingContext context = new SubsystemMarshallingContext(subsystem, xmlStreamWriter);
+        mapper.deparseDocument(parser, context, xmlStreamWriter);
         String out = stringWriter.toString();
+        Assert.assertEquals(normalizeXML(xml), normalizeXML(out));
 
-        System.out.println("out = " + out);
     }
 
-    private ModelNode createSubystemModelNode(List<ModelNode> operations) {
+    @Test
+    public void testGroups() throws Exception {
+        MyParser parser = new AttributeGroupParser();
+        String xml = readResource("groups-subsystem.xml");
+        StringReader strReader = new StringReader(xml);
+
+        XMLMapper mapper = XMLMapper.Factory.create();
+        mapper.registerRootElement(new QName(MyParser.NAMESPACE, "subsystem"), parser);
+
+        XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(new StreamSource(strReader));
+        List<ModelNode> operations = new ArrayList<>();
+        mapper.parseDocument(operations, reader);
+
+        ModelNode subsystem = opsToModel(operations);
+
+        assertEquals("bar", subsystem.get("resource", "foo", "cluster-attr1").asString());
+        assertEquals("baz", subsystem.get("resource", "foo", "cluster-attr2").asString());
+        assertEquals("alice", subsystem.get("resource", "foo", "security-my-attr1").asString());
+        assertEquals("bob", subsystem.get("resource", "foo", "security-my-attr2").asString());
+        assertEquals("bar2", subsystem.get("resource", "foo2", "cluster-attr1").asString());
+        assertEquals("baz2", subsystem.get("resource", "foo2", "cluster-attr2").asString());
+
+        StringWriter stringWriter = new StringWriter();
+        XMLExtendedStreamWriter xmlStreamWriter = createXMLStreamWriter(XMLOutputFactory.newInstance()
+                .createXMLStreamWriter(stringWriter));
+        SubsystemMarshallingContext context = new SubsystemMarshallingContext(subsystem, xmlStreamWriter);
+        mapper.deparseDocument(parser, context, xmlStreamWriter);
+        String out = stringWriter.toString();
+        Assert.assertEquals(normalizeXML(xml), normalizeXML(out));
+
+    }
+
+    @Test
+    public void testSimpleParser() throws Exception {
+
+        MyParser parser = new MyParser();
+
+        String xml = readResource("simple-subsystem.xml");
+        StringReader strReader = new StringReader(xml);
+
+        XMLMapper mapper = XMLMapper.Factory.create();
+        mapper.registerRootElement(new QName(MyParser.NAMESPACE, "subsystem"), parser);
+
+        XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(new StreamSource(strReader));
+        List<ModelNode> operations = new ArrayList<>();
+        mapper.parseDocument(operations, reader);
+
+        Assert.assertEquals(4, operations.size());
+        ModelNode subsystem = opsToModel(operations);
+
+        StringWriter stringWriter = new StringWriter();
+        XMLExtendedStreamWriter xmlStreamWriter = createXMLStreamWriter(XMLOutputFactory.newInstance().createXMLStreamWriter(stringWriter));
+        SubsystemMarshallingContext context = new SubsystemMarshallingContext(subsystem, xmlStreamWriter);
+        mapper.deparseDocument(parser, context, xmlStreamWriter);
+        String out = stringWriter.toString();
+        Assert.assertEquals(normalizeXML(xml), normalizeXML(out));
+    }
+
+    private ModelNode opsToModel(List<ModelNode> operations) {
         ModelNode subsystem = new ModelNode();
-        subsystem.set(operations.get(0));
-        subsystem.remove("address");
-        subsystem.remove("operation");
 
-        ModelNode addResourceOp = operations.get(1);
-        ModelNode resource = addResourceOp.clone();
-        resource.remove("operation");
-        resource.remove("address");
+        for (ModelNode addResourceOp : operations) {
+            ModelNode resource = addResourceOp.clone();
 
-        subsystem.get("resource", "foo").set(resource);
+            resource.remove("operation");
+            PathAddress address = PathAddress.pathAddress(resource.remove("address"));
+            subsystem.get(address.getLastElement().getKeyValuePair()).set(resource);
+        }
 
-        ModelNode addResourceOp1 = operations.get(2);
-        ModelNode resource2 = addResourceOp1.clone();
-        resource2.remove("operation");
-        resource2.remove("address");
-
-        subsystem.get("resource", "foo2").set(resource2);
-
-        System.out.println("subsystem = " + subsystem);
+        //System.out.println("subsystem = " + subsystem);
         return subsystem;
     }
 
-    private static class MyParser implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<ModelNode> {
+    public static String normalizeXML(String xml) throws Exception {
+        // Remove all white space adjoining tags ("trim all elements")
+        xml = xml.replaceAll("\\s*<", "<");
+        xml = xml.replaceAll(">\\s*", ">");
 
-        protected static final String NAMESPACE = "urn:jboss:domain:my-namespace:1.0";
-        protected static final MyParser INSTANCE = new MyParser();
+        DOMImplementationRegistry registry = DOMImplementationRegistry.newInstance();
+        DOMImplementationLS domLS = (DOMImplementationLS) registry.getDOMImplementation("LS");
+        LSParser lsParser = domLS.createLSParser(DOMImplementationLS.MODE_SYNCHRONOUS, null);
 
-        private static final PersistentResourceXMLDescription xmlDescription;
+        LSInput input = domLS.createLSInput();
+        input.setStringData(xml);
+        Document document = lsParser.parse(input);
 
-        protected  static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "foo");
+        LSSerializer lsSerializer = domLS.createLSSerializer();
+        lsSerializer.getDomConfig().setParameter("comments", Boolean.FALSE);
+        lsSerializer.getDomConfig().setParameter("format-pretty-print", Boolean.TRUE);
+        return lsSerializer.writeToString(document);
+    }
 
-        protected  static final PersistentResourceDefinition RESOURCE_INSTANCE;
+    private static class MyParser extends PersistentResourceXMLParser {
 
-        static {
-            final AttributeDefinition clusterAttr1 = create("cluster-attr1", ModelType.STRING)
-                    .setAttributeGroup("cluster")
-                    .setXmlName("attr1")
+        protected static final String NAMESPACE = "urn:jboss:domain:test:1.0";
+
+        protected static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "foo");
+
+
+        static final AttributeDefinition clusterAttr1 = create("cluster-attr1", ModelType.STRING)
+                .setAttributeGroup("cluster")
+                .setXmlName("attr1")
+                .build();
+        static final AttributeDefinition clusterAttr2 = create("cluster-attr2", ModelType.STRING)
+                .setAttributeGroup("cluster")
+                .setXmlName("attr2")
+                .build();
+
+        static final AttributeDefinition securityAttr1 = create("security-my-attr1", ModelType.STRING)
+                .setAttributeGroup("security")
+                .setXmlName("my-attr1")
+                .build();
+        static final AttributeDefinition securityAttr2 = create("security-my-attr2", ModelType.STRING)
+                .setAttributeGroup("security")
+                .setXmlName("my-attr2")
+                .build();
+        static final AttributeDefinition nonGroupAttr1 = create("non-group-attr", ModelType.STRING)
+                .setXmlName("no-attr1")
+                .build();
+        static final StringListAttributeDefinition ALIAS = new StringListAttributeDefinition.Builder("alias")
+                .setAllowNull(true)
+                .setElementValidator(new StringLengthValidator(1))
+                .setAttributeParser(AttributeParser.COMMA_DELIMITED_STRING_LIST)
+                .setAttributeMarshaller(AttributeMarshaller.COMMA_STRING_LIST)
+                .build();
+
+        static final SimpleAttributeDefinition BUFFER_SIZE = new SimpleAttributeDefinitionBuilder("buffer-size", ModelType.INT)
+                .setAllowNull(true)
+                .setDefaultValue(new ModelNode(1024))
+                .setAllowExpression(true)
+                .build();
+        static final SimpleAttributeDefinition BUFFERS_PER_REGION = new SimpleAttributeDefinitionBuilder("buffers-per-region", ModelType.INT)
+                .setAllowNull(true)
+                .setDefaultValue(new ModelNode(1024))
+                .setAllowExpression(true)
+                .build();
+        static final SimpleAttributeDefinition MAX_REGIONS = new SimpleAttributeDefinitionBuilder("max-regions", ModelType.INT)
+                .setAllowNull(true)
+                .setAllowExpression(true)
+                .setDefaultValue(new ModelNode(10))
+                .build();
+
+
+        protected static final PersistentResourceDefinition RESOURCE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("resource"), new NonResolvingResourceDescriptionResolver()) {
+            @Override
+            public Collection<AttributeDefinition> getAttributes() {
+                Collection<AttributeDefinition> attributes = new ArrayList<>();
+                attributes.add(clusterAttr1);
+                attributes.add(clusterAttr1);
+                attributes.add(securityAttr1);
+                attributes.add(securityAttr2);
+                attributes.add(nonGroupAttr1);
+                attributes.add(ALIAS);
+                return attributes;
+            }
+        };
+
+        protected static final PersistentResourceDefinition BUFFER_CACHE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("buffer-cache"), new NonResolvingResourceDescriptionResolver()) {
+            @Override
+            public Collection<AttributeDefinition> getAttributes() {
+                Collection<AttributeDefinition> attributes = new ArrayList<>();
+                attributes.add(BUFFER_SIZE);
+                attributes.add(BUFFERS_PER_REGION);
+                attributes.add(MAX_REGIONS);
+                attributes.add(ALIAS);
+                return attributes;
+            }
+        };
+
+
+        PersistentResourceDefinition SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(SUBSYSTEM_PATH, new NonResolvingResourceDescriptionResolver()) {
+
+            @Override
+            public Collection<AttributeDefinition> getAttributes() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            protected List<? extends PersistentResourceDefinition> getChildren() {
+                List<PersistentResourceDefinition> children = new ArrayList<>();
+                children.add(RESOURCE_INSTANCE);
+                children.add(BUFFER_CACHE_INSTANCE);
+                return children;
+            }
+        };
+
+
+        @Override
+        public PersistentResourceXMLDescription getParserDescription() {
+            return builder(SUBSYSTEM_ROOT_INSTANCE, NAMESPACE)
+                    .addChild(
+                            builder(RESOURCE_INSTANCE)
+                                    .setXmlWrapperElement("resources")
+                                    .addAttributes(
+                                            // cluster group
+                                            clusterAttr1,
+                                            clusterAttr2,
+                                            // security group
+                                            securityAttr1,
+                                            securityAttr2,
+                                            //no group element
+                                            nonGroupAttr1,
+                                            ALIAS
+                                    )
+                    )
+                    .addChild(
+                            builder(BUFFER_CACHE_INSTANCE)
+                                    .addAttributes(BUFFER_SIZE, BUFFERS_PER_REGION, MAX_REGIONS)
+                                    .addAttribute(ALIAS, AttributeParser.STRING_LIST, AttributeMarshaller.STRING_LIST)
+                    )
                     .build();
-            final AttributeDefinition clusterAttr2 = create("cluster-attr2", ModelType.STRING)
-                    .setAttributeGroup("cluster")
-                    .setXmlName("attr2")
-                    .build();
+        }
+    }
 
-            final AttributeDefinition securityAttr1 = create("security-my-attr1", ModelType.STRING)
-                    .setAttributeGroup("security")
-                    .setXmlName("my-attr1")
-                    .build();
-            final AttributeDefinition securityAttr2 = create("security-my-attr2", ModelType.STRING)
-                    .setAttributeGroup("security")
-                    .setXmlName("my-attr2")
-                    .build();
+    static class AttributeGroupParser extends MyParser {
 
 
-            RESOURCE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("resource"), new NonResolvingResourceDescriptionResolver()) {
-                @Override
-                public Collection<AttributeDefinition> getAttributes() {
-                    Collection<AttributeDefinition> attributes = new ArrayList<>();
-                    attributes.add(clusterAttr1);
-                    attributes.add(clusterAttr1);
-                    attributes.add(securityAttr1);
-                    attributes.add(securityAttr2);
-                    return attributes;
-                }
-            };
-
-
-            PersistentResourceDefinition SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(SUBSYSTEM_PATH, new NonResolvingResourceDescriptionResolver()) {
-
-                @Override
-                public Collection<AttributeDefinition> getAttributes() {
-                    return Collections.emptyList();
-                }
-
-                @Override
-                protected List<? extends PersistentResourceDefinition> getChildren() {
-                    List<PersistentResourceDefinition> children = new ArrayList<>();
-                    children.add(RESOURCE_INSTANCE);
-                    return children;
-                }
-            };
-
-            xmlDescription = builder(SUBSYSTEM_ROOT_INSTANCE)
+        @Override
+        public PersistentResourceXMLDescription getParserDescription() {
+            return builder(SUBSYSTEM_ROOT_INSTANCE, NAMESPACE)
                     .addChild(
                             builder(RESOURCE_INSTANCE)
                                     .addAttributes(
@@ -201,22 +363,18 @@ public class PersistentResourceXMLParserTestCase {
                                             clusterAttr2,
                                             // security group
                                             securityAttr1,
-                                            securityAttr2
-                                            )
+                                            securityAttr2,
+                                            //no group element
+                                            nonGroupAttr1,
+                                            ALIAS
+                                    )
+                    )
+                    .addChild(
+                            builder(BUFFER_CACHE_INSTANCE)
+                                    .addAttributes(BUFFER_SIZE, BUFFERS_PER_REGION, MAX_REGIONS)
+                                    .addAttribute(ALIAS, AttributeParser.STRING_LIST, AttributeMarshaller.STRING_LIST)
                     )
                     .build();
-        }
-
-        @Override
-        public void readElement(XMLExtendedStreamReader reader, List<ModelNode> list) throws XMLStreamException {
-            xmlDescription.parse(reader, PathAddress.EMPTY_ADDRESS, list);
-        }
-
-        @Override
-        public void writeContent(XMLExtendedStreamWriter writer, ModelNode modelNode) throws XMLStreamException {
-            ModelNode model = new ModelNode();
-            model.get(SUBSYSTEM_PATH.getKeyValuePair()).set(modelNode);
-            xmlDescription.persist(writer, model, NAMESPACE);
         }
     }
 }

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/groups-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/groups-subsystem.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:test:1.0">
+    <resource name="foo" no-attr1="yada" alias="localhost,some.host">
+        <cluster attr1="bar" attr2="baz"/>
+        <security my-attr1="alice" my-attr2="bob"/>
+    </resource>
+    <resource name="foo2" no-attr1="blah" alias="localhost,some.host,bah,boh,yak">
+        <cluster attr1="bar2" attr2="baz2"/>
+    </resource>
+</subsystem>

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/groups-wrappers-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/groups-wrappers-subsystem.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:test:1.0">
+    <resources>
+        <resource name="foo" no-attr1="yada" alias="localhost,some.host" >
+            <cluster attr1="bar" attr2="baz"/>
+            <security my-attr1="alice" my-attr2="bob"/>
+        </resource>
+        <resource name="foo2" no-attr1="blah" alias="localhost,some.host,bah,boh,yak" >
+            <cluster attr1="bar2" attr2="baz2"/>
+        </resource>
+    </resources>
+</subsystem>

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/server-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/server-subsystem.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:test:1.0">
+    <server name="default" >
+            <security enabled="${security.enabled:false}" />
+            <statistics enabled="${statistics.enabled:true}" />
+      </server>
+
+</subsystem>

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/simple-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/simple-subsystem.xml
@@ -1,0 +1,10 @@
+<subsystem xmlns="urn:jboss:domain:test:1.0">
+    <resources>
+          <resource name="foo" no-attr1="yada" alias="localhost,some.host" >
+              <cluster attr1="bar" attr2="baz"/>
+              <security my-attr1="alice" my-attr2="bob"/>
+          </resource>
+    </resources>
+    <buffer-cache name="default" buffer-size="1025" buffers-per-region="1054" max-regions="15" alias="entry1 entry2 entry3" />
+    <buffer-cache name="extra" buffer-size="1025" buffers-per-region="1054" max-regions="15"/>
+</subsystem>


### PR DESCRIPTION
- it now properly supports mixing attribute groups & wrappers
- add support for multiple resources inside wrapper element
- add option to override also marshaller inside parser definition
- add tests to make sure this works properly

rework internals to not use map<attribute-name, attribute> to properly support multiple groups with same xml names for different attributes