### PR TITLE
[WFCORE-557] Remove usage of common-core in logging.

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
@@ -37,7 +37,6 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.wildfly.security.manager"/>
         <module name="org.jboss.as.server"/>
-        <module name="org.jboss.common-core"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -74,6 +74,16 @@
     <dependencies>
         <dependency>
             <groupId>org.jboss</groupId>
+            <artifactId>jboss-dmr</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.modules</groupId>
+            <artifactId>jboss-modules</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss</groupId>
             <artifactId>staxmapper</artifactId>
         </dependency>
 
@@ -85,6 +95,12 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -95,6 +111,12 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -140,6 +162,7 @@
             <artifactId>jboss-stdio</artifactId>
         </dependency>
 
+        <!-- Test dependencies -->
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman</artifactId>
@@ -161,6 +184,12 @@
         <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman-bmunit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/logging/src/main/java/org/jboss/as/logging/LoggingProfileContextSelector.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingProfileContextSelector.java
@@ -22,10 +22,10 @@
 
 package org.jboss.as.logging;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import org.jboss.logmanager.LogContext;
-import org.jboss.util.collection.ConcurrentSkipListMap;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -33,7 +33,7 @@ import org.jboss.util.collection.ConcurrentSkipListMap;
 public final class LoggingProfileContextSelector {
     private static final LoggingProfileContextSelector INSTANCE = new LoggingProfileContextSelector();
 
-    private final ConcurrentMap<String, LogContext> profileContexts = new ConcurrentSkipListMap<String, LogContext>();
+    private final ConcurrentMap<String, LogContext> profileContexts = new ConcurrentHashMap<>();
 
     private LoggingProfileContextSelector() {
 

--- a/subsystem-test/framework/pom.xml
+++ b/subsystem-test/framework/pom.xml
@@ -49,6 +49,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-common-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>
@@ -71,6 +76,11 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-deployment-repository</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Also added some explicit dependencies to the subsystem-tests so subsystems could use exclusions.