### PR TITLE
[WFCORE-613] Add the Elytron module to the core feature pack.

### DIFF
--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -335,6 +335,11 @@
 
         <dependency>
             <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-security-manager</artifactId>
         </dependency>
 

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.security.elytron">
+
+    <exports>
+        <exclude path="org/wildfly/security/_private"/>
+        <exclude path="org/wildfly/wildfly/security/manager/_private"/>
+        <exclude path="org/wildfly/security/sasl/digest/_private"/>
+        <exclude path="org/wildfly/security/util/_private"/>
+    </exports>
+
+    <resources>
+        <artifact name="${org.wildfly.security:wildfly-elytron}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.modules"/>
+        <module name="javax.api" />
+        <module name="sun.jdk"/>
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
         <version.org.eclipse.aether>1.0.0.v20140518</version.org.eclipse.aether>
         <version.org.wildfly.build-tools>1.0.0.Alpha8</version.org.wildfly.build-tools>
         <version.org.wildfly.legacy.test>1.0.0.Alpha9</version.org.wildfly.legacy.test>
+        <version.org.wildfly.security.elytron>1.0.0.Alpha1</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.manager>1.1.2.Final</version.org.wildfly.security.manager>
         <version.org.wildfly.checkstyle-config>1.0.3.Final</version.org.wildfly.checkstyle-config>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
@@ -1402,6 +1403,12 @@
                 <groupId>org.wildfly.legacy.test</groupId>
                 <artifactId>wildfly-legacy-spi</artifactId>
                 <version>${version.org.wildfly.legacy.test}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.security</groupId>
+                <artifactId>wildfly-elytron</artifactId>
+                <version>${version.org.wildfly.security.elytron}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This pull request is just the first stage to get the project included in the build which will also allow it to trickle into WildFly.

In addition to the core Elytron work the project also includes the SASL mechanisms from JBoss SASL and the WildFly SecurityManager.  

Once this module is included as step 1 we can start to move SecurityManager use to Elytron and then remove the existing module.