### PR TITLE
WFLY-3564 deprecate non supported target controller versions

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -58,35 +58,16 @@ public class TransformersTestParameter extends ClassloaderParameter {
     }
 
     public static List<TransformersTestParameter> setupVersions(){
-        boolean includeLegacy = System.getProperties().containsKey(TEST_OLD_LEGACY);
-
         List<TransformersTestParameter> data = new ArrayList<TransformersTestParameter>();
-        //AS releases
-        /*if (includeLegacy) {
-            data.add(new TransformersTestParameter(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.V7_1_2_FINAL));
-            data.add(new TransformersTestParameter(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.V7_1_3_FINAL));
-            data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.V7_2_0_FINAL));
-        }*/
         data.add(new TransformersTestParameter(ModelVersion.create(4, 0, 0), ModelTestControllerVersion.MASTER));
 
         //EAP releases - these will only get tested if the EAPRepositoryReachableUtil.TEST_TRANSFORMERS_EAP system property is set AND the EAP repostitory is available
-        if (EAPRepositoryReachableUtil.isReachable()) {
-            /*if (includeLegacy) {
-                data.add(new TransformersTestParameter(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.EAP_6_0_0));
-                data.add(new TransformersTestParameter(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.EAP_6_0_1));
-                data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_0));
-                data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_1));
-            }*/
+        if (EAPRepositoryReachableUtil.isReachable()) { //we only test EAP 6.2/AS7.3 and newer
             data.add(new TransformersTestParameter(ModelVersion.create(1, 5, 0), ModelTestControllerVersion.EAP_6_2_0));
             data.add(new TransformersTestParameter(ModelVersion.create(1, 6, 0), ModelTestControllerVersion.EAP_6_3_0));
             data.add(new TransformersTestParameter(ModelVersion.create(1, 7, 0), ModelTestControllerVersion.EAP_6_4_0));
         }
 
-
-       /* for (int i = 0 ; i < data.size() ; i++) {
-            Object entry = data.get(i);
-            System.out.println("Parameter " + i + ": " + entry);
-        }*/
         return data;
     }
 

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -27,8 +27,11 @@ import java.util.Properties;
 public enum ModelTestControllerVersion {
     //AS releases
     MASTER (CurrentVersion.VERSION, false, null),
+    @Deprecated
     V7_1_2_FINAL ("7.1.2.Final", false, "7.1.2", false),
+    @Deprecated
     V7_1_3_FINAL ("7.1.3.Final", false, "7.1.2", false),
+    @Deprecated
     V7_2_0_FINAL ("7.2.0.Final", false, "7.2.0" ,false),
 
     //WILDFLY RELEASES
@@ -37,9 +40,13 @@ public enum ModelTestControllerVersion {
     WILDFLY_8_2_0_FINAL ("8.2.0.Final", false, "8.0.0", false),
 
     //EAP releases
+    @Deprecated
     EAP_6_0_0 ("7.1.2.Final-redhat-1", true, "7.1.2", false),
+    @Deprecated
     EAP_6_0_1 ("7.1.3.Final-redhat-4", true, "7.1.2", false),
+    @Deprecated
     EAP_6_1_0 ("7.2.0.Final-redhat-8", true, "7.2.0", false),
+    @Deprecated
     EAP_6_1_1 ("7.2.1.Final-redhat-10", true, "7.2.0" ,false),
 
     EAP_6_2_0 ("7.3.0.Final-redhat-14", true, "7.3.0"), //EAP 6.2 is the earliest version we support for transformers
@@ -94,7 +101,7 @@ public enum ModelTestControllerVersion {
                 props.load(ModelTestControllerVersion.class.getResourceAsStream("version.properties"));
                 VERSION = props.getProperty("as.version");
             } catch (Exception e) {
-                VERSION = "8.0.0.Beta2-SNAPSHOT";
+                VERSION = "10.0.0.Alpha5-SNAPSHOT";
                 e.printStackTrace();
             }
         }


### PR DESCRIPTION
mostly cleanup, all the real work was done some time ago.