### PR TITLE
[WFCORE-898] Upgrade to WildFly Elytron 1.0.0.CR1.

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
@@ -27,8 +27,6 @@
     <exports>
         <exclude path="org/wildfly/security/_private"/>
         <exclude path="org/wildfly/wildfly/security/manager/_private"/>
-        <exclude path="org/wildfly/security/sasl/digest/_private"/>
-        <exclude path="org/wildfly/security/util/_private"/>
     </exports>
 
     <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <version.org.wildfly.build-tools>1.1.0.Beta2</version.org.wildfly.build-tools>
         <version.org.wildfly.common>1.0.0.Alpha3</version.org.wildfly.common>
         <version.org.wildfly.legacy.test>1.0.0.Alpha9</version.org.wildfly.legacy.test>
-        <version.org.wildfly.security.elytron>1.0.0.Alpha3</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.0.0.CR1</version.org.wildfly.security.elytron>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
         <!-- Non-default maven plugin versions and configuration -->


### PR DESCRIPTION
This is a slimmed version of the library containing just the security manager implementation.