### PR TITLE
WFCORE-760: Validate that the "category" attribute for a logger is no…

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_0.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_0.java
@@ -68,6 +68,7 @@ import java.util.Set;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ParseUtils;
+import static org.jboss.as.controller.parsing.ParseUtils.invalidAttributeValue;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
@@ -156,6 +157,9 @@ class LoggingSubsystemParser_1_0 extends LoggingSubsystemParser implements XMLSt
             required.remove(attribute);
             switch (attribute) {
                 case CATEGORY: {
+                    if (value == null || value.trim().isEmpty()) {
+                        throw invalidAttributeValue(reader, i);
+                    }
                     name = value;
                     break;
                 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_1.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_1.java
@@ -71,6 +71,7 @@ import java.util.Set;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ParseUtils;
+import static org.jboss.as.controller.parsing.ParseUtils.invalidAttributeValue;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
@@ -165,6 +166,9 @@ class LoggingSubsystemParser_1_1 extends LoggingSubsystemParser implements XMLSt
             required.remove(attribute);
             switch (attribute) {
                 case CATEGORY: {
+                    if (value == null || value.trim().isEmpty()) {
+                        throw invalidAttributeValue(reader, i);
+                    }
                     name = value;
                     break;
                 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_2.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_2.java
@@ -82,6 +82,7 @@ import java.util.Set;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ParseUtils;
+import static org.jboss.as.controller.parsing.ParseUtils.invalidAttributeValue;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
@@ -183,6 +184,9 @@ class LoggingSubsystemParser_1_2 extends LoggingSubsystemParser implements XMLSt
             required.remove(attribute);
             switch (attribute) {
                 case CATEGORY: {
+                    if (value == null || value.trim().isEmpty()) {
+                        throw invalidAttributeValue(reader, i);
+                    }
                     name = value;
                     break;
                 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_3.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_3.java
@@ -83,6 +83,7 @@ import java.util.Set;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ParseUtils;
+import static org.jboss.as.controller.parsing.ParseUtils.invalidAttributeValue;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
@@ -185,6 +186,9 @@ class LoggingSubsystemParser_1_3 extends LoggingSubsystemParser implements XMLSt
             required.remove(attribute);
             switch (attribute) {
                 case CATEGORY: {
+                    if (value == null || value.trim().isEmpty()) {
+                        throw invalidAttributeValue(reader, i);
+                    }
                     name = value;
                     break;
                 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_4.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_4.java
@@ -84,6 +84,7 @@ import java.util.Set;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ParseUtils;
+import static org.jboss.as.controller.parsing.ParseUtils.invalidAttributeValue;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
@@ -199,6 +200,9 @@ class LoggingSubsystemParser_1_4 extends LoggingSubsystemParser implements XMLSt
             required.remove(attribute);
             switch (attribute) {
                 case CATEGORY: {
+                    if (value == null || value.trim().isEmpty()) {
+                        throw invalidAttributeValue(reader, i);
+                    }
                     name = value;
                     break;
                 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_5.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_1_5.java
@@ -85,6 +85,7 @@ import java.util.Set;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ParseUtils;
+import static org.jboss.as.controller.parsing.ParseUtils.invalidAttributeValue;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
@@ -204,6 +205,9 @@ class LoggingSubsystemParser_1_5 extends LoggingSubsystemParser implements XMLSt
             required.remove(attribute);
             switch (attribute) {
                 case CATEGORY: {
+                    if (value == null || value.trim().isEmpty()) {
+                        throw invalidAttributeValue(reader, i);
+                    }
                     name = value;
                     break;
                 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_2_0.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_2_0.java
@@ -84,6 +84,7 @@ import java.util.Set;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ParseUtils;
+import static org.jboss.as.controller.parsing.ParseUtils.invalidAttributeValue;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
@@ -204,6 +205,9 @@ class LoggingSubsystemParser_2_0 extends LoggingSubsystemParser implements XMLSt
             required.remove(attribute);
             switch (attribute) {
                 case CATEGORY: {
+                    if (value == null || value.trim().isEmpty()) {
+                        throw invalidAttributeValue(reader, i);
+                    }
                     name = value;
                     break;
                 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_3_0.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_3_0.java
@@ -85,6 +85,7 @@ import java.util.Set;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ParseUtils;
+import static org.jboss.as.controller.parsing.ParseUtils.invalidAttributeValue;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
@@ -209,6 +210,9 @@ class LoggingSubsystemParser_3_0 extends LoggingSubsystemParser implements XMLSt
             required.remove(attribute);
             switch (attribute) {
                 case CATEGORY: {
+                    if (value == null || value.trim().isEmpty()) {
+                        throw invalidAttributeValue(reader, i);
+                    }
                     name = value;
                     break;
                 }


### PR DESCRIPTION
…t an empty string. 
Without this fix, such a config fails to start and throws a StringOutOfBoundsException. Now instead, it fails with an invalidAttributeValue error which generates a more useful error message as follows:

javax.xml.stream.XMLStreamException: ParseError at [row,col]:[1,5167]
Message: WFLYCTL0106: Invalid value '' for attribute 'category'

To validate the error manually, i simply added a logger with an empty category to the src/test/resources/logging.xml file and ran the tests, which throws the above error, as expected. A test cannot be written as we cannot add a logger dynamically with an empty category, this can only happen in a config file.