### PR TITLE
[WFCORE-959] Correctly pass 'runtimeOnly' info into child MRRs

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -790,6 +790,7 @@ public class ExtensionRegistry {
         }
 
         @Override
+        @SuppressWarnings("deprecation")
         public void setRuntimeOnly(final boolean runtimeOnly) {
             deployments.setRuntimeOnly(runtimeOnly);
             subdeployments.setRuntimeOnly(runtimeOnly);

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionSubsystemResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionSubsystemResourceDefinition.java
@@ -66,7 +66,7 @@ public class ExtensionSubsystemResourceDefinition extends SimpleResourceDefiniti
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
 
     ExtensionSubsystemResourceDefinition() {
-        super(PathElement.pathElement(SUBSYSTEM), ControllerResolver.getResolver(EXTENSION, SUBSYSTEM));
+        super(new Parameters(PathElement.pathElement(SUBSYSTEM), ControllerResolver.getResolver(EXTENSION, SUBSYSTEM)).setRuntime());
     }
 
     @Override
@@ -75,8 +75,5 @@ public class ExtensionSubsystemResourceDefinition extends SimpleResourceDefiniti
         resourceRegistration.registerReadOnlyAttribute(MINOR_VERSION, null);
         resourceRegistration.registerReadOnlyAttribute(MICRO_VERSION, null);
         resourceRegistration.registerReadOnlyAttribute(XML_NAMESPACES, null);
-
-        // HACK -- workaround WFCORE-17
-        resourceRegistration.setRuntimeOnly(true);
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -90,7 +90,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     ConcreteResourceRegistration(final String valueString, final NodeSubregistry parent, final ResourceDefinition definition,
                                  final AccessConstraintUtilizationRegistry constraintUtilizationRegistry,
-                                 final boolean runtimeOnly, final boolean ordered, CapabilityRegistry capabilityRegistry) {
+                                 final boolean ordered, CapabilityRegistry capabilityRegistry) {
         super(valueString, parent);
         this.constraintUtilizationRegistry = constraintUtilizationRegistry;
         this.capabilityRegistry = capabilityRegistry;
@@ -100,7 +100,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         notificationsUpdater.clear(this);
         orderedChildUpdater.clear(this);
         this.resourceDefinition = definition;
-        this.runtimeOnly.set(runtimeOnly);
+        this.runtimeOnly.set(definition.isRuntime());
         this.accessConstraintDefinitions = buildAccessConstraints();
         this.ordered = ordered;
     }
@@ -169,7 +169,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         if (address == null) {
             throw ControllerLogger.ROOT_LOGGER.cannotRegisterSubmodelWithNullPath();
         }
-        if (isRuntimeOnly()) {
+        if (isRuntimeOnly() && !resourceDefinition.isRuntime()) {
             throw ControllerLogger.ROOT_LOGGER.cannotRegisterSubmodel();
         }
         final ManagementResourceRegistration existing = getSubRegistration(PathAddress.pathAddress(address));
@@ -180,7 +180,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         final NodeSubregistry child = getOrCreateSubregistry(key);
         final boolean ordered = resourceDefinition.isOrderedChild();
         final ManagementResourceRegistration resourceRegistration =
-                child.register(address.getValue(), resourceDefinition, false, ordered);
+                child.register(address.getValue(), resourceDefinition, ordered);
         if (ordered) {
             AbstractResourceRegistration parentRegistration = child.getParent();
             parentRegistration.setOrderedChild(key);

--- a/controller/src/main/java/org/jboss/as/controller/registry/DelegatingManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/DelegatingManagementResourceRegistration.java
@@ -48,7 +48,6 @@ import org.jboss.as.controller.descriptions.OverrideDescriptionProvider;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@SuppressWarnings("deprecation")
 public class DelegatingManagementResourceRegistration implements ManagementResourceRegistration {
 
     /**
@@ -202,6 +201,7 @@ public class DelegatingManagementResourceRegistration implements ManagementResou
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void setRuntimeOnly(boolean runtimeOnly) {
         getDelegate().setRuntimeOnly(runtimeOnly);
     }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
@@ -121,7 +121,10 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * persistent configuration model; {@code false} otherwise
      *
      * @throws SecurityException if the caller does not have {@link ImmutableManagementResourceRegistration#ACCESS_PERMISSION}
+     *
+     * @deprecated this property should be controlled by {@link ResourceDefinition#isRuntime()}
      */
+    @Deprecated
     void setRuntimeOnly(final boolean runtimeOnly);
 
     /**
@@ -393,7 +396,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
                     return false;
                 }
             };
-            return new ConcreteResourceRegistration(null, null, rootResourceDefinition, constraintUtilizationRegistry, rootResourceDefinition.isRuntime(), false, null);
+            return new ConcreteResourceRegistration(null, null, rootResourceDefinition, constraintUtilizationRegistry, false, null);
         }
 
         /**
@@ -443,7 +446,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
             }
             ConcreteResourceRegistration resourceRegistration =
                     new ConcreteResourceRegistration(null, null, resourceDefinition,
-                            constraintUtilizationRegistry, resourceDefinition.isRuntime(), false, registry);
+                            constraintUtilizationRegistry, false, registry);
             resourceDefinition.registerAttributes(resourceRegistration);
             resourceDefinition.registerOperations(resourceRegistration);
             resourceDefinition.registerChildren(resourceRegistration);

--- a/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
@@ -82,9 +82,9 @@ final class NodeSubregistry {
         return new HashSet<String>(snapshot.keySet());
     }
 
-    ManagementResourceRegistration register(final String elementValue, final ResourceDefinition provider, boolean runtimeOnly, boolean ordered) {
+    ManagementResourceRegistration register(final String elementValue, final ResourceDefinition provider, boolean ordered) {
         final AbstractResourceRegistration newRegistry =
-                new ConcreteResourceRegistration(elementValue, this, provider, constraintUtilizationRegistry, runtimeOnly, ordered, capabilityRegistry);
+                new ConcreteResourceRegistration(elementValue, this, provider, constraintUtilizationRegistry, ordered, capabilityRegistry);
         final AbstractResourceRegistration existingRegistry = childRegistriesUpdater.putIfAbsent(this, elementValue, newRegistry);
         if (existingRegistry != null) {
             throw ControllerLogger.ROOT_LOGGER.nodeAlreadyRegistered(getLocationString(elementValue));

--- a/controller/src/test/java/org/jboss/as/controller/test/DisappearingResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/DisappearingResourceTestCase.java
@@ -321,11 +321,9 @@ public class DisappearingResourceTestCase extends AbstractControllerTestBase {
         ManagementResourceRegistration subsystemRegistration = registration.registerSubModel(
                 new SimpleResourceDefinition(SUBSYSTEM_ELEMENT, new NonResolvingResourceDescriptionResolver()));
         ManagementResourceRegistration parentReg = subsystemRegistration.registerSubModel(
-                new SimpleResourceDefinition(PARENT_ELEMENT, new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PARENT_ELEMENT, new NonResolvingResourceDescriptionResolver()).setRuntime()));
         ManagementResourceRegistration runtimeResource = parentReg.registerSubModel(
-                new SimpleResourceDefinition(CHILD_WILDCARD_ELEMENT, new NonResolvingResourceDescriptionResolver()));
-        runtimeResource.setRuntimeOnly(true);
-        parentReg.setRuntimeOnly(true);
+                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(CHILD_WILDCARD_ELEMENT, new NonResolvingResourceDescriptionResolver()).setRuntime()));
         AttributeDefinition runtimeAttr = TestUtils.createAttribute(ATTR, ModelType.LONG, GROUP);
         runtimeResource.registerReadOnlyAttribute(runtimeAttr, new OperationStepHandler() {
             @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadResourceWithRuntimeResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadResourceWithRuntimeResourceTestCase.java
@@ -125,7 +125,7 @@ public class ReadResourceWithRuntimeResourceTestCase extends AbstractControllerT
                 new SimpleResourceDefinition(PathElement.pathElement("resource", "A"), new NonResolvingResourceDescriptionResolver()));
         // /subsystem=mysubsystem/resource=B is a runtime-only resource
         ManagementResourceRegistration runtimeResource = subsystemRegistration.registerSubModel(
-                new SimpleResourceDefinition(PathElement.pathElement("resource", "B"), new NonResolvingResourceDescriptionResolver()));
+                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PathElement.pathElement("resource", "B"), new NonResolvingResourceDescriptionResolver()).setRuntime()));
         AttributeDefinition runtimeAttr = TestUtils.createAttribute("attr", ModelType.LONG);
         runtimeResource.registerReadOnlyAttribute(runtimeAttr, new OperationStepHandler() {
             @Override
@@ -133,7 +133,6 @@ public class ReadResourceWithRuntimeResourceTestCase extends AbstractControllerT
                 context.getResult().set(-1);
             }
         });
-        runtimeResource.setRuntimeOnly(true);
 
         subsystemRegistration.registerProxyController(MockProxyController.ADDRESS.getLastElement(), new MockProxyController());
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessConstraintAppliesToResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessConstraintAppliesToResourceDefinition.java
@@ -72,7 +72,7 @@ public class AccessConstraintAppliesToResourceDefinition extends SimpleResourceD
                     .build();
 
     public AccessConstraintAppliesToResourceDefinition() {
-        super(PATH_ELEMENT, DomainManagementResolver.getResolver("core.access-control.constraint.applies-to"));
+        super(new Parameters(PATH_ELEMENT, DomainManagementResolver.getResolver("core.access-control.constraint.applies-to")).setRuntime());
     }
 
     @Override
@@ -81,9 +81,6 @@ public class AccessConstraintAppliesToResourceDefinition extends SimpleResourceD
         resourceRegistration.registerReadOnlyAttribute(ENTIRE_RESOURCE, new EntireResourceHandler());
         resourceRegistration.registerReadOnlyAttribute(ATTRIBUTES, new AttributesHandler());
         resourceRegistration.registerReadOnlyAttribute(OPERATIONS, new OperationsHandler());
-
-        // HACK -- workaround WFCORE-17
-        resourceRegistration.setRuntimeOnly(true);
     }
 
     static Resource.ResourceEntry createResource(AccessConstraintUtilization constraintUtilization) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/ActiveOperationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/ActiveOperationResourceDefinition.java
@@ -82,7 +82,7 @@ public class ActiveOperationResourceDefinition extends SimpleResourceDefinition 
                     .build();
 
     private ActiveOperationResourceDefinition() {
-        super(PATH_ELEMENT, DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS, ACTIVE_OPERATION));
+        super(new Parameters(PATH_ELEMENT, DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS, ACTIVE_OPERATION)).setRuntime());
     }
 
     @Override
@@ -103,8 +103,5 @@ public class ActiveOperationResourceDefinition extends SimpleResourceDefinition 
         resourceRegistration.registerReadOnlyAttribute(RUNNING_TIME, null);
         resourceRegistration.registerReadOnlyAttribute(EXCLUSIVE_RUNNING_TIME, null);
         resourceRegistration.registerReadOnlyAttribute(CANCELLED, null);
-
-        // HACK -- workaround WFCORE-17
-        resourceRegistration.setRuntimeOnly(true);
     }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/ManagementControllerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/ManagementControllerResourceDefinition.java
@@ -60,8 +60,5 @@ public class ManagementControllerResourceDefinition extends SimpleResourceDefini
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         super.registerChildren(resourceRegistration);
         resourceRegistration.registerSubModel(ActiveOperationResourceDefinition.INSTANCE);
-
-        // HACK -- workaround WFCORE-17
-        resourceRegistration.setRuntimeOnly(true);
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/LogFileResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/LogFileResourceDefinition.java
@@ -55,7 +55,6 @@ import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.logging.logging.LoggingLogger;
 import org.jboss.as.server.ServerEnvironment;
@@ -124,9 +123,8 @@ class LogFileResourceDefinition extends SimpleResourceDefinition {
     private final PathManager pathManager;
 
     protected LogFileResourceDefinition(final PathManager pathManager) {
-        super(LOG_FILE_PATH,
-                LoggingExtension.getResourceDescriptionResolver("log-file"),
-                null, null, Flag.RESTART_NONE, Flag.RESTART_NONE);
+        super(new Parameters(LOG_FILE_PATH,
+                LoggingExtension.getResourceDescriptionResolver("log-file")).setRuntime());
         assert pathManager != null : "PathManager cannot be null";
         this.pathManager = pathManager;
     }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -201,13 +201,12 @@ public class LoggingExtension implements Extension {
             final SimpleResourceDefinition deploymentSubsystem = new SimpleResourceDefinition(LoggingResourceDefinition.SUBSYSTEM_PATH, getResourceDescriptionResolver("deployment"));
             final ManagementResourceRegistration deployments = subsystem.registerDeploymentModel(deploymentSubsystem);
             final ManagementResourceRegistration configurationResource = deployments.registerSubModel(LoggingDeploymentResources.CONFIGURATION);
-            configurationResource.registerSubModel(LoggingDeploymentResources.HANDLER).setRuntimeOnly(true);
-            configurationResource.registerSubModel(LoggingDeploymentResources.LOGGER).setRuntimeOnly(true);
-            configurationResource.registerSubModel(LoggingDeploymentResources.FORMATTER).setRuntimeOnly(true);
-            configurationResource.registerSubModel(LoggingDeploymentResources.FILTER).setRuntimeOnly(true);
-            configurationResource.registerSubModel(LoggingDeploymentResources.POJO).setRuntimeOnly(true);
-            configurationResource.registerSubModel(LoggingDeploymentResources.ERROR_MANAGER).setRuntimeOnly(true);
-            configurationResource.setRuntimeOnly(true);
+            configurationResource.registerSubModel(LoggingDeploymentResources.HANDLER);
+            configurationResource.registerSubModel(LoggingDeploymentResources.LOGGER);
+            configurationResource.registerSubModel(LoggingDeploymentResources.FORMATTER);
+            configurationResource.registerSubModel(LoggingDeploymentResources.FILTER);
+            configurationResource.registerSubModel(LoggingDeploymentResources.POJO);
+            configurationResource.registerSubModel(LoggingDeploymentResources.ERROR_MANAGER);
         }
 
         subsystem.registerXMLElementWriter(LoggingSubsystemWriter.INSTANCE);
@@ -240,7 +239,7 @@ public class LoggingExtension implements Extension {
                     .setParentAttribute(CommonAttributes.FILE)
                     .build();
             final LogFileResourceDefinition logFileResourceDefinition = new LogFileResourceDefinition(pathManager);
-            registration.registerSubModel(logFileResourceDefinition).setRuntimeOnly(true);
+            registration.registerSubModel(logFileResourceDefinition);
         }
 
         final RootLoggerResourceDefinition rootLoggerResourceDefinition = new RootLoggerResourceDefinition(includeLegacyAttributes);

--- a/logging/src/main/java/org/jboss/as/logging/deployments/resources/HandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/resources/HandlerResourceDefinition.java
@@ -87,7 +87,7 @@ class HandlerResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     public HandlerResourceDefinition() {
-        super(PATH, LoggingExtension.getResourceDescriptionResolver("deployment", NAME));
+        super(new Parameters(PATH, LoggingExtension.getResourceDescriptionResolver("deployment", NAME)).setRuntime());
     }
 
     @Override

--- a/logging/src/main/java/org/jboss/as/logging/deployments/resources/LoggerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/resources/LoggerResourceDefinition.java
@@ -66,7 +66,7 @@ class LoggerResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     public LoggerResourceDefinition() {
-        super(PATH, LoggingExtension.getResourceDescriptionResolver("deployment", NAME));
+        super(new Parameters(PATH, LoggingExtension.getResourceDescriptionResolver("deployment", NAME)).setRuntime());
     }
 
     @Override

--- a/logging/src/main/java/org/jboss/as/logging/deployments/resources/LoggingDeploymentResources.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/resources/LoggingDeploymentResources.java
@@ -47,7 +47,7 @@ import org.jboss.logmanager.config.PropertyConfigurable;
  */
 public class LoggingDeploymentResources {
 
-    public static final SimpleResourceDefinition CONFIGURATION = new SimpleResourceDefinition(PathElement.pathElement("configuration"), LoggingExtension.getResourceDescriptionResolver("deployment"));
+    public static final SimpleResourceDefinition CONFIGURATION = new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PathElement.pathElement("configuration"), LoggingExtension.getResourceDescriptionResolver("deployment")).setRuntime());
 
     public static final SimpleResourceDefinition HANDLER = new HandlerResourceDefinition();
 
@@ -146,7 +146,7 @@ public class LoggingDeploymentResources {
                 .build();
 
         public PropertiesResourceDefinition(final String name) {
-            super(PathElement.pathElement(name), LoggingExtension.getResourceDescriptionResolver("deployment", name));
+            super(new Parameters(PathElement.pathElement(name), LoggingExtension.getResourceDescriptionResolver("deployment", name)).setRuntime());
         }
 
         @Override

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/BufferPoolResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/BufferPoolResourceDefinition.java
@@ -79,8 +79,8 @@ class BufferPoolResourceDefinition extends SimpleResourceDefinition {
 
 
     private BufferPoolResourceDefinition() {
-        super(PathElement.pathElement(NAME.getName()),
-                PlatformMBeanUtil.getResolver(BUFFER_POOL));
+        super(new Parameters(PathElement.pathElement(NAME.getName()),
+                PlatformMBeanUtil.getResolver(BUFFER_POOL)).setRuntime());
     }
 
     @Override
@@ -94,9 +94,6 @@ class BufferPoolResourceDefinition extends SimpleResourceDefinition {
         for (AttributeDefinition attribute : METRICS) {
             registration.registerMetric(attribute, BufferPoolMXBeanAttributeHandler.INSTANCE);
         }
-
-        // HACK -- workaround WFCORE-17
-        registration.setRuntimeOnly(true);
     }
 
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/BufferPoolRootResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/BufferPoolRootResourceDefinition.java
@@ -35,8 +35,8 @@ class BufferPoolRootResourceDefinition extends SimpleResourceDefinition {
     static final BufferPoolRootResourceDefinition INSTANCE = new BufferPoolRootResourceDefinition();
 
     private BufferPoolRootResourceDefinition() {
-        super(PlatformMBeanConstants.BUFFER_POOL_PATH,
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.BUFFER_POOL));
+        super(new Parameters(PlatformMBeanConstants.BUFFER_POOL_PATH,
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.BUFFER_POOL)).setRuntime());
     }
 
     @Override
@@ -49,9 +49,6 @@ class BufferPoolRootResourceDefinition extends SimpleResourceDefinition {
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         super.registerChildren(resourceRegistration);
         resourceRegistration.registerSubModel(BufferPoolResourceDefinition.INSTANCE);
-
-        // HACK -- workaround WFCORE-17
-        resourceRegistration.setRuntimeOnly(true);
     }
 }
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ClassLoadingResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ClassLoadingResourceDefinition.java
@@ -51,8 +51,8 @@ class ClassLoadingResourceDefinition extends SimpleResourceDefinition {
     static final ClassLoadingResourceDefinition INSTANCE = new ClassLoadingResourceDefinition();
 
     private ClassLoadingResourceDefinition() {
-        super(PlatformMBeanConstants.CLASS_LOADING_PATH,
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.CLASS_LOADING));
+        super(new Parameters(PlatformMBeanConstants.CLASS_LOADING_PATH,
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.CLASS_LOADING)).setRuntime());
     }
 
     @Override
@@ -66,9 +66,6 @@ class ClassLoadingResourceDefinition extends SimpleResourceDefinition {
         for (SimpleAttributeDefinition attribute : READ_WRITE_ATTRIBUTES) {
             registration.registerReadWriteAttribute(attribute, ClassLoadingMXBeanAttributeHandler.INSTANCE, ClassLoadingMXBeanAttributeHandler.INSTANCE);
         }
-
-        // HACK -- workaround WFCORE-17
-        registration.setRuntimeOnly(true);
     }
 
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CompilationResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CompilationResourceDefinition.java
@@ -46,8 +46,8 @@ class CompilationResourceDefinition extends SimpleResourceDefinition {
     static final CompilationResourceDefinition INSTANCE = new CompilationResourceDefinition();
 
     private CompilationResourceDefinition() {
-        super(PlatformMBeanConstants.COMPILATION_PATH,
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.COMPILATION));
+        super(new Parameters(PlatformMBeanConstants.COMPILATION_PATH,
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.COMPILATION)).setRuntime());
     }
 
     @Override
@@ -62,9 +62,6 @@ class CompilationResourceDefinition extends SimpleResourceDefinition {
         for (SimpleAttributeDefinition attribute : METRICS) {
             registration.registerMetric(attribute, CompilationMXBeanAttributeHandler.INSTANCE);
         }
-
-        // HACK -- workaround WFCORE-17
-        registration.setRuntimeOnly(true);
     }
 
     @Override

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/GarbageCollectorResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/GarbageCollectorResourceDefinition.java
@@ -79,8 +79,8 @@ class GarbageCollectorResourceDefinition extends SimpleResourceDefinition {
     static final GarbageCollectorResourceDefinition INSTANCE = new GarbageCollectorResourceDefinition();
 
     private GarbageCollectorResourceDefinition() {
-        super(PathElement.pathElement(NAME.getName()),
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.GARBAGE_COLLECTOR));
+        super(new Parameters(PathElement.pathElement(NAME.getName()),
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.GARBAGE_COLLECTOR)).setRuntime());
     }
 
     @Override
