### PR TITLE
WFCORE-804 Display attribute definition's capabilty references

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -84,6 +84,7 @@ public abstract class AttributeDefinition {
     private final Boolean nilSignificant;
     private final AttributeParser parser;
     private final String attributeGroup;
+    protected final CapabilityReferenceRecorder referenceRecorder;
 
     // NOTE: Standards for creating a constructor variant are:
     // 1) Expected to be a common use case; no one-offs.
@@ -99,7 +100,7 @@ public abstract class AttributeDefinition {
                 toCopy.isValidateNull(), toCopy.getAlternatives(), toCopy.getRequires(), toCopy.getAttributeMarshaller(),
                 toCopy.isResourceOnly(), toCopy.getDeprecated(),
                 wrapConstraints(toCopy.getAccessConstraints()), toCopy.getNullSignificant(), toCopy.getParser(),
-                toCopy.getAttributeGroup(), toCopy.getAllowedValues(), wrapFlags(toCopy.getFlags()));
+                toCopy.getAttributeGroup(), toCopy.referenceRecorder, toCopy.getAllowedValues(), wrapFlags(toCopy.getFlags()));
     }
 
     protected AttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
@@ -112,7 +113,7 @@ public abstract class AttributeDefinition {
         this(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit, valueCorrector,
                 wrapValidator(validator, allowNull, validateNull, allowExpression, type), validateNull, alternatives, requires,
                 attributeMarshaller, resourceOnly, deprecationData, wrapConstraints(accessConstraints),
-                nilSignificant, parser, null, null, wrapFlags(flags));
+                nilSignificant, parser, null, null, null, wrapFlags(flags));
     }
 
     private static ParameterValidator wrapValidator(ParameterValidator toWrap, boolean allowNull,
@@ -166,7 +167,8 @@ public abstract class AttributeDefinition {
                                 final ParameterCorrector valueCorrector, final ParameterValidator validator, final boolean validateNull,
                                 final String[] alternatives, final String[] requires, AttributeMarshaller attributeMarshaller,
                                 boolean resourceOnly, DeprecationData deprecationData, final List<AccessConstraintDefinition> accessConstraints,
-                                Boolean nilSignificant, AttributeParser parser, final String attributeGroup, ModelNode[] allowedValues, final EnumSet<AttributeAccess.Flag> flags) {
+                                Boolean nilSignificant, AttributeParser parser, final String attributeGroup, CapabilityReferenceRecorder referenceRecorder,
+                                ModelNode[] allowedValues, final EnumSet<AttributeAccess.Flag> flags) {
 
         this.name = name;
         this.xmlName = xmlName == null ? name : xmlName;
@@ -197,6 +199,7 @@ public abstract class AttributeDefinition {
         this.nilSignificant = nilSignificant;
         this.attributeGroup = attributeGroup;
         this.allowedValues = allowedValues;
+        this.referenceRecorder = referenceRecorder;
     }
 
     /**
@@ -812,6 +815,10 @@ public abstract class AttributeDefinition {
                 result.get(ModelDescriptionConstants.REQUIRES).add(required);
             }
         }
+        if (referenceRecorder != null) {
+            result.get(ModelDescriptionConstants.CAPABILITY_REFERENCE).set(referenceRecorder.getBaseRequirementName());
+        }
+
         if (validator instanceof MinMaxValidator) {
             MinMaxValidator minMax = (MinMaxValidator) validator;
             Long min = minMax.getMin();
@@ -858,7 +865,16 @@ public abstract class AttributeDefinition {
      * @param attributeValue the value of the attribute described by this object
      */
     public void addCapabilityRequirements(OperationContext context, ModelNode attributeValue) {
-        // no-op;
+        if (referenceRecorder != null) {
+            if (!attributeValue.isDefined()) {
+                attributeValue = getDefaultValue();
+            }
+            // We can't process expressions, and there's no point processing undefined
+            if (attributeValue != null && attributeValue.isDefined()
+                    && attributeValue.getType() != ModelType.EXPRESSION) {
+                referenceRecorder.addCapabilityRequirements(context, getName(), attributeValue.asString());
+            }
+        }
     }
 
     /**
@@ -873,7 +889,16 @@ public abstract class AttributeDefinition {
      * @param attributeValue the value of the attribute described by this object
      */
     public void removeCapabilityRequirements(OperationContext context, ModelNode attributeValue) {
-        // no-op
+        if (referenceRecorder != null) {
+            if (!attributeValue.isDefined()) {
+                attributeValue = getDefaultValue();
+            }
+            // We can't process expressions, and there's no point processing undefined
+            if (attributeValue != null && attributeValue.isDefined()
+                    && attributeValue.getType() != ModelType.EXPRESSION) {
+                referenceRecorder.removeCapabilityRequirements(context, getName(), attributeValue.asString());
+            }
+        }
     }
 
     /**
@@ -886,7 +911,11 @@ public abstract class AttributeDefinition {
      * @return
      */
     public boolean hasCapabilityRequirements(){
-        return false;
+        return getReferenceRecorder() != null;
+    }
+
+    protected CapabilityReferenceRecorder getReferenceRecorder(){
+        return referenceRecorder;
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/CapabilityReferenceRecorder.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityReferenceRecorder.java
@@ -48,6 +48,23 @@ public interface CapabilityReferenceRecorder {
     void removeCapabilityRequirements(OperationContext context, String attributeName, String... attributeValues);
 
     /**
+     * @return base name of dependant, usually name of the attribute that provides reference to capability
+     */
+    String getBaseDependentName();
+
+    /**
+     *
+     * @return requirement name of the capability this reference depends on
+     */
+    String getBaseRequirementName();
+
+    /**
+     *
+     * @return tells is reference is dynamic or static, in case where it is dynamic it uses base name + name of dependant attribute to construct name of capability
+     */
+    boolean isDynamicDependent();
+
+    /**
      * Default implementation of {@link org.jboss.as.controller.CapabilityReferenceRecorder}.
      * Derives the required capability name from the {@code baseRequirementName} provided to the constructor and from
      * the attribute value. Derives the dependent capability name from the {@code baseDependentName} provided to the
@@ -106,5 +123,21 @@ public interface CapabilityReferenceRecorder {
         protected String getDynamicDependentName(PathAddress currentAddress) {
             return currentAddress.getLastElement().getValue();
         }
+
+        @Override
+        public String getBaseDependentName() {
+            return baseDependentName;
+        }
+
+        @Override
+        public String getBaseRequirementName() {
+            return baseRequirementName;
+        }
+
+        @Override
+        public boolean isDynamicDependent() {
+            return dynamicDependent;
+        }
+
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinition.java
@@ -45,8 +45,6 @@ import org.jboss.dmr.ModelType;
  */
 public class SimpleAttributeDefinition extends AttributeDefinition {
 
-    private final CapabilityReferenceRecorder requirementRecorder;
-
     // NOTE: Standards for creating a constructor variant are:
     // 1) Expected to be a common use case; no one-offs.
     // 2) Max 4 parameters, or 5 only if the fifth is "AttributeAccess.Flag... flags"
@@ -67,7 +65,6 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
                 (ParameterCorrector) null, (ParameterValidator) null, true, (String[]) null, (String[]) null,
                 (AttributeMarshaller) null, false, (DeprecationData) null, (AccessConstraintDefinition[]) null,
                 (Boolean) null, (AttributeParser) null);
-        this.requirementRecorder = null;
     }
 
     /**
@@ -83,7 +80,6 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
                 (ParameterCorrector) null, (ParameterValidator) null, true, (String[]) null, (String[]) null,
                 (AttributeMarshaller) null, false, (DeprecationData) null, (AccessConstraintDefinition[]) null,
                 (Boolean) null, (AttributeParser) null, flags);
-        this.requirementRecorder = null;
     }
 
     /**
@@ -99,7 +95,6 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
                 (ParameterCorrector) null, (ParameterValidator) null, true, (String[]) null, (String[]) null,
                 (AttributeMarshaller) null, false, (DeprecationData) null, (AccessConstraintDefinition[]) null,
                 (Boolean) null, (AttributeParser) null);
-        this.requirementRecorder = null;
     }
 
     /**
@@ -117,7 +112,6 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
                 (ParameterCorrector) null, (ParameterValidator) null, true, (String[]) null, (String[]) null,
                 (AttributeMarshaller) null, false, (DeprecationData) null, (AccessConstraintDefinition[]) null,
                 (Boolean) null, (AttributeParser) null, flags);
-        this.requirementRecorder = null;
     }
 
     /**
@@ -133,7 +127,6 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
                 (ParameterCorrector) null, (ParameterValidator) null, true, (String[]) null, (String[]) null,
                 (AttributeMarshaller) null, false, (DeprecationData) null, (AccessConstraintDefinition[]) null,
                 (Boolean) null, (AttributeParser) null);
-        this.requirementRecorder = null;
     }
 
     /**
@@ -151,16 +144,10 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
                 (ParameterCorrector) null, (ParameterValidator) null, true, (String[]) null, (String[]) null,
                 (AttributeMarshaller) null, false, (DeprecationData) null, (AccessConstraintDefinition[]) null,
                 (Boolean) null, (AttributeParser) null, flags);
-        this.requirementRecorder = null;
     }
 
     protected SimpleAttributeDefinition(AbstractAttributeDefinitionBuilder<?, ? extends SimpleAttributeDefinition> builder) {
         super(builder);
-        if (builder instanceof SimpleAttributeDefinitionBuilder) {
-            this.requirementRecorder = ((SimpleAttributeDefinitionBuilder) builder).getReferenceRecorder();
-        } else {
-            this.requirementRecorder = null;
-        }
     }
 
     /**
@@ -250,39 +237,6 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
     @Override
     public void marshallAsElement(final ModelNode resourceModel, final boolean marshallDefault, final XMLStreamWriter writer) throws XMLStreamException {
         attributeMarshaller.marshallAsElement(this, resourceModel, marshallDefault, writer);
-    }
-
-    @Override
-    public void addCapabilityRequirements(OperationContext context, ModelNode attributeValue) {
-        if (requirementRecorder != null) {
-            if (!attributeValue.isDefined()) {
-                attributeValue = getDefaultValue();
-            }
-            // We can't process expressions, and there's no point processing undefined
-            if (attributeValue != null && attributeValue.isDefined()
-                    && attributeValue.getType() != ModelType.EXPRESSION) {
-                requirementRecorder.addCapabilityRequirements(context, getName(), attributeValue.asString());
-            }
-        }
-    }
-
-    @Override
-    public void removeCapabilityRequirements(OperationContext context, ModelNode attributeValue) {
-        if (requirementRecorder != null) {
-            if (!attributeValue.isDefined()) {
-                attributeValue = getDefaultValue();
-            }
-            // We can't process expressions, and there's no point processing undefined
-            if (attributeValue != null && attributeValue.isDefined()
-                    && attributeValue.getType() != ModelType.EXPRESSION) {
-                requirementRecorder.removeCapabilityRequirements(context, getName(), attributeValue.asString());
-            }
-        }
-    }
-
-    @Override
-    public boolean hasCapabilityRequirements() {
-        return requirementRecorder!=null;
     }
 
     static ModelNode parse(AttributeDefinition attribute, ParameterValidator validator, final String value) throws OperationFailedException  {

--- a/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinitionBuilder.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.controller;
 
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -73,8 +72,6 @@ public class SimpleAttributeDefinitionBuilder extends AbstractAttributeDefinitio
         return new SimpleAttributeDefinitionBuilder(attributeName, basis);
     }
 
-    private CapabilityReferenceRecorder referenceRecorder;
-
     public SimpleAttributeDefinitionBuilder(final String attributeName, final ModelType type) {
         this(attributeName, type, false);
     }
@@ -92,73 +89,8 @@ public class SimpleAttributeDefinitionBuilder extends AbstractAttributeDefinitio
         super(attributeName, basis);
     }
 
-    /**
-     * Records that this attribute's value represents a reference to an instance of a
-     * {@link org.jboss.as.controller.capability.RuntimeCapability#isDynamicallyNamed() dynamic capability}.
-     * <p>
-     * This method is a convenience method equivalent to calling
-     * {@link #setCapabilityReference(CapabilityReferenceRecorder)}
-     * passing in a {@link org.jboss.as.controller.CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder}
-     * constructed using the parameters passed to this method.
-     *
-     * @param referencedCapability the name of the dynamic capability the dynamic portion of whose name is
-     *                             represented by the attribute's value
-     * @param dependentCapability the capability that depends on {@code referencedCapability}
-     * @return the builder
-     *
-     * @see SimpleAttributeDefinition#addCapabilityRequirements(OperationContext, ModelNode)
-     * @see SimpleAttributeDefinition#removeCapabilityRequirements(OperationContext, ModelNode)
-     */
-    public SimpleAttributeDefinitionBuilder setCapabilityReference(String referencedCapability, RuntimeCapability<?> dependentCapability) {
-        return setCapabilityReference(referencedCapability, dependentCapability.getName(), dependentCapability.isDynamicallyNamed());
-    }
-
-    /**
-     * Records that this attribute's value represents a reference to an instance of a
-     * {@link org.jboss.as.controller.capability.RuntimeCapability#isDynamicallyNamed() dynamic capability}.
-     * <p>
-     * This method is a convenience method equivalent to calling
-     * {@link #setCapabilityReference(CapabilityReferenceRecorder)}
-     * passing in a {@link org.jboss.as.controller.CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder}
-     * constructed using the parameters passed to this method.
-     *
-     * @param referencedCapability the name of the dynamic capability the dynamic portion of whose name is
-     *                             represented by the attribute's value
-     * @param dependentCapability the name of the capability that depends on {@code referencedCapability}
-     * @param dynamicDependent {@code true} if {@code dependentCapability} is a dynamic capability, the dynamic
-     *                                     portion of which comes from the name of the resource with which
-     *                                     the attribute is associated
-     * @return the builder
-     *
-     * @see SimpleAttributeDefinition#addCapabilityRequirements(OperationContext, ModelNode)
-     * @see SimpleAttributeDefinition#removeCapabilityRequirements(OperationContext, ModelNode)
-     */
-    public SimpleAttributeDefinitionBuilder setCapabilityReference(String referencedCapability, String dependentCapability, boolean dynamicDependent) {
-        referenceRecorder = new CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder(referencedCapability, dependentCapability, dynamicDependent);
-        return this;
-    }
-
-    /**
-     * Records that this attribute's value represents a reference to an instance of a
-     * {@link org.jboss.as.controller.capability.RuntimeCapability#isDynamicallyNamed() dynamic capability} and assigns the
-     * object that should be used to handle adding and removing capability requirements.
-     *
-     * @param referenceRecorder recorder to handle adding and removing capability requirements. May be {@code null}
-     * @return the builder
-     *
-     * @see SimpleAttributeDefinition#addCapabilityRequirements(OperationContext, ModelNode)
-     * @see SimpleAttributeDefinition#removeCapabilityRequirements(OperationContext, ModelNode)
-     */
-    public SimpleAttributeDefinitionBuilder setCapabilityReference(CapabilityReferenceRecorder referenceRecorder) {
-        this.referenceRecorder = referenceRecorder;
-        return this;
-    }
-
     public SimpleAttributeDefinition build() {
         return new SimpleAttributeDefinition(this);
     }
 
-    CapabilityReferenceRecorder getReferenceRecorder() {
-        return referenceRecorder;
-    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/SimpleListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleListAttributeDefinition.java
@@ -91,6 +91,11 @@ public class SimpleListAttributeDefinition extends ListAttributeDefinition {
     }
 
     @Override
+    protected CapabilityReferenceRecorder getReferenceRecorder() {
+        return valueType.getReferenceRecorder();
+    }
+
+    @Override
     public boolean hasCapabilityRequirements() {
         return valueType.hasCapabilityRequirements();
     }

--- a/controller/src/main/java/org/jboss/as/controller/StringListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/StringListAttributeDefinition.java
@@ -35,11 +35,8 @@ import org.jboss.dmr.ModelType;
  */
 public final class StringListAttributeDefinition extends PrimitiveListAttributeDefinition {
 
-    private final CapabilityReferenceRecorder referenceRecorder;
-
     private StringListAttributeDefinition(Builder builder) {
         super(builder, ModelType.STRING);
-        referenceRecorder = builder.getReferenceRecorder();
     }
 
     public List<String> unwrap(final ExpressionResolver context, final ModelNode model) throws OperationFailedException {
@@ -53,7 +50,7 @@ public final class StringListAttributeDefinition extends PrimitiveListAttributeD
         if (!model.isDefined()) {
             return null;
         }
-        List<String> result = new LinkedList<String>();
+        List<String> result = new LinkedList<>();
         for (ModelNode p : model.asList()) {
             result.add(context.resolveExpressions(p).asString());
         }
@@ -89,14 +86,7 @@ public final class StringListAttributeDefinition extends PrimitiveListAttributeD
         }
     }
 
-    @Override
-    public boolean hasCapabilityRequirements() {
-        return referenceRecorder != null;
-    }
-
     public static class Builder extends ListAttributeDefinition.Builder<Builder, StringListAttributeDefinition> {
-
-        private CapabilityReferenceRecorder referenceRecorder;
 
         public Builder(final String name) {
             super(name);
@@ -114,53 +104,6 @@ public final class StringListAttributeDefinition extends PrimitiveListAttributeD
         @Override
         public StringListAttributeDefinition build() {
             return new StringListAttributeDefinition(this);
-        }
-
-
-
-        /**
-         * Records that this attribute's values represents a reference to an instance of a
-         * {@link org.jboss.as.controller.capability.RuntimeCapability#isDynamicallyNamed() dynamic capability}.
-         * <p>
-         * This method is a convenience method equivalent to calling
-         * {@link #setCapabilityReference(SimpleAttributeDefinition.CapabilityReferenceRecorder)}
-         * passing in a {@link org.jboss.as.controller.SimpleAttributeDefinition.DefaultCapabilityReferenceRecorder}
-         * constructed using the parameters passed to this method.
-         *
-         * @param referencedCapability the name of the dynamic capability the dynamic portion of whose name is
-         *                             represented by the attribute's values
-         * @param dependentCapability the name of the capability that depends on {@code referencedCapability}
-         * @param dynamicDependent {@code true} if {@code dependentCapability} is a dynamic capability, the dynamic
-         *                                     portion of which comes from the name of the resource with which
-         *                                     the attribute is associated
-         * @return the builder
-         *
-         * @see SimpleAttributeDefinition#addCapabilityRequirements(OperationContext, ModelNode)
-         * @see SimpleAttributeDefinition#removeCapabilityRequirements(OperationContext, ModelNode)
-         */
-        public Builder setCapabilityReference(String referencedCapability, String dependentCapability, boolean dynamicDependent) {
-            referenceRecorder = new CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder(referencedCapability, dependentCapability, dynamicDependent);
-            return this;
-        }
-
-        /**
-         * Records that this attribute's values represents a reference to an instance of a
-         * {@link org.jboss.as.controller.capability.RuntimeCapability#isDynamicallyNamed() dynamic capability} and assigns the
-         * object that should be used to handle adding and removing capability requirements.
-         *
-         * @param referenceRecorder recorder to handle adding and removing capability requirements. May be {@code null}
-         * @return the builder
-         *
-         * @see SimpleAttributeDefinition#addCapabilityRequirements(OperationContext, ModelNode)
-         * @see SimpleAttributeDefinition#removeCapabilityRequirements(OperationContext, ModelNode)
-         */
-        public Builder setCapabilityReference(CapabilityReferenceRecorder referenceRecorder) {
-            this.referenceRecorder = referenceRecorder;
-            return this;
-        }
-
-        CapabilityReferenceRecorder getReferenceRecorder() {
-            return referenceRecorder;
         }
 
     }

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -83,6 +83,7 @@ public class ModelDescriptionConstants {
     public static final String CALLER_THREAD = "caller-thread";
     public static final String CALLER_TYPE = "caller-type";
     public static final String CANCELLED = "cancelled";
+    public static final String CAPABILITY_REFERENCE = "capability-reference";
     public static final String CHILD_TYPE = "child-type";
     public static final String CHILDREN = "children";
     public static final String CLASSIFICATION = "classification";

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelDescriptionValidator.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelDescriptionValidator.java
@@ -27,6 +27,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALTERNATIVES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTE_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CAPABILITY_REFERENCE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPRECATED;
@@ -131,6 +132,7 @@ public class ModelTestModelDescriptionValidator {
         paramAndAttributeKeys.put(UNIT, NumericDescriptorValidator.INSTANCE);
         paramAndAttributeKeys.put(EXPRESSIONS_ALLOWED, BooleanDescriptorValidator.INSTANCE);
         paramAndAttributeKeys.put(DEPRECATED, DeprecatedDescriptorValidator.INSTANCE);
+        paramAndAttributeKeys.put(CAPABILITY_REFERENCE, NullDescriptorValidator.INSTANCE);
 
         Map<String, AttributeOrParameterArbitraryDescriptorValidator> validAttributeKeys = new HashMap<String, AttributeOrParameterArbitraryDescriptorValidator>();
         validAttributeKeys.putAll(paramAndAttributeKeys);


### PR DESCRIPTION
I refactored the way CapabilityRecorder is set in builder to have more generic code.
I am also tempted to remove get/setCapabiltyRecorder() as this is impl detail more than anything else.