### PR TITLE
Wfcore 747 master

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-debian.sh
+++ b/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-debian.sh
@@ -100,6 +100,7 @@ if [ "$JBOSS_MODE" = "standalone" ]; then
 	if [ -z "$JBOSS_CONFIG" ]; then
 		JBOSS_CONFIG=standalone.xml
 	fi
+	JBOSS_MARKERFILE="$JBOSS_HOME/standalone/tmp/wildfly-startup-marker"
 else
 	JBOSS_SCRIPT="$JBOSS_HOME/bin/domain.sh"
 	if [ -z "$JBOSS_DOMAIN_CONFIG" ]; then
@@ -108,6 +109,7 @@ else
 	if [ -z "$JBOSS_HOST_CONFIG" ]; then
 		JBOSS_HOST_CONFIG=host.xml
 	fi
+	JBOSS_MARKERFILE="$JBOSS_HOME/domain/tmp/wildfly-startup-marker"
 fi
 
 # Check startup file
@@ -162,6 +164,7 @@ case "$1" in
 		mkdir -p $(dirname "$JBOSS_CONSOLE_LOG")
 		chown $JBOSS_USER $(dirname "$JBOSS_PIDFILE") || true
 		cat /dev/null > "$JBOSS_CONSOLE_LOG"
+		currenttime=$(date +%s%N | cut -b1-13)
 
 		if [ "$JBOSS_MODE" = "standalone" ]; then
 			start-stop-daemon --start --user "$JBOSS_USER" \
@@ -178,15 +181,19 @@ case "$1" in
 		launched=0
 		until [ $count -gt $STARTUP_WAIT ]
 		do
-			grep 'WFLYSRV0025:' "$JBOSS_CONSOLE_LOG" > /dev/null
-			if [ $? -eq 0 ] ; then
-				launched=1
-				break
-			fi
 			sleep 1
 			count=$((count + 1));
+			if [ -f "$JBOSS_MARKERFILE" ]; then
+				markerfiletimestamp=$(grep -o '[0-9]*' "$JBOSS_MARKERFILE") > /dev/null
+				if [ "$markerfiletimestamp" -gt "$currenttime" ] ; then
+					grep -i 'success:' "$JBOSS_MARKERFILE" > /dev/null
+					if [ $? -eq 0 ] ; then
+						launched=1
+						break
+					fi
+				fi
+			fi
 		done
-
 		if check_status; then
 			log_end_msg 0
 		else

--- a/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-redhat.sh
+++ b/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-redhat.sh
@@ -62,6 +62,7 @@ if [ "$JBOSS_MODE" = "standalone" ]; then
 	if [ -z "$JBOSS_CONFIG" ]; then
 		JBOSS_CONFIG=standalone.xml
 	fi
+	JBOSS_MARKERFILE=$JBOSS_HOME/standalone/tmp/wildfly-startup-marker
 else
 	JBOSS_SCRIPT=$JBOSS_HOME/bin/domain.sh
 	if [ -z "$JBOSS_DOMAIN_CONFIG" ]; then
@@ -70,9 +71,11 @@ else
 	if [ -z "$JBOSS_HOST_CONFIG" ]; then
 		JBOSS_HOST_CONFIG=host.xml
 	fi
+	JBOSS_MARKERFILE=$JBOSS_HOME/domain/tmp/wildfly-startup-marker
 fi
 
 prog='wildfly'
+currenttime=$(date +%s%N | cut -b1-13)
 
 start() {
 	echo -n "Starting $prog: "
@@ -118,14 +121,23 @@ start() {
 
 	until [ $count -gt $STARTUP_WAIT ]
 	do
-		grep 'WFLYSRV0025:' $JBOSS_CONSOLE_LOG > /dev/null
-		if [ $? -eq 0 ] ; then
-			launched=true
-			break
-		fi
 		sleep 1
 		let count=$count+1;
+		if [ -f $JBOSS_MARKERFILE ]; then
+			markerfiletimestamp=$(grep -o '[0-9]*' $JBOSS_MARKERFILE) > /dev/null
+			if [ "$markerfiletimestamp" -gt "$currenttime" ] ; then
+				grep -i 'success:' $JBOSS_MARKERFILE > /dev/null
+				if [ $? -eq 0 ] ; then
+					launched=true
+					break
+				fi
+			fi
+		fi
 	done
+
+	if [ "$launched" = "false" ] ; then
+		echo "$prog started with errors, please see server log for details"
+	fi
 
 	touch $JBOSS_LOCKFILE
 	success

--- a/core-feature-pack/src/main/resources/content/bin/init.d/wildfly.conf
+++ b/core-feature-pack/src/main/resources/content/bin/init.d/wildfly.conf
@@ -31,4 +31,4 @@
 # JBOSS_CONSOLE_LOG="/var/log/wildfly/console.log"
 
 ## Additionals args to include in startup
-# JBOSS_OPTS="--admin-only -b 172.0.0.1"
+# JBOSS_OPTS="--admin-only -b 127.0.0.1"

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -147,7 +147,7 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
             this.startTime = -1;
         }
 
-        final BootstrapListener bootstrapListener = new BootstrapListener(serviceContainer, startTime, serviceTarget, futureContainer, prettyVersion + " (Host Controller)");
+        final BootstrapListener bootstrapListener = new BootstrapListener(serviceContainer, startTime, serviceTarget, futureContainer, prettyVersion + " (Host Controller)", environment.getDomainTempDir());
         bootstrapListener.getStabilityMonitor().addController(myController);
 
         // The first default services are registered before the bootstrap operations are executed.
@@ -192,6 +192,7 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
         String prettyVersion = environment.getProductConfig().getPrettyVersionString();
         processState.setStopping();
         ServerLogger.AS_ROOT_LOGGER.serverStopped(prettyVersion, Integer.valueOf((int) (context.getElapsedTime() / 1000000L)));
+        BootstrapListener.deleteStartupMarker(environment.getDomainTempDir());
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -133,7 +133,7 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         }
         CurrentServiceContainer.setServiceContainer(context.getController().getServiceContainer());
 
