### PR TITLE
[1.x] WFCORE-692 read-children-names(include-aliases=true) can return phantom results

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -683,12 +683,16 @@ public class GlobalOperationHandlers {
                     }
                 }
             } else {
-                //PathAddress target = aliasEntry.getTargetAddress();
                 PathAddress target = aliasEntry.convertToTargetAddress(addr.append(element));
                 PathAddress targetParent = target.subAddress(0, target.size() - 1);
                 Resource parentResource = context.readResourceFromRoot(targetParent, false);
-                if (parentResource != null && parentResource.hasChildren(target.getLastElement().getKey())) {
-                    set.add(element.getValue());
+                if (parentResource != null) {
+                    PathElement targetElement = target.getLastElement();
+                    if (targetElement.isWildcard()) {
+                        set.addAll(parentResource.getChildrenNames(targetElement.getKey()));
+                    } else if (parentResource.hasChild(targetElement)) {
+                        set.add(element.getValue());
+                    }
                 }
             }
             if (!element.isWildcard()) {


### PR DESCRIPTION
if another resource exists with the same key as tje target address of a resource alias.

https://issues.jboss.org/browse/WFCORE-692