### PR TITLE
[WFCORE-873] Add attachment to propagate the original address for an

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -401,7 +401,7 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
         // Format wildcard queries as list
         final ModelNode result = context.getResult().setEmptyList();
         context.addStep(new ModelNode(), GlobalOperationHandlers.AbstractMultiTargetHandler.FAKE_OPERATION.clone(),
-            new GlobalOperationHandlers.RegistrationAddressResolver(operation, result,
+            new GlobalOperationHandlers.RegistrationAddressResolver(operation, result, true,
                 new OperationStepHandler() {
                     @Override
                     public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {

--- a/controller/src/main/java/org/jboss/as/controller/registry/AliasAttachments.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AliasAttachments.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.controller.registry;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
+
+/**
+ * This class is private api
+ *
+ * @author Kabir Khan
+ */
+public class AliasAttachments {
+
+    /**
+     * When an operation is called on an alias, the controller invokes AliasStepHandler which creates a clone
+     * of the operation with the 'real' address. Some handlers like r-r-d need the original address, so we put it
+     * into an attachment.
+     * <br/>
+     * Note: This should be developed further by scoping the attachments for the various steps, but
+     * for now since only r-r-d is interested in this, we HACK it by having the r-r-d handler remove it. This avoids
+     * the attachment being kept around in a composite of r-r-d's where a 'real' address follows some alias operations.
+     */
+    public static final OperationContext.AttachmentKey<PathAddress> ALIAS_ORIGINAL_ADDRESS =
+            OperationContext.AttachmentKey.create(PathAddress.class);
+}

--- a/controller/src/main/java/org/jboss/as/controller/registry/AliasStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AliasStepHandler.java
@@ -51,6 +51,10 @@ public class AliasStepHandler implements OperationStepHandler {
         String op = operation.require(OP).asString();
         PathAddress addr = context.getCurrentAddress();
 
+        //Store the original address. This is something we probably want to keep doing,
+        //see the attachment javadoc for a description of the current HACK
+        context.attach(AliasAttachments.ALIAS_ORIGINAL_ADDRESS, addr);
+
         PathAddress mapped = aliasEntry.convertToTargetAddress(addr);
 
         OperationStepHandler targetHandler = context.getRootResourceRegistration().getOperationHandler(mapped, op);

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
@@ -315,8 +315,13 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
             return;
         }
         assertTrue(result.require(CHILDREN).require(SUBSYSTEM).require(MODEL_DESCRIPTION).isDefined());
-        assertEquals(6, result.require(CHILDREN).require(SUBSYSTEM).require(MODEL_DESCRIPTION).keys().size());
+        assertEquals(getExpectedNumberProfiles(), result.require(CHILDREN).require(SUBSYSTEM).require(MODEL_DESCRIPTION).keys().size());
         checkSubsystem1Description(result.require(CHILDREN).require(SUBSYSTEM).require(MODEL_DESCRIPTION).require("subsystem1"), recursive, operations, notifications);
+    }
+
+    protected int getExpectedNumberProfiles() {
+        //Some tests might add more, if so they should override this method
+        return 6;
     }
 
     protected void checkSubsystem1Description(ModelNode result, boolean recursive, boolean operations, boolean notifications) {

--- a/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsAliasesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/GlobalOperationsAliasesTestCase.java
@@ -20,11 +20,14 @@
  */
 package org.jboss.as.controller.test;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES_ONLY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MIN_LENGTH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
@@ -33,6 +36,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NIL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
@@ -42,6 +47,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -55,6 +64,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.OperationContext;
@@ -68,6 +78,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.AliasEntry;
@@ -88,40 +99,47 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
     @Override
     protected void initModel(ManagementModel managementModel) {
         rootRegistration = managementModel.getRootResourceRegistration();
+        rootRegistration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
         GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
         GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
 
         rootRegistration.registerOperationHandler(TestUtils.SETUP_OPERATION_DEF, new OperationStepHandler() {
-            @Override
-            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                final ModelNode model = new ModelNode();
-                //Atttributes
-                model.get("profile", "profileA", "name").set("Profile A");
-                model.get("profile", "profileA", "subsystem", "subsystem1", "attr1").add(1);
-                model.get("profile", "profileA", "subsystem", "subsystem1", "attr1").add(2);
-                //Children
-                model.get("profile", "profileA", "subsystem", "subsystem1", "type1", "thing1", "name").set("Name11");
-                model.get("profile", "profileA", "subsystem", "subsystem1", "type1", "thing1", "value").set("201");
-                model.get("profile", "profileA", "subsystem", "subsystem1", "type1", "thing2", "name").set("Name12");
-                model.get("profile", "profileA", "subsystem", "subsystem1", "type1", "thing2", "value").set("202");
-                model.get("profile", "profileA", "subsystem", "subsystem1", "type2", "other", "name").set("Name2");
+                    @Override
+                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                        final ModelNode model = new ModelNode();
+                        //Atttributes
+                        model.get("profile", "profileA", "name").set("Profile A");
+                        model.get("profile", "profileA", "subsystem", "subsystem1", "attr1").add(1);
+                        model.get("profile", "profileA", "subsystem", "subsystem1", "attr1").add(2);
+                        //Children
+                        model.get("profile", "profileA", "subsystem", "subsystem1", "type1", "thing1", "name").set("Name11");
+                        model.get("profile", "profileA", "subsystem", "subsystem1", "type1", "thing1", "value").set("201");
+                        model.get("profile", "profileA", "subsystem", "subsystem1", "type1", "thing2", "name").set("Name12");
+                        model.get("profile", "profileA", "subsystem", "subsystem1", "type1", "thing2", "value").set("202");
+                        model.get("profile", "profileA", "subsystem", "subsystem1", "type2", "other", "name").set("Name2");
 
-                model.get("profile", "profileB", "name").set("Profile B");
+                        model.get("profile", "profileB", "name").set("Profile B");
 
-                model.get("profile", "profileC", "name").set("Profile C");
-                model.get("profile", "profileC", "subsystem", "subsystem4");
-                model.get("profile", "profileC", "subsystem", "subsystem5", "name").set("Test");
+                        model.get("profile", "profileC", "name").set("Profile C");
+                        model.get("profile", "profileC", "subsystem", "subsystem4");
+                        model.get("profile", "profileC", "subsystem", "subsystem5", "name").set("Test");
 
-                model.get("profile", "profileD", "name").set("Profile D");
-                model.get("profile", "profileD", "subsystem", "subsystem3");
-                model.get("profile", "profileD", "subsystem", "subsystem3", "service", "squatter1", "name").set("TestSquatter1");
-                model.get("profile", "profileD", "subsystem", "subsystem3", "service", "squatter1", "thing1").set("squatter");
-                model.get("profile", "profileD", "subsystem", "subsystem3", "service", "squatter3", "name").set("TestSquatter3");
-                model.get("profile", "profileD", "subsystem", "subsystem3", "service", "squatter3", "thing3").set("squatter");
+                        model.get("profile", "profileD", "name").set("Profile D");
+                        model.get("profile", "profileD", "subsystem", "subsystem3");
+                        model.get("profile", "profileD", "subsystem", "subsystem3", "service", "squatter1", "name").set("TestSquatter1");
+                        model.get("profile", "profileD", "subsystem", "subsystem3", "service", "squatter1", "thing1").set("squatter");
+                        model.get("profile", "profileD", "subsystem", "subsystem3", "service", "squatter3", "name").set("TestSquatter3");
+                        model.get("profile", "profileD", "subsystem", "subsystem3", "service", "squatter3", "thing3").set("squatter");
 
-                createModel(context, model);
-            }
-        }
+                        model.get("profile", "profileE", "name").set("Profile E");
+                        model.get("profile", "profileE", "subsystem", "subsystem7");
+                        model.get("profile", "profileE", "subsystem", "subsystem7", "type", "one");
+                        model.get("profile", "profileE", "subsystem", "subsystem7", "type", "one", "squatter", "one");
+                        model.get("profile", "profileE", "subsystem", "subsystem7", "type", "one", "wildcard", "one");
+
+                        createModel(context, model);
+                    }
+                }
         );
 
         ResourceDefinition profileDef = ResourceBuilder.Factory.create(PathElement.pathElement("profile", "*"),
@@ -279,6 +297,52 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
                     }
                 }
         );
+
+        ManagementResourceRegistration profileESub7Reg = profileReg.registerSubModel(
+                new SimpleResourceDefinition(PathElement.pathElement("subsystem", "subsystem7"), new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration profileESub7TypeReg = profileESub7Reg.registerSubModel(
+                new SimpleResourceDefinition(PathElement.pathElement("type"), new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration profileESub7TypeSquatterOneReg = profileESub7TypeReg.registerSubModel(
+                new SimpleResourceDefinition(PathElement.pathElement("squatter", "one"), new NonResolvingResourceDescriptionResolver()));
+        profileESub7TypeReg.registerAlias(PathElement.pathElement("squatter-alias", "ONE"), new AliasEntry(profileESub7TypeSquatterOneReg) {
+            @Override
+            public PathAddress convertToTargetAddress(PathAddress address) {
+                List<PathElement> list = new ArrayList<PathElement>();
+                final PathElement alias = getAliasAddress().getLastElement();
+                for (PathElement element : address) {
+                    if (element.equals(alias)) {
+                        list.add(getTargetAddress().getLastElement());
+                    } else {
+                        list.add(element);
+                    }
+                }
+                return PathAddress.pathAddress(list);
+            }
+
+        });
+        ManagementResourceRegistration profileESub7TypeWildcardReg = profileESub7TypeReg.registerSubModel(
+                new SimpleResourceDefinition(PathElement.pathElement("wildcard"), new NonResolvingResourceDescriptionResolver()));
+        profileESub7TypeReg.registerAlias(PathElement.pathElement("wildcard-alias"), new AliasEntry(profileESub7TypeWildcardReg) {
+            @Override
+            public PathAddress convertToTargetAddress(PathAddress address) {
+                List<PathElement> list = new ArrayList<PathElement>();
+                final PathElement alias = getAliasAddress().getLastElement();
+                for (PathElement element : address) {
+                    if (element.getKey().equals(alias.getKey())) {
+                        list.add(PathElement.pathElement(getTargetAddress().getLastElement().getKey(), element.getValue()));
+                    } else {
+                        list.add(element);
+                    }
+                }
+                return PathAddress.pathAddress(list);
+            }
+
+        });
+    }
+
+    protected int getExpectedNumberProfiles() {
+        //We have added a profile
+        return 7;
     }
 
     @Test
@@ -698,6 +762,54 @@ public class GlobalOperationsAliasesTestCase extends AbstractGlobalOperationsTes
         operation.get(RECURSIVE).set(true);
         executeForFailure(operation);
     }
+
+    @Test
+    public void testReadResourceDescriptionAliasMultitargetAddress() throws Exception {
+        final PathAddress parentAddress =
+                PathAddress.pathAddress(PROFILE, "profileE")
+                        .append(SUBSYSTEM, "subsystem7")
+                        .append("type", "*");
+        //This maps to /profile=profileE/subsystem=subsystem7/type=*/squatter=one, but the alias should be used
+        final PathAddress squatterAlias = parentAddress.append("squatter-alias", "ONE");
+        ModelNode result = executeForResult(createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, squatterAlias));
+        checkRrdAddress(squatterAlias, result);
+
+        //This maps to /profile=profileE/subsystem=subsystem7/type=*/wildcard=*, but the alias should be used
+        final PathAddress wildCardAlias = parentAddress.append("wildcard-alias", "*");
+        result = executeForResult(createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, wildCardAlias));
+        checkRrdAddress(wildCardAlias, result);
+
+        //Now do the same with a composite with a mixture of real and alias addresses
+        final PathAddress squatterReal = parentAddress.append("squatter", "one");
+        final PathAddress wildcardReal = parentAddress.append("wildcard");
+        ModelNode composite = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+        ModelNode steps = composite.get(STEPS);
+        final PathAddress[] addresses = new PathAddress[]{squatterAlias, squatterReal, wildCardAlias, wildcardReal};
+        for (PathAddress address : addresses) {
+            steps.add(createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, address));
+        }
+        result = executeForResult(composite);
+
+        Assert.assertEquals(addresses.length, result.keys().size());
+        for (int i = 0; i < addresses.length; i++) {
+            ModelNode stepResult = result.get("step-" + (i + 1));
+            Assert.assertTrue(stepResult.isDefined());
+            Assert.assertEquals(SUCCESS, stepResult.get(OUTCOME).asString());
+            boolean server = addresses[i].getElement(0).getKey().equals(HOST);
+            checkRrdAddress(addresses[i], stepResult.get(RESULT));
+        }
+    }
+
+    private void checkRrdAddress(PathAddress expectedAddress, ModelNode result) {
+        List<ModelNode> list = result.asList();
+        Assert.assertEquals(1, list.size());
+        ModelNode entry = list.get(0);
+        Assert.assertEquals(SUCCESS, entry.get(OUTCOME).asString());
+        Assert.assertTrue(entry.hasDefined(ADDRESS));
+        PathAddress returnedAddress = PathAddress.pathAddress(entry.get(ADDRESS));
+        Assert.assertEquals(expectedAddress, returnedAddress);
+    }
+
 
     private void checkNonRecursiveSubsystem1(ModelNode result, boolean includeRuntime) {
         assertEquals(includeRuntime ? 7 : 5, result.keys().size());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ExtensionSetup.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ExtensionSetup.java
@@ -142,6 +142,13 @@ public class ExtensionSetup {
         support.addTestModule(ProfileIncludesExtension.MODULE_NAME, moduleXml, content);
     }
 
+    public static void initializeTestAliasReadResourceAddressExtension(final DomainTestSupport support) throws IOException {
+        final InputStream moduleXml = getModuleXml("test-read-resource-description-alias-address-module.xml");
+        StreamExporter exporter = createResourceRoot(TestAliasReadResourceDescriptionAddressExtension.class, EmptySubsystemParser.class.getPackage());
+        Map<String, StreamExporter> content = Collections.singletonMap("test-alias-read-resource-description-address.jar", exporter);
+        support.addTestModule(TestAliasReadResourceDescriptionAddressExtension.MODULE_NAME, moduleXml, content);
+    }
+
     static StreamExporter createResourceRoot(Class<? extends Extension> extension, Package... additionalPackages) throws IOException {
         final JavaArchive archive = ShrinkWrap.create(JavaArchive.class);
         archive.addPackage(extension.getPackage());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestAliasReadResourceDescriptionAddressExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestAliasReadResourceDescriptionAddressExtension.java
@@ -1,0 +1,150 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.extension;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.AliasEntry;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+
+/**
+ * Fake extension to use in testing extension management.
+ *
+ * @author Kabir Khan
+ */
+public class TestAliasReadResourceDescriptionAddressExtension implements Extension {
+
+    public static final String MODULE_NAME = "org.wildfly.extension.test-alias-read-resource-description-address";
+    public static final String SUBSYSTEM_NAME = "test-alias-read-resource-description-address";
+    public static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
+    public static final PathElement THING_PATH = PathElement.pathElement("thing");
+    public static final PathElement SINGLETON_PATH = PathElement.pathElement("singleton", "one");
+    public static final PathElement SINGLETON_ALIAS_PATH = PathElement.pathElement("singleton-alias", "uno");
+    public static final PathElement WILDCARD_PATH = PathElement.pathElement("wildcard");
+    public static final PathElement WILDCARD_ALIAS_PATH = PathElement.pathElement("wildcard-alias");
+
+    private static final String NAMESPACE = "urn:jboss:test:extension:test:alias:read:resource:description:address:1.0";
+    private static final EmptySubsystemParser PARSER = new EmptySubsystemParser(NAMESPACE);
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        SubsystemRegistration reg = context.registerSubsystem(SUBSYSTEM_NAME, 1, 1, 1);
+        reg.registerXMLElementWriter(PARSER);
+        reg.registerSubsystemModel(new SubsystemResourceDefinition());
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE, PARSER);
+    }
+
+    private static class AbstractResourceDefinition extends SimpleResourceDefinition {
+        public AbstractResourceDefinition(PathElement pathElement) {
+            super(pathElement,
+                    new NonResolvingResourceDescriptionResolver(),
+                    new AbstractAddStepHandler(),
+                    new ModelOnlyRemoveStepHandler());
+        }
+    }
+
+    private static class SubsystemResourceDefinition extends AbstractResourceDefinition {
+        public SubsystemResourceDefinition() {
+            super(SUBSYSTEM_PATH);
+        }
+
+        @Override
+        public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+            resourceRegistration.registerSubModel(new ThingResourceDefinition());
+        }
+    }
+
+    private static class ThingResourceDefinition extends AbstractResourceDefinition {
+        public ThingResourceDefinition() {
+            super(THING_PATH);
+        }
+
+        @Override
+        public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+            ManagementResourceRegistration singleton = resourceRegistration.registerSubModel(new SingletonResourceDefinition());
+            ManagementResourceRegistration wildcard = resourceRegistration.registerSubModel(new WildcardResourceDefinition());
+
+            resourceRegistration.registerAlias(SINGLETON_ALIAS_PATH, new AliasEntry(singleton) {
+                @Override
+                public PathAddress convertToTargetAddress(PathAddress address) {
+                    List<PathElement> list = new ArrayList<>();
+                    final PathElement alias = getAliasAddress().getLastElement();
+                    for (PathElement element : address) {
+                        if (element.equals(alias)) {
+                            list.add(getTargetAddress().getLastElement());
+                        } else {
+                            list.add(element);
+                        }
+                    }
+                    return PathAddress.pathAddress(list);
+                }
+            });
+
+            resourceRegistration.registerAlias(WILDCARD_ALIAS_PATH, new AliasEntry(wildcard) {
+                @Override
+                public PathAddress convertToTargetAddress(PathAddress address) {
+                    List<PathElement> list = new ArrayList<>();
+                    final PathElement alias = getAliasAddress().getLastElement();
+                    for (PathElement element : address) {
+                        if (element.getKey().equals(alias.getKey())) {
+                            list.add(PathElement.pathElement(getTargetAddress().getLastElement().getKey(), element.getValue()));
+                        } else {
+                            list.add(element);
+                        }
+                    }
+                    return PathAddress.pathAddress(list);
+                }
+            });
+        }
+    }
+
+    private static class SingletonResourceDefinition extends AbstractResourceDefinition {
+        public SingletonResourceDefinition() {
+            super(SINGLETON_PATH);
+        }
+    }
+
+    private static class WildcardResourceDefinition extends AbstractResourceDefinition {
+        public WildcardResourceDefinition() {
+            super(WILDCARD_PATH);
+        }
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ReadAliasResourceDescriptionAddressTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ReadAliasResourceDescriptionAddressTestCase.java
@@ -1,0 +1,211 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.test.integration.domain.extension.TestAliasReadResourceDescriptionAddressExtension.MODULE_NAME;
+import static org.jboss.as.test.integration.domain.extension.TestAliasReadResourceDescriptionAddressExtension.SUBSYSTEM_NAME;
+import static org.jboss.as.test.integration.domain.management.util.DomainTestUtils.executeForResult;
+
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.extension.ExtensionSetup;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests that a read-resource-description with a wildcard in the path for an alias returns the alias address in the
+ * address list
+ *
+ * @author Kabir Khan
+ */
+public class ReadAliasResourceDescriptionAddressTestCase {
+
+    private static DomainTestSupport testSupport;
+    private static DomainClient masterClient;
+    private static final PathAddress PROFILE_SINGLETON_ALIAS = PathAddress.pathAddress(PROFILE, "default")
+            .append(SUBSYSTEM, SUBSYSTEM_NAME)
+            .append("thing", "*")
+            .append("singleton-alias", "uno");
+    private static final PathAddress PROFILE_WILDCARD_ALIAS = PathAddress.pathAddress(PROFILE, "default")
+            .append(SUBSYSTEM, SUBSYSTEM_NAME)
+            .append("thing", "*")
+            .append("wildcard-alias", "*");
+    private static final PathAddress SERVER_SINGLETON_ALIAS = PathAddress.pathAddress(HOST, "master")
+            .append(SERVER, "main-one")
+            .append(SUBSYSTEM, SUBSYSTEM_NAME)
+            .append("thing", "*")
+            .append("singleton-alias", "uno");
+    private static final PathAddress SERVER_WILDCARD_ALIAS = PathAddress.pathAddress(HOST, "master")
+            .append(SERVER, "main-one")
+            .append(SUBSYSTEM, SUBSYSTEM_NAME)
+            .append("thing", "*")
+            .append("wildcard-alias", "*");
+    private static final PathAddress PROFILE_SINGLETON_REAL = PathAddress.pathAddress(PROFILE, "default")
+            .append(SUBSYSTEM, SUBSYSTEM_NAME)
+            .append("thing", "*")
+            .append("singleton", "one");
+    private static final PathAddress PROFILE_WILDCARD_REAL = PathAddress.pathAddress(PROFILE, "default")
+            .append(SUBSYSTEM, SUBSYSTEM_NAME)
+            .append("thing", "*")
+            .append("wildcard", "*");
+    private static final PathAddress SERVER_SINGLETON_REAL = PathAddress.pathAddress(HOST, "master")
+            .append(SERVER, "main-one")
+            .append(SUBSYSTEM, SUBSYSTEM_NAME)
+            .append("thing", "*")
+            .append("singleton", "one");
+    private static final PathAddress SERVER_WILDCARD_REAL = PathAddress.pathAddress(HOST, "master")
+            .append(SERVER, "main-one")
+            .append(SUBSYSTEM, SUBSYSTEM_NAME)
+            .append("thing", "*")
+            .append("wildcard", "*");
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(ReadAliasResourceDescriptionAddressTestCase.class.getSimpleName());
+        masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+
+        // Initialize the test extension
+        ExtensionSetup.initializeTestAliasReadResourceAddressExtension(testSupport);
+
+        ModelNode addExtension = Util.createAddOperation(
+                PathAddress.pathAddress(EXTENSION, MODULE_NAME));
+
+        executeForResult(addExtension, masterClient);
+
+        ModelNode addSubsystem = Util.createAddOperation(PathAddress.pathAddress(
+                PathElement.pathElement(PROFILE, "default"),
+                PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME)));
+        executeForResult(addSubsystem, masterClient);
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        ModelNode removeSubsystem = Util.createRemoveOperation(
+                PathAddress.pathAddress(
+                        PathElement.pathElement(PROFILE, "default"),
+                        PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME)));
+        executeForResult(removeSubsystem, masterClient);
+
+        ModelNode removeExtension = Util.createRemoveOperation(
+                PathAddress.pathAddress(EXTENSION, MODULE_NAME));
+        executeForResult(removeExtension, masterClient);
+
+        testSupport = null;
+        masterClient = null;
+        DomainTestSuite.stopSupport();
+    }
+
+    @Test
+    public void testAliasAddressReturned() throws Exception {
+        checkAddressReturned(PROFILE_SINGLETON_ALIAS, PROFILE_WILDCARD_ALIAS, SERVER_SINGLETON_ALIAS, SERVER_WILDCARD_ALIAS);
+    }
+
+    @Test
+    public void testRealAddressReturned() throws Exception {
+        checkAddressReturned(PROFILE_SINGLETON_REAL, PROFILE_WILDCARD_REAL, SERVER_SINGLETON_REAL, SERVER_WILDCARD_REAL);
+    }
+
+    private void checkAddressReturned(PathAddress profileSingleton, PathAddress profileWildcard,
+                                      PathAddress serverSingleton, PathAddress serverWildcard) throws Exception {
+        ModelNode readProfileSingleton = createRrd(profileSingleton);
+        checkAddress(profileSingleton, false,
+                DomainTestUtils.executeForResult(readProfileSingleton, masterClient));
+
+        ModelNode readProfileWildcard = createRrd(profileWildcard);
+        checkAddress(profileWildcard, false,
+                DomainTestUtils.executeForResult(readProfileWildcard, masterClient));
+
+        ModelNode readServerSingleton = createRrd(serverSingleton);
+        checkAddress(serverSingleton, true,
+                DomainTestUtils.executeForResult(readServerSingleton, masterClient));
+
+        ModelNode readServerWildcard = createRrd(serverWildcard);
+        checkAddress(serverWildcard, true,
+                DomainTestUtils.executeForResult(readServerWildcard, masterClient));
+    }
+
+    @Test
+    public void testAddressReturnedComposite() throws Exception {
+        ModelNode composite = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+        ModelNode steps = composite.get(STEPS);
+
+        //Mix up server/profile and real/alias a bit
+        PathAddress[] addresses = new PathAddress[]{
+                SERVER_SINGLETON_REAL, PROFILE_SINGLETON_ALIAS,
+                PROFILE_WILDCARD_REAL, SERVER_SINGLETON_ALIAS,
+                PROFILE_SINGLETON_REAL, PROFILE_WILDCARD_ALIAS,
+                SERVER_WILDCARD_REAL, SERVER_SINGLETON_ALIAS};
+
+        for (PathAddress address : addresses) {
+            steps.add(createRrd(address));
+        }
+        ModelNode result = DomainTestUtils.executeForResult(composite, masterClient);
+
+        Assert.assertEquals(addresses.length, result.keys().size());
+        for (int i = 0; i < addresses.length; i++) {
+            ModelNode stepResult = result.get("step-" + (i + 1));
+            Assert.assertTrue(stepResult.isDefined());
+            Assert.assertEquals(SUCCESS, stepResult.get(OUTCOME).asString());
+            boolean server = addresses[i].getElement(0).getKey().equals(HOST);
+            checkAddress(addresses[i], server, stepResult.get(RESULT));
+        }
+    }
+
+    private void checkAddress(PathAddress expectedAddress, boolean server, ModelNode result) {
+        if (server) {
+            expectedAddress = expectedAddress.subAddress(2);
+        }
+        List<ModelNode> list = result.asList();
+        Assert.assertEquals(1, list.size());
+        ModelNode entry = list.get(0);
+        Assert.assertEquals(SUCCESS, entry.get(OUTCOME).asString());
+        Assert.assertTrue(entry.hasDefined(ADDRESS));
+        PathAddress returnedAddress = PathAddress.pathAddress(entry.get(ADDRESS));
+        Assert.assertEquals(expectedAddress, returnedAddress);
+    }
+
+    private ModelNode createRrd(PathAddress pathAddress) {
+        return Util.createEmptyOperation(READ_RESOURCE_DESCRIPTION_OPERATION, pathAddress);
+    }
+}

--- a/testsuite/domain/src/test/resources/extension/test-read-resource-description-alias-address-module.xml
+++ b/testsuite/domain/src/test/resources/extension/test-read-resource-description-alias-address-module.xml
@@ -1,0 +1,16 @@
+<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.test-alias-read-resource-description-address">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="test-alias-read-resource-description-address.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.msc"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
aliased operation

https://issues.jboss.org/browse/WFCORE-873

Testing with a composite shows that each step gets the correct alias attachment. However, there were some problems with the alias attachment not being removed, hence the hack having RegistrationAddressResolver (currently only used by r-r-d) removing it.

I think this will do for now, since only the top level resource description gets the address. In the recursive case, children don't get the address.
