### PR TITLE
[WFCORE-747], update file name to simple startup-marker

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-debian.sh
+++ b/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-debian.sh
@@ -100,7 +100,7 @@ if [ "$JBOSS_MODE" = "standalone" ]; then
 	if [ -z "$JBOSS_CONFIG" ]; then
 		JBOSS_CONFIG=standalone.xml
 	fi
-	JBOSS_MARKERFILE="$JBOSS_HOME/standalone/tmp/wildfly-startup-marker"
+	JBOSS_MARKERFILE="$JBOSS_HOME/standalone/tmp/startup-marker"
 else
 	JBOSS_SCRIPT="$JBOSS_HOME/bin/domain.sh"
 	if [ -z "$JBOSS_DOMAIN_CONFIG" ]; then
@@ -109,7 +109,7 @@ else
 	if [ -z "$JBOSS_HOST_CONFIG" ]; then
 		JBOSS_HOST_CONFIG=host.xml
 	fi
-	JBOSS_MARKERFILE="$JBOSS_HOME/domain/tmp/wildfly-startup-marker"
+	JBOSS_MARKERFILE="$JBOSS_HOME/domain/tmp/startup-marker"
 fi
 
 # Check startup file

--- a/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-redhat.sh
+++ b/core-feature-pack/src/main/resources/content/bin/init.d/wildfly-init-redhat.sh
@@ -62,7 +62,7 @@ if [ "$JBOSS_MODE" = "standalone" ]; then
 	if [ -z "$JBOSS_CONFIG" ]; then
 		JBOSS_CONFIG=standalone.xml
 	fi
-	JBOSS_MARKERFILE=$JBOSS_HOME/standalone/tmp/wildfly-startup-marker
+	JBOSS_MARKERFILE=$JBOSS_HOME/standalone/tmp/startup-marker
 else
 	JBOSS_SCRIPT=$JBOSS_HOME/bin/domain.sh
 	if [ -z "$JBOSS_DOMAIN_CONFIG" ]; then
@@ -71,7 +71,7 @@ else
 	if [ -z "$JBOSS_HOST_CONFIG" ]; then
 		JBOSS_HOST_CONFIG=host.xml
 	fi
-	JBOSS_MARKERFILE=$JBOSS_HOME/domain/tmp/wildfly-startup-marker
+	JBOSS_MARKERFILE=$JBOSS_HOME/domain/tmp/startup-marker
 fi
 
 prog='wildfly'

--- a/server/src/main/java/org/jboss/as/server/BootstrapListener.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapListener.java
@@ -44,7 +44,7 @@ import org.jboss.msc.service.StabilityStatistics;
  */
 public final class BootstrapListener {
 
-    public static final String MARKER_FILE = "wildfly-startup-marker";
+    public static final String MARKER_FILE = "startup-marker";
 
     private final StabilityMonitor monitor = new StabilityMonitor();
     private final ServiceContainer serviceContainer;


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-747
I should have just use 'startup-marker' since this can also be used for EAP code.