### PR TITLE
[WFCORE-718] Add CLI Command Builder

### DIFF
--- a/launcher/src/main/java/org/wildfly/core/launcher/Arguments.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/Arguments.java
@@ -112,8 +112,20 @@ class Arguments {
                 } else {
                     argument = create(key, value);
                 }
-                map.put(argument.getKey(), Collections.singleton(argument));
+                set(argument);
             }
+        }
+    }
+
+    /**
+     * Sets an argument to the collection of arguments. This guarantees only one value will be assigned to the
+     * argument key.
+     *
+     * @param argument the argument to add
+     */
+    public void set(final Argument argument) {
+        if (argument != null) {
+            map.put(argument.getKey(), Collections.singleton(argument));
         }
     }
 

--- a/launcher/src/main/java/org/wildfly/core/launcher/CliCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/CliCommandBuilder.java
@@ -1,0 +1,688 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.core.launcher;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.wildfly.core.launcher.Arguments.Argument;
+import org.wildfly.core.launcher.logger.LauncherMessages;
+
+/**
+ * Builds a list of commands to create a new process for a CLI instance.
+ * <p>
+ * This builder is not thread safe and the same instance should not be used in multiple threads.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("unused")
+public class CliCommandBuilder implements CommandBuilder {
+
+    enum CliArgument {
+        CONNECT("--connect", "-c"),
+        CONTROLLER("--controller", "controller"),
+        GUI("--gui"),
+        FILE("--file"),
+        COMMAND("--command"),
+        COMMANDS("--commands"),
+        USER("--user", "-u"),
+        PASSWORD("--password", "-p"),
+        TIMEOUT("--timeout"),;
+        private static final Map<String, CliArgument> ENTRIES;
+
+        static {
+            final Map<String, CliArgument> map = new HashMap<>();
+            for (CliArgument arg : values()) {
+                map.put(arg.key, arg);
+                if (arg.altKey != null) {
+                    map.put(arg.altKey, arg);
+                }
+            }
+            ENTRIES = Collections.unmodifiableMap(map);
+        }
+
+        public static CliArgument find(final String key) {
+            return ENTRIES.get(key);
+        }
+
+        public static CliArgument find(final Argument argument) {
+            return ENTRIES.get(argument.getKey());
+        }
+
+        private final String key;
+        private final String altKey;
+
+        CliArgument(final String key) {
+            this(key, null);
+        }
+
+        CliArgument(final String key, final String altKey) {
+            this.key = key;
+            this.altKey = altKey;
+        }
+    }
+
+    private final Environment environment;
+    private final Arguments javaOpts;
+    private final Arguments cliArgs;
+
+    private CliCommandBuilder(final Environment environment) {
+        this.environment = environment;
+        javaOpts = new Arguments();
+        cliArgs = new Arguments();
+        // Add the default logging.properties file
+        javaOpts.add("-Dlogging.configuration=file:" + environment.resolvePath("bin", "jboss-cli-logging.properties"));
+    }
+
+    /**
+     * Creates a command builder for a CLI instance.
+     *
+     * @param wildflyHome the path to the WildFly home directory
+     *
+     * @return a new builder
+     */
+    public static CliCommandBuilder of(final Path wildflyHome) {
+        return new CliCommandBuilder(new Environment(wildflyHome));
+    }
+
+    /**
+     * Creates a command builder for a CLI instance.
+     *
+     * @param wildflyHome the path to the WildFly home directory
+     *
+     * @return a new builder
+     */
+    public static CliCommandBuilder of(final String wildflyHome) {
+        return new CliCommandBuilder(new Environment(wildflyHome));
+    }
+
+    /**
+     * Sets the hostname and port to connect to.
+     * <p>
+     * This sets both the {@code --connect} and {@code --controller} arguments.
+     * </p>
+     *
+     * @param controller the controller argument to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setConnection(final String controller) {
+        addCliArgument(CliArgument.CONNECT);
+        setController(controller);
+        return this;
+    }
+
+    /**
+     * Sets the hostname and port to connect to.
+     * <p>
+     * This sets both the {@code --connect} and {@code --controller} arguments.
+     * </p>
+     *
+     * @param hostname the host name
+     * @param port     the port
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setConnection(final String hostname, final int port) {
+        addCliArgument(CliArgument.CONNECT);
+        setController(hostname, port);
+        return this;
+    }
+
+    /**
+     * Sets the protocol, hostname and port to connect to.
+     * <p>
+     * This sets both the {@code --connect} and {@code --controller} arguments.
+     * </p>
+     *
+     * @param protocol the protocol to use
+     * @param hostname the host name
+     * @param port     the port
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setConnection(final String protocol, final String hostname, final int port) {
+        addCliArgument(CliArgument.CONNECT);
+        setController(protocol, hostname, port);
+        return this;
+    }
+
+    /**
+     * Sets the hostname and port to connect to.
+     *
+     * @param controller the controller argument to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setController(final String controller) {
+        addCliArgument(CliArgument.CONTROLLER, controller);
+        return this;
+    }
+
+    /**
+     * Sets the hostname and port to connect to.
+     *
+     * @param hostname the host name
+     * @param port     the port
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setController(final String hostname, final int port) {
+        setController(formatAddress(null, hostname, port));
+        return this;
+    }
+
+    /**
+     * Sets the protocol, hostname and port to connect to.
+     *
+     * @param protocol the protocol to use
+     * @param hostname the host name
+     * @param port     the port
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setController(final String protocol, final String hostname, final int port) {
+        setController(formatAddress(protocol, hostname, port));
+        return this;
+    }
+
+    /**
+     * Sets the user to use when establishing a connection.
+     *
+     * @param user the user to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setUser(final String user) {
+        addCliArgument(CliArgument.USER, user);
+        return this;
+    }
+
+    /**
+     * Sets the password to use when establishing a connection.
+     *
+     * @param password the password to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setPassword(final String password) {
+        addCliArgument(CliArgument.PASSWORD, password);
+        return this;
+    }
+
+    /**
+     * Sets the path to the script file to execute.
+     *
+     * @param path the path to the script file to execute
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setScriptFile(final String path) {
+        if (path == null) {
+            addCliArgument(CliArgument.FILE, null);
+            return this;
+        }
+        return setScriptFile(Paths.get(path));
+    }
+
+    /**
+     * Sets the path to the script file to execute.
+     *
+     * @param path the path to the script file to execute
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setScriptFile(final Path path) {
+        if (path == null) {
+            addCliArgument(CliArgument.FILE, null);
+        } else {
+            // Make sure the path exists
+            if (Files.notExists(path)) {
+                throw LauncherMessages.MESSAGES.pathDoesNotExist(path);
+            }
+            addCliArgument(CliArgument.FILE, path.toString());
+        }
+        return this;
+    }
+
+    /**
+     * Sets the command to execute.
+     *
+     * @param command the command to execute
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setCommand(final String command) {
+        addCliArgument(CliArgument.COMMAND, command);
+        return this;
+    }
+
+    /**
+     * Sets the commands to execute.
+     *
+     * @param commands the commands to execute
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setCommands(final String... commands) {
+        if (commands == null || commands.length == 0) {
+            addCliArgument(CliArgument.COMMANDS, null);
+            return this;
+        }
+        return setCommands(Arrays.asList(commands));
+    }
+
+    /**
+     * Sets the commands to execute.
+     *
+     * @param commands the commands to execute
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setCommands(final Iterable<String> commands) {
+        if (commands == null) {
+            addCliArgument(CliArgument.COMMANDS, null);
+            return this;
+        }
+        final StringBuilder cmds = new StringBuilder();
+        for (final Iterator<String> iterator = commands.iterator(); iterator.hasNext(); ) {
+            cmds.append(iterator.next());
+            if (iterator.hasNext()) cmds.append(',');
+        }
+        addCliArgument(CliArgument.COMMANDS, cmds.toString());
+        return this;
+    }
+
+    /**
+     * Sets the timeout used when connecting to the server.
+     *
+     * @param timeout the time out to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setTimeout(final int timeout) {
+        if (timeout > 0) {
+            addCliArgument(CliArgument.TIMEOUT, Integer.toString(timeout));
+        } else {
+            addCliArgument(CliArgument.TIMEOUT, null);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the command argument to use the GUI CLI client.
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setUseGui() {
+        if (Environment.isMac()) {
+            addJavaOption("-Djboss.modules.system.pkgs=com.apple.laf,com.apple.laf.resources");
+        } else {
+            addJavaOption("-Djboss.modules.system.pkgs=com.sun.java.swing");
+        }
+        addCliArgument(CliArgument.GUI);
+        return this;
+    }
+
+    /**
+     * Adds a JVM argument to the command ignoring {@code null} arguments.
+     *
+     * @param jvmArg the JVM argument to add
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addJavaOption(final String jvmArg) {
+        if (jvmArg != null && !jvmArg.trim().isEmpty()) {
+            javaOpts.add(jvmArg);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the array of JVM arguments to the command.
+     *
+     * @param javaOpts the array of JVM arguments to add, {@code null} arguments are ignored
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addJavaOptions(final String... javaOpts) {
+        if (javaOpts != null) {
+            for (String javaOpt : javaOpts) {
+                addJavaOption(javaOpt);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Adds the collection of JVM arguments to the command.
+     *
+     * @param javaOpts the collection of JVM arguments to add, {@code null} arguments are ignored
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addJavaOptions(final Iterable<String> javaOpts) {
+        if (javaOpts != null) {
+            for (String javaOpt : javaOpts) {
+                addJavaOption(javaOpt);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Sets the JVM arguments to use. This overrides any default JVM arguments that would normally be added and ignores
+     * {@code null} values in the collection.
+     * <p/>
+     * If the collection is {@code null} the JVM arguments will be cleared and no new arguments will be added.
+     *
+     * @param javaOpts the JVM arguments to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setJavaOptions(final Iterable<String> javaOpts) {
+        this.javaOpts.clear();
+        return addJavaOptions(javaOpts);
+    }
+
+
+    /**
+     * Sets the JVM arguments to use. This overrides any default JVM arguments that would normally be added and ignores
+     * {@code null} values in the array.
+     * <p/>
+     * If the array is {@code null} the JVM arguments will be cleared and no new arguments will be added.
+     *
+     * @param javaOpts the JVM arguments to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setJavaOptions(final String... javaOpts) {
+        this.javaOpts.clear();
+        return addJavaOptions(javaOpts);
+    }
+
+    /**
+     * Returns the JVM arguments.
+     *
+     * @return the JVM arguments
+     */
+    public List<String> getJavaOptions() {
+        return javaOpts.asList();
+    }
+
+    /**
+     * Adds an argument to be passed to the CLI command ignore the argument if {@code null}.
+     *
+     * @param arg the argument to pass
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addCliArgument(final String arg) {
+        if (arg != null) {
+            final Argument argument = Arguments.parse(arg);
+            final CliArgument cliArgument = CliArgument.find(argument.getKey());
+            if (cliArgument != null) {
+                // Remove the alternate key if required
+                if (cliArgument.altKey != null) {
+                    cliArgs.remove(cliArgument.altKey);
+                }
+            }
+            cliArgs.set(argument);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the arguments to the collection of arguments that will be passed to the CLI command ignoring any {@code
+     * null} arguments.
+     *
+     * @param args the arguments to add
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addCliArguments(final String... args) {
+        if (args != null) {
+            for (String arg : args) {
+                addCliArgument(arg);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Adds the arguments to the collection of arguments that will be passed to the CLI command ignoring any {@code
+     * null} arguments.
+     *
+     * @param args the arguments to add
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addCliArguments(final Iterable<String> args) {
+        if (args != null) {
+            for (String arg : args) {
+                addCliArgument(arg);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Adds a directory to the collection of module paths.
+     *
+     * @param moduleDir the module directory to add
+     *
+     * @return the builder
+     *
+     * @throws java.lang.IllegalArgumentException if the path is {@code null}
+     */
+    public CliCommandBuilder addModuleDir(final String moduleDir) {
+        environment.addModuleDir(moduleDir);
+        return this;
+    }
+
+    /**
+     * Adds all the module directories to the collection of module paths.
+     *
+     * @param moduleDirs an array of module paths to add
+     *
+     * @return the builder
+     *
+     * @throws java.lang.IllegalArgumentException if any of the module paths are invalid or {@code null}
+     */
+    public CliCommandBuilder addModuleDirs(final String... moduleDirs) {
+        environment.addModuleDirs(moduleDirs);
+        return this;
+    }
+
+    /**
+     * Adds all the module directories to the collection of module paths.
+     *
+     * @param moduleDirs a collection of module paths to add
+     *
+     * @return the builder
+     *
+     * @throws java.lang.IllegalArgumentException if any of the module paths are invalid or {@code null}
+     */
+    public CliCommandBuilder addModuleDirs(final Iterable<String> moduleDirs) {
+        environment.addModuleDirs(moduleDirs);
+        return this;
+    }
+
+    /**
+     * Replaces any previously set module directories with the collection of module directories.
+     * <p/>
+     * The default module directory will <i>NOT</i> be used if this method is invoked.
+     *
+     * @param moduleDirs the collection of module directories to use
+     *
+     * @return the builder
+     *
+     * @throws java.lang.IllegalArgumentException if any of the module paths are invalid or {@code null}
+     */
+    public CliCommandBuilder setModuleDirs(final Iterable<String> moduleDirs) {
+        environment.setModuleDirs(moduleDirs);
+        return this;
+    }
+
+    /**
+     * Replaces any previously set module directories with the array of module directories.
+     * <p/>
+     * The default module directory will <i>NOT</i> be used if this method is invoked.
+     *
+     * @param moduleDirs the array of module directories to use
+     *
+     * @return the builder
+     *
+     * @throws java.lang.IllegalArgumentException if any of the module paths are invalid or {@code null}
+     */
+    public CliCommandBuilder setModuleDirs(final String... moduleDirs) {
+        environment.setModuleDirs(moduleDirs);
+        return this;
+    }
+
+    /**
+     * Returns the modules paths used on the command line.
+     *
+     * @return the paths separated by the {@link java.io.File#pathSeparator path separator}
+     */
+    public String getModulePaths() {
+        return environment.getModulePaths();
+    }
+
+    /**
+     * Sets the Java home where the Java executable can be found.
+     *
+     * @param javaHome the Java home or {@code null} to use te system property {@code java.home}
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setJavaHome(final String javaHome) {
+        environment.setJavaHome(javaHome);
+        return this;
+    }
+
+    /**
+     * Sets the Java home where the Java executable can be found.
+     *
+     * @param javaHome the Java home or {@code null} to use te system property {@code java.home}
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setJavaHome(final Path javaHome) {
+        environment.setJavaHome(javaHome);
+        return this;
+    }
+
+    /**
+     * Returns the Java home directory where the java executable command can be found.
+     * <p/>
+     * If the directory was not set the system property value, {@code java.home}, should be used.
+     *
+     * @return the path to the Java home directory
+     */
+    public Path getJavaHome() {
+        return environment.getJavaHome();
+    }
+
+    @Override
+    public List<String> buildArguments() {
+        final List<String> cmd = new ArrayList<>();
+        cmd.addAll(getJavaOptions());
+        cmd.add("-jar");
+        cmd.add(environment.getModuleJar().toString());
+        cmd.add("-mp");
+        cmd.add(getModulePaths());
+        cmd.add("org.jboss.as.cli");
+        cmd.add("-D" + Environment.HOME_DIR + "=" + environment.getWildflyHome());
+
+        cmd.addAll(cliArgs.asList());
+        return cmd;
+    }
+
+    @Override
+    public List<String> build() {
+        final List<String> cmd = new ArrayList<>();
+        cmd.add(environment.getJavaCommand());
+        cmd.addAll(buildArguments());
+        return cmd;
+    }
+
+    private CliCommandBuilder addCliArgument(final CliArgument cliArgument) {
+        if (cliArgument.altKey != null) {
+            cliArgs.remove(cliArgument.altKey);
+        }
+        cliArgs.set(Arguments.parse(cliArgument.key));
+        return this;
+    }
+
+    private CliCommandBuilder addCliArgument(final CliArgument cliArgument, final String value) {
+        if (cliArgument.altKey != null) {
+            cliArgs.remove(cliArgument.altKey);
+        }
+        cliArgs.set(cliArgument.key, value);
+        return this;
+    }
+
+
+    private static String formatAddress(final String protocol, final String hostname, final int port) {
+        final char first = hostname.charAt(0);
+        if (first == '[' && hostname.charAt(hostname.length() - 1) != ']') {
+            throw LauncherMessages.MESSAGES.invalidHostname(hostname);
+        }
+        boolean wrapIpv6 = false;
+        if (first != '[' && (first == ':' || Character.digit(first, 16) != -1)) {
+            int counter = 0;
+            for (char c : hostname.toCharArray()) {
+                if (c == ':') {
+                    counter++;
+                } else if (Character.digit(c, 16) == -1) {
+                    // Not IPV6
+                    break;
+                }
+                if (counter > 1) {
+                    wrapIpv6 = true;
+                    break;
+                }
+            }
+        }
+        if (protocol == null) {
+            if (wrapIpv6) {
+                return String.format("[%s]:%d", hostname, port);
+            }
+            return String.format("%s:%d", hostname, port);
+        }
+        if (wrapIpv6) {
+            return String.format("%s://[%s]:%d", protocol, hostname, port);
+        }
+        return String.format("%s://%s:%d", protocol, hostname, port);
+    }
+}

