### PR TITLE
Remove AbstractRemoveStepHandler.getCapabilityRemoveServiceName()

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
@@ -37,7 +37,6 @@ import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceName;
 
 /**
  * Base class for handlers that remove resources.
@@ -151,48 +150,6 @@ public abstract class AbstractRemoveStepHandler implements OperationStepHandler 
 
     protected boolean requiresRuntime(OperationContext context) {
         return context.isDefaultRequiresRuntime();
-    }
-
-    /**
-     * Gets the service name provided by the given capability for the given service type. This can be used by
-     * subclasses to determine the name of a service to remove in {@link org.jboss.as.controller.OperationContext.Stage#RUNTIME}
-     * after the capability itself has been removed in {@link org.jboss.as.controller.OperationContext.Stage#MODEL}
-     * by {@link #recordCapabilitiesAndRequirements(OperationContext, ModelNode, Resource)}.
-     *
-     * @param removed the capability. Must be a capability passed to the constructor, and must not be
-     *                {@link RuntimeCapability#isDynamicallyNamed() dynamically named}
-     * @param serviceType the value type of the service for which a service name is wanted
-     * @return  the service name. Will not be {@code null}
-     *
-     * @throws IllegalArgumentException if {@code serviceType} is {@code null } or
-     *            the capability does not provide a service of type {@code serviceType}
-     */
-    protected final ServiceName getCapabilityRemovedServiceName(RuntimeCapability removed, Class<?> serviceType) {
-        assert capabilities.contains(removed);
-        assert !removed.isDynamicallyNamed();
-        return removed.getCapabilityServiceName(serviceType);
-    }
-
-    /**
-     * Gets the service name provided by the given capability for the given service type. This can be used by
-     * subclasses to determine the name of a service to remove in {@link org.jboss.as.controller.OperationContext.Stage#RUNTIME}
-     * after the capability itself has been removed in {@link org.jboss.as.controller.OperationContext.Stage#MODEL}
-     * by {@link #recordCapabilitiesAndRequirements(OperationContext, ModelNode, Resource)}.
-     *
-     * @param removed the capability. Must be a capability passed to the constructor, and must be
-     *                {@link RuntimeCapability#isDynamicallyNamed() dynamically named}
-     * @param dynamicPart the dynamic part of the capability name. Cannot be {@code null}
-     * @param serviceType the value type of the service for which a service name is wanted
-     * @return  the service name. Will not be {@code null}
-     *
-     * @throws IllegalArgumentException if {@code serviceType} is {@code null } or
-     *            the capability does not provide a service of type {@code serviceType}
-     */
-    protected final ServiceName getCapabilityRemovedServiceName(RuntimeCapability<?> removed, String dynamicPart, Class<?> serviceType) {
-        assert capabilities.contains(removed);
-        assert removed.isDynamicallyNamed();
-        RuntimeCapability<?> full =  removed.fromBaseCapability(dynamicPart);
-        return full.getCapabilityServiceName(serviceType);
     }
 
     private List<PathElement> getChildren(Resource resource) {

--- a/controller/src/main/java/org/jboss/as/controller/ServiceRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ServiceRemoveStepHandler.java
@@ -82,14 +82,12 @@ public class ServiceRemoveStepHandler extends AbstractRemoveStepHandler {
             }
 
             for (RuntimeCapability<?> capability : unavailableCapabilities) {
-                boolean dynamic = capability.isDynamicallyNamed();
-                Class<?> valueType = capability.getCapabilityServiceValueType();
-                if (valueType != null) {
+                if (capability.getCapabilityServiceValueType() != null) {
                     ServiceName sname;
-                    if (dynamic) {
-                        sname = getCapabilityRemovedServiceName(capability, name, valueType);
+                    if (capability.isDynamicallyNamed()) {
+                        sname = capability.getCapabilityServiceName(name);
                     } else {
-                        sname = getCapabilityRemovedServiceName(capability, valueType);
+                        sname = capability.getCapabilityServiceName();
                     }
                     context.removeService(sname);
                 }


### PR DESCRIPTION
These methods were a bad idea. Capability providers should directly use their RuntimeCapability. We don't provide helper methods like this for add or write-attribute use cases, and these helpers are actually more verbose than using the RuntimeCapability directly.

These were only added a couple days ago and were never in an Alpha. The elytron or datasource work may have used them from a snapshot, but they can adapt once an alpha goes out.