### PR TITLE
WFCORE-775 domain mode - server fails to start intermittently

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -1028,7 +1028,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
             return getServerInventory().startServer(serverName, domainModel, blocking);
         }
 
-        public void reconnectServer(String serverName, ModelNode domainModel, byte[] authKey, boolean running, boolean stopping) {
+        public void reconnectServer(String serverName, ModelNode domainModel, String authKey, boolean running, boolean stopping) {
             getServerInventory().reconnectServer(serverName, domainModel, authKey, running, stopping);
         }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerBootstrap.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerBootstrap.java
@@ -41,9 +41,9 @@ public class HostControllerBootstrap {
     private final ShutdownHook shutdownHook;
     private final ServiceContainer serviceContainer;
     private final HostControllerEnvironment environment;
-    private final byte[] authCode;
+    private final String authCode;
 
-    public HostControllerBootstrap(final HostControllerEnvironment environment, final byte[] authCode) {
+    public HostControllerBootstrap(final HostControllerEnvironment environment, final String authCode) {
         this.environment = environment;
         this.authCode = authCode;
         this.shutdownHook = new ShutdownHook();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -84,12 +84,12 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
     private final HostControllerEnvironment environment;
     private final HostRunningModeControl runningModeControl;
     private final ControlledProcessState processState;
-    private final byte[] authCode;
+    private final String authCode;
     private volatile FutureServiceContainer futureContainer;
     private volatile long startTime;
 
     HostControllerService(final HostControllerEnvironment environment, final HostRunningModeControl runningModeControl,
-                          final byte[] authCode, final ControlledProcessState processState) {
+                          final String authCode, final ControlledProcessState processState) {
         this.environment = environment;
         this.runningModeControl = runningModeControl;
         this.authCode = authCode;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -43,6 +43,7 @@ import org.jboss.as.host.controller.logging.HostControllerLogger;
 import org.jboss.as.process.CommandLineArgumentUsageImpl;
 import org.jboss.as.process.CommandLineConstants;
 import org.jboss.as.process.ExitCodes;
+import org.jboss.as.process.ProcessController;
 import org.jboss.as.process.protocol.StreamUtils;
 import org.jboss.as.process.stdin.Base64InputStream;
 import org.jboss.as.version.ProductConfig;
@@ -85,7 +86,7 @@ public final class Main {
         //final PrintStream out = System.out;
         //final PrintStream err = System.err;
 
-        final byte[] authKey = new byte[16];
+        byte[] authKey = new byte[ProcessController.AUTH_BYTES_ENCODED_LENGTH];
         try {
             StreamUtils.readFully(new Base64InputStream(System.in), authKey);
         } catch (IOException e) {
@@ -109,7 +110,7 @@ public final class Main {
         );
         StdioContext.setStdioContextSelector(new SimpleStdioContextSelector(context));
 
-        create(args, authKey);
+        create(args, new String(authKey));
 
         while (in.read() != -1) {}
         exit();
@@ -118,12 +119,12 @@ public final class Main {
     private Main() {
     }
 
-    private static HostControllerBootstrap create(String[] args, final byte[] authCode) {
+    private static HostControllerBootstrap create(String[] args, final String authCode) {
         Main main = new Main();
         return main.boot(args, authCode);
     }
 
-    private HostControllerBootstrap boot(String[] args, final byte[] authCode) {
+    private HostControllerBootstrap boot(String[] args, final String authCode) {
         try {
             // TODO make this settable via an embedding process
             final long startTime = Module.getStartTime();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -32,6 +32,7 @@ import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -110,7 +111,7 @@ public final class Main {
         );
         StdioContext.setStdioContextSelector(new SimpleStdioContextSelector(context));
 
-        create(args, new String(authKey));
+        create(args, new String(authKey, Charset.forName("US-ASCII")));
 
         while (in.read() != -1) {}
         exit();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
@@ -101,7 +101,7 @@ class ManagedServer {
         return serverProcessName.substring(SERVER_PROCESS_NAME_PREFIX.length());
     }
 
-    private final byte[] authKey;
+    private final String authKey;
     private final String serverName;
     private final String serverProcessName;
     private final String hostControllerName;
@@ -120,7 +120,7 @@ class ManagedServer {
     private volatile int operationID = CurrentOperationIdHolder.getCurrentOperationID();
     private volatile ManagedServerBootConfiguration bootConfiguration;
 
-    ManagedServer(final String hostControllerName, final String serverName, final byte[] authKey,
+    ManagedServer(final String hostControllerName, final String serverName, final String authKey,
                   final ProcessControllerClient processControllerClient, final URI managementURI,
                   final TransformationTarget transformationTarget) {
 
@@ -150,7 +150,7 @@ class ManagedServer {
      *
      * @return the auth key
      */
-    byte[] getAuthKey() {
+    String getAuthKey() {
         return authKey;
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ProcessControllerConnectionService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ProcessControllerConnectionService.java
@@ -57,7 +57,7 @@ class ProcessControllerConnectionService implements Service<ProcessControllerCon
     static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("host", "controller", "process-controller-connection");
 
     private final HostControllerEnvironment environment;
-    private final byte[] authCode;
+    private final String authCode;
     private volatile ProcessControllerClient client;
     private volatile ServerInventory serverInventory;
 
@@ -65,7 +65,7 @@ class ProcessControllerConnectionService implements Service<ProcessControllerCon
     private static final int THREAD_POOL_CORE_SIZE = 1;
     private static final int THREAD_POOL_MAX_SIZE = 4;
 
-    ProcessControllerConnectionService(final HostControllerEnvironment environment, final byte[] authCode) {
+    ProcessControllerConnectionService(final HostControllerEnvironment environment, final String authCode) {
         this.environment = environment;
         this.authCode = authCode;
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
@@ -174,7 +174,7 @@ public interface ServerInventory {
      *                recorded but no attempt to contact it will be made
      * @param stopping whether the process is currently stopping
      */
-    void reconnectServer(String serverName, ModelNode domainModel, byte[] authKey, boolean running, boolean stopping);
+    void reconnectServer(String serverName, ModelNode domainModel, String authKey, boolean running, boolean stopping);
 
     /**
      * Reload a server with the given name.

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/StartServersHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/StartServersHandler.java
@@ -133,8 +133,7 @@ public class StartServersHandler implements OperationStepHandler {
                 }
             } else if (info != null){
                 // Reconnect the server using the current authKey
-                final byte[] authKey = info.getAuthKey();
-                serverInventory.reconnectServer(serverName, domainModel, authKey, info.isRunning(), info.isStopping());
+                serverInventory.reconnectServer(serverName, domainModel, info.getAuthKey(), info.isRunning(), info.isStopping());
             }
         }
     }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -588,7 +588,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         }
 
         @Override
-        public void reconnectServer(String serverName, ModelNode domainModel, byte[] authKey, boolean running, boolean stopping) {
+        public void reconnectServer(String serverName, ModelNode domainModel, String authKey, boolean running, boolean stopping) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 

--- a/host-controller/src/test/java/org/jboss/as/host/controller/ServerInventoryImplTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/ServerInventoryImplTestCase.java
@@ -22,6 +22,7 @@ package org.jboss.as.host.controller;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
+import java.util.Base64;
 import static org.hamcrest.CoreMatchers.is;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,12 +32,10 @@ import org.junit.Test;
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
  */
 public class ServerInventoryImplTestCase {
- private static final String HEX_DIGITS = "0123456789abcdef";
     @Test
-    public void testRemoveNullChar() throws UnsupportedEncodingException {
+    public void testEncodingAndDecoding() throws UnsupportedEncodingException {
         byte[] array = new byte[]{0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x00, 0x57, 0x6f, 0x72, 0x6c, 0x64};
-        byte[] expected = new byte[]{0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x01, 0x57, 0x6f, 0x72, 0x6c, 0x64};
-        ServerInventoryImpl.removeNullChar(array);       
-        Assert.assertThat(Arrays.equals(array, expected), is(true));
+        byte[] expected = new byte[]{0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x00, 0x57, 0x6f, 0x72, 0x6c, 0x64};
+        Assert.assertThat(Arrays.equals(Base64.getDecoder().decode(Base64.getEncoder().encode(array)), expected), is(true));
     }
 }

--- a/process-controller/src/main/java/org/jboss/as/process/ManagedProcess.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ManagedProcess.java
@@ -34,6 +34,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -178,7 +179,7 @@ final class ManagedProcess {
             StreamUtils.writeUTFZBytes(base64, hostName);
             StreamUtils.writeInt(base64, port);
             StreamUtils.writeBoolean(base64, managementSubsystemEndpoint);
-            base64.write(asAuthKey.getBytes());
+            base64.write(asAuthKey.getBytes(Charset.forName("US-ASCII")));
             base64.close(); // not flush(). close() writes extra data to the stream allowing Base64 input stream
                             // to distinguish end of message
         } catch (IOException e) {
@@ -229,7 +230,7 @@ final class ManagedProcess {
         try {
             // WFLY-2697 All writing is in Base64
             OutputStream base64 = getBase64OutputStream(stdin);
-            base64.write(authKey.getBytes());
+            base64.write(authKey.getBytes(Charset.forName("US-ASCII")));
             base64.close(); // not flush(). close() writes extra data to the stream allowing Base64 input stream
                             // to distinguish end of message
             ok = true;

--- a/process-controller/src/main/java/org/jboss/as/process/ManagedProcess.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ManagedProcess.java
@@ -61,7 +61,7 @@ final class ManagedProcess {
     private final Object lock;
 
     private final ProcessController processController;
-    private final byte[] authKey;
+    private final String authKey;
     private final boolean isPrivileged;
     private final RespawnPolicy respawnPolicy;
 
@@ -72,7 +72,7 @@ final class ManagedProcess {
     private boolean stopRequested = false;
     private final AtomicInteger respawnCount = new AtomicInteger(0);
 
-    public byte[] getAuthKey() {
+    public String getAuthKey() {
         return authKey;
     }
 
@@ -95,7 +95,7 @@ final class ManagedProcess {
         ;
     }
 
-    ManagedProcess(final String processName, final List<String> command, final Map<String, String> env, final String workingDirectory, final Object lock, final ProcessController controller, final byte[] authKey, final boolean privileged, final boolean respawn) {
+    ManagedProcess(final String processName, final List<String> command, final Map<String, String> env, final String workingDirectory, final Object lock, final ProcessController controller, final String authKey, final boolean privileged, final boolean respawn) {
         if (processName == null) {
             throw ProcessLogger.ROOT_LOGGER.nullVar("processName");
         }
@@ -117,7 +117,7 @@ final class ManagedProcess {
         if (authKey == null) {
             throw ProcessLogger.ROOT_LOGGER.nullVar("authKey");
         }
-        if (authKey.length != 16) {
+        if (authKey.length() != ProcessController.AUTH_BYTES_ENCODED_LENGTH) {
             throw ProcessLogger.ROOT_LOGGER.invalidLength("authKey");
         }
         this.processName = processName;
@@ -169,7 +169,7 @@ final class ManagedProcess {
         }
     }
 
-    public void reconnect(String scheme, String hostName, int port, boolean managementSubsystemEndpoint, byte[] asAuthKey) {
+    public void reconnect(String scheme, String hostName, int port, boolean managementSubsystemEndpoint, String asAuthKey) {
         assert holdsLock(lock); // Call under lock
         try {
             // WFLY-2697 All writing is in Base64
@@ -178,7 +178,7 @@ final class ManagedProcess {
             StreamUtils.writeUTFZBytes(base64, hostName);
             StreamUtils.writeInt(base64, port);
             StreamUtils.writeBoolean(base64, managementSubsystemEndpoint);
-            base64.write(asAuthKey);
+            base64.write(asAuthKey.getBytes());
             base64.close(); // not flush(). close() writes extra data to the stream allowing Base64 input stream
                             // to distinguish end of message
         } catch (IOException e) {
@@ -229,7 +229,7 @@ final class ManagedProcess {
         try {
             // WFLY-2697 All writing is in Base64
             OutputStream base64 = getBase64OutputStream(stdin);
-            base64.write(authKey);
+            base64.write(authKey.getBytes());
             base64.close(); // not flush(). close() writes extra data to the stream allowing Base64 input stream
                             // to distinguish end of message
             ok = true;

--- a/process-controller/src/main/java/org/jboss/as/process/ProcessController.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ProcessController.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Base64;
@@ -117,7 +118,7 @@ public final class ProcessController {
             }
             final ManagedProcess process = new ManagedProcess(processName, command, env, workingDirectory, lock, this, authKey, isPrivileged, respawn);
             processes.put(processName, process);
-            processesByKey.put(new Key(authKey.getBytes()), process);
+            processesByKey.put(new Key(authKey.getBytes(Charset.forName("US-ASCII"))), process);
             processAdded(processName);
         }
     }
@@ -185,7 +186,7 @@ public final class ProcessController {
                 return;
             }
             boolean removed = processes.remove(processName) != null;
-            processesByKey.remove(new Key(process.getAuthKey().getBytes()));
+            processesByKey.remove(new Key(process.getAuthKey().getBytes(Charset.forName("US-ASCII"))));
             if(removed) {
                 processRemoved(processName);
             }
@@ -341,7 +342,7 @@ public final class ProcessController {
                         StreamUtils.writeInt(os, processCollection.size());
                         for (ManagedProcess process : processCollection) {
                             StreamUtils.writeUTFZBytes(os, process.getProcessName());
-                            os.write(process.getAuthKey().getBytes());
+                            os.write(process.getAuthKey().getBytes(Charset.forName("US-ASCII")));
                             StreamUtils.writeBoolean(os, process.isRunning());
                             StreamUtils.writeBoolean(os, process.isStopping());
                         }

--- a/process-controller/src/main/java/org/jboss/as/process/ProcessControllerClient.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ProcessControllerClient.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -114,7 +115,8 @@ public final class ProcessControllerClient implements Closeable {
                             readFully(dataStream, processAuthBytes);
                             final boolean processRunning = StreamUtils.readBoolean(dataStream);
                             final boolean processStopping = StreamUtils.readBoolean(dataStream);
-                            inventory.put(processName, new ProcessInfo(processName, new String(processAuthBytes), processRunning, processStopping));
+                            final String processAuthKey = new String(processAuthBytes, Charset.forName("US-ASCII"));
+                            inventory.put(processName, new ProcessInfo(processName, processAuthKey, processRunning, processStopping));
                         }
                         dataStream.close();
                         ProcessLogger.CLIENT_LOGGER.tracef("Received process_inventory");
@@ -160,7 +162,7 @@ public final class ProcessControllerClient implements Closeable {
             try {
                 os.write(Protocol.AUTH);
                 os.write(1);
-                os.write(authCode.getBytes());
+                os.write(authCode.getBytes(Charset.forName("US-ASCII")));
                 final ProcessControllerClient processControllerClient = new ProcessControllerClient(connection);
                 connection.attach(processControllerClient);
                 ProcessLogger.CLIENT_LOGGER.trace("Sent initial greeting message");
@@ -219,7 +221,7 @@ public final class ProcessControllerClient implements Closeable {
         try {
             os.write(Protocol.ADD_PROCESS);
             writeUTFZBytes(os, processName);
-            os.write(authKey.getBytes());
+            os.write(authKey.getBytes(Charset.forName("US-ASCII")));
             writeInt(os, cmd.length);
             for (String c : cmd) {
                 writeUTFZBytes(os, c);
@@ -305,7 +307,7 @@ public final class ProcessControllerClient implements Closeable {
             writeUTFZBytes(os, managementURI.getHost());
             writeInt(os, managementURI.getPort());
             writeBoolean(os, managementSubsystemEndpoint);
-            os.write(authKey.getBytes());
+            os.write(authKey.getBytes(Charset.forName("US-ASCII")));
             os.close();
         } finally {
             safeClose(os);

--- a/process-controller/src/main/java/org/jboss/as/process/ProcessControllerClient.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ProcessControllerClient.java
@@ -61,7 +61,7 @@ public final class ProcessControllerClient implements Closeable {
         this.connection = connection;
     }
 
-    public static ProcessControllerClient connect(final ProtocolClient.Configuration configuration, final byte[] authCode, final ProcessMessageHandler messageHandler) throws IOException {
+    public static ProcessControllerClient connect(final ProtocolClient.Configuration configuration, final String authCode, final ProcessMessageHandler messageHandler) throws IOException {
         if (configuration == null) {
             throw ProcessLogger.ROOT_LOGGER.nullVar("configuration");
         }
@@ -110,11 +110,11 @@ public final class ProcessControllerClient implements Closeable {
                         final Map<String, ProcessInfo> inventory = new HashMap<String, ProcessInfo>();
                         for (int i = 0; i < cnt; i++) {
                             final String processName = readUTFZBytes(dataStream);
-                            final byte[] processAuthCode = new byte[16];
-                            readFully(dataStream, processAuthCode);
+                            final byte[] processAuthBytes = new byte[ProcessController.AUTH_BYTES_ENCODED_LENGTH];
+                            readFully(dataStream, processAuthBytes);
                             final boolean processRunning = StreamUtils.readBoolean(dataStream);
                             final boolean processStopping = StreamUtils.readBoolean(dataStream);
-                            inventory.put(processName, new ProcessInfo(processName, processAuthCode, processRunning, processStopping));
+                            inventory.put(processName, new ProcessInfo(processName, new String(processAuthBytes), processRunning, processStopping));
                         }
                         dataStream.close();
                         ProcessLogger.CLIENT_LOGGER.tracef("Received process_inventory");
@@ -160,7 +160,7 @@ public final class ProcessControllerClient implements Closeable {
             try {
                 os.write(Protocol.AUTH);
                 os.write(1);
-                os.write(authCode);
+                os.write(authCode.getBytes());
                 final ProcessControllerClient processControllerClient = new ProcessControllerClient(connection);
                 connection.attach(processControllerClient);
                 ProcessLogger.CLIENT_LOGGER.trace("Sent initial greeting message");
@@ -192,7 +192,7 @@ public final class ProcessControllerClient implements Closeable {
         }
     }
 
-    public void addProcess(String processName, byte[] authKey, String[] cmd, String workingDir, Map<String, String> env) throws IOException {
+    public void addProcess(String processName, String authKey, String[] cmd, String workingDir, Map<String, String> env) throws IOException {
         if (processName == null) {
             throw ProcessLogger.ROOT_LOGGER.nullVar("processName");
         }
@@ -211,14 +211,15 @@ public final class ProcessControllerClient implements Closeable {
         if (cmd.length < 1) {
             throw ProcessLogger.ROOT_LOGGER.invalidCommandLen();
         }
-        if (authKey.length != 16) {
+        // this is Base64 encoded, and padded up to 24 bytes
+        if (authKey.length() != ProcessController.AUTH_BYTES_ENCODED_LENGTH) {
             throw ProcessLogger.ROOT_LOGGER.invalidAuthKeyLen();
         }
         final OutputStream os = connection.writeMessage();
         try {
             os.write(Protocol.ADD_PROCESS);
             writeUTFZBytes(os, processName);
-            os.write(authKey);
+            os.write(authKey.getBytes());
             writeInt(os, cmd.length);
             for (String c : cmd) {
                 writeUTFZBytes(os, c);
@@ -292,7 +293,7 @@ public final class ProcessControllerClient implements Closeable {
         }
     }
 
-    public void reconnectProcess(final String processName, final URI managementURI, final boolean managementSubsystemEndpoint, final byte[] authKey) throws IOException {
+    public void reconnectProcess(final String processName, final URI managementURI, final boolean managementSubsystemEndpoint, final String authKey) throws IOException {
         if (processName == null){
             throw ProcessLogger.ROOT_LOGGER.nullVar("processName");
         }
@@ -304,7 +305,7 @@ public final class ProcessControllerClient implements Closeable {
             writeUTFZBytes(os, managementURI.getHost());
             writeInt(os, managementURI.getPort());
             writeBoolean(os, managementSubsystemEndpoint);
-            os.write(authKey);
+            os.write(authKey.getBytes());
             os.close();
         } finally {
             safeClose(os);

--- a/process-controller/src/main/java/org/jboss/as/process/ProcessControllerServerHandler.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ProcessControllerServerHandler.java
@@ -32,6 +32,7 @@ import static org.jboss.as.process.protocol.StreamUtils.safeClose;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -161,7 +162,8 @@ public final class ProcessControllerServerHandler implements ConnectionHandler {
                                 }
                                 final String workingDirectory = readUTFZBytes(dataStream);
                                 ProcessLogger.SERVER_LOGGER.tracef("Received add_process for process %s", processName);
-                                processController.addProcess(processName, new String(authBytes), Arrays.asList(command), env, workingDirectory, false, false);
+                                final String authKey = new String(authBytes, Charset.forName("US-ASCII"));
+                                processController.addProcess(processName, authKey, Arrays.asList(command), env, workingDirectory, false, false);
                             } else {
                                 ProcessLogger.SERVER_LOGGER.tracef("Ignoring add_process message from untrusted source");
                             }
@@ -223,7 +225,9 @@ public final class ProcessControllerServerHandler implements ConnectionHandler {
                                 final boolean managementSubsystemEndpoint = readBoolean(dataStream);
                                 final byte[] authBytes = new byte[ProcessController.AUTH_BYTES_ENCODED_LENGTH];
                                 readFully(dataStream, authBytes);
-                                processController.sendReconnectProcess(processName, scheme, hostName, port, managementSubsystemEndpoint, new String(authBytes));                            } else {
+                                final String authKey = new String(authBytes, Charset.forName("US-ASCII"));
+                                processController.sendReconnectProcess(processName, scheme, hostName, port, managementSubsystemEndpoint, authKey);
+                            } else {
                                 ProcessLogger.SERVER_LOGGER.tracef("Ignoring reconnect_process message from untrusted source");
                             }
                             dataStream.close();

--- a/process-controller/src/main/java/org/jboss/as/process/ProcessInfo.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ProcessInfo.java
@@ -27,11 +27,11 @@ package org.jboss.as.process;
  */
 public final class ProcessInfo {
     private final String processName;
-    private final byte[] authKey;
+    private final String authKey;
     private final boolean running;
     private final boolean stopping;
 
-    ProcessInfo(final String processName, final byte[] authKey, final boolean running, final boolean stopping) {
+    ProcessInfo(final String processName, final String authKey, final boolean running, final boolean stopping) {
         this.processName = processName;
         this.authKey = authKey;
         this.running = running;
@@ -42,7 +42,7 @@ public final class ProcessInfo {
         return processName;
     }
 
-    public byte[] getAuthKey() {
+    public String getAuthKey() {
         return authKey;
     }
 

--- a/process-controller/src/main/java/org/jboss/as/process/logging/ProcessLogger.java
+++ b/process-controller/src/main/java/org/jboss/as/process/logging/ProcessLogger.java
@@ -486,7 +486,7 @@ public interface ProcessLogger extends BasicLogger {
      *
      * @return an {@link IllegalArgumentException} for the error.
      */
-    @Message(id = 25, value = "Authentication key must be 16 bytes long")
+    @Message(id = 25, value = "Authentication key must be 24 bytes long")
     IllegalArgumentException invalidAuthKeyLen();
 
     /**

--- a/server/src/main/java/org/jboss/as/server/DomainServerCommunicationServices.java
+++ b/server/src/main/java/org/jboss/as/server/DomainServerCommunicationServices.java
@@ -63,11 +63,11 @@ public class DomainServerCommunicationServices  implements ServiceActivator, Ser
     private final URI managementURI;
     private final String serverName;
     private final String serverProcessName;
-    private final byte[] authKey;
+    private final String authKey;
 
     private final boolean managementSubsystemEndpoint;
 
-    DomainServerCommunicationServices(ModelNode endpointConfig, URI managementURI, String serverName, String serverProcessName, byte[] authKey, boolean managementSubsystemEndpoint) {
+    DomainServerCommunicationServices(ModelNode endpointConfig, URI managementURI, String serverName, String serverProcessName, String authKey, boolean managementSubsystemEndpoint) {
         this.endpointConfig = endpointConfig;
         this.managementURI = managementURI;
         this.serverName = serverName;
@@ -116,7 +116,7 @@ public class DomainServerCommunicationServices  implements ServiceActivator, Ser
      * @return the service activator
      */
     public static ServiceActivator create(final ModelNode endpointConfig, final URI managementURI, final String serverName, final String serverProcessName,
-                                          final byte[] authKey, final boolean managementSubsystemEndpoint) {
+                                          final String authKey, final boolean managementSubsystemEndpoint) {
 
         return new DomainServerCommunicationServices(endpointConfig, managementURI, serverName, serverProcessName, authKey, managementSubsystemEndpoint);
     }

--- a/server/src/main/java/org/jboss/as/server/DomainServerMain.java
+++ b/server/src/main/java/org/jboss/as/server/DomainServerMain.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import org.jboss.as.network.NetworkUtils;
 
 import org.jboss.as.process.ExitCodes;
+import org.jboss.as.process.ProcessController;
 import org.jboss.as.process.protocol.StreamUtils;
 import org.jboss.as.process.stdin.Base64InputStream;
 import org.jboss.as.server.mgmt.domain.HostControllerClient;
@@ -92,9 +93,9 @@ public final class DomainServerMain {
         );
         StdioContext.setStdioContextSelector(new SimpleStdioContextSelector(context));
 
-        final byte[] authKey = new byte[16];
+        final byte[] asAuthBytes = new byte[ProcessController.AUTH_BYTES_ENCODED_LENGTH];
         try {
-            StreamUtils.readFully(initialInput, authKey);
+            StreamUtils.readFully(initialInput, asAuthBytes);
         } catch (IOException e) {
             e.printStackTrace();
             SystemExiter.exit(ExitCodes.FAILED);
@@ -134,8 +135,9 @@ public final class DomainServerMain {
                 final String hostName = StreamUtils.readUTFZBytes(initialInput);
                 final int port = StreamUtils.readInt(initialInput);
                 final boolean managementSubsystemEndpoint = StreamUtils.readBoolean(initialInput);
-                final byte[] asAuthKey = new byte[16];
+                final byte[] asAuthKey = new byte[ProcessController.AUTH_BYTES_ENCODED_LENGTH];
                 StreamUtils.readFully(initialInput, asAuthKey);
+
                 URI hostControllerUri = new URI(scheme, null, NetworkUtils.formatPossibleIpv6Address(hostName), port, null, null, null);
 
                 // Get the host-controller server client
@@ -145,7 +147,7 @@ public final class DomainServerMain {
                     final HostControllerClient client = getRequiredService(container,
                             HostControllerConnectionService.SERVICE_NAME, HostControllerClient.class);
                     // Reconnect to the host-controller
-                    client.reconnect(hostControllerUri, asAuthKey, managementSubsystemEndpoint);
+                    client.reconnect(hostControllerUri, new String(asAuthBytes), managementSubsystemEndpoint);
                 }
 
             } catch (InterruptedIOException e) {

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerClient.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerClient.java
@@ -87,7 +87,7 @@ public class HostControllerClient implements Closeable {
         this.controller = controller;
     }
 
-    public void reconnect(final URI uri, final byte[] authKey, final boolean mgmtSubsystemEndpoint) throws IOException, URISyntaxException {
+    public void reconnect(final URI uri, final String authKey, final boolean mgmtSubsystemEndpoint) throws IOException, URISyntaxException {
         // In case the server is out of sync after the reconnect, set reload required
         final boolean mgmtEndpointChanged = this.managementSubsystemEndpoint != mgmtSubsystemEndpoint;
         connection.asyncReconnect(uri, authKey, new HostControllerConnection.ReconnectCallback() {

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnection.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnection.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.server.mgmt.domain;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
@@ -150,7 +148,7 @@ class HostControllerConnection extends FutureManagementChannel {
      * @param authKey         the updated authentication key
      * @param callback        the current callback
      */
-    synchronized void asyncReconnect(final URI reconnectUri, byte[] authKey, final ReconnectCallback callback) {
+    synchronized void asyncReconnect(final URI reconnectUri, String authKey, final ReconnectCallback callback) {
         if (getState() != State.OPEN) {
             return;
         }
@@ -382,16 +380,16 @@ class HostControllerConnection extends FutureManagementChannel {
      * @param authKey the authentication key
      * @return the callback handler
      */
-    static CallbackHandler createClientCallbackHandler(final String userName, final byte[] authKey) {
+    static CallbackHandler createClientCallbackHandler(final String userName, final String authKey) {
         return new ClientCallbackHandler(userName, authKey);
     }
 
     private static class ClientCallbackHandler implements CallbackHandler {
 
         private final String userName;
-        private final byte[] authKey;
+        private final String authKey;
 
-        private ClientCallbackHandler(String userName, byte[] authKey) {
+        private ClientCallbackHandler(String userName, String authKey) {
             this.userName = userName;
             this.authKey = authKey;
         }
@@ -409,7 +407,7 @@ class HostControllerConnection extends FutureManagementChannel {
                     ncb.setName(userName);
                 } else if (current instanceof PasswordCallback) {
                     PasswordCallback pcb = (PasswordCallback) current;
-                    pcb.setPassword(new String(authKey, UTF_8).toCharArray());
+                    pcb.setPassword(authKey.toCharArray());
                 } else {
                     throw new UnsupportedCallbackException(current);
                 }

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
@@ -76,7 +76,7 @@ public class HostControllerConnectionService implements Service<HostControllerCl
     private final String serverName;
     private final String userName;
     private final String serverProcessName;
-    private final byte[] initialAuthKey;
+    private final String initialAuthKey;
     private final int connectOperationID;
     private final boolean managementSubsystemEndpoint;
     private volatile ResponseAttachmentInputStreamSupport responseAttachmentSupport;
@@ -84,7 +84,7 @@ public class HostControllerConnectionService implements Service<HostControllerCl
     private HostControllerClient client;
 
     public HostControllerConnectionService(final URI connectionURI, final String serverName, final String serverProcessName,
-                                           final byte[] authKey, final int connectOperationID,
+                                           final String authKey, final int connectOperationID,
                                            final boolean managementSubsystemEndpoint) {
         this.connectionURI= connectionURI;
         this.serverName = serverName;


### PR DESCRIPTION
WFCORE-775
Forgot to send-pr.

This changes the authKey generation from a 16 byte array to a base 64 encoded string. The amount  of information present remains the same, the string will be 24 bytes in length, however.

java.utils.Base64 is used, JDK8 only, backports would need to utilize an alternative encoder.