--- a/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
@@ -46,7 +46,6 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
     private static final String DOMAIN_CONFIG_DIR = "jboss.domain.config.dir";
     private static final String DOMAIN_LOG_DIR = "jboss.domain.log.dir";
 
-    private final Path javaHome;
     private Path hostControllerJavaHome;
     private Path serverJavaHome;
     private Path baseDir;
@@ -63,8 +62,7 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
      * @param javaHome    the default Java home directory
      */
     private DomainCommandBuilder(final Path wildflyHome, final Path javaHome) {
-        super(wildflyHome);
-        this.javaHome = javaHome;
+        super(wildflyHome, javaHome);
         hostControllerJavaOpts = new Arguments();
         hostControllerJavaOpts.addAll(DEFAULT_VM_ARGUMENTS);
         processControllerJavaOpts = new Arguments();
@@ -81,7 +79,7 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
      * @return a new builder
      */
     public static DomainCommandBuilder of(final Path wildflyHome) {
-        return new DomainCommandBuilder(validateWildFlyDir(wildflyHome), validateJavaHome(System.getProperty("java.home")));
+        return new DomainCommandBuilder(validateWildFlyDir(wildflyHome), Environment.getDefaultJavaHome());
     }
 
     /**
@@ -94,7 +92,7 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
      * @return a new builder
      */
     public static DomainCommandBuilder of(final String wildflyHome) {
-        return new DomainCommandBuilder(validateWildFlyDir(wildflyHome), validateJavaHome(System.getProperty("java.home")));
+        return new DomainCommandBuilder(validateWildFlyDir(wildflyHome), Environment.getDefaultJavaHome());
     }
 
     /**
@@ -785,7 +783,7 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
 
     @Override
     public Path getJavaHome() {
-        return javaHome;
+        return environment.getJavaHome();
     }
 
     @Override

--- a/launcher/src/main/java/org/wildfly/core/launcher/Environment.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/Environment.java
@@ -1,0 +1,359 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.core.launcher;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+
+import org.wildfly.core.launcher.logger.LauncherMessages;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class Environment {
+    private static final String JAVA_EXE;
+    private static final Path JAVA_HOME;
+    private static final boolean MAC;
+    private static final boolean WINDOWS;
+    private static final boolean JAVA_1_8_PLUS;
+
+    static final String HOME_DIR = "jboss.home.dir";
+    static final String MODULES_JAR_NAME = "jboss-modules.jar";
+
+    static {
+        final String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+        MAC = os.startsWith("mac");
+        WINDOWS = os.contains("win");
+        String exe = "java";
+        if (WINDOWS) {
+            exe = "java.exe";
+        }
+        JAVA_EXE = exe;
+        String javaHome = System.getenv("JAVA_HOME");
+        if (javaHome == null) {
+            javaHome = System.getProperty("java.home");
+        }
+        JAVA_HOME = Paths.get(javaHome);
+        final String jvmVersion = System.getProperty("java.specification.version");
+
+        // Versions below 8 should add a MaxPermSize
+        JAVA_1_8_PLUS = VersionComparator.compareVersion(jvmVersion, "1.8") < 0;
+    }
+
+    private final Path wildflyHome;
+    private Path javaHome;
+    private final List<String> modulesDirs;
+    private boolean addDefaultModuleDir;
+
+    Environment(final String wildflyHome) {
+        this(validateWildFlyDir(wildflyHome));
+    }
+
+    Environment(final Path wildflyHome) {
+        this.wildflyHome = validateWildFlyDir(wildflyHome);
+        modulesDirs = new ArrayList<>();
+        addDefaultModuleDir = true;
+    }
+
+    /**
+     * Returns the WildFly Home directory.
+     *
+     * @return the WildFly home directory
+     */
+    public Path getWildflyHome() {
+        return wildflyHome;
+    }
+
+    /**
+     * Returns the full path to the {@code jboss-modules.jar}.
+     *
+     * @return the path to {@code jboss-modules.jar}
+     */
+    public Path getModuleJar() {
+        return resolvePath(MODULES_JAR_NAME);
+    }
+
+    /**
+     * Adds a directory to the collection of module paths.
+     *
+     * @param moduleDir the module directory to add
+     *
+     * @throws java.lang.IllegalArgumentException if the path is {@code null}
+     */
+    public void addModuleDir(final String moduleDir) {
+        if (moduleDir == null) {
+            throw LauncherMessages.MESSAGES.nullParam("moduleDir");
+        }
+        // Validate the path
+        final Path path = Paths.get(moduleDir).normalize();
+        modulesDirs.add(path.toString());
+    }
+
+    /**
+     * Adds all the module directories to the collection of module paths.
+     *
+     * @param moduleDirs an array of module paths to add
+     *
+     * @throws java.lang.IllegalArgumentException if any of the module paths are invalid or {@code null}
+     */
+    public void addModuleDirs(final String... moduleDirs) {
+        // Validate and add each path
+        for (String path : moduleDirs) {
+            addModuleDir(path);
+        }
+    }
+
+    /**
+     * Adds all the module directories to the collection of module paths.
+     *
+     * @param moduleDirs a collection of module paths to add
+     *
+     * @throws java.lang.IllegalArgumentException if any of the module paths are invalid or {@code null}
+     */
+    public void addModuleDirs(final Iterable<String> moduleDirs) {
+        // Validate and add each path
+        for (String path : moduleDirs) {
+            addModuleDir(path);
+        }
+    }
+
+    /**
+     * Replaces any previously set module directories with the collection of module directories.
+     * <p/>
+     * The default module directory will <i>NOT</i> be used if this method is invoked.
+     *
+     * @param moduleDirs the collection of module directories to use
+     *
+     * @throws java.lang.IllegalArgumentException if any of the module paths are invalid or {@code null}
+     */
+    public void setModuleDirs(final Iterable<String> moduleDirs) {
+        this.modulesDirs.clear();
+        // Process each module directory
+        for (String path : moduleDirs) {
+            addModuleDir(path);
+        }
+        addDefaultModuleDir = false;
+    }
+
+    /**
+     * Replaces any previously set module directories with the array of module directories.
+     * <p/>
+     * The default module directory will <i>NOT</i> be used if this method is invoked.
+     *
+     * @param moduleDirs the array of module directories to use
+     *
+     * @throws java.lang.IllegalArgumentException if any of the module paths are invalid or {@code null}
+     */
+    public void setModuleDirs(final String... moduleDirs) {
+        this.modulesDirs.clear();
+        // Process each module directory
+        for (String path : moduleDirs) {
+            addModuleDir(path);
+        }
+        addDefaultModuleDir = false;
+    }
+
+    /**
+     * Returns the modules paths used on the command line.
+     *
+     * @return the paths separated by the {@link File#pathSeparator path separator}
+     */
+    public String getModulePaths() {
+        final StringBuilder result = new StringBuilder();
+        if (addDefaultModuleDir) {
+            result.append(wildflyHome.resolve("modules").toString());
+        }
+        if (!modulesDirs.isEmpty()) {
+            if (addDefaultModuleDir) result.append(File.pathSeparator);
+            for (Iterator<String> iterator = modulesDirs.iterator(); iterator.hasNext(); ) {
+                result.append(iterator.next());
+                if (iterator.hasNext()) {
+                    result.append(File.pathSeparator);
+                }
+            }
+        }
+        return result.toString();
+    }
+
+    /**
+     * Sets the Java home where the Java executable can be found.
+     *
+     * @param javaHome the Java home or {@code null} to use te system property {@code java.home}
+     */
+    public void setJavaHome(final String javaHome) {
+        if (javaHome == null) {
+            this.javaHome = null;
+        } else {
+            this.javaHome = validateJavaHome(javaHome);
+        }
+    }
+
+    /**
+     * Sets the Java home where the Java executable can be found.
+     *
+     * @param javaHome the Java home or {@code null} to use te system property {@code java.home}
+     */
+    public void setJavaHome(final Path javaHome) {
+        if (javaHome == null) {
+            this.javaHome = null;
+        } else {
+            this.javaHome = validateJavaHome(javaHome);
+        }
+    }
+
+    /**
+     * Returns the Java home directory where the java executable command can be found.
+     * <p/>
+     * If the directory was not set the system property value, {@code java.home}, should be used.
+     *
+     * @return the path to the Java home directory
+     */
+    public Path getJavaHome() {
+        final Path path;
+        if (javaHome == null) {
+            path = JAVA_HOME;
+        } else {
+            path = javaHome;
+        }
+        return path;
+    }
+
+    /**
+     * Returns the Java executable command.
+     *
+     * @return the java command to use
+     */
+    public String getJavaCommand() {
+        return getJavaCommand(javaHome);
+    }
+
+    /**
+     * Returns the Java executable command.
+     *
+     * @param javaHome the java home directory or {@code null} to use the default
+     *
+     * @return the java command to use
+     */
+    public String getJavaCommand(final Path javaHome) {
+        final Path dir;
+        if (javaHome == null) {
+            dir = getJavaHome();
+        } else {
+            dir = javaHome;
+        }
+        final String exe;
+        if (dir == null) {
+            exe = "java";
+        } else {
+            exe = dir.resolve("bin").resolve("java").toString();
+        }
+        if (exe.contains(" ")) {
+            return "\"" + exe + "\"";
+        }
+        return exe;
+    }
+
+    /**
+     * Resolves a path relative to the WildFly home directory.
+     * <p>
+     * Note this does not validate whether or not the path is valid or exists.
+     * </p>
+     *
+     * @param paths the paths to resolve
+     *
+     * @return the path
+     */
+    public Path resolvePath(final String... paths) {
+        Path result = wildflyHome;
+        for (String path : paths) {
+            result = result.resolve(path);
+        }
+        return result;
+    }
+
+    public static boolean isMac() {
+        return MAC;
+    }
+
+    public static boolean isWindows() {
+        return WINDOWS;
+    }
+
+    public static boolean supportsMaxPermSize() {
+        return JAVA_1_8_PLUS;
+    }
+
+    static Path getDefaultJavaHome() {
+        return JAVA_HOME;
+    }
+
+    static Path validateWildFlyDir(final String wildflyHome) {
+        if (wildflyHome == null) {
+            throw LauncherMessages.MESSAGES.pathDoesNotExist(null);
+        }
+        return validateWildFlyDir(Paths.get(wildflyHome));
+    }
+
+    static Path validateWildFlyDir(final Path wildflyHome) {
+        if (wildflyHome == null || Files.notExists(wildflyHome)) {
+            throw LauncherMessages.MESSAGES.pathDoesNotExist(wildflyHome);
+        }
+        if (!Files.isDirectory(wildflyHome)) {
+            throw LauncherMessages.MESSAGES.invalidDirectory(wildflyHome);
+        }
+        final Path result = wildflyHome.toAbsolutePath().normalize();
+        if (Files.notExists(result.resolve(MODULES_JAR_NAME))) {
+            throw LauncherMessages.MESSAGES.invalidDirectory(MODULES_JAR_NAME, wildflyHome);
+        }
+        return result;
+    }
+
+    static Path validateJavaHome(final String javaHome) {
+        if (javaHome == null) {
+            throw LauncherMessages.MESSAGES.pathDoesNotExist(null);
+        }
+        return validateJavaHome(Paths.get(javaHome));
+    }
+
+    static Path validateJavaHome(final Path javaHome) {
+        if (javaHome == null || Files.notExists(javaHome)) {
+            throw LauncherMessages.MESSAGES.pathDoesNotExist(javaHome);
+        }
+        if (!Files.isDirectory(javaHome)) {
+            throw LauncherMessages.MESSAGES.invalidDirectory(javaHome);
+        }
+        final Path result = javaHome.toAbsolutePath().normalize();
+        final Path exe = result.resolve("bin").resolve(JAVA_EXE);
+        if (Files.notExists(exe)) {
+            final int count = exe.getNameCount();
+            throw LauncherMessages.MESSAGES.invalidDirectory(exe.subpath(count - 2, count).toString(), javaHome);
+        }
+        return result;
+    }
+}

