### PR TITLE
[WFCORE-754] : WildFly fails to start with -bmanagement= option and with specific IP settings

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryService.java
@@ -101,7 +101,7 @@ class ServerInventoryService implements Service<ServerInventory> {
         ROOT_LOGGER.debug("Starting Host Controller Server Inventory");
         try {
             final ProcessControllerConnectionService processControllerConnectionService = client.getValue();
-            URI managementURI = new URI(protocol, null, NetworkUtils.formatPossibleIpv6Address(interfaceBinding.getValue().getAddress().getHostName()), port, null, null, null);
+            URI managementURI = new URI(protocol, null, NetworkUtils.formatAddress(interfaceBinding.getValue().getAddress()), port, null, null, null);
             serverInventory = new ServerInventoryImpl(domainController, environment, managementURI, processControllerConnectionService.getClient(), extensionRegistry);
             processControllerConnectionService.setServerInventory(serverInventory);
             serverCallback.getValue().setCallbackHandler(serverInventory.getServerCallbackHandler());


### PR DESCRIPTION
Wrong usage of address.getHostName() before formatting address to IPv6.

Jira: https://issues.jboss.org/browse/WFCORE-754
Upstream: https://github.com/wildfly/wildfly-core/pull/820