### PR TITLE
[WFCORE-778] Don't register a default io worker requirement on an HC if no endpoint was configured

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityReferenceRecorder.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityReferenceRecorder.java
@@ -35,7 +35,7 @@ public interface CapabilityReferenceRecorder {
      * Registers capability requirement information to the given context.
      * @param context the context
      * @param attributeName the name of the attribute
-     * @param attributeValue the values of the attribute
+     * @param attributeValues the values of the attribute
      */
     void addCapabilityRequirements(OperationContext context, String attributeName, String... attributeValues);
 
@@ -43,7 +43,7 @@ public interface CapabilityReferenceRecorder {
      * Deregisters capability requirement information from the given context.
      * @param context the context
      * @param attributeName the name of the attribute
-     * @param attributeValue the values of the attribute
+     * @param attributeValues the values of the attribute
      */
     void removeCapabilityRequirements(OperationContext context, String attributeName, String... attributeValues);
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/WorkerThreadPoolVsEndpointHandler.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/WorkerThreadPoolVsEndpointHandler.java
@@ -87,7 +87,11 @@ class WorkerThreadPoolVsEndpointHandler implements OperationStepHandler {
             context.addResource(PathAddress.pathAddress(RemotingEndpointResource.ENDPOINT_PATH), Resource.Factory.create());
 
             // Record the requirement of the default xnio worker
-            RemotingEndpointResource.WORKER.addCapabilityRequirements(context, new ModelNode()); // use an undefined node to WORKER will use its default value
+            // WFCORE-778 don't do this on an HC so we won't mistakenly trigger a requirement
+            // in a profile meant for servers that don't have the io subsystem
+            if (context.getProcessType().isServer()) {
+                RemotingEndpointResource.WORKER.addCapabilityRequirements(context, new ModelNode()); // use an undefined node so WORKER will use its default value
+            }
         }
     }
 }


### PR DESCRIPTION
This is a minimal impact workaround to the problem.

In versions prior to the IO subsystem, the "endpoint" element in the remoting subsystem configuration did not exist. So I am using the absence of a configuration=endpoint resource as an indication that the subsystem is meant to be used in a profile that does not support IO. If it doesn't exist, this patch avoids adding the org.wildfly.io.worker.default requirement on an HC. It will still be added on a current version server, so the possibility remains that the profile will validate on the HC but will later fail on a server.

Our standard configs since 8.0 have included the following in the remoting subsystem:

```
<endpoint worker="default"/>
```

That means any config based on those will have the configuration=endpoint resource. So the likelihood of a domain profile with an invalid config is small. It would mean a user chose to remove that element.

I have verified that the xml marshaller for remoting will not marshal a default 'endpoint' element based on the presence of the placeholder resource created by the WorkerThreadPoolVsEndpointHandler OSH (the one modified by this commit.) So persistence of the xml due to some unrelated change will not result in that element suddenly appearing and problem on subsequent reload/restart.