### PR TITLE
[WFCORE-884] Add a capability for interfaces

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/common/AbstractSocketBindingGroupAddHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/AbstractSocketBindingGroupAddHandler.java
@@ -43,6 +43,7 @@ public abstract class AbstractSocketBindingGroupAddHandler extends AbstractAddSt
      * Create the AbstractSocketBindingGroupAddHandler
      */
     protected AbstractSocketBindingGroupAddHandler() {
+        super(AbstractSocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY);
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/InterfaceAddHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/InterfaceAddHandler.java
@@ -36,8 +36,9 @@ import org.jboss.dmr.ModelNode;
  */
 public class InterfaceAddHandler extends AbstractAddStepHandler {
 
-
+    @Deprecated
     public static final InterfaceAddHandler NAMED_INSTANCE = new InterfaceAddHandler(false);
+    @Deprecated
     public static final InterfaceAddHandler SPECIFIED_INSTANCE = new InterfaceAddHandler(true);
 
     private final boolean specified;

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/InterfaceRemoveHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/InterfaceRemoveHandler.java
@@ -32,6 +32,7 @@ public class InterfaceRemoveHandler extends AbstractRemoveStepHandler {
 
     public static final String OPERATION_NAME = REMOVE;
 
+    @Deprecated
     public static final InterfaceRemoveHandler INSTANCE = new InterfaceRemoveHandler();
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/SocketBindingGroupRemoveHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/SocketBindingGroupRemoveHandler.java
@@ -24,6 +24,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REM
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.resource.AbstractSocketBindingGroupResourceDefinition;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -41,6 +42,7 @@ public class SocketBindingGroupRemoveHandler extends AbstractRemoveStepHandler {
      * Create the AbstractSocketBindingRemoveHandler
      */
     protected SocketBindingGroupRemoveHandler() {
+        super(AbstractSocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY);
     }
 
     protected boolean requiresRuntime(OperationContext context) {

--- a/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingGroupResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingGroupResourceDefinition.java
@@ -35,6 +35,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.logging.ControllerLogger;
@@ -53,6 +54,10 @@ import org.jboss.dmr.ModelType;
  */
 public abstract class AbstractSocketBindingGroupResourceDefinition extends SimpleResourceDefinition {
 
+    public static final String SOCKET_BINDING_GROUP_CAPABILITY_NAME = "org.wildfly.domain.socket-binding-group";
+    public static final RuntimeCapability SOCKET_BINDING_GROUP_CAPABILITY = RuntimeCapability.Builder.of(SOCKET_BINDING_GROUP_CAPABILITY_NAME, true)
+            .build();
+
     // Common attributes
 
     public static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SOCKET_BINDING_GROUP);
@@ -62,10 +67,11 @@ public abstract class AbstractSocketBindingGroupResourceDefinition extends Simpl
             .setValidator(new StringLengthValidator(1)).build();
 
     public static final SimpleAttributeDefinition DEFAULT_INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.DEFAULT_INTERFACE, ModelType.STRING, false)
-            .setAllowExpression(true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
-            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-
-
+            .setAllowExpression(true)
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setCapabilityReference("org.wildfly.network.interface", SOCKET_BINDING_GROUP_CAPABILITY)
+            .build();
 
     private final List<AccessConstraintDefinition> accessConstraints;
 
@@ -119,4 +125,8 @@ public abstract class AbstractSocketBindingGroupResourceDefinition extends Simpl
 
     }
 
+    @Override
+    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerCapability(SOCKET_BINDING_GROUP_CAPABILITY);
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingResourceDefinition.java
@@ -49,6 +49,9 @@ import org.jboss.dmr.ModelType;
  */
 public abstract class AbstractSocketBindingResourceDefinition extends SimpleResourceDefinition {
 
+
+    public static final String SOCKET_BINDING_CAPABILITY_NAME = "org.wildfly.network.socket-binding";
+
     // Common attributes
 
     public static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SOCKET_BINDING);
@@ -58,8 +61,11 @@ public abstract class AbstractSocketBindingResourceDefinition extends SimpleReso
             .setValidator(new StringLengthValidator(1)).build();
 
     public static final SimpleAttributeDefinition INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.INTERFACE, ModelType.STRING, true)
-            .setAllowExpression(true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true))
-            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+            .setAllowExpression(true)
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true))
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setCapabilityReference("org.wildfly.network.interface", SOCKET_BINDING_CAPABILITY_NAME, true)
+            .build();
 
     public static final SimpleAttributeDefinition PORT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PORT, ModelType.INT, true)
             .setAllowExpression(true)

