### PR TITLE
[WFCORE-759] Creating ordered child resources driven by resource

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/DelegatingResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/DelegatingResourceDefinition.java
@@ -81,4 +81,14 @@ public class DelegatingResourceDefinition implements ResourceDefinition {
         }
         return false;
     }
+
+    @Override
+    public boolean isOrderedChild() {
+        if (delegate != null) {
+            return delegate.isOrderedChild();
+        }
+        return false;
+    }
 }
+
+

--- a/controller/src/main/java/org/jboss/as/controller/ResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ResourceDefinition.java
@@ -93,4 +93,11 @@ public interface ResourceDefinition {
      * @since WildFly Core 1.0, WildFly 9.0
      */
     boolean isRuntime();
+
+    /**
+     * Whether this is an ordered child or not
+     *
+     * @return {@code true} if this child is ordered within the parent, false otherwise
+     */
+    boolean isOrderedChild();
 }

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -748,6 +748,16 @@ public class ExtensionRegistry {
 
     private static class DeploymentManagementResourceRegistration implements ManagementResourceRegistration {
 
+        @Override
+        public boolean isOrderedChildResource() {
+            return false;
+        }
+
+        @Override
+        public Set<String> getOrderedChildTypes() {
+            return Collections.emptySet();
+        }
+
         private final ManagementResourceRegistration deployments;
         private final ManagementResourceRegistration subdeployments;
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/AbstractResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AbstractResourceRegistration.java
@@ -514,6 +514,8 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
         return pathAddress;
     }
 
+    protected abstract void setOrderedChild(String key);
+
     private static class RootInvocation {
         final AbstractResourceRegistration root;
         final PathAddress pathAddress;

--- a/controller/src/main/java/org/jboss/as/controller/registry/AliasResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AliasResourceRegistration.java
@@ -33,7 +33,6 @@ import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.NotificationDefinition;
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
@@ -42,6 +41,7 @@ import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.OverrideDescriptionProvider;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.registry.OperationEntry.EntryType;
 import org.jboss.dmr.ModelNode;
 
@@ -291,6 +291,21 @@ final class AliasResourceRegistration extends AbstractResourceRegistration imple
 
     @Override
     protected void registerAlias(PathElement address, AliasEntry alias, AbstractResourceRegistration target) {
+        throw alreadyRegistered();
+    }
+
+    @Override
+    public boolean isOrderedChildResource() {
+        return target.isOrderedChildResource();
+    }
+
+    @Override
+    public Set<String> getOrderedChildTypes() {
+        return target.getOrderedChildTypes();
+    }
+
+    @Override
+    public void setOrderedChild(String key) {
         throw alreadyRegistered();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/DelegatingImmutableManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/DelegatingImmutableManagementResourceRegistration.java
@@ -153,4 +153,14 @@ public class DelegatingImmutableManagementResourceRegistration implements Immuta
     public AliasEntry getAliasEntry() {
         return delegate.getAliasEntry();
     }
+
+    @Override
+    public boolean isOrderedChildResource() {
+        return delegate.isOrderedChildResource();
+    }
+
+    @Override
+    public Set<String> getOrderedChildTypes() {
+        return delegate.getOrderedChildTypes();
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/DelegatingManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/DelegatingManagementResourceRegistration.java
@@ -320,7 +320,19 @@ public class DelegatingManagementResourceRegistration implements ManagementResou
         return getDelegate().getAliasEntry();
     }
 
+    @Override
+    public Set<String> getOrderedChildTypes() {
+        return getDelegate().getOrderedChildTypes();
+    }
+
+    @Override
+    public boolean isOrderedChildResource() {
+        return getDelegate().isOrderedChildResource();
+    }
+
     private ManagementResourceRegistration getDelegate() {
         return delegateProvider.getDelegateRegistration();
     }
+
+
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ImmutableManagementResourceRegistration.java
@@ -31,6 +31,7 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProxyController;
+import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.security.ControllerPermission;
@@ -235,4 +236,20 @@ public interface ImmutableManagementResourceRegistration {
     ImmutableManagementResourceRegistration getSubModel(PathAddress address);
 
     List<AccessConstraintDefinition> getAccessConstraints();
+
+
+    /**
+     * Return @code true} if a child resource registration was registered using
+     * {@link #registerSubModel(ResourceDefinition)}, and {@code false} otherwise
+     *
+     * @return whether this is an ordered child or not
+     */
+    boolean isOrderedChildResource();
+
+    /**
+     * Return the names of the child types registered to be ordered.
+     *
+     * @return the set of ordered child types, and and empty set if there are none
+     */
+    Set<String> getOrderedChildTypes();
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/LegacyResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/LegacyResourceDefinition.java
@@ -22,6 +22,13 @@
 
 package org.jboss.as.controller.registry;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
@@ -32,13 +39,6 @@ import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
@@ -152,6 +152,11 @@ public class LegacyResourceDefinition implements ResourceDefinition {
     @Override
     public boolean isRuntime() {
         return false; //maybe read it from model description
+    }
+
+    @Override
+    public boolean isOrderedChild() {
+        return false;
     }
 }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
@@ -449,8 +449,13 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
                 public boolean isRuntime() {
                     return false;
                 }
+
+                @Override
+                public boolean isOrderedChild() {
+                    return false;
+                }
             };
-            return new ConcreteResourceRegistration(null, null, rootResourceDefinition, constraintUtilizationRegistry, rootResourceDefinition.isRuntime());
+            return new ConcreteResourceRegistration(null, null, rootResourceDefinition, constraintUtilizationRegistry, rootResourceDefinition.isRuntime(), false);
         }
 
         /**
@@ -480,7 +485,9 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
             if (resourceDefinition == null) {
                 throw ControllerLogger.ROOT_LOGGER.nullVar("rootModelDescriptionProviderFactory");
             }
-            ConcreteResourceRegistration resourceRegistration = new ConcreteResourceRegistration(null, null, resourceDefinition, constraintUtilizationRegistry, resourceDefinition.isRuntime());
+            ConcreteResourceRegistration resourceRegistration =
+                    new ConcreteResourceRegistration(null, null, resourceDefinition,
+                            constraintUtilizationRegistry, resourceDefinition.isRuntime(), false);
             resourceDefinition.registerAttributes(resourceRegistration);
             resourceDefinition.registerOperations(resourceRegistration);
             resourceDefinition.registerChildren(resourceRegistration);

--- a/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
@@ -29,13 +29,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintUtilizationRegistry;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.logging.ControllerLogger;
 
 /**
  * A registry of values within a specific key type.
@@ -78,8 +78,9 @@ final class NodeSubregistry {
         return new HashSet<String>(snapshot.keySet());
     }
 
-    ManagementResourceRegistration register(final String elementValue, final ResourceDefinition provider, boolean runtimeOnly) {
-        final AbstractResourceRegistration newRegistry = new ConcreteResourceRegistration(elementValue, this, provider, constraintUtilizationRegistry, runtimeOnly);
+    ManagementResourceRegistration register(final String elementValue, final ResourceDefinition provider, boolean runtimeOnly, boolean ordered) {
+        final AbstractResourceRegistration newRegistry =
+                new ConcreteResourceRegistration(elementValue, this, provider, constraintUtilizationRegistry, runtimeOnly, ordered);
         final AbstractResourceRegistration existingRegistry = childRegistriesUpdater.putIfAbsent(this, elementValue, newRegistry);
         if (existingRegistry != null) {
             throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(getLocationString(elementValue));

--- a/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
@@ -33,7 +33,6 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.NotificationDefinition;
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -44,6 +43,7 @@ import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.OverrideDescriptionProvider;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -349,8 +349,25 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
     }
 
     @Override
+    public void setOrderedChild(String key) {
+        throw alreadyRegistered();
+    }
+
+    @Override
     protected void registerAlias(PathElement address, AliasEntry alias, AbstractResourceRegistration target) {
         throw ControllerLogger.ROOT_LOGGER.proxyHandlerAlreadyRegistered(getLocationString());
+    }
+
+    @Override
+    public boolean isOrderedChildResource() {
+        checkPermission();
+        return false;
+    }
+
+    @Override
+    public Set<String> getOrderedChildTypes() {
+        checkPermission();
+        return Collections.emptySet();
     }
 
     /**
@@ -411,6 +428,16 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
                 return this;
             }
             return new ChildRegistration(pathAddress.append(address));
+        }
+
+        @Override
+        public boolean isOrderedChildResource() {
+            return false;
+        }
+
+        @Override
+        public Set<String> getOrderedChildTypes() {
+            return Collections.emptySet();
         }
 
         // For all other methods, ProxyControllerRegistration behavior is ok, so delegate

--- a/controller/src/test/java/org/jboss/as/controller/ListAttributeDefinitionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ListAttributeDefinitionTestCase.java
@@ -77,6 +77,11 @@ public class ListAttributeDefinitionTestCase {
             public boolean isRuntime() {
                 return false;
             }
+
+            @Override
+            public boolean isOrderedChild() {
+                return false;
+            }
         };
 
         ImmutableManagementResourceRegistration registration = ManagementResourceRegistration.Factory.create(resource);
@@ -132,6 +137,11 @@ public class ListAttributeDefinitionTestCase {
 
             @Override
             public boolean isRuntime() {
+                return false;
+            }
+
+            @Override
+            public boolean isOrderedChild() {
                 return false;
             }
         };

--- a/controller/src/test/java/org/jboss/as/controller/test/OrderedChildResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/OrderedChildResourceTestCase.java
@@ -158,13 +158,7 @@ public class OrderedChildResourceTestCase extends AbstractControllerTestBase {
         public ParentResourceDefinition() {
             super(PARENT_MAIN,
                     new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES) {
-                        @Override
-                        protected ResourceCreator getResourceCreator() {
-                            return new OrderedResourceCreator(false, CHILD.getKey());
-                        }
-
-                    },
+                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES),
                     new ModelOnlyRemoveStepHandler());
         }
 
@@ -184,21 +178,10 @@ public class OrderedChildResourceTestCase extends AbstractControllerTestBase {
         public OrderedChildResourceDefinition() {
             super(CHILD,
                     new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES) {
-                        @Override
-                        protected ResourceCreator getResourceCreator() {
-                            return new OrderedResourceCreator(true);
-                        }
-                    }, new ModelOnlyRemoveStepHandler());
+                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES),
+                    new ModelOnlyRemoveStepHandler(), false, true);
         }
-
-
-        @Override
-        protected boolean isOrderedChildResource() {
-            return true;
-        }
-
-
+        
         @Override
         public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
             resourceRegistration.registerReadWriteAttribute(ATTR, null, new ModelOnlyWriteAttributeHandler(ATTR));

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -877,6 +877,16 @@ public abstract class AbstractOperationTestCase {
 
         }
 
+        @Override
+        public boolean isOrderedChildResource() {
+            return false;
+        }
+
+        @Override
+        public Set<String> getOrderedChildTypes() {
+            return Collections.emptySet();
+        }
+
         public void registerProxyController(PathElement address, ProxyController proxyController) {
 
         }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOrderedChildResourceSyncModelTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOrderedChildResourceSyncModelTestCase.java
@@ -66,17 +66,14 @@ import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.controller.resource.AbstractSocketBindingGroupResourceDefinition;
 import org.jboss.as.domain.controller.operations.deployment.SyncModelParameters;
 import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
 import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
-import org.jboss.as.domain.controller.resources.SocketBindingResourceDefinition;
 import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
 import org.jboss.as.host.controller.mgmt.HostControllerRegistrationHandler;
 import org.jboss.as.host.controller.util.AbstractControllerTestBase;
 import org.jboss.as.repository.ContentReference;
 import org.jboss.as.repository.HostFileRepository;
-import org.jboss.as.server.services.net.*;
 import org.jboss.as.server.services.net.SocketBindingGroupResourceDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -281,13 +278,7 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
         public SubsystemResourceDefinition() {
             super(SUBSYSTEM_ELEMENT,
                     new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES) {
-                        @Override
-                        protected ResourceCreator getResourceCreator() {
-                            return new OrderedResourceCreator(false, ORDERED_CHILD.getKey());
-                        }
-
-                    },
+                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES),
                     new ModelOnlyRemoveStepHandler());
         }
 
@@ -318,13 +309,8 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
 
     abstract class AbstractChildResourceDefinition extends SimpleResourceDefinition {
         public AbstractChildResourceDefinition(PathElement element, OperationStepHandler addHandler) {
-            super(element, new NonResolvingResourceDescriptionResolver(), addHandler, new ModelOnlyRemoveStepHandler());
-        }
-
-        @Override
-        protected boolean isOrderedChildResource() {
-            //'true' here adds the 'add-index' parameter to the add operation
-            return localIndexedAdd;
+            super(element, new NonResolvingResourceDescriptionResolver(),
+                    addHandler, new ModelOnlyRemoveStepHandler(), false, true);
         }
 
         @Override
@@ -338,13 +324,7 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
 
         OrderedChildResourceDefinition() {
             super(ORDERED_CHILD,
-                    new AbstractAddStepHandler((REQUEST_ATTRIBUTES)) {
-                        @Override
-                        protected ResourceCreator getResourceCreator() {
-                            return new OrderedResourceCreator(true, EXTRA_CHILD.getKey());
-                        }
-
-                    });
+                    new AbstractAddStepHandler((REQUEST_ATTRIBUTES)));
         }
 
         @Override
@@ -358,13 +338,7 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
     class ExtraChildResourceDefinition extends AbstractChildResourceDefinition {
         public ExtraChildResourceDefinition() {
             super(EXTRA_CHILD,
-                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES) {
-                        @Override
-                        protected ResourceCreator getResourceCreator() {
-                            return new OrderedResourceCreator(true);
-                        }
-
-                    });
+                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES));
         }
     }
 

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -468,6 +468,14 @@ public abstract class ModelTestModelControllerService extends AbstractController
         public boolean isRuntime() {
             return delegate.isRuntime();
         }
+
+        @Override
+        public boolean isOrderedChild() {
+            if (delegate == null) {
+                return false;
+            }
+            return delegate.isOrderedChild();
+        }
     }
 
     //These are here to overload the constuctor used for the different legacy controllers

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -1146,6 +1146,16 @@ final class SubsystemTestDelegate {
         }
 
         @Override
+        public boolean isOrderedChildResource() {
+            return false;
+        }
+
+        @Override
+        public Set<String> getOrderedChildTypes() {
+            return Collections.emptySet();
+        }
+
+        @Override
         public void registerProxyController(PathElement address, ProxyController proxyController) {
         }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/OrderedChildResourceExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/OrderedChildResourceExtension.java
@@ -93,13 +93,7 @@ public class OrderedChildResourceExtension implements Extension {
         public SubsystemResourceDefinition() {
             super(SUBSYSTEM_PATH,
                     new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES) {
-                        @Override
-                        protected ResourceCreator getResourceCreator() {
-                            return new OrderedResourceCreator(false, CHILD.getKey());
-                        }
-
-                    },
+                    new AbstractAddStepHandler(REQUEST_ATTRIBUTES),
                     new ModelOnlyRemoveStepHandler());
         }
 
@@ -124,19 +118,10 @@ public class OrderedChildResourceExtension implements Extension {
 
         public OrderedChildResourceDefinition() {
             super(CHILD, new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {
-                        @Override
-                        protected ResourceCreator getResourceCreator() {
-                            return new OrderedResourceCreator(true);
-                        }
-
-                    },
-                    new ModelOnlyRemoveStepHandler());
-        }
-
-        @Override
-        protected boolean isOrderedChildResource() {
-            return true;
+                    new AbstractAddStepHandler(),
+                    new ModelOnlyRemoveStepHandler(),
+                    false,
+                    true);
         }
     }
 


### PR DESCRIPTION
registration. All that is needed now is to call the SimpleResourceDefinition constructor with ordered=true. This ends up as ResourceDefinition.isOrderedChild() = true, and then the framework can figure out the rest.

~~https://github.com/wildfly/wildfly/pull/7611 needs merging before this can pass the full integration tests.~~ MERGED

https://issues.jboss.org/browse/WFCORE-759
https://issues.jboss.org/browse/WFCORE-764 is for getting rid of the deprecated methods once this is in a release and full can be adjusted to not use them