### PR TITLE
Get framework set up for testing the current client against old versions

### DIFF
--- a/testsuite/client-old-server/pom.xml
+++ b/testsuite/client-old-server/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- 
+  Set these VM properties in your IDE debugger 
+
+  -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+  -Djboss.home=${workspace_loc:wildfly-build}/target/wildfly-2.0.0.Alpha4-SNAPSHOT 
+  -DallowConnectingToRunningServer=true
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly.core</groupId>
+        <artifactId>wildfly-core-testsuite</artifactId>
+        <version>2.0.0.Alpha5-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>wildfly-core-testsuite-client-old-server</artifactId>
+    <name>WildFly Core Test Suite: Current Client Old Server</name>
+
+    <properties>
+        <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}</jbossas.project.dir>
+        <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-test-runner</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-testsuite-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-model-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-model-test-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-threads</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-core-build</artifactId>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                    <!-- parallel>none</parallel -->
+                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+
+                    <!-- System properties to forked surefire JVM which runs clients. -->
+                    <argLine>${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
+
+                    <environmentVariables>
+                        <JBOSS_HOME>${wildfly.home}</JBOSS_HOME>
+                    </environmentVariables>
+
+                    <systemPropertyVariables>
+                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                        <jboss.home>${wildfly.home}</jboss.home>
+                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.build</groupId>
+                <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>server-provisioning</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <config-file>server-provisioning.xml</config-file>
+                            <server-name>wildfly-core</server-name>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${version.antrun.plugin}</version>
+                <executions>
+                    <execution>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <target>
+                                <copy file="${project.build.testOutputDirectory}/mgmt-users.properties" todir="${project.build.directory}/wildfly-core/standalone/configuration" overwrite="true" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/testsuite/client-old-server/server-provisioning.xml
+++ b/testsuite/client-old-server/server-provisioning.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="true">
+    <feature-packs>
+        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-feature-pack" version="${project.version}" />
+    </feature-packs>
+</server-provisioning>

--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/ClientAgainstOldServerTestCase.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/ClientAgainstOldServerTestCase.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright ${year}, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.client.old.server;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRODUCT_VERSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELEASE_VERSION;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.inject.Inject;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentManager;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.client.old.server.util.LargeDeploymentFile;
+import org.wildfly.client.old.server.util.OldVersionTestParameter;
+import org.wildfly.client.old.server.util.OldVersionTestRunner;
+import org.wildfly.client.old.server.util.Version;
+import org.wildfly.core.testrunner.ManagementClient;
+
+
+/**
+ * The OldVersionTestRunner generates the file, and its size is controlled by -Djboss.test.client.old.server.size={@code <bytes>}.
+ * The default is 1GB.
+ *
+ * @author Kabir Khan
+ */
+@RunWith(OldVersionTestRunner.class)
+public class ClientAgainstOldServerTestCase {
+
+    // Max time to wait for some action to complete, in s
+    private static final int TIMEOUT = TimeoutUtil.adjust(120);
+
+    private final Version.AsVersion version;
+
+    @Inject
+    protected ManagementClient managementClient;
+
+    @Inject
+    protected LargeDeploymentFile testDeploymentFile;
+
+    public ClientAgainstOldServerTestCase(OldVersionTestParameter param) {
+        this.version = param.getAsVersion();
+    }
+
+    @OldVersionTestRunner.OldVersionParameter
+    public static List<OldVersionTestParameter> parameters(){
+        return OldVersionTestParameter.setupVersions();
+    }
+
+    @Test
+    public void testVersion() throws Exception {
+        checkVersion();
+    }
+
+    @Test
+    public void testDeployment() throws Exception {
+        final ModelControllerClient client = managementClient.getControllerClient();
+        final ServerDeploymentManager manager = ServerDeploymentManager.Factory.create(client);
+
+        //Deploy
+        try (final InputStream is = testDeploymentFile.getInputStream()){
+            Future<?> future = manager.execute(
+                    manager.newDeploymentPlan().add(testDeploymentFile.getName(), is).deploy(testDeploymentFile.getName()).build());
+            awaitDeploymentExecution(future);
+        }
+
+        //Check there
+        ModelNode findDeployment = Util.createEmptyOperation(READ_RESOURCE_OPERATION,
+                PathAddress.pathAddress(DEPLOYMENT, testDeploymentFile.getName()));
+        Assert.assertTrue(
+                managementClient.executeForResult(findDeployment).isDefined());
+
+        //Undeploy
+        Future<?> future = manager.execute(manager.newDeploymentPlan().undeploy(testDeploymentFile.getName()).remove(testDeploymentFile.getName()).build());
+        awaitDeploymentExecution(future);
+
+        //Check deployment is gone
+        ModelNode result = client.execute(findDeployment);
+        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+    }
+
+    private void checkVersion() throws Exception {
+        String attribute = version.isEap() ? PRODUCT_VERSION : RELEASE_VERSION;
+        String actual = managementClient.executeForResult(Util.getReadAttributeOperation(PathAddress.EMPTY_ADDRESS, attribute)).asString();
+        String expected = this.version.getVersion();
+        Assert.assertTrue("Expected version to contain '" + expected +"' but the version was '" + actual + "'", actual.contains(expected));
+    }
+
+    private void awaitDeploymentExecution(Future<?> future) {
+        try {
+            future.get(TIMEOUT, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        } catch (TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/ClientAgainstOldServerTestCase.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/ClientAgainstOldServerTestCase.java
@@ -28,7 +28,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRO
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELEASE_VERSION;
 
-import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -93,11 +92,9 @@ public class ClientAgainstOldServerTestCase {
         final ServerDeploymentManager manager = ServerDeploymentManager.Factory.create(client);
 
         //Deploy
-        try (final InputStream is = testDeploymentFile.getInputStream()){
-            Future<?> future = manager.execute(
-                    manager.newDeploymentPlan().add(testDeploymentFile.getName(), is).deploy(testDeploymentFile.getName()).build());
-            awaitDeploymentExecution(future);
-        }
+        Future<?> future = manager.execute(
+                manager.newDeploymentPlan().add(testDeploymentFile.getName(), testDeploymentFile.getFile()).deploy(testDeploymentFile.getName()).build());
+        awaitDeploymentExecution(future);
 
         //Check there
         ModelNode findDeployment = Util.createEmptyOperation(READ_RESOURCE_OPERATION,
@@ -106,7 +103,7 @@ public class ClientAgainstOldServerTestCase {
                 managementClient.executeForResult(findDeployment).isDefined());
 
         //Undeploy
-        Future<?> future = manager.execute(manager.newDeploymentPlan().undeploy(testDeploymentFile.getName()).remove(testDeploymentFile.getName()).build());
+        future = manager.execute(manager.newDeploymentPlan().undeploy(testDeploymentFile.getName()).remove(testDeploymentFile.getName()).build());
         awaitDeploymentExecution(future);
 
         //Check deployment is gone

--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/LargeDeploymentFile.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/LargeDeploymentFile.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright ${year}, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.client.old.server.util;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+
+/**
+ * @author Kabir Khan
+ */
+public class LargeDeploymentFile {
+    private final File file;
+
+    public LargeDeploymentFile(File file) {
+        this.file = file;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public InputStream getInputStream() throws FileNotFoundException {
+        return new BufferedInputStream(new FileInputStream(file));
+    }
+
+    public String getName() {
+        return file.getName();
+    }
+}

--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/OldVersionCopier.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/OldVersionCopier.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright ${year}, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.client.old.server.util;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.xnio.IoUtils;
+
+/**
+ * @author Kabir Khan
+ */
+public class OldVersionCopier {
+
+    static String OLD_VERSIONS_DIR = "jboss.test.client.old.server.dir";
+
+    private final Version.AsVersion version;
+    private final File oldVersionsBaseDir;
+    private final File targetOldVersions = new File("target/old-versions/");
+
+
+    private OldVersionCopier(Version.AsVersion version, File oldVersionsBaseDir) {
+        this.version = version;
+        this.oldVersionsBaseDir = oldVersionsBaseDir;
+    }
+
+    static File expandOldVersion(Version.AsVersion version) {
+        OldVersionCopier copier = new OldVersionCopier(version, obtainOldVersionsDir());
+        return copier.expandAsInstance(version);
+    }
+
+
+    private static File obtainOldVersionsDir() {
+        String error = "System property '" + OLD_VERSIONS_DIR + "' must be set to a directory containing old versions";
+        String oldVersionsDir = System.getProperty(OLD_VERSIONS_DIR);
+        if (oldVersionsDir == null) {
+            throw new RuntimeException(error);
+        }
+        File file = new File(oldVersionsDir);
+        if (!file.exists() || !file.isDirectory()) {
+            throw new RuntimeException(error);
+        }
+        return file;
+    }
+
+
+    private File expandAsInstance(Version.AsVersion version) {
+        createIfNotExists(targetOldVersions);
+
+        File file = new File(oldVersionsBaseDir, version.getZipFileName());
+        if (!file.exists()) {
+            throw new RuntimeException("Old version not found in " + file.getAbsolutePath());
+        }
+        try {
+            File expanded = expandAsInstance(file);
+            return expanded;
+        } catch(Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private File expandAsInstance(final File file) throws Exception {
+        File versionDir = new File(targetOldVersions, version.getFullVersionName());
+        createIfNotExists(versionDir);
+
+        final ZipFile zipFile = new ZipFile(file);
+        try {
+            for (Enumeration<? extends ZipEntry> en = zipFile.entries() ; en.hasMoreElements() ; ) {
+                final ZipEntry entry = en.nextElement();
+                final File output = new File(versionDir, entry.getName());
+                if (entry.isDirectory()) {
+                    createIfNotExists(output);
+                } else {
+                    inputStreamToFile(zipFile.getInputStream(entry), output);
+                }
+
+            }
+        } finally {
+            IoUtils.safeClose(zipFile);
+        }
+
+        File[] files = versionDir.listFiles();
+        if (files.length != 1) {
+            //If this really becomes a problem, inspect the directory structures
+            throw new RuntimeException("The unzipped file contains more than one file in " + versionDir.getAbsolutePath() + ". Unable to determine the true distribution");
+        }
+        return files[0];
+    }
+
+    private void inputStreamToFile(InputStream input, File output) throws Exception {
+        final InputStream in = new BufferedInputStream(input);
+        try {
+            final OutputStream out = new BufferedOutputStream(new FileOutputStream(output));
+            try {
+                byte[] buf = new byte[1024];
+                int len = in.read(buf);
+                while (len != -1) {
+                    out.write(buf, 0, len);
+                    len = in.read(buf);
+                }
+            } finally {
+                IoUtils.safeClose(out);
+            }
+        } finally {
+            IoUtils.safeClose(in);
+        }
+    }
+
+    private void createIfNotExists(File file) {
+        if (!file.exists()) {
+            if (!file.mkdirs() && file.exists()) {
+                throw new RuntimeException("Could not create " + targetOldVersions);
+            }
+        }
+    }
+}

--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/OldVersionTestParameter.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/OldVersionTestParameter.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright ${year}, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.client.old.server.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Kabir Khan
+ */
+public class OldVersionTestParameter {
+    private final Version.AsVersion version;
+
+    public OldVersionTestParameter(Version.AsVersion version) {
+        this.version = version;
+    }
+
+    public Version.AsVersion getAsVersion() {
+        return version;
+    }
+
+    public static List<OldVersionTestParameter> setupVersions() {
+        List<OldVersionTestParameter> data = new ArrayList<>();
+        //These two need a much higher time out (x20)
+        //data.add(new OldVersionTestParameter(Version.AsVersion.AS_7_1_2_FINAL));
+        //data.add(new OldVersionTestParameter(Version.AsVersion.AS_7_1_3_FINAL));
+
+        //7.2.0 does not exist on TeamCity yet
+        //data.add(new OldVersionTestParameter(Version.AsVersion.AS_7_2_0_FINAL));
+
+        data.add(new OldVersionTestParameter(Version.AsVersion.EAP_6_2_0));
+        data.add(new OldVersionTestParameter(Version.AsVersion.EAP_6_3_0));
+        data.add(new OldVersionTestParameter(Version.AsVersion.EAP_6_4_0));
+
+        //8.0.0 and 8.1.0 do not exist on TeamCity yet
+        //data.add(new OldVersionTestParameter(Version.AsVersion.WF_8_0_0_FINAL));
+        //data.add(new OldVersionTestParameter(Version.AsVersion.WF_8_1_0_FINAL));
+        return data;
+    }
+
+    @Override
+    public String toString() {
+        return "OldVersionTestParameter={version=" + version + "}";
+    }
+}

--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/OldVersionTestRunner.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/OldVersionTestRunner.java
@@ -1,0 +1,347 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright ${year}, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.client.old.server.util;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.junit.runner.Result;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.Suite;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerController;
+
+/**
+ * @author Kabir Khan
+ */
+public class OldVersionTestRunner extends Suite {
+
+    private static final String LARGE_DEPLOYMENT_NAME = "large-deployment.xml";
+
+    static final String DEPLOYMENT_SIZE = "jboss.test.client.old.server.size";
+
+    static String OLD_VERSIONS_DIR = OldVersionCopier.OLD_VERSIONS_DIR;
+
+    //On OS X we seem to need to specify the JRE, i.e. (on my machine):
+    //  /Library/Java/JavaVirtualMachines/jdk1.7.0_71.jdk/Contents/Home/jre
+    //rather than
+    //  /Library/Java/JavaVirtualMachines/jdk1.7.0_71.jdk/Contents/Home
+    //The latter variety causes problems like:
+    //  "Cannot run program "/Library/Java/JavaVirtualMachines/jdk1.7.0_71.jdk/Contents/Home/bin/java": error=2, No such file or directory"
+    static final String JDK7_LOCATION = "jboss.test.client.old.server.jdk7";
+
+    /**
+     * Annotation for a method which provides parameters to be injected into the
+     * test class constructor by <code>Parameterized</code>
+     */
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    public static @interface OldVersionParameter {
+        /**
+         * <p>
+         * Optional pattern to derive the test's name from the parameters. Use
+         * numbers in braces to refer to the parameters or the additional data
+         * as follows:
+         * </p>
+         *
+         * <pre>
+         * {index} - the current parameter index
+         * {0} - the first parameter value
+         * {1} - the second parameter value
+         * etc...
+         * </pre>
+         * <p>
+         * Default value is "{index}" for compatibility with previous JUnit
+         * versions.
+         * </p>
+         *
+         * @return {@link MessageFormat} pattern string, except the index
+         *         placeholder.
+         * @see MessageFormat
+         */
+        String name() default "{index}";
+    }
+
+    private class TestClassRunnerForParameters extends BlockJUnit4ClassRunner {
+        private final OldVersionTestParameter parameter;
+
+        private final String fName;
+
+        private final ServerController controller = new ServerController();
+        private final LargeDeploymentFile largeDeploymentFile;
+
+        TestClassRunnerForParameters(Class<?> klass, OldVersionTestParameter parameters,
+                                     String name) throws InitializationError {
+            super(klass);
+            fName = name;
+            this.parameter = parameters;
+            try {
+                this.largeDeploymentFile = createTestFile();
+            } catch (IOException e) {
+                throw new InitializationError(e);
+            }
+        }
+
+        private void doInject(Class<?> klass, Object instance) {
+            Class c = klass;
+            try {
+                while (c != null && c != Object.class) {
+                    for (Field field : c.getDeclaredFields()) {
+                        if ((instance == null && Modifier.isStatic(field.getModifiers()) ||
+                                instance != null && !Modifier.isStatic(field.getModifiers()))) {
+                            if (field.isAnnotationPresent(Inject.class)) {
+                                field.setAccessible(true);
+                                if (field.getType() == ManagementClient.class && controller.isStarted()) {
+                                    field.set(instance, controller.getClient());
+                                } else if (field.getType() == ModelControllerClient.class && controller.isStarted()) {
+                                    field.set(instance, controller.getClient().getControllerClient());
+                                } else if (field.getType() == ServerController.class) {
+                                    field.set(instance, controller);
+                                } else if (field.getType() == LargeDeploymentFile.class) {
+                                    field.set(instance, largeDeploymentFile);
+                                }
+                            }
+                        }
+                    }
+                    c = c.getSuperclass();
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to inject", e);
+            }
+        }
+
+        @Override
+        public Object createTest() throws Exception {
+            return createTestUsingConstructorInjection();
+        }
+
+        private Object createTestUsingConstructorInjection() throws Exception {
+            Object test =  getTestClass().getOnlyConstructor().newInstance(parameter);
+            doInject(getTestClass().getJavaClass(), test);
+            return test;
+        }
+
+
+        @Override
+        protected String getName() {
+            return fName;
+        }
+
+        @Override
+        protected String testName(FrameworkMethod method) {
+            return method.getName() + getName();
+        }
+
+        @Override
+        protected void validateConstructor(List<Throwable> errors) {
+            validateOnlyOneConstructor(errors);
+        }
+
+        @Override
+        protected void validateFields(List<Throwable> errors) {
+            super.validateFields(errors);
+        }
+
+        @Override
+        protected Statement classBlock(RunNotifier notifier) {
+            return childrenInvoker(notifier);
+        }
+
+        @Override
+        protected Annotation[] getRunnerAnnotations() {
+            return new Annotation[0];
+        }
+
+        @Override
+        public void run(final RunNotifier notifier){
+            if (controller.isStarted()) {
+                controller.stop();
+            }
+            setupServer();
+            try {
+                controller.start();
+            } catch (RuntimeException e) {
+                throw new RuntimeException(parameter.getAsVersion() +  ": " + e.getMessage(), e);
+            }
+            try {
+                doInject(super.getTestClass().getJavaClass(), null);
+                notifier.addListener(new RunListener() {
+                    @Override
+                    public void testRunFinished(Result result) throws Exception {
+                        super.testRunFinished(result);
+                        controller.stop();
+                        largeDeploymentFile.getFile().delete();
+                    }
+                });
+                super.run(notifier);
+            } finally {
+                controller.stop();
+            }
+        }
+
+
+        private void setupServer() {
+            Version.AsVersion version = parameter.getAsVersion();
+            File file = OldVersionCopier.expandOldVersion(version);
+            System.setProperty("jboss.home", file.getAbsolutePath());
+            System.setProperty("management.protocol", version.getManagementProtocol());
+            System.setProperty("management.port", version.getManagementPort());
+            if (version.getJdk() == Version.JDK.JDK7) {
+                String jdk7 = System.getProperty(JDK7_LOCATION, System.getenv("JDK_17"));
+                if (jdk7 == null) {
+                    throw new IllegalStateException("Could not determine jdk7 home from either -D" + JDK7_LOCATION + " or $JDK_17");
+                }
+                System.setProperty("legacy.java.home", jdk7);
+            }
+        }
+    }
+
+    private static final List<Runner> NO_RUNNERS = Collections
+            .<Runner>emptyList();
+
+    private final ArrayList<Runner> runners = new ArrayList<Runner>();
+
+    /**
+     * Only called reflectively. Do not use programmatically.
+     */
+    public OldVersionTestRunner(Class<?> klass) throws Throwable {
+        super(klass, NO_RUNNERS);
+        OldVersionParameter parameters = getParametersMethod().getAnnotation(
+                OldVersionParameter.class);
+        createRunnersForParameters(allParameters(), parameters.name());
+
+    }
+
+    @Override
+    protected List<Runner> getChildren() {
+        return runners;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Iterable<OldVersionTestParameter> allParameters() throws Throwable {
+        Object parameters = getParametersMethod().invokeExplosively(null);
+        if (parameters instanceof Iterable) {
+            return (Iterable<OldVersionTestParameter>) parameters;
+        } else {
+            throw parametersMethodReturnedWrongType();
+        }
+    }
+
+    private FrameworkMethod getParametersMethod() throws Exception {
+        List<FrameworkMethod> methods = getTestClass().getAnnotatedMethods(
+                OldVersionParameter.class);
+        for (FrameworkMethod each : methods) {
+            if (each.isStatic() && each.isPublic()) {
+                return each;
+            }
+        }
+
+        throw new Exception("No public static parameters method on class "
+                + getTestClass().getName());
+    }
+
+    private void createRunnersForParameters(Iterable<OldVersionTestParameter> allParameters,
+                                            String namePattern) throws Exception {
+        try {
+            int i = 0;
+            for (OldVersionTestParameter parametersOfSingleTest : allParameters) {
+                String name = nameFor(namePattern, i, parametersOfSingleTest);
+                TestClassRunnerForParameters runner = new TestClassRunnerForParameters(
+                        getTestClass().getJavaClass(), parametersOfSingleTest,
+                        name);
+                runners.add(runner);
+                ++i;
+            }
+        } catch (ClassCastException e) {
+            throw parametersMethodReturnedWrongType();
+        }
+    }
+
+    private String nameFor(String namePattern, int index, OldVersionTestParameter parameters) {
+        String finalPattern = namePattern.replaceAll("\\{index\\}",
+                Integer.toString(index));
+        String name = MessageFormat.format(finalPattern, parameters);
+        return "[" + name + "]";
+    }
+
+    private Exception parametersMethodReturnedWrongType() throws Exception {
+        String className = getTestClass().getName();
+        String methodName = getParametersMethod().getName();
+        String message = MessageFormat.format(
+                "{0}.{1}() must return an Iterable of arrays.",
+                className, methodName);
+        return new Exception(message);
+    }
+
+    private LargeDeploymentFile createTestFile() throws IOException {
+        //Default to a 1GB deployment
+        int size = Integer.getInteger(DEPLOYMENT_SIZE, 1024 * 1024 * 1024);
+        Path path = Paths.get(new File(".").getAbsolutePath(), "target", "deployment");
+        File dir = path.toFile();
+        if (!dir.exists()) {
+            Files.createDirectories(path);
+        }
+
+        path = Paths.get(path.toString(), LARGE_DEPLOYMENT_NAME);
+        File file = path.toFile();
+        if (!file.exists()) {
+            byte[] bytes = new byte[1024];
+            for (int i = 0 ; i < 1024 ; i++) {
+                bytes[i] = (byte)i;
+            }
+            try (BufferedOutputStream writer = new BufferedOutputStream(new FileOutputStream(file))) {
+                int max = size/1024;
+                for (int i = 0 ; i < max ; i++) {
+                    writer.write(bytes);
+                }
+            }
+        }
+
+        return new LargeDeploymentFile(file);
+    }
+
+}

--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/Version.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/Version.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright ${year}, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.client.old.server.util;
+
+/**
+ * @author Kabir Khan
+ */
+public class Version {
+
+    static final String AS = "jboss-as-";
+    static final String WILDFLY = "wildfly-";
+    static final String EAP = "jboss-eap-";
+
+    public enum AsVersion {
+        AS_7_1_2_FINAL(AS, "7.1.2.Final", false, JDK.JDK7, "remote", "9999"),
+        AS_7_1_3_FINAL(AS, "7.1.3.Final", false, JDK.JDK7, "remote", "9999"),
+        AS_7_2_0_FINAL(AS, "7.2.0.Final", false, JDK.JDK7, "remote", "9999"),
+        EAP_6_2_0(EAP, "6.2.0", true, JDK.JDK8, "remote", "9999"),
+        EAP_6_3_0(EAP, "6.3.0", true, JDK.JDK8, "remote", "9999"),
+        EAP_6_4_0(EAP, "6.4.0", true, JDK.JDK8, "remote", "9999"),
+        WF_8_0_0_FINAL(WILDFLY, "8.0.0.Final", false, JDK.JDK8, "http-remoting", "9990"),
+        WF_8_1_0_FINAL(WILDFLY, "8.1.0.Final", false, JDK.JDK8, "http-remoting", "9990");
+
+
+        private final String basename;
+        private final String version;
+        private final boolean eap;
+        private final JDK jdk;
+        private final String managementProtocol;
+        private final String managementPort;
+        AsVersion(String basename, String version, boolean eap, JDK jdk, String managementProtocol, String managementPort){
+            this.basename = basename;
+            this.version = version;
+            this.eap = eap;
+            this.jdk = jdk;
+            this.managementProtocol = managementProtocol;
+            this.managementPort = managementPort;
+        }
+
+        public String getBaseName() {
+            return basename;
+        }
+
+        public boolean isEap() {
+            return eap;
+        }
+
+        public JDK getJdk() {
+            return jdk;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public String getManagementProtocol() {
+            return managementProtocol;
+        }
+
+        public String getManagementPort() {
+            return managementPort;
+        }
+
+        public String getFullVersionName() {
+            return basename + version;
+        }
+        public String getZipFileName() {
+            return  getFullVersionName() + ".zip";
+        }
+    }
+
+    enum JDK {
+        JDK7,
+        JDK8
+    }
+}

--- a/testsuite/client-old-server/src/test/resources/mgmt-users.properties
+++ b/testsuite/client-old-server/src/test/resources/mgmt-users.properties
@@ -1,0 +1,2 @@
+#testSuite=testSuitePassword
+testSuite=29a64f8524f32269aa9b681efc347f96

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -461,6 +461,14 @@
             </modules>
         </profile>
 
+        <profile>
+            <!-- Current Client, old server -->
+            <id>client-old-server.profile</id>
+            <activation><property><name>jboss.test.client.old.server.dir</name></property></activation>
+            <modules>
+                <module>client-old-server</module>
+            </modules>
+        </profile>
 
 
     </profiles>


### PR DESCRIPTION
Refactor the Server in test-runner to not use static fields, so that we
can change the values.

As mentioned in my comment https://issues.jboss.org/browse/JBIDE-19641?focusedCommentId=13077135&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13077135 this needs some setup:
-Djboss.test.client.old.server.dir=<path-to-dir-containing zips> 
-Djboss.test.client.old.server.jdk7=%env.JDK_17%

TeamCity currently only has the EAP zips, so I want to merge this first and to explore what JVM options are needed before uploading all the other versions. We probably don't want this as part of normal PR/master-ignore etc. runs, so I will create a custom job (similar to the mixed domain job) and see where that gets me.



