### PR TITLE
[WFCORE-746] :  [WFCORE-746] : Provides a UUID per server instance

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1223,4 +1223,7 @@ public interface HostControllerLogger extends BasicLogger {
 
     @Message(id=159, value="Invalid discovery type %s")
     String invalidDiscoveryType(String type);
+
+    @Message(id = 160, value = "Could not read or create the domain UUID in file: %s")
+    IllegalStateException couldNotObtainDomainUuid(@Cause Throwable cause, Path file);
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -56,6 +56,7 @@ import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler
 import org.jboss.as.controller.operations.common.ValidateOperationHandler;
 import org.jboss.as.controller.operations.common.XmlMarshallingHandler;
 import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.resource.InterfaceDefinition;
@@ -101,6 +102,7 @@ import org.jboss.as.server.controller.resources.ServerRootResourceDefinition;
 import org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition;
 import org.jboss.as.server.controller.resources.VaultResourceDefinition;
 import org.jboss.as.server.operations.CleanObsoleteContentHandler;
+import org.jboss.as.server.operations.InstanceUuidReadHandler;
 import org.jboss.as.server.operations.RunningModeReadHandler;
 import org.jboss.as.server.operations.SuspendStateReadHandler;
 import org.jboss.as.server.services.net.SpecifiedInterfaceResolveHandler;
@@ -151,6 +153,11 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition SERVER_STATE = new SimpleAttributeDefinitionBuilder("server-state", ModelType.STRING)
             .setAllowNull(true)
             .setMinSize(1)
+            .setStorageRuntime()
+            .build();
+
+    public static final SimpleAttributeDefinition UUID = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.UUID, ModelType.STRING, false)
+            .setValidator(new StringLengthValidator(1, true))
             .setStorageRuntime()
             .build();
 
@@ -319,6 +326,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
         hostRegistration.registerOperationHandler(SnapshotListHandler.DEFINITION, snapshotList);
         SnapshotTakeHandler snapshotTake = new SnapshotTakeHandler(configurationPersister.getHostPersister());
         hostRegistration.registerOperationHandler(SnapshotTakeHandler.DEFINITION, snapshotTake);
+        hostRegistration.registerReadOnlyAttribute(UUID, new InstanceUuidReadHandler(environment));
 
         ignoredRegistry.registerResources(hostRegistration);
 

--- a/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
@@ -12,6 +12,7 @@ host.management-minor-version=The minor version of the JBoss AS management inter
 host.management-micro-version=The micro version of the JBoss AS management interface that is provided by this host controller.
 host.running-mode=The current running mode of the Host Controller. Either NORMAL (normal operations) or ADMIN_ONLY.  An ADMIN_ONLY server will start any configured management interfaces and accept management requests, but will not start servers or, if this host controller is the master for the domain, accept incoming connections from slave host controllers.
 host.suspend-state=The suspend state of the host
+host.uuid=Unique Id of this server instance.
 host.management=Configuration of the host's management system.
 host.management.interface=Interface on which the host's socket for intra-domain management communication should be opened.
 host.directory-grouping=Describes how the writable directories for servers managed by this host controller should be organized. The default value, 'by-server', indicates each server's writable directories should be grouped under the server's name in the domain/servers directory. The alternative, 'by-type' indicates each server's writable directories should be grouped based on their "type" (i.e. "data", "log", "tmp") with directories of a given type for all servers appearing in the domain level directory for that type, e.g. domain/data/servers/server-name.

