### PR TITLE
[WFCORE-893] Add a default io subsystem to profiles using a legacy re…

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -22,10 +22,19 @@
 
 package org.jboss.as.remoting;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODULE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.List;
+import java.util.Map;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -33,7 +42,9 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.parsing.ProfileParsingCompletionHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.OperationTransformer;
 import org.jboss.as.controller.transform.ResourceTransformer;
@@ -42,6 +53,7 @@ import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+import org.jboss.as.remoting.logging.RemotingLogger;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -75,6 +87,8 @@ public class RemotingExtension implements Extension {
 
     private static final ModelVersion VERSION_1_3 = ModelVersion.create(1, 3);
     private static final ModelVersion VERSION_2_1 = ModelVersion.create(2, 1);
+
+    private static final String IO_EXTENSION_MODULE = "org.wildfly.extension.io";
 
     @Override
     public void initialize(ExtensionContext context) {
@@ -173,6 +187,69 @@ public class RemotingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_1_2.getUriString(), RemotingSubsystem12Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_2_0.getUriString(), RemotingSubsystem20Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_3_0.getUriString(), RemotingSubsystem30Parser.INSTANCE);
+
+        context.setProfileParsingCompletionHandler(new IOCompletionHandler());
+    }
+
+    private static class IOCompletionHandler implements ProfileParsingCompletionHandler {
+
+        @Override
+        public void handleProfileParsingCompletion(Map<String, List<ModelNode>> profileBootOperations, List<ModelNode> otherBootOperations) {
+
+            // If the namespace used for our subsystem predates the introduction of the IO subsystem,
+            // check if the profile includes io and if not add it
+
+            String legacyNS = null;
+            List<ModelNode> legacyRemotingOps = null;
+            for (Namespace ns : Namespace.values()) {
+                String nsString = ns.getUriString();
+                if (nsString != null && nsString.startsWith("urn:jboss:domain:remoting:1.")) {
+                    legacyRemotingOps = profileBootOperations.get(nsString);
+                    if (legacyRemotingOps != null) {
+                        legacyNS = nsString;
+                        break;
+                    }
+                }
+            }
+
+            if (legacyRemotingOps != null) {
+                boolean foundIO = false;
+                for (String ns : profileBootOperations.keySet()) {
+                    if (ns.startsWith("urn:jboss:domain:io:")) {
+                        foundIO = true;
+                        break;
+                    }
+                }
+
+                if (!foundIO) {
+                    // legacy Remoting subsystem and no io subsystem, add it
+
+                    // See if we need to add the extension as well
+                    boolean hasIoExtension = false;
+                    for (ModelNode op : otherBootOperations) {
+                        PathAddress pa = PathAddress.pathAddress(op.get(OP_ADDR));
+                        if (pa.size() == 1 && EXTENSION.equals(pa.getElement(0).getKey())
+                                && IO_EXTENSION_MODULE.equals(pa.getElement(0).getValue())) {
+                            hasIoExtension = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasIoExtension) {
+                        final ModelNode addIoExtensionOp = Util.createAddOperation(PathAddress.pathAddress(EXTENSION, IO_EXTENSION_MODULE));
+                        addIoExtensionOp.get(MODULE).set(IO_EXTENSION_MODULE);
+                        otherBootOperations.add(addIoExtensionOp);
+                    }
+
+                    PathAddress subsystemAddress = PathAddress.pathAddress(SUBSYSTEM, "io");
+                    legacyRemotingOps.add(Util.createAddOperation(subsystemAddress));
+                    legacyRemotingOps.add(Util.createAddOperation(subsystemAddress.append("worker", "default")));
+                    legacyRemotingOps.add(Util.createAddOperation(subsystemAddress.append("buffer-pool", "default")));
+
+                    RemotingLogger.ROOT_LOGGER.addingIOSubsystem(legacyNS);
+                }
+            }
+        }
     }
 
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/logging/RemotingLogger.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/logging/RemotingLogger.java
@@ -124,4 +124,9 @@ public interface RemotingLogger extends BasicLogger {
 
     @Message(id = 23, value = "Only one of '%s' configuration or '%s' configuration is allowed")
     String workerThreadsEndpointConfigurationChoiceRequired(String workerThreads, String endpoint);
+
+    @LogMessage(level = INFO)
+    @Message(id = 24, value = "The remoting subsystem is present but no io subsystem was found. An io subsystem " +
+            "was not required when remoting schema '%s' was current but now is, so a default subsystem is being added.")
+    void addingIOSubsystem(String legacyNS);
 }

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestUtil.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestUtil.java
@@ -23,13 +23,24 @@
 package org.jboss.as.remoting;
 
 import static org.jboss.as.controller.capability.RuntimeCapability.buildDynamicCapabilityName;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.extension.ExtensionRegistryType;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.dmr.ModelType;
+import org.wildfly.extension.io.IOExtension;
 
 /**
  * Utilities for the remoting subsystem tests.
@@ -56,13 +67,23 @@ class RemotingSubsystemTestUtil {
                 protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration, RuntimeCapabilityRegistry capabilityRegistry) {
                     super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
                     AdditionalInitialization.registerCapabilities(capabilityRegistry,
-                            buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
-                                    RemotingEndpointResource.WORKER.getDefaultValue().asString()),
                             // This one is specified in one of the test configs
                             buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY, "default-remoting"));
+
+                    // Deal with the fact that legacy parsers will add the io extension/subsystem
+                    registerIOExtension(extensionRegistry, rootRegistration);
                 }
             };
 
+    static void registerIOExtension(ExtensionRegistry extensionRegistry, ManagementResourceRegistration rootRegistration) {
+        ManagementResourceRegistration extReg = rootRegistration.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement(EXTENSION, "org.wildfly.extension.io"),
+                NonResolvingResourceDescriptionResolver.INSTANCE, new ModelOnlyAddStepHandler(), ModelOnlyRemoveStepHandler.INSTANCE));
+        extReg.registerReadOnlyAttribute(new SimpleAttributeDefinitionBuilder("module", ModelType.STRING).build(), null);
+
+        Extension ioe = new IOExtension();
+        ioe.initialize(extensionRegistry.getExtensionContext("org.wildfly.extension.io", rootRegistration, ExtensionRegistryType.MASTER));
+
+    }
     private RemotingSubsystemTestUtil() {
         //
     }


### PR DESCRIPTION
…moting config

This also tweaks the model test validation code to defer validation of boot ops until after the ModelController's initModel method gets a chance to run. That method is where tests can hook in and register resource definitions that allow the validation to complete.