### PR TITLE
upgrade to XNIO 3.3.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <version.org.jboss.staxmapper>1.2.0.Beta1</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.0.2.GA</version.org.jboss.stdio>
         <version.org.jboss.threads>2.2.0.Final</version.org.jboss.threads>
-        <version.org.jboss.xnio>3.3.0.Final</version.org.jboss.xnio>
+        <version.org.jboss.xnio>3.3.1.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.mockito>1.9.5</version.org.mockito>


### PR DESCRIPTION
Change to "avoid ACE when getting SASL providers" is expected to help with EJB30-SEC TCK failures