### PR TITLE
WFCORE-85 Remove non socket-binding attributes from management interfaces

### DIFF
--- a/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
@@ -24,19 +24,13 @@ package org.jboss.as.server.mgmt;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HTTP_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_INTERFACE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.server.logging.ServerLogger.ROOT_LOGGER;
 
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationContext.Stage;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -47,14 +41,11 @@ import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.parsing.Attribute;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.server.controller.descriptions.ServerDescriptions;
 import org.jboss.as.server.operations.HttpManagementAddHandler;
 import org.jboss.as.server.operations.HttpManagementRemoveHandler;
@@ -70,49 +61,23 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
 
     private static final PathElement RESOURCE_PATH = PathElement.pathElement(MANAGEMENT_INTERFACE, HTTP_INTERFACE);
 
-    private static final OperationStepHandler VALIDATING_HANDLER = new HttpManagementValidatingHandler();
-
     public static final SimpleAttributeDefinition SECURITY_REALM = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SECURITY_REALM, ModelType.STRING, true)
                 .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
                 .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SECURITY_REALM_REF))
                 .setNullSignficant(true)
                 .build();
 
-    public static final SimpleAttributeDefinition INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.INTERFACE, ModelType.STRING, false)
-                .setAllowExpression(true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
-                .setAlternatives(ModelDescriptionConstants.SOCKET_BINDING, ModelDescriptionConstants.SECURE_SOCKET_BINDING)
-                .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SOCKET_CONFIG))
-                .setDeprecated(ModelVersion.create(1,4))
-                .build();
-
-    public static final SimpleAttributeDefinition HTTP_PORT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PORT, ModelType.INT, true)
-            .setAllowExpression(true).setValidator(new IntRangeValidator(0, 65535, true, true))
-            .setAlternatives(ModelDescriptionConstants.SOCKET_BINDING, ModelDescriptionConstants.SECURE_SOCKET_BINDING)
-            .setRequires(ModelDescriptionConstants.INTERFACE)
-            .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SOCKET_CONFIG))
-            .setDeprecated(ModelVersion.create(1,4))
-            .build();
-
-    public static final SimpleAttributeDefinition HTTPS_PORT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SECURE_PORT, ModelType.INT, true)
-            .setAllowExpression(true).setValidator(new IntRangeValidator(0, 65535, true, true))
-            .setAlternatives(ModelDescriptionConstants.SOCKET_BINDING, ModelDescriptionConstants.SECURE_SOCKET_BINDING)
-            .setRequires(ModelDescriptionConstants.INTERFACE)
-            .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SOCKET_CONFIG))
-            .setDeprecated(ModelVersion.create(1,4))
-            .build();
-
     public static final SimpleAttributeDefinition SOCKET_BINDING = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, true)
             .setXmlName(Attribute.HTTP.getLocalName())
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
-            .setAlternatives(ModelDescriptionConstants.INTERFACE)
             .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SOCKET_CONFIG))
             .build();
 
     public static final SimpleAttributeDefinition SECURE_SOCKET_BINDING = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SECURE_SOCKET_BINDING, ModelType.STRING, true)
             .setXmlName(Attribute.HTTPS.getLocalName())
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
-            .setAlternatives(ModelDescriptionConstants.INTERFACE)
             .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SOCKET_CONFIG))
+            .setRequires(SECURITY_REALM.getName())
             .build();
 
     public static final SimpleAttributeDefinition CONSOLE_ENABLED = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.CONSOLE_ENABLED, ModelType.BOOLEAN, true)
@@ -146,8 +111,9 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
-    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, HTTP_PORT, HTTPS_PORT, SECURITY_REALM, SOCKET_BINDING,
-                                                                                                 SECURE_SOCKET_BINDING, CONSOLE_ENABLED, HTTP_UPGRADE_ENABLED, SASL_PROTOCOL, SERVER_NAME, ALLOWED_ORIGINS};
+    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {
+            SECURITY_REALM, SOCKET_BINDING, SECURE_SOCKET_BINDING, CONSOLE_ENABLED, HTTP_UPGRADE_ENABLED, SASL_PROTOCOL, SERVER_NAME, ALLOWED_ORIGINS
+    };
 
     public static final HttpManagementResourceDefinition INSTANCE = new HttpManagementResourceDefinition();
 
