### PR TITLE
Drop wildfly-security-manager, use Elytron version instead

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -55,7 +55,7 @@
 
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <dependency>

--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -339,11 +339,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-self-contained</artifactId>
         </dependency>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -39,7 +39,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.as.controller-client"/>
         <module name="org.jboss.as.protocol"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.patching.cli" optional="true" services="import"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
@@ -38,7 +38,7 @@
         <module name="org.jboss.as.controller-client" export="true"/>
         <module name="org.jboss.as.core-security"/>
         <module name="org.jboss.as.protocol"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.dmr" export="true"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.logmanager"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-scanner/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-scanner/main/module.xml
@@ -44,7 +44,7 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.threads"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.manager" />
+        <module name="org.wildfly.security.elytron" />
         <module name="org.jboss.as.server" />
         <module name="org.jboss.as.deployment-repository"/>
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
@@ -37,7 +37,7 @@
 
     <dependencies>
         <module name="io.undertow.core"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.controller"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-management/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-management/main/module.xml
@@ -37,7 +37,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.wildfly.security.manager" />
+        <module name="org.wildfly.security.elytron" />
         <module name="org.jboss.as.controller" />
         <module name="org.jboss.common-core"/>
         <module name="org.jboss.as.core-security"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
@@ -58,7 +58,7 @@
         <module name="org.jboss.as.process-controller"/>
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.remoting"/>
-        <module name="org.wildfly.security.manager" services="import"/>
+        <module name="org.wildfly.security.elytron" services="import"/>
         <module name="org.jboss.as.server" services="import"/>
         <module name="org.jboss.as.version"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
@@ -43,7 +43,7 @@
         <module name="org.jboss.as.domain-management"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.remoting" />
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server" />
         <module name="org.jboss.remoting" />
         <module name="org.jboss.msc"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
@@ -35,7 +35,7 @@
         <module name="javax.api"/>
         <module name="org.apache.log4j"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.msc"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
@@ -33,7 +33,7 @@
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging" />
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/patching/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/patching/main/module.xml
@@ -41,6 +41,6 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.staxmapper"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/platform-mbean/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/platform-mbean/main/module.xml
@@ -39,7 +39,7 @@
         <module name="javax.api"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.controller-client"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/process-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/process-controller/main/module.xml
@@ -40,7 +40,7 @@
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="org.wildfly.security.manager" services="import"/>
+        <module name="org.wildfly.security.elytron" services="import"/>
         <module name="org.jboss.as.version" export="true"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.logmanager" services="import"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
@@ -43,7 +43,7 @@
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.server"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.security" optional="true"/>
         <module name="org.jboss.as.threads"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -65,7 +65,7 @@
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.self-contained" optional="true"/>
-        <module name="org.wildfly.security.manager" services="import"/>
+        <module name="org.wildfly.security.elytron" services="import"/>
         <module name="org.jboss.as.version"/>
         <module name="org.picketbox" optional="true"/>
         <module name="io.undertow.core" />

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
@@ -46,6 +46,6 @@
         <module name="org.jboss.as.jmx" services="import"/>
         <module name="org.jboss.as.server" export="true"/>
         <module name="org.jboss.vfs" services="import"/>
-        <module name="org.wildfly.security.manager" services="import"/>
+        <module name="org.wildfly.security.elytron" services="import"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/threads/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/threads/main/module.xml
@@ -34,7 +34,7 @@
     <dependencies>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/invocation/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/invocation/main/module.xml
@@ -37,6 +37,6 @@
         <module name="org.jboss.classfilewriter"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/embedded/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/embedded/main/module.xml
@@ -38,7 +38,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.controller-client"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
@@ -39,7 +39,7 @@
         <module name="sun.jdk"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.security" optional="true"/>
         <module name="org.jboss.msc"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/request-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/request-controller/main/module.xml
@@ -39,7 +39,7 @@
         <module name="sun.jdk"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.security" optional="true"/>
         <module name="org.jboss.msc"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/manager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/manager/main/module.xml
@@ -27,18 +27,14 @@
         <property name="jboss.api" value="private"/>
     </properties>
 
-    <exports>
-        <exclude path="org/wildfly/security/manager/_private"/>
-    </exports>
-
-    <resources>
-        <artifact name="${org.wildfly.security:wildfly-security-manager}"/>
-    </resources>
-
     <dependencies>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.modules"/>
-        <module name="javax.api"/>
-        <module name="sun.jdk"/>
+        <module name="org.wildfly.security.elytron" export="true">
+            <exports>
+                <include-set>
+                    <path name="org/wildfly/security/manager"/>
+                    <path name="org/wildfly/security/manager/action"/>
+                </include-set>
+            </exports>
+        </module>
     </dependencies>
 </module>

--- a/domain-http/interface/pom.xml
+++ b/domain-http/interface/pom.xml
@@ -60,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/embedded/pom.xml
+++ b/embedded/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>

--- a/host-controller/pom.xml
+++ b/host-controller/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -105,7 +105,7 @@
 
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <dependency>

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -40,7 +40,7 @@
     <dependencies>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/platform-mbean/pom.xml
+++ b/platform-mbean/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1409,6 +1409,12 @@
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>*</artifactId>
+                        <groupId>*</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/process-controller/pom.xml
+++ b/process-controller/pom.xml
@@ -56,7 +56,7 @@
     <dependencies>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/remoting/subsystem/pom.xml
+++ b/remoting/subsystem/pom.xml
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -72,7 +72,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/vault/module/security-module.xml
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/vault/module/security-module.xml
@@ -27,7 +27,7 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.modules"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.picketbox"/>
         <module name="javax.xml.stream.api"/>


### PR DESCRIPTION
Drop the wildfly-security-manager artifact.  Redefine security manager module to re-export Elytron APIs.  Move all internal modules to point at the Elytron module directly.