### PR TITLE
Support a SELF_CONTAINED mode of operation:

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ProcessType.java
+++ b/controller/src/main/java/org/jboss/as/controller/ProcessType.java
@@ -32,7 +32,8 @@ public enum ProcessType {
     EMBEDDED_SERVER(true, false),
     STANDALONE_SERVER(true, false),
     HOST_CONTROLLER(false, true),
-    APPLICATION_CLIENT(true, false);
+    APPLICATION_CLIENT(true, false),
+    SELF_CONTAINED(true,false);
 
     private final boolean server;
     private final boolean domain;

--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -340,6 +340,11 @@
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-self-contained</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
         </dependency>
 

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/self-contained/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/self-contained/main/module.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.self-contained">
+    <resources>
+        <artifact name="${org.wildfly.core:wildfly-self-contained}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.as.deployment-repository"/>
+        <module name="org.jboss.msc"/>
+        <module name="org.jboss.vfs"/>
+        <module name="org.jboss.as.controller"/>
+    </dependencies>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -64,6 +64,7 @@
         <module name="org.jboss.as.process-controller"/>
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.remoting"/>
+        <module name="org.jboss.as.self-contained" optional="true"/>
         <module name="org.wildfly.security.manager" services="import"/>
         <module name="org.jboss.as.security" optional="true" services="import"/>
         <module name="org.jboss.as.version"/>

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,7 @@
         <module>protocol</module>
         <module>remoting</module>
         <module>request-controller</module>
+        <module>self-contained</module>
         <module>server</module>
         <module>subsystem-test</module>
         <module>testsuite</module>
@@ -804,6 +805,12 @@
             <dependency>
                 <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-request-controller</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-self-contained</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/self-contained/pom.xml
+++ b/self-contained/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-core-parent</artifactId>
+        <version>1.0.0.Beta4-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.wildfly.core</groupId>
+    <artifactId>wildfly-self-contained</artifactId>
+
+    <name>WildFly: Self-Contained</name>
+
+    <dependencies>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.jboss.msc</groupId>
+            <artifactId>jboss-msc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-deployment-repository</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/self-contained/src/main/java/org/jboss/as/selfcontained/SelfContainedConfigurationPersister.java
+++ b/self-contained/src/main/java/org/jboss/as/selfcontained/SelfContainedConfigurationPersister.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.selfcontained;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
+import org.jboss.as.controller.persistence.ConfigurationPersister;
+import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementWriter;
+
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Set;
+
+/** A read-only configuration persister that provides configuration
+ *  from a pre-computed list of operations.
+ *
+ * @author Bob McWhirter
+ */
+public class SelfContainedConfigurationPersister implements ExtensibleConfigurationPersister {
+
+    /** Pre-computed configuration */
+    private final List<ModelNode> containerDefinition;
+
+    /** Construct with a pre-computed list of operations.
+     *
+     * @param containerDefinition The list of configuration operations.
+     */
+    public SelfContainedConfigurationPersister(List<ModelNode> containerDefinition) {
+        this.containerDefinition = containerDefinition;
+    }
+
+    @Override
+    public ConfigurationPersister.PersistenceResource store(ModelNode model, Set<PathAddress> affectedAddresses) throws ConfigurationPersistenceException {
+        return new ConfigurationPersister.PersistenceResource() {
+            @Override
+            public void commit() {
+            }
+
+            @Override
+            public void rollback() {
+            }
+        };
+    }
+
+    @Override
+    public void marshallAsXml(ModelNode model, OutputStream output) throws ConfigurationPersistenceException {
+    }
+
+    @Override
+    public List<ModelNode> load() throws ConfigurationPersistenceException {
+        return this.containerDefinition;
+    }
+
+    @Override
+    public void successfulBoot() throws ConfigurationPersistenceException {
+    }
+
+    @Override
+    public String snapshot() throws ConfigurationPersistenceException {
+        return null;
+    }
+
+    @Override
+    public SnapshotInfo listSnapshots() {
+        return ConfigurationPersister.NULL_SNAPSHOT_INFO;
+    }
+
+    @Override
+    public void deleteSnapshot(String name) {
+    }
+
+    @Override
+    public void registerSubsystemWriter(String name, XMLElementWriter<SubsystemMarshallingContext> writer) {
+        // writing is not supported
+    }
+
+    @Override
+    public void unregisterSubsystemWriter(String name) {
+    }
+}

--- a/self-contained/src/main/java/org/jboss/as/selfcontained/SelfContainedContentRepository.java
+++ b/self-contained/src/main/java/org/jboss/as/selfcontained/SelfContainedContentRepository.java
@@ -1,0 +1,124 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.selfcontained;
+
+import org.jboss.as.repository.ContentReference;
+import org.jboss.as.repository.ContentRepository;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.vfs.VirtualFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/** A content-repository capable of providing a static bit of content.
+ *
+ * @see org.jboss.as.selfcontained.SelfContainedContentService
+ *
+ * @author Bob McWhirter
+ */
+public class SelfContainedContentRepository implements ContentRepository, Service<ContentRepository> {
+
+    /** Install the service. */
+    public static void addService(ServiceTarget serviceTarget) {
+        SelfContainedContentRepository contentRepository = new SelfContainedContentRepository();
+        serviceTarget.addService(SERVICE_NAME, contentRepository)
+                .addDependency( SelfContainedContentService.NAME, VirtualFile.class, contentRepository.getContentInjector() )
+                .install();
+    }
+
+    private InjectedValue<VirtualFile> contentInjector = new InjectedValue<>();
+
+    public Injector<VirtualFile> getContentInjector() {
+        return this.contentInjector;
+    }
+
+    @Override
+    public byte[] addContent(InputStream stream) throws IOException {
+        return new byte[0];
+    }
+
+    @Override
+    public void addContentReference(ContentReference reference) {
+    }
+
+    @Override
+    public VirtualFile getContent(byte[] hash) {
+        // the [0] array is a sentinal for the self-contained content.
+        if ( hash.length == 1 && hash[0] == 0 ) {
+            return this.contentInjector.getValue();
+        }
+        return null;
+    }
+
+    @Override
+    public boolean hasContent(byte[] hash) {
+        if ( hash.length == 1 && hash[0] == 0 ){
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean syncContent(ContentReference reference) {
+        return true;
+    }
+
+    @Override
+    public void removeContent(ContentReference reference) {
+
+    }
+
+    @Override
+    public Map<String, Set<String>> cleanObsoleteContent() {
+        HashMap<String, Set<String>> result = new HashMap<>();
+        result.put( ContentRepository.MARKED_CONTENT, Collections.<String>emptySet());
+        result.put( ContentRepository.DELETED_CONTENT, Collections.<String>emptySet());
+        return result;
+    }
+
+    @Override
+    public void start(StartContext startContext) throws StartException {
+
+    }
+
+    @Override
+    public void stop(StopContext stopContext) {
+
+    }
+
+    @Override
+    public ContentRepository getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+}

--- a/self-contained/src/main/java/org/jboss/as/selfcontained/SelfContainedContentService.java
+++ b/self-contained/src/main/java/org/jboss/as/selfcontained/SelfContainedContentService.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.selfcontained;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.vfs.VirtualFile;
+
+/** Simple service to provide the VirtualFile to the SelfContainedContentRepository.
+ *
+ * @author Bob McWhirter
+ */
+public class SelfContainedContentService implements Service<VirtualFile> {
+
+    public static final ServiceName NAME = ServiceName.JBOSS.append( "self-contained", "content" );
+    private final VirtualFile content;
+
+    public SelfContainedContentService(VirtualFile content) {
+        this.content = content;
+    }
+
+    @Override
+    public void start(StartContext startContext) throws StartException {
+
+    }
+
+    @Override
+    public void stop(StopContext stopContext) {
+
+    }
+
+    @Override
+    public VirtualFile getValue() throws IllegalStateException, IllegalArgumentException {
+        return this.content;
+    }
+}

--- a/self-contained/src/main/java/org/jboss/as/selfcontained/SelfContainedContentServiceActivator.java
+++ b/self-contained/src/main/java/org/jboss/as/selfcontained/SelfContainedContentServiceActivator.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.selfcontained;
+
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceRegistryException;
+import org.jboss.vfs.VFS;
+import org.jboss.vfs.VirtualFile;
+
+import java.io.File;
+import java.io.IOException;
+
+/** Activator for the SelfContainedContentService.
+ *
+ * @see org.jboss.as.selfcontained.SelfContainedContentService
+ *
+ * @author Bob McWhirter
+ */
+public class SelfContainedContentServiceActivator implements ServiceActivator {
+
+    private final File content;
+
+    public SelfContainedContentServiceActivator(File content) {
+        this.content = content;
+    }
+
+    @Override
+    public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        VirtualFile mountPoint = VFS.getRootVirtualFile().getChild( "ROOT.war" );
+        try {
+            VFS.mountReal( content, mountPoint );
+            SelfContainedContentService service = new SelfContainedContentService( mountPoint );
+            serviceActivatorContext.getServiceTarget().addService( SelfContainedContentService.NAME, service ).install();
+        } catch (IOException e) {
+            throw new ServiceRegistryException(e);
+        }
+
+    }
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -67,6 +67,10 @@
             <artifactId>wildfly-network</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-self-contained</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-security-manager</artifactId>
         </dependency>

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -35,6 +35,7 @@ import java.util.TreeSet;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.repository.ContentRepository;
+import org.jboss.as.selfcontained.SelfContainedContentRepository;
 import org.jboss.as.server.deployment.ContentCleanerService;
 import org.jboss.as.server.deployment.DeploymentMountProvider;
 import org.jboss.as.server.logging.ServerLogger;
@@ -71,6 +72,7 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
     private final RunningModeControl runningModeControl;
     private final ControlledProcessState processState;
     private final boolean standalone;
+    private final boolean selfContained;
     private volatile FutureServiceContainer futureContainer;
     private volatile long startTime;
 
@@ -81,6 +83,7 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         runningModeControl = configuration.getRunningModeControl();
         startTime = configuration.getStartTime();
         standalone = configuration.getServerEnvironment().isStandalone();
+        selfContained = configuration.getServerEnvironment().isSelfContained();
         this.processState = processState;
     }
 
@@ -134,7 +137,11 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         bootstrapListener.getStabilityMonitor().addController(myController);
         // Install either a local or remote content repository
         if(standalone) {
-            ContentRepository.Factory.addService(serviceTarget, serverEnvironment.getServerContentDir());
+            if ( selfContained ) {
+                SelfContainedContentRepository.addService(serviceTarget);
+            } else {
+                ContentRepository.Factory.addService(serviceTarget, serverEnvironment.getServerContentDir());
+            }
         } else {
             RemoteFileRepositoryService.addService(serviceTarget, serverEnvironment.getServerContentDir());
         }

--- a/server/src/main/java/org/jboss/as/server/SelfContainedContainer.java
+++ b/server/src/main/java/org/jboss/as/server/SelfContainedContainer.java
@@ -1,0 +1,130 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.server;
+
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
+import org.jboss.as.process.ExitCodes;
+import org.jboss.as.selfcontained.SelfContainedConfigurationPersister;
+import org.jboss.as.selfcontained.SelfContainedContentServiceActivator;
+import org.jboss.as.version.ProductConfig;
+import org.jboss.dmr.ModelNode;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.stdio.LoggingOutputStream;
+import org.jboss.stdio.NullInputStream;
+import org.jboss.stdio.SimpleStdioContextSelector;
+import org.jboss.stdio.StdioContext;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * The main-class entry point for self-contained server instances.
+ *
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author John Bailey
+ * @author Brian Stansberry
+ * @author Anil Saldhana
+ * @author Bob McWhirter
+ */
+public final class SelfContainedContainer {
+    // Capture System.out and System.err before they are redirected by STDIO
+    private static final PrintStream STDERR = System.err;
+
+    public SelfContainedContainer() {
+    }
+
+    /**
+     * The main method.
+     *
+     * @param containerDefinition The container definition.
+     */
+    public void start(final List<ModelNode> containerDefinition, File content) {
+        Thread.currentThread().setContextClassLoader(Module.getCallerModule().getClassLoader());
+        try {
+            if (java.util.logging.LogManager.getLogManager().getClass().getName().equals("org.jboss.logmanager.LogManager")) {
+                // Make sure our original stdio is properly captured.
+                try {
+                    Class.forName(org.jboss.logmanager.handlers.ConsoleHandler.class.getName(), true, org.jboss.logmanager.handlers.ConsoleHandler.class.getClassLoader());
+                } catch (Throwable ignored) {
+                }
+                // Install JBoss Stdio to avoid any nasty crosstalk, after command line arguments are processed.
+                StdioContext.install();
+                final StdioContext context = StdioContext.create(
+                        new NullInputStream(),
+                        new LoggingOutputStream(org.jboss.logmanager.Logger.getLogger("stdout"), org.jboss.logmanager.Level.INFO),
+                        new LoggingOutputStream(org.jboss.logmanager.Logger.getLogger("stderr"), org.jboss.logmanager.Level.ERROR)
+                );
+                StdioContext.setStdioContextSelector(new SimpleStdioContextSelector(context));
+            }
+
+            Module.registerURLStreamHandlerFactoryModule(Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("org.jboss.vfs")));
+            ServerEnvironment serverEnvironment = determineEnvironment( WildFlySecurityManager.getSystemPropertiesPrivileged(), WildFlySecurityManager.getSystemEnvironmentPrivileged(), ServerEnvironment.LaunchType.SELF_CONTAINED);
+            if (serverEnvironment == null) {
+                abort(null);
+            } else {
+                final Bootstrap bootstrap = Bootstrap.Factory.newInstance();
+                final Bootstrap.Configuration configuration = new Bootstrap.Configuration(serverEnvironment);
+                configuration.setConfigurationPersisterFactory(
+                        new Bootstrap.ConfigurationPersisterFactory() {
+                            @Override
+                            public ExtensibleConfigurationPersister createConfigurationPersister(ServerEnvironment serverEnvironment, ExecutorService executorService) {
+                                SelfContainedConfigurationPersister persister = new SelfContainedConfigurationPersister( containerDefinition );
+                                configuration.getExtensionRegistry().setWriterRegistry(persister);
+                                return persister;
+                            }
+                        });
+                configuration.setModuleLoader(Module.getBootModuleLoader());
+
+                bootstrap.bootstrap(configuration, Collections.<ServiceActivator>singletonList(new SelfContainedContentServiceActivator(content))).get();
+            }
+        } catch (Throwable t) {
+            abort(t);
+        }
+    }
+
+    private static void abort(Throwable t) {
+        try {
+            if (t != null) {
+                t.printStackTrace(STDERR);
+            }
+        } finally {
+            SystemExiter.exit(ExitCodes.FAILED);
+        }
+    }
+
+    public static ServerEnvironment determineEnvironment(Properties systemProperties, Map<String, String> systemEnvironment, ServerEnvironment.LaunchType launchType) {
+        ProductConfig productConfig = new ProductConfig(Module.getBootModuleLoader(), WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.HOME_DIR, null), systemProperties);
+        return new ServerEnvironment(null, systemProperties, systemEnvironment, null, null, launchType, RunningMode.NORMAL, productConfig);
+    }
+
+}
+

