### PR TITLE
[WFCORE-659] standalone.sh fails to start server with debug argument

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -13,9 +13,9 @@ do
     case "$1" in
       --debug)
           DEBUG_MODE=true
-          shift
-          if [ -n "$1" ] && [ "${1#*-}" = "$1" ]; then
-              DEBUG_PORT=$1
+          if [ -n "$2" ] && [ "$2" = `echo "$2" | sed 's/-//'` ]; then
+              DEBUG_PORT=$2
+              shift
           fi
           ;;
       -Djava.security.manager*)


### PR DESCRIPTION
...on solaris 10 and HP-UX hosts

Solaris sh doesn't seem to support variety of substitutions.