### PR TITLE
[WFCORE-654] : Configuration files get default permissions when written.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFilePersistenceResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFilePersistenceResource.java
@@ -52,7 +52,7 @@ public class ConfigurationFilePersistenceResource extends AbstractFilePersistenc
         final File tempFileName = FilePersistenceUtils.createTempFile(fileName);
         try {
             try {
-                FilePersistenceUtils.writeToTempFile(marshalled, tempFileName);
+                FilePersistenceUtils.writeToTempFile(marshalled, tempFileName, fileName);
             } catch (Exception e) {
                 MGMT_OP_LOGGER.failedToStoreConfiguration(e, fileName.getName());
                 return;

--- a/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceResource.java
@@ -48,7 +48,7 @@ public class FilePersistenceResource extends AbstractFilePersistenceResource {
     protected void doCommit(ExposedByteArrayOutputStream marshalled) {
         final File tempFileName = FilePersistenceUtils.createTempFile(fileName);
         try {
-            FilePersistenceUtils.writeToTempFile(marshalled, tempFileName);
+            FilePersistenceUtils.writeToTempFile(marshalled, tempFileName, fileName);
             FilePersistenceUtils.moveTempFileToMain(tempFileName, fileName);
         } catch (Exception e) {
             MGMT_OP_LOGGER.failedToStoreConfiguration(e, fileName.getName());


### PR DESCRIPTION
Using Nio2 API to try to create the temporary configuration file with the same attributes as the orignal configuration file.

Jira: https://issues.jboss.org/browse/WFCORE-654