### PR TITLE
[WFCORE-833] Capability-based model reference validation for profiles…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -310,23 +310,55 @@ public abstract class AbstractControllerService implements Service<ModelControll
         finishBoot();
     }
 
+    /**
+     * Boot with the given operations, performing full model and capability registry validation.
+     *
+     * @param bootOperations the operations. Cannot be {@code null}
+     * @param rollbackOnRuntimeFailure {@code true} if the boot should fail if operations fail in the runtime stage
+     * @return {@code true} if boot was successful
+     * @throws ConfigurationPersistenceException
+     */
     protected boolean boot(List<ModelNode> bootOperations, boolean rollbackOnRuntimeFailure) throws ConfigurationPersistenceException {
         return boot(bootOperations, rollbackOnRuntimeFailure, false, ModelControllerImpl.getMutableRootResourceRegistrationProvider());
     }
 
+    /**
+     * Boot with the given operations, optionally disabling model and capability registry validation.
+     *
+     * @param bootOperations the operations. Cannot be {@code null}
+     * @param rollbackOnRuntimeFailure {@code true} if the boot should fail if operations fail in the runtime stage
+     * @param skipModelValidation {@code true} if model and capability validation should be skipped.
+     * @return {@code true} if boot was successful
+     * @throws ConfigurationPersistenceException
+     */
     protected boolean boot(List<ModelNode> bootOperations, boolean rollbackOnRuntimeFailure, boolean skipModelValidation) throws ConfigurationPersistenceException {
         return boot(bootOperations, rollbackOnRuntimeFailure, skipModelValidation, ModelControllerImpl.getMutableRootResourceRegistrationProvider());
     }
 
+    /**
+     * @deprecated internal use only  only for use by legacy test controllers
+     */
+    @Deprecated
     protected boolean boot(List<ModelNode> bootOperations, boolean rollbackOnRuntimeFailure,
             MutableRootResourceRegistrationProvider parallelBootRootResourceRegistrationProvider) throws ConfigurationPersistenceException {
         return boot(bootOperations, rollbackOnRuntimeFailure, false, parallelBootRootResourceRegistrationProvider);
     }
 
+    /**
+     * Boot, optionally disabling model and capability registry validation, using the given provider for the root
+     * {@link ManagementResourceRegistration}.
+     *
+     * @param bootOperations the operations. Cannot be {@code null}
+     * @param rollbackOnRuntimeFailure {@code true} if the boot should fail if operations fail in the runtime stage
+     * @param skipModelValidation {@code true} if model and capability validation should be skipped.
+     * @param parallelBootRootResourceRegistrationProvider provider of the root resource registration
+     * @return {@code true} if boot was successful
+     * @throws ConfigurationPersistenceException
+     */
     protected boolean boot(List<ModelNode> bootOperations, boolean rollbackOnRuntimeFailure, boolean skipModelValidation,
-            MutableRootResourceRegistrationProvider parallelBootRootResourceRegistrationProvider) throws ConfigurationPersistenceException {
+                           MutableRootResourceRegistrationProvider parallelBootRootResourceRegistrationProvider) throws ConfigurationPersistenceException {
         return controller.boot(bootOperations, OperationMessageHandler.logging, ModelController.OperationTransactionControl.COMMIT,
-                rollbackOnRuntimeFailure, parallelBootRootResourceRegistrationProvider, skipModelValidation);
+                rollbackOnRuntimeFailure, parallelBootRootResourceRegistrationProvider, skipModelValidation, skipModelValidation);
     }
 
     /** @deprecated internal use only  only for use by legacy test controllers */
