### PR TITLE
[WFCORE-114] : Get RuntimeVaultReader into WildFly Core

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
@@ -59,8 +59,7 @@
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.remoting"/>
         <module name="org.wildfly.security.manager" services="import"/>
-        <module name="org.jboss.as.security" optional="true" services="import"/>
-        <module name="org.jboss.as.server"/>
+        <module name="org.jboss.as.server" services="import"/>
         <module name="org.jboss.as.version"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.logmanager" services="import"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -66,7 +66,6 @@
         <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.self-contained" optional="true"/>
         <module name="org.wildfly.security.manager" services="import"/>
-        <module name="org.jboss.as.security" optional="true" services="import"/>
         <module name="org.jboss.as.version"/>
         <module name="org.picketbox" optional="true"/>
         <module name="io.undertow.core" />

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1115,4 +1115,42 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 225, value="Unable to create temporary directory")
     RuntimeException unableToCreateSelfContainedDir();
 
+    /**
+     * Creates a {@link RuntimeException}
+     * @param e the underlying exception
+     * @return
+     */
+    @Message(id = 226, value = "Runtime Exception:")
+    RuntimeException runtimeException(@Cause Throwable e);
+
+    /**
+     * Create a {@link org.jboss.as.server.services.security.VaultReaderException} to indicate there was an exception while reading from the vault
+     * @param t underlying exception
+     * @return {@link org.jboss.as.server.services.security.VaultReaderException}
+     */
+    @Message(id = 227, value = "Vault Reader Exception:")
+    VaultReaderException vaultReaderException(@Cause Throwable t);
+
+    /**
+     * Create a {@link SecurityException}
+     * @param t underlying exception
+     * @return {@link SecurityException}
+     */
+    @Message(id = 228, value = "Security Exception")
+    SecurityException securityException(@Cause Throwable t);
+
+    /**
+     * Create a {@link SecurityException}
+     * @param msg message that is passed in creating the exception
+     * @return {@link SecurityException}
+     */
+    @Message(id = 229, value = "Security Exception: %s")
+    SecurityException securityException(String msg);
+
+    /**
+     * Create a {@link SecurityException} to indicate that the vault is not initialized
+     * @return {@link SecurityException}
+     */
+    @Message(id = 230, value = "Vault is not initialized")
+    SecurityException vaultNotInitializedException();
 }

