### PR TITLE
Allow list attributes to be marshalled as elements.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -626,7 +626,11 @@ public abstract class AttributeDefinition {
      *          if thrown by {@code writer}
      */
     public void marshallAsElement(final ModelNode resourceModel, final boolean marshallDefault, final XMLStreamWriter writer) throws XMLStreamException{
-        throw ControllerLogger.ROOT_LOGGER.couldNotMarshalAttributeAsElement(getName());
+        if (this.attributeMarshaller.isMarshallableAsElement()) {
+            this.attributeMarshaller.marshallAsElement(this, resourceModel, marshallDefault, writer);
+        } else {
+            throw ControllerLogger.ROOT_LOGGER.couldNotMarshalAttributeAsElement(getName());
+        }
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/AttributeMarshaller.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeMarshaller.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.controller;
 
+import java.util.Iterator;
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
@@ -82,27 +84,24 @@ public abstract class AttributeMarshaller {
         return false;
     }
 
-    private static class ListMarshaller extends AttributeMarshaller {
+    private static class ListMarshaller extends DefaultAttributeMarshaller {
         private final char delimiter;
 
-        private ListMarshaller(char delimiter) {
+        ListMarshaller(char delimiter) {
             this.delimiter = delimiter;
         }
 
         @Override
-        public void marshallAsAttribute(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
+        protected String asString(ModelNode value) {
             StringBuilder builder = new StringBuilder();
-            if (resourceModel.hasDefined(attribute.getName())) {
-                for (ModelNode p : resourceModel.get(attribute.getName()).asList()) {
-                    builder.append(p.asString()).append(delimiter);
+            Iterator<ModelNode> values = value.asList().iterator();
+            while (values.hasNext()) {
+                builder.append(values.next().asString());
+                if (values.hasNext()) {
+                    builder.append(this.delimiter);
                 }
             }
-            if (builder.length() > 2) {
-                builder.setLength(builder.length() - 1);
-            }
-            if (builder.length() > 0) {
-                writer.writeAttribute(attribute.getXmlName(), builder.toString());
-            }
+            return builder.toString();
         }
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/DefaultAttributeMarshaller.java
+++ b/controller/src/main/java/org/jboss/as/controller/DefaultAttributeMarshaller.java
@@ -32,13 +32,17 @@ import org.jboss.dmr.ModelNode;
  */
 public class DefaultAttributeMarshaller extends AttributeMarshaller {
 
-
+    @Override
     public void marshallAsAttribute(final AttributeDefinition attribute, final ModelNode resourceModel, final boolean marshallDefault, final XMLStreamWriter writer) throws XMLStreamException {
         if (isMarshallable(attribute, resourceModel, marshallDefault)) {
-            writer.writeAttribute(attribute.getXmlName(), resourceModel.get(attribute.getName()).asString());
+            writer.writeAttribute(attribute.getXmlName(), this.asString(resourceModel.get(attribute.getName())));
         }
     }
 
+    /**
+     * Use {@link #marshallAsElement(AttributeDefinition, ModelNode, boolean, XMLStreamWriter)} instead.
+     */
+    @Deprecated
     public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel, XMLStreamWriter writer) throws XMLStreamException {
         marshallAsElement(attribute, resourceModel, true, writer);
     }
@@ -47,7 +51,7 @@ public class DefaultAttributeMarshaller extends AttributeMarshaller {
     public void marshallAsElement(final AttributeDefinition attribute, final ModelNode resourceModel, final boolean marshallDefault, final XMLStreamWriter writer) throws XMLStreamException {
         if (isMarshallable(attribute, resourceModel, marshallDefault)) {
             writer.writeStartElement(attribute.getXmlName());
-            String content = resourceModel.get(attribute.getName()).asString();
+            String content = this.asString(resourceModel.get(attribute.getName()));
             if (content.indexOf('\n') > -1) {
                 // Multiline content. Use the overloaded variant that staxmapper will format
                 writer.writeCharacters(content);
@@ -58,5 +62,14 @@ public class DefaultAttributeMarshaller extends AttributeMarshaller {
             }
             writer.writeEndElement();
         }
+    }
+
+    @Override
+    public boolean isMarshallableAsElement() {
+        return true;
+    }
+
+    protected String asString(ModelNode value) {
+        return value.asString();
     }
 }


### PR DESCRIPTION
Other cleanup:
AttributeDefinition.marshallAsElement(...) should defer to the AttributeMarshaller to determine if the value can be marshalled as an element.
Fix return value of DefaultAttributeMarshaller.isMarshallableAsElement().