### PR TITLE
[WFCORE-802] Allow log files in subdirectories of the relative jbossserver.log.dir to be listed as log file resources.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -832,12 +832,16 @@ public interface LoggingLogger extends BasicLogger {
     IllegalStateException extensionNotInitialized();
 
     /**
-     * Creates an exception indicating a failure to read the log file
+     * Creates an exception indicating a failure to read the log file.
+     * <p>
+     * Thrown as a {@link RuntimeException} because the operation did not fail. The cause is likely a failure to read
+     * the file at an OS level.
+     * </p>
      *
      * @param cause the cause of the error
      * @param name  the name of the file that was not found
      *
-     * @return an {@link OperationFailedException} for the error
+     * @return an {@link RuntimeException} for the error
      */
     @Message(id = 79, value = "Failed to read the log file '%s'")
     RuntimeException failedToReadLogFile(@Cause Throwable cause, String name);
@@ -908,4 +912,8 @@ public interface LoggingLogger extends BasicLogger {
      */
     @Message(id = 86, value = "Could not determine deployment name from the address %s.")
     IllegalArgumentException deploymentNameNotFound(PathAddress address);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 87, value = "Failed to process logging directory %s. Log files cannot be listed.")
+    void errorProcessingLogDirectory(String logDir);
 }


### PR DESCRIPTION
Currently subdirectories of the `jboss.server.log.dir` are ignored when listing log files as resources. This change allows log files in subdirectories to be listed under the `subsystem=logging/log-file=*` resource. The deprecated `subsystem=logging:list-log-files` and `subsystem=logging:read-log-file` operations do not files in the subdirectories.