### PR TITLE
[WFCORE-903] :  Resubmit fixed version of WFCORE-860 

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -121,7 +121,9 @@ public class ModelDescriptionConstants {
     public static final String DEFAULT_REQUIRES_ADDRESSABLE = "default-requires-addressable";
     public static final String DEPLOY = "deploy";
     public static final String DEPLOYMENT = "deployment";
+    public static final String DEPLOYMENT_DEPLOYED_NOTIFICATION = "deployment-deployed";
     public static final String DEPLOYMENT_OVERLAY = "deployment-overlay";
+    public static final String DEPLOYMENT_UNDEPLOYED_NOTIFICATION = "deployment-undeployed";
     public static final String DEPRECATED = "deprecated";
     public static final String DESCRIBE = "describe";
     public static final String DESCRIPTION = "description";
@@ -409,6 +411,7 @@ public class ModelDescriptionConstants {
     public static final String SENSITIVITY_CLASSIFICATION = "sensitivity-classification";
     public static final String SERVER = "server";
     public static final String SERVERS = "servers";
+    public static final String SERVER_BOOTING = "server-booting";
     public static final String SERVER_CONFIG = "server-config";
     public static final String SERVER_GROUP = "server-group";
     public static final String SERVER_GROUPS = "server-groups";

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
@@ -27,6 +27,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CAN
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_DEPLOYED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_UNDEPLOYED_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
@@ -52,6 +54,8 @@ import java.io.FileFilter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -72,6 +76,8 @@ import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ControlledProcessStateService;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.notification.Notification;
+import org.jboss.as.controller.notification.NotificationHandler;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.server.deployment.DeploymentAddHandler;
 import org.jboss.as.server.deployment.DeploymentDeployHandler;
@@ -91,7 +97,7 @@ import org.jboss.dmr.Property;
  *
  * @author Brian Stansberry
  */
-class FileSystemDeploymentService implements DeploymentScanner {
+class FileSystemDeploymentService implements DeploymentScanner, NotificationHandler {
 
     static final Pattern ARCHIVE_PATTERN = Pattern.compile("^.*\\.(?:(?:[SsWwJjEeRr][Aa][Rr])|(?:[Ww][Aa][Bb])|(?:[Ee][Ss][Aa]))$");
 
@@ -152,6 +158,74 @@ class FileSystemDeploymentService implements DeploymentScanner {
     private final String relativePath;
     private final PropertyChangeListener propertyChangeListener;
     private Future<?> undeployScanTask;
+
+    @Override
+    public void handleNotification(Notification notification) {
+        if (acquireScanLock()) {
+            try {
+                switch (notification.getType()) {
+                    case DEPLOYMENT_DEPLOYED_NOTIFICATION: {
+                        String runtimeName = notification.getData().get(DEPLOYMENT).asString();
+                        if (!deployed.containsKey(runtimeName)) {
+                            updateDeploymentStatusAfterNotification(deploymentDir.toPath(), runtimeName);
+                        }
+                        break;
+                    }
+                    case DEPLOYMENT_UNDEPLOYED_NOTIFICATION: {
+                        String runtimeName = notification.getData().get(DEPLOYMENT).asString();
+                        if (deployed.containsKey(runtimeName)) {
+                            clearMarkers(deployed.get(runtimeName).parentFolder.toPath(), runtimeName);
+                            deployed.remove(runtimeName);
+                        }
+                        break;
+                    }
+                    default:
+                    //ignore
+                }
+            } finally {
+                releaseScanLock();
+            }
+        }
+    }
+
+    private void updateDeploymentStatusAfterNotification(Path dir, String runtimeName) {
+        Path undeployedMarker = dir.resolve(runtimeName + UNDEPLOYED);
+        if (Files.exists(undeployedMarker)) {
+            try {
+                Files.delete(undeployedMarker);
+            } catch (IOException ioex) {
+                ROOT_LOGGER.cannotRemoveDeploymentMarker(undeployedMarker.toFile());
+            }
+            Path deployedMarker = dir.resolve(runtimeName + DEPLOYED);
+            try {
+                deployedMarker = Files.createFile(deployedMarker);
+                final Path deploymentFile = dir.resolve(runtimeName);
+                boolean isArchive = Files.exists(deploymentFile) && Files.isRegularFile(deploymentFile);
+                if (Files.exists(deploymentFile)) {
+                    Files.setLastModifiedTime(deployedMarker, Files.getLastModifiedTime(deploymentFile));
+                }
+                deployed.put(runtimeName, new DeploymentMarker(Files.getLastModifiedTime(deployedMarker).toMillis(), isArchive, dir.toFile()));
+            } catch (IOException ioex) {
+                ROOT_LOGGER.errorWritingDeploymentMarker(ioex, deployedMarker.toString());
+            }
+        }
+    }
+
+    private void clearMarkers(Path dir, String runtimeName) {
+        String fileName = runtimeName + DO_DEPLOY;
+        try {
+            Files.deleteIfExists(dir.resolve(fileName));
+            fileName = runtimeName + FAILED_DEPLOY;
+            Files.deleteIfExists(dir.resolve(fileName));
+            fileName = runtimeName + SKIP_DEPLOY;
+            Files.deleteIfExists(dir.resolve(fileName));
+            fileName = runtimeName + DEPLOYED;
+            Files.deleteIfExists(dir.resolve(fileName));
+        } catch (IOException ioex) {
+            ROOT_LOGGER.cannotRemoveDeploymentMarker(fileName);
+        }
+
+    }
 
     private class DeploymentScanRunnable implements Runnable {
 
@@ -422,7 +496,7 @@ class FileSystemDeploymentService implements DeploymentScanner {
 
         if (acquireScanLock()) {
             try {
-                ROOT_LOGGER.tracef("Performing a post-boot forced undeploy scan for scan directory %oManu", deploymentDir.getAbsolutePath());
+                ROOT_LOGGER.tracef("Performing a post-boot forced undeploy scan for scan directory %s", deploymentDir.getAbsolutePath());
                 ScanContext scanContext = new ScanContext(deploymentOperations);
 
                 // Add remove actions to the plan for anything we count as
@@ -1332,6 +1406,7 @@ class FileSystemDeploymentService implements DeploymentScanner {
             addOp.get(PERSISTENT).set(false);
             addOp.get(OWNER).set(resourceAddress);
             final ModelNode deployOp = Util.getEmptyOperation(DeploymentDeployHandler.OPERATION_NAME, address);
+            deployOp.get(OWNER).set(resourceAddress);
             return getCompositeUpdate(addOp, deployOp);
         }
 
@@ -1383,7 +1458,9 @@ class FileSystemDeploymentService implements DeploymentScanner {
         @Override
         protected ModelNode getUpdate() {
             final ModelNode address = new ModelNode().add(DEPLOYMENT, deploymentName);
-            return Util.getEmptyOperation(DeploymentRedeployHandler.OPERATION_NAME, address);
+            final ModelNode redployOp = Util.getEmptyOperation(DeploymentRedeployHandler.OPERATION_NAME, address);
+            redployOp.get(OWNER).set(resourceAddress);
+            return redployOp;
         }
 
         @Override
@@ -1422,6 +1499,7 @@ class FileSystemDeploymentService implements DeploymentScanner {
         protected ModelNode getUpdate() {
             final ModelNode address = new ModelNode().add(DEPLOYMENT, deploymentName);
             final ModelNode undeployOp = Util.getEmptyOperation(DeploymentUndeployHandler.OPERATION_NAME, address);
+            undeployOp.get(OWNER).set(resourceAddress);
             final ModelNode removeOp = Util.getEmptyOperation(DeploymentRemoveHandler.OPERATION_NAME, address);
             return getCompositeUpdate(undeployOp, removeOp);
         }

--- a/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
@@ -22,6 +22,8 @@
 package org.jboss.as.server.controller.resources;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_DEPLOYED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_UNDEPLOYED_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WEB_URL;
 
 import java.util.Collections;
@@ -35,6 +37,7 @@ import javax.xml.stream.XMLStreamWriter;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.ObjectListAttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationDefinition;
@@ -324,15 +327,14 @@ public class DeploymentAttributes {
             .build();
 
     //Full replace deployment definition
-
-    private static final AttributeDefinition FULL_REPLACE_ENABLED = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ENABLED, ModelType.BOOLEAN, true)
-            .setAllowExpression(ENABLED.isAllowExpression())
-            .build();
     public static final Map<String, AttributeDefinition> FULL_REPLACE_DEPLOYMENT_ATTRIBUTES = createAttributeMap(NAME, RUNTIME_NAME_NILLABLE, CONTENT_ALL, ENABLED);
     public static final OperationDefinition FULL_REPLACE_DEPLOYMENT_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.FULL_REPLACE_DEPLOYMENT, DEPLOYMENT_RESOLVER)
             .setParameters(FULL_REPLACE_DEPLOYMENT_ATTRIBUTES.values().toArray(new AttributeDefinition[FULL_REPLACE_DEPLOYMENT_ATTRIBUTES.size()]))
             .addAccessConstraint(ApplicationTypeAccessConstraintDefinition.DEPLOYMENT)
             .build();
+
+    public static final NotificationDefinition NOTIFICATION_DEPLOYMENT_DEPLOYED = NotificationDefinition.Builder.create(DEPLOYMENT_DEPLOYED_NOTIFICATION, DEPLOYMENT_RESOLVER).build();
+    public static final NotificationDefinition NOTIFICATION_DEPLOYMENT_UNDEPLOYED = NotificationDefinition.Builder.create(DEPLOYMENT_UNDEPLOYED_NOTIFICATION, DEPLOYMENT_RESOLVER).build();
 
     private static SimpleAttributeDefinition createContentValueTypeAttribute(String name, ModelType type, ParameterValidator validator, boolean allowExpression) {
         SimpleAttributeDefinitionBuilder builder = SimpleAttributeDefinitionBuilder.create(name, type, true);

--- a/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentResourceDefinition.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEP
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReadResourceNameOperationStepHandler;
@@ -72,6 +73,13 @@ public abstract class DeploymentResourceDefinition extends SimpleResourceDefinit
         return ApplicationTypeAccessConstraintDefinition.DEPLOYMENT_AS_LIST;
     }
 
+    @Override
+    public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+        for (NotificationDefinition notif : parent.getNotifications()) {
+            resourceRegistration.registerNotification(notif);
+        }
+    }
+
     protected DeploymentResourceParent getParent() {
         return parent;
     }
@@ -82,13 +90,17 @@ public abstract class DeploymentResourceDefinition extends SimpleResourceDefinit
     public static enum DeploymentResourceParent {
         DOMAIN (DeploymentAttributes.DOMAIN_RESOURCE_ATTRIBUTES, DeploymentAttributes.DOMAIN_ADD_ATTRIBUTES),
         SERVER_GROUP (DeploymentAttributes.SERVER_GROUP_RESOURCE_ATTRIBUTES, DeploymentAttributes.SERVER_GROUP_ADD_ATTRIBUTES),
-        SERVER (DeploymentAttributes.SERVER_RESOURCE_ATTRIBUTES, DeploymentAttributes.SERVER_ADD_ATTRIBUTES);
+        SERVER (DeploymentAttributes.SERVER_RESOURCE_ATTRIBUTES, DeploymentAttributes.SERVER_ADD_ATTRIBUTES,
+            new NotificationDefinition[] {DeploymentAttributes.NOTIFICATION_DEPLOYMENT_DEPLOYED, DeploymentAttributes.NOTIFICATION_DEPLOYMENT_UNDEPLOYED});
 
         final AttributeDefinition[] resourceAttributes;
         final AttributeDefinition[] addAttributes;
-        private DeploymentResourceParent(AttributeDefinition[] resourceAttributes, AttributeDefinition[] addAttributes) {
+        final NotificationDefinition[] notifications;
+
+        private DeploymentResourceParent(AttributeDefinition[] resourceAttributes, AttributeDefinition[] addAttributes, NotificationDefinition... notifications) {
             this.resourceAttributes = resourceAttributes;
             this.addAttributes = addAttributes;
+            this.notifications = notifications == null ? new NotificationDefinition[0] : notifications;
         }
 
         AttributeDefinition[] getResourceAttributes() {
@@ -97,6 +109,10 @@ public abstract class DeploymentResourceDefinition extends SimpleResourceDefinit
 
         AttributeDefinition[] getAddAttributes() {
             return addAttributes;
+        }
+
+        NotificationDefinition[] getNotifications() {
+            return notifications;
         }
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
@@ -139,7 +139,7 @@ public class DeploymentAddHandler implements OperationStepHandler {
         }
 
         if (ENABLED.resolveModelAttribute(context, newModel).asBoolean() && context.isNormalServer()) {
-            DeploymentHandlerUtil.deploy(context, runtimeName, name, vaultReader, contentItem);
+            DeploymentHandlerUtil.deploy(context, operation, runtimeName, name, vaultReader, contentItem);
             DeploymentUtils.enableAttribute(newModel);
         }
 

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentDeployHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentDeployHandler.java
@@ -48,6 +48,7 @@ public class DeploymentDeployHandler implements OperationStepHandler {
         this.vaultReader = vaultReader;
     }
 
+    @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
         ModelNode model = resource.getModel();
@@ -58,7 +59,7 @@ public class DeploymentDeployHandler implements OperationStepHandler {
         final String name = address.getLastElement().getValue();
         final String runtimeName = RUNTIME_NAME.resolveModelAttribute(context, model).asString();
         final DeploymentHandlerUtil.ContentItem[] contents = getContents(CONTENT_ALL.resolveModelAttribute(context, model));
-        DeploymentHandlerUtil.deploy(context, runtimeName, name, vaultReader, contents);
+        DeploymentHandlerUtil.deploy(context, operation, runtimeName, name, vaultReader, contents);
         DeploymentUtils.enableAttribute(model);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
@@ -168,7 +168,7 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
         if (ENABLED.resolveModelAttribute(context, deploymentModel).asBoolean()) {
             DeploymentHandlerUtil.replace(context, deploymentModel, runtimeName, name, replacedRuntimeName, vaultReader, contentItem);
         } else if (wasDeployed) {
-            DeploymentHandlerUtil.undeploy(context, name, runtimeName, vaultReader);
+            DeploymentHandlerUtil.undeploy(context, operation, name, runtimeName, vaultReader);
         }
 
         context.completeStep(new OperationContext.ResultHandler() {

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentHandlerUtil.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentHandlerUtil.java
@@ -20,8 +20,12 @@ package org.jboss.as.server.deployment;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_DEPLOYED_NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_UNDEPLOYED_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_BOOTING;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.OWNER;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.getContents;
 import static org.jboss.msc.service.ServiceController.Mode.REMOVE;
 
@@ -32,6 +36,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.notification.Notification;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -84,7 +89,7 @@ public class DeploymentHandlerUtil {
     private DeploymentHandlerUtil() {
     }
 
-    public static void deploy(final OperationContext context, final String deploymentUnitName, final String managementName, final AbstractVaultReader vaultReader, final ContentItem... contents) throws OperationFailedException {
+    public static void deploy(final OperationContext context, final ModelNode operation, final String deploymentUnitName, final String managementName, final AbstractVaultReader vaultReader, final ContentItem... contents) throws OperationFailedException {
         assert contents != null : "contents is null";
 
         if (context.isNormalServer()) {
@@ -94,6 +99,17 @@ public class DeploymentHandlerUtil {
             final ManagementResourceRegistration mutableRegistration = context.getResourceRegistrationForUpdate();
 
             DeploymentResourceSupport.cleanup(deployment);
+            ModelNode notificationData = new ModelNode();
+            notificationData.get(NAME).set(managementName);
+            notificationData.get(SERVER_BOOTING).set(context.isBooting());
+            if (operation.hasDefined(OWNER.getName())) {
+                try {
+                    notificationData.get(OWNER.getName()).set(OWNER.resolveModelAttribute(context, operation));
+                } catch (OperationFailedException ex) {//No resolvable owner we won't set one
+                }
+            }
+            notificationData.get(DEPLOYMENT).set(deploymentUnitName);
+            context.emit(new Notification(DEPLOYMENT_DEPLOYED_NOTIFICATION, context.getCurrentAddress(), ServerLogger.ROOT_LOGGER.deploymentDeployedNotification(managementName, deploymentUnitName), notificationData));
 
             context.addStep(new OperationStepHandler() {
                 public void execute(OperationContext context, ModelNode operation) {
@@ -278,14 +294,26 @@ public class DeploymentHandlerUtil {
         }
     }
 
-    public static void undeploy(final OperationContext context, final String managementName, final String deploymentUnitName, final AbstractVaultReader vaultReader) {
+    public static void undeploy(final OperationContext context, final ModelNode operation, final String managementName, final String deploymentUnitName, final AbstractVaultReader vaultReader) {
         if (context.isNormalServer()) {
             final Resource deployment = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
             final ImmutableManagementResourceRegistration registration = context.getResourceRegistration();
             final ManagementResourceRegistration mutableRegistration = context.getResourceRegistrationForUpdate();
             DeploymentResourceSupport.cleanup(deployment);
+            ModelNode notificationData = new ModelNode();
+            notificationData.get(NAME).set(managementName);
+            notificationData.get(SERVER_BOOTING).set(context.isBooting());
+            if (operation.hasDefined(OWNER.getName())) {
+                try {
+                    notificationData.get(OWNER.getName()).set(OWNER.resolveModelAttribute(context, operation));
+                } catch (OperationFailedException ex) {//No resolvable owner we won't set one
+                }
+            }
+            notificationData.get(DEPLOYMENT).set(deploymentUnitName);
+            context.emit(new Notification(DEPLOYMENT_UNDEPLOYED_NOTIFICATION, context.getCurrentAddress(), ServerLogger.ROOT_LOGGER.deploymentUndeployedNotification(managementName, deploymentUnitName), notificationData));
 
             context.addStep(new OperationStepHandler() {
+                @Override
                 public void execute(OperationContext context, ModelNode operation) {
                     final ServiceRegistry registry = context.getServiceRegistry(true);
 

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentUndeployHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentUndeployHandler.java
@@ -44,6 +44,7 @@ public class DeploymentUndeployHandler implements OperationStepHandler {
         this.vaultReader = vaultReader;
     }
 
+    @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         ModelNode model = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel();
         final String deploymentUnitName = RUNTIME_NAME.resolveModelAttribute(context, model).asString();
@@ -53,7 +54,7 @@ public class DeploymentUndeployHandler implements OperationStepHandler {
         PathAddress address = PathAddress.pathAddress(opAddr);
         final String managementName = address.getLastElement().getValue();
 
-        DeploymentHandlerUtil.undeploy(context, managementName, deploymentUnitName, vaultReader);
+        DeploymentHandlerUtil.undeploy(context, operation, managementName, deploymentUnitName, vaultReader);
         DeploymentUtils.disableAttribute(model);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1159,4 +1159,10 @@ public interface ServerLogger extends BasicLogger {
 
     @Message(id = 232, value = "Could not get module info for module name: %s")
     OperationFailedException couldNotGetModuleInfo(String moduleName, @Cause Throwable cause);
+
+    @Message(id = 233, value = "Undeployed \"%s\" (runtime-name: \"%s\")")
+    String deploymentUndeployedNotification(String managementName, String deploymentUnitName);
+
+    @Message(id = 234, value = "Deployed \"%s\" (runtime-name : \"%s\")")
+    String deploymentDeployedNotification(String managementName, String deploymentUnitName);
 }

--- a/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
+++ b/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
@@ -236,3 +236,5 @@ deployment.enabled-time=Last time the application was enabled
 deployment.enabled-timestamp=Last timestamp the application was enabled. Format is yyyy-MM-dd HH:mm:ss,SSS zzz.
 deployment.disabled-time=Last time the application was disabled
 deployment.disabled-timestamp=Last timestamp the application was disabled. Format is yyyy-MM-dd HH:mm:ss,SSS zzz.
+deployment.deployment-deployed=Notification sent when a deployment is deployed.
+deployment.deployment-undeployed=Notification sent when a deployment is undeployed.

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/AbstractDeploymentUnitTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/AbstractDeploymentUnitTestCase.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.test.manualmode.deployment;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public abstract class AbstractDeploymentUnitTestCase {
+
+    protected void addDeploymentScanner(int scanInterval) throws Exception {
+        ModelNode addOp = Util.createAddOperation(PathAddress.pathAddress(PathElement.pathElement(EXTENSION, "org.jboss.as.deployment-scanner")));
+        ModelNode result = executeOperation(addOp);
+        assertEquals("Unexpected outcome of adding the test deployment scanner extension: " + addOp, ModelDescriptionConstants.SUCCESS, result.get(OUTCOME).asString());
+        addOp = Util.createAddOperation(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, "deployment-scanner")));
+        result = executeOperation(addOp);
+        assertEquals("Unexpected outcome of adding the test deployment scanner subsystem: " + addOp, ModelDescriptionConstants.SUCCESS, result.get(OUTCOME).asString());
+        // add deployment scanner
+        final ModelNode op = getAddDeploymentScannerOp(scanInterval);
+        result = executeOperation(op);
+        assertEquals("Unexpected outcome of adding the test deployment scanner: " + op, ModelDescriptionConstants.SUCCESS, result.get(OUTCOME).asString());
+    }
+
+    protected void removeDeploymentScanner() throws Exception {
+        boolean ok = false;
+        try {
+            // remove deployment scanner
+            final ModelNode op = getRemoveDeploymentScannerOp();
+            ModelNode result = executeOperation(op);
+            assertEquals("Unexpected outcome of removing the test deployment scanner: " + op, ModelDescriptionConstants.SUCCESS, result.get("outcome").asString());
+            ok = true;
+        } finally {
+            try {
+                boolean wasOK = ok;
+                ok = false;
+                ModelNode removeOp = Util.createRemoveOperation(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, "deployment-scanner")));
+                ModelNode result = executeOperation(removeOp);
+                if (wasOK) {
+                    assertEquals("Unexpected outcome of removing the test deployment scanner subsystem: " + removeOp, ModelDescriptionConstants.SUCCESS, result.get("outcome").asString());
+                } // else don't override the previous assertion error in this finally block
+                ok = wasOK;
+            } finally {
+                ModelNode removeOp = Util.createRemoveOperation(PathAddress.pathAddress(PathElement.pathElement(EXTENSION, "org.jboss.as.deployment-scanner")));
+                ModelNode result = executeOperation(removeOp);
+                if (ok) {
+                    assertEquals("Unexpected outcome of removing the test deployment scanner extension: " + removeOp, ModelDescriptionConstants.SUCCESS, result.get("outcome").asString());
+                }  // else don't override the previous assertion error in this finally block
+            }
+        }
+    }
+
+    protected abstract ModelNode executeOperation(ModelNode op) throws IOException;
+
+    protected abstract File getDeployDir();
+
+    protected ModelNode getAddDeploymentScannerOp(int scanInterval) {
+        final ModelNode op = Util.createAddOperation(getTestDeploymentScannerResourcePath());
+        op.get("scan-interval").set(scanInterval);
+        op.get("path").set(getDeployDir().getAbsolutePath());
+        return op;
+    }
+
+    protected ModelNode getRemoveDeploymentScannerOp() {
+        return createOpNode("subsystem=deployment-scanner/scanner=testScanner", "remove");
+    }
+
+    protected PathAddress getTestDeploymentScannerResourcePath() {
+        return PathAddress.pathAddress(PathElement.pathElement("subsystem", "deployment-scanner"), PathElement.pathElement("scanner", "testScanner"));
+    }
+
+    protected boolean exists(PathAddress address) throws IOException {
+        final ModelNode operation = Util.createEmptyOperation(READ_RESOURCE_OPERATION, address);
+        operation.get(INCLUDE_RUNTIME).set(true);
+        operation.get(RECURSIVE).set(true);
+
+        final ModelNode result = executeOperation(operation);
+        return SUCCESS.equals(result.get(OUTCOME).asString());
+    }
+
+    protected String deploymentState(final PathAddress address) throws IOException {
+        final ModelNode operation = Util.createEmptyOperation(READ_ATTRIBUTE_OPERATION, address);
+        operation.get(NAME).set("status");
+
+        final ModelNode result = executeOperation(operation);
+        if (SUCCESS.equals(result.get(OUTCOME).asString())) {
+            return result.get(RESULT).asString();
+        }
+        return FAILED;
+    }
+
+    protected boolean isRunning() throws IOException {
+        final ModelNode operation = Util.createEmptyOperation(READ_ATTRIBUTE_OPERATION, PathAddress.EMPTY_ADDRESS);
+        operation.get(NAME).set("server-state");
+
+        final ModelNode result = executeOperation(operation);
+        if (SUCCESS.equals(result.get(OUTCOME).asString())) {
+            return "running".equals(result.get(RESULT).asString());
+        }
+        return false;
+    }
+
+    protected void createDeployment(final File file, final String dependency) throws IOException {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class);
+        final String dependencies = "Dependencies: " + dependency;
+        archive.add(new StringAsset(dependencies), "META-INF/MANIFEST.MF");
+        archive.as(ZipExporter.class).exportTo(file);
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerOperationRollbackTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerOperationRollbackTestCase.java
@@ -63,7 +63,6 @@ public class DeploymentScannerOperationRollbackTestCase extends AbstractDeployme
             try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
                 final File deploymentOne = new File(deployDir, "deployment-one.jar");
                 createDeployment(deploymentOne, "org.jboss.modules");
-                // Add a new de
                 addDeploymentScanner(client);
                 prepareRollback(client);
                 try {


### PR DESCRIPTION
Fix consist in release the lock when the notification is processed.

WFCORE-860: Use notifications to help the scanner get a proper status of all deployments between scans
When a deployment is deployed or undeployed from out of a scanner, a notification is sent to the scanner so it can update the status.

Jira: https://issues.jboss.org/browse/WFCORE-903
Original Issue Jira : https://issues.jboss.org/browse/WFCORE-860