### PR TITLE
WFCORE-731 TransformerAttachmentGrabber always returns null with map …

### DIFF
--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TransformerAttachmentGrabber.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TransformerAttachmentGrabber.java
@@ -65,6 +65,6 @@ public class TransformerAttachmentGrabber implements OperationStepHandler {
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 attachment = context.getAttachment(TransformerOperationAttachment.KEY);
             }
-        }, OperationContext.Stage.MODEL);
+        }, OperationContext.Stage.RUNTIME);
     }
 }


### PR DESCRIPTION
…operations

Kabir, this pretty much does the job and works also for map operations. Let me know if you see a problem here or if you wanna do something fancier..

Jira
https://issues.jboss.org/browse/WFCORE-731