### PR TITLE
[WFCORE-623] add missing methods to ModelControllerClient.Factory

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
@@ -30,6 +30,7 @@ import javax.security.auth.callback.CallbackHandler;
 
 import org.jboss.as.cli.ControllerAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.ModelControllerClientConfiguration;
 import org.jboss.as.protocol.ProtocolTimeoutHandler;
 
 /**
@@ -59,7 +60,17 @@ public interface ModelControllerClientFactory {
                 ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler, String clientBindAddress) throws IOException {
             // TODO - Make use of the ProtocolTimeoutHandler
             Map<String, String> saslOptions = disableLocalAuth ? DISABLED_LOCAL_AUTH : ENABLED_LOCAL_AUTH;
-            return ModelControllerClient.Factory.create(address.getProtocol(), address.getHost(), address.getPort(), handler, sslContext, connectionTimeout, saslOptions, clientBindAddress);
+            ModelControllerClientConfiguration config = new ModelControllerClientConfiguration.Builder()
+                    .setProtocol(address.getProtocol())
+                    .setHostName(address.getHost())
+                    .setPort(address.getPort())
+                    .setHandler(handler)
+                    .setSslContext(sslContext)
+                    .setConnectionTimeout(connectionTimeout)
+                    .setSaslOptions(saslOptions)
+                    .setClientBindAddress(clientBindAddress)
+                    .build();
+            return ModelControllerClient.Factory.create(config);
         }
     };
 

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -30,7 +30,6 @@ import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
-import org.jboss.as.controller.client.impl.ClientConfigurationImpl;
 
 import org.jboss.as.controller.client.impl.RemotingModelControllerClient;
 import org.jboss.dmr.ModelNode;
@@ -148,7 +147,7 @@ public interface ModelControllerClient extends Closeable {
          * @return A model controller client
          */
         public static ModelControllerClient create(final InetAddress address, final int port) {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHostName(address.getHostAddress())
                     .setPort(port)
                     .build());
