### PR TITLE
[WFCORE-282] Wildcard read support across domain processes

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CompositeOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/CompositeOperationHandler.java
@@ -107,7 +107,9 @@ public final class CompositeOperationHandler implements OperationStepHandler {
         for (int i = size - 1; i >= 0; i --) {
             final ModelNode subOperation = list.get(i);
             String stepName = "step-" + (i+1);
-            context.addStep(responseMap.get(stepName).setEmptyObject(), subOperation, stepHandlerMap.get(stepName), OperationContext.Stage.MODEL, true);
+            final OperationStepHandler osh = stepHandlerMap.get(stepName);
+            context.addStep(responseMap.get(stepName).setEmptyObject(), subOperation, osh, OperationContext.Stage.MODEL, true);
+            ControllerLogger.MGMT_OP_LOGGER.tracef("Registered composite op step for %s using %s", subOperation, osh);
         }
 
         context.completeStep(new OperationContext.RollbackHandler() {

--- a/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.controller;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_CONTROL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
@@ -29,6 +30,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUPS;
 
 import java.io.IOException;
@@ -169,10 +171,12 @@ public class ProxyStepHandler implements OperationStepHandler {
         if (finalResult != null) {
             // operation failed before it could commit
             ModelNode responseNode = finalResult.getResponseNode();
+            ControllerLogger.MGMT_OP_LOGGER.tracef("Remote operation %s failed before commit with response %s", operation, responseNode);
             context.getResult().set(responseNode.get(RESULT));
             ModelNode failureDesc = responseNode.get(FAILURE_DESCRIPTION);
             RuntimeException stdFailure = translateFailureDescription(failureDesc);
             if (stdFailure != null) {
+                ControllerLogger.MGMT_OP_LOGGER.tracef("Converted failure response to %s", stdFailure);
                 throw stdFailure;
             }
             context.getFailureDescription().set(failureDesc);

--- a/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.controller;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ABSOLUTE_ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_CONTROL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
@@ -282,7 +283,7 @@ public class ProxyStepHandler implements OperationStepHandler {
         } else {
             ModelNode result = responseHeaders.clone();
             for (ModelNode accItem : result.get(ACCESS_CONTROL).asList()) {
-                ModelNode itemAddrNode = accItem.get("absolute-address");
+                ModelNode itemAddrNode = accItem.get(ABSOLUTE_ADDRESS);
                 PathAddress itemAddr = PathAddress.pathAddress(itemAddrNode);
                 itemAddrNode.set(proxyController.getProxyNodeAddress().append(itemAddr).toModelNode());
             }

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -30,6 +30,7 @@ public class ModelDescriptionConstants {
 
     // KEEP THESE IN ALPHABETICAL ORDER!
 
+    public static final String ABSOLUTE_ADDRESS = "absolute-address";
     public static final String ACCESS = "access";
     public static final String ACCESS_CONSTRAINTS = "access-constraints";
     public static final String ACCESS_CONTROL = "access-control";
@@ -328,6 +329,7 @@ public class ModelDescriptionConstants {
     public static final String RECURSIVE_DEPTH = "recursive-depth";
     public static final String RECYCLE = "recycle";
     public static final String REDEPLOY = "redeploy";
+    public static final String RELATIVE_ADDRESS = "relative-address";
     public static final String RELATIVE_TO = "relative-to";
     public static final String RELEASE_CODENAME = "release-codename";
     public static final String RELEASE_VERSION = "release-version";

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/Util.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/Util.java
@@ -119,6 +119,10 @@ public class Util {
         return getWriteAttributeOperation(PathAddress.pathAddress(address), attributeName, value);
     }
 
+    public static ModelNode getWriteAttributeOperation(final PathAddress  address, String attributeName, String value) {
+        return getWriteAttributeOperation(address, attributeName, new ModelNode().set(value));
+    }
+
     public static ModelNode getWriteAttributeOperation(final PathAddress address, String attributeName, ModelNode value) {
         ModelNode op = createEmptyOperation(WRITE_ATTRIBUTE_OPERATION, address);
         op.get(NAME).set(attributeName);

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -177,11 +177,13 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
             } catch (ResourceNotAddressableException rnae) {
                 // Just report the failure to the filter and complete normally
                 reportInaccesible(context, operation, filteredData);
+                ControllerLogger.MGMT_OP_LOGGER.tracef("Caught ResourceNotAddressableException in %s", this);
             } catch (Resource.NoSuchResourceException nsre) {
                 // It's possible this is a remote failure, in which case we
                 // don't get ResourceNotAddressableException. So see if
                 // it was due to any authorization denial
                 AuthorizationResult.Decision decision = context.authorize(operation, EnumSet.of(Action.ActionEffect.ADDRESS)).getDecision();
+                ControllerLogger.MGMT_OP_LOGGER.tracef("Caught NoSuchResourceException in %s. Authorization decision is %s", this ,decision);
                 if (decision == AuthorizationResult.Decision.DENY) {
                     // Just report the failure to the filter and complete normally
                     reportInaccesible(context, operation, filteredData);
@@ -193,6 +195,8 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
                 PathAddress pa = PathAddress.pathAddress(operation.get(OP_ADDR));
                 filteredData.addReadRestrictedResource(pa);
                 context.getResult().set(new ModelNode());
+                ControllerLogger.MGMT_OP_LOGGER.tracef("Caught UnauthorizedException in %s", this);
+
             }
         }
     }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -251,7 +251,6 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
         final Resource resource = nullSafeReadResource(context, registry);
 
         final Map<String, Set<String>> childrenByType = registry != null ? GlobalOperationHandlers.getChildAddresses(context, address, registry, resource, null) : Collections.<String, Set<String>>emptyMap();
-
         if (!attributesOnly) {
             // Next, process child resources
             for (Map.Entry<String, Set<String>> entry : childrenByType.entrySet()) {

--- a/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
@@ -137,6 +137,11 @@ final class NodeSubregistry {
             result = searchControl.getWildCardRegistry().getOperationEntry(searchControl.getIterator(), operationName, inherited);
         }
 
+        // If there is no concrete registry and wildcard query
+        if (result == null && child.equals("*")) {
+            return inherited;
+        }
+
         return result;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/remote/BlockingQueueOperationListener.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/BlockingQueueOperationListener.java
@@ -61,7 +61,7 @@ public class BlockingQueueOperationListener<T extends TransactionalProtocolClien
 
     @Override
     public void operationPrepared(final TransactionalProtocolClient.PreparedOperation<T> prepared) {
-        ControllerLogger.MGMT_OP_LOGGER.tracef("received prepared operation  %s", prepared.getOperation());
+        ControllerLogger.MGMT_OP_LOGGER.tracef("received prepared operation  %s", prepared);
         if(! queue.offer(prepared)) {
             prepared.rollback();
         }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -600,7 +600,8 @@ class TestModelControllerService extends ModelTestModelControllerService {
 
             HostModelUtil.createRootRegistry(
                     rootRegistration,
-                    env, ignoredRegistry,
+                    env,
+                    ignoredRegistry,
                     new HostModelRegistrar() {
 
                         @Override

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
@@ -52,8 +52,8 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.as.domain.controller.ServerIdentity;
+import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -205,11 +205,19 @@ public class DomainFinalResultHandler implements OperationStepHandler {
         } else if (provider.getServer() == null) {
             String hostName = provider.getHost();
             boolean forMaster = hostName.equals(domainOperationContext.getLocalHostInfo().getLocalHostName());
-            ModelNode hostResponse = forMaster ? domainOperationContext.getCoordinatorResult()
-                    : domainOperationContext.getHostControllerResults().get(hostName);
-                result = getHostControllerResult(hostResponse, stepLabels);
+            ModelNode hostResponse;
+            if (hostName.equals("*")) {
+                hostResponse = domainOperationContext.getCoordinatorResult();
+            } else {
+                hostResponse = forMaster ? domainOperationContext.getCoordinatorResult()  : domainOperationContext.getHostControllerResults().get(hostName);
+            }
+            result = getHostControllerResult(hostResponse, stepLabels);
         } else {
-            result = domainOperationContext.getServerResult(provider.getHost(), provider.getServer(), stepLabels);
+            if (provider.getServer().equals("*")) {
+                result = getHostControllerResult(domainOperationContext.getCoordinatorResult(), stepLabels);
+            } else {
+                result = domainOperationContext.getServerResult(provider.getHost(), provider.getServer(), stepLabels);
+            }
         }
 
         return result == null ? new ModelNode() : result;

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
@@ -40,6 +40,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -58,24 +59,35 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
- * Assembles the overall result for a domain operation from individual host and server results.
+ * Assembles the overall result for a domain operation from individual host and server results. This handler does
+ * nothing in {@code execute} except registering a {@link org.jboss.as.controller.OperationContext.ResultHandler}.
+ * The work is done in the result handler, which processes data gathered by other handlers.
+ * <p>This handler should be registered before any of the typical kinds of handlers that actually deal with
+ * the resource and operation indicated by the management operation. This ensures that its result handler
+ * will execute after any result handler registered by those other handlers, ensuring that this handler will
+ * see all available data.</p>
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-public class DomainFinalResultHandler implements OperationStepHandler {
+class DomainFinalResultHandler implements OperationStepHandler {
 
-    private final DomainOperationContext domainOperationContext;
+    private final MultiphaseOverallContext multiphaseContext;
+    private final HostControllerExecutionSupport executionSupport;
 
-    public DomainFinalResultHandler(DomainOperationContext domainOperationContext) {
-        this.domainOperationContext = domainOperationContext;
+    DomainFinalResultHandler(MultiphaseOverallContext multiphaseContext, HostControllerExecutionSupport executionSupport) {
+        this.multiphaseContext = multiphaseContext;
+        this.executionSupport = executionSupport;
     }
 
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
 
+        // Just register a result handler.
+
         context.completeStep(new OperationContext.ResultHandler() {
             @Override
             public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                DomainControllerLogger.CONTROLLER_LOGGER.tracef("Establishing final response -- result action is %s", resultAction);
                 // On the way out, fix up the response
                 final boolean isDomain = isDomainOperation(operation);
                 boolean shouldContinue = collectDomainFailure(context, isDomain);
@@ -84,10 +96,26 @@ public class DomainFinalResultHandler implements OperationStepHandler {
 
                     ModelNode contextResult = context.getResult();
                     contextResult.setEmptyObject(); // clear out any old data
-                    contextResult.set(getDomainResults(operation));
+
+                    // Format any local response for easy searching, putting it in the same format
+                    // a slave would send in response to DomainSlaveHandler
+                    ModelNode localDomainFormatted;
+                    if (executionSupport == null) {
+                        localDomainFormatted = new ModelNode();
+                    } else {
+                        ModelNode localResponse = multiphaseContext.getLocalContext().getLocalResponse();
+                        localDomainFormatted = localResponse.clone();
+                        localDomainFormatted.get(RESULT).clear();
+                        ModelNode domainResults = executionSupport.getFormattedDomainResult(localResponse.get(RESULT));
+                        localDomainFormatted.get(RESULT, DOMAIN_RESULTS).set(domainResults);
+                        DomainControllerLogger.CONTROLLER_LOGGER.tracef("Domain formatted result for local response %s is %s",
+                                localResponse, localDomainFormatted);
+                    }
+
+                    contextResult.set(getDomainResults(operation, localDomainFormatted));
 
                     // If we have server results we know all was ok on the slaves
-                    Map<ServerIdentity, ModelNode> serverResults = domainOperationContext.getServerResults();
+                    Map<ServerIdentity, ModelNode> serverResults = multiphaseContext.getServerResults();
                     if (serverResults.size() > 0) {
                         populateServerGroupResults(context, serverResults);
                     } else {
@@ -107,9 +135,9 @@ public class DomainFinalResultHandler implements OperationStepHandler {
     }
 
     private boolean collectDomainFailure(OperationContext context, final boolean isDomain) {
-        final ModelNode coordinator = domainOperationContext.getCoordinatorResult();
+        final ModelNode coordinator = multiphaseContext.getLocalContext().getLocalResponse();
         ModelNode domainFailure = null;
-        if (isDomain &&  coordinator != null && coordinator.has(FAILURE_DESCRIPTION)) {
+        if (isDomain && coordinator.has(FAILURE_DESCRIPTION)) {
             domainFailure = coordinator.hasDefined(FAILURE_DESCRIPTION) ? coordinator.get(FAILURE_DESCRIPTION) : new ModelNode(DomainControllerLogger.ROOT_LOGGER.unexplainedFailure());
         }
         if (domainFailure != null) {
@@ -125,7 +153,7 @@ public class DomainFinalResultHandler implements OperationStepHandler {
         // We ignore a context failure description if the request failed on all servers, as the
         // DomainRolloutStepHandler would have had to set that to trigger model rollback
         // but we still want to record the server results so the user can see the problem
-        if (!domainOperationContext.isFailureReported() && context.hasFailureDescription()) {
+        if (!multiphaseContext.isFailureReported() && context.hasFailureDescription()) {
             ModelNode formattedFailure = new ModelNode();
             if (isDomain) {
                 ModelNode failure = context.getFailureDescription();
@@ -137,7 +165,7 @@ public class DomainFinalResultHandler implements OperationStepHandler {
                 ModelNode hostFailureProperty = new ModelNode();
                 ModelNode contextFailure = context.getFailureDescription();
                 ModelNode hostFailure = contextFailure.isDefined() ? contextFailure : new ModelNode(DomainControllerLogger.ROOT_LOGGER.unexplainedFailure());
-                hostFailureProperty.add(domainOperationContext.getLocalHostInfo().getLocalHostName(), hostFailure);
+                hostFailureProperty.add(multiphaseContext.getLocalHostInfo().getLocalHostName(), hostFailure);
 
                 formattedFailure.get(HOST_FAILURE_DESCRIPTIONS).set(hostFailureProperty);
             }
@@ -150,7 +178,7 @@ public class DomainFinalResultHandler implements OperationStepHandler {
 
     private boolean collectHostFailures(final OperationContext context, final boolean isDomain) {
         ModelNode hostFailureResults = null;
-        for (Map.Entry<String, ModelNode> entry : domainOperationContext.getHostControllerResults().entrySet()) {
+        for (Map.Entry<String, ModelNode> entry : multiphaseContext.getHostControllerPreparedResults().entrySet()) {
             ModelNode hostResult = entry.getValue();
             if (hostResult.has(FAILURE_DESCRIPTION)) {
                 if (hostFailureResults == null) {
@@ -161,13 +189,13 @@ public class DomainFinalResultHandler implements OperationStepHandler {
             }
         }
 
-        final ModelNode coordinator = domainOperationContext.getCoordinatorResult();
-        if (!isDomain && coordinator != null && coordinator.has(FAILURE_DESCRIPTION)) {
+        final ModelNode coordinator = multiphaseContext.getLocalContext().getLocalResponse();
+        if (!isDomain && coordinator.has(FAILURE_DESCRIPTION)) {
             if (hostFailureResults == null) {
                 hostFailureResults = new ModelNode();
             }
             final ModelNode desc = coordinator.hasDefined(FAILURE_DESCRIPTION) ? coordinator.get(FAILURE_DESCRIPTION) : new ModelNode().set(DomainControllerLogger.ROOT_LOGGER.unexplainedFailure());
-            hostFailureResults.get(domainOperationContext.getLocalHostInfo().getLocalHostName()).set(desc);
+            hostFailureResults.get(multiphaseContext.getLocalHostInfo().getLocalHostName()).set(desc);
         }
 
         if (hostFailureResults != null) {
@@ -188,54 +216,84 @@ public class DomainFinalResultHandler implements OperationStepHandler {
         return true;
     }
 
-    private ModelNode getDomainResults(final ModelNode operation, final String... stepLabels) {
-        ResponseProvider provider = new ResponseProvider(operation, domainOperationContext.getLocalHostInfo().getLocalHostName());
-        ModelNode result;
+    private ModelNode getDomainResults(final ModelNode operation, final ModelNode localDomainFormatted, final String... stepLabels) {
+        ResponseProvider provider = new ResponseProvider(operation, multiphaseContext.getLocalHostInfo().getLocalHostName());
+        DomainControllerLogger.CONTROLLER_LOGGER.tracef("Provider for %s is %s", operation, provider);
+        ModelNode result = null;
         if (!provider.isLeaf()) {
             result = new ModelNode();
+
+            ModelNode compositeResult;
+            if (stepLabels.length == 0) {
+                // Initial request; we're already dealing with the result node
+                compositeResult = result;
+            } else {
+                // Add a wrapper 'response'
+                // Outcome for composite is 'success' or we would not be here
+                result.get(OUTCOME).set(SUCCESS);
+                compositeResult = result.get(RESULT);
+            }
+
             String[] nextStepLabels = new String[stepLabels.length + 1];
             System.arraycopy(stepLabels, 0, nextStepLabels, 0, stepLabels.length);
             int i = 1;
-
             for (ModelNode step : provider.getChildren()) {
                 String childStepLabel = "step-" + i++;
                 nextStepLabels[stepLabels.length] = childStepLabel;
-                result.get(childStepLabel).set(getDomainResults(step, nextStepLabels));
+                compositeResult.get(childStepLabel).set(getDomainResults(step, localDomainFormatted, nextStepLabels));
             }
         } else if (provider.getServer() == null) {
             String hostName = provider.getHost();
-            if (hostName.equals("*")) {
-                result = new ModelNode();
-                for (final Map.Entry<String, ModelNode> hostEntry : domainOperationContext.getHostControllerResults().entrySet()) {
-                    final String host = hostEntry.getKey();
-                    boolean forMaster = host.equals(domainOperationContext.getLocalHostInfo().getLocalHostName());
-                    ModelNode hostResponse = forMaster ? domainOperationContext.getCoordinatorResult() : domainOperationContext.getHostControllerResults().get(hostName);
-                    if (hostResponse != null) {
-                        result.add(getHostControllerResult(hostResponse, stepLabels));
+
+            if (hostName.equals(multiphaseContext.getLocalHostInfo().getLocalHostName())) {
+                result = getHostControllerResult(localDomainFormatted, stepLabels);
+            } else {
+                ModelNode hostFinalResult = multiphaseContext.getHostControllerFinalResults().get(hostName);
+                if (hostFinalResult != null) {
+                    result = getHostControllerResult(hostFinalResult, stepLabels);
+                } else {
+                    // Perhaps cancelled; see if there's a prepared result
+                    ModelNode preparedResult = multiphaseContext.getHostControllerPreparedResults().get(hostName);
+                    if (preparedResult != null) {
+                        result = getHostControllerResult(preparedResult, stepLabels);
                     }
                 }
-            } else {
-                boolean forMaster = hostName.equals(domainOperationContext.getLocalHostInfo().getLocalHostName());
-                ModelNode hostResponse = forMaster ? domainOperationContext.getCoordinatorResult()  : domainOperationContext.getHostControllerResults().get(hostName);
-                result = getHostControllerResult(hostResponse, stepLabels);
             }
         } else {
-//            if (provider.getServer().equals("*")) {
-//                result = getHostControllerResult(domainOperationContext.getCoordinatorResult(), stepLabels);
-//            } else {
-//                result = domainOperationContext.getServerResult(provider.getHost(), provider.getServer(), stepLabels);
-//            }
-            result = domainOperationContext.getServerResult(provider.getHost(), provider.getServer(), stepLabels);
+            result = multiphaseContext.getServerResult(provider.getHost(), provider.getServer(), stepLabels);
         }
-
+        DomainControllerLogger.CONTROLLER_LOGGER.tracef("Domain result for %s is %s", operation, result);
         return result == null ? new ModelNode() : result;
     }
 
     private ModelNode getHostControllerResult(final ModelNode fullResult, final String... stepLabels) {
         ModelNode result = null;
-        if (fullResult != null && fullResult.hasDefined(RESULT) && fullResult.get(RESULT).hasDefined(DOMAIN_RESULTS)) {
+        if (fullResult != null && fullResult.hasDefined(RESULT, DOMAIN_RESULTS)) {
             ModelNode domainResults = fullResult.get(RESULT, DOMAIN_RESULTS);
-            result = domainResults.get(stepLabels);
+            if (stepLabels.length == 0) {
+                result = domainResults;
+            } else {
+                ModelNode source = domainResults;
+                for (int i = 0; i < stepLabels.length; i++) {
+                    if (i == 0) {
+                        if (source.hasDefined(stepLabels[i])) {
+                            source = source.get(stepLabels[i]);
+                        } else {
+                            source = new ModelNode();
+                            break;
+                        }
+                    } else {
+                        if (source.hasDefined(RESULT, stepLabels[i])) {
+                            source = source.get(RESULT, stepLabels[i]);
+                        } else {
+                            source = new ModelNode();
+                            break;
+                        }
+
+                    }
+                }
+                result = source;
+            }
             if (result.has(OUTCOME) && !result.hasDefined(OUTCOME)) {
                 if (result.hasDefined(FAILURE_DESCRIPTION)) {
                     result.get(OUTCOME).set(FAILED);
@@ -244,6 +302,11 @@ public class DomainFinalResultHandler implements OperationStepHandler {
                 }
             }
         }
+        if (DomainControllerLogger.CONTROLLER_LOGGER.isTraceEnabled()) {
+            DomainControllerLogger.CONTROLLER_LOGGER.tracef("Host result from %s at %s is %s",
+                    fullResult, Arrays.asList(stepLabels), result);
+        }
+
         return result;
     }
 
@@ -266,7 +329,7 @@ public class DomainFinalResultHandler implements OperationStepHandler {
         ModelNode failureReport = new ModelNode();
         for (String groupName : groupNames) {
             final ModelNode groupNode = new ModelNode();
-            boolean groupFailure = domainOperationContext.isServerGroupRollback(groupName);
+            boolean groupFailure = multiphaseContext.isServerGroupRollback(groupName);
             if (groupFailure) {
                 // TODO revisit if we should report this for the whole group, since the result might not be accurate
                 // groupNode.get(ROLLED_BACK).set(true);
@@ -342,10 +405,16 @@ public class DomainFinalResultHandler implements OperationStepHandler {
                 if (addrSize > 1 && SERVER.equals(opAddr.getElement(1).getKey())
                         && !opAddr.getElement(1).isMultiTarget()) {
                     server =  opAddr.getElement(1).getValue();
-                    composite = composite && addrSize == 2;
+                    //composite = composite && addrSize == 2;
                 } else {
                     server = null;
                 }
+                // 'composite' is false for any op targeted at 'host=x'
+                // If address isn't host=x/server=y, then it just isn't a true
+                // composite op, it's some other op named "composite"
+                // If address *is* host=x/server=y then in this class'
+                // processing we can treat the result as a leaf node anyway
+                composite = false;
             } else {
                 // A domain op
                 host = localHostName;
@@ -379,6 +448,11 @@ public class DomainFinalResultHandler implements OperationStepHandler {
 
         private boolean isLeaf() {
             return children == null;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "{host=" + host + ", server=" + server + ", children=" + children + "}";
         }
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
@@ -232,6 +232,7 @@ public class DomainSlaveHandler implements OperationStepHandler {
                     ResponseAttachmentInputStreamSupport.handleDomainOperationResponseStreams(context, transformedResult, finalResponse.getInputStreams());
 
                     HOST_CONTROLLER_LOGGER.tracef("Final result for remote host %s is %s", hostName, finalResponse.getResponseNode());
+                    HOST_CONTROLLER_LOGGER.tracef("Transformed result from host %s is %s", hostName, transformedResult);
 
                 } catch (InterruptedException e) {
                     interruptThread = true;

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
@@ -63,15 +63,15 @@ import org.jboss.dmr.ModelNode;
  */
 public class DomainSlaveHandler implements OperationStepHandler {
 
-    private final DomainOperationContext domainOperationContext;
+    private final MultiphaseOverallContext multiphaseContext;
     private final Map<String, ProxyController> hostProxies;
     private final DomainControllerRuntimeIgnoreTransformationRegistry runtimeIgnoreTransformationRegistry;
 
     public DomainSlaveHandler(final Map<String, ProxyController> hostProxies,
-                              final DomainOperationContext domainOperationContext,
+                              final MultiphaseOverallContext domainOperationContext,
                               final DomainControllerRuntimeIgnoreTransformationRegistry runtimeIgnoreTransformationRegistry) {
         this.hostProxies = hostProxies;
-        this.domainOperationContext = domainOperationContext;
+        this.multiphaseContext = domainOperationContext;
         this.runtimeIgnoreTransformationRegistry = runtimeIgnoreTransformationRegistry;
     }
 
@@ -102,13 +102,12 @@ public class DomainSlaveHandler implements OperationStepHandler {
                 }
             }
 
-
             ModelNode clonedOp = runtimeIgnoreTransformationRegistry.piggyBackMissingInformationOnHeader(context, proxyController, entry.getKey(), op.clone());
             clonedOp.get(OPERATION_HEADERS, DomainControllerLockIdUtils.DOMAIN_CONTROLLER_LOCK_ID).set(CurrentOperationIdHolder.getCurrentOperationID());
             final HostControllerUpdateTask task = new HostControllerUpdateTask(host, clonedOp, context, proxyController);
             // Execute the operation on the remote host
             final HostControllerUpdateTask.ExecutedHostRequest finalResult = task.execute(listener);
-            domainOperationContext.recordHostRequest(host, finalResult);
+            multiphaseContext.recordHostRequest(host, finalResult);
             finalResults.put(host, finalResult);
         }
 
@@ -137,17 +136,17 @@ public class DomainSlaveHandler implements OperationStepHandler {
                         failedResult.get(FAILURE_DESCRIPTION).set(request.getFailureDescription());
 
                         // Record the failed result
-                        domainOperationContext.addHostControllerResult(hostName, failedResult);
+                        multiphaseContext.addHostControllerPreparedResult(hostName, failedResult);
                     } else {
                         // Record the prepared result
-                        domainOperationContext.addHostControllerResult(hostName, preparedResult);
+                        multiphaseContext.addHostControllerPreparedResult(hostName, preparedResult);
                     }
                     results.add(prepared);
                 }
             } catch (InterruptedException ie) {
                 interrupted = true;
                 // Set rollback only
-                domainOperationContext.setFailureReported(true);
+                multiphaseContext.setFailureReported(true);
                 // Cancel all HCs
                 HOST_CONTROLLER_LOGGER.interruptedAwaitingHostPreparedResponse(finalResults.keySet());
                 for(final HostControllerUpdateTask.ExecutedHostRequest finalResult : finalResults.values()) {
@@ -160,7 +159,7 @@ public class DomainSlaveHandler implements OperationStepHandler {
                         final HostControllerUpdateTask.ExecutedHostRequest request = entry.getValue();
                         final ModelNode result = request.getFinalResult().get().getResponseNode();
                         final ModelNode transformedResult = request.transformResult(result);
-                        domainOperationContext.addHostControllerResult(hostName, transformedResult);
+                        multiphaseContext.addHostControllerPreparedResult(hostName, transformedResult);
                     } catch (Exception e) {
                         final ModelNode result = new ModelNode();
                         result.get(OUTCOME).set(FAILED);
@@ -170,7 +169,7 @@ public class DomainSlaveHandler implements OperationStepHandler {
                         } else {
                             result.get(FAILURE_DESCRIPTION).set(DomainControllerLogger.ROOT_LOGGER.exceptionAwaitingResultFromHost(entry.getKey(), e.getMessage()));
                         }
-                        domainOperationContext.addHostControllerResult(hostName, result);
+                        multiphaseContext.addHostControllerPreparedResult(hostName, result);
                     }
                 }
             }
@@ -201,7 +200,7 @@ public class DomainSlaveHandler implements OperationStepHandler {
         try {
             // Inform the remote hosts whether to commit or roll back their updates
             // Do this in parallel
-            boolean rollback = domainOperationContext.isCompleteRollback();
+            boolean rollback = multiphaseContext.isCompleteRollback();
             for(final TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation> prepared : results) {
 
                 // Clear any thread interrupted status so we know the commit/rollback message will go out
@@ -225,7 +224,7 @@ public class DomainSlaveHandler implements OperationStepHandler {
                 try {
                     final OperationResponse finalResponse = patient ? future.get() : future.get(0, TimeUnit.MILLISECONDS);
                     final ModelNode transformedResult = request.transformResult(finalResponse.getResponseNode());
-                    domainOperationContext.addHostControllerResult(hostName, transformedResult);
+                    multiphaseContext.addHostControllerFinalResult(hostName, transformedResult);
 
                     // Make sure any streams associated with the remote response are properly
                     // integrated with our response

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerExecutionSupport.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerExecutionSupport.java
@@ -31,6 +31,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
@@ -353,9 +354,16 @@ interface HostControllerExecutionSupport {
                     HostControllerExecutionSupport po = steps.get(i);
                     if (po.getDomainOperation() != null) {
                         String label = "step-" + (++resultStep);
-                        ModelNode stepResultNode = resultNode.get(label);
-                        ModelNode formattedStepResultNode = po.getFormattedDomainResult(stepResultNode);
-                        allSteps.get("step-" + (i + 1)).set(formattedStepResultNode);
+                        ModelNode stepResponseNode = resultNode.get(label);
+                        ModelNode formattedStepResponseNode;
+                        if (po instanceof MultiStepOpExecutionSupport) {
+                            formattedStepResponseNode = stepResponseNode.clone();
+                            ModelNode stepResultNode = stepResponseNode.get(RESULT);
+                            formattedStepResponseNode.get(RESULT).set(po.getFormattedDomainResult(stepResultNode));
+                        } else {
+                            formattedStepResponseNode = po.getFormattedDomainResult(stepResponseNode);
+                        }
+                        allSteps.get("step-" + (i + 1)).set(formattedStepResponseNode);
                     }
                     else {
                         allSteps.get("step-" + (i + 1), OUTCOME).set(IGNORED);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/MultiPhaseLocalContext.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/MultiPhaseLocalContext.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.controller.operations.coordination;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Stores contextual information for the local process aspects of
+ * a multi-phase operation executing on the domain.
+ *
+ * @author Brian Stansberry (c) 2015 Red Hat Inc.
+ */
+final class MultiPhaseLocalContext {
+
+    private final boolean coordinator;
+    private final ModelNode localResult = new ModelNode();
+    private final ModelNode localServerOps = new ModelNode();
+
+    MultiPhaseLocalContext(boolean coordinator) {
+        this.coordinator = coordinator;
+    }
+
+    public boolean isCoordinator() {
+        return coordinator;
+    }
+
+    ModelNode getLocalResponse() {
+        return localResult;
+    }
+
+    ModelNode getLocalServerOps() {
+        return localServerOps;
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationRouting.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationRouting.java
@@ -29,7 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 
-import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,6 +41,7 @@ import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
+import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -51,17 +52,17 @@ import org.jboss.dmr.ModelNode;
 class OperationRouting {
 
     static OperationRouting determineRouting(OperationContext context, ModelNode operation,
-                                             final LocalHostControllerInfo localHostControllerInfo) throws OperationFailedException {
+                                             final LocalHostControllerInfo localHostControllerInfo, Set<String> hostNames) throws OperationFailedException {
         final ImmutableManagementResourceRegistration rootRegistration = context.getRootResourceRegistration();
-        return determineRouting(operation, localHostControllerInfo, rootRegistration);
+        return determineRouting(operation, localHostControllerInfo, rootRegistration, hostNames);
     }
 
     private static OperationRouting determineRouting(final ModelNode operation, final LocalHostControllerInfo localHostControllerInfo,
-                                                     final ImmutableManagementResourceRegistration rootRegistration) throws OperationFailedException {
+                                                     final ImmutableManagementResourceRegistration rootRegistration, Set<String> hostNames) throws OperationFailedException {
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
         final String operationName = operation.require(OP).asString();
         final Set<OperationEntry.Flag> operationFlags = resolveOperationFlags(address, operationName, rootRegistration);
-        return determineRouting(operation, address, operationName, operationFlags, localHostControllerInfo, rootRegistration);
+        return determineRouting(operation, address, operationName, operationFlags, localHostControllerInfo, rootRegistration, hostNames);
     }
 
     private static Set<OperationEntry.Flag> resolveOperationFlags(final PathAddress address, final String operationName,
@@ -100,23 +101,37 @@ class OperationRouting {
                                                      final String operationName,
                                                      final Set<OperationEntry.Flag> operationFlags,
                                                      final LocalHostControllerInfo localHostControllerInfo,
-                                                     final ImmutableManagementResourceRegistration rootRegistration)
+                                                     final ImmutableManagementResourceRegistration rootRegistration,
+                                                     Set<String> hostNames)
                                                         throws OperationFailedException {
 
         OperationRouting routing = null;
 
-        String targetHost = null;
+        Set<String> targetHost = null;
         boolean compositeOp = false;
         if (address.size() > 0) {
             PathElement first = address.getElement(0);
-            if (HOST.equals(first.getKey()) && !first.isMultiTarget()) {
-                targetHost = first.getValue();
+            if (HOST.equals(first.getKey())) {
+                if (first.isMultiTarget()) {
+                    if (first.isWildcard()) {
+                        targetHost = new HashSet<>();
+                        targetHost.addAll(hostNames);
+                        targetHost.add(localHostControllerInfo.getLocalHostName());
+                    } else {
+                        targetHost = new HashSet<>();
+                        Collections.addAll(targetHost, first.getSegments());
+                    }
+                } else {
+                    targetHost = Collections.singleton(first.getValue());
+                }
             }
         } else {
             compositeOp = COMPOSITE.equals(operationName);
         }
 
         if (targetHost != null) {
+            // Check for read-only flags. But note they will only exist for addresses on this host,
+            // as we have no accurate flags for ops registered on remote hosts
             if(operationFlags.contains(OperationEntry.Flag.READ_ONLY) && !operationFlags.contains(OperationEntry.Flag.DOMAIN_PUSH_TO_SERVERS)) {
                 routing =  new OperationRouting(targetHost, false);
             }
@@ -131,7 +146,11 @@ class OperationRouting {
                 if(operationFlags.contains(OperationEntry.Flag.HOST_CONTROLLER_ONLY)) {
                     routing = new OperationRouting(targetHost, false);
                 } else {
-                    routing = new OperationRouting(targetHost, true);
+                    // We can't rely on the check for read-only flags above to tell us whether
+                    // remote ops are two step. But, we can treat ops solely directed at remote hosts
+                    // as non-two step, as we don't need two step execution on this host for such ops
+                    boolean twoStep = targetHost.contains(localHostControllerInfo.getLocalHostName());
+                    routing = new OperationRouting(targetHost, twoStep);
                 }
             }
         } else if (compositeOp) {
@@ -139,9 +158,11 @@ class OperationRouting {
             if (operation.hasDefined(STEPS)) {
                 Set<String> allHosts = new HashSet<String>();
                 boolean fwdToAllHosts = false;
+                boolean twoStep = false;
                 for (ModelNode step : operation.get(STEPS).asList()) {
-                    OperationRouting stepRouting = determineRouting(step, localHostControllerInfo, rootRegistration);
+                    OperationRouting stepRouting = determineRouting(step, localHostControllerInfo, rootRegistration, hostNames);
                     if (stepRouting.isTwoStep()) {
+                        twoStep = true;
                         // Make sure we don't loose the information that we have to execute the operation on all hosts
                         fwdToAllHosts = fwdToAllHosts || stepRouting.getHosts().isEmpty();
                     }
@@ -150,25 +171,25 @@ class OperationRouting {
                 if (fwdToAllHosts) {
                     routing = new OperationRouting(true);
                 } else {
-                    routing = new OperationRouting(allHosts);
+                    routing = new OperationRouting(allHosts, twoStep);
                 }
             }
             else {
                 // empty; this will be an error but don't deal with it here
                 // Let our DomainModel deal with it
-                routing = new OperationRouting(localHostControllerInfo.getLocalHostName(), false);
+                routing = new OperationRouting(localHostControllerInfo);
             }
         } else {
             // Domain level operation
             if (operationFlags.contains(OperationEntry.Flag.READ_ONLY) && !operationFlags.contains(OperationEntry.Flag.DOMAIN_PUSH_TO_SERVERS)) {
                 // Direct read of domain model
-                routing = new OperationRouting(localHostControllerInfo.getLocalHostName(), false);
+                routing = new OperationRouting(localHostControllerInfo);
             } else if (!localHostControllerInfo.isMasterDomainController()) {
                 // Route to master
                 routing = new OperationRouting();
             } else if (operationFlags.contains(OperationEntry.Flag.MASTER_HOST_CONTROLLER_ONLY)) {
                 // Deployment ops should be executed on the master DC only
-                routing = new OperationRouting(localHostControllerInfo.getLocalHostName(), false);
+                routing = new OperationRouting(localHostControllerInfo);
             }
         }
 
@@ -176,47 +197,43 @@ class OperationRouting {
             // Write operation to the model or a read that needs to be pushed to servers; everyone gets it
             routing = new OperationRouting(true);
         }
+        DomainControllerLogger.HOST_CONTROLLER_LOGGER.tracef("Routing for operation %s is %s", operation, routing);
         return routing;
 
     }
 
-    private final String singleHost;
     private final Set<String> hosts = new HashSet<String>();
     private final boolean twoStep;
 
     /** Constructor for domain-level requests where we are not master */
     private OperationRouting() {
         twoStep = false;
-        singleHost = null;
     }
 
     /** Constructor for multi-host ops */
     private OperationRouting(final boolean twoStep) {
         this.twoStep = twoStep;
-        singleHost = null;
+    }
+
+    /**
+     * Constructor for a non-two-step request routed to this host
+     *
+     * @param localHostControllerInfo information describing this host
+     */
+    private OperationRouting(LocalHostControllerInfo localHostControllerInfo) {
+        this.hosts.add(localHostControllerInfo.getLocalHostName());
+        this.twoStep = false;
     }
 
     /**
      * Constructor for a request routed to a single host
      *
-     * @param host the name of the host
+     * @param hosts the name of the hosts
      * @param twoStep true if a two-step execution is needed
      */
-    public OperationRouting(String host, boolean twoStep) {
-        this.hosts.add(host);
-        this.twoStep = twoStep;
-        singleHost = host;
-    }
-
-    /**
-     * Constructor for a request routed to multiple hosts
-     *
-     * @param hosts the names of the hosts
-     */
-    public OperationRouting(final Collection<String> hosts) {
+    private OperationRouting(Set<String> hosts, boolean twoStep) {
         this.hosts.addAll(hosts);
-        this.twoStep = true;
-        singleHost = null;
+        this.twoStep = twoStep;
     }
 
     public Set<String> getHosts() {
@@ -224,7 +241,7 @@ class OperationRouting {
     }
 
     public String getSingleHost() {
-        return singleHost;
+        return hosts.size() == 1 ? hosts.iterator().next() : null;
     }
 
     public boolean isTwoStep() {
@@ -232,22 +249,17 @@ class OperationRouting {
     }
 
     public boolean isLocalOnly(final String localHostName) {
-        if (singleHost != null) {
-            return localHostName.equals(singleHost);
-        } else {
-            return hosts.size() == 1 && hosts.contains(localHostName);
-        }
+        return hosts.size() == 1 && hosts.contains(localHostName);
     }
 
     public boolean isLocalCallNeeded(final String localHostName) {
-        return localHostName.equals(singleHost) || hosts.size() == 0 || hosts.contains(localHostName);
+        return hosts.size() == 0 || hosts.contains(localHostName);
     }
 
     @Override
     public String toString() {
         return "OperationRouting{" +
-                "singleHost='" + singleHost + '\'' +
-                ", hosts=" + hosts +
+                "hosts=" + hosts +
                 ", twoStep=" + twoStep +
                 '}';
     }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationRouting.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationRouting.java
@@ -139,6 +139,9 @@ class OperationRouting {
             else if(address.size() > 1) {
                 PathElement first = address.getElement(1);
                 if (SERVER.equals(first.getKey())) {
+                    // A direct request to a server is not handled via two-phase handling
+                    // even if the request is for a write op. A write-op to a server
+                    // is illegal anyway, so there is no reason to handle it two-phase
                     routing =  new OperationRouting(targetHost, false);
                 }
             }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/PrepareStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/PrepareStepHandler.java
@@ -46,7 +46,6 @@ import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.domain.controller.operations.ApplyMissingDomainModelResourcesHandler;
 import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
 import org.jboss.as.host.controller.mgmt.DomainControllerRuntimeIgnoreTransformationRegistry;
-import org.jboss.as.repository.ContentRepository;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -61,7 +60,6 @@ public class PrepareStepHandler  implements OperationStepHandler {
     private final OperationSlaveStepHandler slaveHandler;
 
     public PrepareStepHandler(final LocalHostControllerInfo localHostControllerInfo,
-                              final ContentRepository contentRepository,
                               final Map<String, ProxyController> hostProxies,
                               final Map<String, ProxyController> serverProxies,
                               final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry,
@@ -69,7 +67,7 @@ public class PrepareStepHandler  implements OperationStepHandler {
                               final DomainControllerRuntimeIgnoreTransformationRegistry runtimeIgnoreTransformationRegistry) {
         this.localHostControllerInfo = localHostControllerInfo;
         this.slaveHandler = new OperationSlaveStepHandler(localHostControllerInfo, serverProxies, ignoredDomainResourceRegistry, extensionRegistry);
-        this.coordinatorHandler = new OperationCoordinatorStepHandler(localHostControllerInfo, contentRepository, hostProxies, serverProxies, slaveHandler, runtimeIgnoreTransformationRegistry);
+        this.coordinatorHandler = new OperationCoordinatorStepHandler(localHostControllerInfo, hostProxies, serverProxies, slaveHandler, runtimeIgnoreTransformationRegistry);
     }
 
     public void initialize(ApplyMissingDomainModelResourcesHandler applyMissingDomainModelResourcesHandler) {
@@ -85,7 +83,6 @@ public class PrepareStepHandler  implements OperationStepHandler {
                 && operation.get(OPERATION_HEADERS).hasDefined(EXECUTE_FOR_COORDINATOR)
                 && operation.get(OPERATION_HEADERS).get(EXECUTE_FOR_COORDINATOR).asBoolean()) {
             // Coordinator wants us to execute locally and send result including the steps needed for execution on the servers
-            // TODO verify this is actually the master requesting this
             slaveHandler.execute(context, operation);
         } else {
             // Assign a unique id to this operation to allow tying together of audit logs from various hosts/servers

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
@@ -74,41 +74,36 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
     private final HostControllerExecutionSupport hostControllerExecutionSupport;
     private final PathAddress originalAddress;
     private final ImmutableManagementResourceRegistration originalRegistration;
-    private final ModelNode localResponse;
+    private final MultiPhaseLocalContext multiPhaseLocalContext;
 
     ServerOperationsResolverHandler(final ServerOperationResolver resolver,
                                     final HostControllerExecutionSupport hostControllerExecutionSupport,
                                     final PathAddress originalAddress,
                                     final ImmutableManagementResourceRegistration originalRegistration,
-                                    final ModelNode response) {
+                                    final MultiPhaseLocalContext multiPhaseLocalContext) {
         this.resolver = resolver;
         this.hostControllerExecutionSupport = hostControllerExecutionSupport;
         this.originalAddress = originalAddress;
         this.originalRegistration = originalRegistration;
-        this.localResponse = response;
+        this.multiPhaseLocalContext = multiPhaseLocalContext;
     }
 
     @Override
     public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
 
-        if (context.hasFailureDescription()) {
-            localResponse.get(FAILURE_DESCRIPTION).set(context.getFailureDescription());
-            // We do not allow failures on the host controllers
+        if (multiPhaseLocalContext.getLocalResponse().has(FAILURE_DESCRIPTION)) {
+            // We do not allow failures on the host controllers in a 2-phase op
             context.setRollbackOnly();
         } else {
 
             // Temporary hack to prevent CompositeOperationHandler throwing away domain failure data
             context.attachIfAbsent(CompositeOperationHandler.DOMAIN_EXECUTION_KEY, Boolean.TRUE);
 
+            // Figure out what server ops are needed to correspond to the domain op we have
             boolean nullDomainOp = hostControllerExecutionSupport.getDomainOperation() == null;
-
             // Transformed operations might need to simulate certain behavior, so allow read-only operations to be pushed as well
-            final boolean pushToServers;
-            if(operation.hasDefined(OPERATION_HEADERS)) {
-                pushToServers = operation.get(OPERATION_HEADERS, DOMAIN_PUSH_TO_SERVERS).asBoolean(false);
-            } else {
-                pushToServers = false;
-            }
+            final boolean pushToServers= operation.hasDefined(OPERATION_HEADERS) && operation.get(OPERATION_HEADERS, DOMAIN_PUSH_TO_SERVERS).asBoolean(false);
+
             HostControllerExecutionSupport.ServerOperationProvider provider = nullDomainOp
                 ? NO_OP_PROVIDER
                 : new HostControllerExecutionSupport.ServerOperationProvider() {
@@ -130,14 +125,35 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
                 };
             Map<ServerIdentity, ModelNode> serverOps = hostControllerExecutionSupport.getServerOps(provider);
 
-            ModelNode domainOpResult = nullDomainOp ? new ModelNode(IGNORED) : (context.hasResult() ? context.getResult() : new ModelNode());
+            // Format that data and provide it to the coordinator
+            ModelNode formattedServerOps = getFormattedServerOps(serverOps);
 
-            ModelNode overallResult = localResponse == null ? context.getResult() : localResponse.get(RESULT);
-            createOverallResult(serverOps, domainOpResult, overallResult);
+            if (multiPhaseLocalContext.isCoordinator()) {
+                // We're the coordinator, so just stash the server ops in the multiphase context
+                // for use in the rollout plan
+                multiPhaseLocalContext.getLocalServerOps().set(formattedServerOps);
+                if (HOST_CONTROLLER_LOGGER.isTraceEnabled()) {
+                    HOST_CONTROLLER_LOGGER.tracef("%s server ops local response node is %s", getClass().getSimpleName(), formattedServerOps);
+                }
+            } else {
+                // We're not the coordinator, so we need to propagate the server ops
+                // to the coordinator via the response we send in the prepare part of Stage.DONE
+                // So, change the context result to the special format used for this data
+                ModelNode localResult = nullDomainOp ? new ModelNode(IGNORED) : multiPhaseLocalContext.getLocalResponse().get(RESULT);
+                ModelNode domainResult = hostControllerExecutionSupport.getFormattedDomainResult(localResult);
 
-            if (HOST_CONTROLLER_LOGGER.isTraceEnabled()) {
-                HOST_CONTROLLER_LOGGER.tracef("%s responseNode is %s", getClass().getSimpleName(), overallResult);
+                ModelNode contextResult = context.getResult();
+                contextResult.setEmptyObject();
+                contextResult.get(DOMAIN_RESULTS).set(domainResult);
+                contextResult.get(SERVER_OPERATIONS).set(formattedServerOps);
+
+
+                if (HOST_CONTROLLER_LOGGER.isTraceEnabled()) {
+                    HOST_CONTROLLER_LOGGER.tracef("%s server ops remote response node is %s", getClass().getSimpleName(), contextResult);
+                }
+
             }
+
         }
     }
 
@@ -156,14 +172,7 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
         return result;
     }
 
-    private void createOverallResult(final Map<ServerIdentity, ModelNode> serverOps,
-                                     final ModelNode localResult, final ModelNode overallResult) {
-
-        ModelNode domainResult = hostControllerExecutionSupport.getFormattedDomainResult(localResult);
-
-        overallResult.setEmptyObject();
-        overallResult.get(DOMAIN_RESULTS).set(domainResult);
-
+    private ModelNode getFormattedServerOps(Map<ServerIdentity, ModelNode> serverOps) {
         ModelNode serverOpsNode = new ModelNode();
 
         // Group servers with the same ops together to save bandwidth
@@ -185,7 +194,6 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
             }
             setNode.get(OP).set(entry.getKey());
         }
-
-        overallResult.get(SERVER_OPERATIONS).set(serverOpsNode);
+        return serverOpsNode;
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
@@ -123,6 +123,8 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
                                 op.get(OPERATION_HEADERS).remove(CALLER_TYPE);
                             }
                         }
+
+                        HOST_CONTROLLER_LOGGER.tracef("Server ops for %s -- %s", domainOp, ops);
                         return ops;
                     }
                 };
@@ -158,10 +160,11 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
                                      final ModelNode localResult, final ModelNode overallResult) {
 
         ModelNode domainResult = hostControllerExecutionSupport.getFormattedDomainResult(localResult);
+
         overallResult.setEmptyObject();
         overallResult.get(DOMAIN_RESULTS).set(domainResult);
 
-        ModelNode serverOpsNode = overallResult.get(SERVER_OPERATIONS);
+        ModelNode serverOpsNode = new ModelNode();
 
         // Group servers with the same ops together to save bandwidth
         final Map<ModelNode, Set<ServerIdentity>> bundled = new HashMap<ModelNode, Set<ServerIdentity>>();
@@ -182,5 +185,7 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
             }
             setNode.get(OP).set(entry.getKey());
         }
+
+        overallResult.get(SERVER_OPERATIONS).set(serverOpsNode);
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/plan/RolloutPlanController.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/plan/RolloutPlanController.java
@@ -46,7 +46,7 @@ import java.util.concurrent.ExecutorService;
 import javax.security.auth.Subject;
 
 import org.jboss.as.domain.controller.ServerIdentity;
-import org.jboss.as.domain.controller.operations.coordination.DomainOperationContext;
+import org.jboss.as.domain.controller.operations.coordination.MultiphaseOverallContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 
@@ -68,11 +68,11 @@ public class RolloutPlanController {
     private final Map<String, ServerUpdatePolicy> updatePolicies = new HashMap<String, ServerUpdatePolicy>();
     private final boolean shutdown;
     private final long gracefulShutdownPeriod;
-    private final DomainOperationContext domainOperationContext;
+    private final MultiphaseOverallContext domainOperationContext;
 
     public RolloutPlanController(final Map<String, Map<ServerIdentity, ModelNode>> opsByGroup,
                                  final ModelNode rolloutPlan,
-                                 final DomainOperationContext domainOperationContext,
+                                 final MultiphaseOverallContext domainOperationContext,
                                  final ServerTaskExecutor taskExecutor,
                                  final ExecutorService executor) {
         this.domainOperationContext = domainOperationContext;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -233,7 +233,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
         final ExtensionRegistry hostExtensionRegistry = new ExtensionRegistry(ProcessType.HOST_CONTROLLER, runningModeControl, auditLogger, authorizer, hostControllerInfoAccessor);
         final ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.HOST_CONTROLLER, runningModeControl, auditLogger, authorizer, hostControllerInfoAccessor);
         final DomainControllerRuntimeIgnoreTransformationRegistry runtimeIgnoreTransformationRegistry = new DomainControllerRuntimeIgnoreTransformationRegistry();
-        final PrepareStepHandler prepareStepHandler = new PrepareStepHandler(hostControllerInfo, contentRepository,
+        final PrepareStepHandler prepareStepHandler = new PrepareStepHandler(hostControllerInfo,
                 hostProxies, serverProxies, ignoredRegistry, extensionRegistry, runtimeIgnoreTransformationRegistry);
         final ExpressionResolver expressionResolver = new RuntimeExpressionResolver(vaultReader);
         final DomainModelControllerService service = new DomainModelControllerService(environment, runningModeControl, processState,
@@ -486,7 +486,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
 
     @Override
     protected void initModel(ManagementModel managementModel, Resource modelControllerResource) {
-        HostModelUtil.createRootRegistry(managementModel.getRootResourceRegistration(), environment, ignoredRegistry, this, processType, authorizer, modelControllerResource);
+        HostModelUtil.createRootRegistry(managementModel.getRootResourceRegistration(), environment,
+                ignoredRegistry, this, processType, authorizer, modelControllerResource);
         VersionModelInitializer.registerRootResource(managementModel.getRootResource(), environment != null ? environment.getProductConfig() : null);
         CoreManagementResourceDefinition.registerDomainResource(managementModel.getRootResource(), authorizer.getWritableAuthorizerConfiguration());
         this.modelNodeRegistration = managementModel.getRootResourceRegistration();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
@@ -73,7 +73,8 @@ public class HostModelUtil {
     }
 
 
-    public static void createRootRegistry(final ManagementResourceRegistration root, final HostControllerEnvironment environment,
+    public static void createRootRegistry(final ManagementResourceRegistration root,
+                                          final HostControllerEnvironment environment,
                                           final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry,
                                           final HostModelRegistrar hostModelRegistrar,
                                           final ProcessType processType,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ExtensionSetup.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ExtensionSetup.java
@@ -66,12 +66,20 @@ public class ExtensionSetup {
 
     public static void addExtensionAndSubsystem(final DomainTestSupport support) throws IOException, MgmtOperationException {
         DomainClient masterClient = support.getDomainMasterLifecycleUtil().getDomainClient();
-        PathAddress profileAddress = PathAddress.pathAddress("profile", "profile-a");
-
-        PathAddress subsystemAddress = profileAddress.append("subsystem", "1");
 
         ModelNode addExtension = Util.createAddOperation(PathAddress.pathAddress("extension", TestExtension.MODULE_NAME));
         DomainTestUtils.executeForResult(addExtension, masterClient);
+
+        for (String profileName : new String[]{"profile-a", "profile-b", "profile-shared"}) {
+            addExtensionAndSubsystem(masterClient, profileName);
+        }
+    }
+
+    private static void addExtensionAndSubsystem(final DomainClient masterClient, String profileName) throws IOException, MgmtOperationException {
+
+        PathAddress profileAddress = PathAddress.pathAddress("profile", profileName);
+
+        PathAddress subsystemAddress = profileAddress.append("subsystem", "1");
 
         ModelNode addSubsystem = Util.createAddOperation(subsystemAddress);
         addSubsystem.get("name").set("dummy name");

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/WildCardReadsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/WildCardReadsTestCase.java
@@ -100,4 +100,19 @@ public class WildCardReadsTestCase extends AbstractCliTestBase {
         Assert.assertEquals(1, generic.asInt());
         Assert.assertEquals(specific, generic.get(0).get(ModelDescriptionConstants.RESULT));
     }
+
+    @Test
+    public void testCompositeOperation() throws IOException {
+        cli.sendLine("/host=*/server=*/subsystem=*:read-resource()");
+        CLIOpResult opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        ModelNode specific = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+        Assert.assertEquals(ModelType.LIST, specific.getType());
+
+        for (final ModelNode result : specific.asList()) {
+            Assert.assertTrue(result.hasDefined(ModelDescriptionConstants.OP_ADDR));
+            Assert.assertTrue(result.hasDefined(ModelDescriptionConstants.RESULT));
+        }
+    }
+
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/WildcardReadsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/WildcardReadsTestCase.java
@@ -1,0 +1,376 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.rbac;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ABSOLUTE_ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_CONTROL;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILTERED_ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILTERED_CHILDREN_TYPES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MAJOR_VERSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELATIVE_ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNREADABLE_CHILDREN;
+import static org.jboss.as.test.integration.management.rbac.RbacUtil.MAINTAINER_USER;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.integration.domain.suites.FullRbacProviderTestSuite;
+import org.jboss.as.test.integration.management.rbac.Outcome;
+import org.jboss.as.test.integration.management.rbac.RbacUtil;
+import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests of wildcard reads with RBAC in place.
+ *
+ * @author Brian Stansberry (c) 2015 Red Hat Inc.
+ */
+public class WildcardReadsTestCase extends AbstractRbacTestCase {
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = FullRbacProviderTestSuite.createSupport(WildcardReadsTestCase.class.getSimpleName());
+        masterClientConfig = testSupport.getDomainMasterConfiguration();
+        DomainClient domainClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+        UserRolesMappingServerSetupTask.StandardUsersSetup.INSTANCE.setup(domainClient);
+        AbstractServerGroupScopedRolesTestCase.setupRoles(domainClient);
+        RBACProviderServerGroupScopedRolesTestCase.ServerGroupRolesMappingSetup.INSTANCE.setup(domainClient);
+        AbstractHostScopedRolesTestCase.setupRoles(domainClient);
+        RBACProviderHostScopedRolesTestCase.HostRolesMappingSetup.INSTANCE.setup(domainClient);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        DomainClient domainClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+
+        try {
+            RBACProviderHostScopedRolesTestCase.HostRolesMappingSetup.INSTANCE.tearDown(domainClient);
+        } finally {
+            try {
+                AbstractHostScopedRolesTestCase.tearDownRoles(domainClient);
+            } finally {
+                try {
+                    RBACProviderServerGroupScopedRolesTestCase.ServerGroupRolesMappingSetup.INSTANCE.tearDown(domainClient);
+                } finally {
+                    try {
+                        AbstractServerGroupScopedRolesTestCase.tearDownRoles(domainClient);
+                    } finally {
+                        try {
+                            UserRolesMappingServerSetupTask.StandardUsersSetup.INSTANCE.tearDown(domainClient);
+                        } finally {
+                            FullRbacProviderTestSuite.stopSupport();
+                            testSupport = null;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMaintainer() throws IOException {
+        ModelControllerClient client = getClientForUser(MAINTAINER_USER, false, masterClientConfig);
+
+        ModelNode op = createOpNode("host=*/server=*/subsystem=1/rbac-constrained=*", READ_RESOURCE_OPERATION);
+        configureRoles(op, new String[]{MAINTAINER_USER});
+        ModelNode response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        ModelNode result = response.get(RESULT);
+        assertEquals(result.toString(), ModelType.LIST, result.getType());
+        assertEquals(result.toString(), 2, result.asInt());
+
+        assertTrue(response.toString(), response.hasDefined(RESPONSE_HEADERS, ACCESS_CONTROL));
+
+        validateConstrainedResponse(response, "master", "master-a");
+        validateConstrainedResponse(response, "slave", "slave-b");
+
+        op = createOpNode("host=*/server=*/subsystem=1/rbac-sensitive=*", READ_RESOURCE_OPERATION);
+        configureRoles(op, new String[]{MAINTAINER_USER});
+        response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        // Result should be an empty list as we can't read any of these
+        assertTrue(response.toString(), response.hasDefined(RESULT));
+        assertEquals(response.toString(), ModelType.LIST, response.get(RESULT).getType());
+        assertEquals(response.toString(), 0, response.get(RESULT).asInt());
+
+        op = createOpNode("host=*/server=*/subsystem=1", READ_RESOURCE_OPERATION);
+        op.get(RECURSIVE).set(true);
+        configureRoles(op, new String[]{MAINTAINER_USER});
+        response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        result = response.get(RESULT);
+        assertEquals(result.toString(), ModelType.LIST, result.getType());
+        assertEquals(result.toString(), 2, result.asInt());
+
+        validateSensitiveResponse(response, "master", "master-a");
+        validateSensitiveResponse(response, "slave", "slave-b");
+    }
+
+    @Test
+    public void testHostScopedRole() throws IOException {
+        ModelControllerClient client = getClientForUser(AbstractHostScopedRolesTestCase.MAINTAINER_USER, false, masterClientConfig);
+
+        ModelNode op = createOpNode("host=*/server=*/subsystem=1/rbac-constrained=*", READ_RESOURCE_OPERATION);
+        configureRoles(op, new String[]{AbstractHostScopedRolesTestCase.MAINTAINER_USER});
+        ModelNode response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        ModelNode result = response.get(RESULT);
+        assertEquals(result.toString(), ModelType.LIST, result.getType());
+        assertEquals(result.toString(), 1, result.asInt());
+
+        assertTrue(response.toString(), response.hasDefined(RESPONSE_HEADERS, ACCESS_CONTROL));
+        checkFilteredChildrenType(response, PathAddress.EMPTY_ADDRESS, HOST);
+
+        validateConstrainedResponse(response, "master", "master-a");
+
+        op = createOpNode("host=*/server=*/subsystem=1/rbac-sensitive=*", READ_RESOURCE_OPERATION);
+        configureRoles(op, new String[]{AbstractHostScopedRolesTestCase.MAINTAINER_USER});
+        response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        // Result should be an empty list as we can't read any of these.
+        assertTrue(response.toString(), response.hasDefined(RESULT));
+        assertEquals(response.toString(), ModelType.LIST, response.get(RESULT).getType());
+        assertEquals(response.toString(), 0, response.get(RESULT).asInt());
+
+        assertTrue(response.toString(), response.hasDefined(RESPONSE_HEADERS, ACCESS_CONTROL));
+        checkFilteredChildrenType(response, PathAddress.EMPTY_ADDRESS, HOST);
+        checkFilteredChildrenType(response, PathAddress.pathAddress(PathElement.pathElement(HOST, "master"),
+                        PathElement.pathElement(RUNNING_SERVER, "master-a"), PathElement.pathElement(SUBSYSTEM, "1")),
+                "rbac-sensitive");
+
+        op = createOpNode("host=*/server=*/subsystem=1", READ_RESOURCE_OPERATION);
+        op.get(RECURSIVE).set(true);
+        configureRoles(op, new String[]{MAINTAINER_USER});
+        response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        result = response.get(RESULT);
+        assertEquals(result.toString(), ModelType.LIST, result.getType());
+        assertEquals(result.toString(), 1, result.asInt());
+
+        assertTrue(response.toString(), response.hasDefined(RESPONSE_HEADERS, ACCESS_CONTROL));
+        checkFilteredChildrenType(response, PathAddress.EMPTY_ADDRESS, HOST);
+        checkFilteredChildrenType(response, PathAddress.pathAddress(PathElement.pathElement(HOST, "master"),
+                        PathElement.pathElement(RUNNING_SERVER, "master-a"), PathElement.pathElement(SUBSYSTEM, "1")),
+                "rbac-sensitive");
+
+        validateSensitiveResponse(response, "master", "master-a");
+
+        // Now just read the root, to prove that's handled even when some hosts aren't allowed
+        op = createOpNode("host=*", READ_RESOURCE_OPERATION);
+        configureRoles(op, new String[]{MAINTAINER_USER});
+        response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        result = response.get(RESULT);
+        assertEquals(result.toString(), ModelType.LIST, result.getType());
+        assertEquals(result.toString(), 1, result.asInt());
+
+        assertTrue(response.toString(), response.hasDefined(RESPONSE_HEADERS, ACCESS_CONTROL));
+        checkFilteredChildrenType(response, PathAddress.EMPTY_ADDRESS, HOST);
+
+        ModelNode resultItem = getResultItem(response, PathAddress.pathAddress(HOST, "master"));
+        assertTrue(resultItem.toString(), resultItem.hasDefined(RESULT));
+        assertTrue(resultItem.toString(), resultItem.get(RESULT).keys().contains(MANAGEMENT_MAJOR_VERSION));
+        assertEquals(resultItem.toString(), "master", resultItem.get(RESULT, NAME).asString());
+    }
+
+    @Test
+    public void testServerGroupScopedRole() throws IOException {
+        ModelControllerClient client = getClientForUser(AbstractServerGroupScopedRolesTestCase.MAINTAINER_USER, false, masterClientConfig);
+
+        ModelNode op = createOpNode("host=*/server=*/subsystem=1/rbac-constrained=*", READ_RESOURCE_OPERATION);
+        configureRoles(op, new String[]{AbstractServerGroupScopedRolesTestCase.MAINTAINER_USER});
+        ModelNode response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        ModelNode result = response.get(RESULT);
+        assertEquals(result.toString(), ModelType.LIST, result.getType());
+        assertEquals(result.toString(), 1, result.asInt());
+
+        assertTrue(response.toString(), response.hasDefined(RESPONSE_HEADERS, ACCESS_CONTROL));
+        checkFilteredChildrenType(response, PathAddress.pathAddress(HOST, "slave"), RUNNING_SERVER);
+
+        validateConstrainedResponse(response, "master", "master-a");
+
+        op = createOpNode("host=*/server=*/subsystem=1/rbac-sensitive=*", READ_RESOURCE_OPERATION);
+        configureRoles(op, new String[]{AbstractServerGroupScopedRolesTestCase.MAINTAINER_USER});
+        response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        // Result should be an empty list as we can't read any of these.
+        assertTrue(response.toString(), response.hasDefined(RESULT));
+        assertEquals(response.toString(), ModelType.LIST, response.get(RESULT).getType());
+        assertEquals(response.toString(), 0, response.get(RESULT).asInt());
+
+        assertTrue(response.toString(), response.hasDefined(RESPONSE_HEADERS, ACCESS_CONTROL));
+        checkFilteredChildrenType(response, PathAddress.pathAddress(HOST, "slave"), RUNNING_SERVER);
+        checkFilteredChildrenType(response, PathAddress.pathAddress(PathElement.pathElement(HOST, "master"),
+                        PathElement.pathElement(RUNNING_SERVER, "master-a"), PathElement.pathElement(SUBSYSTEM, "1")),
+                "rbac-sensitive");
+
+        op = createOpNode("host=*/server=*/subsystem=1", READ_RESOURCE_OPERATION);
+        op.get(RECURSIVE).set(true);
+        configureRoles(op, new String[]{MAINTAINER_USER});
+        response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        result = response.get(RESULT);
+        assertEquals(result.toString(), ModelType.LIST, result.getType());
+        assertEquals(result.toString(), 1, result.asInt());
+
+        assertTrue(response.toString(), response.hasDefined(RESPONSE_HEADERS, ACCESS_CONTROL));
+        checkFilteredChildrenType(response, PathAddress.pathAddress(HOST, "slave"), RUNNING_SERVER);
+        checkFilteredChildrenType(response, PathAddress.pathAddress(PathElement.pathElement(HOST, "master"),
+                        PathElement.pathElement(RUNNING_SERVER, "master-a"), PathElement.pathElement(SUBSYSTEM, "1")),
+                "rbac-sensitive");
+
+        validateSensitiveResponse(response, "master", "master-a");
+
+        // Now just read the root, to prove that's handled even when some servers aren't allowed
+        op = createOpNode("host=*/server=*", READ_RESOURCE_OPERATION);
+        configureRoles(op, new String[]{MAINTAINER_USER});
+        response = RbacUtil.executeOperation(client, op, Outcome.SUCCESS);
+
+        result = response.get(RESULT);
+        assertEquals(result.toString(), ModelType.LIST, result.getType());
+        assertEquals(result.toString(), 2, result.asInt());
+
+        assertTrue(response.toString(), response.hasDefined(RESPONSE_HEADERS, ACCESS_CONTROL));
+        checkFilteredChildrenType(response, PathAddress.pathAddress(HOST, "slave"), RUNNING_SERVER);
+
+        ModelNode resultItem = getResultItem(response, PathAddress.pathAddress(PathElement.pathElement(HOST, "slave"), PathElement.pathElement(RUNNING_SERVER, "slave-a")));
+        assertTrue(resultItem.toString(), resultItem.hasDefined(RESULT));
+        assertEquals(resultItem.toString(), 0, resultItem.get(RESULT).asInt());
+
+        resultItem = getResultItem(response, PathAddress.pathAddress(PathElement.pathElement(HOST, "master"), PathElement.pathElement(RUNNING_SERVER, "master-a")));
+        assertTrue(resultItem.toString(), resultItem.hasDefined(RESULT));
+        assertTrue(resultItem.toString(), resultItem.get(RESULT).keys().contains(MANAGEMENT_MAJOR_VERSION));
+        assertEquals(resultItem.toString(), "master", resultItem.get(RESULT, HOST).asString());
+        assertEquals(resultItem.toString(), "master-a", resultItem.get(RESULT, NAME).asString());
+
+        checkFilteredChildrenType(response, PathAddress.pathAddress(HOST, "slave"), RUNNING_SERVER);
+        ModelNode accItem = getAccessControlItem(response, PathAddress.pathAddress(HOST, "slave"));
+        assertTrue(accItem.toString(), accItem.hasDefined(UNREADABLE_CHILDREN));
+        assertEquals(accItem.toString(), ModelType.LIST, accItem.get(UNREADABLE_CHILDREN).getType());
+        assertEquals(accItem.toString(), 1, accItem.get(UNREADABLE_CHILDREN).asInt());
+        assertEquals(accItem.toString(), ModelType.PROPERTY, accItem.get(UNREADABLE_CHILDREN).get(0).getType());
+        assertEquals(accItem.toString(), RUNNING_SERVER, accItem.get(UNREADABLE_CHILDREN).get(0).asProperty().getName());
+        assertEquals(accItem.toString(), "slave-b", accItem.get(UNREADABLE_CHILDREN).get(0).asProperty().getValue().asString());
+    }
+
+    @Override
+    protected void configureRoles(ModelNode op, String[] roles) {
+        // no-op. Role mapping is done based on the client's authenticated Subject
+    }
+
+    private static void checkFilteredChildrenType(ModelNode response, PathAddress reporter, String type) {
+        ModelNode accItem = getAccessControlItem(response, reporter);
+        assert accItem != null;
+        assertEquals(accItem.toString(), reporter, PathAddress.pathAddress(accItem.get(RELATIVE_ADDRESS)));
+        assertTrue(accItem.toString(), accItem.hasDefined(FILTERED_CHILDREN_TYPES));
+        assertEquals(accItem.toString(), ModelType.LIST, accItem.get(FILTERED_CHILDREN_TYPES).getType());
+        assertEquals(accItem.toString(), 1, accItem.get(FILTERED_CHILDREN_TYPES).asInt());
+        assertEquals(accItem.toString(), type, accItem.get(FILTERED_CHILDREN_TYPES).get(0).asString());
+
+    }
+
+    private static ModelNode getResultItem(ModelNode response, PathAddress pathAddress) {
+        for (ModelNode item : response.get(RESULT).asList()) {
+            if (pathAddress.equals(PathAddress.pathAddress(item.get(ADDRESS)))) {
+                return item;
+            }
+        }
+        fail(String.format("No %s in %s", pathAddress, response.get(RESULT)));
+        // Unreachable
+        throw new IllegalStateException();
+    }
+
+    private static ModelNode getAccessControlItem(ModelNode response, PathAddress pathAddress) {
+        for (ModelNode item : response.get(RESPONSE_HEADERS, ACCESS_CONTROL).asList()) {
+            if (pathAddress.equals(PathAddress.pathAddress(item.get(ABSOLUTE_ADDRESS)))) {
+                return item;
+            }
+        }
+        fail(String.format("No %s in %s", pathAddress, response.get(RESPONSE_HEADERS, ACCESS_CONTROL)));
+        // Unreachable
+        throw new IllegalStateException();
+    }
+
+    private static void validateConstrainedResponse(ModelNode response, String host, String server) {
+
+        PathAddress target = PathAddress.pathAddress(PathElement.pathElement(HOST, host),
+                PathElement.pathElement(RUNNING_SERVER, server), PathElement.pathElement(SUBSYSTEM, "1"),
+                PathElement.pathElement("rbac-constrained", "default"));
+        ModelNode item = getResultItem(response, target);
+        assertTrue(item.toString(), item.has(RESULT, "security-domain"));
+        assertFalse(item.toString(), item.hasDefined(RESULT, "security-domain"));
+        assertTrue(item.toString(), item.has(RESULT, "password"));
+        assertFalse(item.toString(), item.hasDefined(RESULT, "password"));
+
+        checkFilteredAttributes(response, target);
+    }
+
+    private static void checkFilteredAttributes(ModelNode response, PathAddress reporter) {
+        ModelNode accItem = getAccessControlItem(response, reporter);
+        assert accItem != null;
+        assertEquals(accItem.toString(), reporter, PathAddress.pathAddress(accItem.get(RELATIVE_ADDRESS)));
+        assertTrue(accItem.toString(), accItem.hasDefined(FILTERED_ATTRIBUTES));
+        assertEquals(accItem.toString(), 2, accItem.get(FILTERED_ATTRIBUTES).asInt());
+        assertTrue(accItem.toString(), accItem.get(FILTERED_ATTRIBUTES).asString().contains("password"));
+        assertTrue(accItem.toString(), accItem.get(FILTERED_ATTRIBUTES).asString().contains("security-domain"));
+
+    }
+
+    private static void validateSensitiveResponse(ModelNode response, String host, String server) {
+        PathAddress subsystemAddr = PathAddress.pathAddress(PathElement.pathElement(HOST, host),
+                PathElement.pathElement(RUNNING_SERVER, server), PathElement.pathElement(SUBSYSTEM, "1"));
+
+        ModelNode resultItem = getResultItem(response, subsystemAddr);
+        assertTrue(resultItem.toString(), resultItem.has(RESULT, "rbac-sensitive"));
+        assertFalse(resultItem.toString(), resultItem.hasDefined(RESULT, "rbac-sensitive"));
+        assertTrue(resultItem.toString(), resultItem.has(RESULT, "rbac-constrained", "default", "password"));
+        assertFalse(resultItem.toString(), resultItem.hasDefined(RESULT, "rbac-constrained", "default", "password"));
+
+        checkFilteredChildrenType(response, subsystemAddr, "rbac-sensitive");
+        checkFilteredAttributes(response, subsystemAddr.append(PathElement.pathElement("rbac-constrained", "default")));
+    }
+
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CompositeOperationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CompositeOperationTestCase.java
@@ -1,0 +1,439 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DIRECTORY_GROUPING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MAJOR_VERSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test of various scenarios involving composite operations in a domain.
+ *
+ * @author Brian Stansberry (c) 2015 Red Hat Inc.
+ */
+public class CompositeOperationTestCase {
+
+    private static final PathElement HOST_MASTER = PathElement.pathElement(HOST, "master");
+    private static final PathElement HOST_SLAVE = PathElement.pathElement(HOST, "slave");
+    private static final PathElement SERVER_ONE = PathElement.pathElement(RUNNING_SERVER, "main-one");
+    private static final PathElement SERVER_THREE = PathElement.pathElement(RUNNING_SERVER, "main-three");
+    private static final PathElement SYS_PROP_ELEMENT = PathElement.pathElement(SYSTEM_PROPERTY, "composite-op");
+    private static final PathElement HOST_SYS_PROP_ELEMENT = PathElement.pathElement(SYSTEM_PROPERTY, "composite-op-host");
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainMasterLifecycleUtil;
+
+    private int sysPropVal = 0;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(CompositeOperationTestCase.class.getSimpleName());
+        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        testSupport = null;
+        domainMasterLifecycleUtil = null;
+        DomainTestSuite.stopSupport();
+    }
+
+    @Before
+    public void setup() throws IOException {
+        sysPropVal = 0;
+        ModelNode op = Util.createAddOperation(PathAddress.pathAddress(SYS_PROP_ELEMENT));
+        op.get(VALUE).set(sysPropVal);
+        domainMasterLifecycleUtil.getDomainClient().execute(op);
+        op = Util.createAddOperation(PathAddress.pathAddress(HOST_MASTER, HOST_SYS_PROP_ELEMENT));
+        op.get(VALUE).set(sysPropVal);
+        domainMasterLifecycleUtil.getDomainClient().execute(op);
+        op = Util.createAddOperation(PathAddress.pathAddress(HOST_SLAVE, HOST_SYS_PROP_ELEMENT));
+        op.get(VALUE).set(sysPropVal);
+        domainMasterLifecycleUtil.getDomainClient().execute(op);
+    }
+
+
+    @After
+    public void tearDown() throws IOException {
+        try {
+            ModelNode op = Util.createRemoveOperation(PathAddress.pathAddress(SYS_PROP_ELEMENT));
+            domainMasterLifecycleUtil.getDomainClient().execute(op);
+        } finally {
+            try {
+                ModelNode op = Util.createRemoveOperation(PathAddress.pathAddress(HOST_MASTER, HOST_SYS_PROP_ELEMENT));
+                domainMasterLifecycleUtil.getDomainClient().execute(op);
+            } finally {
+                ModelNode op = Util.createRemoveOperation(PathAddress.pathAddress(HOST_SLAVE, HOST_SYS_PROP_ELEMENT));
+                domainMasterLifecycleUtil.getDomainClient().execute(op);
+            }
+        }
+    }
+
+    /**
+     * Test of a composite operation that reads from multiple processes.
+     *
+     * @throws IOException
+     * @throws MgmtOperationException
+     */
+    @Test
+    public void testMultipleProcessReadOnlyComposite() throws IOException, MgmtOperationException {
+
+        final ModelNode composite = new ModelNode();
+        composite.get(OP).set(COMPOSITE);
+        final ModelNode steps = composite.get(STEPS);
+
+        final ModelNode address = new ModelNode();
+        address.setEmptyList();
+
+        // host=slave
+        address.add(HOST, "slave");
+        steps.add().set(createReadResourceOperation(address));
+
+        // host=slave,server=main-three
+        address.add(RUNNING_SERVER, "main-three");
+        steps.add().set(createReadResourceOperation(address));
+
+        // host=slave,server=main-three,subsystem=io
+        address.add(SUBSYSTEM, "io");
+        steps.add().set(createReadResourceOperation(address));
+
+        // add steps involving a different host
+        address.setEmptyList();
+
+        // host=master
+        address.add(HOST, "master");
+        steps.add().set(createReadResourceOperation(address));
+
+        // host=master,server=main-one
+        address.add(RUNNING_SERVER, "main-one");
+        steps.add().set(createReadResourceOperation(address));
+
+        // host=master,server=main-one,subsystem=io
+        address.add(SUBSYSTEM, "io");
+        steps.add().set(createReadResourceOperation(address));
+
+        // Now repeat the whole thing, but nested
+
+        final ModelNode nested = steps.add();
+        nested.get(OP).set(COMPOSITE);
+        final ModelNode nestedSteps = nested.get(STEPS);
+
+        address.setEmptyList();
+
+        // host=slave
+        address.add(HOST, "slave");
+        nestedSteps.add().set(createReadResourceOperation(address));
+
+        // host=slave,server=main-three
+        address.add(RUNNING_SERVER, "main-three");
+        nestedSteps.add().set(createReadResourceOperation(address));
+
+        // host=slave,server=main-three,subsystem=io
+        address.add(SUBSYSTEM, "io");
+        nestedSteps.add().set(createReadResourceOperation(address));
+
+        // add steps involving a different host
+        address.setEmptyList();
+
+        // host=master
+        address.add(HOST, "master");
+        nestedSteps.add().set(createReadResourceOperation(address));
+
+        // host=master,server=main-one
+        address.add(RUNNING_SERVER, "main-one");
+        nestedSteps.add().set(createReadResourceOperation(address));
+
+        // host=master,server=main-one,subsystem=io
+        address.add(SUBSYSTEM, "io");
+        nestedSteps.add().set(createReadResourceOperation(address));
+
+        final ModelNode response = domainMasterLifecycleUtil.getDomainClient().execute(composite);
+
+        assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.hasDefined(RESULT));
+        assertFalse(response.toString(), response.has(SERVER_GROUPS));
+
+        validateCompositeReadonlyResponse(response, true);
+    }
+
+    private void validateCompositeReadonlyResponse(ModelNode response, boolean allowNested) {
+
+        int i = 0;
+        for (Property property : response.get(RESULT).asPropertyList()) {
+            assertEquals(property.getName() + " from " + response, "step-" + (++i), property.getName());
+            ModelNode item = property.getValue();
+            assertEquals(property.getName() + " from " + response, ModelType.OBJECT, item.getType());
+            assertEquals(property.getName() + " from " + response, SUCCESS, item.get(OUTCOME).asString());
+            assertTrue(property.getName() + " from " + response, item.hasDefined(RESULT));
+            ModelNode itemResult = item.get(RESULT);
+            assertEquals(property.getName() + " result " + itemResult, ModelType.OBJECT, itemResult.getType());
+            switch (i) {
+                case 1:
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(MANAGEMENT_MAJOR_VERSION));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(RUNNING_SERVER));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(DIRECTORY_GROUPING));
+                    assertEquals(property.getName() + " result " + itemResult, "slave", itemResult.get(NAME).asString());
+                    break;
+                case 2:
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(MANAGEMENT_MAJOR_VERSION));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(SUBSYSTEM));
+                    assertEquals(property.getName() + " result " + itemResult, "main-three", itemResult.get(NAME).asString());
+                    assertEquals(property.getName() + " result " + itemResult, "slave", itemResult.get(HOST).asString());
+                    break;
+                case 3:
+                case 6:
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined("buffer-pool"));
+                    break;
+                case 4:
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(MANAGEMENT_MAJOR_VERSION));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(RUNNING_SERVER));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(DIRECTORY_GROUPING));
+                    assertEquals(property.getName() + " result " + itemResult, "master", itemResult.get(NAME).asString());
+                    break;
+                case 5:
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(MANAGEMENT_MAJOR_VERSION));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(SUBSYSTEM));
+                    assertEquals(property.getName() + " result " + itemResult, "main-one", itemResult.get(NAME).asString());
+                    assertEquals(property.getName() + " result " + itemResult, "master", itemResult.get(HOST).asString());
+                    break;
+                case 7:
+                    if (allowNested) {
+                        // recurse
+                        validateCompositeReadonlyResponse(item, false);
+                        break;
+                    } // else fall through
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+    }
+
+    /**
+     * Test of a composite operation that writes to and reads from multiple processes.
+     */
+    @Test
+    public void testMultipleProcessReadWriteOperation() throws IOException {
+
+        final ModelNode composite = new ModelNode();
+        composite.get(OP).set(COMPOSITE);
+        final ModelNode steps = composite.get(STEPS);
+
+        // Modify the domain-wide prop
+        steps.add().set(Util.getWriteAttributeOperation(PathAddress.pathAddress(SYS_PROP_ELEMENT), VALUE, ++sysPropVal));
+
+        steps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_MASTER, SERVER_ONE, SYS_PROP_ELEMENT), VALUE));
+
+        steps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_SLAVE, SERVER_THREE, SYS_PROP_ELEMENT), VALUE));
+
+        // Modify the host=master prop
+
+        steps.add().set(Util.getWriteAttributeOperation(PathAddress.pathAddress(HOST_MASTER, HOST_SYS_PROP_ELEMENT), VALUE, ++sysPropVal));
+
+        steps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_MASTER, SERVER_ONE, HOST_SYS_PROP_ELEMENT), VALUE));
+
+        steps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_SLAVE, SERVER_THREE, HOST_SYS_PROP_ELEMENT), VALUE));
+
+        // Modify the host=slave prop
+
+        steps.add().set(Util.getWriteAttributeOperation(PathAddress.pathAddress(HOST_SLAVE, HOST_SYS_PROP_ELEMENT), VALUE, ++sysPropVal));
+
+        steps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_MASTER, SERVER_ONE, HOST_SYS_PROP_ELEMENT), VALUE));
+
+        steps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_SLAVE, SERVER_THREE, HOST_SYS_PROP_ELEMENT), VALUE));
+
+        // Now repeat the whole thing, but nested
+
+        final ModelNode nested = steps.add();
+        nested.get(OP).set(COMPOSITE);
+        final ModelNode nestedSteps = nested.get(STEPS);
+
+        // Domain wide
+        nestedSteps.add().set(Util.getWriteAttributeOperation(PathAddress.pathAddress(SYS_PROP_ELEMENT), VALUE, ++sysPropVal));
+
+        nestedSteps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_MASTER, SERVER_ONE, SYS_PROP_ELEMENT), VALUE));
+
+        nestedSteps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_SLAVE, SERVER_THREE, SYS_PROP_ELEMENT), VALUE));
+
+        // host=master
+
+        nestedSteps.add().set(Util.getWriteAttributeOperation(PathAddress.pathAddress(HOST_MASTER, HOST_SYS_PROP_ELEMENT), VALUE, ++sysPropVal));
+
+        nestedSteps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_MASTER, SERVER_ONE, HOST_SYS_PROP_ELEMENT), VALUE));
+
+        nestedSteps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_SLAVE, SERVER_THREE, HOST_SYS_PROP_ELEMENT), VALUE));
+
+        // host=slave
+
+        nestedSteps.add().set(Util.getWriteAttributeOperation(PathAddress.pathAddress(HOST_SLAVE, HOST_SYS_PROP_ELEMENT), VALUE, ++sysPropVal));
+
+        nestedSteps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_MASTER, SERVER_ONE, HOST_SYS_PROP_ELEMENT), VALUE));
+
+        nestedSteps.add().set(Util.getReadAttributeOperation(PathAddress.pathAddress(HOST_SLAVE, SERVER_THREE, HOST_SYS_PROP_ELEMENT), VALUE));
+
+        final ModelNode response = domainMasterLifecycleUtil.getDomainClient().execute(composite);
+
+        assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.hasDefined(RESULT));
+        assertTrue(response.toString(), response.has(SERVER_GROUPS));
+
+        validateCompositeReadWriteResponse(response, true);
+
+        assertTrue(response.toString(), response.hasDefined(SERVER_GROUPS, "main-server-group", HOST, "master", "main-one", "response"));
+        ModelNode serverResp = response.get(SERVER_GROUPS, "main-server-group", HOST, "master", "main-one", "response");
+        validateBasicServerResponse(serverResp, null, 1, null, 2, 2, -1, null, 4, null, 5, 5);
+        assertTrue(response.toString(), response.hasDefined(SERVER_GROUPS, "main-server-group", HOST, "slave", "main-three", "response"));
+        serverResp = response.get(SERVER_GROUPS, "main-server-group", HOST, "slave", "main-three", "response");
+        validateBasicServerResponse(serverResp, null, 1, 0, null, 3, -1, null, 4, 3, null, 6);
+        assertTrue(response.toString(), response.hasDefined(SERVER_GROUPS, "other-server-group", HOST, "slave", "other-two", "response"));
+        serverResp = response.get(SERVER_GROUPS, "other-server-group", HOST, "slave", "other-two", "response");
+        validateBasicServerResponse(serverResp, null, null, -1, null, null);
+
+    }
+
+    private void validateCompositeReadWriteResponse(ModelNode response, boolean allowNested) {
+
+        int i = 0;
+        int baseValue = allowNested ? 0 : 3;
+        for (Property property : response.get(RESULT).asPropertyList()) {
+            assertEquals(property.getName() + " from " + response, "step-" + (++i), property.getName());
+            ModelNode item = property.getValue();
+            if (i != 4 && i != 7) {
+                assertEquals(property.getName() + " from " + response, ModelType.OBJECT, item.getType());
+                assertEquals(property.getName() + " from " + response, SUCCESS, item.get(OUTCOME).asString());
+            }
+            ModelNode itemResult = item.get(RESULT);
+            switch (i) {
+                case 1:
+                    assertFalse(property.getName() + " result " + itemResult, itemResult.isDefined());
+                    break;
+                case 2:
+                case 3:
+                    assertEquals(property.getName() + " result " + itemResult, ModelType.STRING, itemResult.getType());
+                    assertEquals(property.getName() + " result " + itemResult, baseValue + 1, itemResult.asInt());
+                    break;
+                case 4:
+                    //assertFalse(property.getName() + " result " + itemResult, itemResult.isDefined());
+                    break;
+                case 5:
+                case 8:
+                    assertEquals(property.getName() + " result " + itemResult, ModelType.STRING, itemResult.getType());
+                    assertEquals(property.getName() + " result " + itemResult, baseValue + 2, itemResult.asInt());
+                    break;
+                case 6:
+                    assertEquals(property.getName() + " result " + itemResult, ModelType.STRING, itemResult.getType());
+                    assertEquals(property.getName() + " result " + itemResult, baseValue, itemResult.asInt());
+                    break;
+                case 7:
+                    //assertFalse(property.getName() + " result " + itemResult, itemResult.isDefined());
+                    break;
+                case 9:
+                    assertEquals(property.getName() + " result " + itemResult, ModelType.STRING, itemResult.getType());
+                    assertEquals(property.getName() + " result " + itemResult, baseValue + 3, itemResult.asInt());
+                    break;
+                case 10:
+                    if (allowNested) {
+                        // recurse
+                        validateCompositeReadWriteResponse(item, false);
+                        break;
+                    } // else fall through
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+
+    }
+
+    private static void validateBasicServerResponse(ModelNode serverResponse, Integer... values) {
+        assertEquals(serverResponse.toString(), ModelType.OBJECT, serverResponse.getType());
+        assertEquals(serverResponse.toString(), SUCCESS, serverResponse.get(OUTCOME).asString());
+        assertTrue(serverResponse.toString(), serverResponse.hasDefined(RESULT));
+        ModelNode serverResult = serverResponse.get(RESULT);
+        assertEquals(serverResponse.toString(), ModelType.OBJECT, serverResult.getType());
+        List<Property> list = serverResult.asPropertyList();
+        assertTrue(list.size() <= values.length);
+        for (int i = 0; i < list.size(); i++) {
+            ModelNode node = list.get(i).getValue();
+            assertTrue(serverResult.toString(), node.isDefined());
+            assertEquals(serverResult.toString(), ModelType.OBJECT, node.getType());
+            assertEquals(serverResult.toString(), SUCCESS, node.get(OUTCOME).asString());
+            Integer val = values[i];
+            if (val == null) {
+                assertFalse(serverResult.toString(), node.hasDefined(RESULT));
+            } else {
+                assertTrue(serverResult.toString() + " node " + i, node.hasDefined(RESULT));
+                int valInt = val.intValue();
+                if (valInt < 0) {
+                    assertTrue(values.length > i + 1);
+                    Integer[] sub = new Integer[values.length - i];
+                    System.arraycopy(values, i + 1, sub, 0, values.length - i - 1);
+                    validateBasicServerResponse(node, sub);
+                } else {
+                    assertEquals(ModelType.STRING, node.get(RESULT).getType());
+                    assertEquals(String.valueOf(valInt), node.get(RESULT).asString());
+                }
+            }
+        }
+    }
+
+    private static ModelNode createReadResourceOperation(final ModelNode address) {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+        return operation;
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CoreResourceManagementTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CoreResourceManagementTestCase.java
@@ -77,7 +77,6 @@ import static org.jboss.as.test.integration.domain.management.util.DomainTestUti
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -85,10 +84,10 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jboss.as.controller.CompositeOperationHandler;
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.common.SnapshotDeleteHandler;
 import org.jboss.as.controller.operations.common.SnapshotListHandler;
 import org.jboss.as.controller.operations.common.SnapshotTakeHandler;
@@ -751,21 +750,9 @@ public class CoreResourceManagementTestCase {
         validateFailedResponse(response);
 
         String errorCode = getNotAuthorizedErrorCode();
-        Assert.assertEquals(1, response.get(SERVER_GROUPS, "main-server-group", HOST, "master").keys().size());
-        Assert.assertEquals(1, response.get(SERVER_GROUPS, "main-server-group", HOST, "slave").keys().size());
-        ModelNode mainOneResult = response.get(SERVER_GROUPS, "main-server-group", HOST, "master", "main-one");
-        ModelNode mainThreeResult = response.get(SERVER_GROUPS, "main-server-group", HOST, "slave", "main-three");
-        Assert.assertTrue(mainOneResult.isDefined());
-        Assert.assertTrue(mainThreeResult.isDefined());
-
-        List<ModelNode> steps = new ArrayList<ModelNode>();
-        steps.add(mainOneResult);
-        steps.add(mainThreeResult);
-        for (ModelNode stepResponse : steps) {
-            ModelNode stepResult = stepResponse.get("response");
-            ModelNode desc = validateFailedResponse(stepResult);
-            Assert.assertTrue(desc.toString() + " does not contain " + errorCode, desc.toString().contains(errorCode));
-        }
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains(errorCode));
+        Assert.assertTrue(response.toString(), response.hasDefined(RESULT, "step-1", FAILURE_DESCRIPTION));
+        Assert.assertTrue(response.toString(), response.get(RESULT, "step-1", FAILURE_DESCRIPTION).asString().contains(errorCode));
     }
 
     /**
@@ -1051,7 +1038,7 @@ public class CoreResourceManagementTestCase {
             snapshots.add(listResult.get(DIRECTORY).asString() + fileSeparator + curr.asString());
         }
 
-        Assert.assertTrue(snapshots.contains(snapshot));
+        Assert.assertTrue(listResult.toString() + " has " + snapshot, snapshots.contains(snapshot));
 
         ModelNode deleteSnapshotOperation = new ModelNode();
         deleteSnapshotOperation.get(OP).set(SnapshotDeleteHandler.DEFINITION.getName());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -37,6 +37,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses ({
         AuditLogTestCase.class,
+        CompositeOperationTestCase.class,
         CoreResourceManagementTestCase.class,
         DeploymentRolloutFailureTestCase.class,
         DirectoryGroupingByTypeTestCase.class,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -54,7 +54,8 @@ import org.junit.runners.Suite;
         ResponseStreamTestCase.class,
         ServerRestartRequiredTestCase.class,
         ValidateAddressOperationTestCase.class,
-        ValidateOperationOperationTestCase.class
+        ValidateOperationOperationTestCase.class,
+        WildcardOperationsTestCase.class
 })
 public class DomainTestSuite {
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderTestSuite.java
@@ -32,6 +32,7 @@ import org.jboss.as.test.integration.domain.rbac.RBACProviderHostScopedRolesTest
 import org.jboss.as.test.integration.domain.rbac.RBACProviderServerGroupScopedRolesTestCase;
 import org.jboss.as.test.integration.domain.rbac.RBACProviderStandardRolesTestCase;
 import org.jboss.as.test.integration.domain.rbac.RolesIntegrityCheckingTestCase;
+import org.jboss.as.test.integration.domain.rbac.WildcardReadsTestCase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -51,7 +52,8 @@ import org.junit.runners.Suite;
         PermissionsCoverageTestCase.class,
         IncludeAllRoleTestCase.class,
         ListRoleNamesTestCase.class,
-        RolesIntegrityCheckingTestCase.class
+        RolesIntegrityCheckingTestCase.class,
+        WildcardReadsTestCase.class
 })
 public class FullRbacProviderTestSuite {
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/WildcardOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/WildcardOperationsTestCase.java
@@ -1,0 +1,283 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DIRECTORY_GROUPING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MAJOR_VERSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Emanuel Muckenhuber
+ */
+public class WildcardOperationsTestCase {
+
+    private static final String WILDCARD = "*";
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainMasterLifecycleUtil;
+    private static DomainLifecycleUtil domainSlaveLifecycleUtil;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(WildcardOperationsTestCase.class.getSimpleName());
+        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        testSupport = null;
+        domainMasterLifecycleUtil = null;
+        domainSlaveLifecycleUtil = null;
+        DomainTestSuite.stopSupport();
+    }
+
+    @Test
+    public void testBasicWildcardOperations() throws IOException, MgmtOperationException {
+
+        final ModelNode address = new ModelNode();
+        address.setEmptyList();
+
+        // host=*
+        address.add(HOST, WILDCARD);
+        executeReadResource(address, domainMasterLifecycleUtil.getDomainClient());
+
+        // host=*,server=*
+        address.add(RUNNING_SERVER, WILDCARD);
+        executeReadResource(address, domainMasterLifecycleUtil.getDomainClient());
+
+        // host=*,server=*,subsystem=*
+        address.add(SUBSYSTEM, WILDCARD);
+        ModelNode result = executeReadResource(address, domainMasterLifecycleUtil.getDomainClient());
+
+        assertTrue(result.toString(), false);
+        address.setEmptyList();
+
+    }
+
+    @Test
+    public void testNormalCompositeOperation() throws IOException, MgmtOperationException {
+
+        final ModelNode composite = new ModelNode();
+        composite.get(OP).set(COMPOSITE);
+        final ModelNode steps = composite.get(STEPS);
+
+        final ModelNode address = new ModelNode();
+        address.setEmptyList();
+
+        // host=slave
+        address.add(HOST, "slave");
+        steps.add().set(createReadResourceOperation(address));
+
+        // host=slave,server=main-three
+        address.add(RUNNING_SERVER, "main-three");
+        steps.add().set(createReadResourceOperation(address));
+
+        // host=slave,server=main-three,subsystem=io
+        address.add(SUBSYSTEM, "io");
+        steps.add().set(createReadResourceOperation(address));
+
+        // add steps involving a different host
+        address.setEmptyList();
+
+        // host=master
+        address.add(HOST, "master");
+        steps.add().set(createReadResourceOperation(address));
+
+        // host=master,server=main-one
+        address.add(RUNNING_SERVER, "main-one");
+        steps.add().set(createReadResourceOperation(address));
+
+        // host=master,server=main-one,subsystem=io
+        address.add(SUBSYSTEM, "io");
+        steps.add().set(createReadResourceOperation(address));
+
+        final ModelNode response = domainMasterLifecycleUtil.getDomainClient().execute(composite);
+        assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.hasDefined(RESULT));
+
+        int i = 0;
+        for (Property property : response.get(RESULT).asPropertyList()) {
+            assertEquals(property.getName() + " from " + response, "step-" + (++i), property.getName());
+            ModelNode item = property.getValue();
+            assertEquals(property.getName() + " from " + response, ModelType.OBJECT, item.getType());
+            assertEquals(property.getName() + " from " + response, SUCCESS, item.get(OUTCOME).asString());
+            assertTrue(property.getName() + " from " + response, item.hasDefined(RESULT));
+            ModelNode itemResult = item.get(RESULT);
+            assertEquals(property.getName() + " result " + itemResult, ModelType.OBJECT, itemResult.getType());
+            switch (i) {
+                case 1:
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(MANAGEMENT_MAJOR_VERSION));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(RUNNING_SERVER));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(DIRECTORY_GROUPING));
+                    assertEquals(property.getName() + " result " + itemResult, "slave", itemResult.get(NAME).asString());
+                    break;
+                case 2:
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(MANAGEMENT_MAJOR_VERSION));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(SUBSYSTEM));
+                    assertEquals(property.getName() + " result " + itemResult, "main-three", itemResult.get(NAME).asString());
+                    assertEquals(property.getName() + " result " + itemResult, "slave", itemResult.get(HOST).asString());
+                    break;
+                case 3:
+                case 6:
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined("buffer-pool"));
+                    break;
+                case 4:
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(MANAGEMENT_MAJOR_VERSION));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(RUNNING_SERVER));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(DIRECTORY_GROUPING));
+                    assertEquals(property.getName() + " result " + itemResult, "master", itemResult.get(NAME).asString());
+                    break;
+                case 5:
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(MANAGEMENT_MAJOR_VERSION));
+                    assertTrue(property.getName() + " result " + itemResult, itemResult.hasDefined(SUBSYSTEM));
+                    assertEquals(property.getName() + " result " + itemResult, "main-one", itemResult.get(NAME).asString());
+                    assertEquals(property.getName() + " result " + itemResult, "master", itemResult.get(HOST).asString());
+                    break;
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+
+        address.setEmptyList();
+        steps.setEmptyList();
+
+    }
+
+    @Test
+    public void testCompositeOperationWithWildCards() throws IOException, MgmtOperationException {
+
+        final ModelNode composite = new ModelNode();
+        composite.get(OP).set(COMPOSITE);
+        final ModelNode steps = composite.get(STEPS);
+
+        final ModelNode address = new ModelNode();
+        address.setEmptyList();
+
+        // host=*
+        address.add(HOST, WILDCARD);
+        steps.add().set(createReadResourceOperation(address));
+
+        // host=*,server=*
+        address.add(RUNNING_SERVER, WILDCARD);
+        steps.add().set(createReadResourceOperation(address));
+
+        // host=*,server=*,subsystem=*
+        address.add(SUBSYSTEM, WILDCARD);
+        steps.add().set(createReadResourceOperation(address));
+
+        final ModelNode response = domainMasterLifecycleUtil.getDomainClient().execute(composite);
+        assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.hasDefined(RESULT));
+
+        for (Property property : response.get(RESULT).asPropertyList()) {
+            assertEquals(property.getName() + " from " + response.toString(), ModelType.LIST, property.getValue().get(RESULT).getType());
+        }
+
+        address.setEmptyList();
+        steps.setEmptyList();
+
+    }
+
+    static ModelNode executeReadResource(final ModelNode address, final ModelControllerClient client) throws IOException, MgmtOperationException {
+        final ModelNode operation = createReadResourceOperation(address);
+        return assertWildcardResult(operation, client);
+    }
+
+    static ModelNode createReadResourceOperation(final ModelNode address) {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).set(address);
+        return operation;
+    }
+
+    static ModelNode assertWildcardResult(final ModelNode operation, final ModelControllerClient client) throws IOException, MgmtOperationException {
+        final ModelNode result = DomainTestUtils.executeForResult(operation, client);
+
+        assertEquals(ModelType.LIST, result.getType());
+
+        final PathAddress toMatch = PathAddress.pathAddress(operation.get(OP_ADDR));
+        for (final ModelNode r : result.asList()) {
+            assertMatchingAddress(toMatch, r);
+            assertTrue(r.hasDefined(RESULT));
+        }
+        return result;
+    }
+
+    static void assertMatchingAddress(PathAddress toMatch, ModelNode node) {
+        assertTrue(node.hasDefined(OP_ADDR));
+        PathAddress testee = PathAddress.pathAddress(node.get(OP_ADDR));
+        assertEquals(testee + " length matches " + toMatch, toMatch.size(), testee.size());
+        for (int i = 0; i < toMatch.size(); i++) {
+            PathElement matchElement = toMatch.getElement(i);
+            PathElement testeeElement = testee.getElement(i);
+            assertEquals(testee.toString(), matchElement.getKey(), testeeElement.getKey());
+            assertFalse(testeeElement + " is multi-target", testeeElement.isMultiTarget());
+            if (!matchElement.isWildcard()) {
+                if (matchElement.isMultiTarget()) {
+                    boolean matched = false;
+                    for (String option : matchElement.getSegments()) {
+                        if (option.equals(testeeElement.getValue())) {
+                            matched = true;
+                            break;
+                        }
+                    }
+                    assertTrue(testeeElement + " value in " + matchElement.getValue(), matched);
+                } else {
+                    assertEquals(matchElement.getValue(), testeeElement.getValue());
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Support for variations of /host=*/**, /host=*/server=* and /host=x/server=* addresses in the ops that support wildcard reads (read-resource, read-attribute, read-attribute-group, and the upcoming WFCORE-287 'query' op.)

Also includes commits fixing or working around issues found while testing this: WFCORE-619, WFCORE-622 and WFCORE-627.

Compatibility note: Previously, wildcard reads would store any RBAC access-control response header data in the items in the response's "result" node. This change strips them out from there and places them in the top level response, consistent with non-wildcard reads. So instead of

```
{
    "outcome"=>"success",
    "result"=> [{
        "address"=>[("foo","bar")],
        "result"=>{ some stuff},
        "response-headers"=> {
            "access-control"=>[{
                "absolute-address"=>[("foo","bar")]
                ....
            }]
        }
    }]
}
```

It is now

```
{
    "outcome"=>"success",
    "result"=> [{
        "address"=>[("foo","bar")],
        "result"=>{ some stuff}
    }],
    "response-headers"=> {
        "access-control"=>[{
            "absolute-address"=>[("foo","bar")]
            ....
        }]
    }
}
```

I regard the previous structure as being a bug. But input from @heiko-braun or @hpehl on whether that will cause problems in the console is needed before this can be merged.

Note also there is an open issue related to this work in a mixed domain: see WFCORE-621.