### PR TITLE
https://issues.jboss.org/browse/WFCORE-582 CLI: ability to load command ...

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandRegistry.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandRegistry.java
@@ -21,8 +21,11 @@
  */
 package org.jboss.as.cli;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -35,18 +38,34 @@ public class CommandRegistry {
     private final Map<String, CommandHandler> handlers = new HashMap<String, CommandHandler>();
     private final Set<String> tabCompletionCommands = new HashSet<String>();
 
-    public void registerHandler(CommandHandler handler, String... names) {
+    public void registerHandler(CommandHandler handler, String... names) throws CommandLineException {
         registerHandler(handler, true, names);
     }
 
-    public void registerHandler(CommandHandler handler, boolean tabComplete, String... names) {
+    public void registerHandler(CommandHandler handler, boolean tabComplete, String... names) throws RegisterHandlerException {
+        String tabCompleteName = null;
+        RegisterHandlerException error = null;
         for(String name : names) {
-            CommandHandler previous = handlers.put(name, handler);
-            if(previous != null)
-                throw new IllegalStateException("Duplicate command name '" + name + "'. Handlers: " + previous + ", " + handler);
+            if(handlers.containsKey(name)) {
+                if(error == null) {
+                    error = new RegisterHandlerException(name);
+                } else {
+                    error.addCommand(name);
+                }
+            } else {
+                if(tabCompleteName == null) {
+                    tabCompleteName = name;
+                }
+                handlers.put(name, handler);
+            }
         }
-        if(tabComplete) {
-            tabCompletionCommands.add(names[0]);
+
+        if(tabComplete && tabCompleteName != null) {
+            tabCompletionCommands.add(tabCompleteName);
+        }
+
+        if(error != null) {
+            throw error;
         }
     }
 
@@ -67,5 +86,38 @@ public class CommandRegistry {
             tabCompletionCommands.remove(cmdName);
         }
         return handler;
+    }
+
+    public static class RegisterHandlerException extends CommandLineException {
+
+        private static final long serialVersionUID = 1L;
+
+        private List<String> names;
+
+        public RegisterHandlerException(String commandName) {
+            super("");
+            names = Collections.singletonList(commandName);
+        }
+
+        void addCommand(String name) {
+            if(names.size() == 1) {
+                names = new ArrayList<String>(names);
+            }
+            names.add(name);
+        }
+
+        public List<String> getNotAddedNames() {
+            return Collections.unmodifiableList(names);
+        }
+
+        @Override
+        public String getMessage() {
+            final StringBuilder buf = new StringBuilder("The following command names could not be registered since they conflict with the already registered ones: ");
+            buf.append(names.get(0));
+            for(int i = 1; i < names.size(); ++i) {
+                buf.append(", ").append(names.get(i));
+            }
+            return buf.toString();
+        }
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -88,6 +88,7 @@ public class Util {
     public static final String ENABLED = "enabled";
     public static final String EXECUTE = "execute";
     public static final String EXPRESSIONS_ALLOWED = "expressions-allowed";
+    public static final String EXTENSION = "extension";
     public static final String FAILURE_DESCRIPTION = "failure-description";
     public static final String FULL_REPLACE_DEPLOYMENT = "full-replace-deployment";
     public static final String FALSE = "false";
@@ -106,6 +107,7 @@ public class Util {
     public static final String MAX_FAILURE_PERCENTAGE = "max-failure-percentage";
     public static final String MAX_OCCURS = "max-occurs";
     public static final String MIN_OCCURS = "min-occurs";
+    public static final String MODULE = "module";
     public static final String MODULE_SLOT = "module-slot";
     public static final String NAME = "name";
     public static final String NILLABLE = "nillable";

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbeddedControllerHandlerRegistrar.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbeddedControllerHandlerRegistrar.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.CommandRegistry;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -82,7 +83,7 @@ public class EmbeddedControllerHandlerRegistrar {
         modular = obj != null;
     }
 
-    public static AtomicReference<EmbeddedServerLaunch> registerEmbeddedCommands(CommandRegistry commandRegistry, CommandContext ctx) {
+    public static AtomicReference<EmbeddedServerLaunch> registerEmbeddedCommands(CommandRegistry commandRegistry, CommandContext ctx) throws CommandLineException {
         AtomicReference<EmbeddedServerLaunch> serverReference = new AtomicReference<>();
         if (hasModules) {
             commandRegistry.registerHandler(EmbedServerHandler.create(serverReference, ctx, modular), "embed-server");

--- a/cli/src/main/java/org/jboss/as/cli/handlers/CommandCommandHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/CommandCommandHandler.java
@@ -30,6 +30,7 @@ import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandHandler;
 import org.jboss.as.cli.CommandLineCompleter;
+import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.CommandRegistry;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.impl.ArgumentWithValue;
@@ -163,7 +164,7 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
      * @see org.jboss.as.cli.handlers.CommandHandlerWithHelp#doHandle(org.jboss.as.cli.CommandContext)
      */
     @Override
-    protected void doHandle(CommandContext ctx) throws CommandFormatException {
+    protected void doHandle(CommandContext ctx) throws CommandLineException {
 
         final ParsedCommandLine args = ctx.getParsedCommandLine();
         final String action = this.action.getValue(args);

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandHandler.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandHandler.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.management.cli.extensions;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.handlers.CommandHandlerWithHelp;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class CliExtCommandHandler extends CommandHandlerWithHelp {
+
+    public static final String NAME = "test-cli-ext-commands";
+    public static final String OUTPUT = "hello world!";
+
+    public CliExtCommandHandler() {
+        super(NAME, false);
+    }
+
+    @Override
+    protected void doHandle(CommandContext ctx) throws CommandLineException {
+        ctx.printLine(OUTPUT);
+    }
+
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandHandlerProvider.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandHandlerProvider.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.management.cli.extensions;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandHandler;
+import org.jboss.as.cli.CommandHandlerProvider;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class CliExtCommandHandlerProvider implements CommandHandlerProvider {
+
+    @Override
+    public CommandHandler createCommandHandler(CommandContext ctx) {
+        return new CliExtCommandHandler();
+    }
+
+    @Override
+    public boolean isTabComplete() {
+        return false;
+    }
+
+    @Override
+    public String[] getNames() {
+        return new String[]{CliExtCommandHandler.NAME};
+    }
+
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsExtension.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsExtension.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.management.cli.extensions;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class CliExtCommandsExtension implements Extension {
+
+    public static final String SUBSYSTEM_NAME = "test-cli-ext-commands";
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
+        registration.registerSubsystemModel(new CliExtCommandsSubsystemResourceDescription());
+        registration.registerXMLElementWriter(new CliExtCommandsParser());
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        //Don't need a parser, just register a dummy writer in the initialize() method
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, CliExtCommandsParser.NAMESPACE, new CliExtCommandsParser());
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsParser.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsParser.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.management.cli.extensions;
+
+import java.util.List;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class CliExtCommandsParser implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
+
+    public static final String NAMESPACE = "urn:jboss:domain:test-cli-ext-commands:1.0";
+
+    @Override
+    public void readElement(XMLExtendedStreamReader reader,
+            List<ModelNode> ops) throws XMLStreamException {
+        ParseUtils.requireNoAttributes(reader);
+        ParseUtils.requireNoContent(reader);
+        ops.add(Util.createAddOperation(PathAddress.pathAddress(CliExtCommandsSubsystemResourceDescription.PATH)));
+    }
+
+    @Override
+    public void writeContent(XMLExtendedStreamWriter streamWriter,
+            SubsystemMarshallingContext context) throws XMLStreamException {
+        context.startSubsystemElement(NAMESPACE, true);
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsSubsystemResourceDescription.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsSubsystemResourceDescription.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.management.cli.extensions;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class CliExtCommandsSubsystemResourceDescription extends SimpleResourceDefinition {
+
+
+    public static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, CliExtCommandsExtension.SUBSYSTEM_NAME);
+
+    public CliExtCommandsSubsystemResourceDescription() {
+        super(PATH, new NonResolvingResourceDescriptionResolver(), new ModelOnlyAddStepHandler(), new AbstractRemoveStepHandler(){});
+    }
+
+    @Override
+    public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+        super.registerOperations(resourceRegistration);
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsTestCase.java
@@ -1,0 +1,150 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.management.cli.extensions;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.as.cli.CommandHandlerProvider;
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.as.test.integration.management.cli.CliScriptTestBase;
+import org.jboss.as.test.module.util.TestModule;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.xnio.IoUtils;
+
+/**
+ * Testing commands loaded from the available management model extensions.
+ *
+ * @author Alexey Loubyansky
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class CliExtCommandsTestCase extends CliScriptTestBase {
+
+    private static final String MODULE_NAME = "test.cli.extension.commands";
+
+    @Inject
+    private static ServerController containerController;
+
+    private static TestModule testModule;
+
+    @BeforeClass
+    public static void setupServer() throws Exception {
+        createTestModule();
+        setupServerWithExtension();
+    }
+
+    @AfterClass
+    public static void tearDownServer() throws Exception {
+        ModelControllerClient client = null;
+        try {
+            client = containerController.getClient().getControllerClient();
+            ModelNode subsystemResult = client.execute(Util.createRemoveOperation(PathAddress.pathAddress(CliExtCommandsSubsystemResourceDescription.PATH)));
+            ModelNode extensionResult = client.execute(Util.createRemoveOperation(PathAddress.pathAddress(ModelDescriptionConstants.EXTENSION, MODULE_NAME)));
+            ModelTestUtils.checkOutcome(subsystemResult);
+            ModelTestUtils.checkOutcome(extensionResult);
+        } finally {
+            containerController.stop();
+            testModule.remove();
+            IoUtils.safeClose(client);
+        }
+        containerController.stop();
+    }
+
+    @Test
+    public void testExtensionCommand() throws Exception {
+
+        Assert.assertNotEquals(0,
+                execute(containerController.getClient().getMgmtAddress(),
+                        containerController.getClient().getMgmtPort(),
+                        false, // the command won't be available unless the cli connects to the controller
+                        CliExtCommandHandler.NAME,
+                        false));
+
+        assertEquals(0,
+                execute(containerController.getClient().getMgmtAddress(),
+                        containerController.getClient().getMgmtPort(),
+                        true,
+                        CliExtCommandHandler.NAME,
+                        false));
+        // the output may contain other logs from the cli initialization
+        assertTrue(getLastCommandOutput().endsWith(CliExtCommandHandler.OUTPUT + org.jboss.as.cli.Util.LINE_SEPARATOR));
+    }
+
+    private static void createTestModule() throws Exception {
+        final File moduleXml = new File(CliExtCommandsTestCase.class.getResource(CliExtCommandsTestCase.class.getSimpleName() + "-module.xml").toURI());
+        testModule = new TestModule(MODULE_NAME, moduleXml);
+
+        final JavaArchive archive = testModule.addResource("test-cli-ext-commands-module.jar")
+                .addClass(CliExtCommandHandler.class)
+                .addClass(CliExtCommandHandlerProvider.class)
+                .addClass(CliExtCommandsExtension.class)
+                .addClass(CliExtCommandsParser.class)
+                .addClass(CliExtCommandsSubsystemResourceDescription.class);
+
+        ArchivePath services = ArchivePaths.create("/");
+        services = ArchivePaths.create(services, "services");
+
+        final ArchivePath extService = ArchivePaths.create(services, Extension.class.getName());
+        archive.addAsManifestResource(CliExtCommandHandler.class.getPackage(), Extension.class.getName(), extService);
+
+        final ArchivePath cliCmdService = ArchivePaths.create(services, CommandHandlerProvider.class.getName());
+        archive.addAsManifestResource(CliExtCommandHandler.class.getPackage(), CommandHandlerProvider.class.getName(), cliCmdService);
+
+        testModule.create(true);
+    }
+
+    private static void setupServerWithExtension() throws Exception {
+        containerController.start();
+        ManagementClient managementClient = containerController.getClient();
+        ModelControllerClient client = managementClient.getControllerClient();
+
+        //Add the extension
+        final ModelNode addExtension = Util.createAddOperation(PathAddress.pathAddress(ModelDescriptionConstants.EXTENSION, MODULE_NAME));
+        ModelTestUtils.checkOutcome(client.execute(addExtension));
+
+        final ModelNode addSubsystem = Util.createAddOperation(PathAddress.pathAddress(CliExtCommandsSubsystemResourceDescription.PATH));
+        ModelTestUtils.checkOutcome(client.execute(addSubsystem));
+    }
+}

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsTestCase-module.xml
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsTestCase-module.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- ~ JBoss, Home of Professional Open Source. ~ Copyright 2015, Red Hat, 
+	Inc., and individual contributors ~ as indicated by the @author tags. See 
+	the copyright.txt file in the ~ distribution for a full listing of individual 
+	contributors. ~ ~ This is free software; you can redistribute it and/or modify 
+	it ~ under the terms of the GNU Lesser General Public License as ~ published 
+	by the Free Software Foundation; either version 2.1 of ~ the License, or 
+	(at your option) any later version. ~ ~ This software is distributed in the 
+	hope that it will be useful, ~ but WITHOUT ANY WARRANTY; without even the 
+	implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+	See the GNU ~ Lesser General Public License for more details. ~ ~ You should 
+	have received a copy of the GNU Lesser General Public ~ License along with 
+	this software; if not, write to the Free ~ Software Foundation, Inc., 51 
+	Franklin St, Fifth Floor, Boston, MA ~ 02110-1301 USA, or see the FSF site: 
+	http://www.fsf.org. -->
+
+<module xmlns="urn:jboss:module:1.1" name="test.cli.extension.commands">
+  <resources>
+    <resource-root path="test-cli-ext-commands-module.jar"/>
+  </resources>
+  <dependencies>
+    <module name="org.jboss.as.controller"/>
+    <module name="org.jboss.staxmapper"/>
+    <module name="org.jboss.as.cli"/>
+    <module name="javax.xml.stream.api"/>
+  </dependencies>
+</module>

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/org.jboss.as.cli.CommandHandlerProvider
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/org.jboss.as.cli.CommandHandlerProvider
@@ -1,0 +1,1 @@
+org.jboss.as.test.manualmode.management.cli.extensions.CliExtCommandHandlerProvider

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/org.jboss.as.controller.Extension
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/org.jboss.as.controller.Extension
@@ -1,0 +1,1 @@
+org.jboss.as.test.manualmode.management.cli.extensions.CliExtCommandsExtension

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/cli/CliScriptTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/cli/CliScriptTestBase.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 import org.jboss.as.cli.Util;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
-import org.junit.Assert;
+
 
 /**
  * @author Alexey Loubyansky


### PR DESCRIPTION
...handlers from the available in the model extensions

This commit is trying to load CLI command handlers using Java service loader mechanism from the modules of the management model extensions when the CLI (re-)connects to the controller.
It also includes a simple test.

Thanks,
Alexey