### PR TITLE
Update to JBoss Threads 2.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <version.org.jboss.spec.javax.sql.jboss-javax-sql-api_7.0_spec>2.0.0.Beta1</version.org.jboss.spec.javax.sql.jboss-javax-sql-api_7.0_spec>
         <version.org.jboss.staxmapper>1.2.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.0.2.GA</version.org.jboss.stdio>
-        <version.org.jboss.threads>2.2.0.Final</version.org.jboss.threads>
+        <version.org.jboss.threads>2.2.1.Final</version.org.jboss.threads>
         <version.org.jboss.xnio>3.3.1.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>


### PR DESCRIPTION
Fixes a problem where the ACC of the creator of a thread pool is not properly preserved, especially when a security manager is installed.