### PR TITLE
Make it easier to deal with dynamically named capabilities

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -924,6 +924,23 @@ public interface OperationContext extends ExpressionResolver {
     <T> T getCapabilityRuntimeAPI(String capabilityName, Class<T> apiType);
 
     /**
+     * Gets the runtime API associated with a given {@link RuntimeCapability#isDynamicallyNamed() dynamically named}
+     * capability, if there is one.
+     *
+     * @param capabilityBaseName the base name of the capability. Cannot be {@code null}
+     * @param dynamicPart the dynamic part of the capability name. Cannot be {@code null}
+     * @param apiType class of the java type that exposes the API. Cannot be {@code null}
+     * @param <T> the java type that exposes the API
+     * @return the runtime API. Will not return {@code null}
+     *
+     * @throws java.lang.IllegalStateException if {@link #getCurrentStage() the current stage} is {@link Stage#MODEL}. The
+     *                                          complete set of capabilities is not known until the end of the model stage.
+     * @throws java.lang.IllegalArgumentException if the capability does not provide a runtime API
+     * @throws java.lang.ClassCastException if the runtime API exposed by the capability cannot be cast to type {code T}
+     */
+    <T> T getCapabilityRuntimeAPI(String capabilityBaseName, String dynamicPart, Class<T> apiType);
+
+    /**
      * Gets the name of a service associated with a given capability, if there is one.
      * @param capabilityName the name of the capability. Cannot be {@code null}
      * @param serviceType class of the java type that exposes by the service. Cannot be {@code null}
@@ -935,6 +952,22 @@ public interface OperationContext extends ExpressionResolver {
      *            the capability does not provide a service of type {@code serviceType}
      */
     ServiceName getCapabilityServiceName(String capabilityName, Class<?> serviceType);
+
+    /**
+     * Gets the name of a service associated with a given {@link RuntimeCapability#isDynamicallyNamed() dynamically named}
+     * capability, if there is one.
+     *
+     * @param capabilityBaseName the base name of the capability. Cannot be {@code null}
+     * @param dynamicPart the dynamic part of the capability name. Cannot be {@code null}
+     * @param serviceType class of the java type that exposes by the service. Cannot be {@code null}
+     * @return the name of the service. Will not return {@code null}
+     *
+     * @throws java.lang.IllegalStateException if {@link #getCurrentStage() the current stage} is {@link Stage#MODEL}. The
+     *                                          complete set of capabilities is not known until the end of the model stage.
+     * @throws IllegalArgumentException if {@code serviceType} is {@code null } or
+     *            the capability does not provide a service of type {@code serviceType}
+     */
+    ServiceName getCapabilityServiceName(String capabilityBaseName, String dynamicPart, Class<?> serviceType);
 
     /**
      * Whether normally this operation would require a runtime step. It returns {@code true in the following cases}

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -1406,6 +1406,11 @@ final class OperationContextImpl extends AbstractOperationContext {
         return getCapabilityRuntimeAPI(capabilityName, apiType, activeStep);
     }
 
+    @Override
+    public <T> T getCapabilityRuntimeAPI(String capabilityBaseName, String dynamicPart, Class<T> apiType) {
+        return getCapabilityRuntimeAPI(RuntimeCapability.buildDynamicCapabilityName(capabilityBaseName, dynamicPart), apiType, activeStep);
+    }
+
     <T> T getCapabilityRuntimeAPI(String capabilityName, Class<T> apiType, Step step) {
         assert isControllingThread();
         assertCapabilitiesAvailable(currentStage);
@@ -1416,6 +1421,11 @@ final class OperationContextImpl extends AbstractOperationContext {
     @Override
     public ServiceName getCapabilityServiceName(String capabilityName, Class<?> serviceType) {
         return getCapabilityServiceName(capabilityName, serviceType, activeStep);
+    }
+
+    @Override
+    public ServiceName getCapabilityServiceName(String capabilityBaseName, String dynamicPart, Class<?> serviceType) {
+        return getCapabilityServiceName(RuntimeCapability.buildDynamicCapabilityName(capabilityBaseName, dynamicPart), serviceType, activeStep);
     }
 
     ServiceName getCapabilityServiceName(String capabilityName, Class<?> serviceType, Step step) {

--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
@@ -375,8 +375,19 @@ class ParallelBootOperationContext extends AbstractOperationContext {
     }
 
     @Override
+    public <T> T getCapabilityRuntimeAPI(String capabilityBaseName, String dynamicPart, Class<T> apiType) {
+        return primaryContext.getCapabilityRuntimeAPI(RuntimeCapability.buildDynamicCapabilityName(capabilityBaseName, dynamicPart), apiType, activeStep);
+    }
+
+    @Override
     public ServiceName getCapabilityServiceName(String capabilityName, Class<?> type) {
         return primaryContext.getCapabilityServiceName(capabilityName, type, activeStep);
+    }
+
+    @Override
+    public ServiceName getCapabilityServiceName(String capabilityBaseName, String dynamicPart, Class<?> serviceType) {
+        return primaryContext.getCapabilityServiceName(RuntimeCapability.buildDynamicCapabilityName(capabilityBaseName, dynamicPart),
+                serviceType, activeStep);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -404,7 +404,17 @@ class ReadOnlyContext extends AbstractOperationContext {
     }
 
     @Override
+    public <T> T getCapabilityRuntimeAPI(String capabilityBaseName, String dynamicPart, Class<T> apiType) {
+        throw readOnlyContext();
+    }
+
+    @Override
     public ServiceName getCapabilityServiceName(String capabilityName, Class<?> type) {
+        throw readOnlyContext();
+    }
+
+    @Override
+    public ServiceName getCapabilityServiceName(String capabilityBaseName, String dynamicPart, Class<?> serviceType) {
         throw readOnlyContext();
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/management/AuthorizedAddressTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/management/AuthorizedAddressTest.java
@@ -536,7 +536,17 @@ public class AuthorizedAddressTest {
         }
 
         @Override
+        public <T> T getCapabilityRuntimeAPI(String capabilityBaseName, String dynamicPart, Class<T> apiType) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
         public ServiceName getCapabilityServiceName(String capabilityName, Class<?> serviceType) {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public ServiceName getCapabilityServiceName(String capabilityBaseName, String dynamicPart, Class<?> serviceType) {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -670,7 +670,17 @@ public abstract class AbstractOperationTestCase {
         }
 
         @Override
+        public <T> T getCapabilityRuntimeAPI(String capabilityBaseName, String dynamicPart, Class<T> apiType) {
+            return null;
+        }
+
+        @Override
         public ServiceName getCapabilityServiceName(String capabilityName, Class<?> serviceType) {
+            return null;
+        }
+
+        @Override
+        public ServiceName getCapabilityServiceName(String capabilitBaseyName, String dynamicPart, Class<?> serviceType) {
             return null;
         }
 

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerAdd.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerAdd.java
@@ -26,6 +26,7 @@ package org.wildfly.extension.io;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.wildfly.extension.io.WorkerResourceDefinition.ATTRIBUTES;
+import static org.wildfly.extension.io.WorkerResourceDefinition.IO_WORKER_RUNTIME_CAPABILITY_NAME;
 import static org.wildfly.extension.io.WorkerResourceDefinition.WORKER_IO_THREADS;
 import static org.wildfly.extension.io.WorkerResourceDefinition.WORKER_TASK_MAX_THREADS;
 
@@ -38,12 +39,12 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
 import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 import org.wildfly.extension.io.logging.IOLogger;
 import org.xnio.Option;
 import org.xnio.OptionMap;
@@ -190,8 +191,8 @@ class WorkerAdd extends AbstractAddStepHandler {
 
         final WorkerService workerService = new WorkerService(builder.getMap());
 
-        RuntimeCapability<Void> dynamicCapability = RuntimeCapability.fromBaseCapability(WorkerResourceDefinition.IO_WORKER_RUNTIME_CAPABILITY, name);
-        context.getServiceTarget().addService(dynamicCapability.getCapabilityServiceName(XnioWorker.class), workerService)
+        ServiceName serviceName = context.getCapabilityServiceName(IO_WORKER_RUNTIME_CAPABILITY_NAME, name, XnioWorker.class);
+        context.getServiceTarget().addService(serviceName, workerService)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
                 .install();
     }

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
@@ -42,8 +42,9 @@ import org.xnio.XnioWorker;
  */
 class WorkerResourceDefinition extends PersistentResourceDefinition {
 
+    static final String IO_WORKER_RUNTIME_CAPABILITY_NAME = "org.wildfly.extension.io.worker";
     static final RuntimeCapability<Void> IO_WORKER_RUNTIME_CAPABILITY =
-            RuntimeCapability.Builder.of("org.wildfly.extension.io.worker", true, XnioWorker.class).build();
+            RuntimeCapability.Builder.of(IO_WORKER_RUNTIME_CAPABILITY_NAME, true, XnioWorker.class).build();
 
     static final OptionAttributeDefinition WORKER_TASK_CORE_THREADS = new OptionAttributeDefinition.Builder(Constants.WORKER_TASK_CORE_THREADS, Options.WORKER_TASK_CORE_THREADS)
             .setDefaultValue(new ModelNode(2))

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemAdd.java
@@ -29,7 +29,6 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ProcessType;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
@@ -92,9 +91,7 @@ class RemotingSubsystemAdd extends AbstractAddStepHandler {
             }
         }
 
-        final String ioCapability = RuntimeCapability.buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY, workerName);
-        final ServiceName workerService = context.getCapabilityServiceName(ioCapability, XnioWorker.class);
-
+        final ServiceName workerService = context.getCapabilityServiceName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY, workerName, XnioWorker.class);
         serviceTarget.addService(RemotingServices.SUBSYSTEM_ENDPOINT, endpointService)
                 .addDependency(workerService, XnioWorker.class, endpointService.getWorker())
                 .install();


### PR DESCRIPTION
Allow OSHs to get service name for dynamic capabilities from the OC with just the base name and dynamic part strings, with no need to make a call to combine them.