--- a/controller/src/main/java/org/jboss/as/controller/resource/InterfaceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/InterfaceDefinition.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.Set;
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
@@ -67,6 +68,9 @@ import org.jboss.dmr.ModelType;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public class InterfaceDefinition extends SimpleResourceDefinition {
+
+    public static final String INTERFACE_CAPABILITY_NAME = "org.wildfly.network.interface";
+
     public static final String[] OTHERS = new String[]{localName(Element.INET_ADDRESS), localName(Element.LINK_LOCAL_ADDRESS),
             localName(Element.LOOPBACK), localName(Element.LOOPBACK_ADDRESS), localName(Element.MULTICAST), localName(Element.NIC),
             localName(Element.NIC_MATCH), localName(Element.POINT_TO_POINT), localName(Element.PUBLIC_ADDRESS), localName(Element.SITE_LOCAL_ADDRESS),

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/ServerConfigInitializers.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/ServerConfigInitializers.java
@@ -34,8 +34,8 @@ import org.jboss.as.controller.capability.registry.RegistrationPoint;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.resource.AbstractSocketBindingGroupResourceDefinition;
 import org.jboss.as.core.model.test.ModelInitializer;
-import org.jboss.as.domain.controller.operations.SocketBindingGroupResourceDefinition;
 import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
 
 /**
@@ -52,7 +52,7 @@ public final class ServerConfigInitializers {
     private static final String TEST_OTHER_SERVER_GROUP_CAPABILITY = ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY.getDynamicName("other-server-group");
     private static final PathAddress TEST_OTHER_SERVER_GROUP_ADDRESS = PathAddress.pathAddress(SERVER_GROUP, "other-server-group");
 
-    private static final String TEST_FULL_HA_SOCKETS_CAPABILITY = SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY.getDynamicName("full-ha-sockets");
+    private static final String TEST_FULL_HA_SOCKETS_CAPABILITY = AbstractSocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY.getDynamicName("full-ha-sockets");
     private static final PathAddress TEST_FULL_HA_SOCKETS_ADDRESS = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "full-ha-sockets");
     private static final CapabilityContext TEST_SBG_CONTEXT = CapabilityContext.Factory.create(ProcessType.HOST_CONTROLLER, TEST_FULL_HA_SOCKETS_ADDRESS);
 

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/StandardServerGroupInitializers.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/StandardServerGroupInitializers.java
@@ -34,10 +34,10 @@ import org.jboss.as.controller.capability.registry.RegistrationPoint;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.resource.AbstractSocketBindingGroupResourceDefinition;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.ModelInitializer;
 import org.jboss.as.core.model.test.ModelWriteSanitizer;
-import org.jboss.as.domain.controller.operations.SocketBindingGroupResourceDefinition;
 import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
 import org.jboss.as.model.test.ModelFixer;
 import org.jboss.dmr.ModelNode;
@@ -52,7 +52,7 @@ public class StandardServerGroupInitializers {
     private static final PathAddress TEST_PROFILE_ADDRESS = PathAddress.pathAddress(PROFILE, "test");
     private static final CapabilityContext TEST_PROFILE_CONTEXT = CapabilityContext.Factory.create(ProcessType.HOST_CONTROLLER, TEST_PROFILE_ADDRESS);
 
-    private static final String TEST_SBG_CAPABILITY = SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY.getDynamicName("test-sockets");
+    private static final String TEST_SBG_CAPABILITY = AbstractSocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY.getDynamicName("test-sockets");
     private static final PathAddress TEST_SBG_ADDRESS = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "test-sockets");
     private static final CapabilityContext TEST_SBG_CONTEXT = CapabilityContext.Factory.create(ProcessType.HOST_CONTROLLER, TEST_SBG_ADDRESS);
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainIncludesValidationWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainIncludesValidationWriteAttributeHandler.java
@@ -30,13 +30,13 @@ import org.jboss.as.domain.controller.operations.coordination.ServerOperationRes
 import org.jboss.dmr.ModelNode;
 
 /**
- * Write attribute handler to trigger validation when something in the domain model involving references has changed
+ * Write attribute handler to trigger validation when something in the domain model involving includes has changed
  *
  * @author Kabir Khan
  */
-public class DomainReferenceValidationWriteAttributeHandler extends ModelOnlyWriteAttributeHandler {
+public class DomainIncludesValidationWriteAttributeHandler extends ModelOnlyWriteAttributeHandler {
 
-    public DomainReferenceValidationWriteAttributeHandler(AttributeDefinition... attributeDefinitions) {
+    public DomainIncludesValidationWriteAttributeHandler(AttributeDefinition... attributeDefinitions) {
         super(attributeDefinitions);
     }
 
@@ -49,7 +49,7 @@ public class DomainReferenceValidationWriteAttributeHandler extends ModelOnlyWri
             ServerOperationResolver.addToDontPropagateToServersAttachment(context, operation);
         }
 
-        DomainModelReferenceValidator.addValidationStep(context, operation);
+        DomainModelIncludesValidator.addValidationStep(context, operation);
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainSocketBindingGroupRemoveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainSocketBindingGroupRemoveHandler.java
@@ -22,6 +22,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REM
 
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.resource.AbstractSocketBindingGroupResourceDefinition;
 
 /**
  * Handler for the socket-binding-group resource's remove operation.
@@ -39,7 +40,7 @@ public class DomainSocketBindingGroupRemoveHandler extends AbstractRemoveStepHan
      * Create the DomainSocketBindingGroupRemoveHandler
      */
     private DomainSocketBindingGroupRemoveHandler() {
-        super(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY);
+        super(AbstractSocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY);
     }
 
     protected boolean requiresRuntime(OperationContext context) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ServerGroupAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ServerGroupAddHandler.java
@@ -24,11 +24,8 @@ package org.jboss.as.domain.controller.operations;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
-import org.jboss.dmr.ModelNode;
 
 /**
  * @author Emanuel Muckenhuber
@@ -39,12 +36,6 @@ public class ServerGroupAddHandler extends AbstractAddStepHandler {
 
     ServerGroupAddHandler() {
         super(ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY, ServerGroupResourceDefinition.ADD_ATTRIBUTES);
-    }
-
-    @Override
-    protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
-        DomainModelReferenceValidator.addValidationStep(context, operation);
-        super.populateModel(context, operation, resource);
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SocketBindingGroupAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SocketBindingGroupAddHandler.java
@@ -37,7 +37,6 @@ public class SocketBindingGroupAddHandler extends AbstractSocketBindingGroupAddH
     public static final SocketBindingGroupAddHandler INSTANCE = new SocketBindingGroupAddHandler();
 
     private SocketBindingGroupAddHandler() {
-        super(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY);
     }
 
     /**
@@ -47,7 +46,7 @@ public class SocketBindingGroupAddHandler extends AbstractSocketBindingGroupAddH
     protected void populateModel(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         super.populateModel(context, operation, resource);
         SocketBindingGroupResourceDefinition.INCLUDES.validateAndSet(operation, resource.getModel());
-        DomainModelReferenceValidator.addValidationStep(context, operation);
+        DomainModelIncludesValidator.addValidationStep(context, operation);
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SocketBindingGroupResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SocketBindingGroupResourceDefinition.java
@@ -29,7 +29,6 @@ import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.ListAttributeDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PrimitiveListAttributeDefinition;
-import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -44,10 +43,6 @@ import org.jboss.dmr.ModelType;
  * @author Kabir Khan
  */
 public class SocketBindingGroupResourceDefinition extends AbstractSocketBindingGroupResourceDefinition {
-
-    public static final String SOCKET_BINDING_GROUP_CAPABILITY_NAME = "org.wildfly.domain.socket-binding-group";
-    public static final RuntimeCapability SOCKET_BINDING_GROUP_CAPABILITY = RuntimeCapability.Builder.of(SOCKET_BINDING_GROUP_CAPABILITY_NAME, true)
-            .build();
 
     public static SocketBindingGroupResourceDefinition INSTANCE = new SocketBindingGroupResourceDefinition();
 
@@ -87,7 +82,7 @@ public class SocketBindingGroupResourceDefinition extends AbstractSocketBindingG
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
-        resourceRegistration.registerReadWriteAttribute(INCLUDES, null, createReferenceValidationHandler());
+        resourceRegistration.registerReadWriteAttribute(INCLUDES, null, createIncludesValidationHandler());
     }
 
     @Override
@@ -97,13 +92,8 @@ public class SocketBindingGroupResourceDefinition extends AbstractSocketBindingG
         resourceRegistration.registerSubModel(LocalDestinationOutboundSocketBindingResourceDefinition.INSTANCE);
     }
 
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(SOCKET_BINDING_GROUP_CAPABILITY);
-    }
-
-    public static OperationStepHandler createReferenceValidationHandler() {
-        return new DomainReferenceValidationWriteAttributeHandler(INCLUDES);
+    public static OperationStepHandler createIncludesValidationHandler() {
+        return new DomainIncludesValidationWriteAttributeHandler(INCLUDES);
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -54,8 +54,6 @@ import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistryType;
 import org.jboss.as.controller.extension.ExtensionResourceDefinition;
 import org.jboss.as.controller.extension.MutableRootResourceRegistrationProvider;
-import org.jboss.as.controller.operations.common.InterfaceAddHandler;
-import org.jboss.as.controller.operations.common.InterfaceRemoveHandler;
 import org.jboss.as.controller.operations.common.NamespaceAddHandler;
 import org.jboss.as.controller.operations.common.NamespaceRemoveHandler;
 import org.jboss.as.controller.operations.common.SchemaLocationAddHandler;
@@ -73,7 +71,6 @@ import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.resource.InterfaceDefinition;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.controller.transform.SubsystemDescriptionDump;
@@ -108,6 +105,9 @@ import org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition
 import org.jboss.as.server.deploymentoverlay.DeploymentOverlayDefinition;
 import org.jboss.as.server.operations.LaunchTypeHandler;
 import org.jboss.as.server.operations.ServerVersionOperations.DefaultEmptyListAttributeHandler;
+import org.jboss.as.server.services.net.InterfaceAddHandler;
+import org.jboss.as.server.services.net.InterfaceRemoveHandler;
+import org.jboss.as.server.services.net.InterfaceResourceDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -293,7 +293,7 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         super.registerChildren(resourceRegistration);
         resourceRegistration.registerSubModel(SystemPropertyResourceDefinition.createForDomainOrHost(Location.DOMAIN));
-        resourceRegistration.registerSubModel(new InterfaceDefinition(
+        resourceRegistration.registerSubModel(new InterfaceResourceDefinition(
                 InterfaceAddHandler.NAMED_INSTANCE,
                 InterfaceRemoveHandler.INSTANCE,
                 false,

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ProfileResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ProfileResourceDefinition.java
@@ -40,7 +40,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.domain.controller.operations.DomainReferenceValidationWriteAttributeHandler;
+import org.jboss.as.domain.controller.operations.DomainIncludesValidationWriteAttributeHandler;
 import org.jboss.as.domain.controller.operations.GenericModelDescribeOperationHandler;
 import org.jboss.as.domain.controller.operations.ProfileAddHandler;
 import org.jboss.as.domain.controller.operations.ProfileCloneHandler;
@@ -101,7 +101,7 @@ public class ProfileResourceDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         resourceRegistration.registerReadOnlyAttribute(NAME, ReadResourceNameOperationStepHandler.INSTANCE);
-        resourceRegistration.registerReadWriteAttribute(INCLUDES, null, createReferenceValidationHandler());
+        resourceRegistration.registerReadWriteAttribute(INCLUDES, null, createIncludesValidationHandler());
     }
 
     @Override
@@ -110,7 +110,7 @@ public class ProfileResourceDefinition extends SimpleResourceDefinition {
     }
 
 
-    public static OperationStepHandler createReferenceValidationHandler() {
-        return new DomainReferenceValidationWriteAttributeHandler(INCLUDES);
+    public static OperationStepHandler createIncludesValidationHandler() {
+        return new DomainIncludesValidationWriteAttributeHandler(INCLUDES);
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/SocketBindingResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/SocketBindingResourceDefinition.java
@@ -24,6 +24,7 @@ package org.jboss.as.domain.controller.resources;
 
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.server.services.net.SocketBindingAddHandler;
 import org.jboss.as.server.services.net.SocketBindingRemoveHandler;
 import org.jboss.as.controller.resource.AbstractSocketBindingResourceDefinition;
@@ -48,6 +49,11 @@ public class SocketBindingResourceDefinition extends AbstractSocketBindingResour
 
     private SocketBindingResourceDefinition() {
         super(SocketBindingAddHandler.INSTANCE, SocketBindingRemoveHandler.INSTANCE);
+    }
+
+    @Override
+    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerCapability(org.jboss.as.server.services.net.SocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY);
     }
 
     @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -118,7 +118,7 @@ import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.domain.controller.SlaveRegistrationException;
 import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.as.domain.controller.operations.ApplyExtensionsHandler;
-import org.jboss.as.domain.controller.operations.DomainModelReferenceValidator;
+import org.jboss.as.domain.controller.operations.DomainModelIncludesValidator;
 import org.jboss.as.domain.controller.operations.coordination.PrepareStepHandler;
 import org.jboss.as.domain.controller.resources.DomainRootDefinition;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
@@ -552,7 +552,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
                     if (addr.size() > 0 && addr.getLastElement().getKey().equals(SUBSYSTEM)) {
                         //For subsystem adds in domain mode we need to check that the new subsystem does not break the rule
                         //that when profile includes are used, we don't allow overriding subsystems.
-                        DomainModelReferenceValidator.addValidationStep(context, operation);
+                        DomainModelIncludesValidator.addValidationStep(context, operation);
                     }
                 }
             }
@@ -703,7 +703,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
                 final ModelNode result = internalExecute(OperationBuilder.create(validate).build(), OperationMessageHandler.DISCARD, OperationTransactionControl.COMMIT, new OperationStepHandler() {
                     @Override
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                        DomainModelReferenceValidator.validateAtBoot(context, operation);
+                        DomainModelIncludesValidator.validateAtBoot(context, operation);
                     }
                 }).getResponseNode();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -61,7 +61,6 @@ import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.resource.InterfaceDefinition;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.domain.controller.DomainController;
@@ -107,6 +106,7 @@ import org.jboss.as.server.operations.CleanObsoleteContentHandler;
 import org.jboss.as.server.operations.InstanceUuidReadHandler;
 import org.jboss.as.server.operations.RunningModeReadHandler;
 import org.jboss.as.server.operations.SuspendStateReadHandler;
+import org.jboss.as.server.services.net.InterfaceResourceDefinition;
 import org.jboss.as.server.services.net.SocketBindingGroupResourceDefinition;
 import org.jboss.as.server.services.net.SpecifiedInterfaceResolveHandler;
 import org.jboss.as.server.services.security.AbstractVaultReader;
@@ -423,7 +423,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
         hostRegistration.registerSubModel(PathResourceDefinition.createResolvableSpecified(pathManager));
 
         //interface
-        ManagementResourceRegistration interfaces = hostRegistration.registerSubModel(new InterfaceDefinition(
+        ManagementResourceRegistration interfaces = hostRegistration.registerSubModel(new InterfaceResourceDefinition(
                 new HostSpecifiedInterfaceAddHandler(),
                 new HostSpecifiedInterfaceRemoveHandler(),
                 true,

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerAddHandler.java
@@ -37,7 +37,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.registry.PlaceholderResource;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
-import org.jboss.as.domain.controller.operations.DomainModelReferenceValidator;
 import org.jboss.as.host.controller.ServerInventory;
 import org.jboss.as.host.controller.resources.ServerConfigResource;
 import org.jboss.as.host.controller.resources.ServerConfigResourceDefinition;
@@ -99,8 +98,6 @@ public class ServerAddHandler extends AbstractAddStepHandler {
                 context.addResource(PathAddress.EMPTY_ADDRESS, PlaceholderResource.INSTANCE);
             }
         }, OperationContext.Stage.MODEL, true);
-
-        DomainModelReferenceValidator.addValidationStep(context, operation);
     }
 
     protected boolean requiresRuntime(OperationContext context) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRestartRequiredServerConfigWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerRestartRequiredServerConfigWriteAttributeHandler.java
@@ -31,7 +31,6 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.domain.controller.operations.DomainModelReferenceValidator;
 import org.jboss.as.domain.controller.operations.coordination.ServerOperationResolver;
 import org.jboss.dmr.ModelNode;
 
@@ -57,9 +56,6 @@ public class ServerRestartRequiredServerConfigWriteAttributeHandler extends Mode
             //Set an attachment to avoid propagation to the servers, we don't want them to go into restart-required if nothing changed
             ServerOperationResolver.addToDontPropagateToServersAttachment(context, operation);
         }
-
-        // Validate the model references
-        DomainModelReferenceValidator.addValidationStep(context, operation);
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
@@ -78,6 +78,7 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
             .setAllowExpression(true)
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_CONFIG)
+            .setCapabilityReference("org.wildfly.network.interface", HTTP_MANAGEMENT_CAPABILITY)
             .build();
 
     public static final SimpleAttributeDefinition HTTP_PORT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PORT, ModelType.INT, true)
@@ -97,6 +98,7 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_CONFIG)
             .setRequires(SECURITY_REALM.getName())
+            .setCapabilityReference("org.wildfly.network.interface", HTTP_MANAGEMENT_CAPABILITY)
             .build();
 
     public static final SimpleAttributeDefinition CONSOLE_ENABLED = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.CONSOLE_ENABLED, ModelType.BOOLEAN, true)

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/NativeManagementResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/NativeManagementResourceDefinition.java
@@ -73,6 +73,7 @@ public class NativeManagementResourceDefinition extends SimpleResourceDefinition
             .setAllowExpression(true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_CONFIG)
+            .setCapabilityReference("org.wildfly.network.interface", NATIVE_MANAGEMENT_CAPABILITY)
             .build();
 
     public static final SimpleAttributeDefinition NATIVE_PORT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PORT, ModelType.INT, false)

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
@@ -46,11 +46,10 @@ import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.parsing.Attribute;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.resource.InterfaceDefinition;
+import org.jboss.as.controller.resource.AbstractSocketBindingGroupResourceDefinition;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
-import org.jboss.as.domain.controller.operations.SocketBindingGroupResourceDefinition;
 import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
 import org.jboss.as.host.controller.ServerInventory;
 import org.jboss.as.host.controller.descriptions.HostResolver;
