### PR TITLE
Improve IPv6ScopeIdMatchUnitTestCase

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/interfaces/IPv6ScopeIdMatchUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/interfaces/IPv6ScopeIdMatchUnitTestCase.java
@@ -29,6 +29,7 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -122,17 +123,25 @@ public class IPv6ScopeIdMatchUnitTestCase {
                 if (pos > -1) {
                     hostAddress = hostAddress.substring(0, pos);
                 }
-                InetAddressMatchInterfaceCriteria criteria = new InetAddressMatchInterfaceCriteria(hostAddress);
-                assertEquals(address, criteria.isAcceptable(nif, address));
-                criteria = new InetAddressMatchInterfaceCriteria(hostAddress + "%" + nif.getName());
-                assertEquals(address, criteria.isAcceptable(nif, address));
-                criteria = new InetAddressMatchInterfaceCriteria(hostAddress + "%" + address.getScopeId());
-                assertEquals(address, criteria.isAcceptable(nif, address));
-                criteria = new InetAddressMatchInterfaceCriteria(hostAddress + "%" + (address.getScopeId() + 1));
-                assertNull(criteria.isAcceptable(nif, address));
-                criteria = new InetAddressMatchInterfaceCriteria(hostAddress + "%bogus");
-                assertNull(criteria.isAcceptable(nif, address));
+
+                matchCriteriaTest(hostAddress, nif, address, true);
+                if (address.isLinkLocalAddress() || address.isSiteLocalAddress()) {
+                    matchCriteriaTest(hostAddress + "%" + nif.getName(), nif, address, true);
+                    matchCriteriaTest(hostAddress + "%" + address.getScopeId(), nif, address, true);
+                    matchCriteriaTest(hostAddress + "%" + (address.getScopeId() + 1), nif, address, false);
+                    matchCriteriaTest(hostAddress + "%bogus", nif, address, false);
+                }
             }
+        }
+    }
+
+    private static void matchCriteriaTest(String criteriaString, NetworkInterface nif, InetAddress address,
+                                     boolean expectMatch) throws SocketException {
+        InetAddressMatchInterfaceCriteria criteria = new InetAddressMatchInterfaceCriteria(criteriaString);
+        if (expectMatch) {
+            assertEquals(criteriaString, address, criteria.isAcceptable(nif, address));
+        } else {
+            assertNull(criteriaString, criteria.isAcceptable(nif, address));
         }
     }
 }


### PR DESCRIPTION
Improve failure message in test. Don't try and add a scope_id to global IPv6 addresses.

This relates to but isn't expected to correct https://issues.jboss.org/browse/WFCORE-934 I'm trying to get a bit more info to understand the cause, plus fix a flaw in the test that likely is unrelated, but worth fixing anyway.