### PR TITLE
https://issues.jboss.org/browse/WFCORE-838 Decrease Patch Size Per CP

### DIFF
--- a/patching/src/main/java/org/jboss/as/patching/Constants.java
+++ b/patching/src/main/java/org/jboss/as/patching/Constants.java
@@ -40,6 +40,7 @@ public class Constants {
     public static final String NAME = "name";
     public static final String VERBOSE = "verbose";
     public static final String VERSION = "version";
+    public static final String UNKNOWN = "Unknown";
 
     public static final String AGEOUT_HISTORY = "ageout-history";
     public static final String PATCH = "patch";

--- a/patching/src/main/java/org/jboss/as/patching/HashUtils.java
+++ b/patching/src/main/java/org/jboss/as/patching/HashUtils.java
@@ -60,6 +60,14 @@ public class HashUtils {
         }
     }
 
+    public static byte[] hashBytes(byte[] bytes) throws IOException {
+        synchronized (DIGEST) {
+            DIGEST.reset();
+            DIGEST.update(bytes);
+            return DIGEST.digest();
+        }
+    }
+
     private static void updateDigest(MessageDigest digest, File file) throws IOException {
         if (file.isDirectory()) {
             File[] childList = file.listFiles();

--- a/patching/src/main/java/org/jboss/as/patching/ZipUtils.java
+++ b/patching/src/main/java/org/jboss/as/patching/ZipUtils.java
@@ -66,7 +66,7 @@ public class ZipUtils {
             throw new RuntimeException("Failed creating patch file " + zipFile, e); // Only used for generation and tests
         }
 
-        System.out.println("\nPrepared " + zipFile.getName() + " at " + zipFile.getAbsolutePath());
+        //System.out.println("\nPrepared " + zipFile.getName() + " at " + zipFile.getAbsolutePath());
     }
 
     private static void addDirectoryToZip(File dir, String dirName, ZipOutputStream zos) throws IOException {

--- a/patching/src/main/java/org/jboss/as/patching/metadata/PatchMerger.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/PatchMerger.java
@@ -1,0 +1,512 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.patching.metadata;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.as.patching.Constants;
+import org.jboss.as.patching.IoUtils;
+import org.jboss.as.patching.PatchingException;
+import org.jboss.as.patching.ZipUtils;
+import org.jboss.as.patching.logging.PatchLogger;
+import org.jboss.as.patching.metadata.Patch.PatchType;
+import org.jboss.as.patching.runner.PatchUtils;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class PatchMerger {
+
+    private static final String DIRECTORY_PREFIX = "wildfly-patch-";
+    public static final String PATCH_XML_SUFFIX = "-patch.xml";
+    private static final File TEMP_DIR = new File(SecurityActions.getSystemProperty("java.io.tmpdir"));
+
+    public static File merge(File patch1, File patch2, File merged) throws PatchingException {
+
+        final File workDir = createTempDir();
+        final File patch1Dir = expandContent(patch1, workDir, "patch1");
+        final File patch2Dir = expandContent(patch2, workDir, "patch2");
+        final File mergedDir = new File(workDir, "merged");
+
+        final Patch patch1Metadata = parsePatchXml(patch1Dir, patch1);
+        final Patch patch2Metadata = parsePatchXml(patch2Dir, patch2);
+        final Patch mergedMetadata = merge(patch1Metadata, patch2Metadata);
+
+        // list(patch1Dir);
+        // list(patch2Dir);
+
+        if (!mergedDir.mkdirs()) {
+            throw new PatchingException("Failed to create directory " + mergedDir.getAbsolutePath());
+        }
+
+        // merge with the previous versions
+        for (File f : patch1Dir.listFiles(new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name.endsWith(PATCH_XML_SUFFIX);
+            }
+        })) {
+            Patch patch;
+            try {
+                patch = PatchXml.parse(f).resolvePatch(null, null);
+            } catch (Exception e) {
+                throw new PatchingException("Failed to parse " + f.getAbsolutePath(), e);
+            }
+
+            patch = merge(patch, patch2Metadata);
+
+            FileWriter writer = null;
+            try {
+                writer = new FileWriter(new File(mergedDir, f.getName()));
+                PatchXml.marshal(writer, patch);
+            } catch (Exception e) {
+                throw new PatchingException("Failed to marshal merged metadata into " + f.getName(), e);
+            } finally {
+                IoUtils.safeClose(writer);
+            }
+
+        }
+
+        // the latest patch.xml
+        copyFile(new File(patch2Dir, PatchXml.PATCH_XML), new File(mergedDir, patch2Metadata.getIdentity().getVersion() +  PATCH_XML_SUFFIX));
+
+        // merged patch.xml is the metadata from the earliest version to the latest
+        FileWriter writer = null;
+        try {
+            writer = new FileWriter(new File(mergedDir, PatchXml.PATCH_XML));
+            PatchXml.marshal(writer, mergedMetadata);
+        } catch (Exception e) {
+            throw new PatchingException("Failed to marshal merged metadata into " + PatchXml.PATCH_XML, e);
+        } finally {
+            IoUtils.safeClose(writer);
+        }
+
+        try {
+            mergeRootContent(new File(patch1Dir, patch1Metadata.getPatchId()),
+                    new File(patch2Dir, patch2Metadata.getPatchId()), new File(mergedDir, patch2Metadata.getPatchId()));
+        } catch (IOException e) {
+            throw new PatchingException("Failed to merge root modifications", e);
+        }
+
+        try {
+            mergeElementContent(patch1Dir, patch2Dir, mergedDir, patch1Metadata, patch2Metadata);
+        } catch (IOException e) {
+            throw new PatchingException("Failed to merge element modifications", e);
+        }
+
+        // list(mergedDir);
+
+        ZipUtils.zip(mergedDir, merged);
+        IoUtils.recursiveDelete(workDir);
+        return merged;
+    }
+
+    private static void copyFile(File source, File target) throws PatchingException {
+        try {
+            IoUtils.copy(source, target);
+        } catch (IOException e1) {
+            throw new PatchingException("Failed to copy " + source.getAbsolutePath() + " to " + target.getAbsolutePath());
+        }
+    }
+
+    private static void mergeElementContent(final File patch1Dir, final File patch2Dir, final File mergedDir,
+            final Patch patch1Metadata, final Patch patch2Metadata) throws PatchingException, IOException {
+
+        final Map<String, PatchElement> patch2Elements = new HashMap<String, PatchElement>(patch2Metadata.getElements().size());
+        for (PatchElement e : patch2Metadata.getElements()) {
+            patch2Elements.put(e.getProvider().getName(), e);
+        }
+        for (PatchElement e1 : patch1Metadata.getElements()) {
+            final File e1Dir = new File(patch1Dir, e1.getId());
+            final PatchElement e2 = patch2Elements.remove(e1.getProvider().getName());
+            if (e2 == null) {
+                if (e1Dir.exists()) {
+                    IoUtils.copyFile(e1Dir, new File(mergedDir, e1.getId()));
+                }
+            } else {
+                final ContentModifications cp2Mods = new ContentModifications(e2.getModifications());
+                for (ContentModification cp1Mod : e1.getModifications()) {
+                    final ContentModification cp2Mod = cp2Mods.remove(cp1Mod.getItem());
+                    if (cp2Mod == null) {
+                        copyModificationContent(patch1Dir, e1.getId(), mergedDir, e2.getId(), cp1Mod);
+                    } else {
+                        copyModificationContent(patch2Dir, e2.getId(), mergedDir, e2.getId(), cp2Mod);
+                    }
+                }
+                for(ContentModification cp2Mod : cp2Mods.getModifications()) {
+                    copyModificationContent(patch2Dir, e2.getId(), mergedDir, e2.getId(), cp2Mod);
+                }
+            }
+        }
+        for (PatchElement e2 : patch2Elements.values()) {
+            final File e2Dir = new File(patch2Dir, e2.getId());
+            if (e2Dir.exists()) {
+                IoUtils.copyFile(e2Dir, new File(mergedDir, e2.getId()));
+            }
+        }
+    }
+
+    private static void copyModificationContent(final File srcPatchDir, final String srcElementId,
+            final File targetPatchDir, final String targetElementId,
+            final ContentModification mod) throws PatchingException {
+        final ModificationType type = mod.getType();
+        if(type.equals(ModificationType.REMOVE)) {
+            return;
+        }
+        File modSrcDir = new File(srcPatchDir, srcElementId);
+        File modTrgDir = new File(targetPatchDir, targetElementId);
+        final ContentType contentType = mod.getItem().getContentType();
+        if(contentType.equals(ContentType.MODULE)) {
+            modSrcDir = new File(modSrcDir, Constants.MODULES);
+            modTrgDir = new File(modTrgDir, Constants.MODULES);
+            for(String name : mod.getItem().getName().split("\\.")) {
+                modSrcDir = new File(modSrcDir, name);
+                modTrgDir = new File(modTrgDir, name);
+            }
+        } else if(contentType.equals(ContentType.BUNDLE)) {
+            modSrcDir = new File(modSrcDir, Constants.BUNDLES);
+            modTrgDir = new File(modTrgDir, Constants.BUNDLES);
+            for(String name : mod.getItem().getName().split("\\.")) {
+                modSrcDir = new File(modSrcDir, name);
+                modTrgDir = new File(modTrgDir, name);
+            }
+        } else if(ContentType.MISC.equals(contentType)) {
+            modSrcDir = new File(modSrcDir, Constants.MISC);
+            modTrgDir = new File(modTrgDir, Constants.MISC);
+            for (final String path : ((MiscContentItem)mod.getItem()).getPath()) {
+                modSrcDir = new File(modSrcDir, path);
+                modTrgDir = new File(modTrgDir, path);
+            }
+        } else {
+            throw new PatchingException("Unexpected content type " + contentType);
+        }
+        try {
+            IoUtils.copyFile(modSrcDir, modTrgDir);
+        } catch (IOException e) {
+            throw new PatchingException("Failed to copy modification content from " + modSrcDir.getAbsolutePath() + " to " + modTrgDir.getAbsolutePath());
+        }
+    }
+
+    private static void mergeRootContent(final File root1Dir, final File root2Dir, final File mergedRootDir) throws IOException {
+
+        if (root1Dir.exists()) {
+            IoUtils.copyFile(root1Dir, mergedRootDir);
+        }
+        if (root2Dir.exists()) {
+            IoUtils.copyFile(root2Dir, mergedRootDir);
+        }
+    }
+
+    private static Patch parsePatchXml(final File patch1Dir, File patch1) throws PatchingException {
+        final File patch1Xml = new File(patch1Dir, PatchXml.PATCH_XML);
+        if (!patch1Xml.exists()) {
+            throw new PatchingException("Failed to locate " + PatchXml.PATCH_XML + " in " + patch1.getAbsolutePath());
+        }
+        try {
+            return PatchXml.parse(patch1Xml).resolvePatch(null, null);
+        } catch (Exception e) {
+            throw new PatchingException("Failed to parse " + PatchXml.PATCH_XML + " from " + patch1.getAbsolutePath(), e);
+        }
+    }
+
+    private static File expandContent(File patchFile, final File workDir, final String expandDirName) throws PatchingException {
+        final File patchDir;
+        try {
+            if (!patchFile.isDirectory()) {
+                patchDir = new File(workDir, expandDirName);
+                // Save the content
+                final File cachedContent = new File(patchDir, "content");
+                IoUtils.copy(patchFile, cachedContent);
+                // Unpack to the work dir
+                ZipUtils.unzip(cachedContent, patchDir);
+            } else {
+                patchDir = patchFile;
+            }
+        } catch (IOException e) {
+            throw new PatchingException("Failed to unzip " + patchFile.getAbsolutePath());
+        }
+        return patchDir;
+    }
+
+    public static Patch merge(Patch cp1, Patch cp2) throws PatchingException {
+        return merge(cp1, cp2, true);
+    }
+
+    public static Patch merge(Patch cp1, Patch cp2, boolean nextVersion) throws PatchingException {
+
+        // for now support merging only CPs
+        final Identity.IdentityUpgrade cp1Identity = cp1.getIdentity().forType(Patch.PatchType.CUMULATIVE,
+                Identity.IdentityUpgrade.class);
+        final Identity.IdentityUpgrade cp2Identity = cp2.getIdentity().forType(Patch.PatchType.CUMULATIVE,
+                Identity.IdentityUpgrade.class);
+        assertUpgrade(cp1Identity.getPatchType());
+        assertUpgrade(cp2Identity.getPatchType());
+
+        // for now support merging only CPs targeting the same identity name
+        if (!cp1Identity.getName().equals(cp2Identity.getName())) {
+            throw new PatchingException("Patches target different identities: " + cp1Identity.getName() + " and "
+                    + cp2Identity.getName());
+        }
+
+        if (nextVersion && !cp1Identity.getResultingVersion().equals(cp2Identity.getVersion())) {
+            throw new PatchingException(cp1.getPatchId() + " upgrades to version " + cp1Identity.getResultingVersion()
+                    + " but " + cp2.getPatchId() + " targets version " + cp2Identity.getVersion());
+        }
+
+        final PatchBuilder builder = PatchBuilder.create().setPatchId(cp2.getPatchId()).setDescription(cp2.getDescription())
+                .setLink(cp2.getLink());
+
+        builder.upgradeIdentity(cp1Identity.getName(), cp1Identity.getVersion(), cp2Identity.getResultingVersion());
+
+        final Map<String, PatchElement> cp2LayerElements = new HashMap<String, PatchElement>();
+        final Map<String, PatchElement> cp2AddonElements = new HashMap<String, PatchElement>();
+        for (PatchElement pe : cp2.getElements()) {
+            final PatchElementProvider provider = pe.getProvider();
+            assertUpgrade(provider.getPatchType());
+            if (provider.isAddOn()) {
+                cp2AddonElements.put(provider.getName(), pe);
+            } else {
+                cp2LayerElements.put(provider.getName(), pe);
+            }
+        }
+
+        for (final PatchElement cp1El : cp1.getElements()) {
+            final PatchElementProvider provider = cp1El.getProvider();
+            assertUpgrade(provider.getPatchType());
+            final PatchElement cp2El;
+            if (provider.isAddOn()) {
+                cp2El = cp2AddonElements.remove(provider.getName());
+            } else {
+                cp2El = cp2LayerElements.remove(provider.getName());
+            }
+
+            if (cp2El == null) {
+                builder.addElement(cp1El);
+            } else {
+                final PatchElementBuilder elementBuilder = builder.upgradeElement(cp2El.getId(), provider.getName(),
+                        provider.isAddOn()).setDescription(cp2El.getDescription());
+
+                mergeModifications(elementBuilder, cp1El.getModifications(), cp2El.getModifications(), cp1, cp2);
+            }
+        }
+
+        for (PatchElement cp2Element : cp2LayerElements.values()) {
+            builder.addElement(cp2Element);
+        }
+        for (PatchElement cp2Element : cp2AddonElements.values()) {
+            builder.addElement(cp2Element);
+        }
+
+        mergeModifications(builder, cp1.getModifications(), cp2.getModifications(), cp1, cp2);
+
+        return builder.build();
+    }
+
+    private static void mergeModifications(final ModificationBuilderTarget<?> elementBuilder,
+            Collection<ContentModification> cp1Modifications, Collection<ContentModification> cp2Modifications, Patch cp1,
+            Patch cp2) throws PatchingException {
+        final ContentModifications cp2Mods = new ContentModifications(cp2Modifications);
+        for (ContentModification cp1Mod : cp1Modifications) {
+            final ContentModification cp2Mod = cp2Mods.remove(cp1Mod.getItem());
+            if (cp2Mod == null) {
+                elementBuilder.addContentModification(cp1Mod);
+            } else {
+                final ModificationType cp1Type = cp1Mod.getType();
+                final ModificationType cp2Type = cp2Mod.getType();
+
+                final ModificationType modType;
+                if (cp1Type.equals(ModificationType.ADD)) {
+                    if (cp2Type.equals(ModificationType.ADD)) {
+                        throw new PatchingException("Patch " + cp2.getPatchId() + " adds " + cp1Mod.getItem().getRelativePath()
+                                + " already added by patch " + cp1.getPatchId());
+                    }
+                    if (cp2Type.equals(ModificationType.MODIFY)) {
+                        modType = ModificationType.ADD;
+                    } else { // remove cancels add
+                        if(cp1Mod.getItem().getContentType().equals(ContentType.MODULE)) {
+                            // but not for modules where remove is effectively modify (resulting in module.xml indicating an absent module)
+                            // so add becomes an add of an absent module
+                            modType = ModificationType.ADD;
+                        } else {
+                            modType = null;
+                            continue;
+                        }
+                    }
+                } else if (cp1Type.equals(ModificationType.REMOVE)) {
+                    if (cp2Type.equals(ModificationType.REMOVE)) {
+                        throw new PatchingException("Patch " + cp2.getPatchId() + " removes "
+                                + cp1Mod.getItem().getRelativePath() + " already removed by patch " + cp1.getPatchId());
+                    }
+                    /*if (cp2Type.equals(ModificationType.MODIFY)) {
+                        throw new PatchingException("Patch " + cp2.getPatchId() + " modifies "
+                                + cp1Mod.getItem().getRelativePath() + " removed by patch " + cp1.getPatchId());
+                        this could happen since the REMOVE will leave a module.xml indicating the module is absent
+                        so, to re-add the module, it has to be MODIFY, since ADD will fail
+                    }*/
+                    // add after remove makes it modify
+                    modType = ModificationType.MODIFY;
+                } else { // modify
+                    if (cp2Type.equals(ModificationType.ADD)) {
+                        throw new PatchingException("Patch " + cp2.getPatchId() + " adds " + cp1Mod.getItem().getRelativePath()
+                                + " modified by patch " + cp1.getPatchId());
+                    }
+                    if (cp2Type.equals(ModificationType.REMOVE)) {
+                        modType = ModificationType.REMOVE;
+                    } else {
+                        modType = ModificationType.MODIFY;
+                    }
+                }
+
+                if (ModificationType.ADD.equals(modType)) {
+                    final ContentItem cp2Item = cp2Mod.getItem();
+                    if (cp2Item.getContentType().equals(ContentType.MODULE)) {
+                        final ModuleItem module = (ModuleItem) cp2Item;
+                        if(cp2Type.equals(ModificationType.REMOVE)) {
+                            try {
+                                elementBuilder.addModule(module.getName(), module.getSlot(), PatchUtils.getAbsentModuleContentHash(module));
+                            } catch (IOException e) {
+                                throw new PatchingException("Failed to calculate hash for the removed module " + module.getName(), e);
+                            }
+                        } else {
+                            elementBuilder.addModule(module.getName(), module.getSlot(), module.getContentHash());
+                        }
+                    } else if (cp2Item.getContentType().equals(ContentType.MISC)) {
+                        final MiscContentItem misc = (MiscContentItem) cp2Item;
+                        elementBuilder.addFile(misc.getName(), Arrays.asList(misc.getPath()), misc.getContentHash(),
+                                misc.isDirectory());
+                    } else { // bundle
+                        final BundleItem bundle = (BundleItem) cp2Item;
+                        elementBuilder.addBundle(bundle.getName(), bundle.getSlot(), bundle.getContentHash());
+                    }
+                } else if (ModificationType.REMOVE.equals(modType)) {
+                    final ContentItem cp1Item = cp1Mod.getItem();
+                    if (cp1Item.getContentType().equals(ContentType.MODULE)) {
+                        final ModuleItem module = (ModuleItem) cp2Mod.getItem();
+                        elementBuilder.removeModule(module.getName(), module.getSlot(), cp1Mod.getTargetHash());
+                    } else if (cp1Item.getContentType().equals(ContentType.MISC)) {
+                        final MiscContentItem misc = (MiscContentItem) cp2Mod.getItem();
+                        elementBuilder.removeFile(misc.getName(), Arrays.asList(misc.getPath()), cp1Mod.getTargetHash(),
+                                misc.isDirectory());
+                    } else { // bundle
+                        final BundleItem bundle = (BundleItem) cp2Mod.getItem();
+                        elementBuilder.removeBundle(bundle.getName(), bundle.getSlot(), cp1Mod.getTargetHash());
+                    }
+                } else { // modify
+                    final ContentItem cp1Item = cp1Mod.getItem();
+                    if (cp1Item.getContentType().equals(ContentType.MODULE)) {
+                        final ModuleItem module = (ModuleItem) cp2Mod.getItem();
+                        elementBuilder.modifyModule(module.getName(), module.getSlot(), cp1Mod.getTargetHash(),
+                                module.getContentHash());
+                    } else if (cp1Item.getContentType().equals(ContentType.MISC)) {
+                        final MiscContentItem misc = (MiscContentItem) cp2Mod.getItem();
+                        elementBuilder.modifyFile(misc.getName(), Arrays.asList(misc.getPath()), cp1Mod.getTargetHash(),
+                                misc.getContentHash(), misc.isDirectory());
+                    } else { // bundle
+                        final BundleItem bundle = (BundleItem) cp2Mod.getItem();
+                        elementBuilder.modifyBundle(bundle.getName(), bundle.getSlot(), cp1Mod.getTargetHash(),
+                                bundle.getContentHash());
+                    }
+                }
+            }
+        }
+
+        for (ContentModification cp2Mod : cp2Mods.getModifications()) {
+            elementBuilder.addContentModification(cp2Mod);
+        }
+    }
+
+    private static void assertUpgrade(final PatchType patchType) throws PatchingException {
+        if (!PatchType.CUMULATIVE.equals(patchType)) {
+            throw new PatchingException("Merging one-off patches is not supported at this point.");
+        }
+    }
+
+    static File createTempDir() throws PatchingException {
+        return createTempDir(TEMP_DIR);
+    }
+
+    static File createTempDir(final File parent) throws PatchingException {
+        File workDir = null;
+        int count = 0;
+        while (workDir == null || workDir.exists()) {
+            count++;
+            workDir = new File(parent == null ? TEMP_DIR : parent, DIRECTORY_PREFIX + count);
+        }
+        if (!workDir.mkdirs()) {
+            throw new PatchingException(PatchLogger.ROOT_LOGGER.cannotCreateDirectory(workDir.getAbsolutePath()));
+        }
+        return workDir;
+    }
+
+    private static class ContentModifications {
+
+        private final Map<Integer, ContentModification> modifications;
+
+        ContentModifications(Collection<ContentModification> mods) {
+            modifications = new HashMap<Integer, ContentModification>(mods.size());
+            for (ContentModification mod : mods) {
+                modifications.put(getKey(mod.getItem()), mod);
+            }
+        }
+
+        ContentModification remove(ContentItem item) {
+            return modifications.remove(getKey(item));
+        }
+
+        Collection<ContentModification> getModifications() {
+            return modifications.values();
+        }
+
+        private Integer getKey(ContentItem item) {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + item.getContentType().hashCode();
+            result = prime * result + item.getRelativePath().hashCode();
+            return result;
+        }
+    }
+
+    private static void ls(final File f) {
+        System.out.println(f.getAbsolutePath());
+        for(File c : f.listFiles()) {
+            ls(c, "  ");
+        }
+    }
+
+    private static void ls(final File f, String offset) {
+        System.out.println(offset + f.getName());
+        if(f.isDirectory()) {
+            for(File c : f.listFiles()) {
+                ls(c, offset + "  ");
+            }
+        }
+    }
+}

