### PR TITLE
Misc changes for Wildfly Swarm

### DIFF
--- a/self-contained/src/main/java/org/jboss/as/selfcontained/ContentProvider.java
+++ b/self-contained/src/main/java/org/jboss/as/selfcontained/ContentProvider.java
@@ -22,38 +22,16 @@
 
 package org.jboss.as.selfcontained;
 
-import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.StartContext;
-import org.jboss.msc.service.StartException;
-import org.jboss.msc.service.StopContext;
 import org.jboss.vfs.VirtualFile;
 
-/** Simple service to provide the VirtualFile to the SelfContainedContentRepository.
+/** External content-provider for self-contained servers.
  *
  * @author Bob McWhirter
  */
-public class SelfContainedContentService implements Service<VirtualFile> {
+public interface ContentProvider {
 
-    public static final ServiceName NAME = ServiceName.JBOSS.append( "self-contained", "content" );
-    private final VirtualFile content;
+    ServiceName NAME = ServiceName.JBOSS.append( "self-contained", "content-provider" );
 
-    public SelfContainedContentService(VirtualFile content) {
-        this.content = content;
-    }
-
-    @Override
-    public void start(StartContext startContext) throws StartException {
-
-    }
-
-    @Override
-    public void stop(StopContext stopContext) {
-
-    }
-
-    @Override
-    public VirtualFile getValue() throws IllegalStateException, IllegalArgumentException {
-        return this.content;
-    }
+    VirtualFile getContent(int index);
 }

--- a/self-contained/src/main/java/org/jboss/as/selfcontained/ContentProviderServiceActivator.java
+++ b/self-contained/src/main/java/org/jboss/as/selfcontained/ContentProviderServiceActivator.java
@@ -25,36 +25,26 @@ package org.jboss.as.selfcontained;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.msc.service.ServiceActivatorContext;
 import org.jboss.msc.service.ServiceRegistryException;
-import org.jboss.vfs.VFS;
-import org.jboss.vfs.VirtualFile;
+import org.jboss.msc.service.ValueService;
+import org.jboss.msc.value.ImmediateValue;
 
-import java.io.File;
-import java.io.IOException;
-
-/** Activator for the SelfContainedContentService.
- *
- * @see org.jboss.as.selfcontained.SelfContainedContentService
+/**
+ * Activator for the self-contained ContentProvider.
  *
  * @author Bob McWhirter
  */
-public class SelfContainedContentServiceActivator implements ServiceActivator {
+public class ContentProviderServiceActivator implements ServiceActivator {
 
-    private final File content;
+    private final ContentProvider contentProvider;
 
-    public SelfContainedContentServiceActivator(File content) {
-        this.content = content;
+    public ContentProviderServiceActivator(ContentProvider contentProvider) {
+        this.contentProvider = contentProvider;
     }
 
     @Override
     public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
-        VirtualFile mountPoint = VFS.getRootVirtualFile().getChild( "ROOT.war" );
-        try {
-            VFS.mountReal( content, mountPoint );
-            SelfContainedContentService service = new SelfContainedContentService( mountPoint );
-            serviceActivatorContext.getServiceTarget().addService( SelfContainedContentService.NAME, service ).install();
-        } catch (IOException e) {
-            throw new ServiceRegistryException(e);
-        }
-
+        serviceActivatorContext.getServiceTarget()
+                .addService( ContentProvider.NAME, new ValueService<ContentProvider>( new ImmediateValue<ContentProvider>( this.contentProvider ) ) )
+                .install();
     }
 }

--- a/self-contained/src/main/java/org/jboss/as/selfcontained/SelfContainedContentRepository.java
+++ b/self-contained/src/main/java/org/jboss/as/selfcontained/SelfContainedContentRepository.java
@@ -42,7 +42,7 @@ import java.util.Set;
 
 /** A content-repository capable of providing a static bit of content.
  *
- * @see org.jboss.as.selfcontained.SelfContainedContentService
+ * @see org.jboss.as.selfcontained.ContentProvider
  *
  * @author Bob McWhirter
  */
@@ -52,14 +52,14 @@ public class SelfContainedContentRepository implements ContentRepository, Servic
     public static void addService(ServiceTarget serviceTarget) {
         SelfContainedContentRepository contentRepository = new SelfContainedContentRepository();
         serviceTarget.addService(SERVICE_NAME, contentRepository)
-                .addDependency( SelfContainedContentService.NAME, VirtualFile.class, contentRepository.getContentInjector() )
+                .addDependency( ContentProvider.NAME, ContentProvider.class, contentRepository.getContentProviderInjector() )
                 .install();
     }
 
-    private InjectedValue<VirtualFile> contentInjector = new InjectedValue<>();
+    private InjectedValue<ContentProvider> contentProviderInjector = new InjectedValue<>();
 
-    public Injector<VirtualFile> getContentInjector() {
-        return this.contentInjector;
+    public Injector<ContentProvider> getContentProviderInjector() {
+        return this.contentProviderInjector;
     }
 
     @Override
@@ -73,17 +73,17 @@ public class SelfContainedContentRepository implements ContentRepository, Servic
 
     @Override
     public VirtualFile getContent(byte[] hash) {
-        // the [0] array is a sentinal for the self-contained content.
-        if ( hash.length == 1 && hash[0] == 0 ) {
-            return this.contentInjector.getValue();
+        // A single-element array is the sentinal
+        if ( hash.length == 1 ) {
+            return this.contentProviderInjector.getValue().getContent( hash[0] );
         }
         return null;
     }
 
     @Override
     public boolean hasContent(byte[] hash) {
-        if ( hash.length == 1 && hash[0] == 0 ){
-            return true;
+        if ( hash.length == 1 ) {
+            return this.contentProviderInjector.getValue().getContent( hash[0] ) != null;
         }
         return false;
     }


### PR DESCRIPTION
* Adjust how content is provided in order to support multiple deployments.
* Use start() instead of bootstrap() so that quiesence is achieved.
* Rename (simplify) some items.
* Throw exceptions instead of abort()'ing, printing and exiting.
* Do not install StdioContext, to allow user's own
  System.err/System.out usage to continue as expected.