### PR TITLE
[WFCORE-732] Extend tests for CLI commands extensibility

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/DuplicateExtCommandHandler.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/DuplicateExtCommandHandler.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.management.cli.extensions;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.handlers.CommandHandlerWithHelp;
+
+/**
+ * @author Petr Kremensky pkremens@redhat.com
+ */
+public class DuplicateExtCommandHandler extends CommandHandlerWithHelp {
+    public static final String NAME = "echo";
+    public static final String OUTPUT = "hello from " + DuplicateExtCommandHandler.class.getSimpleName();
+
+    public DuplicateExtCommandHandler() {
+        super(NAME, false);
+    }
+
+    @Override
+    protected void doHandle(CommandContext ctx) throws CommandLineException {
+        ctx.printLine(OUTPUT);
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/DuplicateExtCommandHandlerProvider.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/extensions/DuplicateExtCommandHandlerProvider.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.management.cli.extensions;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandHandler;
+import org.jboss.as.cli.CommandHandlerProvider;
+
+/**
+ * @author Petr Kremensky pkremens@redhat.com
+ */
+public class DuplicateExtCommandHandlerProvider implements CommandHandlerProvider {
+    @Override
+    public CommandHandler createCommandHandler(CommandContext ctx) {
+        return new DuplicateExtCommandHandler();
+    }
+
+    @Override
+    public boolean isTabComplete() {
+        return false;
+    }
+
+    @Override
+    public String[] getNames() {
+        return new String[]{DuplicateExtCommandHandler.NAME};
+    }
+}

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsTestCase-module.xml
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/CliExtCommandsTestCase-module.xml
@@ -16,13 +16,15 @@
 	http://www.fsf.org. -->
 
 <module xmlns="urn:jboss:module:1.1" name="test.cli.extension.commands">
-  <resources>
-    <resource-root path="test-cli-ext-commands-module.jar"/>
-  </resources>
-  <dependencies>
-    <module name="org.jboss.as.controller"/>
-    <module name="org.jboss.staxmapper"/>
-    <module name="org.jboss.as.cli"/>
-    <module name="javax.xml.stream.api"/>
-  </dependencies>
+    <resources>
+        <resource-root path="test-cli-ext-commands-module.jar"/>
+    </resources>
+    <dependencies>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.cli"/>
+        <module name="javax.xml.stream.api"/>
+        <module name="org.wildfly.security.elytron"/>
+        <module name="org.jboss.as.protocol"/>
+    </dependencies>
 </module>

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/DuplicateExtCommandTestCase-module.xml
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/DuplicateExtCommandTestCase-module.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- ~ JBoss, Home of Professional Open Source. ~ Copyright 2015, Red Hat,
+	Inc., and individual contributors ~ as indicated by the @author tags. See
+	the copyright.txt file in the ~ distribution for a full listing of individual
+	contributors. ~ ~ This is free software; you can redistribute it and/or modify
+	it ~ under the terms of the GNU Lesser General Public License as ~ published
+	by the Free Software Foundation; either version 2.1 of ~ the License, or
+	(at your option) any later version. ~ ~ This software is distributed in the
+	hope that it will be useful, ~ but WITHOUT ANY WARRANTY; without even the
+	implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+	See the GNU ~ Lesser General Public License for more details. ~ ~ You should
+	have received a copy of the GNU Lesser General Public ~ License along with
+	this software; if not, write to the Free ~ Software Foundation, Inc., 51
+	Franklin St, Fifth Floor, Boston, MA ~ 02110-1301 USA, or see the FSF site:
+	http://www.fsf.org. -->
+
+<module xmlns="urn:jboss:module:1.3" name="test.cli.extension.commands">
+    <resources>
+        <resource-root path="test-cli-duplicate-commands-module.jar"/>
+    </resources>
+    <dependencies>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.cli"/>
+        <module name="javax.xml.stream.api"/>
+    </dependencies>
+</module>

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/test-cli-ext-commands.txt
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/management/cli/extensions/test-cli-ext-commands.txt
@@ -1,0 +1,1 @@
+test-cli-ext-commands--help


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-732 - Extend tests for CLI commands extensibility

Alexey added test as part of https://issues.jboss.org/browse/WFCORE-582. Adding two more tests.

**command name conflict**
* try to register command with name of some standard CLI command
* command is not registered

**help message for custom command**
* add help message to the command from extension
* verify, that help message is available

Adding tests as part of https://issues.jboss.org/browse/EAP7-91 verification procedure.
