### PR TITLE
WFCORE-604, remove left content if deployment fails.

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
@@ -147,6 +147,8 @@ public class DeploymentAddHandler implements OperationStepHandler {
                 public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
                     if (resultAction == ResultAction.KEEP) {
                         contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, contentHash));
+                    } else if (resultAction == ResultAction.ROLLBACK) {
+                        contentRepository.removeContent(ModelContentReference.fromDeploymentName(name, contentHash));
                     }
                 }
             });

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
@@ -147,6 +147,8 @@ public class DeploymentAddHandler implements OperationStepHandler {
                 public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
                     if (resultAction == ResultAction.KEEP) {
                         contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, contentHash));
+                    } else if (resultAction == ResultAction.ROLLBACK) {
+                        contentRepository.removeContent(ModelContentReference.fromDeploymentName(name, contentHash));
                     }
                 }
             });


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-604

DeploymentAddHandler does not remove data in {standalone|domaine}/data/content directory after deployment failure.
Second time, even though new deployment succeed, it does not remove preivous content as contentHash is changed for new file.