### PR TITLE
WFLY-3991 javax.script.ScriptEngineFactory: rhino provider not found

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/sun/scripting/main/service-loader-resources/META-INF/services/javax.script.ScriptEngineFactory
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/sun/scripting/main/service-loader-resources/META-INF/services/javax.script.ScriptEngineFactory
@@ -1,2 +1,1 @@
-com.sun.script.javascript.RhinoScriptEngineFactory
 jdk.nashorn.api.scripting.NashornScriptEngineFactory


### PR DESCRIPTION
since we now have minimum requirement for JDK8 no need to include class name for Rhino