### PR TITLE
Skip validation of runtime resources

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -475,7 +475,7 @@ class ModelControllerImpl implements ModelController {
 
         for (String name : resource.getChildTypes()) {
             for (ResourceEntry entry : resource.getChildren(name)) {
-                if (!entry.isProxy()) {
+                if (!entry.isProxy() && !entry.isRuntime()) {
                     addAllAddresses(current.append(entry.getPathElement()), entry, addresses);
                 }
             }


### PR DESCRIPTION
In PR #582 the resources children are still read which in some cases could be expensive. This stops the resource from being validated as well as being read.