### PR TITLE
WFLY-2422 Introduction of remote-outbound-connection-group concept

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/Attribute.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/Attribute.java
@@ -34,6 +34,7 @@ public enum Attribute {
     CONNECTOR_REF(CommonAttributes.CONNECTOR_REF),
     NAME(CommonAttributes.NAME),
     OUTBOUND_SOCKET_BINDING_REF(CommonAttributes.OUTBOUND_SOCKET_BINDING_REF),
+    OUTBOUND_SOCKET_BINDING_REFS(CommonAttributes.OUTBOUND_SOCKET_BINDING_REFS),
     PROTOCOL(CommonAttributes.PROTOCOL),
     SASL_PROTOCOL(CommonAttributes.SASL_PROTOCOL),
     SECURITY_REALM(CommonAttributes.SECURITY_REALM),

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/CommonAttributes.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/CommonAttributes.java
@@ -41,6 +41,7 @@ interface CommonAttributes {
     String NO_PLAIN_TEXT = "no-plain-text";
     String OUTBOUND_CONNECTION = "outbound-connection";
     String OUTBOUND_SOCKET_BINDING_REF = "outbound-socket-binding-ref";
+    String OUTBOUND_SOCKET_BINDING_REFS = "outbound-socket-binding-refs";
     String PASS_CREDENTIALS = "pass-credentials";
     String POLICY = "policy";
     String PROPERTIES = "properties";
@@ -48,6 +49,7 @@ interface CommonAttributes {
     String PROTOCOL = "protocol";
     String QOP = "qop";
     String REMOTE_OUTBOUND_CONNECTION = "remote-outbound-connection";
+    String REMOTE_OUTBOUND_CONNECTION_GROUP = "remote-outbound-connection-group";
     String REUSE_SESSION= "reuse-session";
     String SASL = "sasl";
     String SASL_POLICY = "sasl-policy";

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/Element.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/Element.java
@@ -52,6 +52,7 @@ public enum Element {
     PROPERTIES("properties"),
     PROPERTY("property"),
     REMOTE_OUTBOUND_CONNECTION("remote-outbound-connection"),
+    REMOTE_OUTBOUND_CONNECTION_GROUP("remote-outbound-connection-group"),
     QOP("qop"),
     REUSE_SESSION("reuse-session"),
     SASL("sasl"),

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/Namespace.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/Namespace.java
@@ -39,12 +39,13 @@ public enum Namespace {
     REMOTING_1_2("urn:jboss:domain:remoting:1.2"),
     REMOTING_2_0("urn:jboss:domain:remoting:2.0"),
     REMOTING_3_0("urn:jboss:domain:remoting:3.0"),
+    REMOTING_3_1("urn:jboss:domain:remoting:3.1")
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = REMOTING_3_0;
+    public static final Namespace CURRENT = REMOTING_3_1;
 
     private final String name;
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupAdd.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.remoting;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.domain.management.SecurityRealm;
+import org.jboss.as.network.OutboundSocketBinding;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.remoting3.Endpoint;
+import org.xnio.OptionMap;
+
+import java.util.List;
+
+/**
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+class RemoteOutboundConnectionGroupAdd extends AbstractAddStepHandler {
+
+    static final RemoteOutboundConnectionGroupAdd INSTANCE = new RemoteOutboundConnectionGroupAdd();
+
+    private RemoteOutboundConnectionGroupAdd() {
+        super(RemoteOutboundConnectionGroupResourceDefinition.ATTRIBUTE_DEFINITIONS);
+    }
+
+    @Override
+    protected void performRuntime(final OperationContext context, final ModelNode operation, final Resource resource)
+            throws OperationFailedException {
+        performRuntime(context, operation, Resource.Tools.readModel(resource));
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode fullModel)
+            throws OperationFailedException {
+        installRuntimeService(context, operation, fullModel);
+    }
+
+    void installRuntimeService(final OperationContext context, final ModelNode operation, final ModelNode fullModel)
+            throws OperationFailedException {
+
+        final PathAddress address = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
+
+        final String groupName = address.getLastElement().getValue();
+
+        final List<ModelNode> socketRefs = RemoteOutboundConnectionGroupResourceDefinition.OUTBOUND_SOCKET_BINDINGS_REFS
+                .resolveModelAttribute(context, fullModel).asList();
+
+        final String protocol = RemoteOutboundConnectionGroupResourceDefinition.PROTOCOL.resolveModelAttribute(context,
+                operation).asString();
+        final String username = RemoteOutboundConnectionGroupResourceDefinition.USERNAME.resolveModelAttribute(context,
+                fullModel).asString();
+        final String securityRealm = fullModel.hasDefined(CommonAttributes.SECURITY_REALM) ? fullModel.require(
+                CommonAttributes.SECURITY_REALM).asString() : null;
+
+        final OptionMap connectionCreationOptions = ConnectorUtils
+                .getOptions(context, fullModel.get(CommonAttributes.PROPERTY));
+
+        for (int i = 0; i < socketRefs.size(); i++) {
+            final String socketRef = socketRefs.get(i).asString();
+            final String connectionName = new StringBuilder(groupName).append(i+1).toString();
+            installConnectionService(context, socketRef, connectionName, username, protocol, securityRealm,
+                    connectionCreationOptions);
+        }
+    }
+
+    void installConnectionService(final OperationContext context, final String socketRef, final String connectionName,
+            final String username, final String protocol, final String securityRealm, final OptionMap options) {
+        final ServiceName outboundSocketBindingDependency = context.getCapabilityServiceName(
+                AbstractOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME, socketRef,
+                OutboundSocketBinding.class);
+        // create the service
+        final RemoteOutboundConnectionService outboundConnectionService = new RemoteOutboundConnectionService(connectionName,
+                options, username, protocol);
+        final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME
+                .append(connectionName);
+
+        // also add an alias service name to easily distinguish between a generic, remote and local type of connection
+        // services
+        final ServiceName aliasServiceName = RemoteOutboundConnectionService.REMOTE_OUTBOUND_CONNECTION_BASE_SERVICE_NAME
+                .append(connectionName);
+        final ServiceBuilder<RemoteOutboundConnectionService> svcBuilder = context
+                .getServiceTarget()
+                .addService(serviceName, outboundConnectionService)
+                .addAliases(aliasServiceName)
+                .addDependency(RemotingServices.SUBSYSTEM_ENDPOINT, Endpoint.class,
+                        outboundConnectionService.getEndpointInjector())
+                .addDependency(outboundSocketBindingDependency, OutboundSocketBinding.class,
+                        outboundConnectionService.getDestinationOutboundSocketBindingInjector());
+
+        if (securityRealm != null) {
+            SecurityRealm.ServiceUtil.addDependency(svcBuilder, outboundConnectionService.getSecurityRealmInjector(),
+                    securityRealm, false);
+        }
+        svcBuilder.install();
+    }
+}

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupAdd.java
@@ -37,6 +37,7 @@ import org.jboss.remoting3.Endpoint;
 import org.xnio.OptionMap;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
@@ -87,6 +88,8 @@ class RemoteOutboundConnectionGroupAdd extends AbstractAddStepHandler {
             installConnectionService(context, socketRef, connectionName, username, protocol, securityRealm,
                     connectionCreationOptions);
         }
+
+        installGroupService(context, groupName, socketRefs.size());
     }
 
     void installConnectionService(final OperationContext context, final String socketRef, final String connectionName,
@@ -117,6 +120,20 @@ class RemoteOutboundConnectionGroupAdd extends AbstractAddStepHandler {
             SecurityRealm.ServiceUtil.addDependency(svcBuilder, outboundConnectionService.getSecurityRealmInjector(),
                     securityRealm, false);
         }
+        svcBuilder.install();
+    }
+
+    void installGroupService(final OperationContext context, final String groupName, final int connectionCount){
+        final Set<ServiceName> connections = RemotingServices.createConnectionServiceNames(groupName, connectionCount);
+        final RemoteOutboundConnectionGroupService groupService = new RemoteOutboundConnectionGroupService(connections);
+        final ServiceName groupServiceName = RemoteOutboundConnectionGroupResourceDefinition.OUTBOUND_CONNECTION_GROUP_BASE_SERVICE_NAME
+                        .append(groupName);
+
+        final ServiceBuilder<RemoteOutboundConnectionGroupService> svcBuilder = context
+                .getServiceTarget()
+                .addService(groupServiceName, groupService)
+                .addDependencies(connections);
+
         svcBuilder.install();
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupRemove.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupRemove.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.remoting;
 
+import java.util.Set;
+
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -29,8 +31,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
-
-import java.util.List;
 
 /**
  * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
@@ -52,11 +52,14 @@ public class RemoteOutboundConnectionGroupRemove extends AbstractRemoveStepHandl
                     .getLastElement().getValue();
             final int connectionsCount = RemoteOutboundConnectionGroupResourceDefinition.OUTBOUND_SOCKET_BINDINGS_REFS
                     .resolveModelAttribute(context, model).asList().size();
-            List<ServiceName> connectionServiceNames = RemotingServices.createConnectionServiceNames(groupName,
+            Set<ServiceName> connectionServiceNames = RemotingServices.createConnectionServiceNames(groupName,
                     connectionsCount);
             for (final ServiceName connectionServiceName : connectionServiceNames) {
                 context.removeService(connectionServiceName);
             }
+            final ServiceName groupServiceName = RemoteOutboundConnectionGroupResourceDefinition.OUTBOUND_CONNECTION_GROUP_BASE_SERVICE_NAME
+                    .append(groupName);
+            context.removeService(groupServiceName);
         } else {
             context.reloadRequired();
         }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupRemove.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupRemove.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.remoting;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
+
+import java.util.List;
+
+/**
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+public class RemoteOutboundConnectionGroupRemove extends AbstractRemoveStepHandler {
+
+    static final RemoteOutboundConnectionGroupRemove INSTANCE = new RemoteOutboundConnectionGroupRemove();
+
+    protected RemoteOutboundConnectionGroupRemove() {
+        super();
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+
+        if (context.isResourceServiceRestartAllowed()) {
+            final String groupName = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR))
+                    .getLastElement().getValue();
+            final int connectionsCount = RemoteOutboundConnectionGroupResourceDefinition.OUTBOUND_SOCKET_BINDINGS_REFS
+                    .resolveModelAttribute(context, model).asList().size();
+            List<ServiceName> connectionServiceNames = RemotingServices.createConnectionServiceNames(groupName,
+                    connectionsCount);
+            for (final ServiceName connectionServiceName : connectionServiceNames) {
+                context.removeService(connectionServiceName);
+            }
+        } else {
+            context.reloadRequired();
+        }
+    }
+
+    @Override
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+        if (context.isResourceServiceRestartAllowed()) {
+            RemoteOutboundConnectionGroupAdd.INSTANCE.performRuntime(context, operation, model);
+        } else {
+            context.revertReloadRequired();
+        }
+    }
+}

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupResourceDefinition.java
@@ -39,6 +39,7 @@ import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceName;
 
 /**
  * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
@@ -46,6 +47,7 @@ import org.jboss.dmr.ModelType;
 class RemoteOutboundConnectionGroupResourceDefinition extends SimpleResourceDefinition {
 
     static final PathElement ADDRESS = PathElement.pathElement(CommonAttributes.REMOTE_OUTBOUND_CONNECTION_GROUP);
+    static final ServiceName OUTBOUND_CONNECTION_GROUP_BASE_SERVICE_NAME = RemotingServices.SUBSYSTEM_ENDPOINT.append("remote-outbound-connection-group");
 
     static final StringListAttributeDefinition OUTBOUND_SOCKET_BINDINGS_REFS = new StringListAttributeDefinition.Builder(
             CommonAttributes.OUTBOUND_SOCKET_BINDING_REFS)

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupResourceDefinition.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.remoting;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeParser;
+import org.jboss.as.controller.DefaultAttributeMarshaller;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+class RemoteOutboundConnectionGroupResourceDefinition extends SimpleResourceDefinition {
+
+    static final PathElement ADDRESS = PathElement.pathElement(CommonAttributes.REMOTE_OUTBOUND_CONNECTION_GROUP);
+
+    static final StringListAttributeDefinition OUTBOUND_SOCKET_BINDINGS_REFS = new StringListAttributeDefinition.Builder(
+            CommonAttributes.OUTBOUND_SOCKET_BINDING_REFS)
+            .setAllowNull(false)
+            .setAttributeParser(AttributeParser.COMMA_DELIMITED_STRING_LIST)
+            .setAttributeMarshaller(new DefaultAttributeMarshaller() {
+                @Override
+                public void marshallAsAttribute(AttributeDefinition attribute, ModelNode resourceModel,
+                        boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
+
+                    StringBuilder builder = new StringBuilder();
+                    if (resourceModel.hasDefined(attribute.getName())) {
+                        for (ModelNode p : resourceModel.get(attribute.getName()).asList()) {
+                            builder.append(p.asString()).append(", ");
+                        }
+                    }
+                    if (builder.length() > 0) {
+                        writer.writeAttribute(attribute.getXmlName(), builder.substring(0, builder.length() - 2));
+                    }
+                }
+            })
+            .setRestartAllServices()
+            .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
+            .build();
+
+    public static final SimpleAttributeDefinition USERNAME = new SimpleAttributeDefinitionBuilder(CommonAttributes.USERNAME, ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true))
+            .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.CREDENTIAL)
+            .addAccessConstraint(RemotingExtension.REMOTING_SECURITY_DEF)
+            .build();
+
+    public static final SimpleAttributeDefinition SECURITY_REALM = new SimpleAttributeDefinitionBuilder(CommonAttributes.SECURITY_REALM, ModelType.STRING, true)
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
+            .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SECURITY_REALM_REF)
+            .addAccessConstraint(RemotingExtension.REMOTING_SECURITY_DEF)
+            .build();
+
+    public static final SimpleAttributeDefinition PROTOCOL = new SimpleAttributeDefinitionBuilder(
+            CommonAttributes.PROTOCOL, ModelType.STRING, true).setValidator(
+                    new EnumValidator<Protocol>(Protocol.class, true, false))
+            .setDefaultValue(new ModelNode(Protocol.HTTP_REMOTING.toString()))
+            .setAllowExpression(true)
+            .build();
+
+    public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = {
+            OUTBOUND_SOCKET_BINDINGS_REFS, USERNAME, SECURITY_REALM, PROTOCOL
+    };
+
+    static final RemoteOutboundConnectionGroupResourceDefinition INSTANCE = new RemoteOutboundConnectionGroupResourceDefinition();
+
+    private RemoteOutboundConnectionGroupResourceDefinition() {
+        super(ADDRESS, RemotingExtension.getResourceDescriptionResolver(CommonAttributes.REMOTE_OUTBOUND_CONNECTION_GROUP),
+                RemoteOutboundConnectionGroupAdd.INSTANCE, RemoteOutboundConnectionGroupRemove.INSTANCE);
+    }
+
+    @Override
+    public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerSubModel(new PropertyResource(CommonAttributes.REMOTE_OUTBOUND_CONNECTION_GROUP));
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        super.registerAttributes(resourceRegistration);
+        resourceRegistration.registerReadWriteAttribute(OUTBOUND_SOCKET_BINDINGS_REFS, null, RemoteOutboundConnectionGroupWriteHandler.INSTANCE);
+        resourceRegistration.registerReadWriteAttribute(USERNAME, null, RemoteOutboundConnectionGroupWriteHandler.INSTANCE);
+        resourceRegistration.registerReadWriteAttribute(SECURITY_REALM, null, RemoteOutboundConnectionGroupWriteHandler.INSTANCE);
+        resourceRegistration.registerReadWriteAttribute(PROTOCOL, null, RemoteOutboundConnectionGroupWriteHandler.INSTANCE);
+    }
+}

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupService.java
@@ -1,0 +1,40 @@
+package org.jboss.as.remoting;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+import java.util.Set;
+
+/**
+ *  @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+public class RemoteOutboundConnectionGroupService implements Service<RemoteOutboundConnectionGroupService> {
+
+    private final Set<ServiceName> remoteOutboundConnections;
+
+    public Set<ServiceName> getRemoteOutboundConnections() {
+        return remoteOutboundConnections;
+    }
+
+    public RemoteOutboundConnectionGroupService(final Set<ServiceName> remoteOutboundConnections){
+        this.remoteOutboundConnections = remoteOutboundConnections;
+    }
+
+    @Override
+    public void start(StartContext startContext) throws StartException {
+
+    }
+
+    @Override
+    public void stop(StopContext stopContext) {
+
+    }
+
+    @Override
+    public RemoteOutboundConnectionGroupService getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+}

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupWriteHandler.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionGroupWriteHandler.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.remoting;
+
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+
+import java.util.List;
+
+/**
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+class RemoteOutboundConnectionGroupWriteHandler extends AbstractWriteAttributeHandler<Boolean> {
+
+    static final RemoteOutboundConnectionGroupWriteHandler INSTANCE = new RemoteOutboundConnectionGroupWriteHandler();
+
+    private RemoteOutboundConnectionGroupWriteHandler() {
+        super(RemoteOutboundConnectionResourceDefinition.ATTRIBUTE_DEFINITIONS);
+    }
+
+    @Override
+    protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Boolean> handbackHolder) throws OperationFailedException {
+        final ModelNode model = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
+        final boolean handback = applyModelToRuntime(context, operation, model);
+        handbackHolder.setHandback(handback);
+        return handback;
+
+    }
+
+    @Override
+    protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode valueToRestore, ModelNode valueToRevert, Boolean handback) throws OperationFailedException {
+        if (handback != null && !handback.booleanValue()) {
+            final ModelNode restored = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
+            restored.get(attributeName).set(valueToRestore);
+            applyModelToRuntime(context, operation, restored);
+        }
+    }
+
+    private boolean applyModelToRuntime(OperationContext context, ModelNode operation, ModelNode fullModel)
+            throws OperationFailedException {
+        final ServiceRegistry registry = context.getServiceRegistry(true);
+        final String groupName = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR)).getLastElement()
+                .getValue();
+        final int connectionsCount = RemoteOutboundConnectionGroupResourceDefinition.OUTBOUND_SOCKET_BINDINGS_REFS.resolveModelAttribute(context, fullModel)
+                .asList().size();
+        final List<ServiceName> serviceNames = RemotingServices.createConnectionServiceNames(groupName,
+                connectionsCount);
+        boolean reloadRequired = false;
+        for (final ServiceName serviceName: serviceNames) {
+            final ServiceController sc = registry.getService(serviceName);
+            if (sc != null && sc.getState() == ServiceController.State.UP) {
+                reloadRequired = true;
+                break;
+            }
+        }
+        if (!reloadRequired) {
+            for (final ServiceName serviceName : serviceNames) {
+                context.removeService(serviceName);
+            }
+            RemoteOutboundConnectionGroupAdd.INSTANCE.installRuntimeService(context, operation, fullModel);
+        }
+        return reloadRequired;
+    }
+}

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -68,7 +68,7 @@ public class RemotingExtension implements Extension {
     static final SensitiveTargetAccessConstraintDefinition REMOTING_SECURITY_DEF = new SensitiveTargetAccessConstraintDefinition(REMOTING_SECURITY);
 
     private static final int MANAGEMENT_API_MAJOR_VERSION = 3;
-    private static final int MANAGEMENT_API_MINOR_VERSION = 0;
+    private static final int MANAGEMENT_API_MINOR_VERSION = 1;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
     private static final ModelVersion CURRENT_VERSION = ModelVersion.create(MANAGEMENT_API_MAJOR_VERSION, MANAGEMENT_API_MINOR_VERSION, MANAGEMENT_API_MICRO_VERSION);
@@ -106,6 +106,8 @@ public class RemotingExtension implements Extension {
         subsystem.registerSubModel(LocalOutboundConnectionResourceDefinition.INSTANCE);
         // (generic) outbound connection
         subsystem.registerSubModel(new GenericOutboundConnectionResourceDefinition());
+
+        subsystem.registerSubModel(RemoteOutboundConnectionGroupResourceDefinition.INSTANCE);
 
         if (context.isRegisterTransformers()) {
             registerTransformers(registration);
@@ -173,6 +175,7 @@ public class RemotingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_1_2.getUriString(), RemotingSubsystem12Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_2_0.getUriString(), RemotingSubsystem20Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_3_0.getUriString(), RemotingSubsystem30Parser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_3_1.getUriString(), RemotingSubsystem31Parser.INSTANCE);
     }
 
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
@@ -23,6 +23,9 @@ package org.jboss.as.remoting;
 
 import static org.jboss.msc.service.ServiceController.Mode.ACTIVE;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.security.auth.callback.CallbackHandler;
 
 import org.jboss.as.controller.OperationContext;
@@ -35,9 +38,6 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.remoting3.Endpoint;
 import org.xnio.OptionMap;
-
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  *
@@ -175,8 +175,8 @@ public class RemotingServices {
         context.removeService(securityProviderName);
     }
 
-    static List<ServiceName> createConnectionServiceNames(final String groupName, final int connectionCount) {
-        final List<ServiceName> serviceNames = new LinkedList<>();
+    static Set<ServiceName> createConnectionServiceNames(final String groupName, final int connectionCount) {
+        final Set<ServiceName> serviceNames = new HashSet<>();
         for (int i = 1; i <= connectionCount; i++) {
             final String connectionName = new StringBuilder(groupName).append(i).toString();
             final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
@@ -36,6 +36,9 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.remoting3.Endpoint;
 import org.xnio.OptionMap;
 
+import java.util.LinkedList;
+import java.util.List;
+
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -170,5 +173,16 @@ public class RemotingServices {
         final ServiceName securityProviderName = RealmSecurityProviderService.createName(connectorName);
         context.removeService(serverServiceName(connectorName));
         context.removeService(securityProviderName);
+    }
+
+    static List<ServiceName> createConnectionServiceNames(final String groupName, final int connectionCount) {
+        final List<ServiceName> serviceNames = new LinkedList<>();
+        for (int i = 1; i <= connectionCount; i++) {
+            final String connectionName = new StringBuilder(groupName).append(i).toString();
+            final ServiceName serviceName = AbstractOutboundConnectionService.OUTBOUND_CONNECTION_BASE_SERVICE_NAME
+                    .append(connectionName);
+            serviceNames.add(serviceName);
+        }
+        return serviceNames;
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem31Parser.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem31Parser.java
@@ -1,0 +1,131 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.remoting;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
+/**
+ * An extension of the parser for version 3.1 of the schema.
+ *
+ *  @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
+ */
+public class RemotingSubsystem31Parser extends RemotingSubsystem30Parser {
+
+    static final RemotingSubsystem31Parser INSTANCE = new RemotingSubsystem31Parser();
+
+    void parseOutboundConnections(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> operations) throws XMLStreamException {
+        // Handle nested elements.
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case REMOTE_OUTBOUND_CONNECTION: {
+                    this.parseRemoteOutboundConnection(reader, address, operations);
+                    break;
+                }
+                case LOCAL_OUTBOUND_CONNECTION: {
+                    this.parseLocalOutboundConnection(reader, address, operations);
+                    break;
+                }
+                case OUTBOUND_CONNECTION: {
+                    this.parseOutboundConnection(reader, address, operations);
+                    break;
+                }
+                case REMOTE_OUTBOUND_CONNECTION_GROUP:
+                    this.parseConnectionGroup(reader,address, operations);
+                    break;
+                default: {
+                    throw unexpectedElement(reader);
+                }
+            }
+        }
+    }
+
+    void parseConnectionGroup(final XMLExtendedStreamReader reader, final ModelNode parentAddress,
+            final List<ModelNode> operations) throws XMLStreamException {
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
+        String name = null;
+        final ModelNode addOperation = Util.createAddOperation();
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case NAME: {
+                    name = value;
+                    break;
+                }
+                case OUTBOUND_SOCKET_BINDING_REFS: {
+                    RemoteOutboundConnectionGroupResourceDefinition.OUTBOUND_SOCKET_BINDINGS_REFS.parseAndSetParameter(value, addOperation, reader);
+                    break;
+                }
+                case USERNAME: {
+                    RemoteOutboundConnectionGroupResourceDefinition.USERNAME.parseAndSetParameter(value, addOperation, reader);
+                    break;
+                }
+                case SECURITY_REALM: {
+                    RemoteOutboundConnectionGroupResourceDefinition.SECURITY_REALM.parseAndSetParameter(value, addOperation, reader);
+                    break;
+                }
+                case PROTOCOL: {
+                    RemoteOutboundConnectionGroupResourceDefinition.SECURITY_REALM.parseAndSetParameter(value, addOperation, reader);
+                    break;
+                }
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        final PathAddress address = PathAddress.pathAddress(PathAddress.pathAddress(parentAddress), PathElement.pathElement(CommonAttributes.REMOTE_OUTBOUND_CONNECTION_GROUP, name));
+        final List<ModelNode> propertyOps = new LinkedList<>();
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case PROPERTIES: {
+                    parseProperties(reader, address.toModelNode(), propertyOps);
+                    break;
+                }
+                default: {
+                    throw unexpectedElement(reader);
+                }
+            }
+        }
+        addOperation.get(OP_ADDR).set(address.toModelNode());
+        operations.add(addOperation);
+        operations.addAll(propertyOps);
+    }
+}

--- a/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
+++ b/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
@@ -131,3 +131,13 @@ property.value=The property value.
 #remoting.sasl.policy.no-plain-text=The optional nested "no-plain-text" element contains a boolean value which specifies whether mechanisms susceptible to simple plain passive attacks (e.g., "PLAIN") are not permitted.    "false" to permit, "true" to deny.
 #remoting.sasl.policy.pass-credentials=The optional nested "pass-credentials" element contains a boolean value which specifies whether mechanisms that pass client credentials are required.
 #remoting.sasl.properties=Additional properties to configure sasl.
+
+remoting.remote-outbound-connection-group=Group of remote-outbound-connections that share the same configuration.
+remote-outbound-connection-group=Group of remote-outbound-connections that share the same configuration.
+remote-outbound-connection-group.add=Add remote-outbound-connection group.
+remote-outbound-connection-group.outbound-socket-binding-refs=List of outbound socket references that will be used to create the connections.
+remote-outbound-connection-group.username=The user name to use when authenticating against the remote server.
+remote-outbound-connection-group.security-realm=Reference to the security realm to use to obtain the password and SSL configuration.
+remote-outbound-connection-group.protocol=The protocol to use for the remote connections. Defaults to http-remoting.
+remote-outbound-connection-group.property=The XNIO Options that will be used during the connections creation.
+remote-outbound-connection-group.remove=Remove remote-outbound-connection group.

--- a/remoting/subsystem/src/main/resources/schema/wildfly-remoting_3_1.xsd
+++ b/remoting/subsystem/src/main/resources/schema/wildfly-remoting_3_1.xsd
@@ -1,0 +1,573 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:domain:remoting:3.1"
+            xmlns="urn:jboss:domain:remoting:3.1"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="3.1">
+
+    <!-- The remoting subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of the Remoting subsystem.
+
+                The 'worker-thread-pool' element configures the worker thread pool.
+                The nested "connector" element(s) define connectors for this subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element name="worker-thread-pool" type="workerThreadsType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                   Deprecated and replaced with the 'endpoint' configuration that can reference a worker from the IO subsystem.
+                   This is only supported for use in managed domain profiles whose servers are all running on
+                   previous versions that do not support the 'endpoint' configuration. Use in a server
+                   running a version after the introduction of the 'endpoint' configuration will result
+                   in an error.
+               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="endpoint" type="endpointType"></xs:element>
+            </xs:choice>
+            <xs:element name="connector" type="connector" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="http-connector" type="http-connector" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="outbound-connections" minOccurs="0" type="outbound-connectionsType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="workerThreadsType">
+           <xs:annotation>
+               <xs:documentation>
+                   <![CDATA[
+                   Deprecated configuration of the worker thread pool.
+
+                   Only supported for legacy servers in a managed domain.
+               ]]>
+               </xs:documentation>
+           </xs:annotation>
+           <xs:attribute name="read-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="write-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-core-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-max-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-keepalive" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-limit" type="xs:integer" use="optional"/>
+       </xs:complexType>
+
+
+    <xs:complexType name="endpointType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                Configures the remoting endpoint.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="worker" type="xs:string" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                The name of the IO subsystem worker the endpoint should use.
+            ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
+        <xs:attribute name="authorize-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        The SASL authorization ID.  Used as authentication user name to use if no authentication {@code CallbackHandler} is specified
+                                    and the selected SASL mechanism demands a user name.
+                       ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="auth-realm" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    The authentication realm to use if no authentication {@code CallbackHandler} is specified.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sasl-protocol" type="xs:string" default="http-remoting">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[Where a SaslServer or SaslClient are created by default the protocol specified it 'remoting', this can be used to override this.
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-message-size" type="xs:long" default="9223372036854775807">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum outbound message size to send.  No messages larger than this well be transmitted; attempting to do so will cause an exception on the writing side.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="buffer-region-size" type="xs:positiveInteger">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The size of allocated buffer regions.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="receive-buffer-size" type="xs:positiveInteger" default="8192">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The size of the largest buffer that this endpoint will accept over a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-retries" type="xs:positiveInteger" default="3">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[Specify the number of times a client is allowed to retry authentication before closing the connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="transmit-window-size" type="xs:positiveInteger" default="131072">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum window size of the transmit direction for connection channels, in bytes.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-messages" type="xs:positiveInteger" default="65535">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of outbound channels to support for a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="send-buffer-size" type="xs:positiveInteger" default="8192">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The size of the largest buffer that this endpoint will transmit over a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-messages" type="xs:positiveInteger" default="80">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of inbound channels to support for a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="receive-window-size" type="xs:positiveInteger" default="131072">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum window size of the receive direction for connection channels, in bytes.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="heartbeat-interval" type="xs:positiveInteger" default="2147483647">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The interval to use for connection heartbeat, in milliseconds.  If the connection is idle in the outbound direction\
+                    for this amount of time, a ping message will be sent, which will trigger a corresponding reply message.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-message-size" type="xs:long" default="9223372036854775807">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum inbound message size to be allowed.  Messages exceeding this size will cause an exception to be thrown on the reading side as well as the writing side.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-channels" type="xs:positiveInteger" default="40">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of concurrent outbound messages on a channel.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-channels" type="xs:positiveInteger" default="40">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of concurrent inbound messages on a channel.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="server-name">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The server side of the connection passes it's name to the client in the initial greeting, by default the name is automatically discovered from the local address of the connection or it can be overridden using this.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="abstractConnector" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The base configuration of a Remoting connector.
+
+                The "name" attribute specifies the unique name of this connector.
+
+                The optional nested "sasl" element contains the SASL authentication configuration for this connector.
+
+                The optional nested "authentication-provider" element contains the name of the authentication provider to
+                use for incoming connections.
+                
+                The optional server-name attribute specifies the server name that should be used in the initial exchange with
+                the client and within the SASL mechanisms used for authentication.
+
+                The optional sasl-protocol attribute specifies the protocol that should be used within the SASL mechanisms. 
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="sasl" type="sasl" minOccurs="0"/>
+            <xs:element name="authentication-provider" type="ref" minOccurs="0"/>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="security-realm" type="xs:string" use="optional"/>
+        <xs:attribute name="server-name" type="xs:string" use="optional" />
+        <xs:attribute name="sasl-protocol" type="xs:string" default="remote" />
+    </xs:complexType>
+    
+    <xs:complexType name="connector">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of a Remoting connector.
+
+                The "socket-binding" attribute specifies the name (or names) of the socket binding(s) to attach to.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstractConnector">
+                <xs:attribute name="socket-binding" type="name-list" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-connector">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of a Remoting HTTP upgrade based connector.
+
+                The "connector-ref" specifies the name of the Undertow http connector to use.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstractConnector">
+                <xs:attribute name="connector-ref" type="name-list" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sasl">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of the SASL authentication layer for this server.
+
+                The optional nested "include-mechanisms" element contains a whitelist of allowed SASL mechanism names.
+                No mechanisms will be allowed which are not present in this list.
+
+                The optional nested "qop" element contains a list of quality-of-protection values, in decreasing order
+                of preference.
+
+                The optional nested "strength" element contains a list of cipher strength values, in decreasing order
+                of preference.
+
+                The optional nested "reuse-session" boolean element specifies whether or not the server should attempt
+                to reuse previously authenticated session information.  The mechanism may or may not support such reuse,
+                and other factors may also prevent it.
+
+                The optional nested "server-auth" boolean element specifies whether the server should authenticate to the
+                client.  Not all mechanisms may support this setting.
+
+                The optional nested "policy" boolean element specifies a policy to use to narrow down the available set
+                of mechanisms.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="include-mechanisms" type="name-listType" minOccurs="0"/>
+            <xs:element name="qop" type="qop-listType" minOccurs="0"/>
+            <xs:element name="strength" type="strength-listType" minOccurs="0"/>
+            <xs:element name="reuse-session" type="boolean-element" minOccurs="0"/>
+            <xs:element name="server-auth" type="boolean-element" minOccurs="0"/>
+            <xs:element name="policy" type="policy" minOccurs="0"/>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="policy">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                Policy criteria items to use in order to choose a SASL mechanism.
+
+                The optional nested "forward-secrecy" element contains a boolean value which specifies whether mechanisms
+                that implement forward secrecy between sessions are required. Forward secrecy means that breaking into
+                one session will not automatically provide information for breaking into future sessions.
+
+                The optional nested "no-active" element contains a boolean value which specifies whether mechanisms
+                susceptible to active (non-dictionary) attacks are not permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-anonymous" element contains a boolean value which specifies whether mechanisms
+                that accept anonymous login are permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-dictionary" element contains a boolean value which specifies whether mechanisms
+                susceptible to passive dictionary attacks are permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-plain-text" element contains a boolean value which specifies whether mechanisms
+                susceptible to simple plain passive attacks (e.g., "PLAIN") are not permitted.    "false" to permit, "true" to deny.
+
+                The optional nested "pass-credentials" element contains a boolean value which specifies whether
+                mechanisms that pass client credentials are required.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="forward-secrecy" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-active" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-anonymous" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-dictionary" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-plain-text" type="boolean-element" minOccurs="0"/>
+            <xs:element name="pass-credentials" type="boolean-element" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="boolean-element">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                An element specifying a boolean value.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="xs:boolean" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="name-listType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                An element specifying a string list.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="name-list" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="name-list">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A set of string items.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <xs:complexType name="qop-listType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                An element specifying a qop list.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="qop-list" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="qop-list">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The SASL quality-of-protection value list.  See http://download.oracle.com/docs/cd/E17409_01/javase/6/docs/api/javax/security/sasl/Sasl.html#QOP
+                for more information.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="auth"/>
+                    <xs:enumeration value="auth-int"/>
+                    <xs:enumeration value="auth-conf"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
+
+    <xs:complexType name="strength-listType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                An element specifying a strength list.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="strength-list" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="strength-list">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The SASL strength value list.  See http://download.oracle.com/docs/cd/E17409_01/javase/6/docs/api/javax/security/sasl/Sasl.html#STRENGTH
+                for more information.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="low"/>
+                    <xs:enumeration value="medium"/>
+                    <xs:enumeration value="high"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
+
+    <xs:complexType name="properties">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A set of free-form properties.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="property"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="property">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A free-form property.  The name is required; the value is optional.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="ref">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A reference to another named service.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-connectionsType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="local-outbound-connection" type="local-outbound-connectionType" />
+            <xs:element name="remote-outbound-connection" type="remote-outbound-connectionType" />
+            <xs:element name="outbound-connection" type="outbound-connectionType" />
+            <xs:element name="remote-outbound-connection-group" type="remote-outbound-connection-groupType" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="base-outbound-connectionType">
+        <xs:all>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="local-outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="outbound-socket-binding-ref" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="remote-outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="outbound-socket-binding-ref" type="xs:string" use="required"/>
+                <xs:attribute name="username" type="xs:string" use="optional"/>
+                <xs:attribute name="security-realm" type="xs:string" use="optional"/>
+                <xs:attribute name="protocol" type="xs:string" use="optional"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="remote-outbound-connection-groupType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="outbound-socket-binding-refs" type="xs:string" use="required"/>
+                <xs:attribute name="username" type="xs:string" use="optional"/>
+                <xs:attribute name="security-realm" type="xs:string" use="optional"/>
+                <xs:attribute name="protocol" type="xs:string" use="optional"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/remoting/subsystem/src/main/resources/subsystem-templates/remoting.xml
+++ b/remoting/subsystem/src/main/resources/subsystem-templates/remoting.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.remoting</extension-module>
-   <subsystem xmlns="urn:jboss:domain:remoting:3.0">
+   <subsystem xmlns="urn:jboss:domain:remoting:3.1">
        <endpoint/>
        <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
    </subsystem>

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
@@ -75,6 +75,7 @@ import org.xnio.XnioWorker;
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  * @author <a href="opalka.richard@gmail.com">Richard Opalka</a>
+ * @author <a href=mailto:tadamski@redhat.com>Tomasz Adamski</a>
  */
 public class RemotingLegacySubsystemTestCase extends AbstractSubsystemBaseTest {
 
@@ -265,6 +266,31 @@ public class RemotingLegacySubsystemTestCase extends AbstractSubsystemBaseTest {
         assertNotNull("Local outbound connection service for outbound connection:" + localOutboundConnectionName + " was null", localOutboundConnectionService);
         LocalOutboundConnectionService localService = (LocalOutboundConnectionService) localOutboundConnectionService.getService();
         assertEquals(2, localService.connectionCreationOptions.size());
+    }
+
+
+    @Test
+    public void testOutboundConnectionGroups() throws Exception {
+        KernelServices services = createKernelServicesBuilder(createRuntimeAdditionalInitialization())
+                .setSubsystemXmlResource("remoting-with-outbound-connection-group.xml")
+                .build();
+
+        ServiceController<?> endPointService = services.getContainer().getRequiredService(RemotingServices.SUBSYSTEM_ENDPOINT);
+        assertNotNull("Endpoint service was null", endPointService);
+
+        final String remoteOutboundConnectionName1 = "group1";
+        ServiceName remoteOutboundConnectionServiceName1 = RemoteOutboundConnectionService.REMOTE_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(remoteOutboundConnectionName1);
+        ServiceController<?> remoteOutboundConnectionService1 = services.getContainer().getRequiredService(remoteOutboundConnectionServiceName1);
+        assertNotNull("Remote outbound connection service for outbound connection:" + remoteOutboundConnectionName1 + " was null", remoteOutboundConnectionService1);
+        RemoteOutboundConnectionService remoteService1 = (RemoteOutboundConnectionService) remoteOutboundConnectionService1.getService();
+        assertEquals(2, remoteService1.connectionCreationOptions.size());
+
+        final String remoteOutboundConnectionName2 = "group2";
+        ServiceName remoteOutboundConnectionServiceName2 = RemoteOutboundConnectionService.REMOTE_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(remoteOutboundConnectionName2);
+        ServiceController<?> remoteOutboundConnectionService2 = services.getContainer().getRequiredService(remoteOutboundConnectionServiceName2);
+        assertNotNull("Local outbound connection service for outbound connection:" + remoteOutboundConnectionName2 + " was null", remoteOutboundConnectionService2);
+        RemoteOutboundConnectionService remoteService2 = (RemoteOutboundConnectionService) remoteOutboundConnectionService2.getService();
+        assertEquals(2, remoteService2.connectionCreationOptions.size());
     }
 
     @Override

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
@@ -278,6 +278,14 @@ public class RemotingLegacySubsystemTestCase extends AbstractSubsystemBaseTest {
         ServiceController<?> endPointService = services.getContainer().getRequiredService(RemotingServices.SUBSYSTEM_ENDPOINT);
         assertNotNull("Endpoint service was null", endPointService);
 
+        final String groupName = "group";
+        final ServiceName groupServiceName = RemoteOutboundConnectionGroupResourceDefinition.OUTBOUND_CONNECTION_GROUP_BASE_SERVICE_NAME
+                .append(groupName);
+        ServiceController<?> groupServiceController = services.getContainer().getRequiredService(groupServiceName);
+        assertNotNull("Remote outbound connection service for outbound connection:" + groupServiceName + " was null", groupServiceController);
+        RemoteOutboundConnectionGroupService groupService = (RemoteOutboundConnectionGroupService) groupServiceController.getService();
+        assertEquals(2, groupService.getRemoteOutboundConnections().size());
+
         final String remoteOutboundConnectionName1 = "group1";
         ServiceName remoteOutboundConnectionServiceName1 = RemoteOutboundConnectionService.REMOTE_OUTBOUND_CONNECTION_BASE_SERVICE_NAME.append(remoteOutboundConnectionName1);
         ServiceController<?> remoteOutboundConnectionService1 = services.getContainer().getRequiredService(remoteOutboundConnectionServiceName1);

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
@@ -106,7 +106,7 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-remoting_3_0.xsd";
+        return "schema/wildfly-remoting_3_1.xsd";
     }
 
     @Override

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-outbound-connection-group.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-outbound-connection-group.xml
@@ -1,0 +1,12 @@
+<subsystem xmlns="urn:jboss:domain:remoting:3.1">
+    <connector name="test-connector" socket-binding="test"/>
+    <outbound-connections>
+        <remote-outbound-connection-group name="group" outbound-socket-binding-refs="dummy-outbound-socket, other-outbound-socket">
+            <properties>
+                <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
+                <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+            </properties>
+        </remote-outbound-connection-group>
+    </outbound-connections>
+</subsystem>
+

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:remoting:3.0">
+<subsystem xmlns="urn:jboss:domain:remoting:3.1">
     <endpoint
         worker="default-remoting"
         send-buffer-size="8191"


### PR DESCRIPTION
Connection group is a tool that is suppose to simplify configuration in cases in which many connections share the same properties. Connections group references will be configured in remoting profile. They are also planned to be used in cluster configuration.

Forum references:
Problems with current implementation:
http://lists.jboss.org/pipermail/wildfly-dev/2015-March/003674.html
Proposed solution:
http://lists.jboss.org/pipermail/wildfly-dev/2015-July/004235.html