### PR TITLE
WFCORE-763 Persisting an empty list [] gets read as a list with empty string [""] resulting in IllegalArgumentException

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
@@ -115,10 +115,12 @@ public abstract class AttributeParser {
     public static final AttributeParser STRING_LIST = new AttributeParser() {
         @Override
         public void parseAndSetParameter(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
-            if (value == null) { return; }
-            final ModelNode node = operation.get(attribute.getName());
-            for (final String element : value.split("[ \\r\\n\\t]+")) {
-                node.add(parse(attribute, element, reader));
+            if (value == null) return;
+            final ModelNode node = operation.get(attribute.getName()).setEmptyList();
+            if (!value.isEmpty()) {
+                for (final String element : value.split("\\s+")) {
+                    node.add(parse(attribute, element, reader));
+                }
             }
         }
     };
@@ -126,15 +128,13 @@ public abstract class AttributeParser {
     public static final AttributeParser COMMA_DELIMITED_STRING_LIST = new AttributeParser() {
         @Override
         public void parseAndSetParameter(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
-            if (value == null) { return; }
-            for (String element : value.split(",")) {
-                parseAndAddParameterElement(attribute, element, operation, reader);
+            if (value == null) return;
+            final ModelNode node = operation.get(attribute.getName()).setEmptyList();
+            if (!value.isEmpty()) {
+                for (String element : value.split(",")) {
+                    node.add(parse(attribute, element, reader));
+                }
             }
-        }
-
-        private void parseAndAddParameterElement(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
-            ModelNode paramVal = parse(attribute, value, reader);
-            operation.get(attribute.getName()).add(paramVal);
         }
     };
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-763

"" will be parsed as an empty list.  Just as an empty list is marshalled to "".