### PR TITLE
[WFCORE-696] Reduce PathAddress creation in access control checks

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/access/constraint/AuditConstraint.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/constraint/AuditConstraint.java
@@ -22,9 +22,6 @@
 
 package org.jboss.as.controller.access.constraint;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.access.Action.ActionEffect;
 import org.jboss.as.controller.access.TargetAttribute;
@@ -71,11 +68,7 @@ public class AuditConstraint extends AllowAllowNotConstraint {
 
         @Override
         public Constraint getRequiredConstraint(Action.ActionEffect actionEffect, Action action, TargetResource target) {
-            return (isAuditOperation(action) || isAuditResource(target)) ? AUDIT : NOT_AUDIT;
-        }
-
-        private boolean isAuditOperation(Action action) {
-            return AuditLogAddressUtil.isAuditLogAddress(PathAddress.pathAddress(action.getOperation().get(OP_ADDR)));
+            return isAuditResource(target) ? AUDIT : NOT_AUDIT;
         }
 
         private boolean isAuditResource(TargetResource target) {

--- a/controller/src/main/java/org/jboss/as/controller/access/constraint/NonAuditConstraint.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/constraint/NonAuditConstraint.java
@@ -22,9 +22,6 @@
 
 package org.jboss.as.controller.access.constraint;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.access.TargetAttribute;
 import org.jboss.as.controller.access.TargetResource;
@@ -70,11 +67,7 @@ public class NonAuditConstraint extends AllowAllowNotConstraint {
 
         @Override
         public Constraint getRequiredConstraint(Action.ActionEffect actionEffect, Action action, TargetResource target) {
-            return (isAuditOperation(action) || isAuditResource(target)) ? AUDIT : NOT_AUDIT;
-        }
-
-        private boolean isAuditOperation(Action action) {
-            return AuditLogAddressUtil.isAuditLogAddress(PathAddress.pathAddress(action.getOperation().get(OP_ADDR)));
+            return isAuditResource(target) ? AUDIT : NOT_AUDIT;
         }
 
         private boolean isAuditResource(TargetResource target) {

--- a/controller/src/main/java/org/jboss/as/controller/access/permission/ManagementPermissionAuthorizer.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/permission/ManagementPermissionAuthorizer.java
@@ -29,6 +29,7 @@ import java.util.Enumeration;
 import java.util.Set;
 
 import org.jboss.as.controller.ControlledProcessState;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.access.Action;
@@ -81,6 +82,7 @@ public class ManagementPermissionAuthorizer implements Authorizer {
 
     @Override
     public AuthorizationResult authorize(Caller caller, Environment callEnvironment, Action action, TargetAttribute target) {
+        assert assertSameAddress(action, target.getTargetResource());
         // TODO a direct "booting" flag might be better
         if (callEnvironment.getProcessState() == ControlledProcessState.State.STARTING) {
             return AuthorizationResult.PERMITTED;
@@ -92,6 +94,7 @@ public class ManagementPermissionAuthorizer implements Authorizer {
 
     @Override
     public AuthorizationResult authorize(Caller caller, Environment callEnvironment, Action action, TargetResource target) {
+        assert assertSameAddress(action, target);
         // TODO a direct "booting" flag might be better
         if (callEnvironment.getProcessState() == ControlledProcessState.State.STARTING) {
             return AuthorizationResult.PERMITTED;
@@ -102,6 +105,12 @@ public class ManagementPermissionAuthorizer implements Authorizer {
         }
         PermissionCollection requiredPerms = permissionFactory.getRequiredPermissions(action, target);
         return authorize(userPerms, requiredPerms);
+    }
+
+    private static boolean assertSameAddress(Action action, TargetResource target) {
+        ModelNode operation = action.getOperation();
+        // operation can be null in some unit tests; to be lazy ignore those cases
+        return operation == null || target.getResourceAddress().equals(PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)));
     }
 
     private AuthorizationResult authorize(PermissionCollection userPermissions, PermissionCollection requiredPermissions) {


### PR DESCRIPTION
Kabir counted 30K PathElement creations during a boot of full WildFly. I bet a lot of them come from here, as this creates 2 addresses per authorization, we authorize every attribute, and there are probably on average at least 2 PathElements per attribute.