### PR TITLE
WFCORE-879 Allow AbstractLegacyExtension to boot in ADMIN_ONLY mode i…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -1242,8 +1242,8 @@ class ModelControllerImpl implements ModelController {
          * @return a map whose keys are missing capabilities and whose values are the names of other capabilities
          *         that require that capability. Will not return {@code null} but may be empty
          */
-        CapabilityValidation validateCapabilityRegistry() {
-            if (!published) {
+        CapabilityValidation validateCapabilityRegistry(boolean forceCheck) {
+            if (!published || forceCheck) {
                 return capabilityRegistry.resolveCapabilities(getRootResource());
             } else {
                 // we're unmodified so nothing to validate

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -423,6 +423,11 @@ public class ExtensionRegistry {
         }
 
         @Override
+        public RunningMode getRunningMode() {
+            return runningModeControl.getRunningMode();
+        }
+
+        @Override
         public void setSubsystemXmlMapping(String subsystemName, String namespaceUri, XMLElementReader<List<ModelNode>> reader) {
             assert subsystemName != null : "subsystemName is null";
             assert namespaceUri != null : "namespaceUri is null";

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3346,4 +3346,9 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = 401, value = "Couldn't build the report")
     RuntimeException failedToBuildReport(@Cause Throwable t);
+
+    @Message(id = 402, value = "Subsystems %s provided by legacy extension '%s' are not supported on servers running this version. " +
+            "Both the subsystem and the extension must be removed or migrated before the server will function.")
+    @LogMessage(level = ERROR)
+    void removeUnsupportedLegacyExtension(List<String> subsystemNames, String extensionName);
 }

--- a/controller/src/main/java/org/jboss/as/controller/parsing/ExtensionParsingContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/ExtensionParsingContext.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 
 import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.RunningMode;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 
@@ -43,6 +44,12 @@ public interface ExtensionParsingContext {
      * @return the current process type. Will not be {@code null}
      */
     ProcessType getProcessType();
+
+    /**
+     * Gets the current running mode of the process.
+     * @return the current running mode. Will not be {@code null}
+     */
+    RunningMode getRunningMode();
 
     /**
      * Set the parser for the profile-wide subsystem configuration XML element.  The element is always


### PR DESCRIPTION
…n standalone servers

Also allows a server to boot in admin only mode when there are unsatisfied requirements (and will continue to allow operations to ignore them until the server is no longer in an error state).

This is necessary for EAP6 migrations, as the remoting services will have an unsatisfied requirement on the XNIO worker that is provided by the new IO subsystem (and added by the Undertow migration op)