--- a/host-controller/src/test/java/org/jboss/as/host/controller/HostControllerEnvironmentTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/HostControllerEnvironmentTestCase.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.host.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.jboss.as.host.controller.HostControllerEnvironment.HOME_DIR;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jboss.as.controller.RunningMode;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Simple test for UUID generation.
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class HostControllerEnvironmentTestCase {
+
+    private static final Path homeDir = new File(System.getProperty("basedir", ".")).toPath().resolve("target").resolve("wildlfy");
+
+    @Before
+    public void clean() throws IOException {
+        if (Files.exists(homeDir)) {
+            Files.walkFileTree(homeDir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+
+            });
+        }
+    }
+
+    @Test
+    public void testUUIDLifeCycle() throws IOException {
+        Map<String, String> hostProperties = new HashMap();
+        Path domainDir = homeDir.resolve("domain");
+        Files.createDirectories(domainDir.resolve("configuration"));
+        Path uuidPath = domainDir.resolve("data").resolve("kernel").resolve("process-uuid");
+        assertThat(Files.notExists(uuidPath), is(true));
+        hostProperties.put(HOME_DIR, homeDir.toAbsolutePath().toString());
+        //Check creation on startup
+        HostControllerEnvironment hcEnvironment = new HostControllerEnvironment(hostProperties, false, "",
+                InetAddress.getLocalHost(), 8080, InetAddress.getLocalHost(), 9990, null, null, null, null, null,
+                RunningMode.NORMAL, true, true, null);
+        assertThat(Files.exists(uuidPath), is(true));
+        List<String> uuids = Files.readAllLines(uuidPath);
+        assertThat(uuids, is(not(nullValue())));
+        assertThat(uuids.size(), is(1));
+        String uuid = uuids.get(0);
+        //Check nothing happens on startup if file is already there
+        hcEnvironment = new HostControllerEnvironment(hostProperties, false, "",
+                InetAddress.getLocalHost(), 8080, InetAddress.getLocalHost(), 9990, null, null, null, null, null,
+                RunningMode.NORMAL, true, true, null);
+        assertThat(Files.exists(uuidPath), is(true));
+        uuids = Files.readAllLines(uuidPath);
+        assertThat(uuids, is(not(nullValue())));
+        assertThat(uuids.size(), is(1));
+        assertThat(uuids.get(0), is(uuid));
+        //Check re-creation on startup
+        Files.delete(uuidPath);
+        assertThat(Files.notExists(uuidPath), is(true));
+        hcEnvironment = new HostControllerEnvironment(hostProperties, false, "",
+                InetAddress.getLocalHost(), 8080, InetAddress.getLocalHost(), 9990, null, null, null, null, null,
+                RunningMode.NORMAL, true, true, null);
+        assertThat(Files.exists(uuidPath), is(true));
+        uuids = Files.readAllLines(uuidPath);
+        assertThat(uuids, is(not(nullValue())));
+        assertThat(uuids.size(), is(1));
+        assertThat(uuids.get(0), is(not(uuid)));
+        Files.delete(uuidPath);
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -131,7 +131,6 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         } else {
             this.startTime = -1;
         }
-
         CurrentServiceContainer.setServiceContainer(context.getController().getServiceContainer());
 
         final BootstrapListener bootstrapListener = new BootstrapListener(container, startTime, serviceTarget, futureContainer, prettyVersion);

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -92,6 +92,7 @@ import org.jboss.as.server.mgmt.HttpManagementResourceDefinition;
 import org.jboss.as.server.mgmt.NativeManagementResourceDefinition;
 import org.jboss.as.server.mgmt.NativeRemotingManagementResourceDefinition;
 import org.jboss.as.server.operations.CleanObsoleteContentHandler;
+import org.jboss.as.server.operations.InstanceUuidReadHandler;
 import org.jboss.as.server.operations.LaunchTypeHandler;
 import org.jboss.as.server.operations.ProcessTypeHandler;
 import org.jboss.as.server.operations.RunningModeReadHandler;
@@ -134,6 +135,11 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
 
     public static final SimpleAttributeDefinition NAME = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.NAME, ModelType.STRING, true)
             .setValidator(new StringLengthValidator(1, true))
+            .build();
+
+    public static final SimpleAttributeDefinition UUID = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.UUID, ModelType.STRING, false)
+            .setValidator(new StringLengthValidator(1, true))
+            .setStorageRuntime()
             .build();
 
     public static final SimpleAttributeDefinition SERVER_GROUP = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SERVER_GROUP, ModelType.STRING)
@@ -352,6 +358,7 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerReadOnlyAttribute(PROCESS_TYPE, ProcessTypeHandler.INSTANCE);
         resourceRegistration.registerReadOnlyAttribute(RUNNING_MODE, new RunningModeReadHandler(runningModeControl));
         resourceRegistration.registerReadOnlyAttribute(SUSPEND_STATE, SuspendStateReadHandler.INSTANCE);
+        resourceRegistration.registerReadOnlyAttribute(UUID, new InstanceUuidReadHandler(serverEnvironment));
 
 
         resourceRegistration.registerReadOnlyAttribute(MANAGEMENT_MAJOR_VERSION, null);

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -33,6 +33,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -1153,4 +1154,7 @@ public interface ServerLogger extends BasicLogger {
      */
     @Message(id = 230, value = "Vault is not initialized")
     SecurityException vaultNotInitializedException();
+
+    @Message(id = 231, value = "Could not read or create the server UUID in file: %s")
+    IllegalStateException couldNotObtainServerUuidFile(@Cause Throwable cause, Path file);
 }

--- a/server/src/main/java/org/jboss/as/server/operations/InstanceUuidReadHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/InstanceUuidReadHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.server.operations;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.operations.common.ProcessEnvironment;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Handler to read the UUID of the instance.
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class InstanceUuidReadHandler implements OperationStepHandler {
+    private final ProcessEnvironment environment;
+
+    public InstanceUuidReadHandler(final ProcessEnvironment environment) {
+        this.environment = environment;
+    }
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        context.getResult().set(environment.getInstanceUuid().toString());
+    }
+}

--- a/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
+++ b/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
@@ -28,6 +28,7 @@ server.product-version=The version of the JBoss AS based product release that is
 server.management-major-version=The major version of the JBoss AS management interface that is provided by this server.
 server.management-minor-version=The minor version of the JBoss AS management interface that is provided by this server.
 server.management-micro-version=The micro version of the JBoss AS management interface that is provided by this server.
