### PR TITLE
[WFCORE-873] Followup - Reinstate use of check alias

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -640,7 +640,7 @@ public class GlobalOperationHandlers {
         @Override
         public void execute(final OperationContext context, final ModelNode ignored) throws OperationFailedException {
             final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-            final PathAddress aliasAddr = WildcardReadResourceDescriptionAddressHack.detachAliasAddress(context, operation);
+            final PathAddress aliasAddr = checkAlias ? WildcardReadResourceDescriptionAddressHack.detachAliasAddress(context, operation) : null;
             execute(aliasAddr == null ? address : aliasAddr, PathAddress.EMPTY_ADDRESS, context);
         }
 


### PR DESCRIPTION
This is a follow up commit from Brian's comment at https://github.com/wildfly/wildfly-core/pull/976#discussion-diff-37642395

Although only r-r-d uses the RegistrationAddressResolver, I think the checkAlias parameter/check makes it clear that the hack is happening. Alternatively, I have removed it completely in https://github.com/wildfly/wildfly-core/pull/985. If this one is merged, that one should be closed.