### PR TITLE
[WFCORE-888] Skip propagating interface add ops to servers for 'named…

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationResolver.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationResolver.java
@@ -325,7 +325,7 @@ public class ServerOperationResolver {
         if (forDomain && hostModel.hasDefined(INTERFACE) && hostModel.get(INTERFACE).keys().contains(pathName)) {
             // Host will take precedence; ignore the domain
             result = Collections.emptyMap();
-        } else if (forDomain && ADD.equals(operation.get(OP).asString()) && InterfaceDefinition.isOperationDefined(operation)) {
+        } else if (forDomain && ADD.equals(operation.get(OP).asString()) && !InterfaceDefinition.isOperationDefined(operation)) {
             // don't create named interfaces
             result = Collections.emptyMap();
         } else if (hostModel.hasDefined(SERVER_CONFIG)) {


### PR DESCRIPTION
…' interfaces, not 'specified' ones