### PR TITLE
[WFCORE-780] Let ServiceRemoveStepHandler use provided capabilities t…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ServiceRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ServiceRemoveStepHandler.java
@@ -8,27 +8,48 @@ import org.jboss.msc.service.ServiceName;
  * Abstract remove step handler that simply removes a service. If the operation is rolled
  * back it delegates the rollback to the corresponding add operations
  * {@link AbstractAddStepHandler#performRuntime(OperationContext, org.jboss.dmr.ModelNode, org.jboss.dmr.ModelNode)}
- * method
+ * method.
  *
  * @author Stuart Douglas
  */
 public class ServiceRemoveStepHandler extends AbstractRemoveStepHandler {
 
+    private static final RuntimeCapability[] NO_CAPABILITIES = new RuntimeCapability[0];
     private final ServiceName baseServiceName;
     private final AbstractAddStepHandler addOperation;
+    private final RuntimeCapability[] unavailableCapabilities;
 
+    /**
+     * Creates a {@code ServiceRemoveStepHandler}.
+     * @param baseServiceName base name to remove. Cannot be {@code null} unless {@code unavailableCapabilities} are provided
+     * @param addOperation the add operation to use to rollback service removal. Cannot be {@code null}
+     * @param unavailableCapabilities capabilities that will no longer be available once the remove occurs. Any services
+     *          {@link RuntimeCapability#getCapabilityServiceValueTypes() exposed by the capabilities} will also be removed
+     */
     public ServiceRemoveStepHandler(final ServiceName baseServiceName, final AbstractAddStepHandler addOperation, final RuntimeCapability ... unavailableCapabilities) {
         super(unavailableCapabilities);
         this.baseServiceName = baseServiceName;
         this.addOperation = addOperation;
+        this.unavailableCapabilities = unavailableCapabilities;
     }
 
+    /**
+     * Creates a {@code ServiceRemoveStepHandler}.
+     * @param baseServiceName base name to remove. Cannot be {@code null}
+     * @param addOperation the add operation to use to rollback service removal. Cannot be {@code null}
+     */
     public ServiceRemoveStepHandler(final ServiceName baseServiceName, final AbstractAddStepHandler addOperation) {
-        this.baseServiceName = baseServiceName;
-        this.addOperation = addOperation;
+        this(baseServiceName, addOperation, NO_CAPABILITIES);
     }
 
-    protected ServiceRemoveStepHandler(final AbstractAddStepHandler addOperation, final RuntimeCapability ... unavailableCapabilities) {
+    /**
+     * Creates a {@code ServiceRemoveStepHandler}.
+     * @param addOperation the add operation to use to rollback service removal. Cannot be {@code null}
+     * @param unavailableCapabilities capabilities that will no longer be available once the remove occurs. Any services
+     *          {@link RuntimeCapability#getCapabilityServiceValueTypes() exposed by the capabilities} will also be removed.
+     *          Cannot be {@code null} or empty.
+     */
+    public ServiceRemoveStepHandler(final AbstractAddStepHandler addOperation, final RuntimeCapability ... unavailableCapabilities) {
         this(null, addOperation, unavailableCapabilities);
     }
 
@@ -36,12 +57,42 @@ public class ServiceRemoveStepHandler extends AbstractRemoveStepHandler {
         this(null, addOperation);
     }
 
+    /**
+     * If the {@link OperationContext#isResourceServiceRestartAllowed() context allows resource removal},
+     * removes services; otherwise puts the process in reload-required state. The following services are
+     * removed:
+     * <ul>
+     *     <li>The service named by the value returned from {@link #serviceName(String, PathAddress)}, if there is one</li>
+     *     <li>The service names associated with any {@code unavailableCapabilities}
+     *         passed to the constructor.</li>
+     * </ul>
+     *
+     * {@inheritDoc}
+     */
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
         if (context.isResourceServiceRestartAllowed()) {
+
             final PathAddress address = context.getCurrentAddress();
             final String name = address.getLastElement().getValue();
-            context.removeService(serviceName(name, address));
+
+            ServiceName nonCapabilityServiceName = serviceName(name, address);
+            if (nonCapabilityServiceName != null) {
+                context.removeService(serviceName(name, address));
+            }
+
+            for (RuntimeCapability<?> capability : unavailableCapabilities) {
+                boolean dynamic = capability.isDynamicallyNamed();
+                for (Class valueType : capability.getCapabilityServiceValueTypes()) {
+                    ServiceName sname;
+                    if (dynamic) {
+                        sname = getCapabilityRemovedServiceName(capability, name, valueType);
+                    } else {
+                        sname = getCapabilityRemovedServiceName(capability, valueType);
+                    }
+                    context.removeService(sname);
+                }
+            }
         } else {
             context.reloadRequired();
         }
@@ -51,7 +102,8 @@ public class ServiceRemoveStepHandler extends AbstractRemoveStepHandler {
      * The service name to be removed. Can be overridden for unusual service naming patterns
      * @param name The name of the resource being removed
      * @param address The address of the resource being removed
-     * @return The service name to remove
+     * @return The service name to remove. May return {@code null} if only removal based on {@code unavailableCapabilities}
+     *         passed to the constructor are to be performed
      */
     protected ServiceName serviceName(String name, PathAddress address) {
         return serviceName(name);
@@ -60,12 +112,20 @@ public class ServiceRemoveStepHandler extends AbstractRemoveStepHandler {
     /**
      * The service name to be removed. Can be overridden for unusual service naming patterns
      * @param name The name of the resource being removed
-     * @return The service name to remove
+     * @return The service name to remove. May return {@code null} if only removal based on {@code unavailableCapabilities}
+     *         passed to the constructor are to be performed
      */
     protected ServiceName serviceName(final String name) {
-        return baseServiceName.append(name);
+        return baseServiceName != null ? baseServiceName.append(name) : null;
     }
 
+    /**
+     * If the {@link OperationContext#isResourceServiceRestartAllowed() context allows resource removal},
+     * attempts to restore services by invoking the {@code performRuntime} method on the @{code addOperation}
+     * handler passed to the constructor; otherwise puts the process in reload-required state.
+     *
+     * {@inheritDoc}
+     */
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         if (context.isResourceServiceRestartAllowed()) {
             addOperation.performRuntime(context, operation, model);

--- a/controller/src/main/java/org/jboss/as/controller/capability/RuntimeCapability.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/RuntimeCapability.java
@@ -163,6 +163,15 @@ public class RuntimeCapability<T> extends AbstractCapability  {
     }
 
     /**
+     * Gets the valid types to pass to {@link #getCapabilityServiceName(Class)}.
+     *
+     * @return  the valid types. Will not be {@code null} but may be empty
+     */
+    public Set<Class<?>> getCapabilityServiceValueTypes() {
+        return serviceNameProvider.getServiceValueTypes();
+    }
+
+    /**
      * Object encapsulating the API exposed by this capability to other capabilities that require it, if it does
      * expose such an API.
      *

--- a/controller/src/main/java/org/jboss/as/controller/capability/ServiceNameProvider.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/ServiceNameProvider.java
@@ -24,6 +24,7 @@ package org.jboss.as.controller.capability;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.msc.service.ServiceName;
@@ -63,6 +64,15 @@ public interface ServiceNameProvider {
     ServiceName getCapabilityServiceName(Class<?> serviceType, String dynamicPortion);
 
     /**
+     * Gets the value types of the services for which this object provides services names.
+     * These are the valid values to pass as the {@code serviceType} parameter to the
+     * {@code getCapabilityServiceName} methods.
+     *
+     * @return the types. Will not be {@code null} but may be empty.
+     */
+    Set<Class<?>> getServiceValueTypes();
+
+    /**
      * Default {@link ServiceNameProvider} implementation that provides
      * a service name that is created by splitting the capability name
      * on any '.' character.
@@ -82,7 +92,7 @@ public interface ServiceNameProvider {
         }
 
         private final String capabilityName;
-        private final Map<Class, ServiceName> serviceNames;
+        private final Map<Class<?>, ServiceName> serviceNames;
 
         /**
          * Creates a provider for the given capability that provides no service names.
@@ -110,7 +120,7 @@ public interface ServiceNameProvider {
          * @param capabilityName the capability name. Cannot be {@code null} or empty
          * @param services the mapping of valid types to services names. Cannot be {@code null}, but can be empty
          */
-        public DefaultProvider(String capabilityName, Map<Class, ServiceName> services) {
+        public DefaultProvider(String capabilityName, Map<Class<?>, ServiceName> services) {
             assert capabilityName != null;
             assert services != null;
             this.capabilityName = capabilityName;
@@ -122,7 +132,7 @@ public interface ServiceNameProvider {
             assert serviceType != null;
             ServiceName result = serviceNames.get(serviceType);
             if (result == null) {
-                for (Map.Entry<Class, ServiceName> entry : serviceNames.entrySet()) {
+                for (Map.Entry<Class<?>, ServiceName> entry : serviceNames.entrySet()) {
                     if (serviceType.isAssignableFrom(entry.getKey())) {
                         return entry.getValue();
                     }
@@ -140,6 +150,11 @@ public interface ServiceNameProvider {
                 throw ControllerLogger.MGMT_OP_LOGGER.nullVar("dynamicPortion");
             }
             return getCapabilityServiceName(serviceType).append(dynamicPortion);
+        }
+
+        @Override
+        public Set<Class<?>> getServiceValueTypes() {
+            return Collections.unmodifiableSet(serviceNames.keySet());
         }
     }
 }


### PR DESCRIPTION
…o figure out the names of services to remove

This also adds helper methods to AbstractRemoveStepHandler to help impls find out service names for the capability they are removing in Stage.RUNTIME. Using OperationContext.getCapabilityServiceName does not work for that, as by the time that call is made in RUNTIME, the capability was removed in MODEL, so the call fails. I'm considering adding some logic to OperationContextImpl to detect and work around that, but that would be more complex and the first commit here I think works reasonably enough.