### PR TITLE
register notifications for the ModelController server root resource

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/ModelParserUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/ModelParserUtils.java
@@ -278,6 +278,7 @@ public class ModelParserUtils {
                 def.registerAttributes(rootRegistration);
                 def.registerOperations(rootRegistration);
                 def.registerChildren(rootRegistration);
+                def.registerNotifications(rootRegistration);
             }
         });
 


### PR DESCRIPTION
* this prevents warnings in tests using this class about resource
  emitting unregistered notifications.