@@ -68,6 +67,7 @@ import org.jboss.as.host.controller.operations.ServerStopHandler;
 import org.jboss.as.host.controller.operations.ServerSuspendHandler;
 import org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition;
 import org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition.Location;
+import org.jboss.as.server.services.net.InterfaceResourceDefinition;
 import org.jboss.as.server.services.net.SpecifiedInterfaceAddHandler;
 import org.jboss.as.server.services.net.SpecifiedInterfaceRemoveHandler;
 import org.jboss.dmr.ModelNode;
@@ -95,13 +95,14 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
             .setDefaultValue(new ModelNode(false)).build();
 
     public static final SimpleAttributeDefinition SOCKET_BINDING_GROUP = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SOCKET_BINDING_GROUP, ModelType.STRING, true)
-            .setCapabilityReference(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY_NAME, SERVER_CONFIG_CAPABILITY_NAME, true)
+            .setCapabilityReference(AbstractSocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY_NAME, SERVER_CONFIG_CAPABILITY_NAME, true)
             .build();
 
     public static final SimpleAttributeDefinition SOCKET_BINDING_DEFAULT_INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE, ModelType.STRING, true)
             .setAllowExpression(false)
             .setXmlName(Attribute.DEFAULT_INTERFACE.getLocalName())
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
+            .setCapabilityReference("org.wildfly.network.interface", SERVER_CONFIG_CAPABILITY)
             .build();
 
     public static final SimpleAttributeDefinition SOCKET_BINDING_PORT_OFFSET = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SOCKET_BINDING_PORT_OFFSET, ModelType.INT, true)