@@ -95,9 +95,6 @@ class GarbageCollectorResourceDefinition extends SimpleResourceDefinition {
         for (SimpleAttributeDefinition attribute : METRICS) {
             registration.registerMetric(attribute, GarbageCollectorMXBeanAttributeHandler.INSTANCE);
         }
-
-        // HACK -- workaround WFCORE-17
-        registration.setRuntimeOnly(true);
     }
 
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/GarbageCollectorRootResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/GarbageCollectorRootResourceDefinition.java
@@ -9,17 +9,14 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 class GarbageCollectorRootResourceDefinition extends SimpleResourceDefinition {
     static final GarbageCollectorRootResourceDefinition INSTANCE = new GarbageCollectorRootResourceDefinition();
     private GarbageCollectorRootResourceDefinition() {
-        super(PlatformMBeanConstants.GARBAGE_COLLECTOR_PATH,
-                PlatformMBeanUtil.getResolver("garbage-collectors"));
+        super(new Parameters(PlatformMBeanConstants.GARBAGE_COLLECTOR_PATH,
+                PlatformMBeanUtil.getResolver("garbage-collectors")).setRuntime());
     }
 
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         super.registerChildren(resourceRegistration);
         resourceRegistration.registerSubModel(GarbageCollectorResourceDefinition.INSTANCE);
-
-        // HACK -- workaround WFCORE-17
-        resourceRegistration.setRuntimeOnly(true);
     }
 }
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryManagerResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryManagerResourceDefinition.java
@@ -65,8 +65,8 @@ class MemoryManagerResourceDefinition extends SimpleResourceDefinition {
     static final MemoryManagerResourceDefinition INSTANCE = new MemoryManagerResourceDefinition();
 
     private MemoryManagerResourceDefinition() {
-        super(PathElement.pathElement(NAME.getName()),
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.MEMORY_MANAGER));
+        super(new Parameters(PathElement.pathElement(NAME.getName()),
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.MEMORY_MANAGER)).setRuntime());
     }
 
     @Override
