### PR TITLE
[WFCORE-690] Add logging configuration information to deployments. This helps show runtime information for the configuration deployments are using.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.logging.deployments.LoggingConfigDeploymentProcessor;
 import org.jboss.as.logging.deployments.LoggingDependencyDeploymentProcessor;
+import org.jboss.as.logging.deployments.LoggingDeploymentResourceProcessor;
 import org.jboss.as.logging.deployments.LoggingProfileDeploymentProcessor;
 import org.jboss.as.logging.logging.LoggingLogger;
 import org.jboss.as.logging.logmanager.ConfigurationPersistence;
@@ -84,6 +85,8 @@ class LoggingSubsystemAdd extends AbstractAddStepHandler {
                 processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_CONFIG,
                         new LoggingConfigDeploymentProcessor(contextSelector, LoggingResourceDefinition.USE_DEPLOYMENT_LOGGING_CONFIG.getName(), useLoggingConfig));
                 processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_PROFILE, new LoggingProfileDeploymentProcessor(contextSelector));
+                processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_LOGGING_DEPLOYMENT_RESOURCES,
+                        new LoggingDeploymentResourceProcessor());
             }
         }, Stage.RUNTIME);
 

--- a/logging/src/main/java/org/jboss/as/logging/deployments/LoggingConfigurationService.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/LoggingConfigurationService.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.deployments;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.logging.logging.LoggingLogger;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.Services;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * A service use to query the logging configuration for the deployment.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LoggingConfigurationService implements Service<LogContextConfiguration> {
+    private final LogContextConfiguration logContextConfiguration;
+    private final String configuration;
+
+    public LoggingConfigurationService(final LogContextConfiguration logContextConfiguration, final String configuration) {
+        this.logContextConfiguration = logContextConfiguration;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void start(final StartContext context) throws StartException {
+        // Nothing needed
+    }
+
+    @Override
+    public void stop(final StopContext context) {
+        // Nothing needed
+    }
+
+    @Override
+    public LogContextConfiguration getValue() throws IllegalStateException, IllegalArgumentException {
+        return logContextConfiguration;
+    }
+
+    /**
+     * Returns an identifier for the configuration being used.
+     * <p>
+     * This will be used as the value for the address of a deployment resource.
+     * </p>
+     *
+     * @return the configuration name
+     */
+    public String getConfiguration() {
+        return configuration;
+    }
+
+    /**
+     * Create the service name used for this service for the deployment.
+     *
+     * @param deployment the deployment for this service
+     *
+     * @return the service name
+     */
+    static ServiceName forDeployment(final DeploymentUnit deployment) {
+        return deployment.getServiceName().append("logging", "configuration");
+    }
+
+    /**
+     * Create the service name used for this service on a deployment.
+     *
+     * @param address the deployments address
+     *
+     * @return the service name
+     */
+    public static ServiceName forDeployment(final PathAddress address) {
+        String deploymentName = null;
+        String subdeploymentName = null;
+        for (PathElement element : address) {
+            if (ModelDescriptionConstants.DEPLOYMENT.equals(element.getKey())) {
+                deploymentName = element.getValue();
+            } else if (ModelDescriptionConstants.SUBDEPLOYMENT.endsWith(element.getKey())) {
+                subdeploymentName = element.getValue();
+            }
+        }
+        if (deploymentName == null) {
+            throw LoggingLogger.ROOT_LOGGER.deploymentNameNotFound(address);
+        }
+        final ServiceName result;
+        if (subdeploymentName == null) {
+            result = Services.deploymentUnitName(deploymentName);
+        } else {
+            result = Services.deploymentUnitName(deploymentName, subdeploymentName);
+        }
+        return result.append("logging", "configuration");
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/deployments/LoggingDeploymentResourceProcessor.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/LoggingDeploymentResourceProcessor.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.deployments;
+
+import org.jboss.as.logging.CommonAttributes;
+import org.jboss.as.logging.deployments.resources.LoggingDeploymentResources;
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentResourceSupport;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.logmanager.Configurator;
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.PropertyConfigurator;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.modules.Module;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * Process a deployment and ensures a logging configuration service has been added.
+ * <p>
+ * Note that in some cases the assumed logging configuration will be wrong. If a deployment is using a custom log
+ * manager, such as logback, the configuration reported on the deployment will be the assumed configuration.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LoggingDeploymentResourceProcessor implements DeploymentUnitProcessor {
+
+    /**
+     * The attachment key used to attach the service.
+     */
+    public static final AttachmentKey<LoggingConfigurationService> LOGGING_CONFIGURATION_SERVICE_KEY = AttachmentKey.create(LoggingConfigurationService.class);
+
+    @Override
+    public final void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        if (deploymentUnit.hasAttachment(Attachments.MODULE)) {
+            LoggingConfigurationService loggingConfigurationService = null;
+            if (deploymentUnit.hasAttachment(LOGGING_CONFIGURATION_SERVICE_KEY)) {
+                loggingConfigurationService = deploymentUnit.getAttachment(LOGGING_CONFIGURATION_SERVICE_KEY);
+                // Remove the attachment as it should no longer be needed
+                deploymentUnit.removeAttachment(LOGGING_CONFIGURATION_SERVICE_KEY);
+            } else {
+                // Get the module
+                final Module module = deploymentUnit.getAttachment(Attachments.MODULE);
+                // Set the deployments class loader to ensure we get the correct log context
+                final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+                try {
+                    WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
+                    LogContextConfiguration logContextConfiguration = null;
+                    final LogContext logContext = LogContext.getLogContext();
+                    final Configurator configurator = logContext.getAttachment(CommonAttributes.ROOT_LOGGER_NAME, Configurator.ATTACHMENT_KEY);
+                    if (configurator instanceof LogContextConfiguration) {
+                        logContextConfiguration = (LogContextConfiguration) configurator;
+                    } else if (configurator instanceof PropertyConfigurator) {
+                        logContextConfiguration = ((PropertyConfigurator) configurator).getLogContextConfiguration();
+                    }
+                    loggingConfigurationService = new LoggingConfigurationService(logContextConfiguration, "default");
+                } finally {
+                    WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+                }
+            }
+
+            final DeploymentResourceSupport deploymentResourceSupport = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_RESOURCE_SUPPORT);
+            // Register the resources
+            LoggingDeploymentResources.registerDeploymentResource(deploymentResourceSupport, loggingConfigurationService);
+            phaseContext.getServiceTarget()
+                    .addService(LoggingConfigurationService.forDeployment(deploymentUnit), loggingConfigurationService)
+                    .install();
+        }
+    }
+
+    @Override
+    public final void undeploy(final DeploymentUnit context) {
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/deployments/resources/HandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/resources/HandlerResourceDefinition.java
@@ -1,0 +1,163 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.deployments.resources;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleListAttributeDefinition;
+import org.jboss.as.controller.SimpleMapAttributeDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.logging.LoggingExtension;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+
+/**
+ * Describes a handler used on a deployment.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class HandlerResourceDefinition extends SimpleResourceDefinition {
+
+    static final String NAME = "handler";
+    public static final PathElement PATH = PathElement.pathElement(NAME);
+
+    static final SimpleAttributeDefinition CLASS_NAME = SimpleAttributeDefinitionBuilder.create("class-name", ModelType.STRING)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition MODULE = SimpleAttributeDefinitionBuilder.create("module", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition ENCODING = SimpleAttributeDefinitionBuilder.create("encoding", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition LEVEL = SimpleAttributeDefinitionBuilder.create("level", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition HANDLER = SimpleAttributeDefinitionBuilder.create("handler", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleListAttributeDefinition HANDLERS = SimpleListAttributeDefinition.Builder.of("handlers", HANDLER)
+            .setAllowNull(true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition FORMATTER = SimpleAttributeDefinitionBuilder.create("formatter", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition FILTER = SimpleAttributeDefinitionBuilder.create("filter", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleMapAttributeDefinition PROPERTIES = new SimpleMapAttributeDefinition.Builder("properties", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition ERROR_MANAGER = SimpleAttributeDefinitionBuilder.create("error-manager", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    public HandlerResourceDefinition() {
+        super(PATH, LoggingExtension.getResourceDescriptionResolver("deployment", NAME));
+    }
+
+    @Override
+    public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerReadOnlyAttribute(CLASS_NAME, new HandlerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final HandlerConfiguration configuration, final ModelNode model) {
+                setModelValue(model, configuration.getClassName());
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(MODULE, new HandlerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final HandlerConfiguration configuration, final ModelNode model) {
+                setModelValue(model, configuration.getModuleName());
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(ENCODING, new HandlerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final HandlerConfiguration configuration, final ModelNode model) {
+                setModelValue(model, configuration.getEncoding());
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(LEVEL, new HandlerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final HandlerConfiguration configuration, final ModelNode model) {
+                setModelValue(model, configuration.getLevel());
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(FORMATTER, new HandlerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final HandlerConfiguration configuration, final ModelNode model) {
+                setModelValue(model, configuration.getFormatterName());
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(FILTER, new HandlerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final HandlerConfiguration configuration, final ModelNode model) {
+                setModelValue(model, configuration.getFilter());
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(HANDLERS, new HandlerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final HandlerConfiguration configuration, final ModelNode model) {
+                final ModelNode handlers = model.setEmptyList();
+                configuration.getHandlerNames().forEach(handlers::add);
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(PROPERTIES, new HandlerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final HandlerConfiguration configuration, final ModelNode model) {
+                addProperties(configuration, model);
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(ERROR_MANAGER, new HandlerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final HandlerConfiguration configuration, final ModelNode model) {
+                setModelValue(model, configuration.getErrorManagerName());
+            }
+        });
+    }
+
+    abstract static class HandlerConfigurationReadStepHandler extends LoggingConfigurationReadStepHandler {
+        @Override
+        protected void updateModel(final LogContextConfiguration logContextConfiguration, final String name, final ModelNode model) {
+            final HandlerConfiguration handlerConfiguration = logContextConfiguration.getHandlerConfiguration(name);
+            updateModel(handlerConfiguration, model);
+
+        }
+
+        protected abstract void updateModel(HandlerConfiguration configuration, ModelNode model);
+    }
+
+}

--- a/logging/src/main/java/org/jboss/as/logging/deployments/resources/LoggerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/resources/LoggerResourceDefinition.java
@@ -1,0 +1,112 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.deployments.resources;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleListAttributeDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.logging.LoggingExtension;
+import org.jboss.as.logging.RootLoggerResourceDefinition;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.LoggerConfiguration;
+
+/**
+ * Describes a logger used on a deployment.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class LoggerResourceDefinition extends SimpleResourceDefinition {
+
+    static final String NAME = "logger";
+    public static final PathElement PATH = PathElement.pathElement(NAME);
+
+    static final SimpleAttributeDefinition LEVEL = SimpleAttributeDefinitionBuilder.create("level", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition HANDLER = SimpleAttributeDefinitionBuilder.create("handler", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleListAttributeDefinition HANDLERS = SimpleListAttributeDefinition.Builder.of("handlers", HANDLER)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition FILTER = SimpleAttributeDefinitionBuilder.create("filter", ModelType.STRING, true)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition USE_PARENT_HANDLERS = SimpleAttributeDefinitionBuilder.create("use-parent-handlers", ModelType.BOOLEAN, true)
+            .setStorageRuntime()
+            .build();
+
+    public LoggerResourceDefinition() {
+        super(PATH, LoggingExtension.getResourceDescriptionResolver("deployment", NAME));
+    }
+
+    @Override
+    public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerReadOnlyAttribute(LEVEL, new LoggerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final LoggerConfiguration configuration, final ModelNode model) {
+                setModelValue(model, configuration.getLevel());
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(FILTER, new LoggerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final LoggerConfiguration configuration, final ModelNode model) {
+                setModelValue(model, configuration.getFilter());
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(HANDLERS, new LoggerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final LoggerConfiguration configuration, final ModelNode model) {
+                final ModelNode handlers = model.setEmptyList();
+                configuration.getHandlerNames().forEach(handlers::add);
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(USE_PARENT_HANDLERS, new LoggerConfigurationReadStepHandler() {
+            @Override
+            protected void updateModel(final LoggerConfiguration configuration, final ModelNode model) {
+                setModelValue(model, configuration.getUseParentHandlers());
+            }
+        });
+    }
+
+    abstract static class LoggerConfigurationReadStepHandler extends LoggingConfigurationReadStepHandler {
+        @Override
+        protected void updateModel(final LogContextConfiguration logContextConfiguration, final String name, final ModelNode model) {
+            final LoggerConfiguration configuration = logContextConfiguration.getLoggerConfiguration(RootLoggerResourceDefinition.ROOT_LOGGER_ATTRIBUTE_NAME.equals(name) ? "" : name);
+            updateModel(configuration, model);
+
+        }
+
+        protected abstract void updateModel(LoggerConfiguration configuration, ModelNode model);
+    }
+
+}

--- a/logging/src/main/java/org/jboss/as/logging/deployments/resources/LoggingConfigurationReadStepHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/resources/LoggingConfigurationReadStepHandler.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.deployments.resources;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.logging.deployments.LoggingConfigurationService;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.PropertyConfigurable;
+import org.jboss.msc.service.ServiceController;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class LoggingConfigurationReadStepHandler implements OperationStepHandler {
+    private static final OperationContext.AttachmentKey<LogContextConfiguration> CONFIGURATION_KEY = OperationContext.AttachmentKey.create(LogContextConfiguration.class);
+
+    @Override
+    public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+        LogContextConfiguration configuration = context.getAttachment(CONFIGURATION_KEY);
+        if (configuration == null) {
+            // Lookup the service
+            final ServiceController<?> controller = context.getServiceRegistry(false).getService(LoggingConfigurationService.forDeployment(context.getCurrentAddress()));
+            if (controller != null) {
+                configuration = (LogContextConfiguration) controller.getValue();
+                context.attachIfAbsent(CONFIGURATION_KEY, configuration);
+            }
+        }
+        // Some deployments may not have a logging configuration associated, e.g. log4j configured deployments
+        if (configuration != null) {
+            final String name = context.getCurrentAddressValue();
+            final ModelNode result = context.getResult();
+            updateModel(configuration, name, result);
+        }
+    }
+
+    /**
+     * Update the model for a resource.
+     *
+     * @param logContextConfiguration the configuration to use
+     * @param name                    the name of the resource
+     * @param model                   the model to update
+     */
+    protected abstract void updateModel(LogContextConfiguration logContextConfiguration, String name, ModelNode model);
+
+    /**
+     * Adds properties to the model in key/value pairs.
+     *
+     * @param configuration the configuration to get the properties from
+     * @param model         the model to update
+     */
+    static void addProperties(final PropertyConfigurable configuration, final ModelNode model) {
+        configuration.getPropertyNames().forEach(name -> setModelValue(model.get(name), configuration.getPropertyValueString(name)));
+    }
+
+    /**
+     * Sets the value of the model if the value is not {@code null}.
+     *
+     * @param model the model to update
+     * @param value the value for the model
+     */
+    static void setModelValue(final ModelNode model, final String value) {
+        if (value != null) {
+            model.set(value);
+        }
+    }
+
+    /**
+     * Sets the value of the model if the value is not {@code null}.
+     *
+     * @param model the model to update
+     * @param value the value for the model
+     */
+    static void setModelValue(final ModelNode model, final Boolean value) {
+        if (value != null) {
+            model.set(value);
+        }
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/deployments/resources/LoggingDeploymentResources.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/resources/LoggingDeploymentResources.java
@@ -1,0 +1,181 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.deployments.resources;
+
+import java.util.Collection;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleMapAttributeDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.logging.LoggingExtension;
+import org.jboss.as.logging.RootLoggerResourceDefinition;
+import org.jboss.as.logging.deployments.LoggingConfigurationService;
+import org.jboss.as.server.deployment.DeploymentResourceSupport;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.config.ObjectConfigurable;
+import org.jboss.logmanager.config.PropertyConfigurable;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LoggingDeploymentResources {
+
+    public static final SimpleResourceDefinition CONFIGURATION = new SimpleResourceDefinition(PathElement.pathElement("configuration"), LoggingExtension.getResourceDescriptionResolver("deployment"));
+
+    public static final SimpleResourceDefinition HANDLER = new HandlerResourceDefinition();
+
+    public static final SimpleResourceDefinition LOGGER = new LoggerResourceDefinition();
+
+    public static final SimpleResourceDefinition FORMATTER = new PropertiesResourceDefinition("formatter") {
+        @Override
+        protected PropertyConfigurable getPropertyConfigurable(final LogContextConfiguration logContextConfiguration, final String name) {
+            return logContextConfiguration.getFormatterConfiguration(name);
+        }
+
+        @Override
+        protected ObjectConfigurable getObjectConfigurable(final LogContextConfiguration logContextConfiguration, final String name) {
+            return logContextConfiguration.getFormatterConfiguration(name);
+        }
+    };
+
+    public static final SimpleResourceDefinition FILTER = new PropertiesResourceDefinition("filter") {
+        @Override
+        protected PropertyConfigurable getPropertyConfigurable(final LogContextConfiguration logContextConfiguration, final String name) {
+            return logContextConfiguration.getFilterConfiguration(name);
+        }
+
+        @Override
+        protected ObjectConfigurable getObjectConfigurable(final LogContextConfiguration logContextConfiguration, final String name) {
+            return logContextConfiguration.getFilterConfiguration(name);
+        }
+    };
+
+    public static final SimpleResourceDefinition POJO = new PropertiesResourceDefinition("pojo") {
+        @Override
+        protected PropertyConfigurable getPropertyConfigurable(final LogContextConfiguration logContextConfiguration, final String name) {
+            return logContextConfiguration.getPojoConfiguration(name);
+        }
+
+        @Override
+        protected ObjectConfigurable getObjectConfigurable(final LogContextConfiguration logContextConfiguration, final String name) {
+            return logContextConfiguration.getPojoConfiguration(name);
+        }
+    };
+
+    public static final SimpleResourceDefinition ERROR_MANAGER = new PropertiesResourceDefinition("error-manager") {
+        @Override
+        protected PropertyConfigurable getPropertyConfigurable(final LogContextConfiguration logContextConfiguration, final String name) {
+            return logContextConfiguration.getErrorManagerConfiguration(name);
+        }
+
+        @Override
+        protected ObjectConfigurable getObjectConfigurable(final LogContextConfiguration logContextConfiguration, final String name) {
+            return logContextConfiguration.getErrorManagerConfiguration(name);
+        }
+    };
+
+    /**
+     * Registers the deployment resources needed.
+     *
+     * @param deploymentResourceSupport the deployment resource support
+     * @param service                   the service, which may be {@code null}, used to find the resource names that need to be registered
+     */
+    public static void registerDeploymentResource(final DeploymentResourceSupport deploymentResourceSupport, final LoggingConfigurationService service) {
+        final PathElement base = PathElement.pathElement("configuration", service.getConfiguration());
+        deploymentResourceSupport.getDeploymentSubModel(LoggingExtension.SUBSYSTEM_NAME, base);
+        final LogContextConfiguration configuration = service.getValue();
+        // Register the child resources if the configuration is not null in cases where a log4j configuration was used
+        if (configuration != null) {
+            registerDeploymentResource(deploymentResourceSupport, base, HANDLER, configuration.getHandlerNames());
+            registerDeploymentResource(deploymentResourceSupport, base, LOGGER, configuration.getLoggerNames());
+            registerDeploymentResource(deploymentResourceSupport, base, FORMATTER, configuration.getFormatterNames());
+            registerDeploymentResource(deploymentResourceSupport, base, FILTER, configuration.getFilterNames());
+            registerDeploymentResource(deploymentResourceSupport, base, POJO, configuration.getPojoNames());
+            registerDeploymentResource(deploymentResourceSupport, base, ERROR_MANAGER, configuration.getErrorManagerNames());
+        }
+    }
+
+    private static void registerDeploymentResource(final DeploymentResourceSupport deploymentResourceSupport, final PathElement base, final ResourceDefinition def, final Collection<String> names) {
+        for (String name : names) {
+            // Replace any blank values with the default root-logger name; this should only happen on loggers
+            final String resourceName = name.isEmpty() ? RootLoggerResourceDefinition.ROOT_LOGGER_ATTRIBUTE_NAME : name;
+            final PathAddress address = PathAddress.pathAddress(base, PathElement.pathElement(def.getPathElement().getKey(), resourceName));
+            deploymentResourceSupport.getDeploymentSubModel(LoggingExtension.SUBSYSTEM_NAME, address);
+        }
+    }
+
+    private abstract static class PropertiesResourceDefinition extends SimpleResourceDefinition {
+
+        static final SimpleAttributeDefinition CLASS_NAME = SimpleAttributeDefinitionBuilder.create("class-name", ModelType.STRING)
+                .setStorageRuntime()
+                .build();
+
+        static final SimpleAttributeDefinition MODULE = SimpleAttributeDefinitionBuilder.create("module", ModelType.STRING, true)
+                .setStorageRuntime()
+                .build();
+
+        static final SimpleMapAttributeDefinition PROPERTIES = new SimpleMapAttributeDefinition.Builder("properties", ModelType.STRING, true)
+                .setStorageRuntime()
+                .build();
+
+        public PropertiesResourceDefinition(final String name) {
+            super(PathElement.pathElement(name), LoggingExtension.getResourceDescriptionResolver("deployment", name));
+        }
+
+        @Override
+        public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
+            resourceRegistration.registerReadOnlyAttribute(CLASS_NAME, new LoggingConfigurationReadStepHandler() {
+                @Override
+                protected void updateModel(final LogContextConfiguration logContextConfiguration, final String name, final ModelNode model) {
+                    final ObjectConfigurable configuration = getObjectConfigurable(logContextConfiguration, name);
+                    setModelValue(model, configuration.getClassName());
+                }
+            });
+            resourceRegistration.registerReadOnlyAttribute(MODULE, new LoggingConfigurationReadStepHandler() {
+                @Override
+                protected void updateModel(final LogContextConfiguration logContextConfiguration, final String name, final ModelNode model) {
+                    final ObjectConfigurable configuration = getObjectConfigurable(logContextConfiguration, name);
+                    setModelValue(model, configuration.getModuleName());
+                }
+            });
+            resourceRegistration.registerReadOnlyAttribute(PROPERTIES, new LoggingConfigurationReadStepHandler() {
+                @Override
+                protected void updateModel(final LogContextConfiguration logContextConfiguration, final String name, final ModelNode model) {
+                    final PropertyConfigurable configuration = getPropertyConfigurable(logContextConfiguration, name);
+                    addProperties(configuration, model);
+                }
+            });
+        }
+
+        protected abstract PropertyConfigurable getPropertyConfigurable(LogContextConfiguration logContextConfiguration, String name);
+
+        protected abstract ObjectConfigurable getObjectConfigurable(LogContextConfiguration logContextConfiguration, String name);
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -32,6 +32,7 @@ import java.util.EnumSet;
 import java.util.logging.Handler;
 
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.logging.Target;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -897,4 +898,14 @@ public interface LoggingLogger extends BasicLogger {
      */
     @Message(id = 85, value = "Resources of type %s cannot be removed")
     UnsupportedOperationException cannotRemoveResourceOfType(String childType);
+
+    /**
+     * Creates an exception indicating the deployment name was not found on the address.
+     *
+     * @param address the invalid address
+     *
+     * @return an {@link IllegalArgumentException} for the error
+     */
+    @Message(id = 86, value = "Could not determine deployment name from the address %s.")
+    IllegalArgumentException deploymentNameNotFound(PathAddress address);
 }

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -606,3 +606,66 @@ logging.custom-formatter.module=The module that the logging handler depends on.
 logging.custom-formatter.properties=Defines the properties used for the logging handler. All properties must be accessible via a setter method.
 logging.custom-formatter.properties.name=Defines the name of the property to set.
 logging.custom-formatter.properties.value=Defines value of the property.
+
+# Logging Deployment descriptions
+logging.deployment=Information about the logging configuration for this deployment. Note that this may not be accurate \
+  if the deployment is using some other means of configuring a log manager such as logback. The resolved configuration \
+  is what loggers not covered by the deployments specific log manager would use.
+logging.deployment.configuration=The configuration being used for the deployment. For configurations within the deployment \
+  this is the path to the configuration file used. For logging profiles it's "profile-" followed by the name of the profile. \
+  Otherwise the value will be "default" to indicate it's using the logging configuration as defined by the logging subsystem.
+
+# Deployment handler descriptions
+logging.deployment.handler=Describes the configured handlers being used on a deployment.
+logging.deployment.handler.encoding=The encoding the handler has been set to use.
+logging.deployment.handler.level=The log level specifying which message levels will be logged by this handler. Message levels lower than this value will be discarded.
+logging.deployment.handler.formatter=The name of the defined formatter that this handler is using.
+logging.deployment.handler.class-name=The class name for the handler.
+logging.deployment.handler.module=The module name the handler was set to use.
+logging.deployment.handler.filter=The name of the filter set on the handler.
+logging.deployment.handler.handlers=Any sub-handlers defined on the handler.
+logging.deployment.handler.handlers.handler=The name of the log handler.
+logging.deployment.handler.properties=Additional properties that were set on the handler.
+logging.deployment.handler.properties.name=Defines the name of the property to set.
+logging.deployment.handler.properties.value=Defines value of the property.
+logging.deployment.handler.error-manager=The error manager that was set on the handler.
+
+# Deployment logger descriptions
+logging.deployment.logger=Describes the configured loggers being used on a deployment.
+logging.deployment.logger.level=The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.
+logging.deployment.logger.filter=The name of the filter set on the logger.
+logging.deployment.logger.handlers=Any handlers defined on the logger.
+logging.deployment.logger.handlers.handler=The name of the log handler.
+logging.deployment.logger.use-parent-handlers=Specifies whether or not this logger sends its output to parent loggers.
+
+# Deployment formatter descriptions
+logging.deployment.formatter=Describes the configured formatters being used on a deployment.
+logging.deployment.formatter.class-name=The class name for the formatter.
+logging.deployment.formatter.module=The module name the formatter was set to use.
+logging.deployment.formatter.properties=Additional properties that were set on the formatter.
+logging.deployment.formatter.properties.name=Defines the name of the property to set.
+logging.deployment.formatter.properties.value=Defines value of the property.
+
+# Deployment filter descriptions
+logging.deployment.filter=Describes the configured filters being used on a deployment.
+logging.deployment.filter.class-name=The class name for the filter.
+logging.deployment.filter.module=The module name the filter was set to use.
+logging.deployment.filter.properties=Additional properties that were set on the filter.
+logging.deployment.filter.properties.name=Defines the name of the property to set.
+logging.deployment.filter.properties.value=Defines value of the property.
+
+# Deployment pojo descriptions
+logging.deployment.pojo=Describes the configured POJO's being used on a deployment.
+logging.deployment.pojo.class-name=The class name for the POJO.
+logging.deployment.pojo.module=The module name the POJO was set to use.
+logging.deployment.pojo.properties=Additional properties that were set on the POJO.
+logging.deployment.pojo.properties.name=Defines the name of the property to set.
+logging.deployment.pojo.properties.value=Defines value of the property.
+
+# Deployment error-manager descriptions
+logging.deployment.error-manager=Describes the configured error managers being used on a deployment.
+logging.deployment.error-manager.class-name=The class name for the error manager.
+logging.deployment.error-manager.module=The module name the error manager was set to use.
+logging.deployment.error-manager.properties=Additional properties that were set on the error manager.
+logging.deployment.error-manager.properties.name=Defines the name of the property to set.
+logging.deployment.error-manager.properties.value=Defines value of the property.

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -573,6 +573,7 @@ public enum Phase {
     public static final int INSTALL_WAB_SERVLETCONTEXT_SERVICE          = 0x2050;
     public static final int INSTALL_PERSISTENCE_SERVICES                = 0x2060;
     public static final int INSTALL_BATCH_RESOURCES                     = 0x2070;
+    public static final int INSTALL_LOGGING_DEPLOYMENT_RESOURCES        = 0x207a;
     public static final int INSTALL_DEPLOYMENT_COMPLETE_SERVICE         = 0x2100;
 
     // CLEANUP

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLog4jXmlTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLog4jXmlTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.logging.perdeploy;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,8 +29,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.LinkedList;
 
 import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -78,5 +82,17 @@ public class JBossLog4jXmlTestCase extends DeploymentBaseTestCase {
         }
         Assert.assertTrue("Log file should contain line: " + traceLine, trace);
         Assert.assertTrue("Log file should contain line: " + fatalLine, fatal);
+    }
+
+    @Test
+    public void testDeploymentConfigurationResource() throws Exception {
+        final ModelNode loggingConfiguration = readDeploymentResource(DEPLOYMENT_NAME);
+        // The address should have jboss-log4j.xml
+        final LinkedList<Property> resultAddress = new LinkedList<>(Operations.getOperationAddress(loggingConfiguration).asPropertyList());
+        final String name = resultAddress.getLast().getValue().asString();
+        Assert.assertTrue("The configuration path did not include jboss-log4j.xml: " + name, name.endsWith("jboss-log4j.xml"));
+        Assert.assertTrue(loggingConfiguration.has("handler"));
+        // A log4j configuration cannot be defined in the model
+        Assert.assertFalse("No handlers should be defined", loggingConfiguration.get("handler").isDefined());
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLoggingPropertiesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/JBossLoggingPropertiesTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.logging.perdeploy;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,8 +29,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.LinkedList;
 
 import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -78,5 +82,27 @@ public class JBossLoggingPropertiesTestCase extends DeploymentBaseTestCase {
         }
         Assert.assertTrue("Log file should contain line: " + traceLine, trace);
         Assert.assertTrue("Log file should contain line: " + fatalLine, fatal);
+    }
+
+    @Test
+    public void testDeploymentConfigurationResource() throws Exception {
+        final ModelNode loggingConfiguration = readDeploymentResource(DEPLOYMENT_NAME);
+        // The address should have jboss-log4j.xml
+        final LinkedList<Property> resultAddress = new LinkedList<>(Operations.getOperationAddress(loggingConfiguration).asPropertyList());
+        Assert.assertTrue("The configuration path did not include jboss-logging.properties", resultAddress.getLast().getValue().asString().contains("jboss-logging.properties"));
+
+        final ModelNode handler = loggingConfiguration.get("handler", "FILE");
+        Assert.assertTrue("The FILE handler was not found effective configuration", handler.isDefined());
+        Assert.assertTrue(handler.hasDefined("properties"));
+        String fileName = null;
+        // Find the fileName property
+        for (Property property : handler.get("properties").asPropertyList()) {
+            if ("fileName".equals(property.getName())) {
+                fileName = property.getValue().asString();
+                break;
+            }
+        }
+        Assert.assertNotNull("fileName property not found", fileName);
+        Assert.assertTrue(fileName.endsWith("jboss-logging-properties-test.log"));
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/Log4jPropertiesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/Log4jPropertiesTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.logging.perdeploy;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,9 +29,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.LinkedList;
 
 import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.logging.Log4jServiceActivator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -79,5 +83,16 @@ public class Log4jPropertiesTestCase extends DeploymentBaseTestCase {
         }
         Assert.assertTrue("Log file should contain line: " + traceLine, trace);
         Assert.assertTrue("Log file should contain line: " + fatalLine, fatal);
+    }
+
+    @Test
+    public void testDeploymentConfigurationResource() throws Exception {
+        final ModelNode loggingConfiguration = readDeploymentResource(DEPLOYMENT_NAME);
+        // The address should have jboss-log4j.xml
+        final LinkedList<Property> resultAddress = new LinkedList<>(Operations.getOperationAddress(loggingConfiguration).asPropertyList());
+        Assert.assertTrue("The configuration path did not include log4j.properties", resultAddress.getLast().getValue().asString().contains("log4j.properties"));
+        Assert.assertTrue(loggingConfiguration.has("handler"));
+        // A log4j configuration cannot be defined in the model
+        Assert.assertFalse("No handlers should be defined", loggingConfiguration.get("handler").isDefined());
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/Log4jXmlTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/Log4jXmlTestCase.java
@@ -29,9 +29,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.logging.Log4jServiceActivator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -79,5 +84,16 @@ public class Log4jXmlTestCase extends DeploymentBaseTestCase {
         }
         Assert.assertTrue("Log file should contain line: " + traceLine, trace);
         Assert.assertTrue("Log file should contain line: " + fatalLine, fatal);
+    }
+
+    @Test
+    public void testDeploymentConfigurationResource() throws Exception {
+        final ModelNode loggingConfiguration = readDeploymentResource(DEPLOYMENT_NAME);
+        // The address should have jboss-log4j.xml
+        final LinkedList<Property> resultAddress = new LinkedList<>(Operations.getOperationAddress(loggingConfiguration).asPropertyList());
+        Assert.assertTrue("The configuration path did not include log4j.xml", resultAddress.getLast().getValue().asString().contains("log4j.xml"));
+        Assert.assertTrue(loggingConfiguration.has("handler"));
+        // A log4j configuration cannot be defined in the model
+        Assert.assertFalse("No handlers should be defined", loggingConfiguration.get("handler").isDefined());
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/LoggingPropertiesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/perdeploy/LoggingPropertiesTestCase.java
@@ -29,8 +29,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.LinkedList;
 
 import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -78,6 +82,28 @@ public class LoggingPropertiesTestCase extends DeploymentBaseTestCase {
         }
         Assert.assertTrue("Log file should contain line: " + traceLine, trace);
         Assert.assertTrue("Log file should contain line: " + fatalLine, fatal);
+    }
+
+    @Test
+    public void testDeploymentConfigurationResource() throws Exception {
+        final ModelNode loggingConfiguration = readDeploymentResource(DEPLOYMENT_NAME);
+        // The address should have jboss-log4j.xml
+        final LinkedList<Property> resultAddress = new LinkedList<>(Operations.getOperationAddress(loggingConfiguration).asPropertyList());
+        Assert.assertTrue("The configuration path did not include logging.properties", resultAddress.getLast().getValue().asString().contains("logging.properties"));
+
+        final ModelNode handler = loggingConfiguration.get("handler", "FILE");
+        Assert.assertTrue("The FILE handler was not found effective configuration", handler.isDefined());
+        Assert.assertTrue(handler.hasDefined("properties"));
+        String fileName = null;
+        // Find the fileName property
+        for (Property property : handler.get("properties").asPropertyList()) {
+            if ("fileName".equals(property.getName())) {
+                fileName = property.getValue().asString();
+                break;
+            }
+        }
+        Assert.assertNotNull("fileName property not found", fileName);
+        Assert.assertTrue(fileName.endsWith("logging-properties-test.log"));
     }
 
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/NonExistingProfileTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/NonExistingProfileTestCase.java
@@ -21,7 +21,7 @@
  */
 package org.jboss.as.test.integration.logging.profiles;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -54,6 +54,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
 public class NonExistingProfileTestCase extends AbstractLoggingTestCase {
 
     private static final String LOG_FILE_NAME = "non-existing-profile-test.log";
+    private static final String RUNTIME_NAME = "test-logging.jar";
     private static final Path loggingTestLog = Paths.get(resolveRelativePath("jboss.server.log.dir"), LOG_FILE_NAME);
 
     static class NonExistingProfileTestCaseSetup implements ServerSetupTask {
@@ -100,7 +101,7 @@ public class NonExistingProfileTestCase extends AbstractLoggingTestCase {
 
     @BeforeClass
     public static void deploy() throws Exception {
-        deploy(createDeployment(Collections.singletonMap("Logging-Profile", "non-existing-profile")), "test-logging.jar");
+        deploy(createDeployment(Collections.singletonMap("Logging-Profile", "non-existing-profile")), RUNTIME_NAME);
     }
 
     @AfterClass
@@ -141,5 +142,17 @@ public class NonExistingProfileTestCase extends AbstractLoggingTestCase {
             }
         }
         Assert.assertTrue(logFound);
+    }
+
+    @Test
+    public void testDeploymentConfigurationResource() throws Exception {
+        // Get the resulting model
+        final ModelNode loggingConfiguration = readDeploymentResource(RUNTIME_NAME, "default");
+
+        Assert.assertTrue("No logging subsystem resource found on the deployment", loggingConfiguration.isDefined());
+
+        // Check the handler exists on the configuration
+        final ModelNode handler = loggingConfiguration.get("handler", "CONSOLE");
+        Assert.assertTrue("The CONSOLE handler was not found effective configuration", handler.isDefined());
     }
 }


### PR DESCRIPTION
Adds a runtime resource to a deployment in an attempt to display the logging configuration a deployment is using. Note that the resulting configuration may not be used on deployments that provide their own log manager, such as deployments that use logback. The resource displayed for these deployments will likely be the `default` resource.

Example:
```
        {
            "address" => [
                ("deployment" => "ear.ear"),
                ("subdeployment" => "logging-profile.war"),
                ("subsystem" => "logging")
            ],
            "outcome" => "success",
            "result" => {"configuration" => {"ear.ear/META-INF/logging.properties" => {
                "error-manager" => undefined,
                "filter" => undefined,
                "formatter" => {"PATTERN" => {
                    "class-name" => "org.jboss.logmanager.formatters.PatternFormatter",
                    "module" => undefined,
                    "properties" => {"pattern" => "[DEPLOYMENT] %d{HH:mm:ss,SSS} %-5p [%c] %s%e%n"}
                }},
                "handler" => {"CONSOLE" => {
                    "class-name" => "org.jboss.logmanager.handlers.FileHandler",
                    "encoding" => undefined,
                    "error-manager" => undefined,
                    "filter" => undefined,
                    "formatter" => "PATTERN",
                    "handlers" => [],
                    "level" => "INFO",
                    "module" => undefined,
                    "properties" => {
                        "autoFlush" => "true",
                        "append" => "false",
                        "fileName" => "/home/jperkins/projects/jboss/wildfly/wildfly/build/target/wildfly-10.0.0.Alpha5-SNAPSHOT/standalone/log/test.log"
                    }
                }},
                "logger" => {"ROOT" => {
                    "filter" => undefined,
                    "handlers" => ["CONSOLE"],
                    "level" => "INFO",
                    "use-parent-handlers" => undefined
                }},
                "pojo" => undefined
            }}}
        },
        {
            "address" => [
                ("deployment" => "ear.ear"),
                ("subdeployment" => "log4j.war"),
                ("subsystem" => "logging")
            ],
            "outcome" => "success",
            "result" => {"configuration" => {"log4j.war/WEB-INF/classes/log4j.properties" => {
                "error-manager" => undefined,
                "filter" => undefined,
                "formatter" => undefined,
                "handler" => undefined,
                "logger" => undefined,
                "pojo" => undefined
            }}}
        }
```

In the above example the deployment, `ear.ear`, has defined a logging-profile. The `logging-profile.war` sub-deployment uses this configuration where as the `log4j.war` uses it's own. 

The `configuration` value also shows which configuration the deployment, or sub-deployment, is using. The values are 
  * `default` if the deployment is using the logging subsystem configuration
  * `profile-$PROFILE_NAME` if the deployment is using a logging profile
  * Or the path the configuration file being used

It may make sense to remove the `profile-` prefix but seemed it would be useful at the same time to see which deployments may be using a logging-profiles.