### PR TITLE
Support --debug flag without port argument

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -16,6 +16,8 @@ do
           shift
           if [ -n "$1" ] && [ "${1#*-}" = "$1" ]; then
               DEBUG_PORT=$1
+          else
+              set -- foo "$@"
           fi
           ;;
       -Djava.security.manager*)


### PR DESCRIPTION
Add a dummy positional parameter in the instance where --debug is
specified but no port is provided. This dummy parameter will be
swallowed instead of the next true parameter.