### PR TITLE
[WFCORE-891] jboss-deployment-structure.xml resource root allows bad references

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser11.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser11.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.server.deployment.module.descriptor;
 
+import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,7 +42,6 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.MountedDeploymentOverlay;
@@ -49,6 +51,7 @@ import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.MountHandle;
 import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jboss.as.server.deployment.module.TempFileProviderService;
+import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.modules.DependencySpec;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
@@ -59,9 +62,6 @@ import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.vfs.VFS;
 import org.jboss.vfs.VirtualFile;
-
-import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
-import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 
 /**
  * @author Stuart Douglas
@@ -750,8 +750,22 @@ public class JBossDeploymentStructureParser11 implements XMLElementReader<ParseR
                         Closeable closable = null;
                         if(overlay != null) {
                             overlay.remountAsZip(false);
-                        } else if(child.isFile()) {
-                            closable = VFS.mountZip(child, child, TempFileProviderService.provider());
+                        } else {
+                            if(!child.exists()) {
+                                // the reference does not exist
+                                throw ServerLogger.ROOT_LOGGER.illegalResoureRootReference(child.getName());
+                            } else if(child.isFile()) {
+                                try {
+                                    // check if the resource-root is within the deployment or not
+                                   if(child.getPathNameRelativeTo(deploymentRootFile) != null) {
+                                      closable = VFS.mountZip(child, child, TempFileProviderService.provider());
+                                   }
+                                } catch(IllegalArgumentException err) {
+                                   throw ServerLogger.ROOT_LOGGER.illegalResoureRootReference(child.getName());
+                                }
+                            }
+                            // the only thing left is either a directory or a jar/sar mounted already by EarStructureProcessor
+                            // not need to do any action
                         }
                         final MountHandle mountHandle = new MountHandle(closable);
                         final ResourceRoot resourceRoot = new ResourceRoot(name, child, mountHandle);

--- a/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser12.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/descriptor/JBossDeploymentStructureParser12.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.server.deployment.module.descriptor;
 
+import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,7 +42,6 @@ import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
-import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.MountedDeploymentOverlay;
@@ -49,6 +51,7 @@ import org.jboss.as.server.deployment.module.ModuleDependency;
 import org.jboss.as.server.deployment.module.MountHandle;
 import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jboss.as.server.deployment.module.TempFileProviderService;
+import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.modules.DependencySpec;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
@@ -59,9 +62,6 @@ import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.vfs.VFS;
 import org.jboss.vfs.VirtualFile;
-
-import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
-import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 
 /**
  * @author Stuart Douglas
@@ -757,8 +757,22 @@ public class JBossDeploymentStructureParser12 implements XMLElementReader<ParseR
                         Closeable closable = null;
                         if(overlay != null) {
                             overlay.remountAsZip(false);
-                        } else if(child.isFile()) {
-                            closable = VFS.mountZip(child, child, TempFileProviderService.provider());
+                        } else {
+                            if(!child.exists()) {
+                                // the reference does not exist
+                                throw ServerLogger.ROOT_LOGGER.illegalResoureRootReference(child.getName());
+                            } else if(child.isFile()) {
+                                try {
+                                    // check if the resource-root is within the deployment or not
+                                   if(child.getPathNameRelativeTo(deploymentRootFile) != null) {
+                                      closable = VFS.mountZip(child, child, TempFileProviderService.provider());
+                                   }
+                                } catch(IllegalArgumentException err) {
+                                  throw ServerLogger.ROOT_LOGGER.illegalResoureRootReference(child.getName());
+                                }
+                            }
+                            // the only thing left is either a directory or a jar/sar mounted already by EarStructureProcessor
+                            // not need to do any action
                         }
                         final MountHandle mountHandle = new MountHandle(closable);
                         final ResourceRoot resourceRoot = new ResourceRoot(name, child, mountHandle);

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1159,4 +1159,14 @@ public interface ServerLogger extends BasicLogger {
 
     @Message(id = 232, value = "Could not get module info for module name: %s")
     OperationFailedException couldNotGetModuleInfo(String moduleName, @Cause Throwable cause);
+
+    @Message(id = 233, value = "Undeployed \"%s\" (runtime-name: \"%s\")")
+    String deploymentUndeployedNotification(String managementName, String deploymentUnitName);
+
+    @Message(id = 234, value = "Deployed \"%s\" (runtime-name : \"%s\")")
+    String deploymentDeployedNotification(String managementName, String deploymentUnitName);
+
+    @Message(id = 235, value = "Illegal resource root reference: %s. Resource root does not exist or it is a reference outside the deployment.")
+    IllegalArgumentException illegalResoureRootReference(String resourceRoot);
+
 }


### PR DESCRIPTION
JIRA https://issues.jboss.org/browse/WFCORE-891

I tried to cover these two use cases:
1) If the project is deployed exploded, then you can reference
outside the deployment; check whether the reference is a child
of the deployment root

2) the project is an archive. In this case you cannot reference outside
the deployment (VFS Zip file system) but you can reference a
non-existant resource-root; check if the file exist or not.

Note: when the JAR is inside the deployment, this is processed by
EarStructureProcessor. So if it is a jar/sar is mounted in that stage.