@@ -195,7 +196,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
         //server paths
         resourceRegistration.registerSubModel(PathResourceDefinition.createSpecifiedNoServices(pathManager));
 
-        resourceRegistration.registerSubModel(new InterfaceDefinition(
+        resourceRegistration.registerSubModel(new InterfaceResourceDefinition(
                 SpecifiedInterfaceAddHandler.INSTANCE,
                 SpecifiedInterfaceRemoveHandler.INSTANCE,
                 true,

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ProfileIncludesHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ProfileIncludesHandlerTestCase.java
@@ -90,7 +90,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
         ModelNode list = new ModelNode().add("profile-two");
         ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
         MockOperationContext operationContext = getOperationContext(addr);
-        ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+        ProfileResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
         operationContext.executeNextStep();
     }
 
@@ -101,7 +101,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
 //        ModelNode list = new ModelNode().add("bad-profile");
 //        ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
 //        MockOperationContext operationContext = getOperationContext(addr);
-//        ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+//        ProfileResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
 //        operationContext.executeNextStep();
 //    }
 
@@ -111,7 +111,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
         ModelNode list = new ModelNode().add("profile-four");
         ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
         MockOperationContext operationContext = getOperationContextWithIncludes(addr);
-        ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+        ProfileResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
         operationContext.executeNextStep();
     }
 
@@ -155,7 +155,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
                 profile4.registerChild(PathElement.pathElement(SUBSYSTEM, "b"), subsystemB);
             }
         });
