### PR TITLE
[WFCORE-810] ProtocolConfigRemoveHandler should check for handler res…

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogProtocolResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogProtocolResourceDefinition.java
@@ -280,7 +280,14 @@ public abstract class SyslogAuditLogProtocolResourceDefinition extends SimpleRes
 
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-            auditLogger.getUpdater().updateHandler(SyslogAuditLogHandlerResourceDefinition.createHandler(pathManager, context, operation, environmentReader));
+            PathAddress handlerAddress = SyslogAuditLogHandlerResourceDefinition.getAffectedHandlerAddress(context);
+            try {
+                Resource handleResource = context.readResourceFromRoot(handlerAddress);
+                String name = Util.getNameFromAddress(handlerAddress);
+                auditLogger.getUpdater().updateHandler(SyslogAuditLogHandlerResourceDefinition.createHandler(pathManager, context, name, handleResource, environmentReader));
+            } catch (Resource.NoSuchResourceException ignored) {
+                // WFCORE-810 handler resource has been removed in this same op, so we do nothing
+            }
         }
 
         @Override
@@ -334,7 +341,7 @@ public abstract class SyslogAuditLogProtocolResourceDefinition extends SimpleRes
 
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-            auditLogger.getUpdater().updateHandler(SyslogAuditLogHandlerResourceDefinition.createHandler(pathManager, context, operation, environmentReader));
+            auditLogger.getUpdater().updateHandler(SyslogAuditLogHandlerResourceDefinition.createHandler(pathManager, context, environmentReader));
         }
 
         @Override
@@ -370,7 +377,7 @@ public abstract class SyslogAuditLogProtocolResourceDefinition extends SimpleRes
 
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-            auditLogger.getUpdater().updateHandler(SyslogAuditLogHandlerResourceDefinition.createHandler(pathManager, context, operation, environmentReader));
+            auditLogger.getUpdater().updateHandler(SyslogAuditLogHandlerResourceDefinition.createHandler(pathManager, context, environmentReader));
         }
 
         @Override


### PR DESCRIPTION
…ource existence

I didn't add a test for this, as an existing test (AuditLogToTCPSyslogTestCase) fails in tearDown because of this in my WFCORE-808 branch. This fixes the problem.