### PR TITLE
[WFCORE-668] Allow devs to turn of INFO logging re specific deprecated a...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -462,12 +462,34 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
     }
 
     /**
-     * Marks the attribute as deprecated since the given API version.
+     * Marks the attribute as deprecated since the given API version. This is equivalent to calling
+     * {@link #setDeprecated(ModelVersion, boolean)} with the {@code notificationUseful} parameter
+     * set to {@code true}.
+     *
      * @param since the API version, with the API being the one (core or a subsystem) in which the attribute is used
      * @return a builder that can be used to continue building the attribute definition
      */
     public BUILDER setDeprecated(ModelVersion since) {
-        this.deprecated = new DeprecationData(since);
+        return setDeprecated(since, true);
+    }
+
+    /**
+     * Marks the attribute as deprecated since the given API version, with the ability to configure that
+     * notifications to the user (e.g. via a log message) about deprecation of the attribute should not be emitted.
+     * Notifying the user should only be done if the user can take some action in response. Advising that
+     * something will be removed in a later release is not useful if there is no alternative in the
+     * current release. If the {@code notificationUseful} param is {@code true} the text
+     * description of the attribute deprecation available from the {@code read-resource-description}
+     * management operation should provide useful information about how the user can avoid using
+     * the attribute.
+     *
+     * @param since the API version, with the API being the one (core or a subsystem) in which the attribute is used
+     * @param notificationUseful whether actively advising the user about the deprecation is useful
+     *
+     * @return a builder that can be used to continue building the attribute definition
+     */
+    public BUILDER setDeprecated(ModelVersion since, boolean notificationUseful) {
+        this.deprecated = new DeprecationData(since, notificationUseful);
         return (BUILDER) this;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -423,8 +423,9 @@ public abstract class AttributeDefinition {
      * @throws OperationFailedException if the value is not valid
      */
     public final void validateAndSet(ModelNode operationObject, final ModelNode model) throws OperationFailedException {
-        if (operationObject.hasDefined(name) && isDeprecated()) {
-            ControllerLogger.DEPRECATED_LOGGER.attributeDeprecated(getName());
+        if (operationObject.hasDefined(name) && deprecationData != null && deprecationData.isNotificationUseful()) {
+            ControllerLogger.DEPRECATED_LOGGER.attributeDeprecated(getName(),
+                    PathAddress.pathAddress(operationObject.get(ModelDescriptionConstants.OP_ADDR)).toCLIStyleString());
         }
         // AS7-6224 -- convert expression strings to ModelType.EXPRESSION *before* correcting
         ModelNode newValue = convertParameterExpressions(operationObject.get(name));

--- a/controller/src/main/java/org/jboss/as/controller/DeprecationData.java
+++ b/controller/src/main/java/org/jboss/as/controller/DeprecationData.java
@@ -23,16 +23,61 @@
 package org.jboss.as.controller;
 
 /**
+ * Encapsulates information about the deprecation of a management resource, attribute or operation.
+ * <p>
+ * <strong>Notifying users about deprecated items:</strong> Some code that uses this class may choose
+ * to proactively notify users (e.g. with a log message) when the deprecated item is used. The
+ * {@link #isNotificationUseful()} method should be checked before emitting any such notification.
+ * Notifying the user should only be done if the user can take some action in response. Advising that
+ * something will be removed in a later release is not useful if there is no alternative in the
+ * current release. If the {@link #isNotificationUseful()} method returns {@code true} the text
+ * description of the deprecated item available from the relevant {@code read-XXX-description}
+ * management operation should provide useful information about how the user can avoid using
+ * the deprecated item.
+ *
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public final class DeprecationData {
-    private ModelVersion since;
+    private final ModelVersion since;
+    private final boolean notificationUseful;
 
+    /**
+     * Creates a new DeprecationData which will return {@code false} from {@link #isNotificationUseful()}.
+     * @param since the version since which the attribute has been deprecated. Cannot be {@code null}
+     */
     public DeprecationData(ModelVersion since) {
-        this.since = since;
+        this(since, false);
     }
 
+    /**
+     * Creates a new DeprecationData, with an option to disable notifications to users when
+     * the use the deprecated item.
+     *
+     * @param since the version since which the attribute has been deprecated. Cannot be {@code null}
+     * @param notificationUseful whether actively advising the user about the deprecation is useful
+     */
+    public DeprecationData(ModelVersion since, boolean notificationUseful) {
+        assert since != null;
+        this.since = since;
+        this.notificationUseful = notificationUseful;
+    }
+
+    /**
+     * Gets the version since which the attribute has been deprecated.
+     * @return  the version
+     */
     public ModelVersion getSince() {
         return since;
+    }
+
+    /**
+     * Gets whether actively advising the user about the deprecation is useful. Code that
+     * proactively notifies a user (e.g. with a log message) when a deprecated item is
+     * used should check this method before producing such a notification.
+     *
+     * @return {@code true} if advising the user is useful
+     */
+    public boolean isNotificationUseful()  {
+        return notificationUseful;
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/OperationDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationDefinition.java
@@ -138,8 +138,9 @@ public abstract class OperationDefinition {
      * @throws OperationFailedException if the value is not valid
      */
     public void validateOperation(final ModelNode operation) throws OperationFailedException {
-        if (operation.hasDefined(ModelDescriptionConstants.OPERATION_NAME) && isDeprecated()) {
-            ControllerLogger.DEPRECATED_LOGGER.attributeDeprecated(getName());
+        if (operation.hasDefined(ModelDescriptionConstants.OPERATION_NAME) && deprecationData != null && deprecationData.isNotificationUseful()) {
+            ControllerLogger.DEPRECATED_LOGGER.operationDeprecated(getName(),
+                    PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)).toCLIStyleString());
         }
         for (AttributeDefinition ad : this.parameters) {
             ad.validateOperation(operation);

--- a/controller/src/main/java/org/jboss/as/controller/SimpleOperationDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleOperationDefinitionBuilder.java
@@ -137,8 +137,33 @@ public class SimpleOperationDefinitionBuilder {
         return this;
     }
 
+    /**
+     * Marks the operation as deprecated since the given API version. This is equivalent to calling
+     * {@link #setDeprecated(ModelVersion, boolean)} with the {@code notificationUseful} parameter
+     * set to {@code true}.
+     * @param since the API version, with the API being the one (core or a subsystem) in which the attribute is used
+     * @return a builder that can be used to continue building the attribute definition
+     */
     public SimpleOperationDefinitionBuilder setDeprecated(ModelVersion since) {
-        this.deprecationData = new DeprecationData(since);
+        return setDeprecated(since, true);
+    }
+
+    /**
+     * Marks the attribute as deprecated since the given API version, with the ability to configure that
+     * notifications to the user (e.g. via a log message) about deprecation of the operation should not be emitted.
+     * Notifying the user should only be done if the user can take some action in response. Advising that
+     * something will be removed in a later release is not useful if there is no alternative in the
+     * current release. If the {@code notificationUseful} param is {@code true} the text
+     * description of the operation deprecation available from the {@code read-operation-description}
+     * management operation should provide useful information about how the user can avoid using
+     * the operation.
+     *
+     * @param since the API version, with the API being the one (core or a subsystem) in which the attribute is used
+     * @param notificationUseful whether actively advising the user about the deprecation is useful
+     * @return a builder that can be used to continue building the attribute definition
+     */
+    public SimpleOperationDefinitionBuilder setDeprecated(ModelVersion since, boolean notificationUseful) {
+        this.deprecationData = new DeprecationData(since, notificationUseful);
         return this;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -417,8 +417,10 @@ public interface ControllerLogger extends BasicLogger {
     void interruptedWaitingStability();
 
     @LogMessage(level = Level.INFO)
-    @Message(id = 28, value = "Attribute %s is deprecated, and it might be removed in future version!")
-    void attributeDeprecated(String name);
+    @Message(id = 28, value = "Attribute '%s' in the resource at address '%s' is deprecated, and may be removed in " +
+            "future version. See the attribute description in the output of the read-resource-description operation " +
+            "to learn more about the deprecation.")
+    void attributeDeprecated(String name, String address);
 
     /**
      * Logs a warning message indicating a temp file could not be deleted.
@@ -3314,5 +3316,11 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = 394, value = "Capability '%s' does not provide services of type '%s'")
     IllegalArgumentException invalidCapabilityServiceType(String capabilityName, Class<?> serviceType);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 395, value = "Operation %s against the resource at address %s is deprecated, and it might be removed in " +
+            "future version. See the the output of the read-operation-description operation" +
+            "to learn more about the deprecation.")
+    void operationDeprecated(String name, String address);
 
 }


### PR DESCRIPTION
...ttributes and operations

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1213421, where we're spamming the EAP logs about deprecated attributes that the user has no choice but to use in those releases. We even use them in our standard configs. This PR lets devs selectively turn off such logging when it adds no value for the attribute/operation in question. The EAP fix would backport this and then turn off the logging for the noisy attributes.

This also improves the log messages.