@@ -77,9 +77,6 @@ class MemoryManagerResourceDefinition extends SimpleResourceDefinition {
         for (AttributeDefinition attribute : METRICS) {
             registration.registerMetric(attribute, MemoryManagerMXBeanAttributeHandler.INSTANCE);
         }
-
-        // HACK -- workaround WFCORE-17
-        registration.setRuntimeOnly(true);
     }
 
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryManagerRootResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryManagerRootResourceDefinition.java
@@ -33,17 +33,14 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 class MemoryManagerRootResourceDefinition extends SimpleResourceDefinition {
     static final MemoryManagerRootResourceDefinition INSTANCE = new MemoryManagerRootResourceDefinition();
     private MemoryManagerRootResourceDefinition() {
-        super(PlatformMBeanConstants.MEMORY_MANAGER_PATH,
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.MEMORY_MANAGER));
+        super(new Parameters(PlatformMBeanConstants.MEMORY_MANAGER_PATH,
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.MEMORY_MANAGER)).setRuntime());
     }
 
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         super.registerChildren(resourceRegistration);
         resourceRegistration.registerSubModel(MemoryManagerResourceDefinition.INSTANCE);
-
-        // HACK -- workaround WFCORE-17
-        resourceRegistration.setRuntimeOnly(true);
     }
 }
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolResourceDefinition.java
@@ -180,8 +180,8 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
 
 
     private MemoryPoolResourceDefinition() {
-        super(PathElement.pathElement(NAME.getName()),
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.MEMORY_POOL));
+        super(new Parameters(PathElement.pathElement(NAME.getName()),
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.MEMORY_POOL)).setRuntime());
     }
 
     @Override
