### PR TITLE
[WFCORE-900] Be forgiving if the 'dependent' param to OperationContex…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityContext.java
@@ -54,14 +54,12 @@ public interface CapabilityContext {
 
     /**
      * Gets whether a given capability associated with this context can satisfy the given requirement.
-     * @param dependent id of the dependent capability. Cannot be {@code null}
-     * @param required name of the capability associated with this capability context. May be {@code null} if the
-     *                 dependent name is not known.
      * @param context resolution context in use for this resolution run
      *
      * @return {@code true} if the requirement can be satisfied from this context; {@code false} otherwise
      */
-    boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context);
+    boolean canSatisfyRequirement(String requiredName, CapabilityContext dependentContext,
+                                  CapabilityResolutionContext context);
 
     /**
      * Gets whether a consistency check must be performed when other capabilities depend on capabilities
@@ -100,7 +98,7 @@ public interface CapabilityContext {
          * @return {@code true}, always
          */
         @Override
-        public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
+        public boolean canSatisfyRequirement(String requiredName, CapabilityContext dependentContext, CapabilityResolutionContext context) {
             return true;
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityRegistry.java
@@ -79,10 +79,9 @@ public interface CapabilityRegistry<C extends CapabilityRegistration, R extends 
     /**
      * Gets whether a capability with the given name is registered.
      * @param capabilityName the name of the capability. Cannot be {@code null}
-     * @param dependentName
      * @param context the context in which to check for the capability
      * @return {@code true} if there is a capability with the given name registered
      *
      */
-    boolean hasCapability(String capabilityName, String dependentName, CapabilityContext context);
+    boolean hasCapability(String capabilityName, CapabilityContext context);
 }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/DelegatingRuntimeCapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/DelegatingRuntimeCapabilityRegistry.java
@@ -94,8 +94,8 @@ public class DelegatingRuntimeCapabilityRegistry implements RuntimeCapabilityReg
     }
 
     @Override
