### PR TITLE
DiscardPolicy needs to be public as it's used by public API

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/transform/description/DiscardPolicy.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/description/DiscardPolicy.java
@@ -28,7 +28,7 @@ package org.jboss.as.controller.transform.description;
  *
  * @author Emanuel Muckenhuber
  */
-enum DiscardPolicy {
+public enum DiscardPolicy {
         /**
          * Don't discard the resource or operation.
          */


### PR DESCRIPTION
see org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder#addChildResource(org.jboss.as.controller.PathElement, org.jboss.as.controller.transform.description.DynamicDiscardPolicy)