### PR TITLE
[WFCORE-787] Discard any management model changes before beginning ro…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -346,8 +346,20 @@ abstract class AbstractOperationContext implements OperationContext {
      * @return the result action
      */
     ResultAction executeOperation() {
+
+        assert isControllingThread();
         try {
-            return completeStepInternal();
+            /** Execution has begun */
+            executing = true;
+
+            processStages();
+
+            if (resultAction == ResultAction.KEEP) {
+                report(MessageSeverity.INFO, ControllerLogger.ROOT_LOGGER.operationSucceeded());
+            } else {
+                report(MessageSeverity.INFO, ControllerLogger.ROOT_LOGGER.operationRollingBack());
+            }
+            return resultAction;
         } finally {
             // On failure close any attached response streams
             if (resultAction != ResultAction.KEEP && !isBooting()) {
@@ -366,20 +378,6 @@ abstract class AbstractOperationContext implements OperationContext {
                     }
                 }
             }
-        }
-    }
-
-    private ResultAction completeStepInternal() {
-        try {
-            doCompleteStep();
-            if (resultAction == ResultAction.KEEP) {
-                report(MessageSeverity.INFO, ControllerLogger.ROOT_LOGGER.operationSucceeded());
-            } else {
-                report(MessageSeverity.INFO, ControllerLogger.ROOT_LOGGER.operationRollingBack());
-            }
-            return resultAction;
-        } finally {
-            respectInterruption = false;
         }
     }
 
