### PR TITLE
[WFCORE-901] Update the utility to properly test our standard configs and legacy configs

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -178,7 +178,13 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
 
             String[] cmds = cmdsList.toArray(new String[cmdsList.size()]);
 
-            EmbeddedServerReference hostController = EmbeddedServerFactory.createHostController(ModuleLoader.forClass(getClass()), jbossHome, cmds);
+            EmbeddedServerReference hostController;
+            if (this.jbossHome == null) {
+                // Modular environment
+                hostController = EmbeddedServerFactory.createHostController(ModuleLoader.forClass(getClass()), jbossHome, cmds);
+            } else {
+                hostController = EmbeddedServerFactory.createHostController(jbossHome.getAbsolutePath(), null, null, cmds);
+            }
             hostController.start();
             hostControllerReference.set(new EmbeddedServerLaunch(hostController, restorer));
 

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedServerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedServerFactory.java
@@ -195,6 +195,21 @@ public class EmbeddedServerFactory {
         return (EmbeddedServerReference) create(moduleLoader, jbossHomeDir, cmdargs);
     }
 
+    public static EmbeddedServerReference createHostController(String jbossHomePath, String modulePath, String[] systemPackages, String[] cmdargs) {
+        if (jbossHomePath == null || jbossHomePath.isEmpty()) {
+            throw EmbeddedLogger.ROOT_LOGGER.invalidJBossHome(jbossHomePath);
+        }
+        File jbossHomeDir = new File(jbossHomePath);
+        if (!jbossHomeDir.isDirectory()) {
+            throw EmbeddedLogger.ROOT_LOGGER.invalidJBossHome(jbossHomePath);
+        }
+
+        if (modulePath == null)
+            modulePath = jbossHomeDir.getAbsolutePath() + File.separator + "modules";
+
+        return createHostController(setupModuleLoader(modulePath, systemPackages), jbossHomeDir, cmdargs);
+    }
+
     /**
      * Create an embedded host controller with an already established module loader.
      *

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -751,7 +751,9 @@ public class DomainModelControllerService extends AbstractControllerService impl
                 }
             } else {
                 // Die!
-                ROOT_LOGGER.unsuccessfulBoot();
+                String failed = ROOT_LOGGER.unsuccessfulBoot();
+                ROOT_LOGGER.fatal(failed);
+                bootstrapListener.bootFailure(failed);
                 SystemExiter.exit(ExitCodes.HOST_CONTROLLER_ABORT_EXIT_CODE);
             }
         }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -366,9 +366,8 @@ public interface HostControllerLogger extends BasicLogger {
     @Message(id = 33, value = "Caught exception during boot")
     void caughtExceptionDuringBoot(@Cause Exception e);
 
-    @LogMessage(level = Level.FATAL)
     @Message(id = 34, value = "Host Controller boot has failed in an unrecoverable manner; exiting. See previous messages for details.")
-    void unsuccessfulBoot();
+    String unsuccessfulBoot();
 
     @LogMessage(level = Level.ERROR)
     @Message(id = 35, value = "Installation of the domain-wide configuration has failed. Because the running mode of this Host Controller is ADMIN_ONLY boot has been allowed to proceed. If ADMIN_ONLY mode were not in effect the process would be terminated due to a critical boot failure.")

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -22,10 +22,19 @@
 
 package org.jboss.as.remoting;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODULE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.List;
+import java.util.Map;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -33,7 +42,9 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.parsing.ProfileParsingCompletionHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.OperationTransformer;
 import org.jboss.as.controller.transform.ResourceTransformer;
@@ -42,6 +53,7 @@ import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+import org.jboss.as.remoting.logging.RemotingLogger;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -75,6 +87,8 @@ public class RemotingExtension implements Extension {
 
     private static final ModelVersion VERSION_1_3 = ModelVersion.create(1, 3);
     private static final ModelVersion VERSION_2_1 = ModelVersion.create(2, 1);
+
+    private static final String IO_EXTENSION_MODULE = "org.wildfly.extension.io";
 
     @Override
     public void initialize(ExtensionContext context) {
@@ -173,6 +187,69 @@ public class RemotingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_1_2.getUriString(), RemotingSubsystem12Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_2_0.getUriString(), RemotingSubsystem20Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_3_0.getUriString(), RemotingSubsystem30Parser.INSTANCE);
+
+        context.setProfileParsingCompletionHandler(new IOCompletionHandler());
+    }
+
+    private static class IOCompletionHandler implements ProfileParsingCompletionHandler {
+
+        @Override
+        public void handleProfileParsingCompletion(Map<String, List<ModelNode>> profileBootOperations, List<ModelNode> otherBootOperations) {
+
+            // If the namespace used for our subsystem predates the introduction of the IO subsystem,
+            // check if the profile includes io and if not add it
+
+            String legacyNS = null;
+            List<ModelNode> legacyRemotingOps = null;
+            for (Namespace ns : Namespace.values()) {
+                String nsString = ns.getUriString();
+                if (nsString != null && nsString.startsWith("urn:jboss:domain:remoting:1.")) {
+                    legacyRemotingOps = profileBootOperations.get(nsString);
+                    if (legacyRemotingOps != null) {
+                        legacyNS = nsString;
+                        break;
+                    }
+                }
+            }
+
+            if (legacyRemotingOps != null) {
+                boolean foundIO = false;
+                for (String ns : profileBootOperations.keySet()) {
+                    if (ns.startsWith("urn:jboss:domain:io:")) {
+                        foundIO = true;
+                        break;
+                    }
+                }
+
+                if (!foundIO) {
+                    // legacy Remoting subsystem and no io subsystem, add it
+
+                    // See if we need to add the extension as well
+                    boolean hasIoExtension = false;
+                    for (ModelNode op : otherBootOperations) {
+                        PathAddress pa = PathAddress.pathAddress(op.get(OP_ADDR));
+                        if (pa.size() == 1 && EXTENSION.equals(pa.getElement(0).getKey())
+                                && IO_EXTENSION_MODULE.equals(pa.getElement(0).getValue())) {
+                            hasIoExtension = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasIoExtension) {
+                        final ModelNode addIoExtensionOp = Util.createAddOperation(PathAddress.pathAddress(EXTENSION, IO_EXTENSION_MODULE));
+                        addIoExtensionOp.get(MODULE).set(IO_EXTENSION_MODULE);
+                        otherBootOperations.add(addIoExtensionOp);
+                    }
+
+                    PathAddress subsystemAddress = PathAddress.pathAddress(SUBSYSTEM, "io");
+                    legacyRemotingOps.add(Util.createAddOperation(subsystemAddress));
+                    legacyRemotingOps.add(Util.createAddOperation(subsystemAddress.append("worker", "default")));
+                    legacyRemotingOps.add(Util.createAddOperation(subsystemAddress.append("buffer-pool", "default")));
+
+                    RemotingLogger.ROOT_LOGGER.addingIOSubsystem(legacyNS);
+                }
+            }
+        }
     }
 
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/logging/RemotingLogger.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/logging/RemotingLogger.java
@@ -124,4 +124,9 @@ public interface RemotingLogger extends BasicLogger {
 
     @Message(id = 23, value = "Only one of '%s' configuration or '%s' configuration is allowed")
     String workerThreadsEndpointConfigurationChoiceRequired(String workerThreads, String endpoint);
+
+    @LogMessage(level = INFO)
+    @Message(id = 24, value = "The remoting subsystem is present but no io subsystem was found. An io subsystem " +
+            "was not required when remoting schema '%s' was current but now is, so a default subsystem is being added.")
+    void addingIOSubsystem(String legacyNS);
 }

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestUtil.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestUtil.java
@@ -23,13 +23,24 @@
 package org.jboss.as.remoting;
 
 import static org.jboss.as.controller.capability.RuntimeCapability.buildDynamicCapabilityName;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.extension.ExtensionRegistryType;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.dmr.ModelType;
+import org.wildfly.extension.io.IOExtension;
 
 /**
  * Utilities for the remoting subsystem tests.
@@ -56,13 +67,23 @@ class RemotingSubsystemTestUtil {
                 protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration, RuntimeCapabilityRegistry capabilityRegistry) {
                     super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
                     AdditionalInitialization.registerCapabilities(capabilityRegistry,
-                            buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
-                                    RemotingEndpointResource.WORKER.getDefaultValue().asString()),
                             // This one is specified in one of the test configs
                             buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY, "default-remoting"));
+
+                    // Deal with the fact that legacy parsers will add the io extension/subsystem
+                    registerIOExtension(extensionRegistry, rootRegistration);
                 }
             };
 
+    static void registerIOExtension(ExtensionRegistry extensionRegistry, ManagementResourceRegistration rootRegistration) {
+        ManagementResourceRegistration extReg = rootRegistration.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement(EXTENSION, "org.wildfly.extension.io"),
+                NonResolvingResourceDescriptionResolver.INSTANCE, new ModelOnlyAddStepHandler(), ModelOnlyRemoveStepHandler.INSTANCE));
+        extReg.registerReadOnlyAttribute(new SimpleAttributeDefinitionBuilder("module", ModelType.STRING).build(), null);
+
+        Extension ioe = new IOExtension();
+        ioe.initialize(extensionRegistry.getExtensionContext("org.wildfly.extension.io", rootRegistration, ExtensionRegistryType.MASTER));
+
+    }
     private RemotingSubsystemTestUtil() {
         //
     }

--- a/server/src/main/java/org/jboss/as/server/BootstrapListener.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapListener.java
@@ -83,7 +83,11 @@ public final class BootstrapListener {
         }
     }
 
-    protected void done(final long bootstrapTime, final StabilityStatistics statistics) {
+    public void bootFailure(String message) {
+        futureContainer.failed(new Exception(message));
+    }
+
+    private void done(final long bootstrapTime, final StabilityStatistics statistics) {
         futureContainer.done(serviceContainer);
         if (serviceContainer.isShutdown()) {
             // Do not print boot statistics because server

--- a/server/src/main/java/org/jboss/as/server/FutureServiceContainer.java
+++ b/server/src/main/java/org/jboss/as/server/FutureServiceContainer.java
@@ -37,4 +37,8 @@ public class FutureServiceContainer extends AsyncFutureTask<ServiceContainer> {
     void done(final ServiceContainer container) {
         setResult(container);
     }
+
+    void failed(Throwable cause) {
+        setFailed(cause);
+    }
 }

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -377,7 +377,9 @@ public final class ServerService extends AbstractControllerService {
             bootstrapListener.printBootStatistics();
         } else {
             // Die!
-            ServerLogger.ROOT_LOGGER.unsuccessfulBoot();
+            String message = ServerLogger.ROOT_LOGGER.unsuccessfulBoot();
+            ServerLogger.ROOT_LOGGER.fatal(message);
+            bootstrapListener.bootFailure(message);
             SystemExiter.exit(1);
         }
     }

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -366,9 +366,8 @@ public interface ServerLogger extends BasicLogger {
     void caughtExceptionDuringBoot(@Cause Exception e);
 
 
-    @LogMessage(level = Logger.Level.FATAL)
     @Message(id = 56, value = "Server boot has failed in an unrecoverable manner; exiting. See previous messages for details.")
-    void unsuccessfulBoot();
+    String unsuccessfulBoot();
 
     /**
      * Logs an error message indicating the content for a configured deployment was unavailable at boot but boot

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/ModelParserUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/ModelParserUtils.java
@@ -20,102 +20,25 @@
  */
 package org.jboss.as.test.shared;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import javax.xml.namespace.QName;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
