### PR TITLE
stop loop when received response is null

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -1007,7 +1007,9 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                 response = readLine("Accept certificate? [N]o, [T]emporarily : ", false, true);
             }
 
-            if (response != null && response.length() == 1) {
+            if (response == null)
+                return false;
+            else if (response.length() == 1) {
                 switch (response.toLowerCase(Locale.ENGLISH).charAt(0)) {
                     case 'n':
                         return false;


### PR DESCRIPTION
commit https://github.com/aeshell/aesh/commit/ab1d8d56cb2db8f45bf8c9801f5b1d4a574892b4 in aesh 0.33.14 is made to avoid CLI freeze if it's no longer connected. blockingQueue.poll() will return null if queue is empty rather than waiting. 
But, unconditional loop in https://github.com/wildfly/wildfly-core/blob/669eef7efc3bc9479e23c3449c5cd2ae903b3189/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java#L1002 can receive this null before CLI is totally shutdown and print massive prompt messages "Accept certificate? [N]o, [T]emporarily, [P]ermenantly :" as reported in https://bugzilla.redhat.com/show_bug.cgi?id=1238263

Since you don't input null value in console, it should return false in that case.