--- a/patching/src/main/java/org/jboss/as/patching/metadata/SecurityActions.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/SecurityActions.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.patching.metadata;
+
+import static java.lang.System.getProperty;
+import static java.lang.System.getSecurityManager;
+import static java.security.AccessController.doPrivileged;
+
+import org.wildfly.security.manager.action.ReadPropertyAction;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+class SecurityActions {
+
+    private SecurityActions() {
+    }
+
+    static String getSystemProperty(final String key) {
+        return getSecurityManager() == null ? getProperty(key) : doPrivileged(new ReadPropertyAction(key));
+    }
+}

--- a/patching/src/main/java/org/jboss/as/patching/runner/AbstractPatchingTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/AbstractPatchingTask.java
@@ -44,7 +44,7 @@ abstract class AbstractPatchingTask<T extends ContentItem> implements PatchingTa
 
     private boolean ignoreApply;   // completely ignore the apply step
     private boolean skipExecution; // Skip the execution step
-    private byte[] backupHash = NO_CONTENT; // The backup hash
+    protected byte[] backupHash = NO_CONTENT; // The backup hash
 
     AbstractPatchingTask(PatchingTaskDescription description, Class<T> expected) {
         this.description = description;

--- a/patching/src/main/java/org/jboss/as/patching/runner/ModuleRemoveTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/ModuleRemoveTask.java
@@ -27,7 +27,6 @@ import static org.jboss.as.patching.IoUtils.copy;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import org.jboss.as.patching.IoUtils;
 import org.jboss.as.patching.logging.PatchLogger;
@@ -56,11 +55,11 @@ class ModuleRemoveTask extends AbstractModuleTask {
     @Override
     byte[] apply(PatchingTaskContext context, PatchContentLoader loader) throws IOException {
         final File targetDir = context.getTargetFile(contentItem);
-        if(! targetDir.mkdirs()) {
+        if(!targetDir.exists() && ! targetDir.mkdirs()) {
             throw PatchLogger.ROOT_LOGGER.cannotCreateDirectory(targetDir.getAbsolutePath());
         }
         final File moduleXml = new File(targetDir, MODULE_XML);
-        final ByteArrayInputStream is = new ByteArrayInputStream(getFileContent(contentItem));
+        final ByteArrayInputStream is = new ByteArrayInputStream(PatchUtils.getAbsentModuleContent(contentItem));
         try {
             return copy(is, moduleXml);
         } finally {
@@ -80,14 +79,4 @@ class ModuleRemoveTask extends AbstractModuleTask {
         final ModuleItem item = createContentItem(contentItem, itemHash);
         return new ContentModification(item, targetHash, ModificationType.MODIFY);
     }
-
-    static byte[] getFileContent(final ModuleItem item) {
-        final StringBuilder builder = new StringBuilder(128);
-        builder.append("<?xml version='1.0' encoding='UTF-8'?>\n<module-absent xmlns=\"urn:jboss:module:1.2\"");
-        builder.append(" name=\"").append(item.getName()).append("\"");
-        builder.append(" slot=\"").append(item.getSlot()).append("\"");
-        builder.append(" />\n");
-        return builder.toString().getBytes(StandardCharsets.UTF_8);
-    }
-
 }

--- a/patching/src/main/java/org/jboss/as/patching/runner/PatchUtils.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/PatchUtils.java
@@ -46,7 +46,9 @@ import java.util.Properties;
 
 import org.jboss.as.patching.Constants;
 import org.jboss.as.patching.DirectoryStructure;
+import org.jboss.as.patching.HashUtils;
 import org.jboss.as.patching.installation.PatchableTarget;
+import org.jboss.as.patching.metadata.ModuleItem;
 
 /**
  * @author Emanuel Muckenhuber
@@ -260,5 +262,19 @@ public final class PatchUtils {
             return new File(file.getParentFile(), fileName.substring(0, fileName.length() - JAR_EXT.length()) + BACKUP_EXT);
         }
         return file;
+    }
+
+    public static byte[] getAbsentModuleContent(final ModuleItem item) {
+        final StringBuilder builder = new StringBuilder(128);
+        builder.append("<?xml version='1.0' encoding='UTF-8'?>\n<module-absent xmlns=\"urn:jboss:module:1.2\"");
+        builder.append(" name=\"").append(item.getName()).append("\"");
+        builder.append(" slot=\"").append(item.getSlot()).append("\"");
+        builder.append(" />\n");
+        return builder.toString().getBytes(StandardCharsets.UTF_8);
+    }
+
+    public static byte[] getAbsentModuleContentHash(final ModuleItem item) throws IOException {
+        final byte[] content = getAbsentModuleContent(item);
+        return HashUtils.hashBytes(content);
     }
 }

--- a/patching/src/test/java/org/jboss/as/patching/cli/RollbackLastUnitTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/cli/RollbackLastUnitTestCase.java
@@ -149,7 +149,7 @@ public class RollbackLastUnitTestCase extends AbstractTaskTestCase {
         Patch patch2 = PatchBuilder.create()
                 .setPatchId(patchID2)
                 .setDescription(randomString())
-                .upgradeIdentity(productConfig.getProductName(), productConfig.getProductVersion(), productConfig.getProductName() + "CP2")
+                .upgradeIdentity(productConfig.getProductName(), productConfig.getProductVersion() + "CP1", productConfig.getProductVersion() + "CP2")
                 .getParent()
                 .addContentModification(fileModified2)
                 .upgradeElement(patchElementId2, "base", false)

--- a/patching/src/test/java/org/jboss/as/patching/installation/LayerTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/installation/LayerTestCase.java
@@ -41,13 +41,9 @@ import static org.jboss.as.patching.runner.TestUtils.randomString;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.util.List;
-import java.util.Properties;
 
-import org.jboss.as.patching.Constants;
 import org.jboss.as.patching.DirectoryStructure;
-import org.jboss.as.patching.IoUtils;
 import org.jboss.as.patching.metadata.ContentModification;
 import org.jboss.as.patching.metadata.Patch;
 import org.jboss.as.patching.metadata.PatchBuilder;
@@ -66,7 +62,7 @@ public class LayerTestCase extends AbstractTaskTestCase {
     @Test
     public void layerNotInLayersConf() throws Exception {
         String layerName = randomString();
-        installLayer(env.getModuleRoot(), null, layerName);
+        installLayers(false, layerName);
 
         InstalledIdentity installedIdentity = loadInstalledIdentity();
 
@@ -79,7 +75,7 @@ public class LayerTestCase extends AbstractTaskTestCase {
     @Test
     public void installedLayer() throws Exception {
         String layerName = randomString();
-        installLayer(env.getModuleRoot(), env.getInstalledImage().getLayersConf(), layerName);
+        installLayers(layerName);
 
         TestUtils.tree(env.getInstalledImage().getJbossHome());
         InstalledIdentity installedIdentity = loadInstalledIdentity();
@@ -106,7 +102,7 @@ public class LayerTestCase extends AbstractTaskTestCase {
     public void patchLayer() throws Exception {
         // add a layer
         String layerName = "mylayer";//randomString();
-        installLayer(env.getModuleRoot(), env.getInstalledImage().getLayersConf(), layerName);
+        installLayers(layerName);
 
         InstalledIdentity installedIdentity = loadInstalledIdentity();
 
@@ -149,7 +145,7 @@ public class LayerTestCase extends AbstractTaskTestCase {
     public void patchAndRollbackLayer() throws Exception {
         // add a layer
         String layerName = randomString();
-        installLayer(env.getModuleRoot(), env.getInstalledImage().getLayersConf(), layerName);
+        installLayers(layerName);
 
         InstalledIdentity installedIdentity = loadInstalledIdentity();
 
@@ -210,7 +206,7 @@ public class LayerTestCase extends AbstractTaskTestCase {
         // add a layer
         String layerName = "layer1";
         String layer2Name = "layer2";
-        installLayer(env.getModuleRoot(), env.getInstalledImage().getLayersConf(), layerName, layer2Name);
+        installLayers(layerName, layer2Name);
 
         InstalledIdentity installedIdentity = loadInstalledIdentity();
 
@@ -238,30 +234,6 @@ public class LayerTestCase extends AbstractTaskTestCase {
             fail("duplicate element patch-id error expected");
         } catch(IllegalStateException e) {
             // expected
-        }
-    }
-
-    private static void installLayer(File baseDir, File layerConf, String... layers) throws Exception {
-        for (String layer : layers) {
-            IoUtils.mkdir(baseDir, "system", "layers", layer);
-        }
-        if (layerConf != null) {
-            Properties props = new Properties();
-            StringBuilder str = new StringBuilder();
-            for (int i = 0; i < layers.length; i++) {
-                if (i > 0) {
-                    str.append(',');
-                }
-                str.append(layers[i]);
-            }
-            props.put(Constants.LAYERS, str.toString());
-            props.put(Constants.EXCLUDE_LAYER_BASE, "true");
-            final FileOutputStream os = new FileOutputStream(layerConf);
-            try {
-                props.store(os, "");
-            } finally {
-                IoUtils.safeClose(os);
-            }
         }
     }
 }

--- a/patching/src/test/java/org/jboss/as/patching/runner/AbstractTaskTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/runner/AbstractTaskTestCase.java
@@ -30,10 +30,13 @@ import static org.jboss.as.patching.IoUtils.mkdir;
 import static org.jboss.as.patching.runner.TestUtils.randomString;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
+import org.jboss.as.patching.Constants;
 import org.jboss.as.patching.DirectoryStructure;
 import org.jboss.as.patching.IoUtils;
 import org.jboss.as.patching.PatchingException;
@@ -91,24 +94,68 @@ public abstract class AbstractTaskTestCase {
     }
 
     protected PatchingResult executePatch(final File file) throws IOException, PatchingException {
-        final PatchTool tool = newPatchTool();
+        return executePatch(newPatchTool(), file);
+    }
+
+    protected PatchingResult executePatch(final PatchTool tool, final File file) throws IOException, PatchingException {
         final PatchingResult result = tool.applyPatch(file, ContentVerificationPolicy.STRICT);
         result.commit();
         return result;
     }
 
     protected PatchingResult rollback(String patchId) throws IOException, PatchingException {
-        return rollback(patchId, false);
+        return rollback(newPatchTool(), patchId);
+    }
+
+    protected PatchingResult rollback(PatchTool tool, String patchId) throws IOException, PatchingException {
+        return rollback(tool, patchId, false);
     }
 
     protected PatchingResult rollback(String patchId, final boolean rollbackTo) throws IOException, PatchingException {
-        return rollback(patchId, rollbackTo, ContentVerificationPolicy.STRICT);
+        return rollback(newPatchTool(), patchId, rollbackTo);
+    }
+
+    protected PatchingResult rollback(PatchTool tool, String patchId, final boolean rollbackTo) throws IOException, PatchingException {
+        return rollback(tool, patchId, rollbackTo, ContentVerificationPolicy.STRICT);
     }
 
     protected PatchingResult rollback(String patchId, boolean rollbackTo, ContentVerificationPolicy policy) throws IOException, PatchingException {
-        final PatchTool tool = newPatchTool();
+        return rollback(newPatchTool(), patchId, rollbackTo, policy);
+    }
+
+    protected PatchingResult rollback(PatchTool tool, String patchId, boolean rollbackTo, ContentVerificationPolicy policy) throws IOException, PatchingException {
         final PatchingResult result = tool.rollback(patchId, policy, rollbackTo, true);
         result.commit();
         return result;
+    }
+
+    protected void installLayers(String... layers) throws Exception {
+        installLayers(true, layers);
+    }
+
+    protected void installLayers(boolean reflectInConf, String... layers) throws Exception {
+        final File baseDir = env.getModuleRoot();
+        for (String layer : layers) {
+            IoUtils.mkdir(baseDir, "system", "layers", layer);
+        }
+        if (reflectInConf) {
+            final File layerConf = env.getInstalledImage().getLayersConf();
+            Properties props = new Properties();
+            StringBuilder str = new StringBuilder();
+            for (int i = 0; i < layers.length; i++) {
+                if (i > 0) {
+                    str.append(',');
+                }
+                str.append(layers[i]);
+            }
+            props.put(Constants.LAYERS, str.toString());
+            //props.put(Constants.EXCLUDE_LAYER_BASE, "true");
+            final FileOutputStream os = new FileOutputStream(layerConf);
+            try {
+                props.store(os, "");
+            } finally {
+                IoUtils.safeClose(os);
+            }
+        }
     }
 }

--- a/patching/src/test/java/org/jboss/as/patching/runner/ContentModificationUtils.java
+++ b/patching/src/test/java/org/jboss/as/patching/runner/ContentModificationUtils.java
@@ -25,7 +25,6 @@ package org.jboss.as.patching.runner;
 import static org.jboss.as.patching.Constants.BUNDLES;
 import static org.jboss.as.patching.Constants.MISC;
 import static org.jboss.as.patching.Constants.MODULES;
-import static org.jboss.as.patching.Constants.SYSTEM;
 import static org.jboss.as.patching.HashUtils.hashFile;
 import static org.jboss.as.patching.IoUtils.NO_CONTENT;
 import static org.jboss.as.patching.IoUtils.newFile;
@@ -40,10 +39,7 @@ import static org.jboss.as.patching.runner.TestUtils.touch;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Array;
-import java.util.Arrays;
 
-import org.jboss.as.patching.Constants;
 import org.jboss.as.patching.metadata.BundleItem;
 import org.jboss.as.patching.metadata.ContentModification;
 import org.jboss.as.patching.metadata.MiscContentItem;
@@ -70,8 +66,12 @@ public class ContentModificationUtils {
     }
 
     public static ContentModification removeModule(File existingModule) throws IOException {
-        byte[] existingHash = hashFile(existingModule);
-        return new ContentModification(new ModuleItem(existingModule.getName(), ModuleItem.MAIN_SLOT, NO_CONTENT), existingHash, REMOVE);
+        return removeModule(existingModule, existingModule.getName());
+    }
+
+    public static ContentModification removeModule(File moduleDir, String moduleName) throws IOException {
+        byte[] existingHash = hashFile(moduleDir);
+        return new ContentModification(new ModuleItem(moduleName, ModuleItem.MAIN_SLOT, NO_CONTENT), existingHash, REMOVE);
     }
 
     public static ContentModification modifyModule(File patchDir, String patchElementID, File existingModule, String newContent) throws IOException {

--- a/patching/src/test/java/org/jboss/as/patching/runner/PatchingAssert.java
+++ b/patching/src/test/java/org/jboss/as/patching/runner/PatchingAssert.java
@@ -188,7 +188,7 @@ public class PatchingAssert {
         fail("count not found module for " + moduleName + " in " + asList(modulesPath));
     }
 
-    static void assertDefinedAbsentModule(File modulesDir, String moduleName) throws Exception {
+    public static void assertDefinedAbsentModule(File modulesDir, String moduleName) throws Exception {
             final File modulePath = PatchContentLoader.getModulePath(modulesDir, moduleName, "main");
             final File moduleXml = new File(modulePath, "module.xml");
             if (moduleXml.exists()) {

--- a/patching/src/test/java/org/jboss/as/patching/runner/TestUtils.java
+++ b/patching/src/test/java/org/jboss/as/patching/runner/TestUtils.java
@@ -257,7 +257,7 @@ public class TestUtils {
     }
 
     public static File createZippedPatchFile(File sourceDir, String zipFileName) {
-        tree(sourceDir);
+        //tree(sourceDir);
         File zipFile = new File(sourceDir.getParent(), zipFileName + ".zip");
         ZipUtils.zip(sourceDir, zipFile);
         return zipFile;

--- a/patching/src/test/java/org/jboss/as/patching/tests/MergingPatchContentTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/MergingPatchContentTestCase.java
@@ -1,0 +1,426 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.patching.tests;
+
+import static org.jboss.as.patching.Constants.BASE;
+import static org.jboss.as.patching.HashUtils.hashFile;
+import static org.jboss.as.patching.IoUtils.mkdir;
+import static org.jboss.as.patching.runner.PatchingAssert.assertDefinedAbsentModule;
+import static org.jboss.as.patching.runner.PatchingAssert.assertDefinedModule;
+import static org.jboss.as.patching.runner.PatchingAssert.assertDirExists;
+import static org.jboss.as.patching.runner.PatchingAssert.assertFileContent;
+import static org.jboss.as.patching.runner.PatchingAssert.assertFileDoesNotExist;
+import static org.jboss.as.patching.runner.PatchingAssert.assertFileExists;
+import static org.jboss.as.patching.runner.PatchingAssert.assertPatchHasBeenApplied;
+import static org.jboss.as.patching.runner.TestUtils.createPatchXMLFile;
+import static org.jboss.as.patching.runner.TestUtils.createZippedPatchFile;
+import static org.jboss.as.patching.runner.TestUtils.dump;
+import static org.jboss.as.patching.runner.TestUtils.randomString;
+import static org.jboss.as.patching.runner.TestUtils.touch;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.jboss.as.patching.HashUtils;
+import org.jboss.as.patching.IoUtils;
+import org.jboss.as.patching.installation.InstalledIdentity;
+import org.jboss.as.patching.metadata.ContentModification;
+import org.jboss.as.patching.metadata.Patch;
+import org.jboss.as.patching.metadata.PatchBuilder;
+import org.jboss.as.patching.metadata.PatchMerger;
+import org.jboss.as.patching.runner.AbstractTaskTestCase;
+import org.jboss.as.patching.runner.ContentModificationUtils;
+import org.jboss.as.patching.tool.PatchTool;
+import org.jboss.as.patching.tool.PatchingResult;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class MergingPatchContentTestCase extends AbstractTaskTestCase {
+
+    final String moduleName = "org.jboss.test";
+
+    private File standaloneSh;
+    private byte[] originalStandaloneHash;
+
+    private File addedByCP1;
+    private File addedByCP1RemovedByCP3;
+    private File addedByCP2;
+
+    private Patch cp1;
+    private String baseCP1ID = "base-CP1";
+    private String layer1CP1ID = "layer1-CP1";
+    private String layer2CP1ID = "layer2-CP1";
+    private ContentModification cp1BaseModuleAdded;
+    private ContentModification cp1BaseModule2Added;
+    private ContentModification cp1Layer1ModuleAdded;
+    private ContentModification cp1Layer2ModuleAdded;
+    private ContentModification cp1Layer2Module2Added;
+    private ContentModification cp1StandaloneModified;
+    private ContentModification cp1AddedByCP1Added;
+
+    private Patch cp2;
+    private String baseCP2ID = "base-CP2";
+    private String layer2CP2ID = "layer2-CP2";
+    private ContentModification cp2BaseModuleModified;
+    private ContentModification cp2BaseModule2Removed;
+    private ContentModification cp2StandaloneModified;
+    private ContentModification cp2AddedByCp2Added;
+    private ContentModification cp2Layer2ModuleRemoved;
+    private ContentModification cp2Layer2Module3Added;
+
+    private Patch cp3;
+    private String baseCP3ID = "base-CP3";
+    private ContentModification cp3BaseModuleModified;
+    private ContentModification cp3BaseModule2Added;
+    private ContentModification cp3StandaloneModified;
+
+    private File cp1Zip;
+    private File cp2Zip;
+    private File cp3Zip;
+    private File mergedZip;
+
+    private PatchTool tool;
+
+    @Before
+    public void init() throws Exception {
+
+        installLayers("layer1", "layer2");
+
+        final File binDir = mkdir(env.getInstalledImage().getJbossHome(), "bin");
+
+        standaloneSh = touch(binDir, "standalone.sh");
+        dump(standaloneSh, "original script to run standalone server");
+        originalStandaloneHash = hashFile(standaloneSh);
+
+        addedByCP1 = new File(binDir, "added-by-cp1.txt");
+        addedByCP1RemovedByCP3 = new File(binDir, "added-by-cp1-removed-by-cp3.txt");
+        addedByCP2 = new File(binDir, "added-by-cp2.txt");
+
+        tool = newPatchTool();
+    }
+
+    /**
+     * This test creates three consequent CPs and applies them one by one first.
+     * Then creates a merged CP.
+     * Then rollsback one by one applying the merged CP and verifying the latest CP
+     * has been applied.
+     * This also tests the "undo", i.e. a rollback as one step, of the merged CP.
+     */
+    @Test
+    public void testMain() throws Exception {
+
+        final InstalledIdentity installedIdentity = loadInstalledIdentity();
+
+        PatchingResult result;
+
+        assertNotPatched();
+
+        prepareCP1(installedIdentity);
+        result = executePatch(tool, cp1Zip);
+        assertCP1State(result);
+
+        prepareCP2(installedIdentity);
+        result = executePatch(tool, cp2Zip);
+        assertCP2State(result);
+
+        prepareCP3(installedIdentity);
+        result = executePatch(tool, cp3Zip);
+        assertCP3State(result);
+
+//        ls(installedIdentity.getInstalledImage().getJbossHome());
+
+        mergedZip = new File(tempDir, "merged-patch.zip");
+        PatchMerger.merge(cp1Zip, cp2Zip, mergedZip);
+        PatchMerger.merge(mergedZip, cp3Zip, mergedZip);
+
+//        File mergedDir = mkdir(tempDir, "merged2");
+//        ZipUtils.unzip(mergedZip, mergedDir);
+//        ls(mergedDir);
+//        less(new File(mergedDir, "patch.xml"));
+
+        result = rollback(tool, cp3.getPatchId());
+        assertCP2State(result);
+        result = executePatch(tool, mergedZip);
+        assertCP3State(result);
+
+        result = rollback(tool, cp3.getPatchId());
+        assertCP2State(result);
+        result = rollback(tool, cp2.getPatchId());
+        assertCP1State(result);
+        result = executePatch(tool, mergedZip);
+        assertCP3State(result);
+
+        result = rollback(tool, cp3.getPatchId());
+        assertCP1State(result);
+        result = rollback(tool, cp1.getPatchId());
+        assertNotPatched();
+
+        result = executePatch(tool, mergedZip);
+        assertCP3State(result);
+
+        result = rollback(tool, cp3.getPatchId());
+        assertNotPatched();
+    }
+
+    private void assertCP3State(PatchingResult result) throws Exception {
+        assertPatchHasBeenApplied(result, cp3);
+
+        assertFileExists(standaloneSh);
+        assertFileContent(cp3StandaloneModified.getItem().getContentHash(), standaloneSh);
+        assertFileExists(addedByCP1);
+        assertFileContent(cp1AddedByCP1Added.getItem().getContentHash(), addedByCP1);
+        assertFileDoesNotExist(addedByCP1RemovedByCP3);
+        assertFileExists(addedByCP2);
+        assertFileContent(cp2AddedByCp2Added.getItem().getContentHash(), addedByCP2);
+
+        final InstalledIdentity installedIdentity = loadInstalledIdentity();
+        File modulePatchDir = installedIdentity.getLayer(BASE).loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(baseCP3ID);
+        assertDirExists(modulePatchDir);
+        assertDefinedModule(modulePatchDir, moduleName, cp3BaseModuleModified.getItem().getContentHash());
+        assertDefinedModule(modulePatchDir, moduleName + 2, cp3BaseModule2Added.getItem().getContentHash());
+
+        modulePatchDir = installedIdentity.getLayer("layer1").loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(layer1CP1ID);
+        assertDirExists(modulePatchDir);
+        assertDefinedModule(modulePatchDir, moduleName, cp1Layer1ModuleAdded.getItem().getContentHash());
+
+        modulePatchDir = installedIdentity.getLayer("layer2").loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(layer2CP2ID);
+        assertDirExists(modulePatchDir);
+        assertDefinedModule(modulePatchDir, moduleName + "2", cp1Layer2Module2Added.getItem().getContentHash());
+        assertDefinedModule(modulePatchDir, moduleName + "3", cp2Layer2Module3Added.getItem().getContentHash());
+        if(IoUtils.newFile(modulePatchDir, "org", "jboss", "test").exists()) {
+            assertDefinedAbsentModule(modulePatchDir, moduleName);
+        }
+    }
+
+    private void assertCP2State(PatchingResult result) throws Exception {
+        assertPatchHasBeenApplied(result, cp2);
+
+        assertFileExists(standaloneSh);
+        assertFileContent(cp2StandaloneModified.getItem().getContentHash(), standaloneSh);
+        assertFileExists(addedByCP1);
+        assertFileContent(cp1AddedByCP1Added.getItem().getContentHash(), addedByCP1);
+        assertFileExists(addedByCP1RemovedByCP3);
+        assertFileExists(addedByCP2);
+        assertFileContent(cp2AddedByCp2Added.getItem().getContentHash(), addedByCP2);
+
+        final InstalledIdentity installedIdentity = loadInstalledIdentity();
+        File modulePatchDiry = installedIdentity.getLayer(BASE).loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(baseCP2ID);
+        assertDirExists(modulePatchDiry);
+        assertDefinedModule(modulePatchDiry, moduleName, cp2BaseModuleModified.getItem().getContentHash());
+        assertDefinedAbsentModule(modulePatchDiry, moduleName + "2");
+
+        modulePatchDiry = installedIdentity.getLayer("layer1").loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(layer1CP1ID);
+        assertDirExists(modulePatchDiry);
+        assertDefinedModule(modulePatchDiry, moduleName, cp1Layer1ModuleAdded.getItem().getContentHash());
+
+        modulePatchDiry = installedIdentity.getLayer("layer2").loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(layer2CP2ID);
+        assertDirExists(modulePatchDiry);
+        assertDefinedAbsentModule(modulePatchDiry, moduleName);
+        assertDefinedModule(modulePatchDiry, moduleName + "2", cp1Layer2Module2Added.getItem().getContentHash());
+        assertDefinedModule(modulePatchDiry, moduleName + "3", cp2Layer2Module3Added.getItem().getContentHash());
+    }
+
+    private void assertCP1State(PatchingResult result) throws Exception {
+        assertPatchHasBeenApplied(result, cp1);
+
+        assertFileExists(standaloneSh);
+        assertFileContent(cp1StandaloneModified.getItem().getContentHash(), standaloneSh);
+        assertFileExists(addedByCP1);
+        assertFileContent(cp1AddedByCP1Added.getItem().getContentHash(), addedByCP1);
+        assertFileExists(addedByCP1RemovedByCP3);
+        assertFileDoesNotExist(addedByCP2);
+
+        final InstalledIdentity installedIdentity = loadInstalledIdentity();
+        File modulePatchDir = installedIdentity.getLayer(BASE).loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(baseCP1ID);
+        assertDirExists(modulePatchDir);
+        assertDefinedModule(modulePatchDir, moduleName, cp1BaseModuleAdded.getItem().getContentHash());
+        assertDefinedModule(modulePatchDir, moduleName + "2", cp1BaseModule2Added.getItem().getContentHash());
+
+        modulePatchDir = installedIdentity.getLayer("layer1").loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(layer1CP1ID);
+        assertDirExists(modulePatchDir);
+        assertDefinedModule(modulePatchDir, moduleName, cp1Layer1ModuleAdded.getItem().getContentHash());
+
+        modulePatchDir = installedIdentity.getLayer("layer2").loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(layer2CP1ID);
+        assertDirExists(modulePatchDir);
+        assertDefinedModule(modulePatchDir, moduleName, cp1Layer2ModuleAdded.getItem().getContentHash());
+        assertDefinedModule(modulePatchDir, moduleName + "2", cp1Layer2Module2Added.getItem().getContentHash());
+    }
+
+    private void assertNotPatched() throws Exception {
+
+        assertFileExists(standaloneSh);
+        assertFileContent(originalStandaloneHash, standaloneSh);
+        assertFileDoesNotExist(addedByCP1);
+        assertFileDoesNotExist(addedByCP1RemovedByCP3);
+        assertFileDoesNotExist(addedByCP2);
+
+        final InstalledIdentity installedIdentity = loadInstalledIdentity();
+        Assert.assertTrue(installedIdentity.getAllInstalledPatches().isEmpty());
+    }
+
+    private void prepareCP3(final InstalledIdentity installedIdentity) throws IOException, Exception {
+        final String cp3ID = "CP3";
+        final File cp3Dir = mkdir(tempDir, cp3ID);
+
+        cp3StandaloneModified = ContentModificationUtils.modifyMisc(cp3Dir, cp3ID, "updated by cp3", standaloneSh, "bin", standaloneSh.getName());
+        cp3BaseModuleModified = ContentModificationUtils.modifyModule(cp3Dir, baseCP3ID, moduleName, cp2BaseModuleModified.getItem().getContentHash(), "cp3 content");
+
+        // cp3BaseModule2Added = ContentModificationUtils.addModule(cp3Dir, baseCP3ID, moduleName + "2"); the patchgen tool
+        // would generate an update instead
+        final File absentModuleXml = IoUtils.newFile(installedIdentity.getLayer("base").loadTargetInfo()
+                .getDirectoryStructure().getModulePatchDirectory(baseCP2ID), "org", "jboss", "test2", "main", "module.xml");
+        cp3BaseModule2Added = ContentModificationUtils.modifyModule(cp3Dir, baseCP3ID, moduleName + "2",
+                HashUtils.hashFile(absentModuleXml), "cp3 content");
+
+        final ContentModification cp3AddedByCP1RemovedByCP3Removed = ContentModificationUtils.removeMisc(addedByCP1RemovedByCP3, "bin", addedByCP1RemovedByCP3.getName());
+
+        cp3 = PatchBuilder.create()
+                .setPatchId(cp3ID)
+                .setDescription(randomString())
+                .upgradeIdentity(installedIdentity.getIdentity().getName(), productConfig.getProductVersion() + "_CP2", productConfig.getProductVersion() + "_CP3")
+                    .getParent()
+                .upgradeElement(baseCP3ID, BASE, false)
+                    .addContentModification(cp3BaseModuleModified)
+                    .addContentModification(cp3BaseModule2Added)
+                    .getParent()
+                .addContentModification(cp3StandaloneModified)
+                .addContentModification(cp3AddedByCP1RemovedByCP3Removed)
+                .build();
+        createPatchXMLFile(cp3Dir, cp3);
+        cp3Zip = createZippedPatchFile(cp3Dir, cp3ID);
+    }
+
+    private void prepareCP2(final InstalledIdentity installedIdentity) throws Exception {
+
+        final String cp2ID = "CP2";
+        final File cp2Dir = mkdir(tempDir, cp2ID);
+
+        cp2BaseModuleModified = ContentModificationUtils.modifyModule(cp2Dir, baseCP2ID, moduleName, cp1BaseModuleAdded.getItem().getContentHash(), "cp2 content");
+        final File baseModule2Dir = IoUtils.newFile(
+                installedIdentity.getLayer("base").loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(baseCP1ID),
+                "org", "jboss", "test2");
+        cp2BaseModule2Removed = ContentModificationUtils.removeModule(baseModule2Dir, moduleName + 2);
+
+        final File layer2ModuleDir = IoUtils.newFile(
+                installedIdentity.getLayer("layer2").loadTargetInfo().getDirectoryStructure().getModulePatchDirectory(layer2CP1ID),
+                "org", "jboss", "test");
+        cp2Layer2ModuleRemoved = ContentModificationUtils.removeModule(layer2ModuleDir, moduleName);
+        cp2Layer2Module3Added = ContentModificationUtils.addModule(cp2Dir, layer2CP2ID, moduleName + "3");
+
+        cp2StandaloneModified = ContentModificationUtils.modifyMisc(cp2Dir, cp2ID, "updated by cp2", cp1StandaloneModified.getItem().getContentHash(), "bin", standaloneSh.getName());
+        cp2AddedByCp2Added = ContentModificationUtils.addMisc(cp2Dir, cp2ID, "added by cp2", "bin", addedByCP2.getName());
+
+        cp2 = PatchBuilder.create()
+                .setPatchId(cp2ID)
+                .setDescription(randomString())
+                .upgradeIdentity(installedIdentity.getIdentity().getName(), productConfig.getProductVersion() + "_CP1", productConfig.getProductVersion() + "_CP2")
+                    .getParent()
+                .upgradeElement(baseCP2ID, BASE, false)
+                    .addContentModification(cp2BaseModuleModified)
+                    .addContentModification(cp2BaseModule2Removed)
+                    .getParent()
+                .upgradeElement(layer2CP2ID, "layer2", false)
+                    .addContentModification(cp2Layer2ModuleRemoved)
+                    .addContentModification(cp2Layer2Module3Added)
+                    .getParent()
+                .addContentModification(cp2StandaloneModified)
+                .addContentModification(cp2AddedByCp2Added)
+                .build();
+        createPatchXMLFile(cp2Dir, cp2);
+        cp2Zip = createZippedPatchFile(cp2Dir, cp2ID);
+    }
+
+    private void prepareCP1(final InstalledIdentity installedIdentity) throws Exception {
+
+        final String cp1ID = "CP1";
+        final File cp1Dir = mkdir(tempDir, cp1ID);
+
+        cp1BaseModuleAdded = ContentModificationUtils.addModule(cp1Dir, baseCP1ID, moduleName);
+        cp1BaseModule2Added = ContentModificationUtils.addModule(cp1Dir, baseCP1ID, moduleName + 2);
+        cp1Layer1ModuleAdded = ContentModificationUtils.addModule(cp1Dir, layer1CP1ID, moduleName);
+        cp1Layer2ModuleAdded = ContentModificationUtils.addModule(cp1Dir, layer2CP1ID, moduleName);
+        cp1Layer2Module2Added = ContentModificationUtils.addModule(cp1Dir, layer2CP1ID, moduleName + "2");
+        cp1StandaloneModified = ContentModificationUtils.modifyMisc(cp1Dir, cp1ID, "updated by cp1", standaloneSh, "bin", standaloneSh.getName());
+        cp1AddedByCP1Added = ContentModificationUtils.addMisc(cp1Dir, cp1ID, "added by cp1", "bin", addedByCP1.getName());
+        final ContentModification cp1AddedByCP1RemovedByCP3Added = ContentModificationUtils.addMisc(cp1Dir, cp1ID, "added by cp1", "bin", addedByCP1RemovedByCP3.getName());
+
+        cp1 = PatchBuilder.create()
+                .setPatchId(cp1ID)
+                .setDescription(randomString())
+                .upgradeIdentity(installedIdentity.getIdentity().getName(), installedIdentity.getIdentity().getVersion(), productConfig.getProductVersion() + "_CP1")
+                    .getParent()
+                .upgradeElement(baseCP1ID, BASE, false)
+                    .addContentModification(cp1BaseModuleAdded)
+                    .addContentModification(cp1BaseModule2Added)
+                    .getParent()
+                .upgradeElement(layer1CP1ID, "layer1", false)
+                    .addContentModification(cp1Layer1ModuleAdded)
+                    .getParent()
+                .upgradeElement(layer2CP1ID, "layer2", false)
+                    .addContentModification(cp1Layer2ModuleAdded)
+                    .addContentModification(cp1Layer2Module2Added)
+                    .getParent()
+                .addContentModification(cp1StandaloneModified)
+                .addContentModification(cp1AddedByCP1Added)
+                .addContentModification(cp1AddedByCP1RemovedByCP3Added)
+                .build();
+        createPatchXMLFile(cp1Dir, cp1);
+        cp1Zip = createZippedPatchFile(cp1Dir, cp1ID);
+    }
+
+/*    private static void ls(final File f) {
+        System.out.println(f.getAbsolutePath());
+        for(File c : f.listFiles()) {
+            ls(c, "  ");
+        }
+    }
+
+    private static void ls(final File f, String offset) {
+        System.out.println(offset + f.getName());
+        if(f.isDirectory()) {
+            for(File c : f.listFiles()) {
+                ls(c, offset + "  ");
+            }
+        }
+    }
+
+    private static void less(File f) throws Exception {
+
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new FileReader(f));
+            String line = reader.readLine();
+            while(line != null) {
+                System.out.println(line);
+                line = reader.readLine();
+            }
+        } finally {
+            IoUtils.safeClose(reader);
+        }
+    }
+*/}

--- a/patching/src/test/java/org/jboss/as/patching/tests/MergingPatchMetadataTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/MergingPatchMetadataTestCase.java
@@ -1,0 +1,357 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.patching.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.jboss.as.patching.metadata.ContentItem;
+import org.jboss.as.patching.metadata.ContentModification;
+import org.jboss.as.patching.metadata.ContentType;
+import org.jboss.as.patching.metadata.Identity;
+import org.jboss.as.patching.metadata.Identity.IdentityUpgrade;
+import org.jboss.as.patching.metadata.LayerType;
+import org.jboss.as.patching.metadata.ModificationType;
+import org.jboss.as.patching.metadata.ModuleItem;
+import org.jboss.as.patching.metadata.Patch;
+import org.jboss.as.patching.metadata.Patch.PatchType;
+import org.jboss.as.patching.metadata.PatchBuilder;
+import org.jboss.as.patching.metadata.PatchElement;
+import org.jboss.as.patching.metadata.PatchElementBuilder;
+import org.jboss.as.patching.metadata.PatchElementProvider;
+import org.jboss.as.patching.metadata.PatchMerger;
+import org.jboss.as.patching.runner.PatchUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class MergingPatchMetadataTestCase {
+
+    protected static final MessageDigest DIGEST;
+
+    static {
+        try {
+            DIGEST = MessageDigest.getInstance("SHA-1");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static byte[] digest(String str) {
+        DIGEST.reset();
+        return DIGEST.digest(str.getBytes());
+    }
+
+    @Test
+    public void testAddModify() throws Exception {
+
+        final Patch cp1 = generateCP("base", "cp1", ModificationType.ADD);
+        final Patch cp2 = generateCP("cp1", "cp2", ModificationType.MODIFY);
+        final Patch merged = PatchMerger.merge(cp1, cp2);
+
+//        StringWriter writer = new StringWriter();
+//        PatchXml.marshal(writer, cp1);
+//        System.out.println(writer.getBuffer().toString());
+//        writer = new StringWriter();
+//        PatchXml.marshal(writer, cp2);
+//        System.out.println(writer.getBuffer().toString());
+//        writer = new StringWriter();
+//        PatchXml.marshal(writer, merged);
+//        System.out.println(writer.getBuffer().toString());
+
+        assertEquals("cp2", merged.getPatchId());
+        assertEquals("cp2" + " description", merged.getDescription());
+
+        final IdentityUpgrade identity = merged.getIdentity().forType(PatchType.CUMULATIVE, Identity.IdentityUpgrade.class);
+        assertEquals("base", identity.getVersion());
+        assertEquals("cp2", identity.getResultingVersion());
+        assertEquals(PatchType.CUMULATIVE, identity.getPatchType());
+
+        final List<PatchElement> elements = merged.getElements();
+        assertEquals(1, elements.size());
+        final PatchElement e = elements.get(0);
+        assertEquals("base-" + "cp2", e.getId());
+
+        final PatchElementProvider provider = e.getProvider();
+        assertEquals("base", provider.getName());
+        assertEquals(PatchType.CUMULATIVE, provider.getPatchType());
+        assertEquals(LayerType.Layer, provider.getLayerType());
+
+        assertEquals(3, e.getModifications().size());
+
+        for(ContentModification mod : e.getModifications()) {
+            assertEquals(ModificationType.ADD, mod.getType());
+            final ContentItem item = mod.getItem();
+            assertEquals(0, mod.getTargetHash().length);
+            if(ContentType.MODULE.equals(item.getContentType())) {
+                Assert.assertArrayEquals(moduleHash("cp2"), item.getContentHash());
+            } else if(ContentType.MISC.equals(item.getContentType())) {
+                Assert.assertArrayEquals(miscHash("cp2"), item.getContentHash());
+            } else {
+                Assert.assertArrayEquals(bundleHash("cp2"), item.getContentHash());
+            }
+        }
+    }
+
+    @Test
+    public void testAddRemove() throws Exception {
+
+        final Patch cp1 = generateCP("base", "cp1", ModificationType.ADD);
+        final Patch cp2 = generateCP("cp1", "cp2", ModificationType.REMOVE);
+        final Patch merged = PatchMerger.merge(cp1, cp2);
+
+//        StringWriter writer = new StringWriter();
+//        PatchXml.marshal(writer, cp1);
+//        System.out.println(writer.getBuffer().toString());
+//        writer = new StringWriter();
+//        PatchXml.marshal(writer, cp2);
+//        System.out.println(writer.getBuffer().toString());
+//        writer = new StringWriter();
+//        PatchXml.marshal(writer, merged);
+//        System.out.println(writer.getBuffer().toString());
+
+        assertEquals("cp2", merged.getPatchId());
+        assertEquals("cp2" + " description", merged.getDescription());
+
+        final IdentityUpgrade identity = merged.getIdentity().forType(PatchType.CUMULATIVE, Identity.IdentityUpgrade.class);
+        assertEquals("base", identity.getVersion());
+        assertEquals("cp2", identity.getResultingVersion());
+        assertEquals(PatchType.CUMULATIVE, identity.getPatchType());
+
+        final List<PatchElement> elements = merged.getElements();
+        assertEquals(1, elements.size());
+        final PatchElement e = elements.get(0);
+        assertEquals("base-" + "cp2", e.getId());
+
+        final PatchElementProvider provider = e.getProvider();
+        assertEquals("base", provider.getName());
+        assertEquals(PatchType.CUMULATIVE, provider.getPatchType());
+        assertEquals(LayerType.Layer, provider.getLayerType());
+
+        //assertEquals(0, e.getModifications().size());
+        // for modules remove is effectively a modify which changes the module xml to indicate an absent module
+        // so, it will remain an add of an absent module
+        assertEquals(1, e.getModifications().size());
+        final ContentModification mod = e.getModifications().iterator().next();
+        assertEquals(ModificationType.ADD, mod.getType());
+        Assert.assertArrayEquals(PatchUtils.getAbsentModuleContentHash((ModuleItem) mod.getItem()), mod.getItem().getContentHash());
+    }
+
+    @Test
+    public void testModifyRemove() throws Exception {
+
+        final Patch cp1 = generateCP("base", "cp1", ModificationType.MODIFY);
+        final Patch cp2 = generateCP("cp1", "cp2", ModificationType.REMOVE);
+        final Patch merged = PatchMerger.merge(cp1, cp2);
+
+//        StringWriter writer = new StringWriter();
+//        PatchXml.marshal(writer, cp1);
+//        System.out.println(writer.getBuffer().toString());
+//        writer = new StringWriter();
+//        PatchXml.marshal(writer, cp2);
+//        System.out.println(writer.getBuffer().toString());
+//        writer = new StringWriter();
+//        PatchXml.marshal(writer, merged);
+//        System.out.println(writer.getBuffer().toString());
+
+        assertEquals("cp2", merged.getPatchId());
+        assertEquals("cp2" + " description", merged.getDescription());
+
+        final IdentityUpgrade identity = merged.getIdentity().forType(PatchType.CUMULATIVE, Identity.IdentityUpgrade.class);
+        assertEquals("base", identity.getVersion());
+        assertEquals("cp2", identity.getResultingVersion());
+        assertEquals(PatchType.CUMULATIVE, identity.getPatchType());
+
+        final List<PatchElement> elements = merged.getElements();
+        assertEquals(1, elements.size());
+        final PatchElement e = elements.get(0);
+        assertEquals("base-" + "cp2", e.getId());
+
+        final PatchElementProvider provider = e.getProvider();
+        assertEquals("base", provider.getName());
+        assertEquals(PatchType.CUMULATIVE, provider.getPatchType());
+        assertEquals(LayerType.Layer, provider.getLayerType());
+
+        assertEquals(3, e.getModifications().size());
+
+        for(ContentModification mod : e.getModifications()) {
+            assertEquals(ModificationType.REMOVE, mod.getType());
+            final ContentItem item = mod.getItem();
+            assertEquals(0, item.getContentHash().length);
+            if(ContentType.MODULE.equals(item.getContentType())) {
+                Assert.assertArrayEquals(moduleHash("base"), mod.getTargetHash());
+            } else if(ContentType.MISC.equals(item.getContentType())) {
+                Assert.assertArrayEquals(miscHash("base"), mod.getTargetHash());
+            } else {
+                Assert.assertArrayEquals(bundleHash("base"), mod.getTargetHash());
+            }
+        }
+    }
+
+    @Test
+    public void testRemoveAdd() throws Exception {
+
+        final Patch cp1 = generateCP("base", "cp1", ModificationType.REMOVE);
+        final Patch cp2 = generateCP("cp1", "cp2", ModificationType.ADD);
+        final Patch merged = PatchMerger.merge(cp1, cp2);
+
+//        StringWriter writer = new StringWriter();
+//        PatchXml.marshal(writer, cp1);
+//        System.out.println(writer.getBuffer().toString());
+//        writer = new StringWriter();
+//        PatchXml.marshal(writer, cp2);
+//        System.out.println(writer.getBuffer().toString());
+//        writer = new StringWriter();
+//        PatchXml.marshal(writer, merged);
+//        System.out.println(writer.getBuffer().toString());
+
+        assertEquals("cp2", merged.getPatchId());
+        assertEquals("cp2" + " description", merged.getDescription());
+
+        final IdentityUpgrade identity = merged.getIdentity().forType(PatchType.CUMULATIVE, Identity.IdentityUpgrade.class);
+        assertEquals("base", identity.getVersion());
+        assertEquals("cp2", identity.getResultingVersion());
+        assertEquals(PatchType.CUMULATIVE, identity.getPatchType());
+
+        final List<PatchElement> elements = merged.getElements();
+        assertEquals(1, elements.size());
+        final PatchElement e = elements.get(0);
+        assertEquals("base-" + "cp2", e.getId());
+
+        final PatchElementProvider provider = e.getProvider();
+        assertEquals("base", provider.getName());
+        assertEquals(PatchType.CUMULATIVE, provider.getPatchType());
+        assertEquals(LayerType.Layer, provider.getLayerType());
+
+        assertEquals(3, e.getModifications().size());
+
+        for(ContentModification mod : e.getModifications()) {
+            assertEquals(ModificationType.MODIFY, mod.getType());
+            final ContentItem item = mod.getItem();
+            if(ContentType.MODULE.equals(item.getContentType())) {
+                Assert.assertArrayEquals(moduleHash("base"), mod.getTargetHash());
+                Assert.assertArrayEquals(moduleHash("cp2"), item.getContentHash());
+            } else if(ContentType.MISC.equals(item.getContentType())) {
+                Assert.assertArrayEquals(miscHash("base"), mod.getTargetHash());
+                Assert.assertArrayEquals(miscHash("cp2"), item.getContentHash());
+            } else {
+                Assert.assertArrayEquals(bundleHash("base"), mod.getTargetHash());
+                Assert.assertArrayEquals(bundleHash("cp2"), item.getContentHash());
+            }
+        }
+    }
+
+    @Test
+    public void testModifyModify() throws Exception {
+
+        final Patch cp1 = generateCP("base", "cp1", ModificationType.MODIFY);
+        final Patch cp2 = generateCP("cp1", "cp2", ModificationType.MODIFY);
+        final Patch merged = PatchMerger.merge(cp1, cp2);
+
+//        StringWriter writer = new StringWriter();
+//        PatchXml.marshal(writer, cp1);
+//        System.out.println(writer.getBuffer().toString());
+//        writer = new StringWriter();
+//        PatchXml.marshal(writer, cp2);
+//        System.out.println(writer.getBuffer().toString());
+//        writer = new StringWriter();
+//        PatchXml.marshal(writer, merged);
+//        System.out.println(writer.getBuffer().toString());
+
+        assertEquals("cp2", merged.getPatchId());
+        assertEquals("cp2" + " description", merged.getDescription());
+
+        final IdentityUpgrade identity = merged.getIdentity().forType(PatchType.CUMULATIVE, Identity.IdentityUpgrade.class);
+        assertEquals("base", identity.getVersion());
+        assertEquals("cp2", identity.getResultingVersion());
+        assertEquals(PatchType.CUMULATIVE, identity.getPatchType());
+
+        final List<PatchElement> elements = merged.getElements();
+        assertEquals(1, elements.size());
+        final PatchElement e = elements.get(0);
+        assertEquals("base-" + "cp2", e.getId());
+
+        final PatchElementProvider provider = e.getProvider();
+        assertEquals("base", provider.getName());
+        assertEquals(PatchType.CUMULATIVE, provider.getPatchType());
+        assertEquals(LayerType.Layer, provider.getLayerType());
+
+        assertEquals(3, e.getModifications().size());
+
+        for(ContentModification mod : e.getModifications()) {
+            assertEquals(ModificationType.MODIFY, mod.getType());
+            final ContentItem item = mod.getItem();
+            if(ContentType.MODULE.equals(item.getContentType())) {
+                Assert.assertArrayEquals(moduleHash("base"), mod.getTargetHash());
+                Assert.assertArrayEquals(moduleHash("cp2"), item.getContentHash());
+            } else if(ContentType.MISC.equals(item.getContentType())) {
+                Assert.assertArrayEquals(miscHash("base"), mod.getTargetHash());
+                Assert.assertArrayEquals(miscHash("cp2"), item.getContentHash());
+            } else {
+                Assert.assertArrayEquals(bundleHash("base"), mod.getTargetHash());
+                Assert.assertArrayEquals(bundleHash("cp2"), item.getContentHash());
+            }
+        }
+    }
+
+    protected Patch generateCP(final String currentCP, final String nextCP, ModificationType type) {
+        final PatchBuilder patchBuilder = PatchBuilder.create().setPatchId(nextCP).setDescription(nextCP + " description");
+
+        patchBuilder.upgradeIdentity("identity", currentCP, nextCP);
+        final PatchElementBuilder elementBuilder = patchBuilder.upgradeElement("base-" + nextCP, "base", false);
+        if(ModificationType.ADD.equals(type)) {
+            elementBuilder.addModule("org.jboss.test", "main", moduleHash(nextCP))
+                .addBundle("org.jboss.test", "main", bundleHash(nextCP))
+                .addFile("test.txt", Arrays.asList(new String[]{"org","jboss","test"}), miscHash(nextCP), false);
+        } else if(ModificationType.MODIFY.equals(type)) {
+            elementBuilder.modifyModule("org.jboss.test", "main", moduleHash(currentCP), moduleHash(nextCP))
+                .modifyBundle("org.jboss.test", "main", bundleHash(currentCP), bundleHash(nextCP))
+                .modifyFile("test.txt", Arrays.asList(new String[]{"org","jboss","test"}), miscHash(currentCP), miscHash(nextCP), false);
+        } else {
+            elementBuilder.removeModule("org.jboss.test", "main", moduleHash(currentCP))
+                .removeBundle("org.jboss.test", "main", bundleHash(currentCP))
+                .removeFile("test.txt", Arrays.asList(new String[] { "org", "jboss", "test" }), miscHash(currentCP), false);
+        }
+
+        return patchBuilder.build();
+    }
+
+    protected byte[] miscHash(final String nextCP) {
+        return digest("file:" + nextCP + ":org.jboss.test");
+    }
+
+    protected byte[] bundleHash(final String nextCP) {
+        return digest("bundle:" + nextCP + ":org.jboss.test:main");
+    }
+
+    protected byte[] moduleHash(final String nextCP) {
+        return digest("module:" + nextCP + ":org.jboss.test:main");
+    }
+}


### PR DESCRIPTION
An improvement of the patch bundle concept currently used for CPs where a bundle contains a number of CP patches from which only those relevant to the target installation will be applied.
The structure and format of the patched data, checksum verification and all the rest of the mechanism of application the changes stays the same.
This commit introduces support for multiple patch.xml files - one per identity version the patch can be applied to and update that identity to the version of the latest CP included in the patch.

Thanks,
Alexey