-    public boolean hasCapability(String capabilityName, String dependentName, CapabilityContext context) {
-        return getDelegate().hasCapability(capabilityName, dependentName, context);
+    public boolean hasCapability(String capabilityName, CapabilityContext context) {
+        return getDelegate().hasCapability(capabilityName, context);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/HostCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/HostCapabilityContext.java
@@ -36,8 +36,7 @@ class HostCapabilityContext implements CapabilityContext {
     static final HostCapabilityContext INSTANCE = new HostCapabilityContext();
 
     @Override
-    public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        CapabilityContext dependentContext = dependent.getContext();
+    public boolean canSatisfyRequirement(String requiredName, CapabilityContext dependentContext, CapabilityResolutionContext context) {
         return dependentContext == CapabilityContext.GLOBAL || dependentContext instanceof HostCapabilityContext;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/ProfileChildCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/ProfileChildCapabilityContext.java
@@ -45,8 +45,7 @@ class ProfileChildCapabilityContext extends IncludingResourceCapabilityContext {
     }
 
     @Override
-    public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        CapabilityContext dependentContext = dependent.getContext();
+    public boolean canSatisfyRequirement(String requiredName, CapabilityContext dependentContext, CapabilityResolutionContext context) {
         boolean result = equals(dependentContext);
         if (!result && dependentContext instanceof ProfileChildCapabilityContext) {
             Set<CapabilityContext> includers = getIncludingContexts(context);

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/ProfilesCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/ProfilesCapabilityContext.java
@@ -35,9 +35,8 @@ class ProfilesCapabilityContext implements CapabilityContext {
     public static final ProfilesCapabilityContext INSTANCE = new ProfilesCapabilityContext();
 
     @Override
-    public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        CapabilityContext depCtx = dependent.getContext();
-        return depCtx instanceof ProfilesCapabilityContext || depCtx instanceof ServerGroupsCapabilityContext;
+    public boolean canSatisfyRequirement(String requiredName, CapabilityContext dependentContext, CapabilityResolutionContext context) {
+        return dependentContext instanceof ProfilesCapabilityContext || dependentContext instanceof ServerGroupsCapabilityContext;
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistry.java
@@ -39,10 +39,25 @@ public interface RuntimeCapabilityRegistry extends CapabilityRegistry<RuntimeCap
      * @param <T> the java type that exposes the API
      * @return the runtime API. Will not return {@code null}
      *
+     * @throws java.lang.IllegalStateException if no capability with the given name is available in the given context
      * @throws java.lang.IllegalArgumentException if the capability does not provide a runtime API
      * @throws java.lang.ClassCastException if the runtime API exposed by the capability cannot be cast to type {code T}
      */
     <T> T getCapabilityRuntimeAPI(String capabilityName, CapabilityContext context, Class<T> apiType);
 
+    /**
+     * Gets the name of the service provided by the capability, if there is one.
+     *
+     * @param capabilityName the name of the capability. Cannot be {@code null}
+     * @param context the context in which to resolve the capability. Cannot be {@code null}
+     * @param serviceType the type of the value provided by the service. May be {@code null} if the caller is
+     *                    unconcerned about checking that its understanding of the service type provided by the
+     *                    capability is correct
+     * @return the service name. Will not return {@code null}
+     *
+     * @throws java.lang.IllegalStateException if no capability with the given name is available in the given context
+     * @throws java.lang.IllegalArgumentException if the capability does not provide a service, or if {@code serviceType}
+     *             is not {@code null} and the type of the service the capability provides is not assignable from it
+     */
     ServiceName getCapabilityServiceName(String capabilityName, CapabilityContext context, Class<?> serviceType);
 }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/ServerConfigCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/ServerConfigCapabilityContext.java
@@ -34,8 +34,8 @@ class ServerConfigCapabilityContext implements CapabilityContext {
     static final ServerConfigCapabilityContext INSTANCE = new ServerConfigCapabilityContext();
 
     @Override
-    public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        return dependent.getContext() instanceof ServerConfigCapabilityContext;
+    public boolean canSatisfyRequirement(String requiredName, CapabilityContext dependentContext, CapabilityResolutionContext context) {
+        return dependentContext instanceof ServerConfigCapabilityContext;
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/ServerGroupsCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/ServerGroupsCapabilityContext.java
@@ -32,9 +32,8 @@ class ServerGroupsCapabilityContext implements CapabilityContext {
     static final ServerGroupsCapabilityContext INSTANCE = new ServerGroupsCapabilityContext();
 
     @Override
-    public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        CapabilityContext depCtx = dependent.getContext();
-        return depCtx instanceof ServerConfigCapabilityContext;
+    public boolean canSatisfyRequirement(String requiredName, CapabilityContext dependentContext, CapabilityResolutionContext context) {
+        return dependentContext instanceof ServerConfigCapabilityContext;
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/SocketBindingGroupChildContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/SocketBindingGroupChildContext.java
@@ -45,8 +45,7 @@ class SocketBindingGroupChildContext extends IncludingResourceCapabilityContext 
     }
 
     @Override
-    public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        CapabilityContext dependentContext = dependent.getContext();
+    public boolean canSatisfyRequirement(String requiredName, CapabilityContext dependentContext, CapabilityResolutionContext context) {
         boolean result;
         if (dependentContext instanceof SocketBindingGroupChildContext) {
             result = equals(dependentContext);

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/SocketBindingGroupsCapabilityContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/SocketBindingGroupsCapabilityContext.java
@@ -37,10 +37,10 @@ class SocketBindingGroupsCapabilityContext implements CapabilityContext {
     static final SocketBindingGroupsCapabilityContext INSTANCE = new SocketBindingGroupsCapabilityContext();
 
     @Override
-    public boolean canSatisfyRequirement(CapabilityId dependent, String required, CapabilityResolutionContext context) {
-        CapabilityContext depCtx = dependent.getContext();
-        return (depCtx instanceof SocketBindingGroupsCapabilityContext || depCtx instanceof ServerGroupsCapabilityContext
-                || depCtx instanceof ServerConfigCapabilityContext);
+    public boolean canSatisfyRequirement(String requiredName, CapabilityContext dependentContext, CapabilityResolutionContext context) {
+        return dependentContext instanceof SocketBindingGroupsCapabilityContext
+                || dependentContext instanceof ServerGroupsCapabilityContext
+                || dependentContext instanceof ServerConfigCapabilityContext;
     }
 
     @Override

--- a/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
@@ -123,7 +123,9 @@ abstract class AbstractCapabilityResolutionTestCase {
     protected static ModelNode getCapabilityOperation(PathAddress pathAddress, String capability, String requirement) {
 
         ModelNode op = Util.createEmptyOperation(CAPABILITY, pathAddress);
-        op.get(CAPABILITY).set(capability);
+        if (capability != null) {
+            op.get(CAPABILITY).set(capability);
+        }
         if (requirement != null) {
             op.get(REQUIREMENT).set(requirement);
         }
@@ -242,11 +244,13 @@ abstract class AbstractCapabilityResolutionTestCase {
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
 
-            String capName = operation.require(CAPABILITY).asString();
-            RuntimeCapability.Builder rcb = RuntimeCapability.Builder.of(capName);
+            String capName = operation.hasDefined(CAPABILITY) ? operation.require(CAPABILITY).asString() : null;
+            RuntimeCapability.Builder rcb = capName == null ? null : RuntimeCapability.Builder.of(capName);
             if (operation.hasDefined(REQUIREMENT)) {
                 final String reqName = operation.get(REQUIREMENT).asString();
-                rcb.addRequirements(reqName);
+                if (capName != null) {
+                    rcb.addRequirements(reqName);
+                }
                 context.addStep(new OperationStepHandler() {
                     @Override
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
@@ -256,7 +260,9 @@ abstract class AbstractCapabilityResolutionTestCase {
             }  else {
                 context.getResult().set(true);
             }
-            context.registerCapability(rcb.build(), null);
+            if (capName != null) {
+                context.registerCapability(rcb.build(), null);
+            }
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/SocketCapabilityResolutionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/SocketCapabilityResolutionUnitTestCase.java
@@ -261,4 +261,13 @@ public class SocketCapabilityResolutionUnitTestCase extends AbstractCapabilityRe
         assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
     }
 
+    @Test
+    public void testWFCORE900() {
+        ModelNode op = getCompositeOperation(getCapabilityOperation(SOCKET_A_1, "cap_a"), getCapabilityOperation(GLOBAL_A, null, "cap_a"));
+        ModelNode response = controller.execute(op, null, null, null);
+        // NOTE: IT IS FINE TO CHANGE THESE ASSERTIONS IF WFCORE-900 SUPPORT IS RESCINDED!
+        assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(RESULT, "step-2", RESULT).asBoolean());
+    }
+
 }


### PR DESCRIPTION
…t.hasOptionalCapability is null

This also fixes some incorrect, although harmlessly so, use of CapabilityContext.