### PR TITLE
[WFCORE-558] Drop common-core dependency in org.jboss.vfs module.xml

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/vfs/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/vfs/main/module.xml
@@ -33,7 +33,6 @@
     </resources>
 
     <dependencies>
-        <module name="org.jboss.common-core"/>
         <module name="org.jboss.logging"/>
     </dependencies>
 </module>


### PR DESCRIPTION
@ctomc I noticed this dependency is still in the module.xml but I don't think it's needed.