### PR TITLE
[WFCORE-870] :  Seeing frequent "java.lang.UnsupportedOperationException: 'acl:acl' not supported as initial attribute" on Solaris arch

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
@@ -113,16 +113,18 @@ class FilePersistenceUtils {
         return tempFileName;
     }
 
-    static void createTempFileWithAttributes(Path tempFilePath, File fileName) throws IOException {
+    static Path createTempFileWithAttributes(Path tempFilePath, File fileName) throws IOException {
         Path exisitingFilePath = fileName.toPath();
         List<FileAttribute> attributes = new ArrayList<>(2);
         attributes.addAll(getPosixAttributes(exisitingFilePath));
         attributes.addAll(getAclAttributes(exisitingFilePath));
-        if (attributes.isEmpty()) {
-            Files.createFile(tempFilePath);
-        } else {
-            Files.createFile(tempFilePath, attributes.toArray(new FileAttribute<?>[attributes.size()]));
+        if (!attributes.isEmpty()) {
+            try {
+                return Files.createFile(tempFilePath, attributes.toArray(new FileAttribute<?>[attributes.size()]));
+            } catch (UnsupportedOperationException ex) {
+            }
         }
+        return Files.createFile(tempFilePath);
     }
 
     private static List<FileAttribute<Set<PosixFilePermission>>> getPosixAttributes(Path file) throws IOException {


### PR DESCRIPTION

Catching the exception and creating the file without the ACL attibutes if it fails.

Build : http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=63789&tab=buildResultsDiv&buildTypeId=WildFlyCore_MasterSolaris

Jira: https://issues.jboss.org/browse/WFCORE-870