### PR TITLE
[WFCORE-638] :Deployment runtime-name mismatch between content repo and server-group and logs

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentFullReplaceHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentFullReplaceHandler.java
@@ -153,7 +153,7 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
         deploymentModel.get(CONTENT).set(content);
 
         // Update server groups
-        final Resource root = context.readResource(PathAddress.EMPTY_ADDRESS);
+        final Resource root = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
         if (root.hasChild(PathElement.pathElement(SERVER_GROUP))) {
             ModelNode enabled = correctedOperation.get(ENABLED.getName());
             for (final Resource.ResourceEntry serverGroupResource : root.getChildren(SERVER_GROUP)) {


### PR DESCRIPTION
The server-group reference is now correctly updated.

Jira: https://issues.jboss.org/browse/WFCORE-638