### PR TITLE
WFCORE-685 Speed up PathElement Validation

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PathElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/PathElement.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.controller;
 
-import java.util.regex.Pattern;
-
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -41,12 +39,6 @@ public class PathElement {
     private final String value;
     private final boolean multiTarget;
     private final int hashCode;
-
-    /**
-     * A valid key contains alphanumerics and underscores, cannot start with a
-     * number, and cannot start or end with {@code -}.
-     */
-    private static final Pattern VALID_KEY_PATTERN = Pattern.compile("\\*|[_a-zA-Z](?:[-_a-zA-Z0-9]*[_a-zA-Z0-9])?");
 
     /**
      * Construct a new instance with a wildcard value.
@@ -81,7 +73,7 @@ public class PathElement {
      * @param value the path value or wildcard to match
      */
     PathElement(final String key, final String value) {
-        if (key == null || !VALID_KEY_PATTERN.matcher(key).matches()) {
+        if (!isValidKey(key)) {
             final String element = key + "=" + value;
             throw new OperationClientIllegalArgumentException(ControllerLogger.ROOT_LOGGER.invalidPathElementKey(element, key));
         }
@@ -108,6 +100,56 @@ public class PathElement {
         this.multiTarget = multiTarget;
         hashCode = key.hashCode() * 19 + value.hashCode();
     }
+
+    /**
+     * A valid key contains alphanumerics and underscores, cannot start with a
+     * number, and cannot start or end with {@code -}.
+     */
+    private static boolean isValidKey(final String s) {
+        // Equivalent to this regex \*|[_a-zA-Z](?:[-_a-zA-Z0-9]*[_a-zA-Z0-9]) but faster
+        if (s == null) {
+            return false;
+        }
+        if (s.equals(WILDCARD_VALUE)) {
+            return true;
+        }
+        int lastIndex = s.length() - 1;
+        if (lastIndex == -1) {
+            return false;
+        }
+        if (!isValidKeyStartCharacter(s.charAt(0))) {
+          return false;
+        }
+        for (int i = 1; i < lastIndex; i++) {
+          if (!isValidKeyCharacter(s.charAt(i))) {
+            return false;
+          }
+        }
+        if (lastIndex > 0 && !isValidKeyEndCharacter(s.charAt(lastIndex))) {
+          return false;
+        }
+        return true;
+      }
+
+      private static boolean isValidKeyStartCharacter(final char c) {
+        return c == '_'
+            || c >= 'a' && c <= 'z'
+            || c >= 'A' && c <= 'Z';
+      }
+
+      private static boolean isValidKeyEndCharacter(final char c) {
+        return c == '_'
+            || c >= '0' && c <= '9'
+            || c >= 'a' && c <= 'z'
+            || c >= 'A' && c <= 'Z';
+      }
+
+      private static boolean isValidKeyCharacter(char c) {
+        return c == '_' || c == '-'
+            || c >= '0' && c <= '9'
+            || c >= 'a' && c <= 'z'
+            || c >= 'A' && c <= 'Z';
+      }
 
     /**
      * Get the path key.

--- a/controller/src/test/java/org/jboss/as/controller/PathElementTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/PathElementTestCase.java
@@ -1,0 +1,80 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2015, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.controller;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="philippe.marschall@gmail.com">Philippe Marschall</a>
+ */
+public class PathElementTestCase {
+
+    @Test
+    public void validKey() {
+        String[] validKeys = {
+                "*",
+                "a",
+                "z",
+                "A",
+                "Z",
+                "_",
+                "a-a",
+                "a-1",
+                "a0",
+                "a1",
+                "a9",
+                "_1",
+                "_a",
+                "__",
+        };
+        for (String key : validKeys) {
+            PathElement pathElement = PathElement.pathElement(key);
+            assertEquals(key, pathElement.getKey());
+        }
+    }
+
+    @Test
+    public void invalidkey() {
+        String[] invalidKeys = {
+                null,
+                "",
+                "-",
+                "1",
+                "a-",
+                "-a"
+        };
+            for (String key : invalidKeys) {
+                try {
+                    PathElement.pathElement(key);
+                    fail("key " + key + " should be invalid");
+                } catch (IllegalArgumentException e) {
+                    // should reach here
+                }
+
+            }
+    }
+
+}


### PR DESCRIPTION
During benchmarking of our WildFly instance creating the regex matcher for
controller path element validation has popped up.

 * implement path element validation using a one pass iteration over all
   characters rather than a regex
 * do not call #toCharArray as it allocates a new char[]

We did some microbenchmarks with JMH and doing the validation this way
is more than an order of magnitude faster.

Issue: WFCORE-685
https://issues.jboss.org/browse/WFCORE-685