### PR TITLE
[WFCORE-747] Use read-attribute server-state to exam EAP service startup result

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-debian.sh
+++ b/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-debian.sh
@@ -63,6 +63,14 @@ if [ -z "$JBOSS_HOME" ]; then
 fi
 export JBOSS_HOME
 
+if [ -z "$JBOSS_MANAGEMENT_NATIVE_HOST" ]; then
+  JBOSS_MANAGEMENT_NATIVE_HOST=127.0.0.1
+fi
+
+if [ -z "$JBOSS_MANAGEMENT_NATIVE_PORT" ]; then
+  JBOSS_MANAGEMENT_NATIVE_PORT=9999
+fi
+
 # Check if wildfly is installed
 if [ ! -f "$JBOSS_HOME/jboss-modules.jar" ]; then
 	log_failure_msg "$NAME is not installed in \"$JBOSS_HOME\""
@@ -178,8 +186,8 @@ case "$1" in
 		launched=0
 		until [ $count -gt $STARTUP_WAIT ]
 		do
-			grep 'WFLYSRV0025:' "$JBOSS_CONSOLE_LOG" > /dev/null
-			if [ $? -eq 0 ] ; then
+			state=$(sh $JBOSS_HOME/bin/jboss-cli.sh -c --controller=$JBOSS_MANAGEMENT_NATIVE_HOST:$JBOSS_MANAGEMENT_NATIVE_PORT --command="read-attribute server-state")
+			if [ "$state" = "running" ] ; then
 				launched=1
 				break
 			fi

--- a/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-redhat.sh
+++ b/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-redhat.sh
@@ -30,6 +30,14 @@ if [ -z "$JBOSS_HOME" ]; then
 fi
 export JBOSS_HOME
 
+if [ -z "$JBOSS_MANAGEMENT_NATIVE_HOST" ]; then
+  JBOSS_MANAGEMENT_NATIVE_HOST=127.0.0.1
+fi
+
+if [ -z "$JBOSS_MANAGEMENT_NATIVE_PORT" ]; then
+  JBOSS_MANAGEMENT_NATIVE_PORT=9999
+fi
+
 if [ -z "$JBOSS_PIDFILE" ]; then
 	JBOSS_PIDFILE=/var/run/wildfly/wildfly.pid
 fi
@@ -114,8 +122,8 @@ start() {
 
 	until [ $count -gt $STARTUP_WAIT ]
 	do
-		grep 'WFLYSRV0025:' $JBOSS_CONSOLE_LOG > /dev/null
-		if [ $? -eq 0 ] ; then
+		state=$(sh $JBOSS_HOME/bin/jboss-cli.sh -c --controller=$JBOSS_MANAGEMENT_NATIVE_HOST:$JBOSS_MANAGEMENT_NATIVE_PORT --command="read-attribute server-state")
+		if [ "$state" = "running" ] ; then
 			launched=true
 			break
 		fi

--- a/core-feature-pack/src/main/resources/content/bin/init.d/wildfly.conf
+++ b/core-feature-pack/src/main/resources/content/bin/init.d/wildfly.conf
@@ -31,4 +31,10 @@
 # JBOSS_CONSOLE_LOG="/var/log/wildfly/console.log"
 
 ## Additionals args to include in startup
-# JBOSS_OPTS="--admin-only -b 172.0.0.1"
+# JBOSS_OPTS="--admin-only -b 127.0.0.1"
+
+## The default management host address
+# JBOSS_MANAGEMENT_NATIVE_HOST=127.0.0.1
+
+## The default management port number
+# JBOSS_MANAGEMENT_NATIVE_PORT=9999


### PR DESCRIPTION
see description and comment in https://issues.jboss.org/browse/WFCORE-747