+server.uuid=Unique Id of this server instance.
 server.env=The server environment.
 server.env.base-dir=The base directory for JBoss Application Server.
 server.env.config-dir=The directory where the configurations are stored.

--- a/server/src/test/java/org/jboss/as/server/ServerEnvironmentTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/ServerEnvironmentTestCase.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.server;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.jboss.as.server.ServerEnvironment.HOME_DIR;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
+import java.util.Properties;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.persistence.ConfigurationFile;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Simple test for UUID generation.
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class ServerEnvironmentTestCase {
+
+    private static final Path homeDir = new File(System.getProperty("basedir", ".")).toPath().resolve("target").resolve("wildlfy");
+
+    @Before
+    public void clean() throws IOException {
+        if (Files.exists(homeDir)) {
+            Files.walkFileTree(homeDir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+
+            });
+        }
+    }
+
+    @Test
+    public void testUUIDLifeCycle() throws IOException {
+        Properties props = new Properties();
+        Path standaloneDir = homeDir.resolve("standalone");
+        Files.createDirectories(standaloneDir.resolve("configuration"));
+        Files.createFile(standaloneDir.resolve("configuration").resolve("standalone.xml"));
+        Path uuidPath = standaloneDir.resolve("data").resolve("kernel").resolve("process-uuid");
+        assertThat(Files.notExists(uuidPath), is(true));
+        props.put(HOME_DIR, homeDir.toAbsolutePath().toString());
+        //Check creation on startup
+        ServerEnvironment serverEnvironment = new ServerEnvironment(null, props, System.getenv(), "standalone.xml",
+                ConfigurationFile.InteractionPolicy.READ_ONLY, ServerEnvironment.LaunchType.STANDALONE, RunningMode.NORMAL, null);
+        assertThat(Files.exists(uuidPath), is(true));
+        List<String> uuids = Files.readAllLines(uuidPath);
+        assertThat(uuids, is(not(nullValue())));
+        assertThat(uuids.size(), is(1));
+        String uuid = uuids.get(0);
+        //Check nothing happens on startup if file is already there
+        serverEnvironment = new ServerEnvironment(null, props, System.getenv(), "standalone.xml",
+                ConfigurationFile.InteractionPolicy.READ_ONLY, ServerEnvironment.LaunchType.STANDALONE, RunningMode.NORMAL, null);
+        assertThat(Files.exists(uuidPath), is(true));
+        uuids = Files.readAllLines(uuidPath);
+        assertThat(uuids, is(not(nullValue())));
+        assertThat(uuids.size(), is(1));
+        assertThat(uuids.get(0), is(uuid));
+        //Check re-creation on startup
+        Files.delete(uuidPath);
+        assertThat(Files.notExists(uuidPath), is(true));
+        serverEnvironment = new ServerEnvironment(null, props, System.getenv(), "standalone.xml",
+                ConfigurationFile.InteractionPolicy.READ_ONLY, ServerEnvironment.LaunchType.STANDALONE, RunningMode.NORMAL, null);
+        assertThat(Files.exists(uuidPath), is(true));
+        uuids = Files.readAllLines(uuidPath);
+        assertThat(uuids, is(not(nullValue())));
+        assertThat(uuids.size(), is(1));
+        assertThat(uuids.get(0), is(not(uuid)));
+        Files.delete(uuidPath);
+    }
+}

--- a/server/src/test/java/org/jboss/as/server/test/InterfaceManagementUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/test/InterfaceManagementUnitTestCase.java
@@ -295,7 +295,7 @@ public class InterfaceManagementUnitTestCase {
             this.rootResourceDefinition = rootResourceDefinition;
 
             Properties properties = new Properties();
-            properties.put("jboss.home.dir", ".");
+            properties.put("jboss.home.dir", System.getProperty("basedir", ".") + File.separatorChar + "target");
 
             final String hostControllerName = "hostControllerName"; // Host Controller name may not be null when in a managed domain
             environment = new ServerEnvironment(hostControllerName, properties, new HashMap<String, String>(), null, null, ServerEnvironment.LaunchType.DOMAIN, null, new ProductConfig(Module.getBootModuleLoader(), ".", properties));

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
@@ -279,6 +279,7 @@ public class BasicOperationsUnitTestCase {
         final ModelNode result = managementClient.getControllerClient().execute(operation);
         assertEquals(result.get(FAILURE_DESCRIPTION).isDefined() ? result.get(FAILURE_DESCRIPTION).asString() : "", SUCCESS, result.get(OUTCOME).asString());
         assertTrue(result.hasDefined(RESULT));
+        assertTrue(result.get(RESULT).hasDefined(ModelDescriptionConstants.UUID));
     }
 
     @Test


### PR DESCRIPTION
Provides a type 4 UUID for a server instance.
The UUID will be saved in $JBOSS_DATA_DIR/kernel/process-uuid and will be (re)created on server instance startup if it doesn't exist.
This UUID should be accessible through the Management API.

Jira: https://issues.jboss.org/browse/WFCORE-746