-        ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+        ProfileResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
         operationContext.executeNextStep();
     }
 
@@ -180,7 +180,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
                     profile4.registerChild(PathElement.pathElement(SUBSYSTEM, "a"), subsystemB);
                 }
             });
-            ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+            ProfileResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
             operationContext.executeNextStep();
             Assert.fail("Expected error");
         } catch (OperationFailedException expected) {
@@ -216,7 +216,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
                     profile5.registerChild(PathElement.pathElement(SUBSYSTEM, "x"), subsystemC);
                 }
             });
-            ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+            ProfileResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
             operationContext.executeNextStep();
             Assert.fail("Expected error");
         } catch (OperationFailedException expected) {
@@ -251,7 +251,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
                     //profile-four is empty
                 }
             });
-            ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+            ProfileResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
             operationContext.executeNextStep();
             Assert.fail("Expected error");
         } catch (OperationFailedException expected) {
@@ -343,7 +343,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
         }
 
         public void addStep(OperationStepHandler step, OperationContext.Stage stage) throws IllegalArgumentException {
-            if (step instanceof DomainModelReferenceValidator) {
+            if (step instanceof DomainModelIncludesValidator) {
                 nextStep = step;
             }
         }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReloadRequiredServerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReloadRequiredServerTestCase.java
@@ -84,7 +84,7 @@ public class ReloadRequiredServerTestCase extends AbstractOperationTestCase {
         operation.get(VALUE).set("profile-two");
 
         try {
-            operationContext.executeStep(ServerGroupResourceDefinition.createReferenceValidationHandler(), operation);
+            operationContext.executeStep(ServerGroupResourceDefinition.createRestartRequiredHandler(), operation);
         } catch (RuntimeException e) {
             final Throwable t = e.getCause();
             if (t instanceof OperationFailedException) {
@@ -118,7 +118,7 @@ public class ReloadRequiredServerTestCase extends AbstractOperationTestCase {
         operation.get(VALUE).set("profile-one");
 
         try {
-            operationContext.executeStep(ServerGroupResourceDefinition.createReferenceValidationHandler(), operation);
+            operationContext.executeStep(ServerGroupResourceDefinition.createRestartRequiredHandler(), operation);
         } catch (RuntimeException e) {
             final Throwable t = e.getCause();
             if (t instanceof OperationFailedException) {
@@ -160,7 +160,7 @@ public class ReloadRequiredServerTestCase extends AbstractOperationTestCase {
 //        operation.get(VALUE).set("does-not-exist");
 //
 //        try {
-//            operationContext.executeStep(ServerGroupResourceDefinition.createReferenceValidationHandler(), operation);
+//            operationContext.executeStep(ServerGroupResourceDefinition.createRestartRequiredHandler(), operation);
 //        } catch (RuntimeException e) {
 //            final Throwable t = e.getCause();
 //            if (t instanceof OperationFailedException) {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
@@ -248,7 +248,7 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         operation.get(VALUE).set(profileName);
 
         try {
-            operationContext.executeStep(ServerGroupResourceDefinition.createReferenceValidationHandler(), operation);
+            operationContext.executeStep(ServerGroupResourceDefinition.createRestartRequiredHandler(), operation);
         } catch (RuntimeException e) {
             final Throwable t = e.getCause();
             if (t instanceof OperationFailedException) {
@@ -327,7 +327,7 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         operation.get(VALUE).set(socketBindingGroupName);
 
         try {
-            operationContext.executeStep(ServerGroupResourceDefinition.createReferenceValidationHandler(), operation);
+            operationContext.executeStep(ServerGroupResourceDefinition.createRestartRequiredHandler(), operation);
         } catch (RuntimeException e) {
             final Throwable t = e.getCause();
             if (t instanceof OperationFailedException) {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SocketBindingGroupIncludesHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SocketBindingGroupIncludesHandlerTestCase.java
@@ -97,7 +97,7 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
         ModelNode list = new ModelNode().add("binding-two");
         ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
         MockOperationContext operationContext = getOperationContext(addr);
-        SocketBindingGroupResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+        SocketBindingGroupResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
         operationContext.executeNextStep();
     }
 
@@ -108,7 +108,7 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
 //        ModelNode list = new ModelNode().add("bad-SocketBindingGroup");
 //        ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
 //        MockOperationContext operationContext = getOperationContext(addr);
-//        SocketBindingGroupResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+//        SocketBindingGroupResourceDefinition.createRestartRequiredHandler().execute(operationContext, op);
 //        operationContext.executeNextStep();
 //    }
 
@@ -118,7 +118,7 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
         ModelNode list = new ModelNode().add("binding-four");
         ModelNode op = Util.getWriteAttributeOperation(addr, INCLUDES, list);
         MockOperationContext operationContext = getOperationContextWithIncludes(addr);
-        SocketBindingGroupResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+        SocketBindingGroupResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
         operationContext.executeNextStep();
     }
 
@@ -162,7 +162,7 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
                 SocketBindingGroup4.registerChild(PathElement.pathElement(SUBSYSTEM, "b"), subsystemB);
             }
         });
-        SocketBindingGroupResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+        SocketBindingGroupResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
         operationContext.executeNextStep();
     }
 
@@ -187,7 +187,7 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
                     SocketBindingGroup4.registerChild(PathElement.pathElement(SOCKET_BINDING, "a"), subsystemB);
                 }
             });
-            SocketBindingGroupResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+            SocketBindingGroupResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
             operationContext.executeNextStep();
             Assert.fail("Expected error");
         } catch (OperationFailedException expected) {
@@ -224,7 +224,7 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
                     group5.registerChild(PathElement.pathElement(SOCKET_BINDING, "x"), bindingC);
                 }
             });
