### PR TITLE
Nested attribute groups

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -40,6 +40,7 @@ import org.jboss.dmr.ModelType;
  * @param <ATTRIBUTE> the type of {@link org.jboss.as.controller.AttributeDefinition} produced by the {@link #build()} method
  *
  * @author Tomaz Cerar
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
  */
 @SuppressWarnings("unchecked")
 public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends AbstractAttributeDefinitionBuilder, ATTRIBUTE extends AttributeDefinition> {
@@ -66,7 +67,7 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
     protected AccessConstraintDefinition[] accessConstraints;
     protected Boolean nullSignificant;
     protected AttributeParser parser;
-    protected String attributeGroup;
+    protected AttributeGroup attributeGroup;
 
     /**
      * Creates a builder for an attribute with the give name and type. Equivalent to
@@ -522,12 +523,17 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
     /**
      * Sets the name of the attribute group with which this attribute is associated.
      *
-     * @param attributeGroup the attribute group name. Cannot be an empty string but can be {@code null}
-     *                       if the attribute is not associated with a group.
+     * @param attributeGroupComponents the components that constitute attribute group name. Can be {@code null} if the attribute
+     *        is not associated with a group. Non of components can be {@code null} or empty string.
      * @return a builder that can be used to continue building the attribute definition
      */
-    public BUILDER setAttributeGroup(String attributeGroup) {
-        assert attributeGroup == null || attributeGroup.length() > 0;
+    public BUILDER setAttributeGroup(String... attributeGroupComponents) {
+        final AttributeGroup attributeGroup;
+        if (attributeGroupComponents == null) {
+            attributeGroup = null;
+        } else {
+            attributeGroup = new AttributeGroup(attributeGroupComponents);
+        }
         this.attributeGroup = attributeGroup;
         return (BUILDER) this;
     }
@@ -664,7 +670,7 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
         return parser;
     }
 
-    public String getAttributeGroup() {
+    public AttributeGroup getAttributeGroup() {
         return attributeGroup;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributesXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributesXMLDescription.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+public abstract class AbstractAttributesXMLDescription implements AttributesXMLDescription{
+
+    protected final Map<String, PropertiesAttributeDefinition> propertyAttributes =new LinkedHashMap<String, PropertiesAttributeDefinition>();
+    protected final List<String> tags=new LinkedList<>();
+
+    @Override
+    public List<String> getTags() {
+        return tags;
+    }
+
+    protected void registerPropertyAttribute(final AttributeDefinition attribute) {
+        final PropertiesAttributeDefinition property = (PropertiesAttributeDefinition) attribute;
+        if (!property.isWrapped()) {
+            propertyAttributes.put(property.getXmlName(), property);
+            tags.add(property.getXmlName());
+        } else {
+            propertyAttributes.put(property.getWrapperElement(), property);
+            tags.add(property.getWrapperElement());
+        }
+    }
+
+    protected void parseProperty(final String tag, final XMLExtendedStreamReader reader, final ModelNode operation)
+            throws XMLStreamException {
+        final PropertiesAttributeDefinition property = propertyAttributes.get(tag);
+        if (!property.isWrapped()) {
+            property.parse(reader, operation);
+        } else {
+            while (reader.hasNext()) {
+                if (reader.nextTag() == XMLStreamConstants.END_ELEMENT) {
+                    if (property.getWrapperElement().equals(reader.getLocalName())) {
+                        break;
+                    }
+                    // else continue to the next children
+                    continue;
+                }
+                property.parse(reader, operation);
+            }
+        }
+    }
+
+    protected boolean willCreatePropertyTags(final ModelNode resourceModel) {
+        for (final PropertiesAttributeDefinition property : propertyAttributes.values()) {
+            if (resourceModel.hasDefined(property.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected void persistAttributes(final Collection<? extends AttributeDefinition> attributes,
+            final XMLExtendedStreamWriter writer, final ModelNode resourceModel,
+            final Map<String, AttributeMarshaller> attributeMarshallers, final boolean marshallDefault) throws XMLStreamException {
+        for (final AttributeDefinition attribute : attributes) {
+            final AttributeMarshaller marshaller = attributeMarshallers.containsKey(attribute.getName()) ? attributeMarshallers
+                    .get(attribute.getName()) : attribute.getAttributeMarshaller();
+            if (marshaller.isMarshallable(attribute, resourceModel, marshallDefault)) {
+                marshaller.marshallAsAttribute(attribute, resourceModel, marshallDefault, writer);
+            }
+        }
+    }
+
+}

--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -58,6 +58,7 @@ import org.jboss.dmr.ModelType;
  * methods for validation.
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
  */
 public abstract class AttributeDefinition {
 
@@ -84,7 +85,7 @@ public abstract class AttributeDefinition {
     private final List<AccessConstraintDefinition> accessConstraints;
     private final Boolean nilSignificant;
     private final AttributeParser parser;
-    private final String attributeGroup;
+    private final AttributeGroup attributeGroup;
 
     // NOTE: Standards for creating a constructor variant are:
     // 1) Expected to be a common use case; no one-offs.
@@ -167,7 +168,7 @@ public abstract class AttributeDefinition {
                                 final ParameterCorrector valueCorrector, final ParameterValidator validator, final boolean validateNull,
                                 final String[] alternatives, final String[] requires, AttributeMarshaller attributeMarshaller,
                                 boolean resourceOnly, DeprecationData deprecationData, final List<AccessConstraintDefinition> accessConstraints,
-                                Boolean nilSignificant, AttributeParser parser, final String attributeGroup, ModelNode[] allowedValues, final EnumSet<AttributeAccess.Flag> flags) {
+                                Boolean nilSignificant, AttributeParser parser, final AttributeGroup attributeGroup, ModelNode[] allowedValues, final EnumSet<AttributeAccess.Flag> flags) {
 
         this.name = name;
         this.xmlName = xmlName == null ? name : xmlName;
@@ -290,7 +291,7 @@ public abstract class AttributeDefinition {
      *
      * @return the name of the group, or {@code null} if the attribute is not associated with a group
      */
-    public String getAttributeGroup() {
+    public AttributeGroup getAttributeGroup() {
         return attributeGroup;
     }
 
@@ -781,7 +782,11 @@ public abstract class AttributeDefinition {
         result.get(ModelDescriptionConstants.TYPE).set(type);
         result.get(ModelDescriptionConstants.DESCRIPTION); // placeholder
         if (attributeGroup != null) {
-            result.get(ModelDescriptionConstants.ATTRIBUTE_GROUP).set(attributeGroup);
+            final ModelNode attributeGroupNode = new ModelNode();
+            for (final String component : attributeGroup) {
+                attributeGroupNode.add(component);
+            }
+            result.get(ModelDescriptionConstants.ATTRIBUTE_GROUP).set(attributeGroupNode);
         }
         result.get(ModelDescriptionConstants.EXPRESSIONS_ALLOWED).set(isAllowExpression());
         if (forOperation) {
@@ -996,7 +1001,7 @@ public abstract class AttributeDefinition {
     public static final class NameAndGroup implements Comparable<NameAndGroup> {
 
         private final String name;
-        private final String group;
+        private final AttributeGroup group;
 
         public NameAndGroup(AttributeDefinition ad) {
             this(ad.getName(), ad.getAttributeGroup());
@@ -1007,7 +1012,7 @@ public abstract class AttributeDefinition {
             this.group = null;
         }
 
-        public NameAndGroup(String name, String group) {
+        public NameAndGroup(String name, AttributeGroup group) {
             this.name = name;
             this.group = group;
         }
@@ -1016,7 +1021,7 @@ public abstract class AttributeDefinition {
             return name;
         }
 
-        public String getGroup() {
+        public AttributeGroup getGroup() {
             return group;
         }
 
@@ -1030,7 +1035,7 @@ public abstract class AttributeDefinition {
             } else if (o.group == null) {
                 return 1;
             } else {
-                int groupComp = group.compareTo(o.group);
+                int groupComp = this.group.compareTo(o.group);
                 if (groupComp != 0) {
                     return groupComp;
                 }

--- a/controller/src/main/java/org/jboss/as/controller/AttributeGroup.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeGroup.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+
+package org.jboss.as.controller;
+
+import org.jboss.dmr.ModelNode;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *  Group of an {@link org.jboss.as.controller.AttributeDefinition} which consist of a list of {@link java.lang.String} elements.
+ *
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+public final class AttributeGroup implements Comparable<AttributeGroup>, Iterable<String> {
+
+    private final List<String> elements;
+
+    public AttributeGroup(final String... elements) {
+        this.elements = new LinkedList<>();
+        for (final String element : elements) {
+            this.elements.add(element);
+        }
+    }
+
+    public AttributeGroup(final Iterable<ModelNode> elements) {
+        this.elements = new LinkedList<>();
+        for (final ModelNode element : elements) {
+            this.elements.add(element.asString());
+        }
+    }
+
+    @Override
+    public int compareTo(final AttributeGroup o) {
+        final Iterator<String> ai = this.elements.iterator();
+        final Iterator<String> bi = o.elements.iterator();
+        while (ai.hasNext() || bi.hasNext()) {
+            if (!ai.hasNext()) {
+                return -1;
+            }
+            if (!bi.hasNext()) {
+                return 1;
+            }
+            int r = ai.next().compareTo(bi.next());
+            if (r != 0) {
+                return r;
+            }
+        }
+        return 0;
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return elements.iterator();
+    }
+
+    @Override
+    public String toString() {
+        return String.join(".", elements);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        for (String s : elements) {
+            result = result * prime + s.hashCode();
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (!(o instanceof AttributeGroup)) {
+            return false;
+        } else {
+            return this.compareTo((AttributeGroup) o) == 0;
+        }
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/AttributesXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributesXMLDescription.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import java.util.Collection;
+import java.util.Map;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+ * XML description of attributes in a {@link org.jboss.as.controller.registry.Resource}. Allows parsing and persisting
+ * Resource's attributes XML configuration.
+ *
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+interface AttributesXMLDescription {
+
+
+    /**
+     * Registers {@link org.jboss.as.controller.AttributeDefinition} in the description.
+     *
+     * @param attributeDefinition Attribute to be registered.
+     */
+    void registerAttribute(AttributeDefinition attributeDefinition);
+
+    /**
+     * List of {@link org.jboss.as.controller.AttributeDefinition} that are part of root XML tag of the described
+     * {@link org.jboss.as.controller.registry.Resource}.
+     *
+     * @return Map of root attributes.
+     */
+    Map<String, AttributeDefinition> getRootAttributes();
+
+    /**
+     * Collection of XML tags that can be created by this description.
+     * {@link org.jboss.as.controller.PersistentResourceXMLDescription} uses this list to determine whether parsing of a given
+     * tag can be delegated to {@link org.jboss.as.controller.AttributesXMLDescription} implementation.
+     *
+     * @return Tags collection.
+     */
+    Collection<String> getTags();
+
+    /**
+     * Parse XML tag. {@link org.jboss.as.controller.PersistentResourceXMLDescription} delegates parsing the tag to
+     * {@link org.jboss.as.controller.AttributesXMLDescription} implementation based on Collection of tags returned by
+     * {@link #getTags()} method.
+     *
+     * @param tag Tag to be parsed.
+     * @param reader XML reader.
+     * @param attributeParsers Map of attribute parsers. If attribute is no present in the map then it's default parser should be used.
+     * @param operation Result {@link org.jboss.dmr.ModelNode} operation to which parsed attributes should be added.
+     * @throws XMLStreamException
+     */
+    void parseTag(String tag, XMLExtendedStreamReader reader, Map<String, AttributeParser> attributeParsers, ModelNode operation) throws XMLStreamException;
+
+    /**
+     * {@link org.jboss.as.controller.PersistentResourceXMLDescription} uses this method to determine whether the description
+     * will create nested xml tags in root {@link org.jboss.as.controller.registry.Resource} tag when persisting given model.
+     *
+     * @param resourceModel The model, a non-null node of {@link org.jboss.dmr.ModelType#OBJECT}.
+     * @param marshallDefault {@code true} if the value should be marshalled even if it matches the default value.
+     * @return {@code true} if nested tags will be created when persisting given resourceModel
+     */
+    boolean willCreateTags(final ModelNode resourceModel, final boolean marshallDefault);
+
+    /**
+     * Persist attributes of a given {@link org.jboss.as.controller.registry.Resource}.
+     *
+     * @param writer XML writer.
+     * @param resourceModel   The model, a non-null node of {@link org.jboss.dmr.ModelType#OBJECT}.
+     * @param marshallDefault {@code true} if the value should be marshalled even if it matches the default value.
+     * @throws XMLStreamException
+     */
+    void persist(XMLExtendedStreamWriter writer, ModelNode resourceModel, final Map<String, AttributeMarshaller> attributeMarshallers, boolean marshallDefault) throws XMLStreamException;
+
+}

--- a/controller/src/main/java/org/jboss/as/controller/IgnoreGroupsAttributesXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/IgnoreGroupsAttributesXMLDescription.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+ * {@link org.jboss.as.controller.AttributesXMLDescription} implementation which ignores attributes groups. All non-property
+ * attributes are persisted as root attributes.
+ *
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+public class IgnoreGroupsAttributesXMLDescription extends AbstractAttributesXMLDescription {
+
+    private final Map<String,AttributeDefinition> rootAttributes = new LinkedHashMap<>();
+
+    @Override
+    public void registerAttribute(final AttributeDefinition attribute) {
+        if(attribute instanceof  PropertiesAttributeDefinition){
+            registerPropertyAttribute(attribute);
+        } else {
+            rootAttributes.put(attribute.getXmlName(), attribute);
+        }
+    }
+
+    @Override
+    public Map<String, AttributeDefinition> getRootAttributes() {
+        return rootAttributes;
+    }
+
+    @Override
+    public void parseTag(String tag, XMLExtendedStreamReader reader, Map<String, AttributeParser> attributeParsers,
+            ModelNode operation) throws XMLStreamException {
+        parseProperty(tag, reader, operation);
+    }
+
+    @Override
+    public boolean willCreateTags(final ModelNode resourceModel, final boolean marshallDefault){
+        return willCreatePropertyTags(resourceModel);
+    }
+
+    @Override
+    public void persist(XMLExtendedStreamWriter writer, ModelNode resourceModel,
+            final Map<String, AttributeMarshaller> attributeMarshallers, boolean marshallDefault) throws XMLStreamException {
+        final Collection<AttributeDefinition> attributes = rootAttributes.values();
+        persistAttributes(attributes, writer, resourceModel, attributeMarshallers, marshallDefault);
+        final Collection<PropertiesAttributeDefinition> properties = propertyAttributes.values();
+        persistAttributes(properties, writer, resourceModel, attributeMarshallers, marshallDefault);
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/NestGroupedAttributesXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/NestGroupedAttributesXMLDescription.java
@@ -1,0 +1,218 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+public class NestGroupedAttributesXMLDescription extends AbstractAttributesXMLDescription {
+
+    final Node root = new Node(null);
+
+    @Override
+    public void registerAttribute(final AttributeDefinition attribute) {
+        if (attribute.getAttributeGroup() == null) {
+            if (attribute instanceof PropertiesAttributeDefinition) {
+                registerPropertyAttribute(attribute);
+            } else {
+                root.addAttribute(attribute);
+            }
+        } else {
+            registerGroupedAttribute(attribute);
+        }
+    }
+
+    private void registerGroupedAttribute(final AttributeDefinition attribute) {
+        Node n = root;
+        for (final String element : attribute.getAttributeGroup()) {
+            if (n == root) {
+                tags.add(element);
+            }
+            Node t = n.getChild(element);
+            if (t == null) {
+                t = n.addChild(element);
+            }
+            n = t;
+        }
+        n.addAttribute(attribute);
+    }
+
+    @Override
+    public void parseTag(final String tag, final XMLExtendedStreamReader reader,
+            final Map<String, AttributeParser> attributeParsers, ModelNode operation) throws XMLStreamException {
+        final Node node = root.getChild(tag);
+        if (node != null) {
+            parseNode(reader, attributeParsers, node, operation);
+        } else {
+            parseProperty(tag, reader, operation);
+        }
+    }
+
+    private void parseNode(final XMLExtendedStreamReader reader, final Map<String, AttributeParser> attributeParsers,
+                           final Node node, final ModelNode operation) throws XMLStreamException {
+        final Map<String, AttributeDefinition> attributes = node.getAttributes();
+        for (int i = 0; i < reader.getAttributeCount(); i++) {
+            final String attributeName = reader.getAttributeLocalName(i);
+            final String value = reader.getAttributeValue(i);
+            if (attributes.containsKey(attributeName)) {
+                final AttributeDefinition attribute = attributes.get(attributeName);
+                final AttributeParser parser = attributeParsers.containsKey(attributeName) ? attributeParsers.get(attributeName)
+                        : attribute.getParser();
+                assert parser != null;
+                parser.parseAndSetParameter(attribute, value, operation, reader);
+            } else {
+                throw ParseUtils.unexpectedAttribute(reader, i, attributes.keySet());
+            }
+        }
+        while (reader.hasNext()) {
+            if (reader.nextTag() == XMLStreamConstants.END_ELEMENT) {
+                // break the loop at the end of the parent element
+                if (node.element.equals(reader.getLocalName())) {
+                    break;
+                }
+                // else continue to the next children
+                continue;
+            }
+            final Node child = node.getChild(reader.getLocalName());
+            if (child != null) {
+                parseNode(reader, attributeParsers, child, operation);
+            } else {
+                throw ParseUtils.unexpectedElement(reader, node.children.keySet());
+            }
+        }
+    }
+
+    @Override
+    public boolean willCreateTags(final ModelNode resourceModel, final boolean marshallDefault) {
+        final boolean groupedAttributesTags = (checkNodeXML(root, resourceModel, marshallDefault) == NodeXML.NESTED_TAGS);
+        final boolean propertiesTags = willCreatePropertyTags(resourceModel);
+        return groupedAttributesTags || propertiesTags;
+    }
+
+    @Override
+    public void persist(final XMLExtendedStreamWriter writer, final ModelNode resourceModel,
+            final Map<String, AttributeMarshaller> attributeMarshallers, final boolean marshallDefault) throws XMLStreamException {
+        final Collection<AttributeDefinition> rootAttributes = root.getAttributes().values();
+        persistAttributes(rootAttributes, writer, resourceModel, attributeMarshallers, marshallDefault);
+        for (final Node node : root.getChildren()) {
+            persistNode(node, writer, resourceModel, attributeMarshallers, marshallDefault);
+        }
+        final Collection<PropertiesAttributeDefinition> properties = propertyAttributes.values();
+        persistAttributes(properties, writer, resourceModel, attributeMarshallers, marshallDefault);
+    }
+
+    private void persistNode(final Node node, final XMLExtendedStreamWriter writer, final ModelNode resourceModel,
+            final Map<String, AttributeMarshaller> attributeMarshallers, final boolean marshallDefault)
+            throws XMLStreamException {
+        final NodeXML nodeXML = checkNodeXML(node, resourceModel, marshallDefault);
+        if (nodeXML == NodeXML.NESTED_TAGS) {
+            writer.writeStartElement(node.getElement());
+        } else if (nodeXML == NodeXML.EMPTY_TAG) {
+            writer.writeEmptyElement(node.getElement());
+        }
+
+        final Collection<AttributeDefinition> nodeAttributes = node.getAttributes().values();
+        persistAttributes(nodeAttributes, writer, resourceModel, attributeMarshallers, marshallDefault);
+        for (final Node child : node.getChildren()) {
+            persistNode(child, writer, resourceModel, attributeMarshallers, marshallDefault);
+        }
+
+        if (nodeXML == NodeXML.NESTED_TAGS) {
+            writer.writeEndElement();
+        }
+    }
+
+    private NodeXML checkNodeXML(final Node node, final ModelNode model, final boolean marshalDefault){
+        for(final Node child: node.getChildren()){
+            if(checkNodeXML(child, model, marshalDefault)!=NodeXML.NONE){
+                return NodeXML.NESTED_TAGS;
+            }
+        }
+        for(final AttributeDefinition attribute: node.getAttributes().values()){
+            final AttributeMarshaller marshaller=attribute.getAttributeMarshaller();
+            if(marshaller.isMarshallable(attribute, model, marshalDefault)){
+                return NodeXML.EMPTY_TAG;
+            }
+        }
+        return NodeXML.NONE;
+    }
+
+    @Override
+    public Map<String, AttributeDefinition> getRootAttributes() {
+        return root.getAttributes();
+    }
+
+    private class Node {
+        private final String element;
+        private final Map<String, Node> children = new LinkedHashMap<>();
+        private final Map<String, AttributeDefinition> attributes = new LinkedHashMap<>();
+
+        public Node(final String element) {
+            this.element = element;
+        }
+
+        public String getElement() {
+            return element;
+        }
+
+        public Node getChild(final String child) {
+            return children.get(child);
+        }
+
+        public Collection<Node> getChildren() {
+            return children.values();
+        }
+
+        public Node addChild(final String name) {
+            final Node child = new Node(name);
+            children.put(name, child);
+            return child;
+        }
+
+        public Map<String, AttributeDefinition> getAttributes() {
+            return attributes;
+        }
+
+        public void addAttribute(final AttributeDefinition attribute) {
+            attributes.put(attribute.getXmlName(), attribute);
+        }
+     }
+
+    private enum NodeXML {
+        NESTED_TAGS,
+        EMPTY_TAG,
+        NONE
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/PropertiesAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PropertiesAttributeDefinition.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
-import javax.xml.stream.XMLStreamConstants;
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
@@ -47,12 +47,18 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  *
  * @author Jason T. Greene
  * @author Tomaz Cerar<
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
  */
 //todo maybe replace with SimpleMapAttributeDefinition?
 public final class PropertiesAttributeDefinition extends MapAttributeDefinition {
 
+    final boolean wrapXmlElement;
+    final String wrapperElement;
+
     private PropertiesAttributeDefinition(final Builder builder) {
         super(builder);
+        this.wrapXmlElement = builder.wrapXmlElement;
+        this.wrapperElement = builder.wrapperElement;
     }
 
     @Override
@@ -95,15 +101,17 @@ public final class PropertiesAttributeDefinition extends MapAttributeDefinition 
     }
 
     public void parse(final XMLExtendedStreamReader reader, final ModelNode operation) throws XMLStreamException {
-        while (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT) {
-            if (reader.getLocalName().equals(getXmlName())) {
-                final String[] array = requireAttributes(reader, org.jboss.as.controller.parsing.Attribute.NAME.getLocalName(), org.jboss.as.controller.parsing.Attribute.VALUE.getLocalName());
-                parseAndAddParameterElement(array[0], array[1], operation, reader);
-                ParseUtils.requireNoContent(reader);
-            } else {
-                throw ParseUtils.unexpectedElement(reader);
-            }
-        }
+        final String[] array = requireAttributes(reader, org.jboss.as.controller.parsing.Attribute.NAME.getLocalName(), org.jboss.as.controller.parsing.Attribute.VALUE.getLocalName());
+        parseAndAddParameterElement(array[0], array[1], operation, reader);
+        ParseUtils.requireNoContent(reader);
+    }
+
+    public boolean isWrapped() {
+        return wrapXmlElement;
+    }
+
+    public String getWrapperElement() {
+        return wrapperElement;
     }
 
     private static class PropertiesAttributeMarshaller extends AttributeMarshaller {

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -171,6 +171,7 @@ public class ModelDescriptionConstants {
     public static final String FULL_REPLACE_DEPLOYMENT = "full-replace-deployment";
     public static final String GRACEFUL_SHUTDOWN_TIMEOUT = "graceful-shutdown-timeout";
     public static final String GROUP = "group";
+    public static final String GROUP_ELEMENT = "group-element";
     public static final String GROUP_ATTRIBUTE = "group-attribute";
     public static final String GROUP_DN_ATTRIBUTE = "group-dn-attribute";
     public static final String GROUP_NAME_ATTRIBUTE = "group-name-attribute";

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationAttributes.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationAttributes.java
@@ -21,8 +21,11 @@
  */
 package org.jboss.as.controller.operations.global;
 
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ParameterCorrector;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleListAttributeDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
@@ -32,6 +35,7 @@ import org.jboss.dmr.ModelType;
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
  */
 class GlobalOperationAttributes {
 
@@ -90,4 +94,26 @@ class GlobalOperationAttributes {
     .setAllowNull(true)
     .build();
 
+    static final AttributeDefinition GROUP_ELEMENT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.GROUP_ELEMENT, ModelType.STRING, true)
+    .setAllowNull(false)
+    .build();
+
+    static final SimpleListAttributeDefinition ATTRIBUTE_GROUP = new SimpleListAttributeDefinition.Builder(ModelDescriptionConstants.NAME, GROUP_ELEMENT)
+    .setAllowNull(true)
+    .setCorrector(StringToListCorrector.INSTANCE)
+    .build();
+
+    private static class StringToListCorrector implements ParameterCorrector {
+        private static final StringToListCorrector INSTANCE = new StringToListCorrector();
+
+        @Override
+        public ModelNode correct(final ModelNode newValue, final ModelNode currentValue) {
+            ModelNode result = newValue;
+            if (newValue.getType() == ModelType.STRING) {
+                result = new ModelNode();
+                result.add(newValue);
+            }
+            return result;
+        }
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeGroupNamesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeGroupNamesHandler.java
@@ -62,8 +62,9 @@ public class ReadAttributeGroupNamesHandler implements OperationStepHandler {
         TreeSet<String> groupNames = new TreeSet<String>();
         for (final String attributeName : attributeNames) {
             final AttributeAccess attribute = registry.getAttributeAccess(PathAddress.EMPTY_ADDRESS, attributeName);
-            if (attribute.getAttributeDefinition().getAttributeGroup() != null) {
-                groupNames.add(attribute.getAttributeDefinition().getAttributeGroup());
+            final String attributeGroup = attribute.getAttributeDefinition().getAttributeGroup().toString();
+            if (attributeGroup != null) {
+                groupNames.add(attributeGroup);
             }
         }
         for (String groupName : groupNames) {

--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
@@ -47,6 +47,7 @@ import javax.xml.transform.stream.StreamSource;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.AttributeParser;
+import org.jboss.as.controller.NestGroupedAttributesXMLDescription;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
@@ -75,6 +76,7 @@ import org.w3c.dom.ls.LSSerializer;
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
  * @author Tomaz Cerar
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
  */
 public class PersistentResourceXMLParserTestCase {
 
@@ -113,12 +115,21 @@ public class PersistentResourceXMLParserTestCase {
 
         ModelNode subsystem = opsToModel(operations);
 
-        assertEquals("bar", subsystem.get("resource", "foo", "cluster-attr1").asString());
-        assertEquals("baz", subsystem.get("resource", "foo", "cluster-attr2").asString());
-        assertEquals("alice", subsystem.get("resource", "foo", "security-my-attr1").asString());
-        assertEquals("bob", subsystem.get("resource", "foo", "security-my-attr2").asString());
-        assertEquals("bar2", subsystem.get("resource", "foo2", "cluster-attr1").asString());
-        assertEquals("baz2", subsystem.get("resource", "foo2", "cluster-attr2").asString());
+        assertEquals("yada", subsystem.get("resource", "resource1", "root-attr1").asString());
+        assertEquals("bar", subsystem.get("resource", "resource1", "base1-attr1").asString());
+        assertEquals("baz", subsystem.get("resource", "resource1", "base1-attr2").asString());
+        assertEquals("foo", subsystem.get("resource", "resource1", "base1-nested1-attr1").asString());
+        assertEquals("bob", subsystem.get("resource", "resource1", "base1-nested1-attr2").asString());
+        assertEquals("apple", subsystem.get("resource", "resource1", "base1-nested2-attr1").asString());
+        assertEquals("dog", subsystem.get("resource", "resource1", "base1-nested2-attr2").asString());
+        assertEquals("abc", subsystem.get("resource", "resource1", "base2-attr1").asString());
+        assertEquals("bah", subsystem.get("resource", "resource1", "base2-nested1-attr1").asString());
+
+        assertEquals("yada2", subsystem.get("resource", "resource2", "root-attr1").asString());
+        assertEquals("baz2", subsystem.get("resource", "resource2", "base1-attr2").asString());
+        assertEquals("bar2", subsystem.get("resource", "resource2", "base1-attr1").asString());
+        assertEquals("foo2", subsystem.get("resource", "resource2", "base1-nested1-attr1").asString());
+        assertEquals("bob2", subsystem.get("resource", "resource2", "base1-nested1-attr2").asString());
 
         StringWriter stringWriter = new StringWriter();
         XMLExtendedStreamWriter xmlStreamWriter = createXMLStreamWriter(XMLOutputFactory.newInstance()
@@ -145,12 +156,21 @@ public class PersistentResourceXMLParserTestCase {
 
         ModelNode subsystem = opsToModel(operations);
 
-        assertEquals("bar", subsystem.get("resource", "foo", "cluster-attr1").asString());
-        assertEquals("baz", subsystem.get("resource", "foo", "cluster-attr2").asString());
-        assertEquals("alice", subsystem.get("resource", "foo", "security-my-attr1").asString());
-        assertEquals("bob", subsystem.get("resource", "foo", "security-my-attr2").asString());
-        assertEquals("bar2", subsystem.get("resource", "foo2", "cluster-attr1").asString());
-        assertEquals("baz2", subsystem.get("resource", "foo2", "cluster-attr2").asString());
+        assertEquals("yada", subsystem.get("resource", "resource1", "root-attr1").asString());
+        assertEquals("bar", subsystem.get("resource", "resource1", "base1-attr1").asString());
+        assertEquals("baz", subsystem.get("resource", "resource1", "base1-attr2").asString());
+        assertEquals("foo", subsystem.get("resource", "resource1", "base1-nested1-attr1").asString());
+        assertEquals("bob", subsystem.get("resource", "resource1", "base1-nested1-attr2").asString());
+        assertEquals("apple", subsystem.get("resource", "resource1", "base1-nested2-attr1").asString());
+        assertEquals("dog", subsystem.get("resource", "resource1", "base1-nested2-attr2").asString());
+        assertEquals("abc", subsystem.get("resource", "resource1", "base2-attr1").asString());
+        assertEquals("bah", subsystem.get("resource", "resource1", "base2-nested1-attr1").asString());
+
+        assertEquals("yada2", subsystem.get("resource", "resource2", "root-attr1").asString());
+        assertEquals("baz2", subsystem.get("resource", "resource2", "base1-attr2").asString());
+        assertEquals("bar2", subsystem.get("resource", "resource2", "base1-attr1").asString());
+        assertEquals("foo2", subsystem.get("resource", "resource2", "base1-nested1-attr1").asString());
+        assertEquals("bob2", subsystem.get("resource", "resource2", "base1-nested1-attr2").asString());
 
         StringWriter stringWriter = new StringWriter();
         XMLExtendedStreamWriter xmlStreamWriter = createXMLStreamWriter(XMLOutputFactory.newInstance()
@@ -263,26 +283,52 @@ public class PersistentResourceXMLParserTestCase {
         protected static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "foo");
 
 
-        static final AttributeDefinition clusterAttr1 = create("cluster-attr1", ModelType.STRING)
-                .setAttributeGroup("cluster")
+        static final AttributeDefinition rootAttr1 = create("root-attr1", ModelType.STRING)
                 .setXmlName("attr1")
                 .build();
-        static final AttributeDefinition clusterAttr2 = create("cluster-attr2", ModelType.STRING)
-                .setAttributeGroup("cluster")
+
+        static final AttributeDefinition rootAttr2 = create("root-attr2", ModelType.STRING)
                 .setXmlName("attr2")
                 .build();
 
-        static final AttributeDefinition securityAttr1 = create("security-my-attr1", ModelType.STRING)
-                .setAttributeGroup("security")
-                .setXmlName("my-attr1")
+        static final AttributeDefinition base1Attr1 = create("base1-attr1", ModelType.STRING)
+                .setAttributeGroup("base1")
+                .setXmlName("attr1")
                 .build();
-        static final AttributeDefinition securityAttr2 = create("security-my-attr2", ModelType.STRING)
-                .setAttributeGroup("security")
-                .setXmlName("my-attr2")
+        static final AttributeDefinition base1Attr2 = create("base1-attr2", ModelType.STRING)
+                .setAttributeGroup("base1")
+                .setXmlName("attr2")
                 .build();
-        static final AttributeDefinition nonGroupAttr1 = create("non-group-attr", ModelType.STRING)
-                .setXmlName("no-attr1")
+
+        static final AttributeDefinition base1Nested1Attr1 = create("base1-nested1-attr1", ModelType.STRING)
+                .setAttributeGroup("base1","nested1")
+                .setXmlName("attr1")
                 .build();
+        static final AttributeDefinition base1Nested1Attr2 = create("base1-nested1-attr2", ModelType.STRING)
+                .setAttributeGroup("base1","nested1")
+                .setXmlName("attr2")
+                .build();
+
+        static final AttributeDefinition base1Nested2Attr1 = create("base1-nested2-attr1", ModelType.STRING)
+                .setAttributeGroup("base1","nested2")
+                .setXmlName("attr1")
+                .build();
+        static final AttributeDefinition base1Nested2Attr2 = create("base1-nested2-attr2", ModelType.STRING)
+                .setAttributeGroup("base1","nested2")
+                .setXmlName("attr2")
+                .build();
+
+        static final AttributeDefinition base2Attr1 = create("base2-attr1", ModelType.STRING)
+                .setAttributeGroup("base2")
+                .setXmlName("attr1")
+                .build();
+
+        static final AttributeDefinition base2Nested1Attr1 = create("base2-nested1-attr1", ModelType.STRING)
+                .setAttributeGroup("base2","nested1")
+                .setXmlName("attr1")
+                .build();
+
+
         static final StringListAttributeDefinition ALIAS = new StringListAttributeDefinition.Builder("alias")
                 .setAllowNull(true)
                 .setElementValidator(new StringLengthValidator(1))
@@ -328,11 +374,16 @@ public class PersistentResourceXMLParserTestCase {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
-                attributes.add(clusterAttr1);
-                attributes.add(clusterAttr1);
-                attributes.add(securityAttr1);
-                attributes.add(securityAttr2);
-                attributes.add(nonGroupAttr1);
+                attributes.add(rootAttr1);
+                attributes.add(rootAttr2);
+                attributes.add(base1Attr1);
+                attributes.add(base1Attr2);
+                attributes.add(base1Nested1Attr1);
+                attributes.add(base1Nested1Attr2);
+                attributes.add(base1Nested2Attr1);
+                attributes.add(base1Nested2Attr2);
+                attributes.add(base2Attr1);
+                attributes.add(base2Nested1Attr1);
                 attributes.add(ALIAS);
                 return attributes;
             }
@@ -391,14 +442,16 @@ public class PersistentResourceXMLParserTestCase {
                             builder(RESOURCE_INSTANCE)
                                     .setXmlWrapperElement("resources")
                                     .addAttributes(
-                                            // cluster group
-                                            clusterAttr1,
-                                            clusterAttr2,
-                                            // security group
-                                            securityAttr1,
-                                            securityAttr2,
-                                            //no group element
-                                            nonGroupAttr1,
+                                            rootAttr1,
+                                            rootAttr2,
+                                            base1Attr1,
+                                            base1Attr2,
+                                            base1Nested1Attr1,
+                                            base1Nested1Attr2,
+                                            base1Nested2Attr1,
+                                            base1Nested2Attr2,
+                                            base2Attr1,
+                                            base2Nested1Attr1,
                                             ALIAS
                                     )
                     )
@@ -420,14 +473,16 @@ public class PersistentResourceXMLParserTestCase {
                     .addChild(
                             builder(RESOURCE_INSTANCE)
                                     .addAttributes(
-                                            // cluster group
-                                            clusterAttr1,
-                                            clusterAttr2,
-                                            // security group
-                                            securityAttr1,
-                                            securityAttr2,
-                                            //no group element
-                                            nonGroupAttr1,
+                                            rootAttr1,
+                                            rootAttr2,
+                                            base1Attr1,
+                                            base1Attr2,
+                                            base1Nested1Attr1,
+                                            base1Nested1Attr2,
+                                            base1Nested2Attr1,
+                                            base1Nested2Attr2,
+                                            base2Attr1,
+                                            base2Nested1Attr1,
                                             ALIAS
                                     )
                     )

--- a/controller/src/test/java/org/jboss/as/controller/test/DisappearingResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/DisappearingResourceTestCase.java
@@ -277,7 +277,7 @@ public class DisappearingResourceTestCase extends AbstractControllerTestBase {
         attributeOutLatch.countDown();
 
         ModelNode op = Util.createOperation(READ_ATTRIBUTE_GROUP_OPERATION, CHILD_B_ADDRESS);
-        op.get(NAME).set(GROUP);
+        op.get(NAME).add(GROUP);
         ModelNode rsp = executeCheckForFailure(op);
         //noinspection ThrowableResultOfMethodCallIgnored
         assertTrue(rsp.toString(), rsp.get(FAILURE_DESCRIPTION).asString().contains(ControllerLogger.MGMT_OP_LOGGER.managementResourceNotFound(CHILD_B_ADDRESS).getMessage()));
@@ -289,7 +289,7 @@ public class DisappearingResourceTestCase extends AbstractControllerTestBase {
         attributeOutLatch.countDown();
 
         ModelNode op = Util.createOperation(READ_ATTRIBUTE_GROUP_OPERATION, CHILD_WILDCARD_ADDRESS);
-        op.get(NAME).set(GROUP);
+        op.get(NAME).add(GROUP);
         op.get(INCLUDE_RUNTIME).set(true);
         ModelNode result = executeForResult(op);
         assertEquals(result.toString(), ModelType.LIST, result.getType());
@@ -301,7 +301,7 @@ public class DisappearingResourceTestCase extends AbstractControllerTestBase {
         attributeOutLatch.countDown();
 
         ModelNode op = Util.createOperation(READ_ATTRIBUTE_GROUP_OPERATION, CHILD_WILDCARD_ADDRESS);
-        op.get(NAME).set(GROUP);
+        op.get(NAME).add(GROUP);
         op.get(INCLUDE_RUNTIME).set(true);
         ModelNode result = executeForResult(op);
         assertEquals(result.toString(), ModelType.LIST, result.getType());

--- a/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsTestCase.java
@@ -352,7 +352,7 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
 //          result = executeForResult(operation);
 //        assertNotNull(result);
 //        assertEquals(ModelType.LIST, result.getType());
-//        assertTrue(result.asList().isEmpty());
+//        assertTrue(result.asList().createsTags());
         try {
             result = executeForResult(operation);
             fail("Expected error for type1 child under subsystem4");
@@ -466,7 +466,7 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
 //          result = executeForResult(operation);
 //        assertNotNull(result);
 //        assertEquals(ModelType.LIST, result.getType());
-//        assertTrue(result.asList().isEmpty());
+//        assertTrue(result.asList().createsTags());
         try {
             result = executeForResult(operation);
             fail("Expected error for type1 child under subsystem4");
@@ -534,7 +534,7 @@ public class GlobalOperationsTestCase extends AbstractGlobalOperationsTestCase {
 //          result = executeForResult(operation);
 //        assertNotNull(result);
 //        assertEquals(ModelType.LIST, result.getType());
-//        assertTrue(result.asList().isEmpty());
+//        assertTrue(result.asList().createsTags());
         try {
             result = executeForResult(operation);
             fail("Expected error for type1 child under subsystem4");

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadAttributeGroupTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadAttributeGroupTestCase.java
@@ -85,7 +85,7 @@ public class ReadAttributeGroupTestCase extends AbstractControllerTestBase {
     @Test
     public void testSimpleAttributeGroup() throws Exception {
         ModelNode operation = createOperation(READ_ATTRIBUTE_GROUP_OPERATION, "subsystem", "basicSubsystem");
-        operation.get(NAME).set("group1");
+        operation.get(NAME).add("group1");
 
         ModelNode result = executeForResult(operation);
         assertNotNull(result);
@@ -100,7 +100,7 @@ public class ReadAttributeGroupTestCase extends AbstractControllerTestBase {
     @Test
     public void testRuntimeAttributeGroup() throws Exception {
         ModelNode operation = createOperation(READ_ATTRIBUTE_GROUP_OPERATION, "subsystem", "basicSubsystem");
-        operation.get(NAME).set("group1");
+        operation.get(NAME).add("group1");
         operation.get(INCLUDE_RUNTIME).set(true);
 
         ModelNode result = executeForResult(operation);
@@ -116,7 +116,7 @@ public class ReadAttributeGroupTestCase extends AbstractControllerTestBase {
     @Test
     public void testResolveAttributeGroup() throws Exception {
         ModelNode operation = createOperation(READ_ATTRIBUTE_GROUP_OPERATION, "subsystem", "basicSubsystem");
-        operation.get(NAME).set("group1");
+        operation.get(NAME).add("group1");
         operation.get(RESOLVE_EXPRESSIONS).set(true);
 
         ModelNode result = executeForResult(operation);
@@ -132,7 +132,7 @@ public class ReadAttributeGroupTestCase extends AbstractControllerTestBase {
      @Test
     public void testAliasAttributeGroup() throws Exception {
         ModelNode operation = createOperation(READ_ATTRIBUTE_GROUP_OPERATION, "subsystem", "basicSubsystem");
-        operation.get(NAME).set("group2");
+        operation.get(NAME).add("group2");
         operation.get(INCLUDE_ALIASES).set(true);
 
         ModelNode result = executeForResult(operation);

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/groups-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/groups-subsystem.xml
@@ -17,12 +17,19 @@
   -->
 
 <subsystem xmlns="urn:jboss:domain:test:1.0">
-    <resource name="foo" no-attr1="yada" alias="localhost,some.host">
-        <cluster attr1="bar" attr2="baz"/>
-        <security my-attr1="alice" my-attr2="bob"/>
+    <resource name="resource1" attr1="yada" alias="localhost,some.host">
+        <base1 attr1="bar" attr2="baz">
+                <nested1 attr1="foo" attr2="bob"/>
+                <nested2 attr1="apple" attr2="dog"/>
+        </base1>
+        <base2 attr1="abc">
+                <nested1 attr1="bah"/>
+        </base2>
     </resource>
-    <resource name="foo2" no-attr1="blah" alias="localhost,some.host,bah,boh,yak">
-        <cluster attr1="bar2" attr2="baz2"/>
+    <resource name="resource2" attr1="yada2" alias="localhost2,some.host2">
+        <base1 attr1="bar2" attr2="baz2">
+            <nested1 attr1="foo2" attr2="bob2"/>
+        </base1>
     </resource>
     <buffer-cache name="default" buffer-size="1025" buffers-per-region="1054" max-regions="15" alias="entry1 entry2 entry3" />
 </subsystem>

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/groups-wrappers-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/groups-wrappers-subsystem.xml
@@ -18,12 +18,19 @@
 
 <subsystem xmlns="urn:jboss:domain:test:1.0">
     <resources>
-        <resource name="foo" no-attr1="yada" alias="localhost,some.host" >
-            <cluster attr1="bar" attr2="baz"/>
-            <security my-attr1="alice" my-attr2="bob"/>
+        <resource name="resource1" attr1="yada" alias="localhost,some.host">
+            <base1 attr1="bar" attr2="baz">
+                <nested1 attr1="foo" attr2="bob"/>
+                <nested2 attr1="apple" attr2="dog"/>
+            </base1>
+            <base2 attr1="abc">
+                <nested1 attr1="bah"/>
+            </base2>
         </resource>
-        <resource name="foo2" no-attr1="blah" alias="localhost,some.host,bah,boh,yak" >
-            <cluster attr1="bar2" attr2="baz2"/>
+        <resource name="resource2" attr1="yada2" alias="localhost2,some.host2">
+            <base1 attr1="bar2" attr2="baz2">
+                <nested1 attr1="foo2" attr2="bob2"/>
+            </base1>
         </resource>
     </resources>
 </subsystem>

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/simple-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/simple-subsystem.xml
@@ -1,9 +1,13 @@
 <subsystem xmlns="urn:jboss:domain:test:1.0">
     <resources>
-          <resource name="foo" no-attr1="yada" alias="localhost,some.host" >
-              <cluster attr1="bar" attr2="baz"/>
-              <security my-attr1="alice" my-attr2="bob"/>
-          </resource>
+        <resource name="resource1" attr1="yada" alias="localhost,some.host">
+            <base1 attr1="bar" attr2="baz">
+                <nested1 attr1="foo" attr2="bob"/>
+            </base1>
+            <base2 attr1="abc">
+                <nested1 attr1="bah"/>
+            </base2>
+        </resource>
     </resources>
     <buffer-cache name="default" buffer-size="1025" buffers-per-region="1054" max-regions="15" alias="entry1 entry2 entry3" />
     <buffer-cache name="extra" buffer-size="1025" buffers-per-region="1054" max-regions="15"/>

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ReadAttributeGroupTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ReadAttributeGroupTestCase.java
@@ -105,7 +105,7 @@ public class ReadAttributeGroupTestCase extends AbstractRbacTestCase {
         ModelControllerClient client = getClientForUser(userName);
         assertTrue(canExecuteOperation(client, READ_ATTRIBUTE_GROUP_OPERATION, TEST_DS));
         ModelNode operation = createOpNode(TEST_DS, READ_ATTRIBUTE_GROUP_OPERATION);
-        operation.get(NAME).set("security");
+        operation.get(NAME).add("security");
         ModelNode attributesNode = RbacUtil.executeOperation(client, operation, Outcome.SUCCESS).get(RESULT);
         assertThat(attributesNode.isDefined(), is(true));
         List<Property> attributes = attributesNode.asPropertyList();


### PR DESCRIPTION
Nested attribute groups are introduced. XML parsing extension enables descriptive XML creation without creating arfiticial child resources. Attribute groups are metadata only, they are not used in addressing and operations (except read-attribute-group).

I have abstracted parsing/persisting xml attributes from PersistentResourceXMLDescription class -
AttributesXMLDescription interface is introduced.

I have provided two implementations of it:
NestGroupedAttributesXMLDescription - creates nested xml tags based on nested elements of the group; if groups consist only of one element then this class works the same as current implementation;
IgnoreGroupsAttributesXMLDescription - attribute groups are ignored during parsing - equivalent of running current code with useElementsForGroups flag set to false

Both classes work correctly with any combination and XML order of root attributes, grouped attributes, property attributes (with wrapping possibility) and children resources (with wrapping possibility).

Passes: widlfy-core tests, wildfly tests, integration tests. 