-import org.jboss.as.controller.AbstractControllerService;
-import org.jboss.as.controller.BootErrorCollector;
-import org.jboss.as.controller.ControlledProcessState;
-import org.jboss.as.controller.ExpressionResolver;
-import org.jboss.as.controller.ManagementModel;
-import org.jboss.as.controller.ModelController;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ProcessType;
-import org.jboss.as.controller.ResourceBuilder;
-import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RunningMode;
-import org.jboss.as.controller.RunningModeControl;
-import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
-import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
-import org.jboss.as.controller.audit.AuditLogger;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
-import org.jboss.as.controller.extension.ExtensionRegistry;
-import org.jboss.as.controller.extension.MutableRootResourceRegistrationProvider;
-import org.jboss.as.controller.extension.RuntimeHostControllerInfoAccessor;
-import org.jboss.as.controller.operations.common.NamespaceAddHandler;
-import org.jboss.as.controller.operations.common.SchemaLocationAddHandler;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.operations.common.XmlMarshallingHandler;
-import org.jboss.as.controller.parsing.Namespace;
-import org.jboss.as.controller.persistence.NullConfigurationPersister;
-import org.jboss.as.controller.persistence.XmlConfigurationPersister;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.controller.resource.InterfaceDefinition;
-import org.jboss.as.controller.services.path.PathManagerService;
-import org.jboss.as.controller.services.path.PathResourceDefinition;
-import org.jboss.as.domain.controller.LocalHostControllerInfo;
-import org.jboss.as.domain.controller.resources.DomainRootDefinition;
-import org.jboss.as.domain.management.CoreManagementResourceDefinition;
-import org.jboss.as.domain.management.audit.EnvironmentNameReader;
-import org.jboss.as.host.controller.discovery.DiscoveryOption;
-import org.jboss.as.host.controller.model.host.HostResourceDefinition;
-import org.jboss.as.host.controller.model.jvm.JvmResourceDefinition;
-import org.jboss.as.host.controller.operations.HostSpecifiedInterfaceAddHandler;
-import org.jboss.as.host.controller.operations.HostSpecifiedInterfaceRemoveHandler;
-import org.jboss.as.host.controller.operations.IsMasterHandler;
-import org.jboss.as.host.controller.operations.LocalDomainControllerAddHandler;
-import org.jboss.as.host.controller.operations.LocalHostControllerInfoImpl;
-import org.jboss.as.host.controller.operations.RemoteDomainControllerAddHandler;
-import org.jboss.as.host.controller.parsing.DomainXml;
-import org.jboss.as.host.controller.parsing.HostXml;
-import org.jboss.as.host.controller.resources.NativeManagementResourceDefinition;
-import org.jboss.as.host.controller.resources.ServerConfigResourceDefinition;
-import org.jboss.as.repository.ContentReference;
-import org.jboss.as.repository.ContentRepository;
-import org.jboss.as.repository.HostFileRepository;
 import org.jboss.as.server.ServerEnvironment;
