### PR TITLE
[WFCORE-839] : Don't store state in InMemoryAuditLogHandlerResourceDefinition.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/audit/AuditLogHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/audit/AuditLogHandler.java
@@ -22,11 +22,14 @@
 package org.jboss.as.controller.audit;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.dmr.ModelNode;
 
 /**
  *  All methods on this class should be called with {@link ManagedAuditLoggerImpl}'s lock taken.
@@ -129,6 +132,10 @@ abstract class AuditLogHandler {
     abstract void initialize();
     abstract void stop();
     abstract void writeLogItem(String formattedItem) throws IOException;
+
+    List<ModelNode> listLastEntries() {
+        return Collections.emptyList();
+    }
 
     interface FailureCountHandler {
         void success();

--- a/controller/src/main/java/org/jboss/as/controller/audit/AuditLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/audit/AuditLogger.java
@@ -190,5 +190,9 @@ public interface AuditLogger {
         @Override
         public void updateSyslogHandlerReconnectTimeout(String name, int reconnectTimeout) {
         }
+
+        @Override
+        public void updateInMemoryHandlerMaxHistory(String name, int maxHistory) {
+        }
     };
 }

--- a/controller/src/main/java/org/jboss/as/controller/audit/InMemoryAuditLogHander.java
+++ b/controller/src/main/java/org/jboss/as/controller/audit/InMemoryAuditLogHander.java
@@ -61,33 +61,29 @@ public final class InMemoryAuditLogHander extends AuditLogHandler {
     private int maxHistory;
     private final AuditLogItemFormatter myFormatter = new InMemoryFormatter();
 
+
     public InMemoryAuditLogHander(String name, int maxHistory) {
         super(name, IN_MEMORY_FORMATTER_NAME, maxHistory);
-        items = new ArrayList<>(maxHistory);
+        this.items = new ArrayList<>(maxHistory);
         this.maxHistory = maxHistory;
         setFormatter(myFormatter);
     }
 
-    public List<ModelNode> getItems() {
+    @Override
+    public List<ModelNode> listLastEntries() {
         return Collections.unmodifiableList(items);
     }
 
     public void setMaxHistory(int maxHistory) {
-        synchronized (items) {
-            this.maxHistory = maxHistory;
-            while (maxHistory < items.size()) {
-                items.remove(0);
-            }
+        this.maxHistory = maxHistory;
+        while (maxHistory < items.size()) {
+            items.remove(0);
         }
     }
 
     @Override
     void setFormatter(AuditLogItemFormatter formatter) {
-        if (formatter != null) {
-            super.setFormatter(formatter);
-        } else {
-            super.setFormatter(myFormatter);
-        }
+        super.setFormatter(myFormatter);
     }
 
     public AuditLogItemFormatter getFormatter() {
@@ -103,12 +99,10 @@ public final class InMemoryAuditLogHander extends AuditLogHandler {
     }
 
     private void addItem(ModelNode item) {
-        synchronized (items) {
-            if (items.size() == maxHistory) {
-                items.remove(0);
-            }
-            items.add(item);
+        if (items.size() == maxHistory) {
+            items.remove(0);
         }
+        items.add(item);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/audit/ManagedAuditLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/audit/ManagedAuditLogger.java
@@ -25,8 +25,11 @@
 package org.jboss.as.controller.audit;
 
 
+import java.util.Collections;
+import java.util.List;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.audit.SyslogAuditLogHandler.Facility;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Abstract base class for {@link AuditLogger} implementations.
@@ -149,7 +152,13 @@ public interface ManagedAuditLogger extends AuditLogger {
     void updateSyslogHandlerReconnectTimeout(String name, int reconnectTimeout);
     //ImmediateUpdates - end
 
-
+    /**
+     * Update the handler history size.
+     *
+     * @param name the name of the handler
+     * @param maxHistory the history size of the handler
+     */
+    void updateInMemoryHandlerMaxHistory(String name, int maxHistory);
     /**
      * Remove a formatter
      *
@@ -180,6 +189,16 @@ public interface ManagedAuditLogger extends AuditLogger {
      * @return the formatter
      */
     JsonAuditLogItemFormatter getJsonFormatter(String name);
+
+    /**
+     * Gets the last log entries
+     *
+     * @param name the name of the handler
+     * @return the last log entries of the handler
+     */
+    default List<ModelNode> listLastEntries(String name){
+        return Collections.emptyList();
+    }
 
     /**
      * Callback for the controller to call before the controller is booted

--- a/controller/src/main/java/org/jboss/as/controller/audit/ManagedAuditLoggerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/audit/ManagedAuditLoggerImpl.java
@@ -507,6 +507,27 @@ public class ManagedAuditLoggerImpl implements ManagedAuditLogger, ManagedAuditL
         }
     }
 
+    @Override
+    public List<ModelNode> listLastEntries(String name) {
+        config.lock();
+        try {
+            return config.getConfiguredHandler(name).listLastEntries();
+        } finally {
+            config.unlock();
+        }
+    }
+
+    @Override
+    public void updateInMemoryHandlerMaxHistory(String name, int maxHistory) {
+        config.lock();
+        try {
+            InMemoryAuditLogHander handler = (InMemoryAuditLogHander)config.getConfiguredHandler(name);
+            handler.setMaxHistory(maxHistory);
+        } finally {
+            config.unlock();
+        }
+    }
+
 
     /**
      * Abstract base class for core and new configuration


### PR DESCRIPTION
Updating ManagedAuditLogger to be able to access the last log entries with only a real implemntation in the InMemoryAuditLogHander.

Jira: https://issues.jboss.org/browse/WFCORE-839