--- a/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
@@ -48,7 +48,6 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
     private static final String SERVER_LOG_DIR = "jboss.server.log.dir";
 
     private Path baseDir;
-    private Path javaHome;
     private final Arguments javaOpts;
     private String debugArg;
     private String modulesLocklessArg;
@@ -270,11 +269,7 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
      * @return the builder
      */
     public StandaloneCommandBuilder setJavaHome(final String javaHome) {
-        if (javaHome == null) {
-            this.javaHome = null;
-        } else {
-            this.javaHome = validateJavaHome(javaHome);
-        }
+        environment.setJavaHome(javaHome);
         return this;
     }
 
@@ -286,11 +281,7 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
      * @return the builder
      */
     public StandaloneCommandBuilder setJavaHome(final Path javaHome) {
-        if (javaHome == null) {
-            this.javaHome = null;
-        } else {
-            this.javaHome = validateJavaHome(javaHome);
-        }
+        environment.setJavaHome(javaHome);
         return this;
     }
 
@@ -465,13 +456,7 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
 
     @Override
     public Path getJavaHome() {
-        final Path path;
-        if (javaHome == null) {
-            path = validateJavaHome(System.getProperty("java.home"));
-        } else {
-            path = javaHome;
-        }
-        return path;
+        return environment.getJavaHome();
     }
 
     @Override