@@ -334,7 +366,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
     protected ModelNode internalExecute(final ModelNode operation, final OperationMessageHandler handler,
                                         final ModelController.OperationTransactionControl control,
                                         final OperationAttachments attachments, final OperationStepHandler prepareStep) {
-        OperationResponse or = controller.internalExecute(operation, handler, control, attachments, prepareStep, false);
+        OperationResponse or = controller.internalExecute(operation, handler, control, attachments, prepareStep, false, false);
         ModelNode result = or.getResponseNode();
         try {
             or.close();
@@ -346,12 +378,17 @@ public abstract class AbstractControllerService implements Service<ModelControll
     }
 
     protected OperationResponse internalExecute(final Operation operation, final OperationMessageHandler handler, final ModelController.OperationTransactionControl control, final OperationStepHandler prepareStep) {
-        return controller.internalExecute(operation.getOperation(), handler, control, operation, prepareStep, false);
+        return controller.internalExecute(operation.getOperation(), handler, control, operation, prepareStep, false, false);
     }
 
     protected OperationResponse internalExecute(final Operation operation, final OperationMessageHandler handler, final ModelController.OperationTransactionControl control,
                                                 final OperationStepHandler prepareStep, final boolean attemptLock) {
-        return controller.internalExecute(operation.getOperation(), handler, control, operation, prepareStep, attemptLock);
+        return controller.internalExecute(operation.getOperation(), handler, control, operation, prepareStep, attemptLock, false);
+    }
+
+    protected OperationResponse internalExecute(final Operation operation, final OperationMessageHandler handler, final ModelController.OperationTransactionControl control,
+                                                final OperationStepHandler prepareStep, final boolean attemptLock, final boolean partialModel) {
+        return controller.internalExecute(operation.getOperation(), handler, control, operation, prepareStep, attemptLock, partialModel);
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -69,10 +69,10 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-import org.jboss.as.controller.ConfigurationChangesCollector.ConfigurationChange;
 
 import javax.security.auth.Subject;
 
+import org.jboss.as.controller.ConfigurationChangesCollector.ConfigurationChange;
 import org.jboss.as.controller.access.Caller;
 import org.jboss.as.controller.access.Environment;
 import org.jboss.as.controller.audit.AuditLogger;

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -209,7 +209,7 @@ class ModelControllerImpl implements ModelController {
      */
     @Override
     public ModelNode execute(final ModelNode operation, final OperationMessageHandler handler, final OperationTransactionControl control, final OperationAttachments attachments) {
-        OperationResponse or = internalExecute(operation, handler, control, attachments, prepareStep, false);
+        OperationResponse or = internalExecute(operation, handler, control, attachments, prepareStep, false, false);
         ModelNode result = or.getResponseNode();
         try {
             or.close();
@@ -222,7 +222,7 @@ class ModelControllerImpl implements ModelController {
 
     @Override
     public OperationResponse execute(Operation operation, OperationMessageHandler handler, OperationTransactionControl control) {
-        return internalExecute(operation.getOperation(), handler, control, operation, prepareStep, false);
+        return internalExecute(operation.getOperation(), handler, control, operation, prepareStep, false, false);
     }
 
     private AbstractOperationContext getDelegateContext(final int operationId) {
@@ -310,10 +310,11 @@ class ModelControllerImpl implements ModelController {
      * @param attachments the operation attachments
      * @param prepareStep the prepare step to be executed before any other steps
      * @param attemptLock set to {@code true} to try to obtain the controller lock
+     * @param partialModel {@code true} if the model will only be partially complete after this operation
      * @return the result of the operation
      */
     protected OperationResponse internalExecute(final ModelNode operation, final OperationMessageHandler handler, final OperationTransactionControl control,
-        final OperationAttachments attachments, final OperationStepHandler prepareStep, final boolean attemptLock) {
+                                                final OperationAttachments attachments, final OperationStepHandler prepareStep, final boolean attemptLock, boolean partialModel) {
 
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
@@ -375,7 +376,7 @@ class ModelControllerImpl implements ModelController {
                     operation.get(OP_ADDR), this, processType, runningModeControl.getRunningMode(),
                     contextFlags, handler, attachments, managementModel.get(), originalResultTxControl, processState, auditLogger,
                     bootingFlag.get(), hostServerGroupTracker, blockingTimeoutConfig, accessMechanism, notificationSupport,
-                    false, extraValidationStepHandler);
+                    false, extraValidationStepHandler, partialModel);
             // Try again if the operation-id is already taken
             if(activeOperations.putIfAbsent(operationID, context) == null) {
                 CurrentOperationIdHolder.setCurrentOperationID(operationID);
@@ -433,7 +434,8 @@ class ModelControllerImpl implements ModelController {
     }
 
     boolean boot(final List<ModelNode> bootList, final OperationMessageHandler handler, final OperationTransactionControl control,
-              final boolean rollbackOnRuntimeFailure, MutableRootResourceRegistrationProvider parallelBootRootResourceRegistrationProvider, boolean skipModelValidation) {
+                 final boolean rollbackOnRuntimeFailure, MutableRootResourceRegistrationProvider parallelBootRootResourceRegistrationProvider,
+                 final boolean skipModelValidation, final boolean partialModel) {
 
         final Integer operationID = random.nextInt();
 
@@ -445,14 +447,14 @@ class ModelControllerImpl implements ModelController {
         final AbstractOperationContext context = new OperationContextImpl(operationID, INITIAL_BOOT_OPERATION, EMPTY_ADDRESS,
                 this, processType, runningModeControl.getRunningMode(),
                 contextFlags, handler, null, managementModel.get(), control, processState, auditLogger, bootingFlag.get(),
-                hostServerGroupTracker, null, null, notificationSupport, true, extraValidationStepHandler);
+                hostServerGroupTracker, null, null, notificationSupport, true, extraValidationStepHandler, true);
 
         // Add to the context all ops prior to the first ExtensionAddHandler as well as all ExtensionAddHandlers; save the rest.
         // This gets extensions registered before proceeding to other ops that count on these registrations
         BootOperations bootOperations = organizeBootOperations(bootList, operationID, parallelBootRootResourceRegistrationProvider);
         OperationContext.ResultAction resultAction = bootOperations.invalid ? OperationContext.ResultAction.ROLLBACK : OperationContext.ResultAction.KEEP;
         if (bootOperations.initialOps.size() > 0) {
-            // Run the steps up to the last ExtensionAddHandlerß
+            // Run the steps up to the last ExtensionAddHandler
             for (ParsedBootOp initialOp : bootOperations.initialOps) {
                 context.addBootStep(initialOp);
             }
@@ -464,7 +466,7 @@ class ModelControllerImpl implements ModelController {
                     EMPTY_ADDRESS, this, processType, runningModeControl.getRunningMode(),
                     contextFlags, handler, null, managementModel.get(), control, processState, auditLogger,
                             bootingFlag.get(), hostServerGroupTracker, null, null, notificationSupport, true,
-                            extraValidationStepHandler);
+                            extraValidationStepHandler, partialModel);
 
             for (ParsedBootOp parsedOp : bootOperations.postExtensionOps) {
                 if (parsedOp.handler == null) {
@@ -494,7 +496,7 @@ class ModelControllerImpl implements ModelController {
                         EMPTY_ADDRESS, this, processType, runningModeControl.getRunningMode(),
                         contextFlags, handler, null, managementModel.get(), control, processState, auditLogger,
                                 bootingFlag.get(), hostServerGroupTracker, null, null, notificationSupport, false,
-                                extraValidationStepHandler);
+                                extraValidationStepHandler, partialModel);
                 validateContext.addModifiedResourcesForModelValidation(validateAddresses);
                 resultAction = validateContext.executeOperation();
             }
@@ -1237,14 +1239,16 @@ class ModelControllerImpl implements ModelController {
          * Compares the registered requirements to the registered capabilities, returning any missing
          * or inconsistent requirements.
          *
-         * Cannot be called while other threads may be adding or removing capabilities
+         * @param forceCheck  {@code true} if a full validation should be performed regardless of whether
+         *                    any changes have occurred since the last check
+         * @param hostXmlOnly {@code true} if a Host Controller boot is occurring and only host model data is present
          *
          * @return a map whose keys are missing capabilities and whose values are the names of other capabilities
          *         that require that capability. Will not return {@code null} but may be empty
          */
-        CapabilityValidation validateCapabilityRegistry(boolean forceCheck) {
+        CapabilityValidation validateCapabilityRegistry(boolean forceCheck, boolean hostXmlOnly) {
             if (!published || forceCheck) {
-                return capabilityRegistry.resolveCapabilities(getRootResource());
+                return capabilityRegistry.resolveCapabilities(getRootResource(), hostXmlOnly);
             } else {
                 // we're unmodified so nothing to validate
                 return CapabilityValidation.OK;
@@ -1467,7 +1471,8 @@ class ModelControllerImpl implements ModelController {
 
         }
 
-        synchronized CapabilityValidation resolveCapabilities(Resource rootResource) {
+        synchronized CapabilityValidation resolveCapabilities(Resource rootResource, boolean hostXmlOnly) {
+
             resolutionContext.setRootResource(rootResource);
 
             Map<CapabilityId, Set<RuntimeRequirementRegistration>> missing = new HashMap<>();
@@ -1486,6 +1491,14 @@ class ModelControllerImpl implements ModelController {
                     SatisfactoryCapability satisfactory = findSatisfactoryCapability(req.getRequiredName(), dependentContext, dependentName, !forServer);
                     if (satisfactory == null) {
                         // Missing
+                        if (hostXmlOnly && dependentName.startsWith("org.wildfly.domain.server-config.")
+                                && (req.getRequiredName().startsWith("org.wildfly.domain.server-group.")
+                                || req.getRequiredName().startsWith("org.wildfly.domain.socket-binding-group."))) {
+                            // HACK. We can't resolve these now as we have no domain model at this part of boot
+                            // We can resolve them when the domain model ops run, so wait to validate then
+                            ControllerLogger.MGMT_OP_LOGGER.tracef("Ignoring that dependent %s cannot resolve required capability %s as the 'hostXmlOnly' param is set", dependentId, req.getRequiredName());
+                            continue;
+                        }
                         CapabilityId basicId = new CapabilityId(req.getRequiredName(), dependentContext);
                         Set<RuntimeRequirementRegistration> set = missing.get(basicId);
                         if (set == null) {

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityResolutionContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityResolutionContext.java
@@ -110,8 +110,8 @@ public abstract class CapabilityResolutionContext {
      *
      * @param <T> the attachment value type
      */
-    @SuppressWarnings("UnusedDeclaration")
     public static final class AttachmentKey<T> {
+
         private final Class<T> valueClass;
 
         /**

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/HostCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/HostCapabilityContext.java
@@ -31,9 +31,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOS
  *
  * @author Brian Stansberry
  */
-public final class HostCapabilityContext implements CapabilityContext {
+class HostCapabilityContext implements CapabilityContext {
 
-    public static final HostCapabilityContext INSTANCE = new HostCapabilityContext();
+    static final HostCapabilityContext INSTANCE = new HostCapabilityContext();
 
     @Override
     public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/ProfilesCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/ProfilesCapabilityContext.java
@@ -22,37 +22,22 @@
 
 package org.jboss.as.controller.capability.registry;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
-
-import java.util.Map;
-import java.util.Set;
-
 /**
- * {@link CapabilityContext} for the children of a Host Controller {@code profile} resource.
- * Note this does not include the profile capability itself.
+ * {@link CapabilityContext} specifically used for the {@code org.wildfly.domain.profile} capability.
+ * <p>
+ * <strong>NOTE:</strong> This context is not used for child resources (subsystems) in the 'profile'
+ * part of the Host Controller resource tree.
  *
  * @author Brian Stansberry
- *
- * @see ProfilesCapabilityContext
  */
-class ProfileChildCapabilityContext extends IncludingResourceCapabilityContext {
+class ProfilesCapabilityContext implements CapabilityContext {
 
-    private static final CapabilityResolutionContext.AttachmentKey<Map<String, Set<CapabilityContext>>> PROFILE_KEY =
-            CapabilityResolutionContext.AttachmentKey.create(Map.class);
-
-    ProfileChildCapabilityContext(String value) {
-        super(PROFILE_KEY, PROFILE, value);
-    }
+    public static final ProfilesCapabilityContext INSTANCE = new ProfilesCapabilityContext();
 
     @Override
     public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        CapabilityContext dependentContext = dependent.getContext();
-        boolean result = equals(dependentContext);
-        if (!result && dependentContext instanceof ProfileChildCapabilityContext) {
-            Set<CapabilityContext> includers = getIncludingContexts(context);
-            result = includers.contains(dependentContext);
-        }
-        return result;
+        CapabilityContext depCtx = dependent.getContext();
+        return depCtx instanceof ProfilesCapabilityContext || depCtx instanceof ServerGroupsCapabilityContext;
     }
 
     @Override
@@ -61,7 +46,7 @@ class ProfileChildCapabilityContext extends IncludingResourceCapabilityContext {
     }
 
     @Override
-    protected CapabilityContext createIncludedContext(String name) {
-        return new ProfileChildCapabilityContext(name);
+    public String getName() {
+        return "profiles";
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/ServerConfigCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/ServerConfigCapabilityContext.java
@@ -22,37 +22,20 @@
 
 package org.jboss.as.controller.capability.registry;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
-
-import java.util.Map;
-import java.util.Set;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 
 /**
- * {@link CapabilityContext} for the children of a Host Controller {@code profile} resource.
- * Note this does not include the profile capability itself.
+ * {@link CapabilityContext} used for capabilities scoped to a Host Controller {@code server-config} resource.
  *
  * @author Brian Stansberry
- *
- * @see ProfilesCapabilityContext
  */
-class ProfileChildCapabilityContext extends IncludingResourceCapabilityContext {
+class ServerConfigCapabilityContext implements CapabilityContext {
 
-    private static final CapabilityResolutionContext.AttachmentKey<Map<String, Set<CapabilityContext>>> PROFILE_KEY =
-            CapabilityResolutionContext.AttachmentKey.create(Map.class);
-
-    ProfileChildCapabilityContext(String value) {
-        super(PROFILE_KEY, PROFILE, value);
-    }
+    static final ServerConfigCapabilityContext INSTANCE = new ServerConfigCapabilityContext();
 
     @Override
     public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        CapabilityContext dependentContext = dependent.getContext();
-        boolean result = equals(dependentContext);
-        if (!result && dependentContext instanceof ProfileChildCapabilityContext) {
-            Set<CapabilityContext> includers = getIncludingContexts(context);
-            result = includers.contains(dependentContext);
-        }
-        return result;
+        return dependent.getContext() instanceof ServerConfigCapabilityContext;
     }
 
     @Override
@@ -61,7 +44,7 @@ class ProfileChildCapabilityContext extends IncludingResourceCapabilityContext {
     }
 
     @Override
-    protected CapabilityContext createIncludedContext(String name) {
-        return new ProfileChildCapabilityContext(name);
+    public String getName() {
+        return ModelDescriptionConstants.SERVER_CONFIG;
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/ServerGroupsCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/ServerGroupsCapabilityContext.java
@@ -22,37 +22,19 @@
 
 package org.jboss.as.controller.capability.registry;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
-
-import java.util.Map;
-import java.util.Set;
-
 /**
- * {@link CapabilityContext} for the children of a Host Controller {@code profile} resource.
- * Note this does not include the profile capability itself.
+ * {@link CapabilityContext} used for capabilities scoped to a Host Controller {@code server-config} resource.
  *
  * @author Brian Stansberry
- *
- * @see ProfilesCapabilityContext
  */
-class ProfileChildCapabilityContext extends IncludingResourceCapabilityContext {
+class ServerGroupsCapabilityContext implements CapabilityContext {
 
-    private static final CapabilityResolutionContext.AttachmentKey<Map<String, Set<CapabilityContext>>> PROFILE_KEY =
-            CapabilityResolutionContext.AttachmentKey.create(Map.class);
-
-    ProfileChildCapabilityContext(String value) {
-        super(PROFILE_KEY, PROFILE, value);
-    }
+    static final ServerGroupsCapabilityContext INSTANCE = new ServerGroupsCapabilityContext();
 
     @Override
     public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        CapabilityContext dependentContext = dependent.getContext();
-        boolean result = equals(dependentContext);
-        if (!result && dependentContext instanceof ProfileChildCapabilityContext) {
-            Set<CapabilityContext> includers = getIncludingContexts(context);
-            result = includers.contains(dependentContext);
-        }
-        return result;
+        CapabilityContext depCtx = dependent.getContext();
+        return depCtx instanceof ServerConfigCapabilityContext;
     }
 
     @Override
@@ -61,7 +43,7 @@ class ProfileChildCapabilityContext extends IncludingResourceCapabilityContext {
     }
 
     @Override
-    protected CapabilityContext createIncludedContext(String name) {
-        return new ProfileChildCapabilityContext(name);
+    public String getName() {
+        return "server-groups";
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/SocketBindingGroupChildContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/SocketBindingGroupChildContext.java
@@ -35,22 +35,27 @@ import java.util.Set;
  *
  * @see SocketBindingGroupsCapabilityContext
  */
-public class SocketBindingGroupChildContext extends IncludingResourceCapabilityContext {
+class SocketBindingGroupChildContext extends IncludingResourceCapabilityContext {
 
-    public static final CapabilityResolutionContext.AttachmentKey<Map<String, Set<CapabilityContext>>> SBG_KEY =
+    private static final CapabilityResolutionContext.AttachmentKey<Map<String, Set<CapabilityContext>>> SBG_KEY =
             CapabilityResolutionContext.AttachmentKey.create(Map.class);
 
-    public SocketBindingGroupChildContext(String value) {
+    SocketBindingGroupChildContext(String value) {
         super(SBG_KEY, SOCKET_BINDING_GROUP, value);
     }
 
     @Override
     public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
         CapabilityContext dependentContext = dependent.getContext();
-        boolean result = !(dependentContext instanceof SocketBindingGroupChildContext) || equals(dependentContext);
-        if (!result) {
-            Set<CapabilityContext> includers = getIncludingContexts(context);
-            result = includers.contains(dependentContext);
+        boolean result;
+        if (dependentContext instanceof SocketBindingGroupChildContext) {
+            result = equals(dependentContext);
+            if (!result) {
+                Set<CapabilityContext> includers = getIncludingContexts(context);
+                result = includers.contains(dependentContext);
+            }
+        } else {
+            result = !(dependentContext instanceof ProfilesCapabilityContext) && !(dependentContext instanceof ServerGroupsCapabilityContext);
         }
         return result;
     }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/SocketBindingGroupsCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/SocketBindingGroupsCapabilityContext.java
@@ -22,37 +22,25 @@
 
 package org.jboss.as.controller.capability.registry;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
-
-import java.util.Map;
-import java.util.Set;
-
 /**
- * {@link CapabilityContext} for the children of a Host Controller {@code profile} resource.
- * Note this does not include the profile capability itself.
+ * {@link CapabilityContext} specifically used for the {@code org.wildfly.domain.socket-binding-group} capability.
+ * <p>
+ * <strong>NOTE:</strong> This context is not used for child resources (subsystems) in the 'socket-binding-group'
+ * part of the Host Controller resource tree.
  *
  * @author Brian Stansberry
  *
- * @see ProfilesCapabilityContext
+ * @see SocketBindingGroupChildContext
  */
-class ProfileChildCapabilityContext extends IncludingResourceCapabilityContext {
+class SocketBindingGroupsCapabilityContext implements CapabilityContext {
 
-    private static final CapabilityResolutionContext.AttachmentKey<Map<String, Set<CapabilityContext>>> PROFILE_KEY =
-            CapabilityResolutionContext.AttachmentKey.create(Map.class);
-
-    ProfileChildCapabilityContext(String value) {
-        super(PROFILE_KEY, PROFILE, value);
-    }
+    static final SocketBindingGroupsCapabilityContext INSTANCE = new SocketBindingGroupsCapabilityContext();
 
     @Override
     public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        CapabilityContext dependentContext = dependent.getContext();
-        boolean result = equals(dependentContext);
-        if (!result && dependentContext instanceof ProfileChildCapabilityContext) {
-            Set<CapabilityContext> includers = getIncludingContexts(context);
-            result = includers.contains(dependentContext);
-        }
-        return result;
+        CapabilityContext depCtx = dependent.getContext();
+        return (depCtx instanceof SocketBindingGroupsCapabilityContext || depCtx instanceof ServerGroupsCapabilityContext
+                || depCtx instanceof ServerConfigCapabilityContext);
     }
 
     @Override
@@ -61,7 +49,7 @@ class ProfileChildCapabilityContext extends IncludingResourceCapabilityContext {
     }
 
     @Override
-    protected CapabilityContext createIncludedContext(String name) {
-        return new ProfileChildCapabilityContext(name);
+    public String getName() {
+        return "socket-binding-groups";
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/AbstractSocketBindingGroupAddHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/AbstractSocketBindingGroupAddHandler.java
@@ -25,6 +25,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAM
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.resource.AbstractSocketBindingGroupResourceDefinition;
 import org.jboss.dmr.ModelNode;
@@ -42,6 +43,13 @@ public abstract class AbstractSocketBindingGroupAddHandler extends AbstractAddSt
      * Create the AbstractSocketBindingGroupAddHandler
      */
     protected AbstractSocketBindingGroupAddHandler() {
+    }
+
+    /**
+     * Create the AbstractSocketBindingGroupAddHandler
+     */
+    protected AbstractSocketBindingGroupAddHandler(RuntimeCapability capability) {
+        super(capability);
     }
 
     @Override

--- a/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
@@ -1,0 +1,271 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.persistence.NullConfigurationPersister;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.junit.After;
+import org.junit.Before;
+
+/**
+ * Base class for tests of capability resolution.
+ *
+ * @author Brian Stansberry
+ */
+abstract class AbstractCapabilityResolutionTestCase {
+
+    protected static final String GLOBAL = "global";
+    protected static final PathElement PROFILE_A = PathElement.pathElement(PROFILE, "a");
+    protected static final PathElement PROFILE_B = PathElement.pathElement(PROFILE, "b");
+    protected static final PathElement SBG_A = PathElement.pathElement(SOCKET_BINDING_GROUP, "a");
+    protected static final PathElement SBG_B = PathElement.pathElement(SOCKET_BINDING_GROUP, "b");
+    protected static final PathElement SBG_C = PathElement.pathElement(SOCKET_BINDING_GROUP, "c");
+    protected static final PathElement SBG_D = PathElement.pathElement(SOCKET_BINDING_GROUP, "d");
+    protected static final PathAddress GLOBAL_A = PathAddress.pathAddress(PathElement.pathElement(GLOBAL, "a"));
+    protected static final PathAddress SUBSYSTEM_A_1 = PathAddress.pathAddress(PROFILE_A, PathElement.pathElement(SUBSYSTEM, "1"));
+    protected static final PathAddress SUBSYSTEM_A_2 = PathAddress.pathAddress(PROFILE_A, PathElement.pathElement(SUBSYSTEM, "2"));
+    protected static final PathAddress SUBSYSTEM_B_1 = PathAddress.pathAddress(PROFILE_B, PathElement.pathElement(SUBSYSTEM, "1"));
+    protected static final PathAddress SUBSYSTEM_B_2 = PathAddress.pathAddress(PROFILE_B, PathElement.pathElement(SUBSYSTEM, "2"));
+    protected static final PathAddress SOCKET_A_1 = PathAddress.pathAddress(SBG_A, PathElement.pathElement(SOCKET_BINDING, "1"));
+    protected static final PathAddress SOCKET_A_2 = PathAddress.pathAddress(SBG_A, PathElement.pathElement(SOCKET_BINDING, "2"));
+    protected static final PathAddress SOCKET_B_1 = PathAddress.pathAddress(SBG_B, PathElement.pathElement(SOCKET_BINDING, "1"));
+    protected static final PathAddress SOCKET_B_2 = PathAddress.pathAddress(SBG_B, PathElement.pathElement(SOCKET_BINDING, "2"));
+    protected static final PathAddress SOCKET_C_3 = PathAddress.pathAddress(SBG_C, PathElement.pathElement(SOCKET_BINDING, "3"));
+
+    private static final String CAPABILITY = "capability";
+    private static final String REQUIREMENT = "requirement";
+
+    protected ModelController controller;
+    private ServiceContainer container;
+
+    @Before
+    public void setupController() throws InterruptedException {
+        System.out.println("=========  New Test \n");
+
+        container = ServiceContainer.Factory.create("test");
+        ServiceTarget target = container.subTarget();
+        ModelControllerService svc = new ModelControllerService();
+        ServiceBuilder<ModelController> builder = target.addService(ServiceName.of("ModelController"), svc);
+        builder.install();
+        svc.awaitStartup(30, TimeUnit.SECONDS);
+        controller = svc.getValue();
+
+        assertEquals(ControlledProcessState.State.RUNNING, svc.getCurrentProcessState());
+    }
+
+    @After
+    public void shutdownServiceContainer() {
+        if (container != null) {
+            container.shutdown();
+            try {
+                container.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            finally {
+                container = null;
+            }
+        }
+        System.out.println("======================");
+    }
+
+    protected static ModelNode getCapabilityOperation(PathAddress pathAddress, String capability) {
+        return getCapabilityOperation(pathAddress, capability, null);
+    }
+
+    protected static ModelNode getCapabilityOperation(PathAddress pathAddress, String capability, String requirement) {
+
+        ModelNode op = Util.createEmptyOperation(CAPABILITY, pathAddress);
+        op.get(CAPABILITY).set(capability);
+        if (requirement != null) {
+            op.get(REQUIREMENT).set(requirement);
+        }
+        return op;
+    }
+
+    protected static ModelNode getParentIncludeOperation(PathAddress pathAddress, String... includes) {
+
+        ModelNode op = Util.createEmptyOperation("include", pathAddress);
+        ModelNode includesNode = op.get(INCLUDES);
+        for (String include : includes) {
+            includesNode.add(include);
+        }
+        return op;
+    }
+
+    protected static ModelNode getCompositeOperation(ModelNode... steps) {
+
+        ModelNode op = new ModelNode();
+        op.get(OP).set(COMPOSITE);
+        op.get(OP_ADDR).setEmptyList();
+        for (ModelNode step : steps) {
+            op.get("steps").add(step);
+        }
+        return op;
+    }
+
+    protected static void validateMissingFailureDesc(ModelNode response, String step, String cap, String context) {
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.hasDefined(FAILURE_DESCRIPTION));
+        String failDesc = response.get(FAILURE_DESCRIPTION).asString();
+        int loc = -1;
+        if (step != null) {
+            loc = failDesc.indexOf(step);
+            assertTrue(response.toString(), loc > 0);
+        }
+        int lastLoc = loc;
+        loc = failDesc.indexOf("WFLYCTL0369");
+        assertTrue(response.toString(), loc > lastLoc);
+        lastLoc = loc;
+        loc = failDesc.indexOf(cap);
+        assertTrue(response.toString(), loc > lastLoc);
+        lastLoc = loc;
+        loc = failDesc.indexOf(context);
+        assertTrue(response.toString(), loc > lastLoc);
+
+    }
+
+    protected static void validateInconsistentFailureDesc(ModelNode response, String step, String req, String cap, String context) {
+
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.hasDefined(FAILURE_DESCRIPTION));
+        String failDesc = response.get(RESULT, step, FAILURE_DESCRIPTION).asString();
+        int lastLoc = -1;
+        int loc = failDesc.indexOf("WFLYCTL0399");
+        assertTrue(response.toString(), loc > lastLoc);
+        lastLoc = loc;
+        loc = failDesc.indexOf(req);
+        assertTrue(response.toString(), loc > lastLoc);
+        lastLoc = loc;
+        loc = failDesc.indexOf(cap);
+        assertTrue(response.toString(), loc > lastLoc);
+        lastLoc = loc;
+        loc = failDesc.indexOf(context);
+        assertTrue(response.toString(), loc > lastLoc);
+    }
+
+    private static ResourceDefinition createResourceDefinition(String key) {
+        PathElement pe = key == null ? null : PathElement.pathElement(key);
+        return ResourceBuilder.Factory.create(pe, new NonResolvingResourceDescriptionResolver()).build();
+    }
+
+    private static class ModelControllerService extends TestModelControllerService {
+
+        ModelControllerService() {
+            super(ProcessType.HOST_CONTROLLER, new NullConfigurationPersister(), new ControlledProcessState(true),
+                    createResourceDefinition(null));
+        }
+
+        @Override
+        protected void initModel(ManagementModel managementModel, Resource modelControllerResource) {
+
+            ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
+            rootRegistration.registerOperationHandler(getOD(COMPOSITE), CompositeOperationHandler.INSTANCE, false);
+
+            // Add a global handler that records capabilities and requirements
+            rootRegistration.registerOperationHandler(getOD(CAPABILITY), new CapabilityOSH(), true);
+
+            // Create resources defs representing something outside of profiles/socket-binding-group and then
+            // a tree for profile and s-b-g. Note these aren't the real resource defs, they just follow the
+            // real address pattern a bit, as those patterns are what drive the WFCORE-750 capability resolution logic
+            rootRegistration.registerSubModel(createResourceDefinition(GLOBAL));
+            ManagementResourceRegistration profile = rootRegistration.registerSubModel(createResourceDefinition(PROFILE));
+            OperationDefinition od = new SimpleOperationDefinitionBuilder("include", new NonResolvingResourceDescriptionResolver()).build();
+            OperationStepHandler includeHandler = new ParentIncludeHandler();
+            profile.registerOperationHandler(od, includeHandler);
+            profile.registerSubModel(createResourceDefinition(SUBSYSTEM));
+            ManagementResourceRegistration sbg = rootRegistration.registerSubModel(createResourceDefinition(SOCKET_BINDING_GROUP));
+            sbg.registerOperationHandler(od, includeHandler);
+            sbg.registerSubModel(createResourceDefinition(SOCKET_BINDING));
+            rootRegistration.registerSubModel(createResourceDefinition(SERVER_GROUP));
+
+            // Add the expected parent resources
+            Resource rootResource = managementModel.getRootResource();
+            rootResource.registerChild(PROFILE_A, Resource.Factory.create());
+            rootResource.registerChild(PROFILE_B, Resource.Factory.create());
+            rootResource.registerChild(SBG_A, Resource.Factory.create());
+            rootResource.registerChild(SBG_B, Resource.Factory.create());
+            rootResource.registerChild(SBG_C, Resource.Factory.create());
+            rootResource.registerChild(SBG_D, Resource.Factory.create());
+        }
+    }
+
+    private static class CapabilityOSH implements OperationStepHandler {
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+            String capName = operation.require(CAPABILITY).asString();
+            RuntimeCapability.Builder rcb = RuntimeCapability.Builder.of(capName);
+            if (operation.hasDefined(REQUIREMENT)) {
+                final String reqName = operation.get(REQUIREMENT).asString();
+                rcb.addRequirements(reqName);
+                context.addStep(new OperationStepHandler() {
+                    @Override
+                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                        context.getResult().set(context.hasOptionalCapability(reqName, capName, null));
+                    }
+                }, OperationContext.Stage.RUNTIME);
+            }  else {
+                context.getResult().set(true);
+            }
+            context.registerCapability(rcb.build(), null);
+        }
+    }
+
+    private static class ParentIncludeHandler implements OperationStepHandler {
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
+            resource.getModel().get(INCLUDES).set(operation.get(INCLUDES));
+        }
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/ServerGroupCapabilityResolutionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ServerGroupCapabilityResolutionUnitTestCase.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+/**
+ * Tests resolution of capabilities related to server groups.
+ *
+ * @author Brian Stansberry
+ */
+public class ServerGroupCapabilityResolutionUnitTestCase extends AbstractCapabilityResolutionTestCase {
+
+    private static final PathAddress PROFILE_A_ADDR = PathAddress.pathAddress(PROFILE_A);
+    private static final PathAddress SERVER_GROUP_A = PathAddress.pathAddress(SERVER_GROUP, "a");
+
+    @Test
+    public void testGoodProfileRef() {
+        ModelNode op = getCompositeOperation(getCapabilityOperation(PROFILE_A_ADDR, "cap_a"), getCapabilityOperation(SERVER_GROUP_A, "dep_a", "cap_a"));
+        ModelNode response = controller.execute(op, null, null, null);
+        assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(RESULT, "step-2", RESULT).asBoolean());
+    }
+
+    /** subsystem=* resources can't provide stuff for server-group=* */
+    @Test
+    public void testInvalidSubsystemSourceOfProfileRef() {
+        ModelNode op = getCompositeOperation(getCapabilityOperation(SUBSYSTEM_A_1, "cap_a"), getCapabilityOperation(SERVER_GROUP_A, "dep_a", "cap_a"));
+        ModelNode response = controller.execute(op, null, null, null);
+        validateMissingFailureDesc(response, "step-2", "cap_a", "server-group");
+    }
+
+    /** socket-binding=* resources can't provide stuff for server-group=* */
+    @Test
+    public void testInvalidSocketBindingSourceOfProfileRef() {
+        ModelNode op = getCompositeOperation(getCapabilityOperation(SOCKET_A_1, "cap_a"), getCapabilityOperation(SERVER_GROUP_A, "dep_a", "cap_a"));
+        ModelNode response = controller.execute(op, null, null, null);
+        validateMissingFailureDesc(response, "step-2", "cap_a", "server-group");
+    }
+
+}

--- a/controller/src/test/java/org/jboss/as/controller/SocketCapabilityResolutionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/SocketCapabilityResolutionUnitTestCase.java
@@ -22,38 +22,16 @@
 
 package org.jboss.as.controller;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDES;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.concurrent.TimeUnit;
-
-import org.jboss.as.controller.capability.RuntimeCapability;
-import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.persistence.NullConfigurationPersister;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.service.ServiceContainer;
-import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.ServiceTarget;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -62,56 +40,7 @@ import org.junit.Test;
  *
  * @author Brian Stansberry
  */
-public class SocketCapabilityResolutionUnitTestCase {
-
-    private static final String CAPABILITY = "capability";
-    private static final String REQUIREMENT = "requirement";
-    private static final String GLOBAL = "global";
-
-    private static final PathAddress GLOBAL_A = PathAddress.pathAddress(PathElement.pathElement(GLOBAL, "a"));
-    private static final PathAddress SUBSYSTEM_A_1 = PathAddress.pathAddress(PathElement.pathElement(PROFILE, "a"), PathElement.pathElement(SUBSYSTEM, "1"));
-    private static final PathAddress SUBSYSTEM_A_2 = PathAddress.pathAddress(PathElement.pathElement(PROFILE, "a"), PathElement.pathElement(SUBSYSTEM, "2"));
-    private static final PathAddress SUBSYSTEM_B_1 = PathAddress.pathAddress(PathElement.pathElement(PROFILE, "b"), PathElement.pathElement(SUBSYSTEM, "1"));
-    private static final PathAddress SUBSYSTEM_B_2 = PathAddress.pathAddress(PathElement.pathElement(PROFILE, "b"), PathElement.pathElement(SUBSYSTEM, "2"));
-    private static final PathAddress SOCKET_A_1 = PathAddress.pathAddress(PathElement.pathElement(SOCKET_BINDING_GROUP, "a"), PathElement.pathElement(SOCKET_BINDING, "1"));
-    private static final PathAddress SOCKET_A_2 = PathAddress.pathAddress(PathElement.pathElement(SOCKET_BINDING_GROUP, "a"), PathElement.pathElement(SOCKET_BINDING, "2"));
-    private static final PathAddress SOCKET_B_1 = PathAddress.pathAddress(PathElement.pathElement(SOCKET_BINDING_GROUP, "b"), PathElement.pathElement(SOCKET_BINDING, "1"));
-    private static final PathAddress SOCKET_B_2 = PathAddress.pathAddress(PathElement.pathElement(SOCKET_BINDING_GROUP, "b"), PathElement.pathElement(SOCKET_BINDING, "2"));
-    private static final PathAddress SOCKET_C_3 = PathAddress.pathAddress(PathElement.pathElement(SOCKET_BINDING_GROUP, "c"), PathElement.pathElement(SOCKET_BINDING, "3"));
-    private static final PathAddress SOCKET_D_4 = PathAddress.pathAddress(PathElement.pathElement(SOCKET_BINDING_GROUP, "d"), PathElement.pathElement(SOCKET_BINDING, "4"));
-
-    private ServiceContainer container;
-    private ModelController controller;
-    @Before
-    public void setupController() throws InterruptedException {
-        System.out.println("=========  New Test \n");
-
-        container = ServiceContainer.Factory.create("test");
-        ServiceTarget target = container.subTarget();
-        ModelControllerService svc = new ModelControllerService();
-        ServiceBuilder<ModelController> builder = target.addService(ServiceName.of("ModelController"), svc);
-        builder.install();
-        svc.awaitStartup(30, TimeUnit.SECONDS);
-        controller = svc.getValue();
-
-        assertEquals(ControlledProcessState.State.RUNNING, svc.getCurrentProcessState());
-    }
-
-    @After
-    public void shutdownServiceContainer() {
-        if (container != null) {
-            container.shutdown();
-            try {
-                container.awaitTermination(5, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-            finally {
-                container = null;
-            }
-        }
-        System.out.println("======================");
-    }
+public class SocketCapabilityResolutionUnitTestCase extends AbstractCapabilityResolutionTestCase {
 
     @Test
     public void testSimpleGlobalRef() {
@@ -332,155 +261,4 @@ public class SocketCapabilityResolutionUnitTestCase {
         assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
     }
 
-    private static class ModelControllerService extends TestModelControllerService {
-
-        ModelControllerService() {
-            super(ProcessType.HOST_CONTROLLER, new NullConfigurationPersister(), new ControlledProcessState(true),
-                    createResourceDefinition(null));
-        }
-
-        @Override
-        protected void initModel(ManagementModel managementModel, Resource modelControllerResource) {
-
-            ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
-            rootRegistration.registerOperationHandler(getOD(COMPOSITE), CompositeOperationHandler.INSTANCE, false);
-
-            // Add a global handler that records capabilities and requirements
-            rootRegistration.registerOperationHandler(getOD(CAPABILITY), new CapabilityOSH(), true);
-
-            // Create resources defs representing something outside of profiles/socket-binding-group and then
-            // a tree for profile and s-b-g. Note these aren't the real resource defs, they just follow the
-            // real address pattern a bit, as those patterns are what drive the WFCORE-750 capability resolution logic
-            rootRegistration.registerSubModel(createResourceDefinition(GLOBAL));
-            ManagementResourceRegistration profile = rootRegistration.registerSubModel(createResourceDefinition(PROFILE));
-            OperationDefinition od = new SimpleOperationDefinitionBuilder("include", new NonResolvingResourceDescriptionResolver()).build();
-            OperationStepHandler includeHandler = new ParentIncludeHandler();
-            profile.registerOperationHandler(od, includeHandler);
-            profile.registerSubModel(createResourceDefinition(SUBSYSTEM));
-            ManagementResourceRegistration sbg = rootRegistration.registerSubModel(createResourceDefinition(SOCKET_BINDING_GROUP));
-            sbg.registerOperationHandler(od, includeHandler);
-            sbg.registerSubModel(createResourceDefinition(SOCKET_BINDING));
-
-            // Add the expected parent resources
-            Resource rootResource = managementModel.getRootResource();
-            rootResource.registerChild(SUBSYSTEM_A_1.getElement(0), Resource.Factory.create());
-            rootResource.registerChild(SUBSYSTEM_B_1.getElement(0), Resource.Factory.create());
-            rootResource.registerChild(SOCKET_A_1.getElement(0), Resource.Factory.create());
-            rootResource.registerChild(SOCKET_B_1.getElement(0), Resource.Factory.create());
-            rootResource.registerChild(SOCKET_C_3.getElement(0), Resource.Factory.create());
-            rootResource.registerChild(SOCKET_D_4.getElement(0), Resource.Factory.create());
-        }
-    }
-
-    private static ResourceDefinition createResourceDefinition(String key) {
-        PathElement pe = key == null ? null : PathElement.pathElement(key);
-        return ResourceBuilder.Factory.create(pe, new NonResolvingResourceDescriptionResolver()).build();
-    }
-
-    private static class CapabilityOSH implements OperationStepHandler {
-
-        @Override
-        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-
-            String capName = operation.require(CAPABILITY).asString();
-            RuntimeCapability.Builder rcb = RuntimeCapability.Builder.of(capName);
-            if (operation.hasDefined(REQUIREMENT)) {
-                final String reqName = operation.get(REQUIREMENT).asString();
-                rcb.addRequirements(reqName);
-                context.addStep(new OperationStepHandler() {
-                    @Override
-                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                        context.getResult().set(context.hasOptionalCapability(reqName, capName, null));
-                    }
-                }, OperationContext.Stage.RUNTIME);
-            }  else {
-                context.getResult().set(true);
-            }
-            context.registerCapability(rcb.build(), null);
-        }
-    }
-
-    private static class ParentIncludeHandler implements OperationStepHandler {
-
-        @Override
-        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
-            resource.getModel().get(INCLUDES).set(operation.get(INCLUDES));
-        }
-    }
-
-    private static ModelNode getCapabilityOperation(PathAddress pathAddress, String capability) {
-        return getCapabilityOperation(pathAddress, capability, null);
-    }
-
-    private static ModelNode getCapabilityOperation(PathAddress pathAddress, String capability, String requirement) {
-
-        ModelNode op = Util.createEmptyOperation(CAPABILITY, pathAddress);
-        op.get(CAPABILITY).set(capability);
-        if (requirement != null) {
-            op.get(REQUIREMENT).set(requirement);
-        }
-        return op;
-    }
-
-    private static ModelNode getParentIncludeOperation(PathAddress pathAddress, String... includes) {
-
-        ModelNode op = Util.createEmptyOperation("include", pathAddress);
-        ModelNode includesNode = op.get(INCLUDES);
-        for (String include : includes) {
-            includesNode.add(include);
-        }
-        return op;
-    }
-
-    private static ModelNode getCompositeOperation(ModelNode... steps) {
-
-        ModelNode op = new ModelNode();
-        op.get(OP).set(COMPOSITE);
-        op.get(OP_ADDR).setEmptyList();
-        for (ModelNode step : steps) {
-            op.get("steps").add(step);
-        }
-        return op;
-    }
-
-    private static void validateMissingFailureDesc(ModelNode response, String step, String cap, String context) {
-        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
-        assertTrue(response.toString(), response.hasDefined(FAILURE_DESCRIPTION));
-        String failDesc = response.get(FAILURE_DESCRIPTION).asString();
-        int loc = -1;
-        if (step != null) {
-            loc = failDesc.indexOf(step);
-            assertTrue(response.toString(), loc > 0);
-        }
-        int lastLoc = loc;
-        loc = failDesc.indexOf("WFLYCTL0369");
-        assertTrue(response.toString(), loc > lastLoc);
-        lastLoc = loc;
-        loc = failDesc.indexOf(cap);
-        assertTrue(response.toString(), loc > lastLoc);
-        lastLoc = loc;
-        loc = failDesc.indexOf(context);
-        assertTrue(response.toString(), loc > lastLoc);
-
-    }
-
-    private static void validateInconsistentFailureDesc(ModelNode response, String step, String req, String cap, String context) {
-
-        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
-        assertTrue(response.toString(), response.hasDefined(FAILURE_DESCRIPTION));
-        String failDesc = response.get(RESULT, step, FAILURE_DESCRIPTION).asString();
-        int lastLoc = -1;
-        int loc = failDesc.indexOf("WFLYCTL0399");
-        assertTrue(response.toString(), loc > lastLoc);
-        lastLoc = loc;
-        loc = failDesc.indexOf(req);
-        assertTrue(response.toString(), loc > lastLoc);
-        lastLoc = loc;
-        loc = failDesc.indexOf(cap);
-        assertTrue(response.toString(), loc > lastLoc);
-        lastLoc = loc;
-        loc = failDesc.indexOf(context);
-        assertTrue(response.toString(), loc > lastLoc);
-    }
 }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/impl/ChildFirstClassLoaderKernelServicesFactory.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/bridge/impl/ChildFirstClassLoaderKernelServicesFactory.java
@@ -23,11 +23,18 @@ package org.jboss.as.core.model.bridge.impl;
 
 import java.util.List;
 
+import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.capability.registry.CapabilityContext;
+import org.jboss.as.controller.capability.registry.RegistrationPoint;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.model.test.AbstractKernelServicesImpl;
@@ -70,6 +77,30 @@ public class ChildFirstClassLoaderKernelServicesFactory {
 
         LegacyModelInitializer(List<LegacyModelInitializerEntry> entries) {
             this.entries = entries;
+        }
+
+        @Override
+        public void populateModel(ManagementModel managementModel) {
+            populateModel(managementModel.getRootResource());
+            for (LegacyModelInitializerEntry entry : entries) {
+                if (entry.getCapabilities() != null) {
+                    PathAddress parent = entry.getParentAddress();
+                    if (parent == null) {
+                        parent = PathAddress.EMPTY_ADDRESS;
+                    }
+                    PathAddress pa = parent.append(entry.getRelativeResourceAddress());
+                    CapabilityContext scope = CapabilityContext.Factory.create(ProcessType.HOST_CONTROLLER, pa);
+                    RuntimeCapabilityRegistry cr = managementModel.getCapabilityRegistry();
+
+                    for (String capabilityName : entry.getCapabilities()) {
+                        RuntimeCapability<Void> capability =
+                                RuntimeCapability.Builder.of(capabilityName).build();
+                        RuntimeCapabilityRegistration reg = new RuntimeCapabilityRegistration(capability, scope,
+                                new RegistrationPoint(pa, null));
+                        cr.registerCapability(reg);
+                    }
+                }
+            }
         }
 
         @Override

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
@@ -685,9 +685,14 @@ public class CoreModelTestDelegate {
         }
 
         @Override
-        public LegacyKernelServicesInitializer initializerCreateModelResource(PathAddress parentAddress, PathElement relativeResourceAddress, ModelNode model) {
-            modelInitializerEntries.add(new LegacyModelInitializerEntry(parentAddress, relativeResourceAddress, model));
+        public LegacyKernelServicesInitializer initializerCreateModelResource(PathAddress parentAddress, PathElement relativeResourceAddress, ModelNode model, String... capabilities) {
+            modelInitializerEntries.add(new LegacyModelInitializerEntry(parentAddress, relativeResourceAddress, model, capabilities));
             return this;
+        }
+
+        @Override
+        public LegacyKernelServicesInitializer initializerCreateModelResource(PathAddress parentAddress, PathElement relativeResourceAddress, ModelNode model) {
+            return initializerCreateModelResource(parentAddress, relativeResourceAddress, model, new String[0]);
         }
 
         @Override

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesInitializer.java
@@ -31,6 +31,8 @@ import org.jboss.dmr.ModelNode;
  */
 public interface LegacyKernelServicesInitializer {
 
+    LegacyKernelServicesInitializer initializerCreateModelResource(PathAddress parentAddress, PathElement relativeResourceAddress, ModelNode model, String... capabilities);
+
     LegacyKernelServicesInitializer initializerCreateModelResource(PathAddress parentAddress, PathElement relativeResourceAddress, ModelNode model);
 
     /**

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyModelInitializerEntry.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyModelInitializerEntry.java
@@ -38,14 +38,16 @@ public class LegacyModelInitializerEntry implements Serializable {
     private final PathAddress parentAddress;
     private final PathElement relativeResourceAddress;
     private final ModelNode model;
+    private final String[] capabilities;
 
-    public LegacyModelInitializerEntry(PathAddress parentAddress, PathElement relativeResourceAddress, ModelNode model) {
+    public LegacyModelInitializerEntry(PathAddress parentAddress, PathElement relativeResourceAddress, ModelNode model, String... capabilities) {
         if (relativeResourceAddress == null) {
             throw new IllegalArgumentException("Null relativeResourceAddress");
         }
         this.parentAddress = parentAddress;
         this.relativeResourceAddress = relativeResourceAddress;
         this.model = model;
+        this.capabilities = capabilities == null || capabilities.length == 0 ? null : capabilities;
     }
 
     public PathAddress getParentAddress() {
@@ -60,6 +62,8 @@ public class LegacyModelInitializerEntry implements Serializable {
         return model;
     }
 
-
+    public String[] getCapabilities() {
+        return capabilities;
+    }
 
 }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/ModelInitializer.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/ModelInitializer.java
@@ -21,6 +21,7 @@
 */
 package org.jboss.as.core.model.test;
 
+import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.registry.Resource;
 
 /**
@@ -33,5 +34,18 @@ import org.jboss.as.controller.registry.Resource;
  */
 public interface ModelInitializer {
 
+    default void populateModel(ManagementModel managementModel) {
+        populateModel(managementModel.getRootResource());
+    }
+
     void populateModel(Resource rootResource);
+
+    /** An initializer that does nothing. */
+    ModelInitializer NO_OP = new ModelInitializer() { // the lambda for this just looked too funky for my tastes
+        @Override
+        public void populateModel(Resource rootResource) {
+            // no-op
+        }
+    };
+
 }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -41,8 +41,8 @@ import java.util.Properties;
 import java.util.concurrent.Executors;
 
 import org.jboss.as.controller.ControlledProcessState;
-import org.jboss.as.controller.DelegatingResourceDefinition;
 import org.jboss.as.controller.ExpressionResolver;
+import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
@@ -167,6 +167,14 @@ class TestModelControllerService extends ModelTestModelControllerService {
     }
 
     @Override
+    protected void initCoreModel(ManagementModel managementModel, Resource modelControllerResource) {
+        super.initCoreModel(managementModel, modelControllerResource);
+        if (modelInitializer != null) {
+            modelInitializer.populateModel(managementModel);
+        }
+    }
+
+    @Override
     protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
         //See server HttpManagementAddHandler
         System.setProperty("jboss.as.test.disable.runtime", "1");
@@ -178,9 +186,6 @@ class TestModelControllerService extends ModelTestModelControllerService {
 
         } else if (type == TestModelType.DOMAIN){
             initializer.initCoreModel(rootResource, rootRegistration, modelControllerResource);
-        }
-        if (modelInitializer != null) {
-            modelInitializer.populateModel(rootResource);
         }
     }
 

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/host/HostModelTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/host/HostModelTestCase.java
@@ -4,6 +4,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.ServerConfigInitializers;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,6 +47,7 @@ public class HostModelTestCase extends AbstractCoreModelTest {
     private void doHostXml(String hostXmlFile) throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder(TestModelType.HOST)
                 .setXmlResource(hostXmlFile)
+                .setModelInitializer(ServerConfigInitializers.XML_MODEL_INITIALIZER, null)
                 .build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
         String xml = kernelServices.getPersistedSubsystemXml();
@@ -56,6 +58,7 @@ public class HostModelTestCase extends AbstractCoreModelTest {
     private void doRemoteHostXml(String hostXmlFile) throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder(TestModelType.HOST)
                 .setXmlResource(hostXmlFile)
+                .setModelInitializer(ServerConfigInitializers.XML_MODEL_INITIALIZER, null)
                 .build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
         String xml = kernelServices.getPersistedSubsystemXml();

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/host/ServerConfigTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/host/ServerConfigTestCase.java
@@ -1,0 +1,117 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.core.model.test.host;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MASTER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.ServerConfigInitializers;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests of server-config aspects of the host model.
+ *
+ * @author Brian Stansberry
+ */
+public class ServerConfigTestCase extends AbstractCoreModelTest {
+
+    @Test
+    public void testAddServerConfigBadSocketBindingGroup() throws Exception {
+
+        KernelServices kernelServices = createKernelServices("host.xml");
+
+        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, MASTER), PathElement.pathElement(SERVER_CONFIG, "server-four"));
+
+        final ModelNode operation = Util.createAddOperation(pa);
+        operation.get(GROUP).set("main-server-group");
+        operation.get(SOCKET_BINDING_GROUP).set("bad-sockets");
+
+        ModelNode response = kernelServices.executeOperation(operation);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
+    }
+
+    @Test
+    public void testChangeServerGroupInvalidSocketBindingGroup() throws Exception {
+
+        KernelServices kernelServices = createKernelServices("host.xml");
+
+        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, MASTER), PathElement.pathElement(SERVER_CONFIG, "server-one"));
+        ModelNode op = Util.getWriteAttributeOperation(pa, SOCKET_BINDING_GROUP, "does-not-exist");
+        ModelNode response = kernelServices.executeOperation(op);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
+    }
+
+    @Test
+    public void testAddServerConfigBadServerGroup() throws Exception {
+
+        KernelServices kernelServices = createKernelServices("host.xml");
+
+        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, MASTER), PathElement.pathElement(SERVER_CONFIG, "server-four"));
+
+        final ModelNode operation = Util.createAddOperation(pa);
+        operation.get(GROUP).set("bad-group");
+
+        ModelNode response = kernelServices.executeOperation(operation);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
+    }
+
+    @Test
+    public void testChangeServerGroupInvalidServerGroup() throws Exception {
+
+        KernelServices kernelServices = createKernelServices("host.xml");
+
+        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, MASTER), PathElement.pathElement(SERVER_CONFIG, "server-one"));
+        ModelNode op = Util.getWriteAttributeOperation(pa, GROUP, "does-not-exist");
+        ModelNode response = kernelServices.executeOperation(op);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
+    }
+
+
+    private KernelServices createKernelServices(String configFile) throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder(TestModelType.HOST)
+                .setXmlResource(configFile)
+                .setModelInitializer(ServerConfigInitializers.XML_MODEL_INITIALIZER, null)
+                .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+        return kernelServices;
+    }
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/interfaces/AbstractSpecifiedInterfacesTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/interfaces/AbstractSpecifiedInterfacesTest.java
@@ -24,6 +24,7 @@ package org.jboss.as.core.model.test.interfaces;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
+import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.core.model.test.TestModelType;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.junit.Assert;
@@ -45,6 +46,7 @@ public abstract class AbstractSpecifiedInterfacesTest extends AbstractCoreModelT
     public void testInterfaces() throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder()
             .setXmlResource(getXmlResource())
+            .setModelInitializer(getModelInitializer(), null)
             .build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
 
@@ -53,6 +55,7 @@ public abstract class AbstractSpecifiedInterfacesTest extends AbstractCoreModelT
 
         kernelServices = createKernelServicesBuilder()
                 .setXml(marshalled)
+                .setModelInitializer(getModelInitializer(), null)
                 .build();
             Assert.assertTrue(kernelServices.isSuccessfulBoot());
     }
@@ -62,4 +65,8 @@ public abstract class AbstractSpecifiedInterfacesTest extends AbstractCoreModelT
     }
 
     protected abstract String getXmlResource();
+
+    protected ModelInitializer getModelInitializer() {
+        return ModelInitializer.NO_OP;
+    }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/interfaces/HostSpecifiedInterfacesTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/interfaces/HostSpecifiedInterfacesTestCase.java
@@ -21,7 +21,9 @@
 */
 package org.jboss.as.core.model.test.interfaces;
 
+import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.ServerConfigInitializers;
 
 /**
  *
@@ -36,6 +38,11 @@ public class HostSpecifiedInterfacesTestCase extends AbstractSpecifiedInterfaces
     @Override
     protected String getXmlResource() {
         return "host.xml";
+    }
+
+    @Override
+    protected ModelInitializer getModelInitializer() {
+        return ServerConfigInitializers.XML_MODEL_INITIALIZER;
     }
 
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/HostServerJvmModelTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/HostServerJvmModelTestCase.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.ServerConfigInitializers;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
@@ -68,6 +69,7 @@ public class HostServerJvmModelTestCase extends AbstractJvmModelTest {
     public void testFullServerJvmXml() throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder()
             .setXmlResource("host-server-full.xml")
+            .setModelInitializer(ServerConfigInitializers.XML_MODEL_INITIALIZER, null)
             .build();
 
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
@@ -83,6 +85,7 @@ public class HostServerJvmModelTestCase extends AbstractJvmModelTest {
     public void testEmptyServerJvmXml() throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder()
             .setXmlResource("host-server-empty.xml")
+            .setModelInitializer(ServerConfigInitializers.XML_MODEL_INITIALIZER, null)
             .build();
 
         Assert.assertTrue(kernelServices.isSuccessfulBoot());

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/AbstractSpecifiedPathsTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/AbstractSpecifiedPathsTestCase.java
@@ -56,6 +56,7 @@ public abstract class AbstractSpecifiedPathsTestCase extends AbstractCoreModelTe
     public void testPaths() throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder()
             .setXmlResource(getXmlResource())
+            .setModelInitializer(getModelInitalizer(), null)
             .build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
 
@@ -64,6 +65,7 @@ public abstract class AbstractSpecifiedPathsTestCase extends AbstractCoreModelTe
 
         kernelServices = createKernelServicesBuilder()
                 .setXml(marshalled)
+                .setModelInitializer(getModelInitalizer(), null)
                 .build();
             Assert.assertTrue(kernelServices.isSuccessfulBoot());
     }
@@ -136,5 +138,9 @@ public abstract class AbstractSpecifiedPathsTestCase extends AbstractCoreModelTe
                 //Default is no-op
             }
         };
+    }
+
+    protected ModelInitializer getModelInitalizer() {
+        return ModelInitializer.NO_OP;
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/HostServerSpecifiedPathsTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/HostServerSpecifiedPathsTestCase.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.ServerConfigInitializers;
 
 /**
  *
@@ -49,6 +50,7 @@ public class HostServerSpecifiedPathsTestCase extends AbstractSpecifiedPathsTest
         return PathAddress.pathAddress(PathElement.pathElement(SERVER_CONFIG, "server-one"));
     }
 
+    @Override
     protected ModelInitializer createEmptyModelInitalizer() {
         return new ModelInitializer() {
             @Override
@@ -56,5 +58,10 @@ public class HostServerSpecifiedPathsTestCase extends AbstractSpecifiedPathsTest
                 rootResource.registerChild(getPathsParent().getLastElement(), Resource.Factory.create());
             }
         };
+    }
+
+    @Override
+    protected ModelInitializer getModelInitalizer() {
+        return ServerConfigInitializers.XML_MODEL_INITIALIZER;
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/HostSpecifiedPathsTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/HostSpecifiedPathsTestCase.java
@@ -22,7 +22,9 @@
 package org.jboss.as.core.model.test.paths;
 
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.ServerConfigInitializers;
 
 /**
  *
@@ -42,6 +44,11 @@ public class HostSpecifiedPathsTestCase extends AbstractSpecifiedPathsTestCase {
     @Override
     protected PathAddress getPathsParent() {
         return PathAddress.EMPTY_ADDRESS;
+    }
+
+    @Override
+    protected ModelInitializer getModelInitalizer() {
+        return ServerConfigInitializers.XML_MODEL_INITIALIZER;
     }
 
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/profile/ProfileTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/profile/ProfileTestCase.java
@@ -21,10 +21,19 @@
 */
 package org.jboss.as.core.model.test.profile;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.TestModelType;
 import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,8 +46,8 @@ public class ProfileTestCase extends AbstractCoreModelTest {
     @Test
     public void testProfileXml() throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder(TestModelType.DOMAIN)
-            .setXmlResource("domain.xml")
-            .build();
+                .setXmlResource("domain.xml")
+                .build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
 
         String marshalled = kernelServices.getPersistedSubsystemXml();
@@ -47,9 +56,44 @@ public class ProfileTestCase extends AbstractCoreModelTest {
         kernelServices = createKernelServicesBuilder(TestModelType.DOMAIN)
                 .setXml(marshalled)
                 .build();
-            Assert.assertTrue(kernelServices.isSuccessfulBoot());
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
 
         ProfileUtils.executeDescribeProfile(kernelServices, "testA");
 
+    }
+
+    @Test
+    public void testBadProfileIncludesRemove() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setXmlResource("domain.xml")
+                .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+        PathAddress addr = PathAddress.pathAddress(PROFILE, "testA");
+        ModelNode op = Util.createRemoveOperation(addr);
+        ModelNode response = kernelServices.executeOperation(op);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0368"));
+
+        ProfileUtils.executeDescribeProfile(kernelServices, "testA");
+
+    }
+
+    @Test
+    public void testBadProfileIncludesWrite() throws Exception {
+
+        KernelServices kernelServices = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setXmlResource("domain.xml")
+                .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+        PathAddress addr = PathAddress.pathAddress(PROFILE, "testA");
+        ModelNode list = new ModelNode().add("bad-profile");
+        ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
+        ModelNode response = kernelServices.executeOperation(op);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
+
+        ProfileUtils.executeDescribeProfile(kernelServices, "testA");
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/servergroup/DomainServerGroupTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/servergroup/DomainServerGroupTestCase.java
@@ -21,16 +21,26 @@
  */
 package org.jboss.as.core.model.test.servergroup;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
-import static org.hamcrest.CoreMatchers.containsString;
 
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.TestModelType;
 import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
 import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -92,15 +102,65 @@ public class DomainServerGroupTestCase extends AbstractCoreModelTest {
         testServerGroupXml("servergroup-with-deployments.xml");
     }
 
+    @Test
+    public void testAddServerGroupBadProfile() throws Exception {
+
+        KernelServices kernelServices = createKernelServices("servergroup.xml");
+
+        PathAddress pa = PathAddress.pathAddress(SERVER_GROUP, "group-three");
+
+        final ModelNode operation = Util.createAddOperation(pa);
+        operation.get(PROFILE).set("bad-profile");
+        operation.get(SOCKET_BINDING_GROUP).set("test-sockets");
+
+        ModelNode response = kernelServices.executeOperation(operation);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
+    }
+
+    @Test
+    public void testChangeServerGroupInvalidProfile() throws Exception {
+
+        KernelServices kernelServices = createKernelServices("servergroup.xml");
+
+        PathAddress pa = PathAddress.pathAddress(SERVER_GROUP, "test");
+        ModelNode op = Util.getWriteAttributeOperation(pa, PROFILE, "does-not-exist");
+        ModelNode response = kernelServices.executeOperation(op);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
+    }
+
+    @Test
+    public void testAddServerGroupBadSocketBindingGroup() throws Exception {
+
+        KernelServices kernelServices = createKernelServices("servergroup.xml");
+
+        PathAddress pa = PathAddress.pathAddress(SERVER_GROUP, "group-three");
+
+        final ModelNode operation = Util.createAddOperation(pa);
+        operation.get(PROFILE).set("test");
+        operation.get(SOCKET_BINDING_GROUP).set("bad-sockets");
+
+        ModelNode response = kernelServices.executeOperation(operation);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
+    }
+
+    @Test
+    public void testChangeServerGroupInvalidSocketBindingGroup() throws Exception {
+
+        KernelServices kernelServices = createKernelServices("servergroup.xml");
+
+        PathAddress pa = PathAddress.pathAddress(SERVER_GROUP, "test");
+        ModelNode op = Util.getWriteAttributeOperation(pa, SOCKET_BINDING_GROUP, "does-not-exist");
+        ModelNode response = kernelServices.executeOperation(op);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
+    }
+
     private void testServerGroupXml(String resource) throws Exception {
 
-        KernelServices kernelServices = createKernelServicesBuilder(TestModelType.DOMAIN)
-                .setXmlResource(resource)
-                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
-                .createContentRepositoryContent("12345678901234567890")
-                .createContentRepositoryContent("09876543210987654321")
-                .build();
-        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+        KernelServices kernelServices = createKernelServices(resource);
 
         String marshalled = kernelServices.getPersistedSubsystemXml();
         ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), resource), marshalled);
@@ -112,6 +172,19 @@ public class DomainServerGroupTestCase extends AbstractCoreModelTest {
                 .createContentRepositoryContent("09876543210987654321")
                 .build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+    }
+
+    private KernelServices createKernelServices(String resource) throws Exception {
+
+        KernelServices kernelServices = createKernelServicesBuilder(TestModelType.DOMAIN)
+                .setXmlResource(resource)
+                .setModelInitializer(StandardServerGroupInitializers.XML_MODEL_INITIALIZER, StandardServerGroupInitializers.XML_MODEL_WRITE_SANITIZER)
+                .createContentRepositoryContent("12345678901234567890")
+                .createContentRepositoryContent("09876543210987654321")
+                .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+        return kernelServices;
 
     }
 

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/shipped/ShippedConfigurationsModelTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/shipped/ShippedConfigurationsModelTestCase.java
@@ -23,13 +23,22 @@ package org.jboss.as.core.model.test.shipped;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 
+import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.capability.registry.CapabilityContext;
+import org.jboss.as.controller.capability.registry.RegistrationPoint;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.core.model.test.ModelWriteSanitizer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.ServerConfigInitializers;
+import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
@@ -45,6 +54,24 @@ public class ShippedConfigurationsModelTestCase extends AbstractCoreModelTest {
     public void testDomainXml() throws Exception {
         testConfiguration(TestModelType.DOMAIN, "domain.xml",
                 new ModelInitializer() {
+                    @Override
+                    public void populateModel(ManagementModel managementModel) {
+                        populateModel(managementModel.getRootResource());
+
+                        RuntimeCapabilityRegistry cr = managementModel.getCapabilityRegistry();
+
+                        RuntimeCapability<Void> capability =
+                                RuntimeCapability.Builder.of(ProfileResourceDefinition.PROFILE_CAPABILITY.getDynamicName("full")).build();
+                        RuntimeCapabilityRegistration reg = new RuntimeCapabilityRegistration(capability, CapabilityContext.GLOBAL,
+                                new RegistrationPoint(PathAddress.pathAddress(PROFILE, "full"), null));
+                        cr.registerCapability(reg);
+
+                        capability = RuntimeCapability.Builder.of(ProfileResourceDefinition.PROFILE_CAPABILITY.getDynamicName("full-ha")).build();
+                        reg = new RuntimeCapabilityRegistration(capability, CapabilityContext.GLOBAL,
+                                new RegistrationPoint(PathAddress.pathAddress(PROFILE, "full-ha"), null));
+                        cr.registerCapability(reg);
+                    }
+
                     public void populateModel(Resource rootResource) {
                         rootResource.registerChild(PathElement.pathElement(PROFILE, "full"), Resource.Factory.create());
                         rootResource.registerChild(PathElement.pathElement(PROFILE, "full-ha"), Resource.Factory.create());
@@ -60,7 +87,7 @@ public class ShippedConfigurationsModelTestCase extends AbstractCoreModelTest {
 
     @Test
     public void testHostXml() throws Exception {
-        testConfiguration(TestModelType.HOST, "host.xml", null, null);
+        testConfiguration(TestModelType.HOST, "host.xml", ServerConfigInitializers.XML_MODEL_INITIALIZER, null);
     }
 
     @Test

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/socketbindinggroups/AbstractSocketBindingGroupTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/socketbindinggroups/AbstractSocketBindingGroupTest.java
@@ -21,6 +21,10 @@
 */
 package org.jboss.as.core.model.test.socketbindinggroups;
 
+import java.io.IOException;
+
+import javax.xml.stream.XMLStreamException;
+
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
@@ -43,23 +47,28 @@ public abstract class AbstractSocketBindingGroupTest extends AbstractCoreModelTe
 
     @Test
     public void testSocketBindingGroups() throws Exception {
-        KernelServices kernelServices = createKernelServicesBuilder()
-                .setXmlResource(getXmlResource())
+        KernelServices kernelServices = createKernelServices();
+
+        String marshalled = kernelServices.getPersistedSubsystemXml();
+        ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), getXmlResource()), marshalled);
+
+        kernelServices = createKernelServicesBuilder()
+                .setXml(marshalled)
                 .build();
             Assert.assertTrue(kernelServices.isSuccessfulBoot());
+    }
 
-            String marshalled = kernelServices.getPersistedSubsystemXml();
-            ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), getXmlResource()), marshalled);
-
-            kernelServices = createKernelServicesBuilder()
-                    .setXml(marshalled)
-                    .build();
-                Assert.assertTrue(kernelServices.isSuccessfulBoot());
-        }
-
-        KernelServicesBuilder createKernelServicesBuilder() {
-            return createKernelServicesBuilder(type);
+    KernelServicesBuilder createKernelServicesBuilder() {
+        return createKernelServicesBuilder(type);
     }
 
     protected abstract String getXmlResource();
+
+    protected KernelServices createKernelServices() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder()
+                .setXmlResource(getXmlResource())
+                .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+        return kernelServices;
+    }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/socketbindinggroups/DomainSocketBindingGroupTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/socketbindinggroups/DomainSocketBindingGroupTestCase.java
@@ -21,7 +21,20 @@
 */
 package org.jboss.as.core.model.test.socketbindinggroups;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT_INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  *
@@ -36,5 +49,44 @@ public class DomainSocketBindingGroupTestCase extends AbstractSocketBindingGroup
     @Override
     protected String getXmlResource() {
         return "domain.xml";
+    }
+
+
+    @Test
+    public void testBadSocketBindingGroupIncludesAdd() throws Exception {
+        KernelServices kernelServices = createKernelServices();
+
+        PathAddress addr = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "bad-add");
+        ModelNode op = Util.createAddOperation(addr);
+        op.get(DEFAULT_INTERFACE).set("public");
+        op.get(INCLUDES).add("test").add("NOT_THERE");
+        ModelNode response = kernelServices.executeOperation(op);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
+    }
+
+    @Test
+    public void testBadSocketBindingGroupIncludesRemove() throws Exception {
+        KernelServices kernelServices = createKernelServices();
+
+        PathAddress addr = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "test");
+        ModelNode op = Util.createRemoveOperation(addr);
+
+        ModelNode response = kernelServices.executeOperation(op);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0368"));
+    }
+
+    @Test
+    public void testBadSocketBindingGroupIncludesWrite() throws Exception {
+        KernelServices kernelServices = createKernelServices();
+
+        PathAddress addr = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "test-with-includes");
+        ModelNode list = new ModelNode().add("test").add("standard-sockets").add("bad-SocketBindingGroup");
+        ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
+
+        ModelNode response = kernelServices.executeOperation(op);
+        Assert.assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        Assert.assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0369"));
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTest.java
@@ -31,6 +31,7 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
+import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -321,6 +322,7 @@ public abstract class AbstractSystemPropertyTest extends AbstractCoreModelTest {
     public void testXml() throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder(true)
                 .setXmlResource(getXmlResource())
+                .setModelInitializer(getModelInitializer(), null)
                 .build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
 
@@ -365,4 +367,8 @@ public abstract class AbstractSystemPropertyTest extends AbstractCoreModelTest {
     protected abstract ModelNode readSystemPropertiesParentModel(KernelServices kernelServices);
 
     protected abstract String getXmlResource();
+
+    protected ModelInitializer getModelInitializer() {
+        return ModelInitializer.NO_OP;
+    }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainServerGroupSystemPropertyTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainServerGroupSystemPropertyTestCase.java
@@ -75,6 +75,12 @@ public class DomainServerGroupSystemPropertyTestCase extends AbstractSystemPrope
     protected String getXmlResource() {
         return "domain-servergroup-systemproperties.xml";
     }
+
+    @Override
+    protected ModelInitializer getModelInitializer() {
+        return StandardServerGroupInitializers.XML_MODEL_INITIALIZER;
+    }
+
     private ModelInitializer BOOT_OP_MODEL_INITIALIZER = new ModelInitializer() {
         @Override
         public void populateModel(Resource rootResource) {

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/HostServerSystemPropertyTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/HostServerSystemPropertyTestCase.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOS
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 
+import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.registry.Resource;
@@ -33,6 +34,7 @@ import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.util.ServerConfigInitializers;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
@@ -61,6 +63,11 @@ public class HostServerSystemPropertyTestCase extends AbstractSystemPropertyTest
         return createKernelServicesBuilder(TestModelType.HOST);
     }
 
+    @Override
+    protected ModelInitializer getModelInitializer() {
+        return ServerConfigInitializers.XML_MODEL_INITIALIZER;
+    }
+
     protected KernelServices createEmptyRoot() throws Exception {
         KernelServices kernelServices = createKernelServicesBuilder(false).setModelInitializer(BOOT_OP_MODEL_INITIALIZER, null).build();
         Assert.assertTrue(kernelServices.isSuccessfulBoot());
@@ -78,6 +85,12 @@ public class HostServerSystemPropertyTestCase extends AbstractSystemPropertyTest
     }
 
     private ModelInitializer BOOT_OP_MODEL_INITIALIZER = new ModelInitializer() {
+        @Override
+        public void populateModel(ManagementModel managementModel) {
+            populateModel(managementModel.getRootResource());
+            ServerConfigInitializers.populateCapabilityRegistry(managementModel.getCapabilityRegistry());
+        }
+
         @Override
         public void populateModel(Resource rootResource) {
             Resource host = Resource.Factory.create();

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/ServerConfigInitializers.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/ServerConfigInitializers.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.core.model.test.util;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+
+import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.capability.registry.CapabilityContext;
+import org.jboss.as.controller.capability.registry.RegistrationPoint;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.core.model.test.ModelInitializer;
+import org.jboss.as.domain.controller.operations.SocketBindingGroupResourceDefinition;
+import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
+
+/**
+ * Model initialization logic for server-config testing.
+ *
+ * @author Brian Stansberry
+ */
+public final class ServerConfigInitializers {
+
+    private static final String TEST_MAIN_SERVER_GROUP_CAPABILITY = ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY.getDynamicName("main-server-group");
+    private static final PathAddress TEST_MAIN_SERVER_GROUP_ADDRESS = PathAddress.pathAddress(SERVER_GROUP, "main-server-group");
+    private static final CapabilityContext TEST_SERVER_GROUP_CONTEXT = CapabilityContext.Factory.create(ProcessType.HOST_CONTROLLER, TEST_MAIN_SERVER_GROUP_ADDRESS);
+
+    private static final String TEST_OTHER_SERVER_GROUP_CAPABILITY = ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY.getDynamicName("other-server-group");
+    private static final PathAddress TEST_OTHER_SERVER_GROUP_ADDRESS = PathAddress.pathAddress(SERVER_GROUP, "other-server-group");
+
+    private static final String TEST_FULL_HA_SOCKETS_CAPABILITY = SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY.getDynamicName("full-ha-sockets");
+    private static final PathAddress TEST_FULL_HA_SOCKETS_ADDRESS = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "full-ha-sockets");
+    private static final CapabilityContext TEST_SBG_CONTEXT = CapabilityContext.Factory.create(ProcessType.HOST_CONTROLLER, TEST_FULL_HA_SOCKETS_ADDRESS);
+
+    public static final ModelInitializer XML_MODEL_INITIALIZER = new ModelInitializer() {
+
+        @Override
+        public void populateModel(ManagementModel managementModel) {
+            RuntimeCapabilityRegistry cr = managementModel.getCapabilityRegistry();
+            populateCapabilityRegistry(cr);
+        }
+
+        public void populateModel(Resource rootResource) {
+            // nothing to do
+        }
+    };
+
+    public static void populateCapabilityRegistry(RuntimeCapabilityRegistry cr) {
+
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(TEST_MAIN_SERVER_GROUP_CAPABILITY).build();
+        RuntimeCapabilityRegistration reg = new RuntimeCapabilityRegistration(capability, TEST_SERVER_GROUP_CONTEXT,
+                new RegistrationPoint(TEST_MAIN_SERVER_GROUP_ADDRESS, null));
+        cr.registerCapability(reg);
+
+        capability = RuntimeCapability.Builder.of(TEST_OTHER_SERVER_GROUP_CAPABILITY).build();
+        reg = new RuntimeCapabilityRegistration(capability, TEST_SERVER_GROUP_CONTEXT,
+                new RegistrationPoint(TEST_OTHER_SERVER_GROUP_ADDRESS, null));
+        cr.registerCapability(reg);
+
+        capability = RuntimeCapability.Builder.of(TEST_FULL_HA_SOCKETS_CAPABILITY).build();
+        reg = new RuntimeCapabilityRegistration(capability, TEST_SBG_CONTEXT,
+                new RegistrationPoint(TEST_FULL_HA_SOCKETS_ADDRESS, null));
+        cr.registerCapability(reg);
+
+    }
+
+    private ServerConfigInitializers() {}
+}

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/StandardServerGroupInitializers.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/StandardServerGroupInitializers.java
@@ -24,12 +24,21 @@ package org.jboss.as.core.model.test.util;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 
+import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.capability.registry.CapabilityContext;
+import org.jboss.as.controller.capability.registry.RegistrationPoint;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.core.model.test.ModelWriteSanitizer;
+import org.jboss.as.domain.controller.operations.SocketBindingGroupResourceDefinition;
+import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
 import org.jboss.as.model.test.ModelFixer;
 import org.jboss.dmr.ModelNode;
 
@@ -38,9 +47,35 @@ import org.jboss.dmr.ModelNode;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class StandardServerGroupInitializers {
+
+    private static final String TEST_PROFILE_CAPABILITY = ProfileResourceDefinition.PROFILE_CAPABILITY.getDynamicName("test");
+    private static final PathAddress TEST_PROFILE_ADDRESS = PathAddress.pathAddress(PROFILE, "test");
+    private static final CapabilityContext TEST_PROFILE_CONTEXT = CapabilityContext.Factory.create(ProcessType.HOST_CONTROLLER, TEST_PROFILE_ADDRESS);
+
+    private static final String TEST_SBG_CAPABILITY = SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY.getDynamicName("test-sockets");
+    private static final PathAddress TEST_SBG_ADDRESS = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "test-sockets");
+    private static final CapabilityContext TEST_SBG_CONTEXT = CapabilityContext.Factory.create(ProcessType.HOST_CONTROLLER, TEST_SBG_ADDRESS);
+
     public static final ModelInitializer XML_MODEL_INITIALIZER = new ModelInitializer() {
+
+        @Override
+        public void populateModel(ManagementModel managementModel) {
+            populateModel(managementModel.getRootResource());
+            RuntimeCapabilityRegistry cr = managementModel.getCapabilityRegistry();
+
+            RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(TEST_PROFILE_CAPABILITY).build();
+            RuntimeCapabilityRegistration reg = new RuntimeCapabilityRegistration(capability, TEST_PROFILE_CONTEXT,
+                    new RegistrationPoint(TEST_PROFILE_ADDRESS, null));
+            cr.registerCapability(reg);
+
+            capability = RuntimeCapability.Builder.of(TEST_SBG_CAPABILITY).build();
+            reg = new RuntimeCapabilityRegistration(capability, TEST_SBG_CONTEXT,
+                    new RegistrationPoint(TEST_SBG_ADDRESS, null));
+            cr.registerCapability(reg);
+        }
+
         public void populateModel(Resource rootResource) {
-            rootResource.registerChild(PathElement.pathElement(PROFILE, "test"), Resource.Factory.create());
+            rootResource.registerChild(TEST_PROFILE_ADDRESS.getElement(0), Resource.Factory.create());
             rootResource.registerChild(PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), Resource.Factory.create());
         }
     };
@@ -56,13 +91,13 @@ public class StandardServerGroupInitializers {
     };
 
     public static LegacyKernelServicesInitializer addServerGroupInitializers(LegacyKernelServicesInitializer legacyKernelServicesInitializer) {
-        legacyKernelServicesInitializer.initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(PROFILE, "test"), null)
-            .initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), null);
+        legacyKernelServicesInitializer.initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, TEST_PROFILE_ADDRESS.getElement(0), null, TEST_PROFILE_CAPABILITY)
+            .initializerCreateModelResource(PathAddress.EMPTY_ADDRESS, PathElement.pathElement(SOCKET_BINDING_GROUP, "test-sockets"), null, TEST_SBG_CAPABILITY);
         return legacyKernelServicesInitializer;
     }
 
     public static final ModelFixer MODEL_FIXER = new ModelFixer() {
-    
+
         @Override
         public ModelNode fixModel(ModelNode modelNode) {
             modelNode.remove(SOCKET_BINDING_GROUP);

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup.xml
@@ -12,7 +12,7 @@
         </deployment-overlay>
     </deployment-overlays>
 
-   <server-groups>
+    <server-groups>
         <server-group name="test" profile="test" management-subsystem-endpoint="true">
 
             <jvm name="full" java-home="javaHome" type="SUN" env-classpath-ignored="true">

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainModelReferenceValidator.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainModelReferenceValidator.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.domain.controller.operations;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
@@ -31,7 +30,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE_DESTINATION_OUTBOUND_SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
@@ -59,9 +57,10 @@ import org.jboss.as.host.controller.logging.HostControllerLogger;
 import org.jboss.dmr.ModelNode;
 
 /**
- * Handler validating that all known model references are present.
+ * Handler validating that all known model references are present, that "including" resources don't involve
+ * cycles, and that including resources don't involve children that override the included resources.
  *
- * This should probably be replaced with model reference validation at the end of the Stage.MODEL.
+ * The model reference part of this is slowly being replaced with capability-based model reference validation..
  *
  * @author Emanuel Muckenhuber
  * @author Kabir Khan
@@ -103,78 +102,85 @@ public class DomainModelReferenceValidator implements OperationStepHandler {
 
     public void validate(final OperationContext context) throws OperationFailedException {
 
-        final Set<String> serverGroups = new HashSet<>();
+//        final Set<String> serverGroups = new HashSet<>();
         final Set<String> interfaces = new HashSet<String>();
 
         final Resource domain = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
         final Set<String> missingProfiles = new HashSet<>();
         final Set<String> missingSocketBindingGroups = new HashSet<>();
-        final Set<String> allProfiles = checkProfileIncludes(domain, missingProfiles);
-        final Set<String> allSocketBindingGroups = checkSocketBindingGroupIncludes(domain, missingSocketBindingGroups);
+        checkProfileIncludes(domain, missingProfiles);
+        checkSocketBindingGroupIncludes(domain, missingSocketBindingGroups);
         final String hostName = determineHostName(domain);
         if (hostName != null) {
             // The testsuite does not always setup the model properly
             final Resource host = domain.getChild(PathElement.pathElement(HOST, hostName));
             for (final Resource.ResourceEntry serverConfig : host.getChildren(SERVER_CONFIG)) {
                 final ModelNode model = serverConfig.getModel();
-                final String group = model.require(GROUP).asString();
-                if (!serverGroups.contains(group)) {
-                    serverGroups.add(group);
-                }
+//                final String group = model.require(GROUP).asString();
+//                if (!serverGroups.contains(group)) {
+//                    serverGroups.add(group);
+//                }
                 if (model.hasDefined(SOCKET_BINDING_DEFAULT_INTERFACE)) {
                     String defaultInterface = model.get(SOCKET_BINDING_DEFAULT_INTERFACE).asString();
                     if (!interfaces.contains(defaultInterface)) {
                         interfaces.add(defaultInterface);
                     }
                 }
-                processSocketBindingGroup(model, allSocketBindingGroups, missingSocketBindingGroups);
+                // BES 2015/08/07 We use capability/requirement validation for this
+                //processSocketBindingGroup(model, allSocketBindingGroups, missingSocketBindingGroups);
             }
         }
 
         // process referenced server-groups
-        for (final Resource.ResourceEntry serverGroup : domain.getChildren(SERVER_GROUP)) {
-            final ModelNode model = serverGroup.getModel();
-            final String profile = model.require(PROFILE).asString();
-            if (!allProfiles.contains(profile)) {
-                missingProfiles.add(profile);
-            }
-            // Process the socket-binding-group
-            processSocketBindingGroup(model, allSocketBindingGroups, missingSocketBindingGroups);
-
-            serverGroups.remove(serverGroup.getName()); // The server-group is present
-        }
+        // BES 2015/08/07 We use capability/requirement validation for this
+//        for (final Resource.ResourceEntry serverGroup : domain.getChildren(SERVER_GROUP)) {
+//            final ModelNode model = serverGroup.getModel();
+//            final String profile = model.require(PROFILE).asString();
+//            if (!allProfiles.contains(profile)) {
+//                missingProfiles.add(profile);
+//            }
+//            // Process the socket-binding-group
+//
+//            processSocketBindingGroup(model, allSocketBindingGroups, missingSocketBindingGroups);
+//
+//            serverGroups.remove(serverGroup.getName()); // The server-group is present
+//        }
 
         // process referenced interfaces
         for (final Resource.ResourceEntry iface : domain.getChildren(INTERFACE)) {
             interfaces.remove(iface.getName());
         }
         // If we are missing a server group
-        if (!serverGroups.isEmpty()) {
-            throw HostControllerLogger.ROOT_LOGGER.missingReferences(SERVER_GROUP, serverGroups);
-        }
+        // BES 2015/08/07 We use capability/requirement validation for this
+//        if (!serverGroups.isEmpty()) {
+//            throw HostControllerLogger.ROOT_LOGGER.missingReferences(SERVER_GROUP, serverGroups);
+//        }
         // We are missing a profile
-        if (!missingProfiles.isEmpty()) {
-            throw HostControllerLogger.ROOT_LOGGER.missingReferences(PROFILE, missingProfiles);
-        }
+        // BES 2015/06/19 We use capability/requirement validation for this
+//        if (!missingProfiles.isEmpty()) {
+//            throw HostControllerLogger.ROOT_LOGGER.missingReferences(PROFILE, missingProfiles);
+//        }
         // Process socket-binding groups
-        if (!missingSocketBindingGroups.isEmpty()) {
-            throw HostControllerLogger.ROOT_LOGGER.missingReferences(SOCKET_BINDING_GROUP, missingSocketBindingGroups);
-        }
+        // BES 2015/08/07 We use capability/requirement validation for this
+//        if (!missingSocketBindingGroups.isEmpty()) {
+//            throw HostControllerLogger.ROOT_LOGGER.missingReferences(SOCKET_BINDING_GROUP, missingSocketBindingGroups);
+//        }
+
         //We are missing an interface
         if (!interfaces.isEmpty()) {
             throw HostControllerLogger.ROOT_LOGGER.missingReferences(INTERFACE, interfaces);
         }
 
     }
-
-    private void processSocketBindingGroup(final ModelNode model, final Set<String> socketBindings, final Set<String> missingSocketBindings) {
-        if (model.hasDefined(SOCKET_BINDING_GROUP)) {
-            final String socketBinding = model.require(SOCKET_BINDING_GROUP).asString();
-            if (!socketBindings.contains(socketBinding)) {
-                missingSocketBindings.add(socketBinding);
-            }
-        }
-    }
+    // BES 2015/08/07 We use capability/requirement validation for this
+//    private void processSocketBindingGroup(final ModelNode model, final Set<String> socketBindings, final Set<String> missingSocketBindings) {
+//        if (model.hasDefined(SOCKET_BINDING_GROUP)) {
+//            final String socketBinding = model.require(SOCKET_BINDING_GROUP).asString();
+//            if (!socketBindings.contains(socketBinding)) {
+//                missingSocketBindings.add(socketBinding);
+//            }
+//        }
+//    }
 
     private String determineHostName(final Resource domain) {
         // This could use a better way to determine the local host name

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileAddHandler.java
@@ -37,7 +37,7 @@ public class ProfileAddHandler extends AbstractAddStepHandler {
     public static final ProfileAddHandler INSTANCE = new ProfileAddHandler();
 
     ProfileAddHandler() {
-        super(ProfileResourceDefinition.ATTRIBUTES);
+        super(ProfileResourceDefinition.PROFILE_CAPABILITY, ProfileResourceDefinition.ATTRIBUTES);
     }
 
     protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileRemoveHandler.java
@@ -24,8 +24,7 @@ package org.jboss.as.domain.controller.operations;
 
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
-import org.jboss.dmr.ModelNode;
+import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
 
 /**
  * @author Emanuel Muckenhuber
@@ -34,10 +33,8 @@ public class ProfileRemoveHandler extends AbstractRemoveStepHandler {
 
     public static final ProfileRemoveHandler INSTANCE = new ProfileRemoveHandler();
 
-    @Override
-    protected void performRemove(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        super.performRemove(context, operation, model);
-        DomainModelReferenceValidator.addValidationStep(context, operation);
+    private ProfileRemoveHandler() {
+        super(ProfileResourceDefinition.PROFILE_CAPABILITY);
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ServerGroupAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ServerGroupAddHandler.java
@@ -22,11 +22,10 @@
 
 package org.jboss.as.domain.controller.operations;
 
-import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
 import org.jboss.dmr.ModelNode;
@@ -34,29 +33,23 @@ import org.jboss.dmr.ModelNode;
 /**
  * @author Emanuel Muckenhuber
  */
-public class ServerGroupAddHandler implements OperationStepHandler {
+public class ServerGroupAddHandler extends AbstractAddStepHandler {
 
     public static OperationStepHandler INSTANCE = new ServerGroupAddHandler();
 
     ServerGroupAddHandler() {
-        //
+        super(ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY, ServerGroupResourceDefinition.ADD_ATTRIBUTES);
     }
 
-    @Deprecated
-    public ServerGroupAddHandler(boolean master) {
-        //
-    }
-
-    /** {@inheritDoc */
-    public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-
-        final Resource resource = context.createResource(PathAddress.EMPTY_ADDRESS);
-        final ModelNode model = resource.getModel();
-
-        for (AttributeDefinition attr : ServerGroupResourceDefinition.ADD_ATTRIBUTES) {
-            attr.validateAndSet(operation, model);
-        }
+    @Override
+    protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
         DomainModelReferenceValidator.addValidationStep(context, operation);
+        super.populateModel(context, operation, resource);
+    }
+
+    @Override
+    protected boolean requiresRuntime(OperationContext context) {
+        return false;
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ServerGroupRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ServerGroupRemoveHandler.java
@@ -39,6 +39,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.domain.controller.logging.DomainControllerLogger;
+import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -49,6 +50,7 @@ public class ServerGroupRemoveHandler extends AbstractRemoveStepHandler {
     // We need the host controller info since the host name is not available during boot-time
     private final LocalHostControllerInfo hostControllerInfo;
     public ServerGroupRemoveHandler(final LocalHostControllerInfo hostControllerInfo) {
+        super(ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY);
         this.hostControllerInfo = hostControllerInfo;
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SocketBindingGroupAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SocketBindingGroupAddHandler.java
@@ -18,6 +18,8 @@
  */
 package org.jboss.as.domain.controller.operations;
 
+import static org.jboss.as.domain.controller.operations.SocketBindingGroupResourceDefinition.INCLUDES;
+
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.operations.common.AbstractSocketBindingGroupAddHandler;
@@ -35,6 +37,7 @@ public class SocketBindingGroupAddHandler extends AbstractSocketBindingGroupAddH
     public static final SocketBindingGroupAddHandler INSTANCE = new SocketBindingGroupAddHandler();
 
     private SocketBindingGroupAddHandler() {
+        super(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY);
     }
 
     /**
@@ -47,4 +50,9 @@ public class SocketBindingGroupAddHandler extends AbstractSocketBindingGroupAddH
         DomainModelReferenceValidator.addValidationStep(context, operation);
     }
 
+    @Override
+    protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        super.recordCapabilitiesAndRequirements(context, operation, resource);
+        INCLUDES.addCapabilityRequirements(context, resource.getModel().get(INCLUDES.getName()));
+    }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SocketBindingGroupResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SocketBindingGroupResourceDefinition.java
@@ -29,6 +29,7 @@ import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.ListAttributeDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PrimitiveListAttributeDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -43,6 +44,10 @@ import org.jboss.dmr.ModelType;
  * @author Kabir Khan
  */
 public class SocketBindingGroupResourceDefinition extends AbstractSocketBindingGroupResourceDefinition {
+
+    public static final String SOCKET_BINDING_GROUP_CAPABILITY_NAME = "org.wildfly.domain.socket-binding-group";
+    public static final RuntimeCapability SOCKET_BINDING_GROUP_CAPABILITY = RuntimeCapability.Builder.of(SOCKET_BINDING_GROUP_CAPABILITY_NAME, true)
+            .build();
 
     public static SocketBindingGroupResourceDefinition INSTANCE = new SocketBindingGroupResourceDefinition();
 
@@ -72,6 +77,7 @@ public class SocketBindingGroupResourceDefinition extends AbstractSocketBindingG
                     }
                 }
             })
+            .setCapabilityReference(SOCKET_BINDING_GROUP_CAPABILITY_NAME, SOCKET_BINDING_GROUP_CAPABILITY_NAME, true)
             .build();
 
     private SocketBindingGroupResourceDefinition() {
@@ -89,6 +95,11 @@ public class SocketBindingGroupResourceDefinition extends AbstractSocketBindingG
         resourceRegistration.registerSubModel(SocketBindingResourceDefinition.INSTANCE);
         resourceRegistration.registerSubModel(RemoteDestinationOutboundSocketBindingResourceDefinition.INSTANCE);
         resourceRegistration.registerSubModel(LocalDestinationOutboundSocketBindingResourceDefinition.INSTANCE);
+    }
+
+    @Override
+    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerCapability(SOCKET_BINDING_GROUP_CAPABILITY);
     }
 
     public static OperationStepHandler createReferenceValidationHandler() {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
@@ -35,6 +35,7 @@ import java.io.DataInput;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -152,8 +153,11 @@ public class HostControllerRegistrationHandler implements ManagementRequestHandl
     }
 
     /**
-     * wrapper to the DomainController and the underlying {@code ModelController} to execute
+     * Wrapper to the DomainController and the underlying {@code ModelController} to execute
      * a {@code OperationStepHandler} implementation directly, bypassing normal domain coordination layer.
+     * TODO This interface probably should be adapted to provide use-case-specific methods instead of generic
+     * "execute whatever I hand you" ones. The "installSlaveExtensions" method needed to be non-generic unless
+     * I was willing to hand a ref to the root MRR to RemoteDomainConnnectionService.
      */
     public interface OperationExecutor {
 
@@ -167,6 +171,14 @@ public class HostControllerRegistrationHandler implements ManagementRequestHandl
          * @return the result
          */
         ModelNode execute(Operation operation, OperationMessageHandler handler, ModelController.OperationTransactionControl control, OperationStepHandler step);
+
+        /**
+         * Execute the operation to install extensions provided by a remote domain controller.
+         *
+         *
+         * @param extensions@return the result
+         */
+        ModelNode installSlaveExtensions(List<ModelNode> extensions);
 
         /**
          * Execute an operation using the current management model.

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -66,9 +66,7 @@ import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.domain.controller.DomainController;
 import org.jboss.as.domain.controller.operations.DomainServerLifecycleHandlers;
-import org.jboss.as.domain.controller.operations.DomainSocketBindingGroupRemoveHandler;
 import org.jboss.as.domain.controller.operations.HostProcessReloadHandler;
-import org.jboss.as.host.controller.operations.InstallationReportHandler;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.audit.EnvironmentNameReader;
 import org.jboss.as.host.controller.DirectoryGrouping;
@@ -88,6 +86,7 @@ import org.jboss.as.host.controller.operations.HostShutdownHandler;
 import org.jboss.as.host.controller.operations.HostSpecifiedInterfaceAddHandler;
 import org.jboss.as.host.controller.operations.HostSpecifiedInterfaceRemoveHandler;
 import org.jboss.as.host.controller.operations.HostXmlMarshallingHandler;
+import org.jboss.as.host.controller.operations.InstallationReportHandler;
 import org.jboss.as.host.controller.operations.IsMasterHandler;
 import org.jboss.as.host.controller.operations.LocalHostControllerInfoImpl;
 import org.jboss.as.host.controller.operations.RemoteDomainControllerAddHandler;
@@ -333,7 +332,6 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
 
 
         DomainServerLifecycleHandlers.initializeServerInventory(serverInventory);
-        DomainSocketBindingGroupRemoveHandler.INSTANCE.initializeServerInventory(serverInventory);
 
         ValidateOperationHandler validateOperationHandler = hostControllerInfo.isMasterDomainController() ? ValidateOperationHandler.INSTANCE : ValidateOperationHandler.SLAVE_HC_INSTANCE;
         hostRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION_PRIVATE, validateOperationHandler);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerAddHandler.java
@@ -28,7 +28,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUN
 import java.io.File;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
-import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -62,6 +61,7 @@ public class ServerAddHandler extends AbstractAddStepHandler {
      * Create the ServerAddHandler
      */
     private ServerAddHandler(LocalHostControllerInfo hostControllerInfo, ServerInventory serverInventory, ControlledProcessState processState, File domainDataDir) {
+        super(ServerConfigResourceDefinition.SERVER_CONFIG_CAPABILITY, ServerConfigResourceDefinition.WRITABLE_ATTRIBUTES);
         this.hostControllerInfo = hostControllerInfo;
         this.serverInventory = serverInventory;
         this.processState = processState;
@@ -83,12 +83,9 @@ public class ServerAddHandler extends AbstractAddStepHandler {
     @Override
     protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
 
-        final ModelNode model = resource.getModel();
-        for (AttributeDefinition attr : ServerConfigResourceDefinition.WRITABLE_ATTRIBUTES) {
-            attr.validateAndSet(operation, model);
-        }
+        super.populateModel(context, operation, resource);
 
-        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+        final PathAddress address = context.getCurrentAddress();
         final PathAddress running = address.subAddress(0, 1).append(PathElement.pathElement(RUNNING_SERVER, address.getLastElement().getValue()));
 
         //Add the running server
@@ -104,11 +101,6 @@ public class ServerAddHandler extends AbstractAddStepHandler {
         }, OperationContext.Stage.MODEL, true);
 
         DomainModelReferenceValidator.addValidationStep(context, operation);
-    }
-
-    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
-        //This will never get called. It is just needed to override the abstract method and is handled by the other populateModel() method
-        throw new IllegalArgumentException();
     }
 
     protected boolean requiresRuntime(OperationContext context) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRemoveHandler.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProxyController;
 import org.jboss.as.host.controller.logging.HostControllerLogger;
+import org.jboss.as.host.controller.resources.ServerConfigResourceDefinition;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -54,6 +55,7 @@ public class ServerRemoveHandler extends AbstractRemoveStepHandler {
      * Create the InterfaceRemoveHandler
      */
     private ServerRemoveHandler() {
+        super(ServerConfigResourceDefinition.SERVER_CONFIG_CAPABILITY);
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
@@ -38,6 +38,7 @@ import org.jboss.as.controller.ReadResourceNameOperationStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.helpers.domain.ServerStatus;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.EnumValidator;
@@ -49,6 +50,8 @@ import org.jboss.as.controller.resource.InterfaceDefinition;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
+import org.jboss.as.domain.controller.operations.SocketBindingGroupResourceDefinition;
+import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
 import org.jboss.as.host.controller.ServerInventory;
 import org.jboss.as.host.controller.descriptions.HostResolver;
 import org.jboss.as.host.controller.model.jvm.JvmResourceDefinition;
@@ -77,6 +80,10 @@ import org.jboss.dmr.ModelType;
  */
 public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
 
+    static final String SERVER_CONFIG_CAPABILITY_NAME = "org.wildfly.domain.server-config";
+    public static final RuntimeCapability SERVER_CONFIG_CAPABILITY = RuntimeCapability.Builder.of(SERVER_CONFIG_CAPABILITY_NAME, true)
+            .build();
+
     public static final AttributeDefinition NAME = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.NAME, ModelType.STRING).setResourceOnly().build();
 
     public static final SimpleAttributeDefinition AUTO_START = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.AUTO_START, ModelType.BOOLEAN, true)
@@ -88,6 +95,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
             .setDefaultValue(new ModelNode(false)).build();
 
     public static final SimpleAttributeDefinition SOCKET_BINDING_GROUP = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SOCKET_BINDING_GROUP, ModelType.STRING, true)
+            .setCapabilityReference(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY_NAME, SERVER_CONFIG_CAPABILITY_NAME, true)
             .build();
 
     public static final SimpleAttributeDefinition SOCKET_BINDING_DEFAULT_INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE, ModelType.STRING, true)
@@ -104,6 +112,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     public static final SimpleAttributeDefinition GROUP = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.GROUP, ModelType.STRING)
+            .setCapabilityReference(ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY_NAME, SERVER_CONFIG_CAPABILITY_NAME, true)
             .build();
 
     public static final SimpleAttributeDefinition STATUS = SimpleAttributeDefinitionBuilder.create(ServerStatusHandler.ATTRIBUTE_NAME, ModelType.STRING)
@@ -197,6 +206,11 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(SystemPropertyResourceDefinition.createForDomainOrHost(Location.SERVER_CONFIG));
         // Server jvm
         resourceRegistration.registerSubModel(JvmResourceDefinition.SERVER);
+    }
+
+    @Override
+    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerCapability(SERVER_CONFIG_CAPABILITY);
     }
 
     public static void registerServerLifecycleOperations(final ManagementResourceRegistration resourceRegistration, final ServerInventory serverInventory) {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ProfileIncludesHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ProfileIncludesHandlerTestCase.java
@@ -94,15 +94,16 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
         operationContext.executeNextStep();
     }
 
-    @Test(expected=OperationFailedException.class)
-    public void testBadProfileIncludesWrite() throws Exception {
-        PathAddress addr = getProfileAddress("profile-one");
-        ModelNode list = new ModelNode().add("bad-profile");
-        ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
-        MockOperationContext operationContext = getOperationContext(addr);
-        ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
-        operationContext.executeNextStep();
-    }
+//    // WFCORE-833 Replaced with test in core-model-test ProfileTestCase
+//    @Test(expected=OperationFailedException.class)
+//    public void testBadProfileIncludesWrite() throws Exception {
+//        PathAddress addr = getProfileAddress("profile-one");
+//        ModelNode list = new ModelNode().add("bad-profile");
+//        ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
+//        MockOperationContext operationContext = getOperationContext(addr);
+//        ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+//        operationContext.executeNextStep();
+//    }
 
     @Test(expected=OperationFailedException.class)
     public void testCyclicProfileIncludesWrite() throws Exception {
@@ -120,17 +121,19 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
         ModelNode op = Util.createRemoveOperation(addr);
         MockOperationContext operationContext = getOperationContextWithIncludes(addr);
         ProfileRemoveHandler.INSTANCE.execute(operationContext, op);
-        operationContext.executeNextStep();
+        // WFCORE-833 no next validation step any more
+        //operationContext.executeNextStep();
     }
 
-    @Test(expected=OperationFailedException.class)
-    public void testBadProfileIncludesRemove() throws Exception {
-        PathAddress addr = getProfileAddress("profile-three");
-        ModelNode op = Util.createRemoveOperation(addr);
-        MockOperationContext operationContext = getOperationContextWithIncludes(addr);
-        ProfileRemoveHandler.INSTANCE.execute(operationContext, op);
-        operationContext.executeNextStep();
-    }
+//    // WFCORE-833 Replaced with test in core-model-test ProfileTestCase
+//    @Test(expected=OperationFailedException.class)
+//    public void testBadProfileIncludesRemove() throws Exception {
+//        PathAddress addr = getProfileAddress("profile-three");
+//        ModelNode op = Util.createRemoveOperation(addr);
+//        MockOperationContext operationContext = getOperationContextWithIncludes(addr);
+//        ProfileRemoveHandler.INSTANCE.execute(operationContext, op);
+//        operationContext.executeNextStep();
+//    }
 
     @Test
     public void testIncludesWithNoOverriddenSubsystems() throws Exception {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReloadRequiredServerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReloadRequiredServerTestCase.java
@@ -131,49 +131,55 @@ public class ReloadRequiredServerTestCase extends AbstractOperationTestCase {
         checkServerOperationResolver(operationContext, operation, pa, false);
     }
 
-    @Test(expected=OperationFailedException.class)
-    public void testChangeServerGroupInvalidProfileMaster() throws Exception {
-        testChangeServerGroupInvalidProfile(true);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testChangeServerGroupInvalidProfileSlave() throws Exception {
-        testChangeServerGroupInvalidProfile(false);
-    }
+//    // WFCORE-833 moved to DomainServerGroupTestCase.testChangeServerGroupInvalidProfile
+//    @Test(expected=OperationFailedException.class)
+//    public void testChangeServerGroupInvalidProfileMaster() throws Exception {
+//        testChangeServerGroupInvalidProfile(true);
+//    }
+//
+//    // WFCORE-833 moved to DomainServerGroupTestCase.testChangeServerGroupInvalidProfile
+//    @Test(expected=OperationFailedException.class)
+//    public void testChangeServerGroupInvalidProfileSlave() throws Exception {
+//        testChangeServerGroupInvalidProfile(false);
+//    }
 
     @Override
     AbstractOperationTestCase.MockOperationContext getOperationContext() {
         return super.getOperationContext();
     }
 
-    private void testChangeServerGroupInvalidProfile(boolean master) throws Exception {
-        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(SERVER_GROUP, "group-one"));
-        final MockOperationContext operationContext = getOperationContext(false, pa);
-
-        final ModelNode operation = new ModelNode();
-        operation.get(OP_ADDR).set(pa.toModelNode());
-        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
-        operation.get(NAME).set(PROFILE);
-        operation.get(VALUE).set("does-not-exist");
-
-        try {
-            operationContext.executeStep(ServerGroupResourceDefinition.createReferenceValidationHandler(), operation);
-        } catch (RuntimeException e) {
-            final Throwable t = e.getCause();
-            if (t instanceof OperationFailedException) {
-                throw (OperationFailedException) t;
-            }
-            throw e;
-        }
-
-        operationContext.verify();
-
-        if (!master) {
-            Assert.assertNull(operationContext.getAttachment(ServerOperationResolver.DONT_PROPAGATE_TO_SERVERS_ATTACHMENT));
-        } else {
-            Assert.fail();
-        }
-    }
+//    // WFCORE-833 moved to DomainServerGroupTestCase.testChangeServerGroupInvalidProfile
+//    private void testChangeServerGroupInvalidProfile(boolean master) throws Exception {
+//        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(SERVER_GROUP, "group-one"));
+//        final MockOperationContext operationContext = getOperationContext(false, pa);
+//
+//        final ModelNode operation = new ModelNode();
+//        operation.get(OP_ADDR).set(pa.toModelNode());
+//        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+//        operation.get(NAME).set(PROFILE);
+//        operation.get(VALUE).set("does-not-exist");
+//
+//        try {
+//            operationContext.executeStep(ServerGroupResourceDefinition.createReferenceValidationHandler(), operation);
+//        } catch (RuntimeException e) {
+//            final Throwable t = e.getCause();
+//            if (t instanceof OperationFailedException) {
+//                throw (OperationFailedException) t;
+//            }
+//            throw e;
+//        }
+//
+//        // WFCORE-833 the rest of this would never have executed because the above would have always thrown the OFE
+//        // when the validation handler ran. So really the above test was just a test of the validation and can
+//        // be replaced with stuff in core-model-test. It also means the 'master' param was meaningless
+//        operationContext.verify();
+//
+//        if (!master) {
+//            Assert.assertNull(operationContext.getAttachment(ServerOperationResolver.DONT_PROPAGATE_TO_SERVERS_ATTACHMENT));
+//        } else {
+//            Assert.fail();
+//        }
+//    }
 
     @Test
     public void testChangeServerConfigGroupMaster() throws Exception {
@@ -227,44 +233,47 @@ public class ReloadRequiredServerTestCase extends AbstractOperationTestCase {
         checkServerOperationResolver(operationContext, operation, pa, false);
     }
 
-    @Test(expected=OperationFailedException.class)
-    public void testChangeServerConfigGroupBadGroupMaster() throws Exception {
-        testChangeServerConfigGroupBadGroup(true);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidServerGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testChangeServerConfigGroupBadGroupMaster() throws Exception {
+//        testChangeServerConfigGroupBadGroup(true);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testChangeServerConfigGroupBadGroupSlave() throws Exception {
-        testChangeServerConfigGroupBadGroup(false);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidServerGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testChangeServerConfigGroupBadGroupSlave() throws Exception {
+//        testChangeServerConfigGroupBadGroup(false);
+//    }
 
-    private void testChangeServerConfigGroupBadGroup(boolean master) throws Exception {
-        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER_CONFIG, "server-one"));
-        final MockOperationContext operationContext = getOperationContext(false, pa);
-
-        final ModelNode operation = new ModelNode();
-        operation.get(OP_ADDR).set(pa.toModelNode());
-        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
-        operation.get(NAME).set(GROUP);
-        operation.get(VALUE).set("bad-group");
-
-        try {
-            operationContext.executeStep(ServerRestartRequiredServerConfigWriteAttributeHandler.INSTANCE, operation);
-        } catch (RuntimeException e) {
-            final Throwable t = e.getCause();
-            if (t instanceof OperationFailedException) {
-                throw (OperationFailedException) t;
-            }
-            throw e;
-        }
-
-        operationContext.verify();
-
-        if (!master) {
-            Assert.assertNull(operationContext.getAttachment(ServerOperationResolver.DONT_PROPAGATE_TO_SERVERS_ATTACHMENT));
-        } else {
-            Assert.fail();
-        }
-    }
+//  // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidServerGroup()
+//    private void testChangeServerConfigGroupBadGroup(boolean master) throws Exception {
+//        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER_CONFIG, "server-one"));
+//        final MockOperationContext operationContext = getOperationContext(false, pa);
+//
+//        final ModelNode operation = new ModelNode();
+//        operation.get(OP_ADDR).set(pa.toModelNode());
+//        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+//        operation.get(NAME).set(GROUP);
+//        operation.get(VALUE).set("bad-group");
+//
+//        try {
+//            operationContext.executeStep(ServerRestartRequiredServerConfigWriteAttributeHandler.INSTANCE, operation);
+//        } catch (RuntimeException e) {
+//            final Throwable t = e.getCause();
+//            if (t instanceof OperationFailedException) {
+//                throw (OperationFailedException) t;
+//            }
+//            throw e;
+//        }
+//
+//        operationContext.verify();
+//
+//        if (!master) {
+//            Assert.assertNull(operationContext.getAttachment(ServerOperationResolver.DONT_PROPAGATE_TO_SERVERS_ATTACHMENT));
+//        } else {
+//            Assert.fail();
+//        }
+//    }
 
     @Test
     public void testChangeServerConfigSocketBindingGroupMaster() throws Exception {
@@ -318,44 +327,50 @@ public class ReloadRequiredServerTestCase extends AbstractOperationTestCase {
 
     }
 
-    @Test(expected=OperationFailedException.class)
-    public void testChangeServerConfigSocketBindingGroupBadGroupMaster() throws Exception {
-        testChangeServerConfigSocketBindingGroupBadGroup(true);
-    }
+//    // WFCORE-833 moved to DomainServerGroupTestCase.testChangeServerGroupInvalidSocketBindingGroup
+//    @Test(expected=OperationFailedException.class)
+//    public void testChangeServerConfigSocketBindingGroupBadGroupMaster() throws Exception {
+//        testChangeServerConfigSocketBindingGroupBadGroup(true);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testChangeServerConfigSocketBindingGroupBadGroupSlave() throws Exception {
-        testChangeServerConfigSocketBindingGroupBadGroup(false);
-    }
+//    // WFCORE-833 moved to DomainServerGroupTestCase.testChangeServerGroupInvalidSocketBindingGroup
+//    @Test(expected=OperationFailedException.class)
+//    public void testChangeServerConfigSocketBindingGroupBadGroupSlave() throws Exception {
+//        testChangeServerConfigSocketBindingGroupBadGroup(false);
+//    }
 
-    private void testChangeServerConfigSocketBindingGroupBadGroup(boolean master) throws Exception {
-        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER_CONFIG, "server-one"));
-        final MockOperationContext operationContext = getOperationContext(false, pa);
-
-        final ModelNode operation = new ModelNode();
-        operation.get(OP_ADDR).set(pa.toModelNode());
-        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
-        operation.get(NAME).set(SOCKET_BINDING_GROUP);
-        operation.get(VALUE).set("bad-group");
-
-        try {
-            operationContext.executeStep(ServerRestartRequiredServerConfigWriteAttributeHandler.INSTANCE, operation);
-        } catch (RuntimeException e) {
-            final Throwable t = e.getCause();
-            if (t instanceof OperationFailedException) {
-                throw (OperationFailedException) t;
-            }
-            throw e;
-        }
-
-        operationContext.verify();
-
-        if (!master) {
-            Assert.assertNull(operationContext.getAttachment(ServerOperationResolver.DONT_PROPAGATE_TO_SERVERS_ATTACHMENT));
-        } else {
-            Assert.fail();
-        }
-    }
+//    // WFCORE-833 moved to DomainServerGroupTestCase.testChangeServerGroupInvalidSocketBindingGroup
+//    private void testChangeServerConfigSocketBindingGroupBadGroup(boolean master) throws Exception {
+//        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER_CONFIG, "server-one"));
+//        final MockOperationContext operationContext = getOperationContext(false, pa);
+//
+//        final ModelNode operation = new ModelNode();
+//        operation.get(OP_ADDR).set(pa.toModelNode());
+//        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+//        operation.get(NAME).set(SOCKET_BINDING_GROUP);
+//        operation.get(VALUE).set("bad-group");
+//
+//        try {
+//            operationContext.executeStep(ServerRestartRequiredServerConfigWriteAttributeHandler.INSTANCE, operation);
+//        } catch (RuntimeException e) {
+//            final Throwable t = e.getCause();
+//            if (t instanceof OperationFailedException) {
+//                throw (OperationFailedException) t;
+//            }
+//            throw e;
+//        }
+//
+//        // WFCORE-833 the rest of this would never have executed because the above would have always thrown the OFE
+//        // when the validation handler ran. So really the above test was just a test of the validation and can
+//        // be replaced with stuff in core-model-test. It also means the 'master' param was meaningless
+//        operationContext.verify();
+//
+//        if (!master) {
+//            Assert.assertNull(operationContext.getAttachment(ServerOperationResolver.DONT_PROPAGATE_TO_SERVERS_ATTACHMENT));
+//        } else {
+//            Assert.fail();
+//        }
+//    }
 
     @Test
     public void testChangeServerConfigSocketBindingPortOffset() throws Exception {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -140,48 +140,55 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         testAddServerConfigBadInfo(master, rollback, false, SocketBindingGroupOverrideType.NONE);
     }
 
+//    // WFCORE-833 moved to ServerConfigTestCase.testAddServerConfigBadServerGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerConfigBadServerGroupeMaster() throws Exception {
+//        testAddServerConfigBadInfo(true, false, true, SocketBindingGroupOverrideType.GOOD);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerConfigBadServerGroupeMaster() throws Exception {
-        testAddServerConfigBadInfo(true, false, true, SocketBindingGroupOverrideType.GOOD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testAddServerConfigBadServerGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerConfigBadServerGroupSlave() throws Exception {
+//        testAddServerConfigBadInfo(false, false, true, SocketBindingGroupOverrideType.GOOD);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerConfigBadServerGroupSlave() throws Exception {
-        testAddServerConfigBadInfo(false, false, true, SocketBindingGroupOverrideType.GOOD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testAddServerConfigBadServerGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerConfigBadServerGroupMasterRollback() throws Exception {
+//        //This won't actually get to the rollback part
+//        testAddServerConfigBadInfo(true, true, true, SocketBindingGroupOverrideType.GOOD);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerConfigBadServerGroupMasterRollback() throws Exception {
-        //This won't actually get to the rollback part
-        testAddServerConfigBadInfo(true, true, true, SocketBindingGroupOverrideType.GOOD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testAddServerConfigBadServerGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerConfigBadServerGroupSlaveRollback() throws Exception {
+//        testAddServerConfigBadInfo(false, true, true, SocketBindingGroupOverrideType.GOOD);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerConfigBadServerGroupSlaveRollback() throws Exception {
-        testAddServerConfigBadInfo(false, true, true, SocketBindingGroupOverrideType.GOOD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testAddServerConfigBadSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerConfigBadSocketBindingGroupOverrideMaster() throws Exception {
+//        testAddServerConfigBadInfo(true, false, false, SocketBindingGroupOverrideType.BAD);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerConfigBadSocketBindingGroupOverrideMaster() throws Exception {
-        testAddServerConfigBadInfo(true, false, false, SocketBindingGroupOverrideType.BAD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testAddServerConfigBadSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerConfigBadSocketBindingGroupOverrideSlave() throws Exception {
+//        testAddServerConfigBadInfo(false, false, false, SocketBindingGroupOverrideType.BAD);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerConfigBadSocketBindingGroupOverrideSlave() throws Exception {
-        testAddServerConfigBadInfo(false, false, false, SocketBindingGroupOverrideType.BAD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testAddServerConfigBadSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerConfigBadSocketBindingGroupOverrideMasterRollback() throws Exception {
+//        //This won't actually get to the rollback part
+//        testAddServerConfigBadInfo(true, true, false, SocketBindingGroupOverrideType.BAD);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerConfigBadSocketBindingGroupOverrideMasterRollback() throws Exception {
-        //This won't actually get to the rollback part
-        testAddServerConfigBadInfo(true, true, false, SocketBindingGroupOverrideType.BAD);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerConfigBadSocketBindingGroupOverrideSlaveRollback() throws Exception {
-        testAddServerConfigBadInfo(false, true, false, SocketBindingGroupOverrideType.BAD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testAddServerConfigBadSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerConfigBadSocketBindingGroupOverrideSlaveRollback() throws Exception {
+//        testAddServerConfigBadInfo(false, true, false, SocketBindingGroupOverrideType.BAD);
+//    }
 
     private void testAddServerConfigBadInfo(boolean master, boolean rollback, boolean badServerGroup, SocketBindingGroupOverrideType socketBindingGroupOverride) throws Exception {
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER_CONFIG, "server-four"));
@@ -279,25 +286,29 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
     }
 
 
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerConfigBadServerGroupMaster() throws Exception {
-        testUpdateServerConfigServerGroup(true, false, true);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidServerGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerConfigBadServerGroupMaster() throws Exception {
+//        testUpdateServerConfigServerGroup(true, false, true);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerConfigBadServerGroupSlave() throws Exception {
-        testUpdateServerConfigServerGroup(false, false, true);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidServerGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerConfigBadServerGroupSlave() throws Exception {
+//        testUpdateServerConfigServerGroup(false, false, true);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerConfigBadServerGroupMasterRollback() throws Exception {
-        testUpdateServerConfigServerGroup(true, true, true);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidServerGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerConfigBadServerGroupMasterRollback() throws Exception {
+//        testUpdateServerConfigServerGroup(true, true, true);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerConfigBadServerGroupSlaveRollback() throws Exception {
-        testUpdateServerConfigServerGroup(false, true, true);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidServerGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerConfigBadServerGroupSlaveRollback() throws Exception {
+//        testUpdateServerConfigServerGroup(false, true, true);
+//    }
 
     private void testUpdateServerConfigServerGroup(boolean master, boolean rollback, boolean badGroup) throws Exception {
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER_CONFIG, "server-one"));
@@ -352,25 +363,29 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
     }
 
 
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerConfigBadSocketBindingGroupMaster() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(true, false, SocketBindingGroupOverrideType.BAD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerConfigBadSocketBindingGroupMaster() throws Exception {
+//        testUpdateServerConfigSocketBindingGroup(true, false, SocketBindingGroupOverrideType.BAD);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerConfigBadSocketBindingGroupSlave() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(false, false, SocketBindingGroupOverrideType.BAD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerConfigBadSocketBindingGroupSlave() throws Exception {
+//        testUpdateServerConfigSocketBindingGroup(false, false, SocketBindingGroupOverrideType.BAD);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerConfigBadSocketBindingGroupMasterRollback() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(true, true, SocketBindingGroupOverrideType.BAD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerConfigBadSocketBindingGroupMasterRollback() throws Exception {
+//        testUpdateServerConfigSocketBindingGroup(true, true, SocketBindingGroupOverrideType.BAD);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerConfigBadSocketBindingGroupSlaveRollback() throws Exception {
-        testUpdateServerConfigSocketBindingGroup(false, true, SocketBindingGroupOverrideType.BAD);
-    }
+//    // WFCORE-833 moved to ServerConfigTestCase.testChangeServerGroupInvalidSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerConfigBadSocketBindingGroupSlaveRollback() throws Exception {
+//        testUpdateServerConfigSocketBindingGroup(false, true, SocketBindingGroupOverrideType.BAD);
+//    }
 
     @Test
     public void testUpdateServerConfigNoSocketBindingGroupMaster() throws Exception {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
@@ -73,47 +73,55 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         testAddServerGroupBadInfo(master, rollback, false, false);
     }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerGroupBadProfileMaster() throws Exception {
-        testAddServerGroupBadInfo(true, false, true, false);
-    }
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testAddServerGroupBadProfile()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerGroupBadProfileMaster() throws Exception {
+//        testAddServerGroupBadInfo(true, false, true, false);
+//    }
+//
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testAddServerGroupBadProfile()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerGroupBadProfileSlave() throws Exception {
+//        testAddServerGroupBadInfo(false, false, true, false);
+//    }
+//
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testAddServerGroupBadProfile()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerGroupBadProfileMasterRollback() throws Exception {
+//        //This won't actually get to the rollback part
+//        testAddServerGroupBadInfo(true, true, true, false);
+//    }
+//
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testAddServerGroupBadProfile()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerGroupBadProfileSlaveRollback() throws Exception {
+//        testAddServerGroupBadInfo(false, true, true, false);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerGroupBadProfileSlave() throws Exception {
-        testAddServerGroupBadInfo(false, false, true, false);
-    }
+      // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testAddServerGroupBadSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerGroupBadSocketBindingGroupMaster() throws Exception {
+//        testAddServerGroupBadInfo(true, false, false, true);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerGroupBadProfileMasterRollback() throws Exception {
-        //This won't actually get to the rollback part
-        testAddServerGroupBadInfo(true, true, true, false);
-    }
+    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testAddServerGroupBadSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerGroupBadSocketBindingGroupSlave() throws Exception {
+//        testAddServerGroupBadInfo(false, false, false, true);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerGroupBadProfileSlaveRollback() throws Exception {
-        testAddServerGroupBadInfo(false, true, true, false);
-    }
+    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testAddServerGroupBadSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerGroupBadSocketBindingGroupMasterRollback() throws Exception {
+//        //This won't actually get to the rollback part
+//        testAddServerGroupBadInfo(true, true, false, true);
+//    }
 
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerGroupBadSocketBindingGroupMaster() throws Exception {
-        testAddServerGroupBadInfo(true, false, false, true);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerGroupBadSocketBindingGroupSlave() throws Exception {
-        testAddServerGroupBadInfo(false, false, false, true);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerGroupBadSocketBindingGroupMasterRollback() throws Exception {
-        //This won't actually get to the rollback part
-        testAddServerGroupBadInfo(true, true, false, true);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testAddServerGroupBadSocketBindingGroupSlaveRollback() throws Exception {
-        testAddServerGroupBadInfo(false, true, false, true);
-    }
+    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testAddServerGroupBadSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testAddServerGroupBadSocketBindingGroupSlaveRollback() throws Exception {
+//        testAddServerGroupBadInfo(false, true, false, true);
+//    }
 
     private void testAddServerGroupBadInfo(boolean master, boolean rollback, boolean badProfile, boolean badSocketBindingGroup) throws Exception {
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(SERVER_GROUP, "group-three"));
@@ -203,25 +211,29 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         testUpdateServerGroupProfile(false, true, false);
     }
 
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerGroupBadProfileMaster() throws Exception {
-        testUpdateServerGroupProfile(true, false, true);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerGroupBadProfileSlave() throws Exception {
-        testUpdateServerGroupProfile(false, false, true);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerGroupBadProfileMasterRollback() throws Exception {
-        testUpdateServerGroupProfile(true, true, true);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerGroupBadProfileSlaveRollback() throws Exception {
-        testUpdateServerGroupProfile(false, true, true);
-    }
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testChangeServerGroupInvalidProfile()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerGroupBadProfileMaster() throws Exception {
+//        testUpdateServerGroupProfile(true, false, true);
+//    }
+//
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testChangeServerGroupInvalidProfile()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerGroupBadProfileSlave() throws Exception {
+//        testUpdateServerGroupProfile(false, false, true);
+//    }
+//
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testChangeServerGroupInvalidProfile()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerGroupBadProfileMasterRollback() throws Exception {
+//        testUpdateServerGroupProfile(true, true, true);
+//    }
+//
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testChangeServerGroupInvalidProfile()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerGroupBadProfileSlaveRollback() throws Exception {
+//        testUpdateServerGroupProfile(false, true, true);
+//    }
 
     private void testUpdateServerGroupProfile(boolean master, boolean rollback, boolean badProfile) throws Exception {
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(SERVER_GROUP, "group-one"));
@@ -277,26 +289,29 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         testUpdateServerGroupSocketBindingGroup(false, true, false);
     }
 
-
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerGroupBadSocketBindingGroupMaster() throws Exception {
-        testUpdateServerGroupSocketBindingGroup(true, false, true);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerGroupBadSocketBindingGroupSlave() throws Exception {
-        testUpdateServerGroupSocketBindingGroup(false, false, true);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerGroupBadSocketBindingGroupMasterRollback() throws Exception {
-        testUpdateServerGroupSocketBindingGroup(true, true, true);
-    }
-
-    @Test(expected=OperationFailedException.class)
-    public void testUpdateServerGroupBadSocketBindingGroupSlaveRollback() throws Exception {
-        testUpdateServerGroupSocketBindingGroup(false, true, true);
-    }
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testChangeServerGroupInvalidSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerGroupBadSocketBindingGroupMaster() throws Exception {
+//        testUpdateServerGroupSocketBindingGroup(true, false, true);
+//    }
+//
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testChangeServerGroupInvalidSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerGroupBadSocketBindingGroupSlave() throws Exception {
+//        testUpdateServerGroupSocketBindingGroup(false, false, true);
+//    }
+//
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testChangeServerGroupInvalidSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerGroupBadSocketBindingGroupMasterRollback() throws Exception {
+//        testUpdateServerGroupSocketBindingGroup(true, true, true);
+//    }
+//
+//    // WFCORE-833 replaced by core-model-test DomainServerGroupTestCase.testChangeServerGroupInvalidSocketBindingGroup()
+//    @Test(expected=OperationFailedException.class)
+//    public void testUpdateServerGroupBadSocketBindingGroupSlaveRollback() throws Exception {
+//        testUpdateServerGroupSocketBindingGroup(false, true, true);
+//    }
 
     private void testUpdateServerGroupSocketBindingGroup(boolean master, boolean rollback, boolean badSocketBindingGroup) throws Exception {
 

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SocketBindingGroupIncludesHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SocketBindingGroupIncludesHandlerTestCase.java
@@ -79,16 +79,17 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
     }
 
 
-    @Test(expected=OperationFailedException.class)
-    public void testBadSocketBindingGroupIncludesAdd() throws Exception {
-        PathAddress addr = getSocketBindingGroupAddress("test");
-        ModelNode op = Util.createAddOperation(addr);
-        op.get(DEFAULT_INTERFACE).set("public");
-        op.get(INCLUDES).add("binding-one").add("NOT_THERE");
-        MockOperationContext operationContext = getOperationContext(addr);
-        SocketBindingGroupAddHandler.INSTANCE.execute(operationContext, op);
-        operationContext.executeNextStep();
-    }
+//    // WFCORE-833 replaced by DomainSocketBindingGroupTestCase.testBadSocketBindingGroupIncludesAdd()
+//    @Test(expected=OperationFailedException.class)
+//    public void testBadSocketBindingGroupIncludesAdd() throws Exception {
+//        PathAddress addr = getSocketBindingGroupAddress("test");
+//        ModelNode op = Util.createAddOperation(addr);
+//        op.get(DEFAULT_INTERFACE).set("public");
+//        op.get(INCLUDES).add("binding-one").add("NOT_THERE");
+//        MockOperationContext operationContext = getOperationContext(addr);
+//        SocketBindingGroupAddHandler.INSTANCE.execute(operationContext, op);
+//        operationContext.executeNextStep();
+//    }
 
     @Test
     public void testGoodSocketBindingGroupIncludesWrite() throws Exception {
@@ -100,15 +101,16 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
         operationContext.executeNextStep();
     }
 
-    @Test(expected=OperationFailedException.class)
-    public void testBadSocketBindingGroupIncludesWrite() throws Exception {
-        PathAddress addr = getSocketBindingGroupAddress("binding-one");
-        ModelNode list = new ModelNode().add("bad-SocketBindingGroup");
-        ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
-        MockOperationContext operationContext = getOperationContext(addr);
-        SocketBindingGroupResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
-        operationContext.executeNextStep();
-    }
+//    // WFCORE-833 replaced by DomainSocketBindingGroupTestCase.testBadSocketBindingGroupIncludesWrite()
+//    @Test(expected=OperationFailedException.class)
+//    public void testBadSocketBindingGroupIncludesWrite() throws Exception {
+//        PathAddress addr = getSocketBindingGroupAddress("binding-one");
+//        ModelNode list = new ModelNode().add("bad-SocketBindingGroup");
+//        ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
+//        MockOperationContext operationContext = getOperationContext(addr);
+//        SocketBindingGroupResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+//        operationContext.executeNextStep();
+//    }
 
     @Test(expected=OperationFailedException.class)
     public void testCyclicSocketBindingGroupIncludesWrite() throws Exception {
@@ -126,17 +128,19 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
         ModelNode op = Util.createRemoveOperation(addr);
         MockOperationContext operationContext = getOperationContextWithIncludes(addr);
         DomainSocketBindingGroupRemoveHandler.INSTANCE.execute(operationContext, op);
-        operationContext.executeNextStep();
+        // WFCORE-833 no next validation step any more
+        //operationContext.executeNextStep();
     }
 
-    @Test(expected=OperationFailedException.class)
-    public void testBadSocketBindingGroupIncludesRemove() throws Exception {
-        PathAddress addr = getSocketBindingGroupAddress("binding-three");
-        ModelNode op = Util.createRemoveOperation(addr);
-        MockOperationContext operationContext = getOperationContextWithIncludes(addr);
-        DomainSocketBindingGroupRemoveHandler.INSTANCE.execute(operationContext, op);
-        operationContext.executeNextStep();
-    }
+//    // WFCORE-833 replaced by DomainSocketBindingGroupTestCase.testBadSocketBindingGroupIncludesRemove()
+//    @Test(expected=OperationFailedException.class)
+//    public void testBadSocketBindingGroupIncludesRemove() throws Exception {
+//        PathAddress addr = getSocketBindingGroupAddress("binding-three");
+//        ModelNode op = Util.createRemoveOperation(addr);
+//        MockOperationContext operationContext = getOperationContextWithIncludes(addr);
+//        DomainSocketBindingGroupRemoveHandler.INSTANCE.execute(operationContext, op);
+//        operationContext.executeNextStep();
+//    }
 
     @Test
     public void testIncludesWithNoOverriddenSubsystems() throws Exception {

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-1way.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-1way.xml
@@ -96,6 +96,10 @@
             <ignored-resources type="socket-binding-group">
                 <instance name="ignored"/>
             </ignored-resources>
+            <ignored-resources type="server-group">
+                <instance name="ignored-profile"/>
+                <instance name="ignored-sockets"/>
+            </ignored-resources>
             <ignored-resources type="foo" wildcard="true">
                 <instance name="ignored"/>
             </ignored-resources>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-2way.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-2way.xml
@@ -98,6 +98,10 @@
             <ignored-resources type="socket-binding-group">
                 <instance name="ignored"/>
             </ignored-resources>
+            <ignored-resources type="server-group">
+                <instance name="ignored-profile"/>
+                <instance name="ignored-sockets"/>
+            </ignored-resources>
             <ignored-resources type="foo" wildcard="true">
                 <instance name="ignored"/>
             </ignored-resources>

--- a/testsuite/patching/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/patching/src/test/resources/host-configs/host-slave.xml
@@ -91,6 +91,10 @@
             <ignored-resources type="foo" wildcard="true">
                 <instance name="ignored"/>
             </ignored-resources>
+            <ignored-resources type="server-group">
+                <instance name="ignored-sockets"/>
+                <instance name="ignored-profile"/>
+            </ignored-resources>
         </remote>
     </domain-controller>
 


### PR DESCRIPTION
…, socket-binding-groups, server-groups and server-configs

Involves changes to AbstractControllerService/ModelControllerImpl/OperationContextImpl to allow partial deferral of capability resolution to account for the fact that during HostController boot the entire set of configured capabilities is not known until the last of several operation executions is complete (i.e. domain.xml content is not known when host.xml content is installed.)

Also includes a fair bit of test fixture tweaks related to supporting capability resolution testing in core-model-test.

This PR includes a fair amount of commented out logic in DomainModelReferenceValidator and in some unit tests of OSHs in the host-controller module. My intent in doing that was to perhaps make it easier for @kabir to see what I was doing here. Once he's had a chance to have a look I can remove the commented code, either in a change to this PR or another one. The unit test changes are because the handlers being directly tested no longer do reference validation. The validation is part of capability resolution. Equivalent testing is now done in core-model-test.