@@ -199,9 +199,6 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
         for (AttributeDefinition attribute : METRICS) {
             registration.registerMetric(attribute, MemoryPoolMXBeanAttributeHandler.INSTANCE);
         }
-
-        // HACK -- workaround WFCORE-17
-        registration.setRuntimeOnly(true);
     }
 
     @Override

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolRootResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolRootResourceDefinition.java
@@ -33,17 +33,14 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 class MemoryPoolRootResourceDefinition extends SimpleResourceDefinition {
     static final MemoryPoolRootResourceDefinition INSTANCE = new MemoryPoolRootResourceDefinition();
     private MemoryPoolRootResourceDefinition() {
-        super(PlatformMBeanConstants.MEMORY_POOL_PATH,
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.MEMORY_POOL));
+        super(new Parameters(PlatformMBeanConstants.MEMORY_POOL_PATH,
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.MEMORY_POOL)).setRuntime());
     }
 
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         super.registerChildren(resourceRegistration);
         resourceRegistration.registerSubModel(MemoryPoolResourceDefinition.INSTANCE);
-
-        // HACK -- workaround WFCORE-17
-        resourceRegistration.setRuntimeOnly(true);
     }
 }
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryResourceDefinition.java
@@ -98,8 +98,7 @@ class MemoryResourceDefinition extends SimpleResourceDefinition {
 
 
     private MemoryResourceDefinition() {
-        super(MEMORY_PATH,
-                PlatformMBeanUtil.getResolver(MEMORY));
+        super(new Parameters(MEMORY_PATH, PlatformMBeanUtil.getResolver(MEMORY)).setRuntime());
     }
 
     @Override
@@ -114,9 +113,6 @@ class MemoryResourceDefinition extends SimpleResourceDefinition {
         for (SimpleAttributeDefinition attribute : METRICS) {
             registration.registerMetric(attribute, MemoryMXBeanAttributeHandler.INSTANCE);
         }
-
-        // HACK -- workaround WFCORE-17
-        registration.setRuntimeOnly(true);
     }
 
     @Override

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/OperatingSystemResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/OperatingSystemResourceDefinition.java
@@ -86,8 +86,8 @@ class OperatingSystemResourceDefinition extends SimpleResourceDefinition {
     static final OperatingSystemResourceDefinition INSTANCE = new OperatingSystemResourceDefinition();
 
     private OperatingSystemResourceDefinition() {
-        super(OPERATING_SYSTEM_PATH,
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.OPERATING_SYSTEM));
+        super(new Parameters(OPERATING_SYSTEM_PATH,
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.OPERATING_SYSTEM)).setRuntime());
     }
 
     @Override
