### PR TITLE
WFCORE-896 Cannot patch EAP once Docs are excluded from installation

### DIFF
--- a/patching/src/main/java/org/jboss/as/patching/logging/PatchLogger.java
+++ b/patching/src/main/java/org/jboss/as/patching/logging/PatchLogger.java
@@ -223,4 +223,13 @@ public interface PatchLogger extends BasicLogger {
 
     @Message(id = 42, value = "Patch bundle is empty")
     String patchBundleIsEmpty();
+
+    @Message(id = 43, value = "Content item type is missing in '%s'")
+    PatchingException contentItemTypeMissing(String condition);
+
+    @Message(id = 44, value = "Unsupported content type '%s'")
+    String unsupportedContentType(String type);
+
+    @Message(id = 45, value = "Unrecognized condition format '%s'")
+    PatchingException unrecognizedConditionFormat(String condition);
 }

--- a/patching/src/main/java/org/jboss/as/patching/metadata/ContentModification.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/ContentModification.java
@@ -33,11 +33,17 @@ public class ContentModification {
     private final ContentItem item;
     private final byte[] targetHash;
     private final ModificationType type;
+    private final ModificationCondition condition;
 
-    public ContentModification(ContentItem item, byte[] targetHash, ModificationType type) {
+    public ContentModification(ContentItem item, byte[] targetHash, ModificationType type, ModificationCondition condition) {
         this.item = item;
         this.targetHash = targetHash;
         this.type = type;
+        this.condition = condition;
+    }
+
+    public ContentModification(ContentItem item, byte[] targetHash, ModificationType type) {
+        this(item, targetHash, type, null);
     }
 
     public ContentModification(ContentItem item, ContentModification existing) {
@@ -60,4 +66,16 @@ public class ContentModification {
         return type;
     }
 
+    /**
+     * Condition which has to be satisfied for this modification to be applied
+     * to the target installation. If the condition is not satisfied,
+     * the modification will be skipped and the patch application process will
+     * proceed applying the remaining modifications in the patch.
+     *
+     * @return  modification condition or null if the modification does not depend
+     * on any condition
+     */
+    public ModificationCondition getCondition() {
+        return condition;
+    }
 }

--- a/patching/src/main/java/org/jboss/as/patching/metadata/ModificationBuilderTarget.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/ModificationBuilderTarget.java
@@ -114,8 +114,12 @@ public abstract class ModificationBuilderTarget<T> {
      * @return the builder
      */
     public T addFile(final String name, final List<String> path, final byte[] newHash, final boolean isDirectory) {
+        return addFile(name, path, newHash, isDirectory, null);
+    }
+
+    public T addFile(final String name, final List<String> path, final byte[] newHash, final boolean isDirectory, ModificationCondition condition) {
         final ContentItem item = createMiscItem(name, path, newHash, isDirectory);
-        addContentModification(createContentModification(item, ModificationType.ADD, NO_CONTENT));
+        addContentModification(createContentModification(item, ModificationType.ADD, NO_CONTENT, condition));
         return returnThis();
     }
 
@@ -130,8 +134,12 @@ public abstract class ModificationBuilderTarget<T> {
      * @return the builder
      */
     public T modifyFile(final String name, final List<String> path, final byte[] existingHash, final byte[] newHash, final boolean isDirectory) {
+        return modifyFile(name, path, existingHash, newHash, isDirectory, null);
+    }
+
+    public T modifyFile(final String name, final List<String> path, final byte[] existingHash, final byte[] newHash, final boolean isDirectory, ModificationCondition condition) {
         final ContentItem item = createMiscItem(name, path, newHash, isDirectory);
-        addContentModification(createContentModification(item, ModificationType.MODIFY, existingHash));
+        addContentModification(createContentModification(item, ModificationType.MODIFY, existingHash, condition));
         return returnThis();
     }
 
@@ -145,8 +153,12 @@ public abstract class ModificationBuilderTarget<T> {
      * @return the builder
      */
     public T removeFile(final String name, final List<String> path, final byte[] existingHash, final boolean isDirectory) {
+        return removeFile(name, path, existingHash, isDirectory, null);
+    }
+
+    public T removeFile(final String name, final List<String> path, final byte[] existingHash, final boolean isDirectory, ModificationCondition condition) {
         final ContentItem item = createMiscItem(name, path, NO_CONTENT, isDirectory);
-        addContentModification(createContentModification(item, ModificationType.REMOVE, existingHash));
+        addContentModification(createContentModification(item, ModificationType.REMOVE, existingHash, condition));
         return returnThis();
     }
 
@@ -199,7 +211,11 @@ public abstract class ModificationBuilderTarget<T> {
     }
 
     protected ContentModification createContentModification(final ContentItem item, final ModificationType type, final byte[] existingHash) {
-        return new ContentModification(item, existingHash, type);
+        return createContentModification(item, type, existingHash, null);
+    }
+
+    protected ContentModification createContentModification(final ContentItem item, final ModificationType type, final byte[] existingHash, ModificationCondition condition) {
+        return new ContentModification(item, existingHash, type, condition);
     }
 
     protected MiscContentItem createMiscItem(final String name, final List<String> path, final byte[] newHash, final boolean isDirectory) {

--- a/patching/src/main/java/org/jboss/as/patching/metadata/ModificationCondition.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/ModificationCondition.java
@@ -1,0 +1,126 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.patching.metadata;
+
+import java.util.Arrays;
+
+import org.jboss.as.patching.PatchingException;
+import org.jboss.as.patching.logging.PatchLogger;
+import org.jboss.as.patching.runner.PatchingTaskContext;
+
+/**
+ * Represents a condition that has to be satisfied during the patch application process
+ * before a certain modification can take place.
+ *
+ * @author Alexey Loubyansky
+ */
+public interface ModificationCondition {
+
+    boolean isSatisfied(PatchingTaskContext ctx) throws PatchingException;
+
+    class Factory {
+
+        /**
+         * Creates a condition which will be satisfied in case the path relative
+         * to the installation root directory exists
+         *
+         * @param path  path relative to the installation root directory
+         * @return  true if the path exists, otherwise - false
+         */
+        public static ModificationCondition exists(ContentItem contentItem) {
+            return new ExistsCondition(contentItem);
+        }
+
+        public static ModificationCondition fromString(String condition) throws PatchingException {
+            assert condition != null : "condition is null";
+            if(condition.startsWith(ExistsCondition.ID)) {
+                String str = condition.substring(ExistsCondition.ID.length() + 1);
+                int i = str.indexOf(':');
+                if(i < 0) {
+                    throw PatchLogger.ROOT_LOGGER.contentItemTypeMissing(condition);
+                }
+                final String typeStr = str.substring(0, i);
+                final ContentType type = ContentType.valueOf(typeStr);
+                str = str.substring(i + 1);
+                ContentItem item;
+                switch(type) {
+                    case MISC:
+                        final String[] s = str.split("/");
+                        final int length = s.length;
+                        final String name = s[length - 1];
+                        final String[] itemPath = Arrays.copyOf(s, length - 1);
+                        item = new MiscContentItem(name, itemPath, null);
+                        break;
+                    case MODULE:
+                    case BUNDLE:
+                    default:
+                        throw new PatchingException(PatchLogger.ROOT_LOGGER.unsupportedContentType(type.name()));
+                }
+                return ModificationCondition.Factory.exists(item);
+            }
+            throw PatchLogger.ROOT_LOGGER.unrecognizedConditionFormat(condition);
+        }
+
+    }
+
+    public static final class ExistsCondition implements ModificationCondition {
+
+        static final String ID = "exists";
+
+        private final ContentItem contentItem;
+
+        private ExistsCondition(ContentItem contentItem) {
+            assert contentItem != null : "contentItem is null";
+            this.contentItem = contentItem;
+        }
+
+        public ContentItem getContentItem() {
+            return contentItem;
+        }
+
+        @Override
+        public boolean isSatisfied(PatchingTaskContext ctx) throws PatchingException {
+            return ctx.getTargetFile(contentItem).exists();
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder buf = new StringBuilder();
+            buf.append(ID).append(':');
+            switch(contentItem.getContentType()) {
+                case MISC:
+                    buf.append(ContentType.MISC.toString());
+                    break;
+                case MODULE:
+                    buf.append(ContentType.MODULE.toString());
+                    break;
+                case BUNDLE:
+                    buf.append(ContentType.BUNDLE.toString());
+                    break;
+                default:
+                    throw new IllegalStateException(PatchLogger.ROOT_LOGGER.unsupportedContentType(contentItem.getContentType().name()));
+            }
+            return buf.append(':').append(contentItem.getRelativePath()).toString();
+        }
+    }
+}

--- a/patching/src/main/java/org/jboss/as/patching/metadata/PatchXml.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/PatchXml.java
@@ -62,16 +62,20 @@ public class PatchXml {
     static {
         MAPPER.registerRootElement(new QName(Namespace.PATCH_1_0.getNamespace(), PatchXml_1_0.Element.PATCH.name), XML1_0);
         MAPPER.registerRootElement(new QName(Namespace.PATCH_1_1.getNamespace(), PatchXml_1_0.Element.PATCH.name), XML1_0);
+        MAPPER.registerRootElement(new QName(Namespace.PATCH_1_2.getNamespace(), PatchXml_1_0.Element.PATCH.name), XML1_0);
         MAPPER.registerRootElement(new QName(Namespace.ROLLBACK_1_0.getNamespace(), PatchXml_1_0.Element.PATCH.name), ROLLBACK_1_0);
         MAPPER.registerRootElement(new QName(Namespace.ROLLBACK_1_1.getNamespace(), PatchXml_1_0.Element.PATCH.name), ROLLBACK_1_0);
+        MAPPER.registerRootElement(new QName(Namespace.ROLLBACK_1_2.getNamespace(), PatchXml_1_0.Element.PATCH.name), ROLLBACK_1_0);
     }
 
     public enum Namespace {
 
         PATCH_1_0("urn:jboss:patch:1.0"),
         PATCH_1_1("urn:jboss:patch:1.1"),
+        PATCH_1_2("urn:jboss:patch:1.2"),
         ROLLBACK_1_0("urn:jboss:patch:rollback:1.0"),
         ROLLBACK_1_1("urn:jboss:patch:rollback:1.1"),
+        ROLLBACK_1_2("urn:jboss:patch:rollback:1.2"),
         PATCH_BUNDLE_1_0("urn:jboss:patch:bundle:1.0"),
         UNKNOWN(null),
         ;

--- a/patching/src/main/java/org/jboss/as/patching/metadata/PatchXml_1_0.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/PatchXml_1_0.java
@@ -41,7 +41,7 @@ class PatchXml_1_0 extends PatchXmlUtils implements XMLStreamConstants, XMLEleme
         // Get started ...
         writer.writeStartDocument();
         writer.writeStartElement(Element.PATCH.name);
-        writer.writeDefaultNamespace(PatchXml.Namespace.PATCH_1_1.getNamespace());
+        writer.writeDefaultNamespace(PatchXml.Namespace.PATCH_1_2.getNamespace());
 
         writePatch(writer, patch);
 

--- a/patching/src/main/java/org/jboss/as/patching/metadata/RollbackPatchXml_1_0.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/RollbackPatchXml_1_0.java
@@ -26,14 +26,15 @@ import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
 
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.patching.Constants;
 import org.jboss.as.patching.DirectoryStructure;
@@ -142,7 +143,7 @@ class RollbackPatchXml_1_0 extends PatchXmlUtils implements XMLStreamConstants, 
         // Get started ...
         writer.writeStartDocument();
         writer.writeStartElement(Element.PATCH.name);
-        writer.writeDefaultNamespace(PatchXml.Namespace.ROLLBACK_1_1.getNamespace());
+        writer.writeDefaultNamespace(PatchXml.Namespace.ROLLBACK_1_2.getNamespace());
 
         writePatch(writer, rollbackPatch);
         writeInstallation(writer, rollbackPatch.getIdentityState());

--- a/patching/src/main/java/org/jboss/as/patching/runner/AbstractPatchingTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/AbstractPatchingTask.java
@@ -27,10 +27,12 @@ import static org.jboss.as.patching.IoUtils.NO_CONTENT;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.jboss.as.patching.PatchingException;
 import org.jboss.as.patching.logging.PatchLogger;
 import org.jboss.as.patching.metadata.ContentItem;
 import org.jboss.as.patching.metadata.ContentModification;
 import org.jboss.as.patching.metadata.ContentType;
+import org.jboss.as.patching.metadata.ModificationCondition;
 
 /**
  * Basic patching task implementation.
@@ -54,6 +56,15 @@ abstract class AbstractPatchingTask<T extends ContentItem> implements PatchingTa
     @Override
     public T getContentItem() {
         return contentItem;
+    }
+
+    @Override
+    public boolean isRelevant(PatchingTaskContext context) throws PatchingException {
+        final ModificationCondition condition = description.getModification().getCondition();
+        if(condition == null) {
+            return true;
+        }
+        return condition.isSatisfied(context);
     }
 
     /**

--- a/patching/src/main/java/org/jboss/as/patching/runner/BundlePatchingTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/BundlePatchingTask.java
@@ -93,11 +93,11 @@ class BundlePatchingTask extends AbstractPatchingTask<BundleItem> {
         final BundleItem item = new BundleItem(contentItem.getName(), contentItem.getSlot(), itemHash);
         switch (original.getType()) {
             case ADD:
-                return new ContentModification(item, targetHash, ModificationType.REMOVE);
+                return new ContentModification(item, targetHash, ModificationType.REMOVE, original.getCondition());
             case REMOVE:
-                return new ContentModification(item, targetHash, ModificationType.ADD);
+                return new ContentModification(item, targetHash, ModificationType.ADD, original.getCondition());
             default:
-                return new ContentModification(item, targetHash, ModificationType.MODIFY);
+                return new ContentModification(item, targetHash, ModificationType.MODIFY, original.getCondition());
         }
     }
 

--- a/patching/src/main/java/org/jboss/as/patching/runner/FileRemoveTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/FileRemoveTask.java
@@ -33,10 +33,12 @@ import java.util.List;
 
 import org.jboss.as.patching.HashUtils;
 import org.jboss.as.patching.IoUtils;
+import org.jboss.as.patching.PatchingException;
 import org.jboss.as.patching.logging.PatchLogger;
 import org.jboss.as.patching.metadata.ContentItem;
 import org.jboss.as.patching.metadata.ContentModification;
 import org.jboss.as.patching.metadata.MiscContentItem;
+import org.jboss.as.patching.metadata.ModificationCondition;
 import org.jboss.as.patching.metadata.ModificationType;
 
 /**
@@ -64,6 +66,15 @@ class FileRemoveTask implements PatchingTask {
     @Override
     public ContentItem getContentItem() {
         return item;
+    }
+
+    @Override
+    public boolean isRelevant(PatchingTaskContext context) throws PatchingException {
+        final ModificationCondition condition = description.getModification().getCondition();
+        if(condition == null) {
+            return true;
+        }
+        return condition.isSatisfied(context);
     }
 
     @Override

--- a/patching/src/main/java/org/jboss/as/patching/runner/FileUpdateTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/FileUpdateTask.java
@@ -50,7 +50,7 @@ final class FileUpdateTask extends AbstractFileTask {
         } else {
             type = ModificationType.MODIFY;
         }
-        return new ContentModification(item, targetHash, type);
+        return new ContentModification(item, targetHash, type, original.getCondition());
     }
 
     protected ContentModification getOriginalModification(byte[] targetHash, byte[] itemHash) {
@@ -61,6 +61,6 @@ final class FileUpdateTask extends AbstractFileTask {
         } else {
             type = ModificationType.MODIFY;
         }
-        return new ContentModification(original.getItem(), original.getTargetHash(), type);
+        return new ContentModification(original.getItem(), original.getTargetHash(), type, original.getCondition());
     }
 }

--- a/patching/src/main/java/org/jboss/as/patching/runner/IdentityPatchRunner.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/IdentityPatchRunner.java
@@ -538,6 +538,9 @@ class IdentityPatchRunner implements InstallationManager.ModificationCompletionC
     static void prepareTasks(final IdentityPatchContext.PatchEntry entry, final IdentityPatchContext context, final List<PreparedTask> tasks, final List<ContentItem> conflicts) throws PatchingException {
         for (final PatchingTasks.ContentTaskDefinition definition : entry.getDefinitions().values()) {
             final PatchingTask task = createTask(definition, context, entry);
+            if(!task.isRelevant(entry)) {
+                continue;
+            }
             try {
                 // backup and validate content
                 if (!task.prepare(entry) || definition.hasConflicts()) {

--- a/patching/src/main/java/org/jboss/as/patching/runner/ModuleRemoveTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/ModuleRemoveTask.java
@@ -71,12 +71,12 @@ class ModuleRemoveTask extends AbstractModuleTask {
     protected ContentModification getOriginalModification(byte[] targetHash, byte[] itemHash) {
         final ModuleItem original = getContentItem();
         final ModuleItem item = new ModuleItem(original.getName(), original.getSlot(), targetHash);
-        return new ContentModification(item, description.getModification().getTargetHash(), ModificationType.MODIFY);
+        return new ContentModification(item, description.getModification().getTargetHash(), ModificationType.MODIFY, description.getModification().getCondition());
     }
 
     @Override
     ContentModification createRollbackEntry(ContentModification original, byte[] targetHash, byte[] itemHash) {
         final ModuleItem item = createContentItem(contentItem, itemHash);
-        return new ContentModification(item, targetHash, ModificationType.MODIFY);
+        return new ContentModification(item, targetHash, ModificationType.MODIFY, original.getCondition());
     }
 }

--- a/patching/src/main/java/org/jboss/as/patching/runner/ModuleUpdateTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/ModuleUpdateTask.java
@@ -107,7 +107,7 @@ class ModuleUpdateTask extends AbstractModuleTask {
         } else {
             type = ModificationType.MODIFY;
         }
-        return new ContentModification(item, targetHash, type);
+        return new ContentModification(item, targetHash, type, original.getCondition());
     }
 
 }

--- a/patching/src/main/java/org/jboss/as/patching/runner/PatchingTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/PatchingTask.java
@@ -25,6 +25,7 @@ package org.jboss.as.patching.runner;
 import java.io.File;
 import java.io.IOException;
 
+import org.jboss.as.patching.PatchingException;
 import org.jboss.as.patching.metadata.ContentItem;
 import org.jboss.as.patching.metadata.MiscContentItem;
 import org.jboss.as.patching.metadata.ModificationType;
@@ -42,6 +43,16 @@ public interface PatchingTask {
      * @return the content item
      */
     ContentItem getContentItem();
+
+    /**
+     * Checks whether this task is relevant in the given context or it can be skipped.
+     *
+     * @param context  patching task context
+     * @return  true if this task is relevant in the current context and should be executed,
+     *          otherwise - false
+     * @throws PatchingException
+     */
+    boolean isRelevant(PatchingTaskContext context) throws PatchingException;
 
     /**
      * Prepare the content modification. This will backup the current target file and check

--- a/patching/src/main/java/org/jboss/as/patching/runner/PatchingTaskDescription.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/PatchingTaskDescription.java
@@ -109,7 +109,7 @@ class PatchingTaskDescription {
         final ContentItem backupItem = definition.getTarget().getItem();
         final ContentModification modification = definition.getTarget().getModification();
         final byte[] target = definition.getLatest().getTargetHash();
-        return new ContentModification(backupItem, target, modification.getType());
+        return new ContentModification(backupItem, target, modification.getType(), modification.getCondition());
     }
 
 }

--- a/patching/src/main/resources/patch-config_1_2.xsd
+++ b/patching/src/main/resources/patch-config_1_2.xsd
@@ -1,0 +1,325 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:patch-config:1.2"
+           targetNamespace="urn:jboss:patch-config:1.2"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+        >
+
+    <xs:element name="patch-config">
+        <xs:annotation>
+            <xs:documentation>
+                Patch description
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <!--xs:element name="id" type="patchIdType" minOccurs="1" maxOccurs="1"/-->
+                <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:choice>
+                    <xs:element name="cumulative" type="cumulative-patchType" maxOccurs="1"/>
+                    <xs:element name="one-off" type="patchType" maxOccurs="1"/>
+                </xs:choice>
+                <xs:element name="element" type="elementType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:choice>
+                    <xs:element name="generate-by-diff" type="generate-by-diffType" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="specified-content" type="specified-contentType" minOccurs="0" maxOccurs="1"/>
+                </xs:choice>
+                <xs:element name="optional-paths" type="optional-pathsType" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="patchType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes the type of the patch
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the project or product name to which this patch applies.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="applies-to-version" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the project or product version to which this patch applies.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="cumulative-patchType">
+        <xs:annotation>
+            <xs:documentation>
+                Cumulative patch release, invalidating all previous one-off patches
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the project or product name to which this patch applies.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="applies-to-version" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the project or product version to which this patch applies.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="resulting-version" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the project or product version that will be installed once this patch is applied.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="generate-by-diffType">
+        <xs:annotation>
+            <xs:documentation>
+                Indicates the patch should be generated by comparing the contents of two distributions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="in-runtime-use" type="contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="specified-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Indicates the patch should be generated by using the specifically identified herein.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="modules" type="modulesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="bundles" type="bundlesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="misc-files" type="misc-filesType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="modulesType">
+        <xs:sequence>
+            <xs:element name="added" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="updated" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="removed" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="bundlesType">
+        <xs:sequence>
+            <xs:element name="added" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="updated" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="removed" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="misc-filesType">
+        <xs:sequence>
+            <xs:element name="added" type="added-misc-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="updated" type="updated-misc-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="removed" type="removed-misc-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="contentType">
+        <xs:annotation>
+            <xs:documentation>
+                A piece of patch content.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Location of the content within the patch file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="slotted-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                A piece of patch content with a name and a slot.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="slot" type="xs:string"/>
+        <xs:attribute name="search-path" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the searchable path under which the slotted content is stored. If not set, the
+                    default path for the type of content (e.g. modules/ or bundles/) is assumed
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="added-misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content that the patch adds to the installation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="contentType">
+                <xs:attribute name="directory" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the added content is a directory.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="updated-misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content in the installation being patched that the patch modifies.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="contentType">
+                <xs:attribute name="directory" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the new version of the content is a directory.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="in-runtime-use" type="xs:boolean">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the content is expected to be in use by a non-admin-only standalone server or Host Controller.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="removed-misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content in the installation being patched that the patch removes.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Location of the content within the patch file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="directory" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the removed content is a directory
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="in-runtime-use" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    Whether the content is expected to be in use by a non-admin-only standalone server or Host Controller.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="elementPatchType">
+        <xs:attribute name="name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The layer name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="elementType">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="cumulative" type="elementPatchType" maxOccurs="1"/>
+                <xs:element name="one-off" type="elementPatchType" maxOccurs="1"/>
+            </xs:choice>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="specified-content" type="specified-contentType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="patch-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The element patch-id.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="optional-pathsType">
+        <xs:annotation>
+            <xs:documentation>
+                Lists filesystem paths that belong to the miscellaneous content
+                for which the patch should be generated but which could be abscent in the target
+                installation (chosen not to be installed by the user, for example) and in that
+                case should simply be skipped instead of aborting the patch altogether.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="path" type="optionalPathType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="optionalPathType">
+        <xs:attribute name="value" type="xs:string" use="required"/>
+            <xs:annotation>
+                <xs:documentation>
+                    Path relative to the installation root with '/' as a name-separator character
+                    which may be skipped during patch application if the path does not exist
+                    in the target installation.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="requires" type="xs:string"/>
+            <xs:annotation>
+                <xs:documentation>
+                    Path relative to the installation root with '/' as a name-separator character
+                    which is required to exist for the path specified in 'value' attribute
+                    to be patched. If 'requires' path does not exist at patch application
+                    then patching 'value' path will be skipped, otherwise, 'value' path
+                    will become a reuquired path to patch.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/patching/src/main/resources/patch_1_2.xsd
+++ b/patching/src/main/resources/patch_1_2.xsd
@@ -1,0 +1,382 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:patch:1.2"
+           targetNamespace="urn:jboss:patch:1.2"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+        >
+
+    <xs:element name="patch">
+        <xs:annotation>
+            <xs:documentation>
+                Patch description
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="link" type="linkType" minOccurs="0" maxOccurs="1"/>
+                <xs:choice>
+                    <xs:element name="upgrade" type="identityUpgradeType" maxOccurs="1"/>
+                    <xs:element name="no-upgrade" type="identityNoUpgradeType" maxOccurs="1"/>
+                </xs:choice>
+                <xs:element name="element" type="elementType" minOccurs="1" maxOccurs="unbounded"/>
+                <xs:element name="misc-files" type="misc-filesType" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="id" type="xs:string" use="required">
+                <xs:annotation>
+                    <xs:documentation>
+                        Unique identifier of the patch.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="upgradeType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes the identity which produced the patch.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="requires" type="requiresType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the identity.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="identityUpgradeBaseType">
+        <xs:complexContent>
+            <xs:extension base="upgradeType">
+                <xs:attribute name="version" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The version of the identity.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="identityUpgradeType">
+        <xs:annotation>
+            <xs:documentation>
+                Indicates that the patch upgrades the version of the identity.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="identityUpgradeBaseType">
+                <xs:attribute name="to-version" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The version of the identity after the patch has been applied.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="identityNoUpgradeType">
+        <xs:annotation>
+            <xs:documentation>
+                Indicates that the patch upgrades the version of the identity.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="identityUpgradeBaseType">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="linkType">
+        <xs:attribute name="url" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="requiresType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes the one-off patches applied to the identity which
+                produced the patch.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="patch" type="one-offType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="one-offType">
+        <xs:annotation>
+            <xs:documentation>
+                One-off patch which was applied to the identity that produced
+                the patch.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="id" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Identifier of the applied one-off patch.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="elementType">
+        <xs:annotation>
+            <xs:documentation>
+                Describes a patch element produced by a layer or an add-on.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:choice>
+                <xs:element name="upgrade" type="elementUpgradeType" maxOccurs="1"/>
+                <xs:element name="no-upgrade" type="elementUpgradeType" maxOccurs="1"/>
+            </xs:choice>
+            <xs:element name="modules" type="modulesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="bundles" type="bundlesType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Unique identifier of the patch element.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="elementUpgradeType">
+        <xs:annotation>
+            <xs:documentation>
+                Indicates that the patch upgrades the version of the identity.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="upgradeType">
+                <xs:attribute name="add-on" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the element is an add-on or layer
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="modulesType">
+        <xs:sequence>
+            <xs:element name="added" type="slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="updated" type="updated-slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="removed" type="removed-slotted-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="bundlesType">
+        <xs:complexContent>
+            <xs:extension base="modulesType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="misc-filesType">
+        <xs:sequence>
+            <xs:element name="added" type="added-misc-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="updated" type="updated-misc-contentType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="removed" type="removed-misc-contentType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:attributeGroup name="slottedGroup">
+        <xs:annotation>
+            <xs:documentation>
+                A piece of patch content with a name and a slot.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="slot" type="xs:string"/>
+    </xs:attributeGroup>
+
+    <xs:complexType name="slotted-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                A piece of patch content with a name and a slot.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attributeGroup ref="slottedGroup"/>
+        <xs:attribute name="hash" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Hash of the content.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="updated-slotted-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous slotted content in the installation being patched that the patch modifies.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="slotted-contentType">
+                <xs:attribute name="new-hash" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The hash of the new content (the item replacing the currently installed one).
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="removed-slotted-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous slotted content in the installation being patched that the patch removes.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="updated-slotted-contentType">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="contentType">
+        <xs:annotation>
+            <xs:documentation>
+                A piece of patch content.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Location of the content within the patch file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="hash" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Hash of the content.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content base type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="contentType">
+                <xs:attribute name="directory" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the content is a directory.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="condition" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The modification should be applied only if the condition specified as the value
+                            of this attribute satisfied.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="added-misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content that the patch adds to the installation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="misc-contentType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="existing-misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content in the installation being patched that the patch modifies.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="misc-contentType">
+                <xs:attribute name="in-runtime-use" type="xs:boolean">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the content is expected to be in use by a non-admin-only standalone server or Host Controller.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="updated-misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content in the installation being patched that the patch modifies.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="existing-misc-contentType">
+                <xs:attribute name="new-hash" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The hash of the new content.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="removed-misc-contentType">
+        <xs:annotation>
+            <xs:documentation>
+                Miscellaneous content in the installation being patched that the patch removes.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="existing-misc-contentType"/>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/patching/src/test/java/org/jboss/as/patching/tests/ModificationConditionTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/ModificationConditionTestCase.java
@@ -1,0 +1,152 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.patching.tests;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.jboss.as.patching.PatchingException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class ModificationConditionTestCase extends AbstractPatchingTest {
+
+    static final String DOCS = "docs";
+    static final String INSTALLED = "installed";
+    static final String MANUAL = "manual.txt";
+    static final String NOT_INSTALLED = "not_installed";
+    static final String OTHER = "other";
+
+    static final String[] INSTALLED_PATH = new String[]{DOCS, INSTALLED};
+    static final String[] NOT_INSTALLED_PATH = new String[]{DOCS, NOT_INSTALLED};
+
+    static final String[] INSTALLED_MANUAL = new String[]{DOCS, INSTALLED, MANUAL};
+    static final String[] NOT_INSTALLED_MANUAL = new String[]{DOCS, NOT_INSTALLED, MANUAL};
+    static final String[] OTHER_MANUAL = new String[]{OTHER, MANUAL};
+
+    @Test
+    public void testMisc() throws IOException, PatchingException {
+
+        final PatchingTestBuilder builder = createDefaultBuilder();
+        final byte[] installedHash = new byte[20];
+        final byte[] notInstalledHash = new byte[20];
+        final byte[] otherHash = new byte[20];
+        final byte[] moduleHash = new byte[20];
+
+        // Create a file
+        final File installedDir = builder.getFile(DOCS, INSTALLED);
+        assertTrue(installedDir.mkdirs());
+
+        final PatchingTestStepBuilder cp1 = builder.createStepBuilder();
+        cp1.setPatchId("CP1")
+                .upgradeIdentity(PRODUCT_VERSION, PRODUCT_VERSION)
+                .upgradeElement("base-CP1", "base", false)
+                .addModuleWithRandomContent("org.jboss.test", moduleHash)
+                .getParent()
+                .addFileWithRandomContent(installedHash, INSTALLED_MANUAL, INSTALLED_PATH)
+                .addFileWithRandomContent(notInstalledHash, NOT_INSTALLED_MANUAL, NOT_INSTALLED_PATH)
+                .addFileWithRandomContent(otherHash, OTHER_MANUAL, INSTALLED_PATH);
+
+        // Apply CP1
+        apply(cp1);
+
+        Assert.assertTrue(builder.hasFile(DOCS, INSTALLED, MANUAL));
+        Assert.assertTrue(builder.hasFile(OTHER, MANUAL));
+        Assert.assertFalse(builder.hasFile(DOCS, NOT_INSTALLED, MANUAL));
+
+        final PatchingTestStepBuilder oneOff1 = builder.createStepBuilder();
+        oneOff1.setPatchId("oneOff1")
+                .oneOffPatchIdentity(PRODUCT_VERSION)
+                .oneOffPatchElement("base-oneOff1", "base", false)
+                .updateModuleWithRandomContent("org.jboss.test", moduleHash, null)
+                .getParent()
+                .updateFileWithRandomContent(installedHash, null, INSTALLED_MANUAL, INSTALLED_PATH)
+                .updateFileWithRandomContent(notInstalledHash, null, NOT_INSTALLED_MANUAL, NOT_INSTALLED_PATH)
+                .updateFileWithRandomContent(otherHash, null, OTHER_MANUAL, INSTALLED_PATH);
+
+        // Apply oneOff1
+        apply(oneOff1);
+
+        Assert.assertTrue(builder.hasFile(DOCS, INSTALLED, MANUAL));
+        Assert.assertTrue(builder.hasFile(OTHER, MANUAL));
+        Assert.assertFalse(builder.hasFile(DOCS, NOT_INSTALLED, MANUAL));
+
+        final PatchingTestStepBuilder cp2 = builder.createStepBuilder();
+        cp2.setPatchId("CP2")
+                .upgradeIdentity(PRODUCT_VERSION, PRODUCT_VERSION)
+                .upgradeElement("base-CP2", "base", false)
+                .updateModuleWithRandomContent("org.jboss.test", moduleHash, null)
+                .getParent()
+                .removeFile(installedHash, INSTALLED_MANUAL, INSTALLED_PATH)
+                .removeFile(notInstalledHash, NOT_INSTALLED_MANUAL, NOT_INSTALLED_PATH)
+                .removeFile(otherHash, OTHER_MANUAL, INSTALLED_PATH);
+
+        // Apply CP2
+        apply(cp2);
+
+        Assert.assertFalse(builder.hasFile(DOCS, INSTALLED, MANUAL));
+        Assert.assertFalse(builder.hasFile(DOCS, NOT_INSTALLED, MANUAL));
+        Assert.assertFalse(builder.hasFile(OTHER, MANUAL));
+
+        rollback(cp2);
+
+        Assert.assertTrue(builder.hasFile(DOCS, INSTALLED, MANUAL));
+        Assert.assertTrue(builder.hasFile(OTHER, MANUAL));
+        Assert.assertFalse(builder.hasFile(DOCS, NOT_INSTALLED, MANUAL));
+
+        rollback(oneOff1);
+
+        Assert.assertTrue(builder.hasFile(DOCS, INSTALLED, MANUAL));
+        Assert.assertTrue(builder.hasFile(OTHER, MANUAL));
+        Assert.assertFalse(builder.hasFile(DOCS, NOT_INSTALLED, MANUAL));
+
+        rollback(cp1);
+
+        Assert.assertFalse(builder.hasFile(DOCS, INSTALLED, MANUAL));
+        Assert.assertFalse(builder.hasFile(OTHER, MANUAL));
+        Assert.assertFalse(builder.hasFile(DOCS, NOT_INSTALLED, MANUAL));
+    }
+
+/*    private void printPatch(PatchingTestStepBuilder cp2) throws Exception {
+        writePatch(cp2.getPatchDir(), cp2.build());
+        BufferedReader reader = null;
+        try {
+            reader = new BufferedReader(new FileReader(new File(cp2.getPatchDir(), "patch.xml")));
+            String line = reader.readLine();
+            while(line != null) {
+                System.out.println(line);
+                line = reader.readLine();
+            }
+        } finally {
+            if(reader != null) {
+                reader.close();
+            }
+        }
+    }
+*/}

--- a/patching/src/test/resources/patch-11-CP.xml
+++ b/patching/src/test/resources/patch-11-CP.xml
@@ -21,7 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<patch xmlns="urn:jboss:patch:1.1" id="patch-01">
+<patch xmlns="urn:jboss:patch:1.2" id="patch-01">
 
     <description>patch-01 description</description>
     <link url="http://www.jboss.org/release/notes/6.4.1" />

--- a/patching/src/test/resources/patch-21-ONE-OFF.xml
+++ b/patching/src/test/resources/patch-21-ONE-OFF.xml
@@ -21,7 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<patch xmlns="urn:jboss:patch:1.1" id="patch-02">
+<patch xmlns="urn:jboss:patch:1.2" id="patch-02">
 
     <description>patch-02 description</description>
     <link url="http://www.jboss.org/release/notes/6.4.1" />


### PR DESCRIPTION
This commit introduces a condition for miscellaneous (type of) content modification, meaning that a modification recorded in the patch for a path that represents a MISC content type would be applied only if the condition specified for this modification is satisfied at the time of the patch application. If the condition is not satisfied, the modification will simply be skipped instead of aborting the whole patch. If a modification appears w/o a condition, the modification will be considered as required as it is currently.

There is a new schema for patch.xml and patch-config.xml that support the expression of the conditions. In patch.xml it's a simple (optional) attribute called 'condition' allowed for any MISC content modification element.
In patch-config.xml there is a new optional element called 'optional-paths'.
The only condition currently supported is the dependency on an existence of a filesystem path (to address the reported issue).

Thanks,
Alexey