### PR TITLE
WFCORE-936 PersistentResourceXMLDescription: do not use asPropertyList() & remove deprected methods 

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -35,13 +35,11 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
  * @author Tomaz Cerar
  * @author Stuart Douglas
  */
-public class PersistentResourceXMLDescription {
+public final class PersistentResourceXMLDescription {
 
     protected final PersistentResourceDefinition resourceDefinition;
     protected final String xmlElementName;
     protected final String xmlWrapperElement;
-    @Deprecated
-    protected final LinkedHashMap<String, AttributeDefinition> attributes; //we dont use it anymore, it is here just for backward compatibilty and make sure PermissionResourceDefinition works
     protected final LinkedHashMap<String, LinkedHashMap<String, AttributeDefinition>> attributesByGroup;
     protected final List<PersistentResourceXMLDescription> children;
     protected final Map<String,AttributeDefinition> attributeElements =  new HashMap<>();
@@ -58,34 +56,10 @@ public class PersistentResourceXMLDescription {
     private final String forcedName;
 
 
-    /**
-     * @deprecated use a {@link org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder builder}
-     */
-    @Deprecated
-    protected PersistentResourceXMLDescription(final PersistentResourceDefinition resourceDefinition, final String xmlElementName, final String xmlWrapperElement, final LinkedHashMap<String, AttributeDefinition> attributes, final List<PersistentResourceXMLDescription> children, final boolean useValueAsElementName, final boolean noAddOperation, final AdditionalOperationsGenerator additionalOperationsGenerator, Map<String, AttributeParser> attributeParsers) {
-        this.resourceDefinition = resourceDefinition;
-        this.xmlElementName = xmlElementName;
-        this.xmlWrapperElement = xmlWrapperElement;
-        this.useElementsForGroups = true;
-        this.attributes = attributes;
-        this.attributesByGroup = new LinkedHashMap<>();
-        this.attributesByGroup.put(null, attributes);
-        this.children = children;
-        this.useValueAsElementName = useValueAsElementName;
-        this.noAddOperation = noAddOperation;
-        this.additionalOperationsGenerator = additionalOperationsGenerator;
-        this.attributeParsers = attributeParsers;
-        this.namespaceURI = null;
-        this.attributeGroups = null;
-        this.attributeMarshallers = null;
-        this.forcedName = null;
-    }
-
     private PersistentResourceXMLDescription(PersistentResourceXMLBuilder builder) {
         this.resourceDefinition = builder.resourceDefinition;
         this.xmlElementName = builder.xmlElementName;
         this.xmlWrapperElement = builder.xmlWrapperElement;
-        this.attributes = new LinkedHashMap<>();
         this.useElementsForGroups = builder.useElementsForGroups;
         this.attributesByGroup = new LinkedHashMap<>();
         this.namespaceURI = builder.namespaceURI;
@@ -431,8 +405,6 @@ public class PersistentResourceXMLDescription {
         protected boolean useValueAsElementName;
         protected boolean noAddOperation;
         protected AdditionalOperationsGenerator additionalOperationsGenerator;
-        @Deprecated
-        protected final LinkedHashMap<String, AttributeDefinition> attributes = new LinkedHashMap<>();
         protected final LinkedList<AttributeDefinition> attributeList = new LinkedList<>();
         protected final List<PersistentResourceXMLBuilder> children = new ArrayList<>();
         protected final LinkedHashMap<String, AttributeParser> attributeParsers = new LinkedHashMap<>();
@@ -459,20 +431,17 @@ public class PersistentResourceXMLDescription {
 
         public PersistentResourceXMLBuilder addAttribute(AttributeDefinition attribute) {
             this.attributeList.add(attribute);
-            this.attributes.put(attribute.getXmlName(), attribute);
             return this;
         }
 
         public PersistentResourceXMLBuilder addAttribute(AttributeDefinition attribute, AttributeParser attributeParser) {
             this.attributeList.add(attribute);
-            this.attributes.put(attribute.getXmlName(), attribute);
             this.attributeParsers.put(attribute.getXmlName(), attributeParser);
             return this;
         }
 
         public PersistentResourceXMLBuilder addAttribute(AttributeDefinition attribute, AttributeParser attributeParser, AttributeMarshaller attributeMarshaller) {
             this.attributeList.add(attribute);
-            this.attributes.put(attribute.getXmlName(), attribute);
             this.attributeParsers.put(attribute.getXmlName(), attributeParser);
             this.attributeMarshallers.put(attribute.getXmlName(), attributeMarshaller);
             return this;
@@ -480,9 +449,6 @@ public class PersistentResourceXMLDescription {
 
         public PersistentResourceXMLBuilder addAttributes(AttributeDefinition... attributes) {
             Collections.addAll(this.attributeList, attributes);
-            for (final AttributeDefinition at : attributes) {
-                this.attributes.put(at.getXmlName(), at);
-            }
             return this;
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -1,10 +1,16 @@
 package org.jboss.as.controller;
 
-import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
-import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.Element;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -16,18 +22,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
 
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.logging.ControllerLogger;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.parsing.Element;
-import org.jboss.as.controller.parsing.ParseUtils;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.Property;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
-import org.jboss.staxmapper.XMLExtendedStreamWriter;
+import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 
 /**
  * A representation of a resource as needed by the XML parser.
@@ -311,15 +310,16 @@ public final class PersistentResourceXMLDescription {
         }
 
         if (wildcard) {
-            for (Property p : model.asPropertyList()) {
+            for (String name : model.keys()) {
+                ModelNode subModel = model.get(name);
                 if (useValueAsElementName) {
-                    writeStartElement(writer, namespaceURI, p.getName());
+                    writeStartElement(writer, namespaceURI, name);
                 } else {
                     writeStartElement(writer, namespaceURI, xmlElementName);
-                    writer.writeAttribute(NAME, p.getName());
+                    writer.writeAttribute(NAME, name);
                 }
-                persistAttributes(writer, p.getValue(), false);
-                persistChildren(writer, p.getValue());
+                persistAttributes(writer, subModel, false);
+                persistChildren(writer, subModel);
                 writer.writeEndElement();
             }
         } else {

--- a/controller/src/main/java/org/jboss/as/controller/SimpleMapAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleMapAttributeDefinition.java
@@ -37,7 +37,6 @@ import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.jboss.dmr.Property;
 
 /**
  * {@link MapAttributeDefinition} for maps with keys of {@link ModelType#STRING}.
@@ -87,10 +86,10 @@ public class SimpleMapAttributeDefinition extends MapAttributeDefinition {
 
         private void marshalToElement(ModelNode resourceModel, XMLStreamWriter writer) throws XMLStreamException {
             if (!resourceModel.isDefined()) { return; }
-            for (Property property : resourceModel.asPropertyList()) {
+            for (String name : resourceModel.keys()) {
                 writer.writeStartElement(PROPERTY.getLocalName());
-                writer.writeAttribute(NAME.getLocalName(), property.getName());
-                writer.writeCharacters(property.getValue().asString());
+                writer.writeAttribute(NAME.getLocalName(), name);
+                writer.writeCharacters(resourceModel.get(name).asString());
                 writer.writeEndElement();
             }
         }


### PR DESCRIPTION
WFCORE-936 PersistentResourceXMLDescription & friends shouldn't use ModelNode#asPropertyList()
also Remove deprecated api that was only used by PermissionsParser.
Make PersistentResourceXMLDescription final as it was originally meant.