### PR TITLE
[WFCORE-764] Remove the deprecated methods relating to ordered child …

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
@@ -173,10 +173,6 @@ public class AbstractAddStepHandler implements OperationStepHandler {
      * @param operation the operation
      */
     protected Resource createResource(final OperationContext context, final ModelNode operation) {
-        ResourceCreator resourceCreator = getResourceCreator();
-        if (resourceCreator != null) {
-            return resourceCreator.createResource(context, operation);
-        }
         ImmutableManagementResourceRegistration registration = context.getResourceRegistration();
         if (registration != null) {
             Set<String> orderedChildTypes = registration.getOrderedChildTypes();
@@ -433,21 +429,9 @@ public class AbstractAddStepHandler implements OperationStepHandler {
     }
 
     /**
-     * Allows overriding of the standard resource creation. If {@code null} is returned, the
-     * standard resource creation mechanism will be used.
-     *
-     * @return the custom resource creator
-     * @deprecated This handler is now smart enough to figure it out itself
-     */
-    @Deprecated
-    protected ResourceCreator getResourceCreator() {
-        return null;
-    }
-
-    /**
      * Interface to handle custom resource creation
      */
-    protected interface ResourceCreator {
+    private interface ResourceCreator {
         /**
          * Create a resource
          *
@@ -462,7 +446,7 @@ public class AbstractAddStepHandler implements OperationStepHandler {
      * and putting the ordered children in the correct place in the parent
      *
      */
-    protected class OrderedResourceCreator implements ResourceCreator {
+    private class OrderedResourceCreator implements ResourceCreator {
         private final Set<String> orderedChildTypes;
         private final boolean indexedAdd;
 

--- a/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
@@ -441,16 +441,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
      */
     @SuppressWarnings("deprecation")
     public boolean isOrderedChild() {
-        return orderedChild || isOrderedChildResource();
-    }
-
-    /**
-     *
-     * @deprecated Use the constructor variants
-     */
-    @Deprecated
-    protected boolean isOrderedChildResource() {
-        return false;
+        return orderedChild;
     }
 
     /**


### PR DESCRIPTION
…resource. Hide the ordered child resource creator, this was simplified in PRs #813 and #821 

For this to work with the core integration tests, https://github.com/wildfly/wildfly/pull/7668 will need to be merged first.