-import org.jboss.as.server.controller.resources.ServerRootResourceDefinition;
-import org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition;
-import org.jboss.as.server.parsing.StandaloneXml;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
-import org.jboss.modules.Module;
-import org.jboss.msc.service.AbstractServiceListener;
-import org.jboss.msc.service.ServiceBuilder;
-import org.jboss.msc.service.ServiceContainer;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.service.StartContext;
-import org.jboss.msc.service.StartException;
-import org.jboss.vfs.VirtualFile;
 import org.junit.Assert;
 
 /**
@@ -124,59 +47,169 @@ import org.junit.Assert;
  */
 public class ModelParserUtils {
 
-    public static ModelNode standaloneXmlTest(File original, File target) throws Exception {
-        ServiceContainer serviceContainer = setupServiceContainer();
+    /**
+     * Tests the ability to boot an admin-only server using the given config, persist the config,
+     * reload it, and confirm that the configuration model from the original boot matches the model
+     * from the reload.
+     *
+     * @param originalConfig the config file to use
+     * @param jbossHome directory to use as $JBOSS_HOME
+     * @return the configuration model read after the reload
+     * @throws Exception
+     */
+    public static ModelNode standaloneXmlTest(File originalConfig, File jbossHome) throws Exception {
+        File serverDir =  new File(jbossHome, "standalone");
+
+        File configCopy = new File(serverDir, "configuration" + File.separatorChar + originalConfig.getName());
+        FileUtils.copyFile(originalConfig, configCopy);
+
+        CLIWrapper cli = new CLIWrapper(false);
         try {
-            FileUtils.copyFile(original, target);
-            // Only instantiate one per container as service names of the paths will be registered on the container
-            final TestPathManagerService pathManager = new TestPathManagerService(serviceContainer);
-            ModelNode originalModel = loadServerModel(serviceContainer, target, pathManager);
-            ModelNode reparsedModel = loadServerModel(serviceContainer, target, pathManager);
-            compare(originalModel, reparsedModel);
-            return reparsedModel;
+
+            String line = "embed-server --admin-only=true --server-config=" + originalConfig.getName() + " --std-out=echo --jboss-home=" + jbossHome.getCanonicalPath();
+            cli.sendLine(line);
+            assertProcessState(cli, "running", TimeoutUtil.adjust(30000), false);
+            ModelNode firstResult = readResourceTree(cli);
+            cli.sendLine("/system-property=model-parser-util:add(value=true)");
+            cli.sendLine("/system-property=model-parser-util:remove");
+            cli.sendLine("reload --admin-only=true");
+            assertProcessState(cli, "running", TimeoutUtil.adjust(30000), false);
+            ModelNode secondResult = readResourceTree(cli);
+            compare(firstResult, secondResult);
+            return secondResult;
+
         } finally {
-            cleanup(serviceContainer);
-        }
-    }
-
-    public static void hostXmlTest(final File original, File target) throws Exception {
-        ServiceContainer serviceContainer = setupServiceContainer();
-        try {
-            FileUtils.copyFile(original, target);
-            ModelNode originalModel = loadHostModel(serviceContainer, target);
-            ModelNode reparsedModel = loadHostModel(serviceContainer, target);
-            compare(originalModel, reparsedModel);
-        } finally {
-            cleanup(serviceContainer);
-        }
-    }
-
-    public static ModelNode domainXmlTest(File original, File target) throws Exception {
-        ServiceContainer serviceContainer = setupServiceContainer();
-        try {
-            FileUtils.copyFile(original, target);
-            ModelNode originalModel = loadDomainModel(serviceContainer, target);
-            ModelNode reparsedModel = loadDomainModel(serviceContainer, target);
-            compare(originalModel, reparsedModel);
-            return reparsedModel;
-        } finally {
-            cleanup(serviceContainer);
-        }
-    }
-
-    private static ServiceContainer setupServiceContainer() {
-        return ServiceContainer.Factory.create("test");
-    }
-
-    private static void cleanup(final ServiceContainer serviceContainer) throws Exception {
-        if (serviceContainer != null) {
-            serviceContainer.shutdown();
             try {
-                serviceContainer.awaitTermination(5, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
+                cli.quit();
+            } finally {
+                System.clearProperty(ServerEnvironment.SERVER_BASE_DIR);
             }
         }
+    }
+
+    /**
+     * Tests the ability to boot an admin-only Host Controller using the given host config, persist the config,
+     * reload it, and confirm that the configuration model from the original boot matches the model
+     * from the reload.
+     *
+     * @param originalConfig the config file to use for the host model
+     * @param jbossHome directory to use as $JBOSS_HOME
+     * @return the host subtree from the configuration model read after the reload
+     * @throws Exception
+     */
+    public static ModelNode hostXmlTest(final File originalConfig, File jbossHome) throws Exception {
+        return hostControllerTest(originalConfig, jbossHome, true);
+    }
+
+    private static ModelNode hostControllerTest(final File originalConfig, final File target, boolean hostXml) throws Exception {
+        File domainDir =  new File(target, "domain");
+
+        File configCopy = new File(domainDir, "configuration" + File.separatorChar + originalConfig.getName());
+        FileUtils.copyFile(originalConfig, configCopy);
+
+        CLIWrapper cli = new CLIWrapper(false);
+        try {
+            String configType = hostXml ? "--host-config=" : "--domain-config=";
+            String line = "embed-host-controller " + configType + originalConfig.getName() + " --std-out=echo --jboss-home=" + target.getCanonicalPath();
+            cli.sendLine(line);
+            assertProcessState(cli, "running", TimeoutUtil.adjust(30000), true);
+            ModelNode firstResult = readResourceTree(cli);
+            String hostName = firstResult.get(HOST).asProperty().getName();
+            cli.sendLine("/system-property=model-parser-util:add(value=true)");
+            cli.sendLine("/system-property=model-parser-util:remove");
+            cli.sendLine("reload --host=" + hostName + " --admin-only=true");
+            assertProcessState(cli, "running", TimeoutUtil.adjust(30000), true);
+            ModelNode secondResult = readResourceTree(cli);
+            compare(pruneDomainModel(firstResult, hostXml), pruneDomainModel(secondResult, hostXml));
+            return secondResult;
+
+        } finally {
+            try {
+                cli.quit();
+            } finally {
+                System.clearProperty(ServerEnvironment.SERVER_BASE_DIR);
+            }
+        }
+    }
+
+    private static ModelNode pruneDomainModel(ModelNode model, boolean forHost) {
+        ModelNode result = new ModelNode();
+        if (forHost) {
+            result.get(HOST).set(model.get(HOST));
+        } else {
+            for (Property prop : model.asPropertyList()) {
+                if (!HOST.equals(prop.getName())) {
+                    result.get(prop.getName()).set(prop.getValue());
+                }
+            }
+        }
+        return result;
+    }
+
+
+    /**
+     * Tests the ability to boot an admin-only Host Controller using the given domain config, persist the config,
+     * reload it, and confirm that the configuration model from the original boot matches the model
+     * from the reload.
+     *
+     * @param originalConfig the config file to use for the domain model
+     * @param jbossHome directory to use as $JBOSS_HOME
+     * @return the configuration model read after the reload, excluding the host subtree
+     * @throws Exception
+     */
+    public static ModelNode domainXmlTest(File originalConfig, File jbossHome) throws Exception {
+        return hostControllerTest(originalConfig, jbossHome, false);
+    }
+
+    private static void assertProcessState(CLIWrapper cli, String expected, int timeout, boolean forHost) throws IOException, InterruptedException {
+        long done = timeout < 1 ? 0 : System.currentTimeMillis() + timeout;
+        String history = "";
+        String state = null;
+        do {
+            try {
+                state = forHost ? getHostState(cli) : getServerState(cli);
+                history += state+"\n";
+            } catch (Exception ignored) {
+                //
+                history += ignored.toString()+ "--" + cli.readOutput() + "\n";
+            }
+            if (expected.equals(state)) {
+                return;
+            } else {
+                Thread.sleep(20);
+            }
+        } while (timeout > 0 && System.currentTimeMillis() < done);
+        assertEquals(history, expected, state);
+    }
+
+    private static String getServerState(CLIWrapper cli) throws IOException {
+        cli.sendLine(":read-attribute(name=server-state)", true);
+        CLIOpResult result = cli.readAllAsOpResult();
+        ModelNode resp = result.getResponseNode();
+        ModelNode stateNode = result.isIsOutcomeSuccess() ? resp.get(RESULT) : resp.get(FAILURE_DESCRIPTION);
+        return stateNode.asString();
+    }
+
+    private static String getHostState(CLIWrapper cli) throws IOException {
+        cli.sendLine("/host=*:read-attribute(name=host-state)", true);
+        CLIOpResult result = cli.readAllAsOpResult();
+        ModelNode resp = result.getResponseNode();
+        ModelNode stateNode;
+        if (result.isIsOutcomeSuccess()) {
+            stateNode = resp.get(RESULT).get(0).get(RESULT);
+        } else {
+            stateNode = resp.get(FAILURE_DESCRIPTION);
+        }
+        return stateNode.asString();
+    }
+
+    private static ModelNode readResourceTree(CLIWrapper cli) {
+        cli.sendLine("/:read-resource(recursive=true)");
+        ModelNode response = ModelNode.fromString(cli.readOutput());
+        assertTrue(response.toString(), SUCCESS.equals(response.get(OUTCOME).asString()));
+        ModelNode firstResult = response.get(RESULT);
+        assertTrue(response.toString(), firstResult.isDefined());
+        return firstResult;
     }
 
     private static void compare(ModelNode node1, ModelNode node2) {
@@ -216,456 +249,4 @@ public class ModelParserUtils {
             Assert.assertEquals("\n\"" + node1.asString() + "\"\n\"" + node2.asString() + "\"\n-----", node1.asString().trim(), node2.asString().trim());
         }
     }
-
-    private static ModelController createController(final ServiceContainer serviceContainer, final ProcessType processType, final ModelNode model, final Setup registration) throws InterruptedException {
-        final ServiceController<?> existingController = serviceContainer.getService(ServiceName.of("ModelController"));
-        if (existingController != null) {
-            final CountDownLatch latch = new CountDownLatch(1);
-            existingController.addListener(new AbstractServiceListener<Object>() {
-                public void listenerAdded(ServiceController<?> serviceController) {
-                    serviceController.setMode(ServiceController.Mode.REMOVE);
-                }
-
-                public void transition(ServiceController<?> serviceController, ServiceController.Transition transition) {
-                    if (transition.equals(ServiceController.Transition.REMOVING_to_REMOVED)) {
-                        latch.countDown();
-                    }
-                }
-            });
-            latch.await();
-        }
-
-        ServiceTarget target = serviceContainer.subTarget();
-        ModelControllerService svc = new ModelControllerService(processType, registration, model);
-        ServiceBuilder<ModelController> builder = target.addService(ServiceName.of("ModelController"), svc);
-        builder.install();
-        svc.latch.await(30, TimeUnit.SECONDS);
-        ModelController controller = svc.getValue();
-        ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
-        controller.execute(setup, null, null, null);
-
-        return controller;
-    }
-
-    private static void executeOperations(ModelController controller, List<ModelNode> ops) {
-        for (final ModelNode op : ops) {
-            op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
-            controller.execute(op, null, null, null);
-        }
-    }
-
-    private static ModelNode loadServerModel(final ServiceContainer serviceContainer, final File file, final PathManagerService pathManagerService) throws Exception {
-        final ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.STANDALONE_SERVER, new RunningModeControl(RunningMode.ADMIN_ONLY), null, null, RuntimeHostControllerInfoAccessor.SERVER);
-        final QName rootElement = new QName(Namespace.CURRENT.getUriString(), "server");
-        final StandaloneXml parser = new StandaloneXml(Module.getBootModuleLoader(), null, extensionRegistry);
-        final XmlConfigurationPersister persister = new XmlConfigurationPersister(file, rootElement, parser, parser);
-        for (Namespace namespace : Namespace.domainValues()) {
-            if (namespace != Namespace.CURRENT) {
-                persister.registerAdditionalRootElement(new QName(namespace.getUriString(), "server"), parser);
-            }
-        }
-        extensionRegistry.setWriterRegistry(persister);
-        final List<ModelNode> ops = persister.load();
-
-        final ModelNode model = new ModelNode();
-        final ModelController controller = createController(serviceContainer, ProcessType.STANDALONE_SERVER, model, new Setup() {
-            @Override
-            public void setup(ModelControllerService modelControllerService, Resource resource, ManagementResourceRegistration rootRegistration, DelegatingConfigurableAuthorizer authorizer) {
-                ServerRootResourceDefinition def = new ServerRootResourceDefinition(new MockContentRepository(), persister, null, null, null, null, extensionRegistry, false, pathManagerService, null, authorizer,
-                        AuditLogger.NO_OP_LOGGER, modelControllerService.getRootResourceRegProvider(),
-                        modelControllerService.getBootErrorCollector());
-                def.registerAttributes(rootRegistration);
-                def.registerOperations(rootRegistration);
-                def.registerChildren(rootRegistration);
-                def.registerNotifications(rootRegistration);
-            }
-        });
-
-        final ModelNode caputreModelOp = new ModelNode();
-        caputreModelOp.get(OP_ADDR).set(PathAddress.EMPTY_ADDRESS.toModelNode());
-        caputreModelOp.get(OP).set("capture-model");
-
-        final List<ModelNode> toRun = new ArrayList<ModelNode>(ops);
-        toRun.add(caputreModelOp);
-        executeOperations(controller, toRun);
-        persister.store(model, null).commit();
-        return model;
-    }
-
-    //TODO use HostInitializer & TestModelControllerService
-    private static ModelNode loadHostModel(final ServiceContainer serviceContainer, final File file) throws Exception {
-        final ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.HOST_CONTROLLER, new RunningModeControl(RunningMode.NORMAL), null, null, RuntimeHostControllerInfoAccessor.SERVER);
-        final QName rootElement = new QName(Namespace.CURRENT.getUriString(), "host");
-        final HostXml parser = new HostXml("host-controller", RunningMode.NORMAL, false, Module.getBootModuleLoader(), null, extensionRegistry);
-        final XmlConfigurationPersister persister = new XmlConfigurationPersister(file, rootElement, parser, parser);
-        for (Namespace namespace : Namespace.domainValues()) {
-            if (namespace != Namespace.CURRENT) {
-                persister.registerAdditionalRootElement(new QName(namespace.getUriString(), "host"), parser);
-            }
-        }
-        final List<ModelNode> ops = persister.load();
-
-        final ModelNode model = new ModelNode();
-
-        final ModelController controller = createController(serviceContainer, ProcessType.HOST_CONTROLLER, model, new Setup() {
-            public void setup(ModelControllerService modelControllerService, Resource resource, ManagementResourceRegistration root, DelegatingConfigurableAuthorizer authorizer) {
-
-                final Resource host = Resource.Factory.create();
-                resource.registerChild(PathElement.pathElement(HOST, "master"), host);
-
-                // TODO maybe make creating of empty nodes part of the MNR description
-                host.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT), Resource.Factory.create());
-                host.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.SERVICE_CONTAINER), Resource.Factory.create());
-
-                // Add of the host itself
-                ManagementResourceRegistration hostRegistration = root.registerSubModel(
-                        ResourceBuilder.Factory.create(PathElement.pathElement(HOST), new NonResolvingResourceDescriptionResolver()).build());
-
-                // Other root resource operations
-                XmlMarshallingHandler xmh = new XmlMarshallingHandler(persister);
-                hostRegistration.registerOperationHandler(XmlMarshallingHandler.DEFINITION, xmh);
-                hostRegistration.registerOperationHandler(NamespaceAddHandler.DEFINITION, NamespaceAddHandler.INSTANCE);
-                hostRegistration.registerOperationHandler(SchemaLocationAddHandler.DEFINITION, SchemaLocationAddHandler.INSTANCE);
-                hostRegistration.registerReadOnlyAttribute(HostResourceDefinition.MASTER, IsMasterHandler.INSTANCE);
-
-                // System Properties
-                ManagementResourceRegistration sysProps = hostRegistration.registerSubModel(SystemPropertyResourceDefinition.createForDomainOrHost(SystemPropertyResourceDefinition.Location.HOST));
-
-                // Central Management
-                final LocalHostControllerInfoImpl hostControllerInfo = new LocalHostControllerInfoImpl(new ControlledProcessState(false), "master");
-                ResourceDefinition nativeDef = new NativeManagementResourceDefinition(hostControllerInfo);
-
-                ResourceDefinition core = CoreManagementResourceDefinition.forHost(authorizer,
-                        AuditLogger.NO_OP_LOGGER, MOCK_PATH_MANAGER, new EnvironmentNameReader() {
-
-                            @Override
-                            public boolean isServer() {
-                                return false;
-                            }
-
-                            @Override
-                            public String getServerName() {
-                                return null;
-                            }
-
-                            @Override
-                            public String getProductName() {
-                                return null;
-                            }
-
-                            @Override
-                            public String getHostName() {
-                                return null;
-                            }
-                        }, new BootErrorCollector(), nativeDef);
-                hostRegistration.registerSubModel(core);
-
-                // Domain controller
-                LocalDomainControllerAddHandler localDcAddHandler = LocalDomainControllerAddHandler.getTestInstance();
-                hostRegistration.registerOperationHandler(LocalDomainControllerAddHandler.DEFINITION, localDcAddHandler, false);
-                RemoteDomainControllerAddHandler remoteDcAddHandler = new MockRemoteDomainControllerAddHandler();
-                hostRegistration.registerOperationHandler(RemoteDomainControllerAddHandler.DEFINITION, remoteDcAddHandler, false);
-
-                // Jvms
-                final ManagementResourceRegistration jvms = hostRegistration.registerSubModel(JvmResourceDefinition.GLOBAL);
-
-                //Paths
-                ManagementResourceRegistration paths = hostRegistration.registerSubModel(PathResourceDefinition.createSpecified(MOCK_PATH_MANAGER));
-
-                //interface
-                ManagementResourceRegistration interfaces = hostRegistration.registerSubModel(new InterfaceDefinition(
-                        HostSpecifiedInterfaceAddHandler.INSTANCE,
-                        HostSpecifiedInterfaceRemoveHandler.INSTANCE,
-                        true,
-                        false
-                ));
-
-                //server configurations
-                hostRegistration.registerSubModel(new ServerConfigResourceDefinition(MOCK_HOST_CONTROLLER_INFO, null, MOCK_PATH_MANAGER, new ControlledProcessState(false), new File(System.getProperty("java.io.tmpdir"))));
-            }
-        });
-
-        final ModelNode caputreModelOp = new ModelNode();
-        caputreModelOp.get(OP_ADDR).set(PathAddress.EMPTY_ADDRESS.toModelNode());
-        caputreModelOp.get(OP).set("capture-model");
-
-        final List<ModelNode> toRun = new ArrayList<ModelNode>(ops);
-        toRun.add(caputreModelOp);
-        executeOperations(controller, toRun);
-
-        model.get(HOST, "master", NAME).set("master");
-        persister.store(model.get(HOST, "master"), null).commit();
-        return model;
-    }
-
-    private static ModelNode loadDomainModel(final ServiceContainer serviceContainer, File file) throws Exception {
-        final ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.HOST_CONTROLLER, new RunningModeControl(RunningMode.NORMAL), null, null, RuntimeHostControllerInfoAccessor.SERVER);
-        final QName rootElement = new QName(Namespace.CURRENT.getUriString(), "domain");
-        final DomainXml parser = new DomainXml(Module.getBootModuleLoader(), null, extensionRegistry);
-        final XmlConfigurationPersister persister = new XmlConfigurationPersister(file, rootElement, parser, parser);
-        for (Namespace namespace : Namespace.domainValues()) {
-            if (namespace != Namespace.CURRENT) {
-                persister.registerAdditionalRootElement(new QName(namespace.getUriString(), "domain"), parser);
-            }
-        }
-        extensionRegistry.setWriterRegistry(persister);
-        final List<ModelNode> ops = persister.load();
-        final ModelNode model = new ModelNode();
-        final ModelController controller = createController(serviceContainer, ProcessType.HOST_CONTROLLER, model, new Setup() {
-            public void setup(ModelControllerService modelControllerService, Resource resource, ManagementResourceRegistration rootRegistration, DelegatingConfigurableAuthorizer authorizer) {
-                DomainRootDefinition def = new DomainRootDefinition(null, null, persister, new MockContentRepository(), new MockFileRepository(), true, null, extensionRegistry, null,
-                        MOCK_PATH_MANAGER, authorizer, null, modelControllerService.getRootResourceRegProvider());
-                def.initialize(rootRegistration);
-            }
-        });
-
-        final ModelNode caputreModelOp = new ModelNode();
-        caputreModelOp.get(OP_ADDR).set(PathAddress.EMPTY_ADDRESS.toModelNode());
-        caputreModelOp.get(OP).set("capture-model");
-
-        final List<ModelNode> toRun = new ArrayList<ModelNode>(ops);
-        toRun.add(caputreModelOp);
-
-        executeOperations(controller, toRun);
-
-        persister.store(model, null).commit();
-        return model;
-    }
-
-    interface Setup {
-
-        void setup(ModelControllerService modelControllerService, Resource resource, ManagementResourceRegistration rootRegistration, DelegatingConfigurableAuthorizer authorizer);
-    }
-
-    static class ModelControllerService extends AbstractControllerService {
-
-        private final CountDownLatch latch = new CountDownLatch(2);
-        private final ModelNode model;
-        private final Setup registration;
-
-        ModelControllerService(final ProcessType processType, final Setup registration, final ModelNode model) {
-            super(processType, new RunningModeControl(RunningMode.ADMIN_ONLY), new NullConfigurationPersister(), new ControlledProcessState(true),
-                    ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build(), null, ExpressionResolver.TEST_RESOLVER, AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer());
-            this.model = model;
-            this.registration = registration;
-        }
-
-        MutableRootResourceRegistrationProvider getRootResourceRegProvider() {
-            return getMutableRootResourceRegistrationProvider();
-        }
-
-        @Override
-        protected BootErrorCollector getBootErrorCollector() {
-            return super.getBootErrorCollector();
-        }
-
-        @Override
-        public void start(StartContext context) throws StartException {
-            super.start(context);
-            latch.countDown();
-        }
-
-        @Override
-        protected void bootThreadDone() {
-            super.bootThreadDone();
-            latch.countDown();
-        }
-
-        @Override
-        protected void initModel(ManagementModel managementModel, Resource modelControllerResource) {
-            ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
-            Resource rootResource = managementModel.getRootResource();
-            registration.setup(this, rootResource, rootRegistration, authorizer);
-
-            rootRegistration.registerOperationHandler(new SimpleOperationDefinitionBuilder("capture-model", new NonResolvingResourceDescriptionResolver()).build(), new OperationStepHandler() {
-                public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                    model.set(Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS)));
-                }
-            });
-            // TODO maybe make creating of empty nodes part of the MNR description
-            rootResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT), Resource.Factory.create());
-            rootResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.SERVICE_CONTAINER), Resource.Factory.create());
-        }
-
-    }
-
-    private static class MockContentRepository implements ContentRepository {
-
-        @Override
-        public byte[] addContent(InputStream stream) throws IOException {
-            return null;
-        }
-
-        @Override
-        public VirtualFile getContent(byte[] hash) {
-            return null;
-        }
-
-        @Override
-        public boolean syncContent(ContentReference reference) {
-            return hasContent(reference.getHash());
-        }
-
-        @Override
-        public boolean hasContent(byte[] hash) {
-            return false;
-        }
-
-        @Override
-        public void removeContent(ContentReference reference) {
-        }
-
-        @Override
-        public void addContentReference(ContentReference reference) {
-        }
-
-        @Override
-        public Map<String, Set<String>> cleanObsoleteContent() {
-            return null;
-        }
-    }
-
-    private static class MockFileRepository implements HostFileRepository {
-
-        @Override
-        public File getFile(String relativePath) {
-            return null;
-        }
-
-        @Override
-        public File getConfigurationFile(String relativePath) {
-            return null;
-        }
-
-        @Override
-        public File[] getDeploymentFiles(ContentReference reference) {
-            return null;
-        }
-
-        @Override
-        public File getDeploymentRoot(ContentReference reference) {
-            return null;
-        }
-
-        @Override
-        public void deleteDeployment(ContentReference reference) {
-        }
-    }
-
-    private static class MockRemoteDomainControllerAddHandler extends RemoteDomainControllerAddHandler {
-
-        /**
-         * Create the ServerAddHandler
-         */
-        protected MockRemoteDomainControllerAddHandler() {
-            super(null, null, null, null, null, null, null, null, MOCK_PATH_MANAGER);
-        }
-
-        @Override
-        protected void initializeDomain(OperationContext context, ModelNode remoteDC) throws OperationFailedException {
-            // no-op
-        }
-    }
-
-    private static class TestPathManagerService extends PathManagerService {
-        private TestPathManagerService(final ServiceTarget target) {
-            final Properties props;
-            if (System.getSecurityManager() == null) {
-                props = System.getProperties();
-            } else {
-                props = AccessController.doPrivileged(new PrivilegedAction<Properties>() {
-                    @Override
-                    public Properties run() {
-                        return System.getProperties();
-                    }
-                });
-            }
-            addHardcodedAbsolutePath(target, ServerEnvironment.SERVER_BASE_DIR, props.getProperty(ServerEnvironment.SERVER_BASE_DIR));
-            addHardcodedAbsolutePath(target, ServerEnvironment.SERVER_CONFIG_DIR, props.getProperty(ServerEnvironment.SERVER_CONFIG_DIR));
-            addHardcodedAbsolutePath(target, ServerEnvironment.SERVER_DATA_DIR, props.getProperty(ServerEnvironment.SERVER_DATA_DIR));
-            addHardcodedAbsolutePath(target, ServerEnvironment.SERVER_LOG_DIR, props.getProperty(ServerEnvironment.SERVER_LOG_DIR));
-            addHardcodedAbsolutePath(target, ServerEnvironment.SERVER_TEMP_DIR, props.getProperty(ServerEnvironment.SERVER_TEMP_DIR));
-        }
-    }
-
-    private static PathManagerService MOCK_PATH_MANAGER = new PathManagerService() {
-    };
-
-    static final LocalHostControllerInfo MOCK_HOST_CONTROLLER_INFO = new LocalHostControllerInfo() {
-
-        @Override
-        public boolean isMasterDomainController() {
-            return true;
-        }
-
-        @Override
-        public String getRemoteDomainControllerUsername() {
-            return null;
-        }
-
-        @Override
-        public List<DiscoveryOption> getRemoteDomainControllerDiscoveryOptions() {
-            return null;
-        }
-
-        @Override
-        public ControlledProcessState.State getProcessState() {
-            return null;
-        }
-
-        @Override
-        public String getNativeManagementSecurityRealm() {
-            return null;
-        }
-
-        @Override
-        public int getNativeManagementPort() {
-            return 0;
-        }
-
-        @Override
-        public String getNativeManagementInterface() {
-            return null;
-        }
-
-        @Override
-        public String getLocalHostName() {
-            return null;
-        }
-
-        @Override
-        public String getHttpManagementSecurityRealm() {
-            return null;
-        }
-
-        @Override
-        public int getHttpManagementSecurePort() {
-            return 0;
-        }
-
-        @Override
-        public int getHttpManagementPort() {
-            return 0;
-        }
-
-        @Override
-        public String getHttpManagementInterface() {
-            return null;
-        }
-
-        @Override
-        public String getHttpManagementSecureInterface() {
-            return null;
-        }
-
-        @Override
-        public boolean isRemoteDomainControllerIgnoreUnaffectedConfiguration() {
-            return false;
-        }
-
-        @Override
-        public Collection<String> getAllowedOrigins() {
-            return Collections.EMPTY_LIST;
-        }
-    };
 }


### PR DESCRIPTION
Switch ModelParserUtils to use offline CLI to test the provided configs, instead of the complex "mock" model controller setups previously used.

Also includes commits for misc issues that prevented this working or would prevent the tests passing. The first two of these are also in separate PRs #973 and #988.

The tests themselves are in full. See https://github.com/wildfly/wildfly/pull/7985 which depends on this to work. WFLY-5138 is the overall JIRA for this.

@luck3y the 3rd commit is for the issue we were chatting about today.

http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=67269&tab=buildResultsDiv&buildTypeId=WF_WildFlyCoreIntegrationExperiments is a custom run showing the combination of this and https://github.com/wildfly/wildfly/pull/7985