### PR TITLE
[WFCORE-818] OperationContext shouldn't require a registered capabili…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -1466,7 +1466,12 @@ final class OperationContextImpl extends AbstractOperationContext {
         assert isControllingThread();
         assertCapabilitiesAvailable(currentStage);
         CapabilityContext context = createCapabilityContext(step);
-        return managementModel.getCapabilityRegistry().getCapabilityServiceName(capabilityName, context, serviceType);
+        try {
+            return managementModel.getCapabilityRegistry().getCapabilityServiceName(capabilityName, context, serviceType);
+        } catch (IllegalStateException ignored) {
+            // not registered. just do it directly
+        }
+        return ServiceName.parse(capabilityName);
     }
 
     private void rejectUserDomainServerUpdates() {


### PR DESCRIPTION
…ty to provide a ServiceName

I'm inclined to remove the Class serviceValueType params from this API altogether but if I do I'll use a different JIRA. The now purely optional type checking isn't worth the API bloat IMO.