### PR TITLE
WFCORE-955

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/IncludingResourceCapabilityScope.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/IncludingResourceCapabilityScope.java
@@ -124,11 +124,12 @@ abstract class IncludingResourceCapabilityScope implements CapabilityScope {
         for (String includer : included.get(key)) {
             if (!includedContext.getName().equals(includer)) { // guard against cycles
                 Set<CapabilityScope> includees = attached.get(includer);
-                includees.add(includedContext);
-                // Continue up the chain
-                storeIncludes(includedContext, includer, attached, included);
+                if (includees != null) {
+                    includees.add(includedContext);
+                    // Continue up the chain
+                    storeIncludes(includedContext, includer, attached, included);
+                } // else 'includer' must have been bogus
             }
-
         }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3351,4 +3351,11 @@ public interface ControllerLogger extends BasicLogger {
             "Both the subsystem and the extension must be removed or migrated before the server will function.")
     @LogMessage(level = ERROR)
     void removeUnsupportedLegacyExtension(List<String> subsystemNames, String extensionName);
+
+    @Message(id = 403, value = "Unexpected exception during execution of the following operation(s): %s")
+    @LogMessage(level = ERROR)
+    void unexpectedOperationExecutionException(@Cause RuntimeException e, List<ModelNode> controllerOperations);
+
+    @Message(id = 404, value = "Unexpected exception during execution: %s")
+    String unexpectedOperationExecutionFailureDescription(RuntimeException e);
 }

--- a/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
@@ -41,6 +41,10 @@ import static org.junit.Assert.assertTrue;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.capability.registry.CapabilityScope;
+import org.jboss.as.controller.capability.registry.RegistrationPoint;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
@@ -233,7 +237,24 @@ abstract class AbstractCapabilityResolutionTestCase {
             rootResource.registerChild(SBG_B, Resource.Factory.create());
             rootResource.registerChild(SBG_C, Resource.Factory.create());
             rootResource.registerChild(SBG_D, Resource.Factory.create());
+
+            // Add capabilities for each of the profiles and sbgs
+            RuntimeCapabilityRegistry capabilityRegistry = managementModel.getCapabilityRegistry();
+            capabilityRegistry.registerCapability(getCapabilityRegistration(PROFILE_A));
+            capabilityRegistry.registerCapability(getCapabilityRegistration(PROFILE_B));
+            capabilityRegistry.registerCapability(getCapabilityRegistration(SBG_A));
+            capabilityRegistry.registerCapability(getCapabilityRegistration(SBG_B));
+            capabilityRegistry.registerCapability(getCapabilityRegistration(SBG_C));
+            capabilityRegistry.registerCapability(getCapabilityRegistration(SBG_D));
         }
+    }
+
+    private static RuntimeCapabilityRegistration getCapabilityRegistration(PathElement pe) {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(pe.getKey() + "." + pe.getValue()).build();
+        PathAddress pa = PathAddress.pathAddress(pe);
+        CapabilityScope scope = CapabilityScope.Factory.create(ProcessType.EMBEDDED_HOST_CONTROLLER, pa);
+        RegistrationPoint rp = new RegistrationPoint(pa, null);
+        return  new RuntimeCapabilityRegistration(capability, scope, rp);
     }
 
     private static class CapabilityOSH implements OperationStepHandler {
@@ -268,7 +289,22 @@ abstract class AbstractCapabilityResolutionTestCase {
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
-            resource.getModel().get(INCLUDES).set(operation.get(INCLUDES));
+            ModelNode oldIncludes = resource.getModel().get(INCLUDES);
+            PathElement pe = context.getCurrentAddress().getElement(0);
+            String type = pe.getKey();
+            String dependent = type + "." + pe.getValue();
+            if (oldIncludes.isDefined()) {
+                for (ModelNode included : oldIncludes.asList()) {
+                    context.deregisterCapabilityRequirement(type + "." + included.asString(), dependent);
+                }
+            }
+            ModelNode newIncludes = operation.get(INCLUDES);
+            oldIncludes.set(operation.get(INCLUDES));
+            if (newIncludes.isDefined()) {
+                for (ModelNode included : newIncludes.asList()) {
+                    context.registerAdditionalCapabilityRequirement(type + "." + included.asString(), dependent, null);
+                }
+            }
         }
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/SocketCapabilityResolutionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/SocketCapabilityResolutionUnitTestCase.java
@@ -270,4 +270,19 @@ public class SocketCapabilityResolutionUnitTestCase extends AbstractCapabilityRe
         assertTrue(response.toString(), response.get(RESULT, "step-2", RESULT).asBoolean());
     }
 
+    @Test
+    public void testWFCORE955() {
+        // First, establish a profile to s-b dep. This ensures we get into the consistent scope logic
+        // that's where the WFCORE-955 issue appeared
+        ModelNode op = getCompositeOperation(getCapabilityOperation(SOCKET_A_1, "cap_a"), getCapabilityOperation(SUBSYSTEM_A_1, "dep_a", "cap_a"));
+        ModelNode response = controller.execute(op, null, null, null);
+        assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(RESULT, "step-2", RESULT).asBoolean());
+
+        // Then change the include of a different profile to something bogus
+        op = getParentIncludeOperation(SUBSYSTEM_B_1.getParent(), "bogus");
+        response = controller.execute(op, null, null, null);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+    }
+
 }


### PR DESCRIPTION
Avoid an NPE when bogus 'includes' values are used in profiles and socket-binding-groups.

Make sure proper cleanup happens if runtime exceptions like this NPE occur.