--- a/server/src/main/java/org/jboss/as/server/ServerPathManagerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerPathManagerService.java
@@ -26,6 +26,8 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 
+import java.io.File;
+
 /**
  * Service containing the paths for a server
  *
@@ -37,13 +39,13 @@ public class ServerPathManagerService extends PathManagerService {
         ServiceBuilder<?> serviceBuilder = serviceTarget.addService(SERVICE_NAME, service);
 
         // Add environment paths
-        service.addHardcodedAbsolutePath(serviceTarget, ServerEnvironment.HOME_DIR, serverEnvironment.getHomeDir().getAbsolutePath());
-        service.addHardcodedAbsolutePath(serviceTarget, ServerEnvironment.SERVER_BASE_DIR, serverEnvironment.getServerBaseDir().getAbsolutePath());
-        service.addHardcodedAbsolutePath(serviceTarget, ServerEnvironment.SERVER_CONFIG_DIR, serverEnvironment.getServerConfigurationDir().getAbsolutePath());
-        service.addHardcodedAbsolutePath(serviceTarget, ServerEnvironment.SERVER_DATA_DIR, serverEnvironment.getServerDataDir().getAbsolutePath());
-        service.addHardcodedAbsolutePath(serviceTarget, ServerEnvironment.SERVER_LOG_DIR, serverEnvironment.getServerLogDir().getAbsolutePath());
-        service.addHardcodedAbsolutePath(serviceTarget, ServerEnvironment.SERVER_TEMP_DIR, serverEnvironment.getServerTempDir().getAbsolutePath());
-        service.addHardcodedAbsolutePath(serviceTarget, ServerEnvironment.CONTROLLER_TEMP_DIR, serverEnvironment.getControllerTempDir().getAbsolutePath());
+        addAbsolutePath(service, serviceTarget, ServerEnvironment.HOME_DIR, serverEnvironment.getHomeDir());
+        addAbsolutePath(service, serviceTarget, ServerEnvironment.SERVER_BASE_DIR, serverEnvironment.getServerBaseDir());
+        addAbsolutePath(service, serviceTarget, ServerEnvironment.SERVER_CONFIG_DIR, serverEnvironment.getServerConfigurationDir());
+        addAbsolutePath(service, serviceTarget, ServerEnvironment.SERVER_DATA_DIR, serverEnvironment.getServerDataDir());
+        addAbsolutePath(service, serviceTarget, ServerEnvironment.SERVER_LOG_DIR, serverEnvironment.getServerLogDir());
+        addAbsolutePath(service, serviceTarget, ServerEnvironment.SERVER_TEMP_DIR, serverEnvironment.getServerTempDir());
+        addAbsolutePath(service, serviceTarget, ServerEnvironment.CONTROLLER_TEMP_DIR, serverEnvironment.getControllerTempDir());
 
         // Add system paths
         service.addHardcodedAbsolutePath(serviceTarget, "user.dir", System.getProperty("user.dir"));
@@ -61,6 +63,14 @@ public class ServerPathManagerService extends PathManagerService {
         }
 
         return serviceBuilder.install();
+    }
+
+    private static void addAbsolutePath(ServerPathManagerService service, ServiceTarget serviceTarget, String name, File path) {
+        if (path == null) {
+            return;
+        }
+
+        service.addHardcodedAbsolutePath(serviceTarget, name, path.getAbsolutePath());
     }
 
 }

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1111,4 +1111,8 @@ public interface ServerLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 224, value="Could not mount overlay %s as parent %s is not a directory")
     void couldNotMountOverlay(String path, VirtualFile parent);
+
+    @Message(id = 225, value="Unable to create temporary directory")
+    RuntimeException unableToCreateSelfContainedDir();
+
 }


### PR DESCRIPTION
- Add a SELF_CONTAINED ProcessType and LaunchType
- Configure ServerEnvironment differently if LaunchType.SELF_CONTAINED is used
- Adjust all path-related operations (properties, ServerPathManagerService) to accomodate
  possibly null paths.
- Add a self-contained module
  - ConfigurationPersister
  - ContentRepository
- Add a SelfContainedContainer to be used by wildfly-boot to launch a self-contained
  Wildfly from within an existing and external main().