@@ -102,9 +102,6 @@ class OperatingSystemResourceDefinition extends SimpleResourceDefinition {
         for (SimpleAttributeDefinition attribute : METRICS) {
             registration.registerMetric(attribute, OperatingSystemMXBeanAttributeHandler.INSTANCE);
         }
-
-        // HACK -- workaround WFCORE-17
-        registration.setRuntimeOnly(true);
     }
 
     @Override

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/PlatformMBeanResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/PlatformMBeanResourceDefinition.java
@@ -12,8 +12,8 @@ public class PlatformMBeanResourceDefinition extends SimpleResourceDefinition {
     static final PlatformMBeanResourceDefinition INSTANCE = new PlatformMBeanResourceDefinition();
 
     private PlatformMBeanResourceDefinition() {
-        super(PlatformMBeanConstants.PLATFORM_MBEAN_PATH,
-                PlatformMBeanUtil.getResolver("platform-mbeans"));
+        super(new Parameters(PlatformMBeanConstants.PLATFORM_MBEAN_PATH,
+                PlatformMBeanUtil.getResolver("platform-mbeans")).setRuntime());
     }
 
     @Override
@@ -32,8 +32,5 @@ public class PlatformMBeanResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(ThreadResourceDefinition.INSTANCE);
 
         resourceRegistration.registerSubModel(BufferPoolRootResourceDefinition.INSTANCE);
-
-        // HACK -- workaround WFCORE-17
-        resourceRegistration.setRuntimeOnly(true);
     }
 }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/RuntimeResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/RuntimeResourceDefinition.java
