### PR TITLE
Fix trace message to use 'kill' rather than 'destroy' for kill_process

### DIFF
--- a/process-controller/src/main/java/org/jboss/as/process/ProcessControllerServerHandler.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ProcessControllerServerHandler.java
@@ -260,7 +260,7 @@ public final class ProcessControllerServerHandler implements ConnectionHandler {
                                 processName = readUTFZBytes(dataStream);
                                 processController.killProcess(processName);
                             } else {
-                                ProcessLogger.SERVER_LOGGER.tracef("Ignoring destroy_process message from untrusted source");
+                                ProcessLogger.SERVER_LOGGER.tracef("Ignoring kill_process message from untrusted source");
                             }
                             dataStream.close();
                             break;


### PR DESCRIPTION
Trivial change to trace message to contain the correct message name.