### PR TITLE
[WFCORE-925] Ability to use proxy in MavenUtil

### DIFF
--- a/model-test/src/main/java/org/jboss/as/model/test/MavenUtil.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/MavenUtil.java
@@ -89,6 +89,8 @@ class MavenUtil {
     private final RepositorySystem REPOSITORY_SYSTEM;
     private final List<RemoteRepository> remoteRepositories;
 
+    private static final String PROXY_HTTP_PREFIX = "http.";
+    private static final String PROXY_HTTPS_PREFIX = "https.";
     private static final String PROXY_HOST = "proxyHost";
     private static final String PROXY_PORT = "proxyPort";
 
@@ -208,8 +210,8 @@ class MavenUtil {
         return urls;
     }
 
-    private static Integer getProxyPort() {
-        String port = System.getProperty(PROXY_PORT);
+    private static Integer getProxyPort(String systemProperty) {
+        String port = System.getProperty(systemProperty);
         if (port != null && !port.isEmpty()) {
             try {
                 Integer intPort = Integer.parseInt(port);
@@ -223,13 +225,17 @@ class MavenUtil {
 
     private static List<RemoteRepository> createRemoteRepositories(boolean useEapRepository) {
         // prepare proxy
-        String proxyHost = System.getProperty(PROXY_HOST);
-        Integer proxyPort = getProxyPort();
+        String httpProxyHost = System.getProperty(String.format("%s%s", PROXY_HTTP_PREFIX, PROXY_HOST));
+        String httpsProxyHost = System.getProperty(String.format("%s%s", PROXY_HTTPS_PREFIX, PROXY_HOST));
+        Integer httpProxyPort = getProxyPort(String.format("%s%s", PROXY_HTTP_PREFIX, PROXY_PORT));
+        Integer httpsProxyPort = getProxyPort(String.format("%s%s", PROXY_HTTPS_PREFIX, PROXY_PORT));
         Proxy httpProxy = null;
         Proxy httpsProxy = null;
-        if (proxyHost != null && proxyPort != null && !proxyHost.isEmpty()) {
-            httpProxy = new Proxy(Proxy.TYPE_HTTP, proxyHost, proxyPort);
-            httpsProxy = new Proxy(Proxy.TYPE_HTTPS, proxyHost, proxyPort);
+        if (httpProxyHost != null && httpProxyPort != null && !httpProxyHost.isEmpty()) {
+            httpProxy = new Proxy(Proxy.TYPE_HTTP, httpProxyHost, httpProxyPort);
+        }
+        if (httpsProxyHost != null && httpsProxyPort != null && !httpsProxyHost.isEmpty()) {
+            httpsProxy = new Proxy(Proxy.TYPE_HTTPS, httpsProxyHost, httpsProxyPort);
         }
 
         String remoteReposFromSysProp = System.getProperty(ChildFirstClassLoaderBuilder.MAVEN_REPOSITORY_URLS);


### PR DESCRIPTION
WildFly Core testsuite can be run on pure-IPv6 machines. Proxy could be used in that case.

But some tests use MavenUtil class for download some dependencies. And this class can not use proxy server. So these tests fail.

https://issues.jboss.org/browse/WFCORE-925