--- a/server/src/main/java/org/jboss/as/server/services/security/RuntimeVaultReader.java
+++ b/server/src/main/java/org/jboss/as/server/services/security/RuntimeVaultReader.java
@@ -1,0 +1,166 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.server.services.security;
+
+import static java.security.AccessController.doPrivileged;
+
+import java.nio.charset.StandardCharsets;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.regex.Pattern;
+
+import org.jboss.as.server.logging.ServerLogger;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleClassLoader;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoadException;
+import org.jboss.modules.ModuleLoader;
+import org.jboss.security.vault.SecurityVault;
+import org.jboss.security.vault.SecurityVaultException;
+import org.jboss.security.vault.SecurityVaultFactory;
+import org.wildfly.security.manager.WildFlySecurityManager;
+import org.wildfly.security.manager.action.GetModuleClassLoaderAction;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class RuntimeVaultReader extends AbstractVaultReader {
+
+    private static final Pattern VAULT_PATTERN = Pattern.compile("VAULT::.*::.*::.*");
+
+    private volatile SecurityVault vault;
+
+
+    /**
+     * This constructor should remain protected to keep the vault as invisible
+     * as possible, but it needs to be exposed for service plug-ability.
+     */
+    public RuntimeVaultReader() {
+    }
+
+    protected void createVault(final String fqn, final Map<String, Object> options) throws VaultReaderException {
+        createVault(fqn, null, options);
+    }
+
+    protected void createVault(final String fqn, final String module, final Map<String, Object> options) throws VaultReaderException {
+        Map<String, Object> vaultOptions = new HashMap<String, Object>(options);
+        SecurityVault vault = null;
+        try {
+            vault = AccessController.doPrivileged(new PrivilegedExceptionAction<SecurityVault>() {
+                @Override
+                public SecurityVault run() throws Exception {
+                    if (fqn == null || fqn.isEmpty()) {
+                        return SecurityVaultFactory.get();
+                    } else if (module == null ){
+                        return SecurityVaultFactory.get(fqn);
+                    } else {
+                        return SecurityVaultFactory.get(getModuleClassLoader(module), fqn);
+                    }
+                }
+            });
+        } catch (PrivilegedActionException e) {
+            Throwable t = e.getCause();
+            if (t instanceof SecurityVaultException) {
+                throw ServerLogger.ROOT_LOGGER.vaultReaderException(t);
+            }
+            if (t instanceof RuntimeException) {
+                throw ServerLogger.ROOT_LOGGER.runtimeException(t);
+            }
+            throw ServerLogger.ROOT_LOGGER.runtimeException(t);
+        }
+        try {
+            vault.init(vaultOptions);
+        } catch (SecurityVaultException e) {
+            throw ServerLogger.ROOT_LOGGER.vaultReaderException(e);
+        }
+        this.vault = vault;
+    }
+
+    protected void destroyVault() {
+        //TODO - there are no cleanup methods in the vault itself
+        vault = null;
+    }
+
+    public String retrieveFromVault(final String password) throws SecurityException {
+        if (isVaultFormat(password)) {
+
+            if (vault == null) {
+                throw ServerLogger.ROOT_LOGGER.vaultNotInitializedException();
+            }
+
+            try {
+                return getValueAsString(password);
+            } catch (SecurityVaultException e) {
+                throw ServerLogger.ROOT_LOGGER.securityException(e);
+            }
+
+        }
+        return password;
+    }
+
+    private String getValueAsString(String vaultString) throws SecurityVaultException {
+        char[] val = getValue(vaultString);
+        if (val != null) {
+            return new String(val);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isVaultFormat(String str) {
+        return str != null && VAULT_PATTERN.matcher(str).matches();
+    }
+
+    private char[] getValue(String vaultString) throws SecurityVaultException {
+        String[] tokens = tokens(vaultString);
+        byte[] sharedKey = null;
+        if (tokens.length > 2) {
+            // only in case of conversion of old vault implementation
+            sharedKey = tokens[3].getBytes(StandardCharsets.UTF_8);
+        }
+
+        return vault.retrieve(tokens[1], tokens[2], sharedKey);
+    }
+
+    private String[] tokens(String vaultString) {
+        StringTokenizer tokenizer = new StringTokenizer(vaultString, "::");
+        int length = tokenizer.countTokens();
+        String[] tokens = new String[length];
+
+        int index = 0;
+        while (tokenizer.hasMoreTokens()) {
+            tokens[index++] = tokenizer.nextToken();
+        }
+        return tokens;
+    }
+
+    private ModuleClassLoader getModuleClassLoader(final String moduleSpec) throws ModuleLoadException {
+        ModuleLoader loader = Module.getCallerModuleLoader();
+        final Module module = loader.loadModule(ModuleIdentifier.fromString(moduleSpec));
+        return WildFlySecurityManager.isChecking() ? doPrivileged(new GetModuleClassLoaderAction(module)) : module.getClassLoader();
+    }
+}

--- a/server/src/main/resources/META-INF/services/org.jboss.as.server.services.security.AbstractVaultReader
+++ b/server/src/main/resources/META-INF/services/org.jboss.as.server.services.security.AbstractVaultReader
@@ -1,0 +1,1 @@
+org.jboss.as.server.services.security.RuntimeVaultReader


### PR DESCRIPTION
Moving RuntimeVaultReader from WildFly to WildFly-Core

Reopening #620 as having this does good and doesn't mean the picketbox lib must be present in core.

Right now (w/o this PR) the way it works is the service loader is in org.jboss.as.security which is visible because HC and server module.xml optionally depend on org.jboss.as.security, with services=import.

With this PR the service loader is in server, which HC already depends on, but now I added services=import too. So the core modules no longer need to depend on org.jboss.as.security as they get nothing from it.

The vault doesn't actually work in core, because there is no picketbox module but server module has an optional dep on picketbox, so if it is present (i.e. in full) then it just works.

I will need to follow up with a PR for full to delete the old org.jboss.as.security RuntimeVaultReader and its service loader file but that's just a cleanup of cruft; it's dead code now because core modules no longer make that stuff visible.