### PR TITLE
WFCORE-640 - Add file permissions checks during execution of add-user.bat/add-user.sh

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
@@ -55,6 +55,7 @@ import org.jboss.msc.service.StartException;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author <a href="mailto:bgaisford@punagroup.com">Brandon Gaisford</a>
  */
 @MessageLogger(projectCode = "WFLYDM", length = 4)
 public interface DomainManagementLogger extends BasicLogger {
@@ -1116,6 +1117,14 @@ public interface DomainManagementLogger extends BasicLogger {
      */
     @Message(id = 105, value = "The suffix (%s) is invalid. A suffix must be a valid date format.")
     OperationFailedException invalidSuffix(String suffix);
+
+    /**
+     * A message indicating file permissions problems found with mgmt-users.properties.
+     *
+     * @return a {@link String} for the message.
+     */
+    @Message(id = 106, value = "File permissions problems found while attempting to update %s file.")
+    String filePermissionsProblemsFound(String file);
 
     /**
      * Information message saying the username and password must be different.

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinder.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinder.java
@@ -53,6 +53,7 @@ import org.jboss.msc.service.StartException;
  * The first state executed, responsible for searching for the relevant properties files.
  *
  * @author <a href="mailto:flemming.harms@gmail.com">Flemming Harms</a>
+ * @author <a href="mailto:bgaisford@punagroup.com">Brandon Gaisford</a>
  */
 public class PropertyFileFinder implements State {
 
@@ -78,6 +79,9 @@ public class PropertyFileFinder implements State {
                 : APPLICATION_USERS_PROPERTIES : fileName;
         if (!findFiles(foundFiles, fileName)) {
             return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.propertiesFileNotFound(fileName), null, stateValues);
+        } else if(!stateValues.isValidFilePermissions()) {
+            return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.filePermissionsProblemsFound(
+                    stateValues.getFilePermissionsProblemPath() + File.separator + fileName), null, stateValues);
         }
         fileName = stateValues.getOptions().getGroupProperties();
 
@@ -93,6 +97,9 @@ public class PropertyFileFinder implements State {
             fileName = fileName == null ? APPLICATION_ROLES_PROPERTIES : fileName;
             if (!findFiles(foundGroupFiles, fileName) && groupFileMandatory) {
                 return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.propertiesFileNotFound(fileName), null, stateValues);
+            } else if(!stateValues.isValidFilePermissions()) {
+                return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.filePermissionsProblemsFound(
+                        stateValues.getFilePermissionsProblemPath() + File.separator + fileName), null, stateValues);
             }
             stateValues.setGroupFiles(foundGroupFiles);
             try {
@@ -181,7 +188,9 @@ public class PropertyFileFinder implements State {
 
     private boolean findFiles(final List<File> foundFiles, final String fileName) {
         File singleFile = new File(fileName);
-        if (singleFile.exists()) {
+
+        // Check for existence and writability (Windows file may have Read-Only bit set)
+        if (singleFile.exists() && singleFile.canWrite()) {
             foundFiles.add(singleFile);
             return true;
         }
@@ -226,8 +235,15 @@ public class PropertyFileFinder implements State {
     private File buildFilePath(final String serverConfigUserDirPropertyName, final String suppliedConfigDir,
             final String serverConfigDirPropertyName, final String serverBaseDirPropertyName, final String defaultBaseDir,
             final String fileName) {
-        return new File(buildDirPath(serverConfigUserDirPropertyName, suppliedConfigDir, serverConfigDirPropertyName,
-                serverBaseDirPropertyName, defaultBaseDir), fileName);
+
+        File dirPath = buildDirPath(serverConfigUserDirPropertyName, suppliedConfigDir, serverConfigDirPropertyName,
+                serverBaseDirPropertyName, defaultBaseDir);
+
+        File file = new File(dirPath, fileName);
+        validatePermissions(dirPath, file);
+
+        return file;
+
     }
 
     /**
@@ -260,6 +276,32 @@ public class PropertyFileFinder implements State {
         }
 
         return new File(new File(stateValues.getOptions().getJBossHome(), defaultBaseDir), "configuration");
+    }
+
+    /**
+     * This method performs a series of permissions checks given the passed directory and full properties file path.
+     *
+     * 1 - Check whether the parent directory dirPath has proper execute and read permissions
+     * 2 - Check whether full properties file path is readable and writable
+     *
+     * If either of the permissions checks fail, setValidFilePermissions flag and setFilePermissionsProblemPath
+     * in StateValues
+     */
+    private void validatePermissions(final File dirPath, final File file) {
+
+        // Check execute and read permissions for parent dirPath
+        if( !dirPath.canExecute() || !dirPath.canRead()  ) {
+            stateValues.setValidFilePermissions(false);
+            stateValues.setFilePermissionsProblemPath(dirPath.getAbsolutePath());
+            return;
+        }
+
+        // Check read and write permissions for properties file
+        if( !file.canRead() || !file.canWrite() ) {
+            stateValues.setValidFilePermissions(false);
+            stateValues.setFilePermissionsProblemPath(dirPath.getAbsolutePath());
+        }
+
     }
 
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/StateValues.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/StateValues.java
@@ -33,10 +33,11 @@ import org.jboss.as.domain.management.security.adduser.AddUser.Interactiveness;
 import org.jboss.as.domain.management.security.adduser.AddUser.RealmMode;
 
 /**
-* Place holder object to pass between the state
-*
-* @author <a href="mailto:flemming.harms@gmail.com">Flemming Harms</a>
-*/
+ * Place holder object to pass between the state
+ *
+ * @author <a href="mailto:flemming.harms@gmail.com">Flemming Harms</a>
+ * @author <a href="mailto:bgaisford@punagroup.com">Brandon Gaisford</a>
+ */
 public class StateValues {
     private final RuntimeOptions options;
     private AddUser.Interactiveness howInteractive = Interactiveness.INTERACTIVE;
@@ -52,6 +53,8 @@ public class StateValues {
     private Set<String> enabledKnownUsers = new HashSet<String>();
     private Set<String> disabledKnownUsers = new HashSet<String>();
     private Map<String, String> knownGroups;
+    private boolean validFilePermissions = true;
+    private String filePermissionsProblemPath;
 
     public StateValues() {
         options = new RuntimeOptions();
@@ -188,5 +191,21 @@ public class StateValues {
 
     public RuntimeOptions getOptions() {
         return options;
+    }
+
+    public boolean isValidFilePermissions() {
+        return validFilePermissions;
+    }
+
+    public void setValidFilePermissions(boolean validFilePermissions) {
+        this.validFilePermissions = validFilePermissions;
+    }
+
+    public String getFilePermissionsProblemPath() {
+        return filePermissionsProblemPath;
+    }
+
+    public void setFilePermissionsProblemPath(String filePermissionsProblemPath) {
+        this.filePermissionsProblemPath = filePermissionsProblemPath;
     }
 }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinderPermissionsTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinderPermissionsTestCase.java
@@ -23,26 +23,20 @@
 package org.jboss.as.domain.management.security.adduser;
 
 import org.jboss.as.domain.management.security.adduser.AddUser.FileMode;
-import org.jboss.msc.service.StartException;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import static java.lang.System.getProperty;
-import static java.lang.System.setProperty;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test the property file finder.
+ * Test the property file finder permissions tests.
  *
- * @author <a href="mailto:flemming.harms@gmail.com">Flemming Harms</a>
+ * @author <a href="mailto:bgaisford@punagroup.com">Brandon Gaisford</a>
  */
 public class PropertyFileFinderPermissionsTestCase extends PropertyTestHelper {
 
@@ -50,15 +44,18 @@ public class PropertyFileFinderPermissionsTestCase extends PropertyTestHelper {
     @Before
     public void setup() throws IOException {
         values.setFileMode(FileMode.MANAGEMENT);
-        values.getOptions().setJBossHome(getProperty("java.io.tmpdir"));
+        values.getOptions().setJBossHome(getProperty("java.io.tmpdir")+File.separator+"permmissions");
     }
 
     private File createPropertyFile(String filename, String mode) throws IOException {
 
-        File domainDir = new File(getProperty("java.io.tmpdir")+File.separator+mode);
-        domainDir.mkdir();
-        domainDir.deleteOnExit();
-        File propertyUserFile = new File(domainDir, filename);
+        File permissionsDir = new File(getProperty("java.io.tmpdir")+File.separator+"permmissions");
+        permissionsDir.mkdir();
+        permissionsDir.deleteOnExit();
+        File parentDir = new File(permissionsDir.getPath()+File.separator+mode);
+        parentDir.mkdir();
+        parentDir.deleteOnExit();
+        File propertyUserFile = new File(parentDir, filename);
         propertyUserFile.createNewFile();
         propertyUserFile.deleteOnExit();
         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(propertyUserFile), StandardCharsets.UTF_8));
@@ -72,67 +69,9 @@ public class PropertyFileFinderPermissionsTestCase extends PropertyTestHelper {
         return propertyUserFile;
     }
 
-    @Test
-    public void overridePropertyfileLocationRead() throws IOException {
-        File domainMgmtUserFile = createPropertyFile("mgmt-users.properties", "domain");
-        File standaloneMgmtUserFile = createPropertyFile("mgmt-users.properties", "standalone");
-        File domainMgmtGroupFile = createPropertyFile("mgmt-groups.properties", "domain");
-        File standaloneMgmtGroupFile = createPropertyFile("mgmt-groups.properties", "standalone");
-
-        System.setProperty("jboss.server.config.user.dir", standaloneMgmtUserFile.getParent());
-        System.setProperty("jboss.domain.config.user.dir", domainMgmtUserFile.getParent());
-        System.setProperty("jboss.server.config.group.dir", standaloneMgmtGroupFile.getParent());
-        System.setProperty("jboss.domain.config.group.dir", domainMgmtGroupFile.getParent());
-        State propertyFileFinder = new PropertyFileFinder(consoleMock, values);
-        State nextState = propertyFileFinder.execute();
-        assertTrue(nextState instanceof PromptRealmState);
-        assertTrue("Expected to find the " + USER_NAME + " in the list of known enabled users", values.getEnabledKnownUsers().contains(USER_NAME));
-        assertTrue("Expected the values.getPropertiesFiles() contained the "+standaloneMgmtUserFile,values.getUserFiles().contains(standaloneMgmtUserFile));
-        assertTrue("Expected the values.getPropertiesFiles() contained the "+domainMgmtUserFile,values.getUserFiles().contains(domainMgmtUserFile));
-    }
-
-    @Test
-    public void overridePropertyfileLocationWrite() throws IOException, StartException {
-        File domainUserFile = createPropertyFile("application-users.properties", "domain");
-        File standaloneUserFile = createPropertyFile("application-users.properties", "standalone");
-        File domainRolesFile = createPropertyFile("application-roles.properties", "domain");
-        File standaloneRolesFile = createPropertyFile("application-roles.properties", "standalone");
-
-        String newUserName = "Hugh.Jackman";
-        values.setGroups(null);
-        values.setUserName(newUserName);
-        values.setFileMode(FileMode.APPLICATION);
-        System.setProperty("jboss.server.config.user.dir", domainUserFile.getParent());
-        System.setProperty("jboss.domain.config.user.dir", standaloneUserFile.getParent());
-        System.setProperty("jboss.server.config.role.dir", domainRolesFile.getParent());
-        System.setProperty("jboss.domain.config.role.dir", standaloneRolesFile.getParent());
-        State propertyFileFinder = new PropertyFileFinder(consoleMock, values);
-        State nextState = propertyFileFinder.execute();
-        assertTrue(nextState instanceof PromptRealmState);
-
-        File locatedDomainPropertyFile = values.getUserFiles().get(values.getUserFiles().indexOf(domainUserFile));
-        File locatedStandalonePropertyFile = values.getUserFiles().get(values.getUserFiles().indexOf(standaloneUserFile));
-        UpdateUser updateUserState = new UpdateUser(consoleMock, values);
-
-        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(updateUserState.consoleUserMessage(locatedDomainPropertyFile.getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE).
-                expectedDisplayText(updateUserState.consoleUserMessage(locatedStandalonePropertyFile.getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE);
-        consoleMock.setResponses(consoleBuilder);
-        updateUserState.update(values);
-
-        assertUserPropertyFile(newUserName);
-        consoleBuilder.validate();
-    }
 
     @Test
     public void testPropertyFileFinderFilePermissions() throws IOException {
-
-        String oldJavaTempDir = getProperty("java.io.tmpdir");
-
-        setProperty("java.io.tmpdir", oldJavaTempDir+File.separator+"permissions");
-        values.getOptions().setJBossHome(getProperty("java.io.tmpdir"));
 
         File domainMgmtUserFile = createPropertyFile("mgmt-users.properties", "domain");
         File standaloneMgmtUserFile = createPropertyFile("mgmt-users.properties", "standalone");
@@ -154,33 +93,27 @@ public class PropertyFileFinderPermissionsTestCase extends PropertyTestHelper {
             standaloneDir.setReadable(true);
         }
 
-//        File permissionsMgmtUserFile2 = createPropertyFile("mgmt-users.properties", "permissions2");
-//        File permissionsMgmtGroupFile2 = createPropertyFile("mgmt-groups.properties", "permissions2");
-//        System.setProperty("jboss.domain.config.user.dir", permissionsMgmtUserFile2.getParent());
-//        System.setProperty("jboss.domain.config.group.dir", permissionsMgmtGroupFile2.getParent());
-//
-//        File permissionsDir2 = permissionsMgmtUserFile2.getParentFile();
-//        State propertyFileFinder2 = new PropertyFileFinder(consoleMock, values);
-//
-//        // Test parent dir without execute
-//        if(permissionsDir2.setExecutable(false)) {
-//            State nextState = propertyFileFinder2.execute();
-//            assertTrue(nextState instanceof ErrorState);
-//            permissionsDir2.setExecutable(true);
-//        }
+        // Test parent dir without execute
+        if(standaloneDir.setExecutable(false)) {
+            State nextState = propertyFileFinder.execute();
+            assertTrue(nextState instanceof ErrorState);
+            standaloneDir.setExecutable(true);
+        }
 
+        // Test file without read
+        if(standaloneMgmtUserFile.setReadable(false)) {
+            State nextState = propertyFileFinder.execute();
+            assertTrue(nextState instanceof ErrorState);
+            standaloneMgmtUserFile.setReadable(true);
+        }
 
-        // Test properties file not writable
-//        if(permissionsMgmtUserFile.setWritable(false)) {
-//
-//        }
-
-
-        // be sure to restore java temp dir
-        setProperty("java.io.tmpdir", oldJavaTempDir);
-        values.getOptions().setJBossHome(getProperty("java.io.tmpdir"));
+        // Test file without write
+        if(standaloneMgmtUserFile.setWritable(false)) {
+            State nextState = propertyFileFinder.execute();
+            assertTrue(nextState instanceof ErrorState);
+            standaloneMgmtUserFile.setWritable(true);
+        }
 
     }
-
 
 }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinderTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinderTestCase.java
@@ -76,9 +76,13 @@ public class PropertyFileFinderTestCase extends PropertyTestHelper {
     public void overridePropertyfileLocationRead() throws IOException {
         File domainMgmtUserFile = createPropertyFile("mgmt-users.properties", "domain");
         File standaloneMgmtUserFile = createPropertyFile("mgmt-users.properties", "standalone");
+        File domainMgmtGroupFile = createPropertyFile("mgmt-groups.properties", "domain");
+        File standaloneMgmtGroupFile = createPropertyFile("mgmt-groups.properties", "standalone");
 
         System.setProperty("jboss.server.config.user.dir", standaloneMgmtUserFile.getParent());
         System.setProperty("jboss.domain.config.user.dir", domainMgmtUserFile.getParent());
+        System.setProperty("jboss.server.config.group.dir", standaloneMgmtGroupFile.getParent());
+        System.setProperty("jboss.domain.config.group.dir", domainMgmtGroupFile.getParent());
         State propertyFileFinder = new PropertyFileFinder(consoleMock, values);
         State nextState = propertyFileFinder.execute();
         assertTrue(nextState instanceof PromptRealmState);
@@ -100,6 +104,8 @@ public class PropertyFileFinderTestCase extends PropertyTestHelper {
         values.setFileMode(FileMode.APPLICATION);
         System.setProperty("jboss.server.config.user.dir", domainUserFile.getParent());
         System.setProperty("jboss.domain.config.user.dir", standaloneUserFile.getParent());
+        System.setProperty("jboss.server.config.role.dir", domainRolesFile.getParent());
+        System.setProperty("jboss.domain.config.role.dir", standaloneRolesFile.getParent());
         State propertyFileFinder = new PropertyFileFinder(consoleMock, values);
         State nextState = propertyFileFinder.execute();
         assertTrue(nextState instanceof PromptRealmState);


### PR DESCRIPTION
I've completed my work on this issue.  Creating pull request.