### PR TITLE
[WFCORE-588] Extra parser delimiter's for StringListAttributeDefiniton

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
@@ -116,14 +116,10 @@ public abstract class AttributeParser {
         @Override
         public void parseAndSetParameter(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
             if (value == null) { return; }
-            for (String element : value.split(" ")) {
-                parseAndAddParameterElement(attribute, element, operation, reader);
+            final ModelNode node = operation.get(attribute.getName());
+            for (final String element : value.split("[ \\r\\n\\t]+")) {
+                node.add(parse(attribute, element, reader));
             }
-        }
-
-        private void parseAndAddParameterElement(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
-            ModelNode paramVal = parse(attribute, value, reader);
-            operation.get(attribute.getName()).add(paramVal);
         }
     };
 


### PR DESCRIPTION
Also split on line feeds, carriage returns and tabs when parsing
StringListAttributeDefinition.