### PR TITLE
[WFCORE-769] : Boot errors should hide the failure description if the failing operation is not accessible

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -771,7 +771,7 @@ abstract class AbstractOperationContext implements OperationContext {
 
     private void addBootFailureDescription() {
         if (isBooting() && activeStep != null && activeStep.response.hasDefined(FAILURE_DESCRIPTION)) {
-            controller.addFailureDescription(activeStep.operation, activeStep.response.get(FAILURE_DESCRIPTION).clone());
+            controller.addFailureDescription(activeStep.operation.clone(), activeStep.response.get(FAILURE_DESCRIPTION).clone());
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/BootErrorCollectorTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/BootErrorCollectorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.controller;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.jboss.as.controller.access.Action.ActionEffect.READ_CONFIG;
+import static org.jboss.as.controller.access.Action.ActionEffect.READ_RUNTIME;
+import static org.jboss.as.controller.access.Action.ActionEffect.ADDRESS;
+import static org.jboss.as.controller.access.Action.ActionEffect.WRITE_CONFIG;
+import static org.jboss.as.controller.access.Action.ActionEffect.WRITE_RUNTIME;
+import static org.jboss.as.controller.registry.OperationEntry.Flag.RUNTIME_ONLY;
+import static org.jboss.as.controller.registry.OperationEntry.Flag.READ_ONLY;
+import static org.junit.Assert.assertThat;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import org.jboss.as.controller.access.Action;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class BootErrorCollectorTest {
+
+    public BootErrorCollectorTest() {
+    }
+
+    /**
+     * Test of getReadBootErrorsHandler method, of class BootErrorCollector.
+     */
+    @Test
+    public void testGetEffects() throws Exception {
+        BootErrorCollector instance = new BootErrorCollector();
+        BootErrorCollector.ListBootErrorsHandler handler = (BootErrorCollector.ListBootErrorsHandler) instance.getReadBootErrorsHandler();
+        assertThat(handler, is(notNullValue()));
+        OperationEntry entry = createOperationEntry(EnumSet.of(READ_ONLY));
+        Set<Action.ActionEffect> effects = handler.getEffects(entry);
+        assertThat(effects.size(), is(3));
+        assertThat(effects, hasItems(ADDRESS, READ_CONFIG, READ_RUNTIME));
+        entry = createOperationEntry(EnumSet.of(READ_ONLY, RUNTIME_ONLY));
+        effects = handler.getEffects(entry);
+        assertThat(effects.size(), is(2));
+        assertThat(effects, hasItems(ADDRESS, READ_RUNTIME));
+        entry = createOperationEntry(EnumSet.noneOf(OperationEntry.Flag.class));
+        effects = handler.getEffects(entry);
+        assertThat(effects.size(), is(5));
+        assertThat(effects, hasItems(ADDRESS, READ_CONFIG, READ_RUNTIME, WRITE_CONFIG, WRITE_RUNTIME));
+        entry = createOperationEntry(EnumSet.of(RUNTIME_ONLY));
+        effects = handler.getEffects(entry);
+        assertThat(effects.size(), is(3));
+        assertThat(effects, hasItems(ADDRESS, READ_RUNTIME, WRITE_RUNTIME));
+    }
+
+    private OperationEntry createOperationEntry(EnumSet<OperationEntry.Flag> flags) throws NoSuchMethodException,
+            SecurityException, InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        Constructor<OperationEntry> constructor = OperationEntry.class.getDeclaredConstructor(OperationStepHandler.class, DescriptionProvider.class,
+                boolean.class, OperationEntry.EntryType.class, EnumSet.class, List.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(null, null, false, OperationEntry.EntryType.PUBLIC, flags, Collections.emptyList());
+    }
+}


### PR DESCRIPTION
Checking the operation that failed to hide or show failure description.

Jira: https://issues.jboss.org/browse/WFCORE-769