### PR TITLE
Use the ServiceName parser to convert a capability into a ServiceName…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/capability/ServiceNameProvider.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/ServiceNameProvider.java
@@ -70,7 +70,7 @@ public interface ServiceNameProvider {
     class DefaultProvider implements ServiceNameProvider {
 
         /**
-         * Converts a capability name to a service name by splitting the capability name on any '.' character.
+         * Converts a capability name to a service name by {@link ServiceName#parse(String) parsing} the capability name.
          *
          * @param capabilityName the capability name. Cannot be {@code null} or empty
          * @return the service name. Will not be {@code null}
@@ -78,7 +78,7 @@ public interface ServiceNameProvider {
         public static ServiceName capabilityToServiceName(String capabilityName) {
             assert capabilityName != null;
             assert capabilityName.length() > 0;
-            return ServiceName.of(capabilityName.split("\\."));
+            return ServiceName.parse(capabilityName);
         }
 
         private final String capabilityName;


### PR DESCRIPTION
… rather than splitting the name based on the dot delimiter.