### PR TITLE
https://issues.jboss.org/browse/WFCORE-608 Using ? as control character ...

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/Console.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Console.java
@@ -103,8 +103,8 @@ public interface Console {
             org.jboss.aesh.console.Console aeshConsole = null;
             try {
                 aeshConsole = new org.jboss.aesh.console.Console();
-            } catch (IOException e) {
-                throw new CliInitializationException(e);
+            } catch (Throwable e) {
+                throw new CliInitializationException("Failed to initialize Aesh console", e);
             }
 
             final org.jboss.aesh.console.Console finalAeshConsole = aeshConsole;


### PR DESCRIPTION
...in .inputrc causes CLI to terminate immediately.

Thanks,
Alexey