@@ -151,8 +151,8 @@ class RuntimeResourceDefinition extends SimpleResourceDefinition {
     static final RuntimeResourceDefinition INSTANCE = new RuntimeResourceDefinition();
 
     private RuntimeResourceDefinition() {
-        super(RUNTIME_PATH,
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.RUNTIME));
+        super(new Parameters(RUNTIME_PATH,
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.RUNTIME)).setRuntime());
     }
 
     @Override
@@ -169,9 +169,6 @@ class RuntimeResourceDefinition extends SimpleResourceDefinition {
         for (AttributeDefinition attribute : METRICS) {
             registration.registerMetric(attribute, RuntimeMXBeanAttributeHandler.INSTANCE);
         }
-
-        // HACK -- workaround WFCORE-17
-        registration.setRuntimeOnly(true);
     }
 
     @Override

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadResourceDefinition.java
@@ -153,8 +153,8 @@ class ThreadResourceDefinition extends SimpleResourceDefinition {
     static final ThreadResourceDefinition INSTANCE = new ThreadResourceDefinition();
 
     private ThreadResourceDefinition() {
-        super(THREADING_PATH,
-                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.THREADING));
+        super(new Parameters(THREADING_PATH,
+                PlatformMBeanUtil.getResolver(PlatformMBeanConstants.THREADING)).setRuntime());
     }
 
     @Override
@@ -173,9 +173,6 @@ class ThreadResourceDefinition extends SimpleResourceDefinition {
         for (AttributeDefinition attribute : METRICS) {
             registration.registerMetric(attribute, ThreadMXBeanAttributeHandler.INSTANCE);
         }
-
-        // HACK -- workaround WFCORE-17
-        registration.setRuntimeOnly(true);
     }
 
     static EnumSet<OperationEntry.Flag> READ_ONLY_RUNTIME_ONLY_FLAG = EnumSet.of(OperationEntry.Flag.RUNTIME_ONLY, OperationEntry.Flag.READ_ONLY);


### PR DESCRIPTION
Deprecate and remove use of MRR.setRuntimeOnly()