### PR TITLE
[WFCORE-892] Increased timeout for CLI executor to avoid test errors

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
@@ -62,8 +62,9 @@ public class CustomCLIExecutor {
             + MANAGEMENT_HTTPS_PORT;
 
     private static Logger LOGGER = Logger.getLogger(CustomCLIExecutor.class);
-    private static final int CLI_PROC_TIMEOUT = 5000;
-    private static final int STATUS_CHECK_INTERVAL = 2000;
+
+    private static final int CLI_PROC_TIMEOUT = TimeoutUtil.adjust(30000);
+    private static final int STATUS_CHECK_INTERVAL = TimeoutUtil.adjust(2000);
     private static final byte[] NEW_LINE = System.lineSeparator().getBytes(StandardCharsets.UTF_8);
 
     public static String execute(File cliConfigFile, String operation) {
@@ -150,7 +151,7 @@ public class CustomCLIExecutor {
         ConsoleConsumer.start(cliProc.getErrorStream(), err);
         boolean wait = true;
         int runningTime = 0;
-        int exitCode = 0;
+        int exitCode = Integer.MIN_VALUE;
         do {
             try {
                 Thread.sleep(STATUS_CHECK_INTERVAL);
@@ -176,6 +177,7 @@ public class CustomCLIExecutor {
             if (runningTime >= CLI_PROC_TIMEOUT) {
                 cliProc.destroy();
                 wait = false;
+                LOGGER.info("A timeout has occurred while invoking CLI command.");
             }
         } while (wait);
 


### PR DESCRIPTION
Manual tests that are using CustomCLIExecutor are failing on IBM JDK 8 due to low timeouts. I have increased timeout for command execution and changed initial value of exitCode to non-zero for better testability.

JIRA: https://issues.jboss.org/browse/WFCORE-892