### PR TITLE
[WFCORE-718] Add CLI command builder.

### DIFF
--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -27,7 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -41,65 +40,35 @@ import org.wildfly.core.launcher.logger.LauncherMessages;
 abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> implements CommandBuilder {
 
     private static final String MODULES_JAR_NAME = "jboss-modules.jar";
-    private static final String JAVA_EXE = "java" + getExeSuffix();
+    private static final String JAVA_EXE;
+    private static final String JAVA_HOME;
 
+    static final boolean IS_MAC;
     static final String HOME_DIR = "jboss.home.dir";
-    static final String SECURITY_MANAGER_ARG = "-secmgr";
-    static final String SECURITY_MANAGER_PROP = "java.security.manager";
-    static final String[] DEFAULT_VM_ARGUMENTS;
 
     static {
-        final String jvmVersion = System.getProperty("java.specification.version");
-        final Collection<String> javaOpts = new ArrayList<>();
-        // Default JVM parameters for all versions
-        javaOpts.add("-Xms64m");
-        javaOpts.add("-Xmx512m");
-        javaOpts.add("-Djava.net.preferIPv4Stack=true");
-        javaOpts.add("-Djava.awt.headless=true");
-        javaOpts.add("-Djboss.modules.system.pkgs=org.jboss.byteman");
-
-        // Versions below 8 should add a MaxPermSize
-        if (VersionComparator.compareVersion(jvmVersion, "1.8") < 0) {
-            javaOpts.add("-XX:MaxPermSize=256m");
+        final String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+        String exe = "java";
+        IS_MAC = os.startsWith("mac");
+        if (os.toLowerCase(Locale.ROOT).contains("win")) {
+            exe = "java.exe";
         }
-        DEFAULT_VM_ARGUMENTS = javaOpts.toArray(new String[javaOpts.size()]);
+        JAVA_EXE = exe;
+        String javaHome = System.getenv("JAVA_HOME");
+        if (javaHome == null) {
+            javaHome = System.getProperty("java.home");
+        }
+        JAVA_HOME = javaHome;
     }
 
     private final Path wildflyHome;
-    private boolean useSecMgr;
     private final List<String> modulesDirs;
-    private Path logDir;
-    private Path configDir;
-    private final Arguments serverArgs;
     private boolean addDefaultModuleDir;
 
     protected AbstractCommandBuilder(final Path wildflyHome) {
         this.wildflyHome = wildflyHome;
-        useSecMgr = false;
         modulesDirs = new ArrayList<>();
-        serverArgs = new Arguments();
         addDefaultModuleDir = true;
-    }
-
-    /**
-     * Sets whether or not the security manager option, {@code -secmgr}, should be used.
-     *
-     * @param useSecMgr {@code true} to use the a security manager, otherwise {@code false}
-     *
-     * @return the builder
-     */
-    public T setUseSecurityManager(final boolean useSecMgr) {
-        this.useSecMgr = useSecMgr;
-        return getThis();
-    }
-
-    /**
-     * Indicates whether or no a security manager should be used for the server launched.
-     *
-     * @return {@code true} if a security manager should be used, otherwise {@code false}
-     */
-    public boolean useSecurityManager() {
-        return useSecMgr;
     }
 
     /**
@@ -209,7 +178,7 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
         }
         if (!modulesDirs.isEmpty()) {
             if (addDefaultModuleDir) result.append(File.pathSeparator);
-            for (Iterator<String>iterator = modulesDirs.iterator(); iterator.hasNext();) {
+            for (Iterator<String> iterator = modulesDirs.iterator(); iterator.hasNext(); ) {
                 result.append(iterator.next());
                 if (iterator.hasNext()) {
                     result.append(File.pathSeparator);
@@ -217,270 +186,6 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
             }
         }
         return result.toString();
-    }
-
-    /**
-     * Returns the log directory for the server.
-     *
-     * @return the log directory
-     */
-    public Path getLogDirectory() {
-        if (logDir == null) {
-            return normalizePath(getBaseDirectory(), "log");
-        }
-        return logDir;
-    }
-
-    /**
-     * Sets the log directory to be used for log files.
-     * <p/>
-     * If set to {@code null}, the default, the log directory will be resolved.
-     *
-     * @param path the path to the log directory or {@code null} to have the log directory resolved
-     *
-     * @return the builder
-     *
-     * @throws java.lang.IllegalArgumentException if the directory is not a valid directory
-     */
-    public T setLogDirectory(final String path) {
-        if (path == null) {
-            logDir = null;
-            return getThis();
-        }
-        return setLogDirectory(Paths.get(path));
-    }
-
-    /**
-     * Sets the log directory to be used for log files.
-     * <p/>
-     * If set to {@code null}, the default, the log directory will be resolved.
-     *
-     * @param path the path to the log directory or {@code null} to have the log directory resolved
-     *
-     * @return the builder
-     *
-     * @throws java.lang.IllegalArgumentException if the directory is not a valid directory
-     */
-    public T setLogDirectory(final Path path) {
-        if (path == null) {
-            logDir = null;
-        } else {
-            if (Files.exists(path) && !Files.isDirectory(path)) {
-                throw LauncherMessages.MESSAGES.invalidDirectory(path);
-            }
-            logDir = path.toAbsolutePath().normalize();
-        }
-        return getThis();
-    }
-
-    /**
-     * Returns the configuration directory for the server.
-     *
-     * @return the configuration directory
-     */
-    public Path getConfigurationDirectory() {
-        if (configDir == null) {
-            return normalizePath(getBaseDirectory(), "configuration");
-        }
-        return configDir;
-    }
-
-    /**
-     * Sets the configuration directory to be used for configuration files.
-     * <p/>
-     * If set to {@code null}, the default, the configuration directory will be resolved.
-     *
-     * @param path the path to the configuration directory or {@code null} to have the configuration directory resolved
-     *
-     * @return the builder
-     *
-     * @throws java.lang.IllegalArgumentException if the directory is not a valid directory
-     */
-    public T setConfigurationDirectory(final String path) {
-        configDir = validateAndNormalizeDir(path, true);
-        return getThis();
-    }
-
-    /**
-     * Sets the configuration directory to be used for configuration files.
-     * <p/>
-     * If set to {@code null}, the default, the configuration directory will be resolved.
-     *
-     * @param path the path to the configuration directory or {@code null} to have the configuration directory resolved
-     *
-     * @return the builder
-     *
-     * @throws java.lang.IllegalArgumentException if the directory is not a valid directory
-     */
-    public T setConfigurationDirectory(final Path path) {
-        configDir = validateAndNormalizeDir(path, true);
-        return getThis();
-    }
-
-    /**
-     * Adds an argument to be passed to the server ignore the argument if {@code null}.
-     *
-     * @param arg the argument to pass
-     *
-     * @return the builder
-     */
-    public T addServerArgument(final String arg) {
-        if (arg != null) {
-            if (SECURITY_MANAGER_ARG.equals(arg)) {
-                setUseSecurityManager(true);
-            } else {
-                serverArgs.add(arg);
-            }
-        }
-        return getThis();
-    }
-
-    /**
-     * Adds the arguments to the collection of arguments that will be passed to the server ignoring any {@code null}
-     * arguments.
-     *
-     * @param args the arguments to add
-     *
-     * @return the builder
-     */
-    public T addServerArguments(final String... args) {
-        if (args != null) {
-            for (String arg : args) {
-                addServerArgument(arg);
-            }
-        }
-        return getThis();
-    }
-
-    /**
-     * Adds the arguments to the collection of arguments that will be passed to the server ignoring any {@code null}
-     * arguments.
-     *
-     * @param args the arguments to add
-     *
-     * @return the builder
-     */
-    public T addServerArguments(final Iterable<String> args) {
-        if (args != null) {
-            for (String arg : args) {
-                addServerArgument(arg);
-            }
-        }
-        return getThis();
-    }
-
-    /**
-     * Sets the server argument {@code --admin-only}.
-     *
-     * @return the builder
-     */
-    public T setAdminOnly() {
-        return addServerArgument("--admin-only");
-    }
-
-    /**
-     * Sets the system property {@code jboss.bind.address} to the address given.
-     * <p/>
-     * This will override any previous value set via {@link #addServerArgument(String)}.
-     * <p/>
-     * <b>Note:</b> This option only works if the standard system property has not been removed from the interface. If
-     * the system property was removed the address provided has no effect.
-     *
-     * @param address the address to set the bind address to
-     *
-     * @return the builder
-     */
-    public T setBindAddressHint(final String address) {
-        addServerArg("-b", address);
-        return getThis();
-    }
-
-    /**
-     * Sets the system property {@code jboss.bind.address.$INTERFACE} to the address given where {@code $INTERFACE} is
-     * the {@code interfaceName} parameter. For example in the default configuration passing {@code management} for the
-     * {@code interfaceName} parameter would result in the system property {@code jboss.bind.address.management} being
-     * set to the address provided.
-     * <p/>
-     * This will override any previous value set via {@link #addServerArgument(String)}.
-     * <p/>
-     * <b>Note:</b> This option only works if the standard system property has not been removed from the interface. If
-     * the system property was removed the address provided has no effect.
-     *
-     * @param interfaceName the name of the interface of the binding address
-     * @param address       the address to bind the management interface to
-     *
-     * @return the builder
-     */
-    public T setBindAddressHint(final String interfaceName, final String address) {
-        if (interfaceName == null) {
-            throw LauncherMessages.MESSAGES.nullParam("interfaceName");
-        }
-        addServerArg("-b" + interfaceName, address);
-        return getThis();
-    }
-
-    /**
-     * Sets the system property {@code jboss.default.multicast.address} to the address given.
-     * <p/>
-     * This will override any previous value set via {@link #addServerArgument(String)}.
-     * <p/>
-     * <b>Note:</b> This option only works if the standard system property has not been removed from the interface. If
-     * the system property was removed the address provided has no effect.
-     *
-     * @param address the address to set the multicast system property to
-     *
-     * @return the builder
-     */
-    public T setMulticastAddressHint(final String address) {
-        addServerArg("-u", address);
-        return getThis();
-    }
-
-    /**
-     * Sets the properties file to use for the server or {@code null} to remove the file. The file must exist.
-     * <p/>
-     * This will override any previous value set via {@link #addServerArgument(String)}..
-     *
-     * @param file the properties file to use or {@code null}
-     *
-     * @return the builder
-     *
-     * @throws java.lang.IllegalArgumentException if the file does not exist or is not a regular file
-     */
-    public T setPropertiesFile(final String file) {
-        final Path path;
-        if (file == null) {
-            path = null;
-        } else {
-            path = Paths.get(file);
-        }
-        return setPropertiesFile(path);
-    }
-
-    /**
-     * Sets the properties file to use for the server or {@code null} to remove the file. The file must exist.
-     * <p/>
-     * This will override any previous value set via {@link #addServerArgument(String)}..
-     *
-     * @param file the properties file to use or {@code null}
-     *
-     * @return the builder
-     *
-     * @throws java.lang.IllegalArgumentException if the file does not exist or is not a regular file
-     */
-    public T setPropertiesFile(final Path file) {
-        if (file == null) {
-            addServerArg("-P", null);
-        } else {
-            if (Files.notExists(file)) {
-                throw LauncherMessages.MESSAGES.pathDoesNotExist(file);
-            }
-            if (!Files.isRegularFile(file)) {
-                throw LauncherMessages.MESSAGES.pathNotAFile(file);
-            }
-            addServerArg("-P", file.toAbsolutePath().normalize().toString());
-        }
-        return getThis();
     }
 
     /**
@@ -528,31 +233,6 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
     }
 
     /**
-     * Returns the command line argument that specifies the logging configuration.
-     *
-     * @param fileName the name of the configuration file
-     *
-     * @return the command line argument
-     */
-    protected String getLoggingPropertiesArgument(final String fileName) {
-        return "-Dlogging.configuration=file:" + normalizePath(getConfigurationDirectory(), fileName);
-    }
-
-    /**
-     * Returns the command line argument that specifies the path the log file that should be used.
-     * <p/>
-     * This is generally only used on the initial boot of the server in standalone. The server will rewrite the
-     * configuration file with hard-coded values.
-     *
-     * @param fileName the name of the file
-     *
-     * @return the command line argument
-     */
-    protected String getBootLogArgument(final String fileName) {
-        return "-Dorg.jboss.boot.log.file=" + normalizePath(getLogDirectory(), fileName);
-    }
-
-    /**
      * Returns the normalized path to the {@code jboss-modules.jar} for launching the server.
      *
      * @return the path to {@code jboss-modules.jar}
@@ -586,44 +266,14 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
     }
 
     /**
-     * Returns the base directory for the server.
-     * <p/>
-     * Example:
-     * For standalone the base directory would be {@code $JBOSS_HOME/standalone}.
-     *
-     * @return the base directory
-     */
-    public abstract Path getBaseDirectory();
-
-    /**
-     * A collection of server command line arguments.
-     *
-     * @return the server arguments
-     */
-    public List<String> getServerArguments() {
-        return serverArgs.asList();
-    }
-
-    /**
      * Returns the concrete builder.
      *
      * @return the concrete builder
      */
     protected abstract T getThis();
 
-    protected void addServerArg(final String key, final String value) {
-        serverArgs.add(key, value);
-    }
-
-    protected String getServerArg(final String key) {
-        return serverArgs.get(key);
-    }
-
-    protected static Path resolveJavaHome(final Path javaHome) {
-        if (javaHome == null) {
-            return validateJavaHome(System.getProperty("java.home"));
-        }
-        return validateJavaHome(javaHome);
+    protected static Path getDefaultJavaHome() {
+        return validateJavaHome(JAVA_HOME);
     }
 
     protected static Path validateWildFlyDir(final String wildflyHome) {
@@ -682,13 +332,5 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
         if (value != null) {
             cmd.add("-D" + key + "=" + value);
         }
-    }
-
-    private static String getExeSuffix() {
-        final String os = System.getProperty("os.name");
-        if (os != null && os.toLowerCase(Locale.ROOT).contains("win")) {
-            return ".exe";
-        }
-        return "";
     }
 }

--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractServerCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractServerCommandBuilder.java
@@ -1,0 +1,425 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.core.launcher;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.wildfly.core.launcher.logger.LauncherMessages;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("unused")
+abstract class AbstractServerCommandBuilder<T extends AbstractServerCommandBuilder<T>> extends AbstractCommandBuilder<T> {
+    static final String SECURITY_MANAGER_ARG = "-secmgr";
+    static final String SECURITY_MANAGER_PROP = "java.security.manager";
+    static final String[] DEFAULT_VM_ARGUMENTS;
+
+    static {
+        final String jvmVersion = System.getProperty("java.specification.version");
+        final Collection<String> javaOpts = new ArrayList<>();
+        // Default JVM parameters for all versions
+        javaOpts.add("-Xms64m");
+        javaOpts.add("-Xmx512m");
+        javaOpts.add("-Djava.net.preferIPv4Stack=true");
+        javaOpts.add("-Djava.awt.headless=true");
+        javaOpts.add("-Djboss.modules.system.pkgs=org.jboss.byteman");
+
+        // Versions below 8 should add a MaxPermSize
+        if (VersionComparator.compareVersion(jvmVersion, "1.8") < 0) {
+            javaOpts.add("-XX:MaxPermSize=256m");
+        }
+        DEFAULT_VM_ARGUMENTS = javaOpts.toArray(new String[javaOpts.size()]);
+    }
+
+    private boolean useSecMgr;
+    private Path logDir;
+    private Path configDir;
+    private final Arguments serverArgs;
+
+    protected AbstractServerCommandBuilder(final Path wildflyHome) {
+        super(wildflyHome);
+        useSecMgr = false;
+        serverArgs = new Arguments();
+    }
+
+    /**
+     * Sets whether or not the security manager option, {@code -secmgr}, should be used.
+     *
+     * @param useSecMgr {@code true} to use the a security manager, otherwise {@code false}
+     *
+     * @return the builder
+     */
+    public T setUseSecurityManager(final boolean useSecMgr) {
+        this.useSecMgr = useSecMgr;
+        return getThis();
+    }
+
+    /**
+     * Indicates whether or no a security manager should be used for the server launched.
+     *
+     * @return {@code true} if a security manager should be used, otherwise {@code false}
+     */
+    public boolean useSecurityManager() {
+        return useSecMgr;
+    }
+
+    /**
+     * Returns the log directory for the server.
+     *
+     * @return the log directory
+     */
+    public Path getLogDirectory() {
+        if (logDir == null) {
+            return normalizePath(getBaseDirectory(), "log");
+        }
+        return logDir;
+    }
+
+    /**
+     * Sets the log directory to be used for log files.
+     * <p/>
+     * If set to {@code null}, the default, the log directory will be resolved.
+     *
+     * @param path the path to the log directory or {@code null} to have the log directory resolved
+     *
+     * @return the builder
+     *
+     * @throws IllegalArgumentException if the directory is not a valid directory
+     */
+    public T setLogDirectory(final String path) {
+        if (path == null) {
+            logDir = null;
+            return getThis();
+        }
+        return setLogDirectory(Paths.get(path));
+    }
+
+    /**
+     * Sets the log directory to be used for log files.
+     * <p/>
+     * If set to {@code null}, the default, the log directory will be resolved.
+     *
+     * @param path the path to the log directory or {@code null} to have the log directory resolved
+     *
+     * @return the builder
+     *
+     * @throws IllegalArgumentException if the directory is not a valid directory
+     */
+    public T setLogDirectory(final Path path) {
+        if (path == null) {
+            logDir = null;
+        } else {
+            if (Files.exists(path) && !Files.isDirectory(path)) {
+                throw LauncherMessages.MESSAGES.invalidDirectory(path);
+            }
+            logDir = path.toAbsolutePath().normalize();
+        }
+        return getThis();
+    }
+
+    /**
+     * Returns the configuration directory for the server.
+     *
+     * @return the configuration directory
+     */
+    public Path getConfigurationDirectory() {
+        if (configDir == null) {
+            return normalizePath(getBaseDirectory(), "configuration");
+        }
+        return configDir;
+    }
+
+    /**
+     * Sets the configuration directory to be used for configuration files.
+     * <p/>
+     * If set to {@code null}, the default, the configuration directory will be resolved.
+     *
+     * @param path the path to the configuration directory or {@code null} to have the configuration directory resolved
+     *
+     * @return the builder
+     *
+     * @throws IllegalArgumentException if the directory is not a valid directory
+     */
+    public T setConfigurationDirectory(final String path) {
+        configDir = validateAndNormalizeDir(path, true);
+        return getThis();
+    }
+
+    /**
+     * Sets the configuration directory to be used for configuration files.
+     * <p/>
+     * If set to {@code null}, the default, the configuration directory will be resolved.
+     *
+     * @param path the path to the configuration directory or {@code null} to have the configuration directory resolved
+     *
+     * @return the builder
+     *
+     * @throws IllegalArgumentException if the directory is not a valid directory
+     */
+    public T setConfigurationDirectory(final Path path) {
+        configDir = validateAndNormalizeDir(path, true);
+        return getThis();
+    }
+
+    /**
+     * Adds an argument to be passed to the server ignore the argument if {@code null}.
+     *
+     * @param arg the argument to pass
+     *
+     * @return the builder
+     */
+    public T addServerArgument(final String arg) {
+        if (arg != null) {
+            if (SECURITY_MANAGER_ARG.equals(arg)) {
+                setUseSecurityManager(true);
+            } else {
+                serverArgs.add(arg);
+            }
+        }
+        return getThis();
+    }
+
+    /**
+     * Adds the arguments to the collection of arguments that will be passed to the server ignoring any {@code null}
+     * arguments.
+     *
+     * @param args the arguments to add
+     *
+     * @return the builder
+     */
+    public T addServerArguments(final String... args) {
+        if (args != null) {
+            for (String arg : args) {
+                addServerArgument(arg);
+            }
+        }
+        return getThis();
+    }
+
+    /**
+     * Adds the arguments to the collection of arguments that will be passed to the server ignoring any {@code null}
+     * arguments.
+     *
+     * @param args the arguments to add
+     *
+     * @return the builder
+     */
+    public T addServerArguments(final Iterable<String> args) {
+        if (args != null) {
+            for (String arg : args) {
+                addServerArgument(arg);
+            }
+        }
+        return getThis();
+    }
+
+    /**
+     * Sets the server argument {@code --admin-only}.
+     *
+     * @return the builder
+     */
+    public T setAdminOnly() {
+        return addServerArgument("--admin-only");
+    }
+
+    /**
+     * Sets the system property {@code jboss.bind.address} to the address given.
+     * <p/>
+     * This will override any previous value set via {@link #addServerArgument(String)}.
+     * <p/>
+     * <b>Note:</b> This option only works if the standard system property has not been removed from the interface. If
+     * the system property was removed the address provided has no effect.
+     *
+     * @param address the address to set the bind address to
+     *
+     * @return the builder
+     */
+    public T setBindAddressHint(final String address) {
+        addServerArg("-b", address);
+        return getThis();
+    }
+
+    /**
+     * Sets the system property {@code jboss.bind.address.$INTERFACE} to the address given where {@code $INTERFACE} is
+     * the {@code interfaceName} parameter. For example in the default configuration passing {@code management} for the
+     * {@code interfaceName} parameter would result in the system property {@code jboss.bind.address.management} being
+     * set to the address provided.
+     * <p/>
+     * This will override any previous value set via {@link #addServerArgument(String)}.
+     * <p/>
+     * <b>Note:</b> This option only works if the standard system property has not been removed from the interface. If
+     * the system property was removed the address provided has no effect.
+     *
+     * @param interfaceName the name of the interface of the binding address
+     * @param address       the address to bind the management interface to
+     *
+     * @return the builder
+     */
+    public T setBindAddressHint(final String interfaceName, final String address) {
+        if (interfaceName == null) {
+            throw LauncherMessages.MESSAGES.nullParam("interfaceName");
+        }
+        addServerArg("-b" + interfaceName, address);
+        return getThis();
+    }
+
+    /**
+     * Sets the system property {@code jboss.default.multicast.address} to the address given.
+     * <p/>
+     * This will override any previous value set via {@link #addServerArgument(String)}.
+     * <p/>
+     * <b>Note:</b> This option only works if the standard system property has not been removed from the interface. If
+     * the system property was removed the address provided has no effect.
+     *
+     * @param address the address to set the multicast system property to
+     *
+     * @return the builder
+     */
+    public T setMulticastAddressHint(final String address) {
+        addServerArg("-u", address);
+        return getThis();
+    }
+
+    /**
+     * Sets the properties file to use for the server or {@code null} to remove the file. The file must exist.
+     * <p/>
+     * This will override any previous value set via {@link #addServerArgument(String)}..
+     *
+     * @param file the properties file to use or {@code null}
+     *
+     * @return the builder
+     *
+     * @throws IllegalArgumentException if the file does not exist or is not a regular file
+     */
+    public T setPropertiesFile(final String file) {
+        final Path path;
+        if (file == null) {
+            path = null;
+        } else {
+            path = Paths.get(file);
+        }
+        return setPropertiesFile(path);
+    }
+
+    /**
+     * Sets the properties file to use for the server or {@code null} to remove the file. The file must exist.
+     * <p/>
+     * This will override any previous value set via {@link #addServerArgument(String)}..
+     *
+     * @param file the properties file to use or {@code null}
+     *
+     * @return the builder
+     *
+     * @throws IllegalArgumentException if the file does not exist or is not a regular file
+     */
+    public T setPropertiesFile(final Path file) {
+        if (file == null) {
+            addServerArg("-P", null);
+        } else {
+            if (Files.notExists(file)) {
+                throw LauncherMessages.MESSAGES.pathDoesNotExist(file);
+            }
+            if (!Files.isRegularFile(file)) {
+                throw LauncherMessages.MESSAGES.pathNotAFile(file);
+            }
+            addServerArg("-P", file.toAbsolutePath().normalize().toString());
+        }
+        return getThis();
+    }
+
+    /**
+     * Returns the Java home directory where the java executable command can be found.
+     * <p/>
+     * If the directory was not set the system property value, {@code java.home}, should be used.
+     *
+     * @return the path to the Java home directory
+     */
+    public abstract Path getJavaHome();
+
+    /**
+     * The java executable command found in the {@link #getJavaHome() Java home} directory.
+     *
+     * @return the java executable command
+     */
+    protected String getJavaCommand() {
+        return getJavaCommand(getJavaHome());
+    }
+
+    /**
+     * Returns the base directory for the server.
+     * <p/>
+     * Example:
+     * For standalone the base directory would be {@code $JBOSS_HOME/standalone}.
+     *
+     * @return the base directory
+     */
+    public abstract Path getBaseDirectory();
+
+    /**
+     * Returns the command line argument that specifies the logging configuration.
+     *
+     * @param fileName the name of the configuration file
+     *
+     * @return the command line argument
+     */
+    protected String getLoggingPropertiesArgument(final String fileName) {
+        return "-Dlogging.configuration=file:" + normalizePath(getConfigurationDirectory(), fileName);
+    }
+
+    /**
+     * Returns the command line argument that specifies the path the log file that should be used.
+     * <p/>
+     * This is generally only used on the initial boot of the server in standalone. The server will rewrite the
+     * configuration file with hard-coded values.
+     *
+     * @param fileName the name of the file
+     *
+     * @return the command line argument
+     */
+    protected String getBootLogArgument(final String fileName) {
+        return "-Dorg.jboss.boot.log.file=" + normalizePath(getLogDirectory(), fileName);
+    }
+
+    /**
+     * A collection of server command line arguments.
+     *
+     * @return the server arguments
+     */
+    public List<String> getServerArguments() {
+        return serverArgs.asList();
+    }
+
+    protected void addServerArg(final String key, final String value) {
+        serverArgs.add(key, value);
+    }
+
+    protected String getServerArg(final String key) {
+        return serverArgs.get(key);
+    }
+}

--- a/launcher/src/main/java/org/wildfly/core/launcher/Arguments.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/Arguments.java
@@ -120,6 +120,17 @@ class Arguments {
     }
 
     /**
+     * Removes the argument from the collection of arguments.
+     *
+     * @param key they key of the argument to remove
+     *
+     * @return the argument or {@code null} if the argument was not found
+     */
+    public Argument remove(final String key) {
+        return map.remove(key);
+    }
+
+    /**
      * Returns the arguments as a list in their command line form.
      *
      * @return the arguments for the command line

--- a/launcher/src/main/java/org/wildfly/core/launcher/CliCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/CliCommandBuilder.java
@@ -1,0 +1,588 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.core.launcher;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.wildfly.core.launcher.Arguments.Argument;
+import org.wildfly.core.launcher.logger.LauncherMessages;
+
+/**
+ * Builds a list of commands to create a new process for a CLI instance.
+ * <p>
+ * This builder is not thread safe and the same instance should not be used in multiple threads.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("unused")
+public class CliCommandBuilder extends AbstractCommandBuilder<CliCommandBuilder> implements CommandBuilder {
+
+    enum CliArgument {
+        CONNECT("--connect", "-c"),
+        CONTROLLER("--controller", "controller"),
+        GUI("--gui"),
+        FILE("--file"),
+        COMMAND("--command"),
+        COMMANDS("--commands"),
+        USER("--user", "-u"),
+        PASSWORD("--password", "-p"),
+        TIMEOUT("--timeout"),;
+        private static final Map<String, CliArgument> ENTRIES;
+
+        static {
+            final Map<String, CliArgument> map = new HashMap<>();
+            for (CliArgument arg : values()) {
+                map.put(arg.key, arg);
+                if (arg.altKey != null) {
+                    map.put(arg.altKey, arg);
+                }
+            }
+            ENTRIES = Collections.unmodifiableMap(map);
+        }
+
+        public static CliArgument find(final String key) {
+            return ENTRIES.get(key);
+        }
+
+        public static CliArgument find(final Argument argument) {
+            return ENTRIES.get(argument.getKey());
+        }
+
+        private final String key;
+        private final String altKey;
+
+        CliArgument(final String key) {
+            this(key, null);
+        }
+
+        CliArgument(final String key, final String altKey) {
+            this.key = key;
+            this.altKey = altKey;
+        }
+    }
+
+    private Path javaHome;
+    private final Arguments javaOpts;
+    private final Arguments cliArgs;
+
+    private CliCommandBuilder(final Path wildflyHome) {
+        super(wildflyHome);
+        javaOpts = new Arguments();
+        cliArgs = new Arguments();
+        // Add the default logging.properties file
+        javaOpts.add("-Dlogging.configuration=file:" + wildflyHome.resolve("bin").resolve("jboss-cli-logging.properties"));
+    }
+
+    /**
+     * Creates a command builder for a CLI instance.
+     *
+     * @param wildflyHome the path to the WildFly home directory
+     *
+     * @return a new builder
+     */
+    public static CliCommandBuilder of(final Path wildflyHome) {
+        return new CliCommandBuilder(validateWildFlyDir(wildflyHome));
+    }
+
+    /**
+     * Creates a command builder for a CLI instance.
+     *
+     * @param wildflyHome the path to the WildFly home directory
+     *
+     * @return a new builder
+     */
+    public static CliCommandBuilder of(final String wildflyHome) {
+        return new CliCommandBuilder(validateWildFlyDir(wildflyHome));
+    }
+
+    /**
+     * Sets the hostname and port to connect to.
+     * <p>
+     * This sets both the {@code --connect} and {@code --controller} arguments.
+     * </p>
+     *
+     * @param controller the controller argument to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setConnection(final String controller) {
+        addCliArgument(CliArgument.CONNECT);
+        addCliArgument(CliArgument.CONTROLLER, controller);
+        return this;
+    }
+
+    /**
+     * Sets the hostname and port to connect to.
+     * <p>
+     * This sets both the {@code --connect} and {@code --controller} arguments.
+     * </p>
+     *
+     * @param hostname the host name
+     * @param port     the port
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setConnection(final String hostname, final int port) {
+        addCliArgument(CliArgument.CONNECT);
+        setController(hostname, port);
+        return this;
+    }
+
+    /**
+     * Sets the protocol, hostname and port to connect to.
+     * <p>
+     * This sets both the {@code --connect} and {@code --controller} arguments.
+     * </p>
+     *
+     * @param protocol the protocol to use
+     * @param hostname the host name
+     * @param port     the port
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setConnection(final String protocol, final String hostname, final int port) {
+        addCliArgument(CliArgument.CONNECT);
+        setController(protocol, hostname, port);
+        return this;
+    }
+
+    /**
+     * Sets the hostname and port to connect to.
+     *
+     * @param controller the controller argument to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setController(final String controller) {
+        addCliArgument(CliArgument.CONTROLLER, controller);
+        return this;
+    }
+
+    /**
+     * Sets the hostname and port to connect to.
+     *
+     * @param hostname the host name
+     * @param port     the port
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setController(final String hostname, final int port) {
+        setController(String.format("%s:%d", hostname, port));
+        return this;
+    }
+
+    /**
+     * Sets the protocol, hostname and port to connect to.
+     *
+     * @param protocol the protocol to use
+     * @param hostname the host name
+     * @param port     the port
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setController(final String protocol, final String hostname, final int port) {
+        setController(String.format("%s://%s:%d", protocol, hostname, port));
+        return this;
+    }
+
+    /**
+     * Sets the user to use when establishing a connection.
+     *
+     * @param user the user to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setUser(final String user) {
+        addCliArgument(CliArgument.USER, user);
+        return this;
+    }
+
+    /**
+     * Sets the password to use when establishing a connection.
+     *
+     * @param password the password to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setPassword(final String password) {
+        addCliArgument(CliArgument.PASSWORD, password);
+        return this;
+    }
+
+    /**
+     * Sets the path to the script file to execute.
+     *
+     * @param path the path to the script file to execute
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setScriptFile(final String path) {
+        if (path == null) {
+            addCliArgument(CliArgument.FILE, null);
+            return this;
+        }
+        return setScriptFile(Paths.get(path));
+    }
+
+    /**
+     * Sets the path to the script file to execute.
+     *
+     * @param path the path to the script file to execute
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setScriptFile(final Path path) {
+        if (path == null) {
+            addCliArgument(CliArgument.FILE, null);
+        } else {
+            // Make sure the path exists
+            if (Files.notExists(path)) {
+                throw LauncherMessages.MESSAGES.pathDoesNotExist(path);
+            }
+            addCliArgument(CliArgument.FILE, path.toString());
+        }
+        return this;
+    }
+
+    /**
+     * Sets the command to execute.
+     *
+     * @param command the command to execute
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setCommand(final String command) {
+        addCliArgument(CliArgument.COMMAND, command);
+        return this;
+    }
+
+    /**
+     * Sets the commands to execute.
+     *
+     * @param commands the commands to execute
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setCommands(final String... commands) {
+        if (commands == null || commands.length == 0) {
+            addCliArgument(CliArgument.COMMANDS, null);
+            return this;
+        }
+        return setCommands(Arrays.asList(commands));
+    }
+
+    /**
+     * Sets the commands to execute.
+     *
+     * @param commands the commands to execute
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setCommands(final Iterable<String> commands) {
+        if (commands == null) {
+            addCliArgument(CliArgument.COMMANDS, null);
+            return this;
+        }
+        final StringBuilder cmds = new StringBuilder();
+        for (final Iterator<String> iterator = commands.iterator(); iterator.hasNext(); ) {
+            cmds.append(iterator.next());
+            if (iterator.hasNext()) cmds.append(',');
+        }
+        addCliArgument(CliArgument.COMMANDS, cmds.toString());
+        return this;
+    }
+
+    /**
+     * Sets the timeout used when connecting to the server.
+     *
+     * @param timeout the time out to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setTimeout(final int timeout) {
+        if (timeout > 0) {
+            addCliArgument(CliArgument.TIMEOUT, Integer.toString(timeout));
+        } else {
+            addCliArgument(CliArgument.TIMEOUT, null);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the command argument to use the GUI CLI client.
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setUseGui() {
+        if (IS_MAC) {
+            addJavaOption("-Djboss.modules.system.pkgs=com.apple.laf,com.apple.laf.resources");
+        } else {
+            addJavaOption("-Djboss.modules.system.pkgs=com.sun.java.swing");
+        }
+        addCliArgument(CliArgument.GUI);
+        return this;
+    }
+
+    /**
+     * Adds a JVM argument to the command ignoring {@code null} arguments.
+     *
+     * @param jvmArg the JVM argument to add
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addJavaOption(final String jvmArg) {
+        if (jvmArg != null && !jvmArg.trim().isEmpty()) {
+            javaOpts.add(jvmArg);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the array of JVM arguments to the command.
+     *
+     * @param javaOpts the array of JVM arguments to add, {@code null} arguments are ignored
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addJavaOptions(final String... javaOpts) {
+        if (javaOpts != null) {
+            for (String javaOpt : javaOpts) {
+                addJavaOption(javaOpt);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Adds the collection of JVM arguments to the command.
+     *
+     * @param javaOpts the collection of JVM arguments to add, {@code null} arguments are ignored
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addJavaOptions(final Iterable<String> javaOpts) {
+        if (javaOpts != null) {
+            for (String javaOpt : javaOpts) {
+                addJavaOption(javaOpt);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Sets the JVM arguments to use. This overrides any default JVM arguments that would normally be added and ignores
+     * {@code null} values in the collection.
+     * <p/>
+     * If the collection is {@code null} the JVM arguments will be cleared and no new arguments will be added.
+     *
+     * @param javaOpts the JVM arguments to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setJavaOptions(final Iterable<String> javaOpts) {
+        this.javaOpts.clear();
+        return addJavaOptions(javaOpts);
+    }
+
+
+    /**
+     * Sets the JVM arguments to use. This overrides any default JVM arguments that would normally be added and ignores
+     * {@code null} values in the array.
+     * <p/>
+     * If the array is {@code null} the JVM arguments will be cleared and no new arguments will be added.
+     *
+     * @param javaOpts the JVM arguments to use
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setJavaOptions(final String... javaOpts) {
+        this.javaOpts.clear();
+        return addJavaOptions(javaOpts);
+    }
+
+    /**
+     * Returns the JVM arguments.
+     *
+     * @return the JVM arguments
+     */
+    public List<String> getJavaOptions() {
+        return javaOpts.asList();
+    }
+
+    /**
+     * Adds an argument to be passed to the CLI command ignore the argument if {@code null}.
+     *
+     * @param arg the argument to pass
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addCliArgument(final String arg) {
+        if (arg != null) {
+            final Argument argument = Arguments.parse(arg);
+            final CliArgument cliArgument = CliArgument.find(argument.getKey());
+            if (cliArgument != null) {
+                cliArgs.remove(cliArgument.key);
+                if (cliArgument.altKey != null) {
+                    cliArgs.remove(cliArgument.altKey);
+                }
+            }
+            cliArgs.add(argument);
+        }
+        return this;
+    }
+
+    /**
+     * Adds the arguments to the collection of arguments that will be passed to the CLI command ignoring any {@code
+     * null} arguments.
+     *
+     * @param args the arguments to add
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addCliArguments(final String... args) {
+        if (args != null) {
+            for (String arg : args) {
+                addCliArgument(arg);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Adds the arguments to the collection of arguments that will be passed to the CLI command ignoring any {@code
+     * null} arguments.
+     *
+     * @param args the arguments to add
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder addCliArguments(final Iterable<String> args) {
+        if (args != null) {
+            for (String arg : args) {
+                addCliArgument(arg);
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Sets the Java home where the Java executable can be found.
+     *
+     * @param javaHome the Java home or {@code null} to use te system property {@code java.home}
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setJavaHome(final String javaHome) {
+        if (javaHome == null) {
+            this.javaHome = null;
+        } else {
+            this.javaHome = validateJavaHome(javaHome);
+        }
+        return this;
+    }
+
+    /**
+     * Sets the Java home where the Java executable can be found.
+     *
+     * @param javaHome the Java home or {@code null} to use te system property {@code java.home}
+     *
+     * @return the builder
+     */
+    public CliCommandBuilder setJavaHome(final Path javaHome) {
+        if (javaHome == null) {
+            this.javaHome = null;
+        } else {
+            this.javaHome = validateJavaHome(javaHome);
+        }
+        return this;
+    }
+
+    @Override
+    public Path getJavaHome() {
+        final Path path;
+        if (javaHome == null) {
+            path = getDefaultJavaHome();
+        } else {
+            path = javaHome;
+        }
+        return path;
+    }
+
+    @Override
+    protected CliCommandBuilder getThis() {
+        return this;
+    }
+
+    @Override
+    public List<String> buildArguments() {
+        final List<String> cmd = new ArrayList<>();
+        cmd.addAll(getJavaOptions());
+        cmd.add("-jar");
+        cmd.add(getModulesJarName());
+        cmd.add("-mp");
+        cmd.add(getModulePaths());
+        cmd.add("org.jboss.as.cli");
+        addSystemPropertyArg(cmd, HOME_DIR, getWildFlyHome());
+
+        cmd.addAll(cliArgs.asList());
+        return cmd;
+    }
+
+    @Override
+    public List<String> build() {
+        final List<String> cmd = new ArrayList<>();
+        cmd.add(getJavaCommand());
+        cmd.addAll(buildArguments());
+        return cmd;
+    }
+
+    private CliCommandBuilder addCliArgument(final CliArgument cliArgument) {
+        cliArgs.remove(cliArgument.key);
+        if (cliArgument.altKey != null) {
+            cliArgs.remove(cliArgument.altKey);
+        }
+        cliArgs.add(cliArgument.key);
+        return this;
+    }
+
+    private CliCommandBuilder addCliArgument(final CliArgument cliArgument, final String value) {
+        cliArgs.remove(cliArgument.key);
+        if (cliArgument.altKey != null) {
+            cliArgs.remove(cliArgument.altKey);
+        }
+        if (value != null && !value.isEmpty()) {
+            cliArgs.add(cliArgument.key, value);
+        }
+        return this;
+    }
+}

--- a/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
@@ -40,7 +40,7 @@ import org.wildfly.core.launcher.Arguments.Argument;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @SuppressWarnings("unused")
-public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBuilder> implements CommandBuilder {
+public class DomainCommandBuilder extends AbstractServerCommandBuilder<DomainCommandBuilder> implements CommandBuilder {
 
     private static final String DOMAIN_BASE_DIR = "jboss.domain.base.dir";
     private static final String DOMAIN_CONFIG_DIR = "jboss.domain.config.dir";
@@ -81,7 +81,7 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
      * @return a new builder
      */
     public static DomainCommandBuilder of(final Path wildflyHome) {
-        return new DomainCommandBuilder(validateWildFlyDir(wildflyHome), validateJavaHome(System.getProperty("java.home")));
+        return new DomainCommandBuilder(validateWildFlyDir(wildflyHome), getDefaultJavaHome());
     }
 
     /**
@@ -94,7 +94,7 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
      * @return a new builder
      */
     public static DomainCommandBuilder of(final String wildflyHome) {
-        return new DomainCommandBuilder(validateWildFlyDir(wildflyHome), validateJavaHome(System.getProperty("java.home")));
+        return new DomainCommandBuilder(validateWildFlyDir(wildflyHome), getDefaultJavaHome());
     }
 
     /**

--- a/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
@@ -38,7 +38,7 @@ import org.wildfly.core.launcher.Arguments.Argument;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @SuppressWarnings("unused")
-public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneCommandBuilder> implements CommandBuilder {
+public class StandaloneCommandBuilder extends AbstractServerCommandBuilder<StandaloneCommandBuilder> implements CommandBuilder {
 
     // JPDA remote socket debugging
     static final String DEBUG_FORMAT = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=%s,address=%d";
@@ -467,7 +467,7 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
     public Path getJavaHome() {
         final Path path;
         if (javaHome == null) {
-            path = validateJavaHome(System.getProperty("java.home"));
+            path = getDefaultJavaHome();
         } else {
             path = javaHome;
         }


### PR DESCRIPTION
The 2.0 PR has some details about why this is desired https://github.com/wildfly/wildfly-core/pull/764.

This is not required for 1.0, but it would be nice to be able to use it in the `wildfly-maven-plugin` which will target 1.0 to stick with a Java 1.7 requirement.

I did not change bring the change for the tests over to the 1.x PR as I didn't want make potential test breaking changes. For 1.x this API will not be used anywhere only to be consumed from other projects.