### PR TITLE
Attr group

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -206,6 +206,9 @@ public class PersistentResourceXMLDescription {
             if (flushRequired && attributeGroups.isEmpty()) {
                 ParseUtils.requireNoContent(reader);
             }
+            if (childAlreadyRead) {
+                throw ParseUtils.unexpectedElement(reader);
+            }
         } else {
             Map<String, PersistentResourceXMLDescription> children = getChildrenMap();
             if (childAlreadyRead || (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
@@ -293,10 +296,11 @@ public class PersistentResourceXMLDescription {
                 writer.writeEndElement();
             }
         } else {
+            final boolean empty = attributeGroups.isEmpty() && propertyAttributes.isEmpty() && children.isEmpty();
             if (useValueAsElementName) {
                 writeStartElement(writer, namespaceURI, resourceDefinition.getPathElement().getValue());
             } else if (isSubsystem) {
-                startSubsystemElement(writer, namespaceURI, children.isEmpty());
+                startSubsystemElement(writer, namespaceURI, empty);
             } else {
                 writeStartElement(writer, namespaceURI, xmlElementName);
             }
@@ -305,7 +309,7 @@ public class PersistentResourceXMLDescription {
             persistChildren(writer, model);
 
             // Do not attempt to write end element if the <subsystem/> has no elements!
-            if (!isSubsystem || !children.isEmpty()) {
+            if (!isSubsystem || !empty) {
                 writer.writeEndElement();
             }
         }

--- a/controller/src/main/java/org/jboss/as/controller/PropertiesAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PropertiesAttributeDefinition.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
-import javax.xml.stream.XMLStreamConstants;
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
@@ -47,12 +47,18 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
  *
  * @author Jason T. Greene
  * @author Tomaz Cerar<
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
  */
 //todo maybe replace with SimpleMapAttributeDefinition?
 public final class PropertiesAttributeDefinition extends MapAttributeDefinition {
 
+    final boolean wrapXmlElement;
+    final String wrapperElement;
+
     private PropertiesAttributeDefinition(final Builder builder) {
         super(builder);
+        this.wrapXmlElement = builder.wrapXmlElement;
+        this.wrapperElement = builder.wrapperElement;
     }
 
     @Override
@@ -95,15 +101,17 @@ public final class PropertiesAttributeDefinition extends MapAttributeDefinition 
     }
 
     public void parse(final XMLExtendedStreamReader reader, final ModelNode operation) throws XMLStreamException {
-        while (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT) {
-            if (reader.getLocalName().equals(getXmlName())) {
-                final String[] array = requireAttributes(reader, org.jboss.as.controller.parsing.Attribute.NAME.getLocalName(), org.jboss.as.controller.parsing.Attribute.VALUE.getLocalName());
-                parseAndAddParameterElement(array[0], array[1], operation, reader);
-                ParseUtils.requireNoContent(reader);
-            } else {
-                throw ParseUtils.unexpectedElement(reader);
-            }
-        }
+        final String[] array = requireAttributes(reader, org.jboss.as.controller.parsing.Attribute.NAME.getLocalName(), org.jboss.as.controller.parsing.Attribute.VALUE.getLocalName());
+        parseAndAddParameterElement(array[0], array[1], operation, reader);
+        ParseUtils.requireNoContent(reader);
+    }
+
+    public boolean isWrapped() {
+        return wrapXmlElement;
+    }
+
+    public String getWrapperElement() {
+        return wrapperElement;
     }
 
     private static class PropertiesAttributeMarshaller extends AttributeMarshaller {

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/groups-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/groups-subsystem.xml
@@ -20,6 +20,10 @@
     <resource name="foo" no-attr1="yada" alias="localhost,some.host">
         <cluster attr1="bar" attr2="baz"/>
         <security my-attr1="alice" my-attr2="bob"/>
+        <property name="prop" value="val"/>
+        <wrapped-properties>
+            <property name="prop" value="val"/>
+        </wrapped-properties>
     </resource>
     <resource name="foo2" no-attr1="blah" alias="localhost,some.host,bah,boh,yak">
         <cluster attr1="bar2" attr2="baz2"/>


### PR DESCRIPTION
I have refactored iiop subsystem to use flat attribute groups, but encoutered following problems:
Bugs: subsystem tag is closed if there are grouped attributes but no children, no exception is thrown when invalid task is read but there are no children. I am proposing fix to those two in first commit.
Properties: if there is properties argument it has to be defined in the subsystem. There is property argument in iiop subsystem but it not mandatory and is not used in standard configuration. I am proposing the change in which properties are parsed/persisted separately and as a result of that: the don't have to be present in subsystem, they can be put in arbitrary place within subsystem argument tags, wrapper properties are parsed correctly. This is a second commit.