@@ -554,29 +552,12 @@ abstract class AbstractOperationContext implements OperationContext {
     abstract Resource getModel();
 
     /**
-     * Perform the work of completing a step.
+     * Perform the work of processing the various OperationContext.Stage queues, and then the DONE stage.
      */
-    private void doCompleteStep() {
-
-        assert isControllingThread();
-        // If someone called this when the operation is done, fail.
-        if (currentStage == null) {
-            throw ControllerLogger.ROOT_LOGGER.operationAlreadyComplete();
-        }
-
-        /** Execution has begun */
-        executing = true;
-
-        // If previous steps have put us in a state where we shouldn't do any more, just stop
-        if (!canContinueProcessing()) {
-            respectInterruption = false;
-            logAuditRecord();
-            operationRollingBack();
-            return;
-        }
+    private void processStages() {
 
         // Locate the next step to execute.
-        ModelNode response = activeStep == null ? null : activeStep.response;
+        ModelNode primaryResponse = null;
         Step step;
         do {
             step = steps.get(currentStage).pollFirst();
@@ -590,10 +571,7 @@ abstract class AbstractOperationContext implements OperationContext {
                 if (!stageCompleted(currentStage)) {
                     // Can't continue
                     resultAction = ResultAction.ROLLBACK;
-                    if (activeStep != null) { // won't be null; this is just a guard against later changes
-                        // kick off the result handler callbacks
-                        activeStep.finalizeStep(null);
-                    }
+                    executeResultHandlerPhase(null);
                     return;
                 }
                 // Proceed to the next stage
@@ -606,55 +584,40 @@ abstract class AbstractOperationContext implements OperationContext {
                             awaitServiceContainerStability();
                         } catch (InterruptedException e) {
                             cancelled = true;
-                            handleContainerStabilityFailure(response, e);
+                            handleContainerStabilityFailure(primaryResponse, e);
+                            executeResultHandlerPhase(null);
                             return;
                         }  catch (TimeoutException te) {
                             // The service container is in an unknown state; but we don't require restart
                             // because rollback may allow the container to stabilize. We force require-restart
                             // in the rollback handling if the container cannot stabilize (see OperationContextImpl.releaseStepLocks)
                             //processState.setRestartRequired();  // don't use our restartRequired() method as this is not reversible in rollback
-                            handleContainerStabilityFailure(response, te);
+                            handleContainerStabilityFailure(primaryResponse, te);
+                            executeResultHandlerPhase(null);
                             return;
                         }
                     }
                 }
             } else {
+                // The response to the first step is what goes to the outside caller
+                if (primaryResponse == null) {
+                    primaryResponse = step.response;
+                }
                 // Execute the step, but make sure we always finalize any steps
                 Throwable toThrow = null;
                 // Whether to return after try/finally
                 boolean exit = false;
                 try {
                     executeStep(step);
-                } catch (RuntimeException re) {
+                } catch (RuntimeException | Error re) {
+                    resultAction = ResultAction.ROLLBACK;
                     toThrow = re;
-                } catch (Error e) {
-                    toThrow = e;
                 } finally {
-                    if (step.resultHandler == null) {
-                        // A recursive step executed
-                        throwThrowable(toThrow);
+                    // See if executeStep put us in a state where we shouldn't do any more
+                    if (toThrow != null || !canContinueProcessing()) {
+                        // We're done.
+                        executeResultHandlerPhase(toThrow);
                         exit = true; // we're on the return path
-                    } else {
-                        // A non-recursive step executed
-                        // See if it put us in a state where we shouldn't do any
-                        // more
-                        if (!canContinueProcessing()) {
-                            // We're done. Do the cleanup that would happen in
-                            // executeStep's finally block
-                            // if this was a recursive step
-                            respectInterruption = false;
-                            logAuditRecord();
-                            operationRollingBack();
-                            step.finalizeStep(toThrow);
-                            exit = true; // we're on the return path
-                        } else {
-                            if (toThrow != null) {
-                                operationRollingBack();
-                            }
-                            throwThrowable(toThrow);
-                            // else move on to next step
-                            response = activeStep.response;
-                        }
                     }
                 }
                 if (exit) {
@@ -663,58 +626,81 @@ abstract class AbstractOperationContext implements OperationContext {
             }
         } while (currentStage != Stage.DONE);
 
-        // All steps are completed without triggering rollback; time for final
-        // processing
+        assert primaryResponse != null; // else ModelControllerImpl executed an op with no steps
 
-        // Prepare persistence of any configuration changes
-        ConfigurationPersister.PersistenceResource persistenceResource = null;
-        if (isModelAffected() && resultAction != ResultAction.ROLLBACK) {
-            try {
-                persistenceResource = createPersistenceResource();
-            } catch (ConfigurationPersistenceException e) {
-                MGMT_OP_LOGGER.failedToPersistConfigurationChange(e);
-                if (response != null) {
-                    response.get(OUTCOME).set(FAILED);
-                    response.get(FAILURE_DESCRIPTION).set(ControllerLogger.ROOT_LOGGER.failedToPersistConfigurationChange(e.getLocalizedMessage()));
+        // All steps ran and canContinueProcessing returned true for the last one, so...
+        executeDoneStage(primaryResponse);
+    }
+
+    private void executeDoneStage(ModelNode primaryResponse) {
+
+        // All steps are completed without triggering rollback;
+        // time for final processing
+
+        Throwable toThrow = null;
+        try {
+            // Prepare persistence of any configuration changes
+            ConfigurationPersister.PersistenceResource persistenceResource = null;
+            if (isModelAffected() && resultAction != ResultAction.ROLLBACK) {
+                try {
+                    persistenceResource = createPersistenceResource();
+                } catch (ConfigurationPersistenceException e) {
+                    MGMT_OP_LOGGER.failedToPersistConfigurationChange(e);
+                    primaryResponse.get(OUTCOME).set(FAILED);
+                    primaryResponse.get(FAILURE_DESCRIPTION).set(ControllerLogger.ROOT_LOGGER.failedToPersistConfigurationChange(e.getLocalizedMessage()));
+                    resultAction = ResultAction.ROLLBACK;
+                    executeResultHandlerPhase(null);
+                    return;
                 }
-                resultAction = ResultAction.ROLLBACK;
-                logAuditRecord();
-                return;
             }
-        }
 
-        // Allow any containing TransactionControl to vote
-        final AtomicReference<ResultAction> ref = new AtomicReference<ResultAction>(
-                transactionControl == null ? ResultAction.KEEP : ResultAction.ROLLBACK);
-        if (transactionControl != null) {
-            if (MGMT_OP_LOGGER.isTraceEnabled()) {
-                MGMT_OP_LOGGER.trace("Prepared response is " + response);
-            }
-            transactionControl.operationPrepared(new ModelController.OperationTransaction() {
-                public void commit() {
-                    ref.set(ResultAction.KEEP);
+            // Allow any containing TransactionControl to vote
+            final AtomicReference<ResultAction> ref = new AtomicReference<ResultAction>(
+                    transactionControl == null ? ResultAction.KEEP : ResultAction.ROLLBACK);
+            if (transactionControl != null) {
+                if (MGMT_OP_LOGGER.isTraceEnabled()) {
+                    MGMT_OP_LOGGER.trace("Prepared response is " + activeStep.response);
                 }
+                transactionControl.operationPrepared(new ModelController.OperationTransaction() {
+                    public void commit() {
+                        ref.set(ResultAction.KEEP);
+                    }
 
-                public void rollback() {
-                    ref.set(ResultAction.ROLLBACK);
-                }
-            }, response);
-        }
-        resultAction = ref.get();
-
-        // Commit the persistence of any configuration changes
-        if (persistenceResource != null) {
-            if (resultAction == ResultAction.ROLLBACK) {
-                persistenceResource.rollback();
-            } else {
-                persistenceResource.commit();
+                    public void rollback() {
+                        ref.set(ResultAction.ROLLBACK);
+                    }
+                }, primaryResponse);
             }
+            resultAction = ref.get();
+
+            // Commit the persistence of any configuration changes
+            if (persistenceResource != null) {
+                if (resultAction == ResultAction.ROLLBACK) {
+                    persistenceResource.rollback();
+                } else {
+                    persistenceResource.commit();
+                }
+            }
+        } catch (Throwable t) {
+            toThrow = t;
+            resultAction = ResultAction.ROLLBACK;
+        } finally {
+            executeResultHandlerPhase(toThrow);
         }
+    }
 
-        logAuditRecord();
-
-        // fire the notifications only after the eventual persistent resource is committed
-        emitNotifications();
+    private void executeResultHandlerPhase(Throwable toThrow) {
+        respectInterruption = false;
+        try {
+            logAuditRecord();
+            emitNotifications();
+        } finally {
+            if (resultAction != ResultAction.KEEP) {
+                operationRollingBack();
+            }
+            // Execute the result handlers
+            activeStep.finalizeStep(toThrow);
+        }
     }
 
     @Override
@@ -823,6 +809,7 @@ abstract class AbstractOperationContext implements OperationContext {
 
     @SuppressWarnings("ConstantConditions")
     private void executeStep(final Step step) {
+
         step.predecessor = this.activeStep;
         this.activeStep = step;
 
@@ -831,10 +818,6 @@ abstract class AbstractOperationContext implements OperationContext {
                 ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(step.handler.getClass());
                 try {
                     step.handler.execute(this, step.operation);
-                    if (step.resultHandler == null) {
-                        // Add a default one
-                        completeStep(ResultHandler.NOOP_RESULT_HANDLER);
-                    }
                     // AS7-6046
                     if (isErrorLoggingNecessary() && step.hasFailed()) {
                         MGMT_OP_LOGGER.operationFailed(step.operation.get(OP), step.operation.get(OP_ADDR),
@@ -849,70 +832,37 @@ abstract class AbstractOperationContext implements OperationContext {
                 }
 
             } catch (Throwable t) {
-                // Special handling for OperationClientException marker
-                // interface
+                // If t doesn't implement OperationClientException marker interface, throw it on to outer catch block
                 if (!(t instanceof OperationClientException)) {
-                    logAuditRecord();
                     throw t;
-                } else if (currentStage != Stage.DONE) {
-                    // Handler threw OCE before calling completeStep(); that's
-                    // equivalent to
-                    // a request that we set the failure description and call
-                    // completeStep()
-                    final ModelNode failDesc = OperationClientException.class.cast(t).getFailureDescription();
-                    step.response.get(FAILURE_DESCRIPTION).set(failDesc);
-                    if (isErrorLoggingNecessary()) {
-                        MGMT_OP_LOGGER.operationFailed(step.operation.get(OP), step.operation.get(OP_ADDR),
-                                step.response.get(FAILURE_DESCRIPTION));
-                    } else {
-                        // A client-side mistake post-boot that only affects model, not runtime, is logged at DEBUG
-                        MGMT_OP_LOGGER.operationFailedOnClientError(step.operation.get(OP), step.operation.get(OP_ADDR),
-                                step.response.get(FAILURE_DESCRIPTION));
-                    }
-
-                    completeStep(ResultHandler.NOOP_RESULT_HANDLER);
+                }
+                // Handler threw OCE; that's equivalent to a request that we set the failure description
+                final ModelNode failDesc = OperationClientException.class.cast(t).getFailureDescription();
+                step.response.get(FAILURE_DESCRIPTION).set(failDesc);
+                if (isErrorLoggingNecessary()) {
+                    MGMT_OP_LOGGER.operationFailed(step.operation.get(OP), step.operation.get(OP_ADDR),
+                            step.response.get(FAILURE_DESCRIPTION));
                 } else {
-                    // Handler threw OCE after calling completeStep()
-                    // Throw it on and let standard error handling deal with it
-                    throw t;
+                    // A client-side mistake post-boot that only affects model, not runtime, is logged at DEBUG
+                    MGMT_OP_LOGGER.operationFailedOnClientError(step.operation.get(OP), step.operation.get(OP_ADDR),
+                            step.response.get(FAILURE_DESCRIPTION));
                 }
             }
         } catch (Throwable t) {
-            if (t instanceof StackOverflowError) {
-                // This can happen with an operation with many, many steps that use the recursive no-arg completeStep()
-                // variant. This should be rare now as handlers are largely migrated from this variant.
-                // But, log a special message for this case
-                MGMT_OP_LOGGER.operationFailedInsufficientStackSpace(t, step.operation.get(OP), step.operation.get(OP_ADDR),
-                        AbstractControllerService.BOOT_STACK_SIZE_PROPERTY, AbstractControllerService.DEFAULT_BOOT_STACK_SIZE);
-            } else {
-                MGMT_OP_LOGGER.operationFailed(t, step.operation.get(OP), step.operation.get(OP_ADDR));
+            // Handling for throwables that don't implement OperationClientException marker interface
+            MGMT_OP_LOGGER.operationFailed(t, step.operation.get(OP), step.operation.get(OP_ADDR));
+
+            // Provide a failure description if there isn't one already
+            if (!step.hasFailed()) {
+                step.response.get(FAILURE_DESCRIPTION).set(ControllerLogger.ROOT_LOGGER.operationHandlerFailed(t.toString()));
             }
-            // If this block is entered, then the step failed
-            // The question is, did it fail before or after calling
-            // completeStep()?
-            if (currentStage != Stage.DONE) {
-                // It failed before, so consider the operation a failure.
-                if (!step.hasFailed()) {
-                    // If the failure is an OperationClientException we just want its localized message, no class name
-                    String cause = t instanceof OperationClientException ? t.getLocalizedMessage() : t.toString();
-                    if (cause == null) {
-                        cause = t.toString();
-                    }
-                    step.response.get(FAILURE_DESCRIPTION).set(ControllerLogger.ROOT_LOGGER.operationHandlerFailed(cause));
-                }
-                step.response.get(OUTCOME).set(FAILED);
-                resultAction = getFailedResultAction(t);
-                if (resultAction == ResultAction.ROLLBACK) {
-                    step.response.get(ROLLED_BACK).set(true);
-                }
-            } else {
-                // It failed after! Just return, ignore the failure
-                report(MessageSeverity.WARN, ControllerLogger.ROOT_LOGGER.stepHandlerFailed(step.handler));
+            step.response.get(OUTCOME).set(FAILED);
+            resultAction = getFailedResultAction(t);
+            if (resultAction == ResultAction.ROLLBACK) {
+                step.response.get(ROLLED_BACK).set(true);
             }
         } finally {
             addBootFailureDescription();
-            // Make sure non-recursive steps finalize
-            finishStep(step);
         }
     }
 
@@ -935,45 +885,6 @@ abstract class AbstractOperationContext implements OperationContext {
         return isBooting() || currentStage == Stage.RUNTIME || currentStage == Stage.VERIFY;
     }
 
-    private void finishStep(Step step) {
-        boolean finalize = true;
-        Throwable toThrow = null;
-        try {
-            if (step.resultHandler != null) {
-                // A non-recursive step executed
-                if (!hasMoreSteps()) {
-                    // this step was the last registered step;
-                    // go ahead and shift back into recursive mode to wrap
-                    // things up
-                    completeStepInternal();
-                } else {
-                    // Let doCompleteStep carry on with subsequent steps.
-                    // If this step has failed in a way that will prevent
-                    // subsequent steps running,
-                    // and doCompleteStep will finalize this step.
-                    // Otherwise, some subsequent step will finalize this step
-                    finalize = false;
-                }
-            }
-        } catch (RuntimeException re) {
-            toThrow = re;
-        } catch (Error e) {
-            toThrow = e;
-        } finally {
-            if (finalize) {
-                // We're on the way out on the recursive call path. Finish off
-                // this step.
-                // Any throwable we caught will get rethrown by this call
-                step.finalizeStep(toThrow);
-            } else {
-                // non-recursive steps get finished off by the succeeding
-                // recursive step
-                // Throw on toThrow if it's not null; otherwise just return
-                throwThrowable(toThrow);
-            }
-        }
-    }
-
     private void handleContainerStabilityFailure(ModelNode response, Exception cause) {
         boolean interrupted = cause instanceof InterruptedException;
         assert interrupted || cause instanceof TimeoutException;
@@ -985,15 +896,9 @@ abstract class AbstractOperationContext implements OperationContext {
         }
         resultAction = ResultAction.ROLLBACK;
         respectInterruption = false;
-        logAuditRecord();
         if (interrupted) {
             Thread.currentThread().interrupt();
         }
-        if (activeStep != null && activeStep.resultHandler != null) {
-            // Finalize
-            activeStep.finalizeStep(null);
-        }
-
     }
 
     private static void throwThrowable(Throwable toThrow) {
@@ -1236,6 +1141,10 @@ abstract class AbstractOperationContext implements OperationContext {
             // Create the outcome node early so it appears at the top of the
             // response
             response.get(OUTCOME);
+            // Initialize a default no-op result handler. This will get used in two cases:
+            // 1) execute completes normally, and OSH just didn't register a handler, meaning default behavior was wanted
+            // 2) execute throws an exception. Here we just want a handler to avoid NPEs later, but we don't want it to do anything
+            this.resultHandler = ResultHandler.NOOP_RESULT_HANDLER;
         }
 
         /**
@@ -1320,11 +1229,7 @@ abstract class AbstractOperationContext implements OperationContext {
         private void finalizeStep(Throwable toThrow) {
             try {
                 finalizeInternal();
-            } catch (RuntimeException t) {
-                if (toThrow == null) {
-                    toThrow = t;
-                }
-            } catch (Error t) {
+            } catch (RuntimeException | Error t) {
                 if (toThrow == null) {
                     toThrow = t;
                 }
@@ -1332,23 +1237,14 @@ abstract class AbstractOperationContext implements OperationContext {
 
             Step step = this.predecessor;
             while (step != null) {
-                if (step.resultHandler != null) {
-                    try {
-                        step.finalizeInternal();
-                    } catch (RuntimeException t) {
-                        if (toThrow == null) {
-                            toThrow = t;
-                        }
-                    } catch (Error t) {
-                        if (toThrow == null) {
-                            toThrow = t;
-                        }
+                try {
+                    step.finalizeInternal();
+                } catch (RuntimeException | Error t) {
+                    if (toThrow == null) {
+                        toThrow = t;
                     }
-                    step = step.predecessor;
-                } else {
-                    AbstractOperationContext.this.activeStep = step;
-                    break;
                 }
+                step = step.predecessor;
             }
 
             throwThrowable(toThrow);
@@ -1424,19 +1320,11 @@ abstract class AbstractOperationContext implements OperationContext {
         }
 
         private void invokeResultHandler() {
-            if (resultHandler != null) {
-                try {
-                    ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(handler.getClass());
-                    try {
-                        resultHandler.handleResult(resultAction, AbstractOperationContext.this, operation);
-                    } finally {
-                        WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
-                    }
-                } finally {
-                    // Clear the result handler so we never try and finalize
-                    // this step again
-                    resultHandler = null;
-                }
+            ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(handler.getClass());
+            try {
+                resultHandler.handleResult(resultAction, AbstractOperationContext.this, operation);
+            } finally {
+                WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
             }
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -782,9 +782,14 @@ class ModelControllerImpl implements ModelController {
 
             @Override
             public void rollback() {
+                model.discard();
                 delegate.rollback();
             }
         };
+    }
+
+    void discardModel(final ManagementModelImpl model) {
+        model.discard();
     }
 
     void acquireLock(Integer permit, final boolean interruptibly) throws InterruptedException {
@@ -1248,6 +1253,15 @@ class ModelControllerImpl implements ModelController {
         private void publish() {
             ModelControllerImpl.this.managementModel.set(this);
             ControllerLogger.MGMT_OP_LOGGER.tracef("published %s", this);
+            published = true;
+        }
+
+        private void discard() {
+            // We don't actually "discard". What we do is mark ourselves as published
+            // without actually publishing. The result is calls against this object
+            // will now see the value of ModelControllerImpl.this.managementModel.get,
+            // which will be
+            ControllerLogger.MGMT_OP_LOGGER.tracef("discarded %s", this);
             published = true;
         }
     }

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -1440,13 +1440,20 @@ class ModelControllerImpl implements ModelController {
 
         synchronized CapabilityRegistryImpl copy() {
             CapabilityRegistryImpl result = new CapabilityRegistryImpl(forServer);
-            result.capabilities.putAll(this.capabilities);
+            copyCapabilities(capabilities, result.capabilities);
             copyRequirements(requirements, result.requirements);
             copyRequirements(runtimeOnlyRequirements, result.runtimeOnlyRequirements);
             if (!forServer) {
                 result.satisfiedByMap.putAll(this.satisfiedByMap);
             }
             return result;
+        }
+
+        private static void copyCapabilities(final Map<CapabilityId, RuntimeCapabilityRegistration> source,
+                                             final Map<CapabilityId, RuntimeCapabilityRegistration> dest) {
+            for (Map.Entry<CapabilityId, RuntimeCapabilityRegistration> entry : source.entrySet()) {
+                dest.put(entry.getKey(), new RuntimeCapabilityRegistration(entry.getValue()));
+            }
         }
 
         private static void copyRequirements(Map<CapabilityId, Map<String, RuntimeRequirementRegistration>> source,

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -437,6 +437,11 @@ final class OperationContextImpl extends AbstractOperationContext {
     }
 
     @Override
+    void operationRollingBack() {
+        modelController.discardModel(managementModel);
+    }
+
+    @Override
     public boolean isRollbackOnRuntimeFailure() {
         return contextFlags.contains(ContextFlag.ROLLBACK_ON_FAIL);
     }

--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
@@ -323,6 +323,15 @@ class ParallelBootOperationContext extends AbstractOperationContext {
     }
 
     @Override
+    void operationRollingBack() {
+        // BES 2015/06/30 hmm. telling the primary context to discarding the management model
+        // here will screw up other parallel contexts that are still running. but if we don't,
+        // during rollback our OSHs will still see the changes made to the model.
+        // Oh well, I'm not going to worry about it as this runs in boot, and a rollback in
+        // boot should just result in the whole process going away anyway.
+    }
+
+    @Override
     public void emit(Notification notification) {
         primaryContext.emit(notification);
     }

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -101,6 +101,11 @@ class ReadOnlyContext extends AbstractOperationContext {
     }
 
     @Override
+    void operationRollingBack() {
+        // don't need to do anything
+    }
+
+    @Override
     void waitForRemovals() throws InterruptedException {
         // nothing here
     }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistration.java
@@ -48,6 +48,16 @@ public class RuntimeCapabilityRegistration extends CapabilityRegistration<Runtim
     }
 
     /**
+     * Copy constructor.
+     *
+     * @param toCopy the registration to copy. Cannot be {@code null}
+     */
+    public RuntimeCapabilityRegistration(RuntimeCapabilityRegistration toCopy) {
+        super(toCopy.getCapability(), toCopy.getCapabilityContext());
+        this.registrationPoints.putAll(toCopy.registrationPoints);
+    }
+
+    /**
      * Gets the registration point that been associated with the registration for the longest period.
      * @return the initial registration point, or {@code null} if there are no longer any registration points
      */

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -271,20 +271,21 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = Message.INHERIT, value = "Operation (%s) failed - address: (%s) - failure description: %s")
     void operationFailed(ModelNode op, ModelNode opAddress, ModelNode failureDescription);
 
-    /**
-     * Logs an error message indicating operation failed.
-     *
-     * @param cause        the cause of the error.
-     * @param op           the operation that failed.
-     * @param opAddress    the address the operation failed on.
-     * @param propertyName the boot stack size property name.
-     * @param defaultSize  the default boot stack size property size.
-     */
-    @LogMessage(level = ERROR)
-    @Message(id = 14, value = "Operation (%s) failed - address: (%s) -- due to insufficient stack space for the thread used to " +
-            "execute operations. If this error is occurring during server boot, setting " +
-            "system property %s to a value higher than [%d] may resolve this problem.")
-    void operationFailedInsufficientStackSpace(@Cause Throwable cause, ModelNode op, ModelNode opAddress, String propertyName, int defaultSize);
+    // WFCORE-792 -- no longer used
+//    /**
+//     * Logs an error message indicating operation failed.
+//     *
+//     * @param cause        the cause of the error.
+//     * @param op           the operation that failed.
+//     * @param opAddress    the address the operation failed on.
+//     * @param propertyName the boot stack size property name.
+//     * @param defaultSize  the default boot stack size property size.
+//     */
+//    @LogMessage(level = ERROR)
+//    @Message(id = 14, value = "Operation (%s) failed - address: (%s) -- due to insufficient stack space for the thread used to " +
+//            "execute operations. If this error is occurring during server boot, setting " +
+//            "system property %s to a value higher than [%d] may resolve this problem.")
+//    void operationFailedInsufficientStackSpace(@Cause Throwable cause, ModelNode op, ModelNode opAddress, String propertyName, int defaultSize);
 
     /**
      * Logs a warning message indicating a wildcard address was detected and will ignore other interface criteria.


### PR DESCRIPTION
…llback

See http://lists.jboss.org/pipermail/wildfly-dev/2015-July/004170.html

After James Perkins reported WFCORE-788, which looks to be a flaw with the WFCORE-787 fix, I debugged how operations were executing and realized the support in AbstractOperationContext  for the no-longer used recursive execution mode was making the logic far too error prone. So I decided to clean that up, and filed WFCORE-792. The second commit in this PR is for that.

Finally, the 3rd commit fixes WFCORE-788 itself by fixing a problem in the CapabilityRegistry copy-on-write behavior where the copy wasn't deep enough, allowing state mutation to leak out of the OperationContext making modifications even if the copy is never published.