### PR TITLE
WFCORE-725 Initial work on removing ClassIndex

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/reflect/ClassIndex.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/reflect/ClassIndex.java
@@ -37,6 +37,7 @@ import org.jboss.invocation.proxy.MethodIdentifier;
  *
  * @author Stuart Douglas
  */
+@Deprecated
 public class ClassIndex {
 
     private final Class<?> moduleClass;

--- a/server/src/main/java/org/jboss/as/server/deployment/reflect/DeploymentClassIndex.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/reflect/DeploymentClassIndex.java
@@ -34,6 +34,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  *
  * @author Stuart Douglas
  */
+@Deprecated
 public class DeploymentClassIndex {
 
     private final Map<String, ClassIndex> index = new HashMap<String, ClassIndex>();


### PR DESCRIPTION
This moves similar functionality found in ClassIndex into DeploymentClassIndex. Once
a core release with these changes has been released then full can remove all references
to ClassIndex, and it can be removed from the code base.