### PR TITLE
Remove uses of the legacy service names for SocketBinding and OutboundSocketBinding

### DIFF
--- a/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
@@ -60,9 +60,10 @@ import org.jboss.dmr.ModelType;
  */
 public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
 
+    public static final String SOCKET_BINDING_CAPABILITY_NAME = "org.wildfly.network.socket-binding";
     private static final String RUNTIME_CAPABILITY_NAME = "org.wildfly.management.http-interface";
-    public static final RuntimeCapability<Void> HTTP_MANAGEMENT_CAPABILITY = RuntimeCapability.Builder
-            .of(RUNTIME_CAPABILITY_NAME).build();
+    public static final RuntimeCapability<Void> HTTP_MANAGEMENT_CAPABILITY = RuntimeCapability.Builder.of(RUNTIME_CAPABILITY_NAME)
+            .build();
 
     private static final PathElement RESOURCE_PATH = PathElement.pathElement(MANAGEMENT_INTERFACE, HTTP_INTERFACE);
 
@@ -76,6 +77,7 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
             .setXmlName(Attribute.HTTP.getLocalName())
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
             .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SOCKET_CONFIG))
+            .setCapabilityReference(SOCKET_BINDING_CAPABILITY_NAME, RUNTIME_CAPABILITY_NAME, false)
             .build();
 
     public static final SimpleAttributeDefinition SECURE_SOCKET_BINDING = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SECURE_SOCKET_BINDING, ModelType.STRING, true)
@@ -83,6 +85,7 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
             .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SOCKET_CONFIG))
             .setRequires(SECURITY_REALM.getName())
+            .setCapabilityReference(SOCKET_BINDING_CAPABILITY_NAME, RUNTIME_CAPABILITY_NAME, false)
             .build();
 
     public static final SimpleAttributeDefinition CONSOLE_ENABLED = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.CONSOLE_ENABLED, ModelType.BOOLEAN, true)

--- a/server/src/main/java/org/jboss/as/server/mgmt/NativeManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/NativeManagementResourceDefinition.java
@@ -58,6 +58,7 @@ import org.jboss.dmr.ModelType;
  */
 public class NativeManagementResourceDefinition extends SimpleResourceDefinition {
 
+    public static final String SOCKET_BINDING_CAPABILITY_NAME = "org.wildfly.network.socket-binding";
     private static final String RUNTIME_CAPABILITY_NAME = "org.wildfly.management.native-interface";
     public static final RuntimeCapability<Void> NATIVE_MANAGEMENT_CAPABILITY = RuntimeCapability.Builder
             .of(RUNTIME_CAPABILITY_NAME).build();
@@ -77,6 +78,7 @@ public class NativeManagementResourceDefinition extends SimpleResourceDefinition
             .setAlternatives(ModelDescriptionConstants.INTERFACE)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .addAccessConstraint(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SOCKET_CONFIG))
+            .setCapabilityReference(SOCKET_BINDING_CAPABILITY_NAME, RUNTIME_CAPABILITY_NAME, false)
             .build();
 
     public static final SimpleAttributeDefinition SERVER_NAME = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SERVER_NAME, ModelType.STRING, true)

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
@@ -27,6 +27,8 @@ import static org.jboss.as.server.mgmt.HttpManagementResourceDefinition.HTTP_MAN
 import static org.jboss.as.server.mgmt.HttpManagementResourceDefinition.SECURE_SOCKET_BINDING;
 import static org.jboss.as.server.mgmt.HttpManagementResourceDefinition.SECURITY_REALM;
 import static org.jboss.as.server.mgmt.HttpManagementResourceDefinition.SOCKET_BINDING;
+import static org.jboss.as.server.mgmt.HttpManagementResourceDefinition.SOCKET_BINDING_CAPABILITY_NAME;
+
 import io.undertow.server.ListenerRegistry;
 
 import java.util.List;