-        final BootstrapListener bootstrapListener = new BootstrapListener(container, startTime, serviceTarget, futureContainer, prettyVersion);
+        final BootstrapListener bootstrapListener = new BootstrapListener(container, startTime, serviceTarget, futureContainer, prettyVersion, serverEnvironment.getServerTempDir());
         bootstrapListener.getStabilityMonitor().addController(myController);
         // Install either a local or remote content repository
         if(standalone) {
@@ -200,6 +200,7 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         CurrentServiceContainer.setServiceContainer(null);
         String prettyVersion = configuration.getServerEnvironment().getProductConfig().getPrettyVersionString();
         ServerLogger.AS_ROOT_LOGGER.serverStopped(prettyVersion, Integer.valueOf((int) (context.getElapsedTime() / 1000000L)));
+        BootstrapListener.deleteStartupMarker(configuration.getServerEnvironment().getServerTempDir());
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/BootstrapListener.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapListener.java
@@ -21,6 +21,13 @@
  */
 package org.jboss.as.server;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.as.server.mgmt.UndertowHttpManagementService;
@@ -37,19 +44,23 @@ import org.jboss.msc.service.StabilityStatistics;
  */
 public final class BootstrapListener {
 
+    public static final String MARKER_FILE = "wildfly-startup-marker";
+
     private final StabilityMonitor monitor = new StabilityMonitor();
     private final ServiceContainer serviceContainer;
     private final ServiceTarget serviceTarget;
     private final long startTime;
     private final String prettyVersion;
     private final FutureServiceContainer futureContainer;
+    private final File tempDir;
 
-    public BootstrapListener(final ServiceContainer serviceContainer, final long startTime, final ServiceTarget serviceTarget, final FutureServiceContainer futureContainer, final String prettyVersion) {
+    public BootstrapListener(final ServiceContainer serviceContainer, final long startTime, final ServiceTarget serviceTarget, final FutureServiceContainer futureContainer, final String prettyVersion, final File tempDir) {
         this.serviceContainer = serviceContainer;
         this.startTime = startTime;
         this.serviceTarget = serviceTarget;
         this.prettyVersion = prettyVersion;
         this.futureContainer = futureContainer;
+        this.tempDir = tempDir;
         serviceTarget.addMonitor(monitor);
     }
 
@@ -92,8 +103,37 @@ public final class BootstrapListener {
         final int started = statistics.getStartedCount();
         if (failed == 0 && problem == 0) {
             ServerLogger.AS_ROOT_LOGGER.startedClean(prettyVersion, bootstrapTime, started, active + passive + onDemand + never + lazy, onDemand + passive + lazy);
+            createStartupMarker("success", startTime);
         } else {
             ServerLogger.AS_ROOT_LOGGER.startedWitErrors(prettyVersion, bootstrapTime, started, active + passive + onDemand + never + lazy, failed + problem, onDemand + passive + lazy);
+            createStartupMarker("error", startTime);
+        }
+    }
+
+    private void createStartupMarker(String result, long startTime) {
+        File file = new File(tempDir, MARKER_FILE);
+        try {
+            Files.deleteIfExists(file.toPath());
+            if (file.createNewFile()) {
+                try (BufferedWriter writer = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8, StandardOpenOption.WRITE)) {
+                    writer.append(result + ":" + String.valueOf(startTime));
+                    writer.flush();
+                } catch (IOException e) {
+                    // ignore
+                }
+            }
+        } catch (IOException e) {
+            // ignore
+        }
+
+    }
+
+    public static void deleteStartupMarker(File tempDir) {
+        File file = new File(tempDir, BootstrapListener.MARKER_FILE);
+        try {
+            Files.deleteIfExists(file.toPath());
+        } catch (IOException e) {
+            // ignore
         }
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-747

Add a marker file to standalone or domain server tmp directory to record server startup state once server is started. It will be removed when server is stopped.
Inside wildfly-init-redhat.sh and wildfly-init-debian.sh, it will read this temporary marker file to exam server startup result before timeout instead of checking volatile log message from console log(key log id changed, log handler removed, etc.)