--- a/launcher/src/main/java/org/wildfly/core/launcher/logger/LauncherMessages.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/logger/LauncherMessages.java
@@ -56,4 +56,7 @@ public interface LauncherMessages {
 
     @Message(id = 5, value = "The parameter %s cannot be null.")
     IllegalArgumentException nullParam(String name);
+
+    @Message(id = 6, value = "Invalid hostname: %s")
+    IllegalArgumentException invalidHostname(CharSequence hostname);
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/FileArgumentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/FileArgumentTestCase.java
@@ -29,13 +29,18 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.core.launcher.CliCommandBuilder;
+import org.wildfly.core.launcher.Launcher;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
@@ -159,30 +164,30 @@ public class FileArgumentTestCase {
         if(jbossDist == null) {
             fail("jboss.dist system property is not set");
         }
+
+        final CliCommandBuilder commandBuilder = CliCommandBuilder.of(jbossDist);
+
         String modulePath = TestSuiteEnvironment.getSystemProperty("module.path");
-        if(modulePath == null) {
-            modulePath = jbossDist + File.separator + "modules";
-            //fail("module.path system property is not set");
+        if (modulePath != null) {
+            commandBuilder.setModuleDirs(modulePath.split(Pattern.quote(File.pathSeparator)));
         }
 
-        final ProcessBuilder builder = new ProcessBuilder();
-        builder.redirectErrorStream(true);
-        final List<String> command = new ArrayList<String>();
-        command.add(TestSuiteEnvironment.getJavaPath());
-        TestSuiteEnvironment.getIpv6Args(command);
-        command.add("-Djboss.cli.config=" + jbossDist + File.separator + "bin" + File.separator + "jboss-cli.xml");
-        command.add("-jar");
-        command.add(jbossDist + File.separatorChar + "jboss-modules.jar");
-        command.add("-mp");
-        command.add(modulePath);
-        command.add("org.jboss.as.cli");
-        command.add("-c");
-        command.add("--controller=" + TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getServerPort());
-        command.add("--file=" + f.getAbsolutePath());
-        builder.command(command);
+        final List<String> ipv6Args = new ArrayList<>();
+        TestSuiteEnvironment.getIpv6Args(ipv6Args);
+        if (!ipv6Args.isEmpty()) {
+            commandBuilder.addJavaOptions(ipv6Args);
+        }
+
+        // Set the CLI configuration path
+        final Path path = Paths.get(jbossDist, "bin", "jboss-cli.xml");
+        commandBuilder.addJavaOptions("-Djboss.cli.config=" + path);
+        commandBuilder.setConnection(TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort());
+        commandBuilder.setScriptFile(f.toPath().toAbsolutePath());
         Process cliProc = null;
         try {
-            cliProc = builder.start();
+            cliProc = Launcher.of(commandBuilder)
+                    .setRedirectErrorStream(true)
+                    .launch();
         } catch (IOException e) {
             fail("Failed to start CLI process: " + e.getLocalizedMessage());
         }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossclircTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossclircTestCase.java
@@ -108,7 +108,7 @@ public class JBossclircTestCase extends CliScriptTestBase {
     public void testScript() throws Exception {
         assertEquals(0, execute(false, "echo $" + VAR_NAME, false,
                 Collections.singletonMap(JBOSS_CLI_RC_PROP, TMP_JBOSS_CLI_RC.getAbsolutePath())));
-        assertTrue(getLastCommandOutput().endsWith(Util.LINE_SEPARATOR + VAR_VALUE + Util.LINE_SEPARATOR));
+        assertTrue(getLastCommandOutput().endsWith(VAR_VALUE + Util.LINE_SEPARATOR));
     }
     
     protected static void ensureRemoved(File f) {


### PR DESCRIPTION
Added a `CliCommandBuilder` and converted the CLI tests to use it.

The main idea behind the launcher is to allow consumers like the `wildfly-maven-plugin` to be execute CLI commands in a modular environment. Some CLI commands seem to prefer, maybe require, a modular environment. This just eases the pain of manually launching the process with some defaults.