@@ -115,12 +117,12 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler {
         final ModelNode socketBindingNode = SOCKET_BINDING.resolveModelAttribute(context, model);
         if (socketBindingNode.isDefined()) {
             final String bindingName = socketBindingNode.asString();
-            socketBindingServiceName = SocketBinding.JBOSS_BINDING_NAME.append(bindingName);
+            socketBindingServiceName = context.getCapabilityServiceName(SOCKET_BINDING_CAPABILITY_NAME, bindingName, SocketBinding.class);
         }
         final ModelNode secureSocketBindingNode = SECURE_SOCKET_BINDING.resolveModelAttribute(context, model);
         if (secureSocketBindingNode.isDefined()) {
             final String bindingName = secureSocketBindingNode.asString();
-            secureSocketBindingServiceName = SocketBinding.JBOSS_BINDING_NAME.append(bindingName);
+            secureSocketBindingServiceName = context.getCapabilityServiceName(SOCKET_BINDING_CAPABILITY_NAME, bindingName, SocketBinding.class);
         }
 
         // Log the config

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
@@ -26,6 +26,7 @@ import static org.jboss.as.server.mgmt.NativeManagementResourceDefinition.ATTRIB
 import static org.jboss.as.server.mgmt.NativeManagementResourceDefinition.NATIVE_MANAGEMENT_CAPABILITY;
 import static org.jboss.as.server.mgmt.NativeManagementResourceDefinition.SECURITY_REALM;
 import static org.jboss.as.server.mgmt.NativeManagementResourceDefinition.SOCKET_BINDING;
+import static org.jboss.as.server.mgmt.NativeManagementResourceDefinition.SOCKET_BINDING_CAPABILITY_NAME;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
@@ -82,7 +83,7 @@ public class NativeManagementAddHandler extends AbstractAddStepHandler {
     static void installNativeManagementConnector(final OperationContext context, final ModelNode model, final ServiceName endpointName, final ServiceTarget serviceTarget) throws OperationFailedException {
 
         final String bindingName = SOCKET_BINDING.resolveModelAttribute(context, model).asString();
-        ServiceName socketBindingServiceName = SocketBinding.JBOSS_BINDING_NAME.append(bindingName);
+        ServiceName socketBindingServiceName = context.getCapabilityServiceName(SOCKET_BINDING_CAPABILITY_NAME, bindingName, SocketBinding.class);
 
         String securityRealm = null;
         final ModelNode realmNode = SECURITY_REALM.resolveModelAttribute(context, model);

--- a/server/src/main/java/org/jboss/as/server/services/net/BindingAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingAddHandler.java
@@ -21,6 +21,7 @@ package org.jboss.as.server.services.net;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CLIENT_MAPPINGS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESTINATION_ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;

--- a/server/src/main/java/org/jboss/as/server/services/net/BindingMetricHandlers.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingMetricHandlers.java
@@ -22,16 +22,14 @@
 
 package org.jboss.as.server.services.net;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY;
 
 import java.net.InetAddress;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
@@ -50,21 +48,19 @@ import org.jboss.msc.service.ServiceName;
  */
 public final class BindingMetricHandlers {
 
-    private static final ServiceName SOCKET_BINDING = SocketBinding.JBOSS_BINDING_NAME;
-
     abstract static class AbstractBindingMetricsHandler implements OperationStepHandler {
 
         /** {@inheritDoc} */
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
-            final PathElement element = address.getLastElement();
 
             context.addStep(new OperationStepHandler() {
                 @Override
                 public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
                     final ModelNode result = context.getResult();
-                    final ServiceController<?> controller = context.getServiceRegistry(false).getRequiredService(SOCKET_BINDING.append(element.getValue()));
+                    final String name = context.getCurrentAddressValue();
+                    ServiceName svcName = SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(name, SocketBinding.class);
+                    final ServiceController<?> controller = context.getServiceRegistry(false).getRequiredService(svcName);
                     if(controller != null && controller.getState() == ServiceController.State.UP) {
                         final SocketBinding binding = SocketBinding.class.cast(controller.getValue());
                         AbstractBindingMetricsHandler.this.execute(operation, binding, result);

--- a/server/src/main/java/org/jboss/as/server/services/net/BindingRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingRemoveHandler.java
@@ -21,14 +21,12 @@
  */
 package org.jboss.as.server.services.net;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY;
 
 import java.net.UnknownHostException;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -52,23 +50,21 @@ public class BindingRemoveHandler extends SocketBindingRemoveHandler {
     }
 
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
-        PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-        String name = address.getLastElement().getValue();
-        ServiceName svcName = SocketBinding.JBOSS_BINDING_NAME.append(name);
+        String name = context.getCurrentAddressValue();
+        ServiceName svcName = SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(name);
         ServiceRegistry registry = context.getServiceRegistry(true);
         ServiceController<?> controller = registry.getService(svcName);
         ServiceController.Substate substate = controller == null ? null : controller.getSubstate();
         if (!context.isResourceServiceRestartAllowed() || (substate != null && substate.getState() == ServiceController.State.UP && substate.isRestState())) {
             context.reloadRequired();
         } else {
-            context.removeService(SocketBinding.JBOSS_BINDING_NAME.append(name));
+            context.removeService(svcName);
         }
     }
 
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-        String name = address.getLastElement().getValue();
-        ServiceName svcName = SocketBinding.JBOSS_BINDING_NAME.append(name);
+        String name = context.getCurrentAddressValue();
+        ServiceName svcName = SOCKET_BINDING_CAPABILITY.getCapabilityServiceName(name);
         ServiceRegistry registry = context.getServiceRegistry(true);
         ServiceController<?> controller = registry.getService(svcName);
         if (controller != null) {

--- a/server/src/main/java/org/jboss/as/server/services/net/LocalDestinationOutboundSocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/LocalDestinationOutboundSocketBindingResourceDefinition.java
@@ -32,7 +32,6 @@ import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -60,7 +59,7 @@ public class LocalDestinationOutboundSocketBindingResourceDefinition extends Out
         super(PathElement.pathElement(ModelDescriptionConstants.LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING),
                 ControllerResolver.getResolver(ModelDescriptionConstants.LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING),
                 LocalDestinationOutboundSocketBindingAddHandler.INSTANCE,
-                new ServiceRemoveStepHandler(OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME, LocalDestinationOutboundSocketBindingAddHandler.INSTANCE,
+                new ServiceRemoveStepHandler(LocalDestinationOutboundSocketBindingAddHandler.INSTANCE,
                         OUTBOUND_SOCKET_BINDING_CAPABILITY));
     }
 

--- a/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/RemoteDestinationOutboundSocketBindingResourceDefinition.java
@@ -32,7 +32,6 @@ import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -64,7 +63,7 @@ public class RemoteDestinationOutboundSocketBindingResourceDefinition extends Ou
         super(PATH,
                 ControllerResolver.getResolver(ModelDescriptionConstants.REMOTE_DESTINATION_OUTBOUND_SOCKET_BINDING),
                 RemoteDestinationOutboundSocketBindingAddHandler.INSTANCE,
-                new ServiceRemoveStepHandler(OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME, RemoteDestinationOutboundSocketBindingAddHandler.INSTANCE,
+                new ServiceRemoveStepHandler(RemoteDestinationOutboundSocketBindingAddHandler.INSTANCE,
                         OUTBOUND_SOCKET_BINDING_CAPABILITY));
     }
 

--- a/server/src/main/java/org/jboss/as/server/services/net/SocketBindingAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SocketBindingAddHandler.java
@@ -32,11 +32,9 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.resource.AbstractSocketBindingResourceDefinition;
-import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -71,18 +69,13 @@ public class SocketBindingAddHandler extends AbstractAddStepHandler {
         return op;
     }
 
-    static final String SOCKET_BINDING_CAPABILITY_NAME = "org.wildfly.network.socket-binding";
-    static final RuntimeCapability<Void> SOCKET_BINDING_CAPABILITY =
-            RuntimeCapability.Builder.of(SOCKET_BINDING_CAPABILITY_NAME, true, SocketBinding.class)
-                    .build(); // TODO require interface capability
-
     public static final SocketBindingAddHandler INSTANCE = new SocketBindingAddHandler();
 
     /**
      * Create the SocketBindingAddHandler
      */
     protected SocketBindingAddHandler() {
-        super(SOCKET_BINDING_CAPABILITY);
+        super(SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY);
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/services/net/SocketBindingRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SocketBindingRemoveHandler.java
@@ -38,6 +38,6 @@ public class SocketBindingRemoveHandler extends AbstractRemoveStepHandler {
      * Create the SocketBindingRemoveHandler
      */
     protected SocketBindingRemoveHandler() {
-        super(SocketBindingAddHandler.SOCKET_BINDING_CAPABILITY);
+        super(SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/SocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SocketBindingResourceDefinition.java
@@ -27,10 +27,12 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.resource.AbstractSocketBindingResourceDefinition;
+import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -40,6 +42,11 @@ import org.jboss.dmr.ModelType;
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
 public class SocketBindingResourceDefinition extends AbstractSocketBindingResourceDefinition {
+
+    static final String SOCKET_BINDING_CAPABILITY_NAME = "org.wildfly.network.socket-binding";
+    static final RuntimeCapability<Void> SOCKET_BINDING_CAPABILITY =
+            RuntimeCapability.Builder.of(SOCKET_BINDING_CAPABILITY_NAME, true, SocketBinding.class)
+                    .build(); // TODO require interface capability
 
     public static final SocketBindingResourceDefinition INSTANCE = new SocketBindingResourceDefinition();
 


### PR DESCRIPTION
Switch these to the capability-based service names.