-            ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+            ProfileResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
             operationContext.executeNextStep();
             Assert.fail("Expected error");
         } catch (OperationFailedException expected) {
@@ -259,7 +259,7 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
                     //binding-five is empty
                 }
             });
-            ProfileResourceDefinition.createReferenceValidationHandler().execute(operationContext, op);
+            ProfileResourceDefinition.createIncludesValidationHandler().execute(operationContext, op);
             operationContext.executeNextStep();
             Assert.fail("Expected error");
         } catch (OperationFailedException expected) {
@@ -353,7 +353,7 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
         }
 
         public void addStep(OperationStepHandler step, Stage stage) throws IllegalArgumentException {
-            if (step instanceof DomainModelReferenceValidator) {
+            if (step instanceof DomainModelIncludesValidator) {
                 nextStep = step;
             }
         }

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -67,7 +67,6 @@ import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.resource.InterfaceDefinition;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
@@ -93,10 +92,10 @@ import org.jboss.as.server.mgmt.HttpManagementResourceDefinition;
 import org.jboss.as.server.mgmt.NativeManagementResourceDefinition;
 import org.jboss.as.server.mgmt.NativeRemotingManagementResourceDefinition;
 import org.jboss.as.server.operations.CleanObsoleteContentHandler;
+import org.jboss.as.server.operations.InstallationReportHandler;
 import org.jboss.as.server.operations.InstanceUuidReadHandler;
 import org.jboss.as.server.operations.LaunchTypeHandler;
 import org.jboss.as.server.operations.ProcessTypeHandler;
-import org.jboss.as.server.operations.InstallationReportHandler;
 import org.jboss.as.server.operations.RunningModeReadHandler;
 import org.jboss.as.server.operations.ServerDomainProcessReloadHandler;
 import org.jboss.as.server.operations.ServerDomainProcessShutdownHandler;
@@ -108,6 +107,7 @@ import org.jboss.as.server.operations.ServerSuspendHandler;
 import org.jboss.as.server.operations.ServerVersionOperations.DefaultEmptyListAttributeHandler;
 import org.jboss.as.server.operations.SetServerGroupHostHandler;
 import org.jboss.as.server.operations.SuspendStateReadHandler;
+import org.jboss.as.server.services.net.InterfaceResourceDefinition;
 import org.jboss.as.server.services.net.NetworkInterfaceRuntimeHandler;
 import org.jboss.as.server.services.net.SocketBindingGroupResourceDefinition;
 import org.jboss.as.server.services.net.SpecifiedInterfaceAddHandler;
@@ -445,7 +445,7 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(PathResourceDefinition.createSpecified(pathManager));
 
         // Interfaces
-        ManagementResourceRegistration interfaces = resourceRegistration.registerSubModel(new InterfaceDefinition(
+        ManagementResourceRegistration interfaces = resourceRegistration.registerSubModel(new InterfaceResourceDefinition(
                 SpecifiedInterfaceAddHandler.INSTANCE,
                 SpecifiedInterfaceRemoveHandler.INSTANCE,
                 true,

--- a/server/src/main/java/org/jboss/as/server/services/net/InterfaceAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/InterfaceAddHandler.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2015, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,32 +20,35 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.domain.controller.operations;
+package org.jboss.as.server.services.net;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
 import org.jboss.dmr.ModelNode;
 
 /**
- * @author Emanuel Muckenhuber
+ * TODO remove this once we can get the superclass out of the controller module to a place
+ * where the NetworkInterface class is visible.
+ *
+ * @author Brian Stansberry
  */
-public class ProfileAddHandler extends AbstractAddStepHandler {
+public class InterfaceAddHandler extends org.jboss.as.controller.operations.common.InterfaceAddHandler {
 
-    public static final ProfileAddHandler INSTANCE = new ProfileAddHandler();
+    public static final InterfaceAddHandler NAMED_INSTANCE = new InterfaceAddHandler(false);
 
-    ProfileAddHandler() {
-        super(ProfileResourceDefinition.PROFILE_CAPABILITY, ProfileResourceDefinition.ATTRIBUTES);
+    /**
+     * Create the InterfaceAddHandler
+     *
+     * @param specified
+     */
+    protected InterfaceAddHandler(boolean specified) {
+        super(specified);
     }
 
-    protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
-        DomainModelIncludesValidator.addValidationStep(context, operation);
-        super.populateModel(context, operation, resource);
-    }
-
-    protected boolean requiresRuntime(OperationContext context) {
-        return false;
+    @Override
+    protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        super.recordCapabilitiesAndRequirements(context, operation, resource);
+        context.registerCapability(InterfaceResourceDefinition.INTERFACE_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue()), null);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/InterfaceRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/InterfaceRemoveHandler.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2015, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,32 +20,34 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.domain.controller.operations;
+package org.jboss.as.server.services.net;
 
-import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
 import org.jboss.dmr.ModelNode;
 
 /**
- * @author Emanuel Muckenhuber
+ * TODO remove this once we can get the superclass out of the controller module to a place
+ * where the NetworkInterface class is visible.
+ *
+ * @author Brian Stansberry
  */
-public class ProfileAddHandler extends AbstractAddStepHandler {
+public class InterfaceRemoveHandler extends org.jboss.as.controller.operations.common.InterfaceRemoveHandler {
 
-    public static final ProfileAddHandler INSTANCE = new ProfileAddHandler();
+    public static final InterfaceRemoveHandler INSTANCE = new InterfaceRemoveHandler();
 
-    ProfileAddHandler() {
-        super(ProfileResourceDefinition.PROFILE_CAPABILITY, ProfileResourceDefinition.ATTRIBUTES);
+    /**
+     * Create the InterfaceRemoveHandler
+     */
+    protected InterfaceRemoveHandler() {
     }
 
-    protected void populateModel(final OperationContext context, final ModelNode operation, final Resource resource) throws OperationFailedException {
-        DomainModelIncludesValidator.addValidationStep(context, operation);
-        super.populateModel(context, operation, resource);
+    @Override
+    protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        super.recordCapabilitiesAndRequirements(context, operation, resource);
+        context.deregisterCapability(InterfaceResourceDefinition.INTERFACE_CAPABILITY.getDynamicName(context.getCurrentAddressValue()));
     }
 
-    protected boolean requiresRuntime(OperationContext context) {
-        return false;
-    }
+
 }

--- a/server/src/main/java/org/jboss/as/server/services/net/InterfaceResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/InterfaceResourceDefinition.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.server.services.net;
+
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.operations.common.InterfaceRemoveHandler;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.resource.InterfaceDefinition;
+import org.jboss.as.network.NetworkInterfaceBinding;
+
+/**
+ * TODO remove this once we can get the superclass out of the controller module to a place
+ * where the NetworkInterface class is visible.
+ *
+ * @author Brian Stansberry
+ */
+public class InterfaceResourceDefinition extends InterfaceDefinition {
+
+    public static final RuntimeCapability<Void> INTERFACE_CAPABILITY =
+            RuntimeCapability.Builder.of(INTERFACE_CAPABILITY_NAME, true, NetworkInterfaceBinding.class).build();
+
+    public InterfaceResourceDefinition(InterfaceAddHandler addHandler, InterfaceRemoveHandler removeHandler,
+                                       boolean updateRuntime, boolean resolvable) {
+        super(addHandler, removeHandler, updateRuntime, resolvable);
+    }
+
+    @Override
+    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerCapability(INTERFACE_CAPABILITY);
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/services/net/OutboundSocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/OutboundSocketBindingResourceDefinition.java
@@ -59,8 +59,11 @@ public abstract class OutboundSocketBindingResourceDefinition extends SimpleReso
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
 
     public static final SimpleAttributeDefinition SOURCE_INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOURCE_INTERFACE, ModelType.STRING, true)
-            .setAllowExpression(true).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true))
-            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+            .setAllowExpression(true)
+            .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true))
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setCapabilityReference("org.wildfly.network.interface", OUTBOUND_SOCKET_BINDING_CAPABILITY)
+            .build();
 
     public static final SimpleAttributeDefinition FIXED_SOURCE_PORT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.FIXED_SOURCE_PORT, ModelType.BOOLEAN, true)
             .setAllowExpression(true).setDefaultValue(new ModelNode().set(false)).build();

--- a/server/src/main/java/org/jboss/as/server/services/net/SocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SocketBindingResourceDefinition.java
@@ -43,10 +43,9 @@ import org.jboss.dmr.ModelType;
  */
 public class SocketBindingResourceDefinition extends AbstractSocketBindingResourceDefinition {
 
-    static final String SOCKET_BINDING_CAPABILITY_NAME = "org.wildfly.network.socket-binding";
-    static final RuntimeCapability<Void> SOCKET_BINDING_CAPABILITY =
-            RuntimeCapability.Builder.of(SOCKET_BINDING_CAPABILITY_NAME, true, SocketBinding.class)
-                    .build(); // TODO require interface capability
+    public static final RuntimeCapability<Void> SOCKET_BINDING_CAPABILITY =
+            RuntimeCapability.Builder.of(AbstractSocketBindingResourceDefinition.SOCKET_BINDING_CAPABILITY_NAME, true, SocketBinding.class)
+                    .build();
 
     public static final SocketBindingResourceDefinition INSTANCE = new SocketBindingResourceDefinition();
 
@@ -62,6 +61,11 @@ public class SocketBindingResourceDefinition extends AbstractSocketBindingResour
         resourceRegistration.registerMetric(BindingMetricHandlers.BoundHandler.ATTRIBUTE_DEFINITION, BindingMetricHandlers.BoundHandler.INSTANCE);
         resourceRegistration.registerMetric(BindingMetricHandlers.BoundAddressHandler.ATTRIBUTE_DEFINITION, BindingMetricHandlers.BoundAddressHandler.INSTANCE);
         resourceRegistration.registerMetric(BindingMetricHandlers.BoundPortHandler.ATTRIBUTE_DEFINITION, BindingMetricHandlers.BoundPortHandler.INSTANCE);
+    }
+
+    @Override
+    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerCapability(SOCKET_BINDING_CAPABILITY);
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/services/net/SpecifiedInterfaceAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SpecifiedInterfaceAddHandler.java
@@ -20,7 +20,6 @@ package org.jboss.as.server.services.net;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.interfaces.ParsedInterfaceCriteria;
-import org.jboss.as.controller.operations.common.InterfaceAddHandler;
 import org.jboss.as.network.NetworkInterfaceBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.Service;

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ControllerInitializer.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ControllerInitializer.java
@@ -79,7 +79,7 @@ public class ControllerInitializer {
     /**
      * Sets the controller being created. Internal use only.
      *
-     * @param service the controller being created.
+     * @param testControllerAccessor the controller being created.
      */
     void setTestModelControllerAccessor(TestControllerAccessor testControllerAccessor) {
         this.testControllerAccessor = testControllerAccessor;


### PR DESCRIPTION
Also renames DomainModelReferenceValidator and removes its use from a few cases left over from WFCORE-833.