### PR TITLE
WFCORE-799 Broken jdk method Files.isWritable() causes a deployment f…

### DIFF
--- a/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
@@ -300,7 +300,7 @@ public interface ContentRepository {
                     }
                 } else if (!Files.isDirectory(dir)) {
                     throw DeploymentRepositoryLogger.ROOT_LOGGER.notADirectory(dir.toAbsolutePath().toString());
-                } else if (!Files.isWritable(dir)) {
+                } else if (!dir.toFile().canWrite()) { //WFCORE-799 workaround for broken Files.isWritable() on Windows in JDK8
                     throw DeploymentRepositoryLogger.ROOT_LOGGER.directoryNotWritable(dir.toAbsolutePath().toString());
                 }
             }


### PR DESCRIPTION
…ailure on windows