### PR TITLE
[WFCORE-905] : CLI command "/host=master/server-config=server-one:remove" did not work if used in a batch.

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerStopHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerStopHandler.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.client.helpers.domain.ServerStatus;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.host.controller.ServerInventory;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -87,7 +88,11 @@ public class ServerStopHandler implements OperationStepHandler {
                 context.authorize(operation, EnumSet.of(Action.ActionEffect.WRITE_RUNTIME));
 
                 final ServerStatus status = serverInventory.stopServer(serverName, timeout, blocking);
-                context.readResource(PathAddress.EMPTY_ADDRESS, false);
+                try {
+                    context.readResource(PathAddress.EMPTY_ADDRESS, false); //reading the resource to persist the autostart state.
+                } catch (Resource.NoSuchResourceException ex) {
+                    //in case the resource no longer exists.
+                }
                 context.getResult().set(status.toString());
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ServerAutoStartTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ServerAutoStartTestCase.java
@@ -23,10 +23,13 @@ package org.jboss.as.test.integration.domain.management;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTO_START;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.START_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STOP_SERVERS;
 import static org.jboss.as.test.integration.domain.management.util.DomainTestSupport.validateResponse;
 import static org.jboss.as.test.integration.domain.management.util.DomainTestUtils.waitUntilState;
@@ -34,10 +37,13 @@ import static org.jboss.as.test.integration.domain.management.util.DomainTestUti
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.jboss.as.controller.PathAddress;
 
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.host.controller.operations.ServerStopHandler;
 import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.dmr.ModelNode;
@@ -215,6 +221,8 @@ public class ServerAutoStartTestCase {
         waitUntilState(client, "master", "main-one", "STARTED");
         waitUntilState(client, "master", "main-two", "STARTED");
         waitUntilState(client, "master", "other-one", "STARTED");
+        //WFCORE-905
+        executeFailingBatch(client);
     }
 
     private void assertAutoStartStatus(final ModelControllerClient client, ModelNode address, boolean autostart) throws IOException {
@@ -255,5 +263,18 @@ public class ServerAutoStartTestCase {
             operation.get(OP_ADDR).add(SERVER_GROUP, groupName);
         }
         validateResponse(client.execute(operation));
+    }
+
+    private void executeFailingBatch(final ModelControllerClient client) throws IOException {
+        ModelNode composite = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+        ModelNode steps = composite.get(STEPS).setEmptyList();
+
+        ModelNode stopServerOne = Util.createOperation(ServerStopHandler.OPERATION_NAME, PathAddress.pathAddress(mainOne));
+        stopServerOne.get(BLOCKING).set(true);
+        steps.add(stopServerOne);
+
+        ModelNode removeServerOne = Util.createRemoveOperation(PathAddress.pathAddress(mainOne));
+        steps.add(removeServerOne);
+        validateResponse(client.execute(composite));
     }
 }


### PR DESCRIPTION
Stopping a server shouldn't fail if the server was removed.

Jira: https://issues.jboss.org/browse/WFCORE-905