### PR TITLE
https://issues.jboss.org/browse/WFCORE-625 Error message in CLI if exten...

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -186,7 +186,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     /** command registry */
     private final CommandRegistry cmdRegistry = new CommandRegistry();
     /** loads command handlers from the domain management model extensions */
-    private ExtensionsLoader extLoader = new ExtensionsLoader(cmdRegistry, this);
+    private ExtensionsLoader extLoader;
 
     private Console console;
 
@@ -486,6 +486,8 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         cmdRegistry.registerHandler(new ShutdownHandler(this, embeddedServerRef), "shutdown");
 
         registerExtraHandlers();
+
+        extLoader = new ExtensionsLoader(cmdRegistry, this);
     }
 
     private void registerExtraHandlers() throws CommandLineException {
@@ -955,7 +957,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
             try {
                 extLoader.loadHandlers(currentAddress);
             } catch (CommandLineException e) {
-                error(Util.getMessagesFromThrowable(e));
+                printLine(Util.getMessagesFromThrowable(e));
             }
         }
     }

--- a/cli/src/main/resources/help/extension-commands.txt
+++ b/cli/src/main/resources/help/extension-commands.txt
@@ -1,0 +1,19 @@
+SYNOPSIS
+
+    extension-commands (--errors | --help)
+
+DESCRIPTION
+
+    In case the --errors argument is present the command will print detailed
+    error messages collected during the last attempt to load additional CLI
+    commands from the management extensions registered in the management model.
+    Without arguments the command does nothing.
+    
+
+ARGUMENTS
+
+ --errors  - optional, instructs to print error messages collected during
+             the last attempt to load additional CLI commands from
+             the management extensions registered in the management model.
+ 
+ --help    - optional, prints this message.


### PR DESCRIPTION
...sion existing on the server is not present in the CLI instalaltion

With this commit, it collects the errors while loading commands from extensions and displays a one line warning saying that there were problems, for more details the user can execute extension-commands --errors.

Thanks,
Alexey