@@ -164,7 +130,7 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        OperationStepHandler writeAttributeHandler = new WriteAttributeHandler(ATTRIBUTE_DEFINITIONS);
+        OperationStepHandler writeAttributeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTE_DEFINITIONS);
         for (AttributeDefinition attr : ATTRIBUTE_DEFINITIONS) {
             resourceRegistration.registerReadWriteAttribute(attr, null, writeAttributeHandler);
         }
@@ -173,49 +139,5 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
     @Override
     public List<AccessConstraintDefinition> getAccessConstraints() {
         return accessConstraints;
-    }
-
-    public static void addValidatingHandler(OperationContext operationContext, ModelNode fromOperation) {
-        ModelNode operation = Util.createOperation("validate-http-interface", PathAddress.pathAddress(fromOperation.require(OP_ADDR)));
-
-        operationContext.addStep(operation, VALIDATING_HANDLER, Stage.MODEL);
-    }
-
-    private static class WriteAttributeHandler extends ReloadRequiredWriteAttributeHandler {
-
-        private WriteAttributeHandler(AttributeDefinition[] attributes) {
-            super(attributes);
-        }
-
-        @Override
-        protected void finishModelStage(OperationContext context, ModelNode operation, String attributeName,
-                ModelNode newValue, ModelNode oldValue, Resource model) throws OperationFailedException {
-            super.finishModelStage(context, operation, attributeName, newValue, oldValue, model);
-            addValidatingHandler(context, operation);
-        }
-
-    }
-
-    private static class HttpManagementValidatingHandler implements OperationStepHandler {
-
-        @Override
-        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            final ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
-            if (model.hasDefined(INTERFACE.getName())
-                    && (model.hasDefined(SOCKET_BINDING.getName())
-                    || model.hasDefined(SECURE_SOCKET_BINDING.getName())
-            )) {
-                throw ROOT_LOGGER.illegalCombinationOfHttpManagementInterfaceConfigurations(
-                        INTERFACE.getName(),
-                        SOCKET_BINDING.getName(),
-                        SECURE_SOCKET_BINDING.getName());
-            }
-
-            if (model.hasDefined(SECURITY_REALM.getName()) == false
-                    && (model.hasDefined(SECURE_SOCKET_BINDING.getName()) || model.hasDefined(HTTPS_PORT.getName()))) {
-                throw ROOT_LOGGER.noSecurityRealmForSsl();
-            }
-        }
-
     }
 }

--- a/server/src/main/java/org/jboss/as/server/mgmt/NativeManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/NativeManagementResourceDefinition.java
@@ -37,7 +37,6 @@ import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.parsing.Attribute;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -66,23 +65,6 @@ public class NativeManagementResourceDefinition extends SimpleResourceDefinition
             .setNullSignficant(true)
             .build();
 
-    public static final SimpleAttributeDefinition INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.INTERFACE, ModelType.STRING, false)
-                .setAllowExpression(true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
-                .setAlternatives(ModelDescriptionConstants.SOCKET_BINDING)
-                .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-                .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SOCKET_CONFIG))
-                .setDeprecated(ModelVersion.create(1, 4))
-                .build();
-
-    public static final SimpleAttributeDefinition NATIVE_PORT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PORT, ModelType.INT, false)
-            .setAllowExpression(true).setValidator(new IntRangeValidator(0, 65535, false, true))
-            .setAlternatives(ModelDescriptionConstants.SOCKET_BINDING)
-            .setRequires(ModelDescriptionConstants.INTERFACE)
-            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SOCKET_CONFIG))
-            .setDeprecated(ModelVersion.create(1,4))
-            .build();
-
     public static final SimpleAttributeDefinition SOCKET_BINDING = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, true)
             .setXmlName(Attribute.NATIVE.getLocalName())
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
@@ -104,7 +86,7 @@ public class NativeManagementResourceDefinition extends SimpleResourceDefinition
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
-    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, NATIVE_PORT, SECURITY_REALM, SOCKET_BINDING, SERVER_NAME, SASL_PROTOCOL };
+    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {SECURITY_REALM, SOCKET_BINDING, SERVER_NAME, SASL_PROTOCOL };
 
     public static final NativeManagementResourceDefinition INSTANCE = new NativeManagementResourceDefinition();
 


### PR DESCRIPTION
Extra validation code is removed as .setRequires() covers that since we added global model validation step.