@@ -163,7 +162,7 @@ public interface ModelControllerClient extends Closeable {
          * @return A model controller client
          */
         public static ModelControllerClient create(final String protocol, final InetAddress address, final int port) {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHostName(address.getHostAddress())
                     .setPort(port)
                     .setProtocol(protocol)
@@ -179,7 +178,7 @@ public interface ModelControllerClient extends Closeable {
          * @return A model controller client
          */
         public static ModelControllerClient create(final InetAddress address, final int port, final CallbackHandler handler) {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHandler(handler)
                     .setHostName(address.getHostAddress())
                     .setPort(port)
@@ -197,7 +196,7 @@ public interface ModelControllerClient extends Closeable {
          * @return A model controller client
          */
         public static ModelControllerClient create(final String protocol, final InetAddress address, final int port, final CallbackHandler handler) {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHandler(handler)
                     .setHostName(address.getHostAddress())
                     .setPort(port)
@@ -217,7 +216,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHandler(handler)
                     .setHostName(address.getHostAddress())
                     .setPort(port)
@@ -238,7 +237,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String protocol, final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHandler(handler)
                     .setHostName(address.getHostAddress())
                     .setPort(port)
@@ -256,7 +255,7 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHostName(hostName)
                     .setPort(port)
                     .build());
@@ -272,7 +271,7 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String protocol, final String hostName, final int port) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHostName(hostName)
                     .setPort(port)
                     .setProtocol(protocol)
@@ -289,7 +288,7 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHandler(handler)
                     .setHostName(hostName)
                     .setPort(port)
@@ -307,7 +306,7 @@ public interface ModelControllerClient extends Closeable {
          * @throws UnknownHostException if the host cannot be found
          */
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHandler(handler)
                     .setHostName(hostName)
                     .setPort(port)
@@ -328,7 +327,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHandler(handler)
                     .setHostName(hostName)
                     .setPort(port)
@@ -350,7 +349,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHandler(handler)
                     .setHostName(hostName)
                     .setPort(port)
@@ -373,7 +372,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setConnectionTimeout(connectionTimeout)
                     .setHandler(handler)
                     .setHostName(hostName)
@@ -396,7 +395,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setConnectionTimeout(connectionTimeout)
                     .setHandler(handler)
                     .setHostName(hostName)
@@ -421,7 +420,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setConnectionTimeout(connectionTimeout)
                     .setHandler(handler)
                     .setHostName(hostName)
@@ -447,7 +446,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setConnectionTimeout(connectionTimeout)
                     .setHandler(handler)
                     .setHostName(hostName)
@@ -474,7 +473,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions, final String clientBindAddress) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setClientBindAddress(clientBindAddress)
                     .setConnectionTimeout(connectionTimeout)
                     .setHandler(handler)
@@ -502,7 +501,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions, final String clientBindAddress) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setClientBindAddress(clientBindAddress)
                     .setConnectionTimeout(connectionTimeout)
                     .setHandler(handler)
@@ -527,7 +526,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHandler(handler)
                     .setHostName(hostName)
                     .setPort(port)
@@ -549,7 +548,7 @@ public interface ModelControllerClient extends Closeable {
          */
         @Deprecated
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
-            return create(new ClientConfigurationImpl.Builder()
+            return create(new ModelControllerClientConfiguration.Builder()
                     .setHandler(handler)
                     .setHostName(hostName)
                     .setPort(port)

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -219,6 +219,7 @@ public interface ModelControllerClient extends Closeable {
                     .setHandler(handler)
                     .setHostName(address.getHostAddress())
                     .setPort(port)
+                    .setSaslOptions(saslOptions)
                     .build());
         }
 

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -358,7 +358,7 @@ public interface ModelControllerClient extends Closeable {
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
          * @param sslContext a pre-initialised SSLContext
-         * @param connectionTimeout
+         * @param connectionTimeout maximum time, in milliseconds, to wait for the connection to be established
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
          */
@@ -401,7 +401,7 @@ public interface ModelControllerClient extends Closeable {
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
          * @param sslContext a pre-initialised SSLContext
-         * @param connectionTimeout
+         * @param connectionTimeout maximum time, in milliseconds, to wait for the connection to be established
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
@@ -425,7 +425,7 @@ public interface ModelControllerClient extends Closeable {
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
          * @param sslContext a pre-initialised SSLContext
-         * @param connectionTimeout
+         * @param connectionTimeout maximum time, in milliseconds, to wait for the connection to be established
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
@@ -449,7 +449,7 @@ public interface ModelControllerClient extends Closeable {
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
          * @param sslContext a pre-initialised SSLContext
-         * @param connectionTimeout
+         * @param connectionTimeout maximum time, in milliseconds, to wait for the connection to be established
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @param clientBindAddress the address to which the client will bind.
          * @return A model controller client
@@ -475,7 +475,7 @@ public interface ModelControllerClient extends Closeable {
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
          * @param sslContext a pre-initialised SSLContext
-         * @param connectionTimeout
+         * @param connectionTimeout maximum time, in milliseconds, to wait for the connection to be established
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @param clientBindAddress the address to which the client will bind.
          * @return A model controller client

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -213,7 +213,9 @@ public interface ModelControllerClient extends Closeable {
          * @param handler     CallbackHandler to obtain authentication information for the call.
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) {
             return create(new ClientConfigurationImpl.Builder()
                     .setHandler(handler)
@@ -232,7 +234,9 @@ public interface ModelControllerClient extends Closeable {
          * @param handler     CallbackHandler to obtain authentication information for the call.
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String protocol, final InetAddress address, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) {
             return create(new ClientConfigurationImpl.Builder()
                     .setHandler(handler)
@@ -320,7 +324,9 @@ public interface ModelControllerClient extends Closeable {
          * @param sslContext a pre-initialised SSLContext
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext) throws UnknownHostException {
             return create(new ClientConfigurationImpl.Builder()
                     .setHandler(handler)
@@ -340,7 +346,9 @@ public interface ModelControllerClient extends Closeable {
          * @param sslContext a pre-initialised SSLContext
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext) throws UnknownHostException {
             return create(new ClientConfigurationImpl.Builder()
                     .setHandler(handler)
@@ -361,7 +369,9 @@ public interface ModelControllerClient extends Closeable {
          * @param connectionTimeout maximum time, in milliseconds, to wait for the connection to be established
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
             return create(new ClientConfigurationImpl.Builder()
                     .setConnectionTimeout(connectionTimeout)
@@ -382,7 +392,9 @@ public interface ModelControllerClient extends Closeable {
          * @param sslContext a pre-initialised SSLContext
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout) throws UnknownHostException {
             return create(new ClientConfigurationImpl.Builder()
                     .setConnectionTimeout(connectionTimeout)
@@ -405,7 +417,9 @@ public interface ModelControllerClient extends Closeable {
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions) throws UnknownHostException {
             return create(new ClientConfigurationImpl.Builder()
                     .setConnectionTimeout(connectionTimeout)
@@ -429,7 +443,9 @@ public interface ModelControllerClient extends Closeable {
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions) throws UnknownHostException {
             return create(new ClientConfigurationImpl.Builder()
                     .setConnectionTimeout(connectionTimeout)
@@ -454,7 +470,9 @@ public interface ModelControllerClient extends Closeable {
          * @param clientBindAddress the address to which the client will bind.
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions, final String clientBindAddress) throws UnknownHostException {
             return create(new ClientConfigurationImpl.Builder()
                     .setClientBindAddress(clientBindAddress)
@@ -480,7 +498,9 @@ public interface ModelControllerClient extends Closeable {
          * @param clientBindAddress the address to which the client will bind.
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions, final String clientBindAddress) throws UnknownHostException {
             return create(new ClientConfigurationImpl.Builder()
                     .setClientBindAddress(clientBindAddress)
@@ -503,7 +523,9 @@ public interface ModelControllerClient extends Closeable {
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
             return create(new ClientConfigurationImpl.Builder()
                     .setHandler(handler)
@@ -523,7 +545,9 @@ public interface ModelControllerClient extends Closeable {
          * @param saslOptions Additional options to be passed to the SASL mechanism.
          * @return A model controller client
          * @throws UnknownHostException if the host cannot be found
+         * @deprecated use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} and {@link #create(ModelControllerClientConfiguration)}
          */
+        @Deprecated
         public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
             return create(new ClientConfigurationImpl.Builder()
                     .setHandler(handler)

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -396,6 +396,29 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *
+         * @param hostName   the remote host
+         * @param port       the port
+         * @param handler    CallbackHandler to obtain authentication information for the call.
+         * @param sslContext a pre-initialised SSLContext
+         * @param connectionTimeout
+         * @param saslOptions Additional options to be passed to the SASL mechanism.
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions) throws UnknownHostException {
+            return create(new ClientConfigurationImpl.Builder()
+                    .setConnectionTimeout(connectionTimeout)
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setSaslOptions(saslOptions)
+                    .setSslContext(sslContext)
+                    .build());
+        }
+
+        /**
+         * Create a client instance for a remote address and port and CallbackHandler.
+         *
          * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
          * @param hostName   the remote host
          * @param port       the port
@@ -417,6 +440,32 @@ public interface ModelControllerClient extends Closeable {
                     .setSslContext(sslContext)
                     .build());
         }
+
+        /**
+         * Create a client instance for a remote address and port and CallbackHandler.
+         *
+         * @param hostName   the remote host
+         * @param port       the port
+         * @param handler    CallbackHandler to obtain authentication information for the call.
+         * @param sslContext a pre-initialised SSLContext
+         * @param connectionTimeout
+         * @param saslOptions Additional options to be passed to the SASL mechanism.
+         * @param clientBindAddress the address to which the client will bind.
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions, final String clientBindAddress) throws UnknownHostException {
+            return create(new ClientConfigurationImpl.Builder()
+                    .setClientBindAddress(clientBindAddress)
+                    .setConnectionTimeout(connectionTimeout)
+                    .setHandler(handler)
+                    .setHostName(hostName)
+                    .setPort(port)
+                    .setSaslOptions(saslOptions)
+                    .setSslContext(sslContext)
+                    .build());
+        }
+
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClientConfiguration.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClientConfiguration.java
@@ -113,7 +113,7 @@ public interface ModelControllerClientConfiguration extends Closeable {
      */
     String getClientBindAddress();
 
-    static class Builder {
+    class Builder {
         private String hostName;
         private String clientBindAddress;
         private int port;
@@ -126,46 +126,97 @@ public interface ModelControllerClientConfiguration extends Closeable {
         public Builder() {
         }
 
+        /**
+         * Sets the remote host name to which the client should connect.
+         *
+         * @param hostName the host name. Cannot be {@code null}
+         * @return a builder to allow continued configuration
+         */
         public Builder setHostName(String hostName) {
             this.hostName = hostName;
             return this;
         }
 
+        /**
+         * Sets the local address to which the client socket should be bound.
+         *
+         * @param clientBindAddress the local address, or {@code null} to choose one automatically
+         * @return a builder to allow continued configuration
+         */
         public Builder setClientBindAddress(String clientBindAddress) {
             this.clientBindAddress = clientBindAddress;
             return this;
         }
 
+        /**
+         * Sets the remote port to which the client should connect
+         * @param port the port
+         * @return a builder to allow continued configuration
+         */
         public Builder setPort(int port) {
             this.port = port;
             return this;
         }
 
+        /**
+         * Sets the handler for callbacks to obtain authentication information.
+         *
+         * @param handler the handler, or {@code null} if callbacks are not supported.
+         *
+         * @return a builder to allow continued configuration
+         */
         public Builder setHandler(CallbackHandler handler) {
             this.handler = handler;
             return this;
         }
 
+        /**
+         * Sets the SASL options for the remote connection
+         * @param saslOptions the sasl options
+         * @return a builder to allow continued configuration
+         */
         public Builder setSaslOptions(Map<String, String> saslOptions) {
             this.saslOptions = saslOptions;
             return this;
         }
 
+        /**
+         * Sets the SSL context for the remote connection
+         * @param sslContext the SSL context
+         * @return a builder to allow continued configuration
+         */
         public Builder setSslContext(SSLContext sslContext) {
             this.sslContext = sslContext;
             return this;
         }
 
+        /**
+         * Sets the protocol to use for communicating with the remote process.
+         *
+         * @param protocol the protocol, or {@code null} if a default protocol for the
+         *                 {@link #setPort(int) specified port} should be used
+         * @return a builder to allow continued configuration
+         */
         public Builder setProtocol(String protocol) {
             this.protocol = protocol;
             return this;
         }
 
+        /**
+         * Maximum time, in milliseconds, to wait for the connection to be established
+         * @param connectionTimeout the timeout
+         * @return a builder to allow continued configuration
+         */
         public Builder setConnectionTimeout(int connectionTimeout) {
             this.connectionTimeout = connectionTimeout;
             return this;
         }
 
+        /**
+         * Builds the configuration object based on this builder's settings.
+         *
+         * @return the configuration
+         */
         public ModelControllerClientConfiguration build() {
            return new ClientConfigurationImpl(hostName, port, handler, saslOptions, sslContext,
                    Factory.createDefaultExecutor(), true, connectionTimeout, protocol, clientBindAddress);
@@ -173,11 +224,11 @@ public interface ModelControllerClientConfiguration extends Closeable {
 
     }
 
-    @Deprecated
     /**
-     * @deprecated Use ModelControllerClientConfiguration.Builder instead.
+     * @deprecated Use {@link org.jboss.as.controller.client.ModelControllerClientConfiguration.Builder} instead.
      */
-    static class Factory {
+    @Deprecated
+    class Factory {
         // Global count of created pools
         private static final AtomicInteger executorCount = new AtomicInteger();
         // Global thread group for created pools. WFCORE-5 static to avoid leaking whenever createDefaultExecutor is called

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractRbacTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractRbacTestCase.java
@@ -58,6 +58,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.ModelControllerClientConfiguration;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.management.util.WildFlyManagedConfiguration;
@@ -155,12 +156,14 @@ public abstract class AbstractRbacTestCase {
 
     private ModelControllerClient createClient(String userName, boolean allowLocalAuth,
                                                WildFlyManagedConfiguration clientConfig) throws UnknownHostException {
-
-        return ModelControllerClient.Factory.create(clientConfig.getHostControllerManagementProtocol(),
-                clientConfig.getHostControllerManagementAddress(),
-                clientConfig.getHostControllerManagementPort(),
-                new RbacAdminCallbackHandler(userName),
-                allowLocalAuth ? Collections.<String, String>emptyMap() : SASL_OPTIONS);
+        ModelControllerClientConfiguration config = new ModelControllerClientConfiguration.Builder()
+                .setProtocol(clientConfig.getHostControllerManagementProtocol())
+                .setHostName(clientConfig.getHostControllerManagementAddress())
+                .setPort(clientConfig.getHostControllerManagementPort())
+                .setHandler(new RbacAdminCallbackHandler(userName))
+                .setSaslOptions(allowLocalAuth ? Collections.<String, String>emptyMap() : SASL_OPTIONS)
+                .build();
+        return ModelControllerClient.Factory.create(config);
     }
 
     public static void removeClientForUser(String userName, boolean allowLocalAuth) throws IOException {

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/AbstractRbacTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/AbstractRbacTestCase.java
@@ -29,7 +29,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.inject.Inject;
+
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.ModelControllerClientConfiguration;
 import org.jboss.as.test.integration.management.rbac.RbacAdminCallbackHandler;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.junit.AfterClass;
@@ -71,11 +73,15 @@ public class AbstractRbacTestCase {
     }
 
     private ModelControllerClient createClient(String userName) throws UnknownHostException {
-        return ModelControllerClient.Factory.create(managementClient.getMgmtProtocol(),
-                managementClient.getMgmtAddress(),
-                managementClient.getMgmtPort(),
-                new RbacAdminCallbackHandler(userName),
-                SASL_OPTIONS);
+        ModelControllerClientConfiguration config = new ModelControllerClientConfiguration.Builder()
+                .setProtocol(managementClient.getMgmtProtocol())
+                .setHostName(managementClient.getMgmtAddress())
+                .setPort(managementClient.getMgmtPort())
+                .setHandler(new RbacAdminCallbackHandler(userName))
+                .setSaslOptions(SASL_OPTIONS)
+                .build();
+
+        return ModelControllerClient.Factory.create(config);
     }
 
     public static void removeClientForUser(String userName) throws IOException {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/interfaces/NativeManagementInterface.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/interfaces/NativeManagementInterface.java
@@ -22,14 +22,14 @@
 
 package org.jboss.as.test.integration.management.interfaces;
 
-import org.jboss.as.controller.client.ModelControllerClient;
-import org.jboss.as.test.integration.management.rbac.RbacAdminCallbackHandler;
-import org.jboss.dmr.ModelNode;
-
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Map;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.ModelControllerClientConfiguration;
+import org.jboss.as.test.integration.management.rbac.RbacAdminCallbackHandler;
+import org.jboss.dmr.ModelNode;
 
 /**
  * @author Ladislav Thon <lthon@redhat.com>
@@ -62,12 +62,13 @@ public class NativeManagementInterface implements ManagementInterface {
     }
 
     public static ManagementInterface create(String host, int port, final String username, final String password) {
-        try {
-            ModelControllerClient client = ModelControllerClient.Factory.create(host, port,
-                    new RbacAdminCallbackHandler(username, password),  SASL_OPTIONS);
-            return new NativeManagementInterface(client);
-        } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
-        }
+        ModelControllerClientConfiguration config = new ModelControllerClientConfiguration.Builder()
+                .setHostName(host)
+                .setPort(port)
+                .setHandler(new RbacAdminCallbackHandler(username, password))
+                .setSaslOptions(SASL_OPTIONS)
+                .build();
+        ModelControllerClient client = ModelControllerClient.Factory.create(config);
+        return new NativeManagementInterface(client);
     }
 }


### PR DESCRIPTION
This supercedes #593 by deprecating the overly complex factory methods and adding on a bunch of other minor fixes to how we build MCCs.