### PR TITLE
WFLY-4885 Include the original cause why loading of console's module failed

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
@@ -239,13 +239,13 @@ public class ManagementHttpServer {
         try {
             consoleHandler = consoleMode.createConsoleHandler(consoleSlot);
         } catch (ModuleLoadException e) {
-            ROOT_LOGGER.consoleModuleNotFound(consoleSlot == null ? "main" : consoleSlot);
+            ROOT_LOGGER.consoleModuleNotFound(consoleSlot == null ? "main" : consoleSlot, e);
         }
 
         try {
             pathHandler.addPrefixPath(ErrorContextHandler.ERROR_CONTEXT, ErrorContextHandler.createErrorContext(consoleSlot));
         } catch (ModuleLoadException e) {
-            ROOT_LOGGER.errorContextModuleNotFound(consoleSlot == null ? "main" : consoleSlot);
+            ROOT_LOGGER.errorContextModuleNotFound(consoleSlot == null ? "main" : consoleSlot, e);
         }
 
         ManagementRootConsoleRedirectHandler rootConsoleRedirectHandler = new ManagementRootConsoleRedirectHandler(consoleHandler);

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/logging/HttpServerLogger.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/logging/HttpServerLogger.java
@@ -53,11 +53,11 @@ public interface HttpServerLogger extends BasicLogger {
 
     @LogMessage(level = ERROR)
     @Message(id = 3, value = "Unable to load console module for slot %s, disabling console")
-    void consoleModuleNotFound(String slot);
+    void consoleModuleNotFound(String slot, @Cause Throwable cause);
 
     @LogMessage(level = ERROR)
     @Message(id = 4, value = "Unable to load error context for slot %s, disabling error context.")
-    void errorContextModuleNotFound(String slot);
+    void errorContextModuleNotFound(String slot, @Cause Throwable cause);
 
     @Message(id = 5, value = "Invalid operation '%s'")
     IllegalArgumentException invalidOperation(@Cause Throwable cause, String value);


### PR DESCRIPTION
The commit here changes the error logging to include the original cause which prevented the console's module from being loaded. This will help debug issues like the one reported in https://issues.jboss.org/browse/WFLY-4885