### PR TITLE
[WFCORE-949] : Removing http-interface autocompletes but fails.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -282,6 +282,7 @@ public class ModelDescriptionConstants {
     public static final String NATIVE = "native";
     public static final String NATIVE_INTERFACE = "native-interface";
     public static final String NATIVE_REMOTING_INTERFACE = "native-remoting-interface";
+    public static final String NATIVE_SUPPORT = "native-support";
     public static final String NETWORK = "network";
     public static final String NILLABLE = "nillable";
     public static final String NIL_SIGNIFICANT = "nil-significant";

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAddHandler.java
@@ -25,9 +25,11 @@ package org.jboss.as.host.controller.operations;
 import static org.jboss.as.host.controller.logging.HostControllerLogger.ROOT_LOGGER;
 import static org.jboss.as.host.controller.resources.HttpManagementResourceDefinition.ATTRIBUTE_DEFINITIONS;
 import static org.jboss.as.host.controller.resources.HttpManagementResourceDefinition.HTTP_MANAGEMENT_CAPABILITY;
+
 import io.undertow.server.ListenerRegistry;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.Executor;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -100,8 +102,7 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler {
 
     @Override
     protected void rollbackRuntime(OperationContext context, ModelNode operation, Resource resource) {
-
-        HttpManagementRemoveHandler.clearHostControllerInfo(hostControllerInfo);
+        clearHostControllerInfo(hostControllerInfo);
     }
 
     static void populateHostControllerInfo(final LocalHostControllerInfoImpl hostControllerInfo, final OperationContext context, final ModelNode model) throws OperationFailedException {
@@ -212,4 +213,12 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler {
         return builder.getMap();
     }
 
+    static void clearHostControllerInfo(LocalHostControllerInfoImpl hostControllerInfo) {
+        hostControllerInfo.setHttpManagementInterface(null);
+        hostControllerInfo.setHttpManagementPort(0);
+        hostControllerInfo.setHttpManagementSecureInterface(null);
+        hostControllerInfo.setHttpManagementSecurePort(0);
+        hostControllerInfo.setHttpManagementSecurityRealm(null);
+        hostControllerInfo.setAllowedOrigins(Collections.emptyList());
+    }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
@@ -144,8 +144,8 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
         super(RESOURCE_PATH,
                 HostModelUtil.getResourceDescriptionResolver("core", "management", "http-interface"),
                 new HttpManagementAddHandler(hostControllerInfo, environment),
-                new HttpManagementRemoveHandler(hostControllerInfo, environment),
-                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_NONE);
+                HttpManagementRemoveHandler.INSTANCE,
+                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
         this.accessConstraints = SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES.wrapAsList();
         setDeprecated(ModelVersion.create(1, 7));
     }
@@ -161,10 +161,5 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
     @Override
     public List<AccessConstraintDefinition> getAccessConstraints() {
         return accessConstraints;
-    }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(HTTP_MANAGEMENT_CAPABILITY);
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/NativeManagementResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/NativeManagementResourceDefinition.java
@@ -119,9 +119,4 @@ public class NativeManagementResourceDefinition extends SimpleResourceDefinition
     public List<AccessConstraintDefinition> getAccessConstraints() {
         return accessConstraints;
     }
-
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(NATIVE_MANAGEMENT_CAPABILITY);
-    }
 }

--- a/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/host/controller/descriptions/LocalDescriptions.properties
@@ -169,6 +169,8 @@ host.core.management.http-interface.secure-port=The port on which the host contr
 host.core.management.http-interface.security-realm=The security realm to use for the HTTP management interface.
 host.core.management.http-interface.console-enabled=Flag that indicates admin console is enabled
 host.core.management.http-interface.http-upgrade-enabled=Flag that indicates HTTP Upgrade is enabled, which allows HTTP requests to be upgraded to native remoting connections
+host.core.management.http-interface.http-upgrade-enabled.deprecated=Use 'native-support=on'.
+host.core.management.http-interface.native-support=Adding support for native remoting connection throught HTTP request upgrade.
 host.core.management.http-interface.sasl-protocol=The name of the protocol to be passed to the SASL mechanisms used for authentication.
 host.core.management.http-interface.server-name=The name of the server used in the initial Remoting exchange and within the SASL mechanisms.
 #host.core.management.security-realm=Security realm

--- a/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorResource.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorResource.java
@@ -18,7 +18,7 @@
 * License along with this software; if not, write to the Free
 * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-*/
+ */
 package org.jboss.as.jmx;
 
 import static org.jboss.as.jmx.CommonAttributes.JMX;
@@ -45,8 +45,8 @@ import org.jboss.dmr.ModelType;
 public class RemotingConnectorResource extends SimpleResourceDefinition {
 
     static final PathElement REMOTE_CONNECTOR_CONFIG_PATH = PathElement.pathElement(REMOTING_CONNECTOR, JMX);
-    static final SimpleAttributeDefinition USE_MANAGEMENT_ENDPOINT =
-            new SimpleAttributeDefinitionBuilder(CommonAttributes.USE_MANAGEMENT_ENDPOINT, ModelType.BOOLEAN, true)
+    static final SimpleAttributeDefinition USE_MANAGEMENT_ENDPOINT
+            = new SimpleAttributeDefinitionBuilder(CommonAttributes.USE_MANAGEMENT_ENDPOINT, ModelType.BOOLEAN, true)
             .setDefaultValue(new ModelNode(true))
             .setAllowExpression(true)
             .build();
@@ -67,7 +67,7 @@ public class RemotingConnectorResource extends SimpleResourceDefinition {
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        final OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(USE_MANAGEMENT_ENDPOINT){
+        final OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(USE_MANAGEMENT_ENDPOINT) {
             @Override
             protected void recordCapabilitiesAndRequirements(OperationContext context, AttributeDefinition attributeDefinition, ModelNode newValue, ModelNode oldValue) {
                 super.recordCapabilitiesAndRequirements(context, attributeDefinition, newValue, oldValue);

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/logging/RemotingLogger.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/logging/RemotingLogger.java
@@ -32,6 +32,7 @@ import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -129,4 +130,7 @@ public interface RemotingLogger extends BasicLogger {
     @Message(id = 24, value = "The remoting subsystem is present but no io subsystem was found. An io subsystem " +
             "was not required when remoting schema '%s' was current but now is, so a default subsystem is being added.")
     void addingIOSubsystem(String legacyNS);
+
+    @Message(id = 25, value = "Can't remove %s as JMX uses it as remoting endpoint")
+    OperationFailedException couldNotRemoveResource(PathAddress address);
 }

--- a/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
@@ -131,7 +131,7 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
         super(RESOURCE_PATH,
                 ServerDescriptions.getResourceDescriptionResolver("core.management.http-interface"),
                 HttpManagementAddHandler.INSTANCE, HttpManagementRemoveHandler.INSTANCE,
-                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_NONE);
+                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
         this.accessConstraints = SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES.wrapAsList();
         setDeprecated(ModelVersion.create(1, 7));
     }

--- a/server/src/main/java/org/jboss/as/server/mgmt/NativeManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/NativeManagementResourceDefinition.java
@@ -104,7 +104,7 @@ public class NativeManagementResourceDefinition extends SimpleResourceDefinition
         super(RESOURCE_PATH,
                 ServerDescriptions.getResourceDescriptionResolver("core.management.native-interface"),
                 NativeManagementAddHandler.INSTANCE, NativeManagementRemoveHandler.INSTANCE,
-                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_NONE);
+                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
         this.accessConstraints = SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES.wrapAsList();
         setDeprecated(ModelVersion.create(3));
     }

--- a/server/src/main/java/org/jboss/as/server/operations/NativeRemotingManagementRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeRemotingManagementRemoveHandler.java
@@ -22,16 +22,13 @@
 
 package org.jboss.as.server.operations;
 
-import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.domain.management.access.RbacSanityCheckOperation;
-import org.jboss.as.remoting.RemotingServices;
-import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceName;
 
 /**
  * The remove handler for the Native Remoting Interface when running a standalone server.
@@ -39,13 +36,12 @@ import org.jboss.msc.service.ServiceName;
  *
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
-public class NativeRemotingManagementRemoveHandler extends AbstractRemoveStepHandler {
+public class NativeRemotingManagementRemoveHandler extends ReloadRequiredRemoveStepHandler {
 
     public static final NativeRemotingManagementRemoveHandler INSTANCE = new NativeRemotingManagementRemoveHandler();
 
     private NativeRemotingManagementRemoveHandler() {
     }
-
 
     @Override
     protected void performRemove(OperationContext context, ModelNode operation, ModelNode model)
@@ -54,23 +50,8 @@ public class NativeRemotingManagementRemoveHandler extends AbstractRemoveStepHan
         super.performRemove(context, operation, model);
     }
 
-
     @Override
     protected boolean requiresRuntime(OperationContext context) {
         return context.getProcessType() != ProcessType.EMBEDDED_SERVER || context.getRunningMode() != RunningMode.ADMIN_ONLY;
-    }
-
-    @Override
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-
-        final ServiceName endpointName = RemotingServices.SUBSYSTEM_ENDPOINT;
-
-        // Remove management Channel
-        ManagementRemotingServices.removeManagementChannelServices(context, endpointName, ManagementRemotingServices.MANAGEMENT_CHANNEL);
-    }
-
-    @Override
-    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        NativeRemotingManagementAddHandler.INSTANCE.performRuntime(context, operation, model);
     }
 }

--- a/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
+++ b/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
@@ -112,6 +112,8 @@ core.management.http-interface.socket-binding=The name of the socket binding con
 core.management.http-interface.secure-socket-binding=The name of the socket binding configuration to use for the HTTPS management interface's socket.
 core.management.http-interface.console-enabled=Flag that indicates admin console is enabled
 core.management.http-interface.http-upgrade-enabled=Flag that indicates HTTP Upgrade is enabled, which allows HTTP requests to be upgraded to native remoting connections
+core.management.http-interface.http-upgrade-enabled.deprecated=Use 'native-support=on'.
+core.management.http-interface.native-support=Adding support for native remoting connection throught HTTP request upgrade.
 core.service-container=The central container that manages all services in a running standalone server or in a host controller in a management domain.
 core.module-loading=The modular classloading system.
 core.module-loading.module-roots=A list of filesystem locations under which the module loading system looks for modules, arranged in order of precedence.

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AdditionalInitialization.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AdditionalInitialization.java
@@ -158,6 +158,23 @@ public class AdditionalInitialization extends AdditionalParsers {
     }
 
     /**
+     * Simple utility method to register a
+     * {@link org.jboss.as.controller.capability.RuntimeCapability RuntimeCapability<?>} for each of the given
+     * capability. They will be registered against {@link CapabilityScope#GLOBAL} and with the root resource and no
+     * specific attribute as their {@link org.jboss.as.controller.capability.registry.RegistrationPoint}.
+     *
+     * @param capabilityRegistry registry to use
+     * @param capabilities the capabilities.
+     */
+    public static void registerCapabilities(RuntimeCapabilityRegistry capabilityRegistry, RuntimeCapability<?>... capabilities) {
+        for (final RuntimeCapability<?> capability : capabilities) {
+            capabilityRegistry.registerCapability(new RuntimeCapabilityRegistration(capability, CapabilityScope.GLOBAL,
+                    new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
+
+        }
+    }
+
+    /**
      * Simple utility method to register a {@link org.jboss.as.controller.capability.RuntimeCapability} with the
      * specified {@link org.jboss.as.controller.capability.RuntimeCapability#getRuntimeAPI() runtime API}
      * for each of the given capability names. They will be registered against {@link CapabilityScope#GLOBAL}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HTTPSManagementInterfaceTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HTTPSManagementInterfaceTestCase.java
@@ -95,9 +95,7 @@ public class HTTPSManagementInterfaceTestCase {
 
     @BeforeClass
     public static void setupDomain() throws Exception {
-
         keyMaterialSetup();
-
         DomainTestSupport.Configuration configuration = DomainTestSupport.Configuration.create(
                 HTTPSManagementInterfaceTestCase.class.getSimpleName(), "domain-configs/domain-minimal.xml", "host-configs/host-master-no-http.xml", null);
         WildFlyManagedConfiguration masterConfig = configuration.getMasterConfiguration();
@@ -114,19 +112,15 @@ public class HTTPSManagementInterfaceTestCase {
 
     @AfterClass
     public static void tearDownDomain() throws Exception {
-
         httpManagementRealmSetup.tearDown(domainMasterLifecycleUtil.getDomainClient());
-
         testSupport.stop();
         testSupport = null;
         domainMasterLifecycleUtil = null;
-
         FileUtils.deleteDirectory(WORK_DIR);
     }
 
     @Before
     public void addHttpInterface() throws Exception {
-
         ModelNode operation = createOpNode("host=master/core-service=management/management-interface=http-interface",
                 ModelDescriptionConstants.ADD);
         operation.get("interface").set("management");
@@ -139,10 +133,10 @@ public class HTTPSManagementInterfaceTestCase {
 
     @After
     public void removeHttpInterface() throws Exception {
-
         ModelNode operation = createOpNode("host=master/core-service=management/management-interface=http-interface",
                 ModelDescriptionConstants.REMOVE);
         CoreUtils.applyUpdate(operation, domainMasterLifecycleUtil.getDomainClient());
+        reload();
     }
 
     /**

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
@@ -101,8 +101,6 @@ public class HTTPSConnectionWithCLITestCase {
 
     @BeforeClass
     public static void prepareServer() throws Exception {
-
-        LOGGER.info("*** starting server");
         containerController.start();
         ManagementClient mgmtClient = containerController.getClient();
         //final ModelControllerClient client = mgmtClient.getControllerClient();
@@ -112,7 +110,6 @@ public class HTTPSConnectionWithCLITestCase {
 
         // To apply new security realm settings for http interface reload of
         // server is required
-        LOGGER.info("*** reload server");
         reloadServer();
         picketLinkModule = PicketBoxModuleUtil.createTestModule();
     }
@@ -124,7 +121,6 @@ public class HTTPSConnectionWithCLITestCase {
      */
     @Test
     public void testDefaultCLIConfiguration() throws InterruptedException, IOException {
-
         String cliOutput = CustomCLIExecutor.execute(null, TESTING_OPERATION, HTTPS_CONTROLLER, true, "N");
         assertThat("Untrusted client should not be authenticated.", cliOutput, not(containsString("\"outcome\" => \"success\"")));
 
@@ -137,7 +133,6 @@ public class HTTPSConnectionWithCLITestCase {
      */
     @Test
     public void testUntrustedCLICertificate() throws InterruptedException, IOException {
-
         String cliOutput = CustomCLIExecutor.execute(UNTRUSTED_JBOSS_CLI_FILE, TESTING_OPERATION, HTTPS_CONTROLLER);
         assertThat("Untrusted client should not be authenticated.", cliOutput, not(containsString("\"outcome\" => \"success\"")));
 
@@ -150,7 +145,6 @@ public class HTTPSConnectionWithCLITestCase {
      */
     @Test
     public void testTrustedCLICertificate() throws InterruptedException, IOException {
-
         String cliOutput = CustomCLIExecutor.execute(TRUSTED_JBOSS_CLI_FILE, TESTING_OPERATION, HTTPS_CONTROLLER);
         assertThat("Client with valid certificate should be authenticated.", cliOutput, containsString("\"outcome\" => \"success\""));
 
@@ -158,8 +152,6 @@ public class HTTPSConnectionWithCLITestCase {
 
     @AfterClass
     public static void resetTestConfiguration() throws Exception {
-
-        LOGGER.info("*** reseting test configuration");
         ModelControllerClient client = HTTPSManagementInterfaceTestCase.getNativeModelControllerClient();
         ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
                 MANAGEMENT_NATIVE_PORT, "remoting");
@@ -172,7 +164,6 @@ public class HTTPSConnectionWithCLITestCase {
         keystoreFilesSetup.tearDown(managementClient);
         managementNativeRealmSetup.tearDown(managementClient);
 
-        LOGGER.info("*** stopping container");
         containerController.stop();
         picketLinkModule.remove();
         FileUtils.deleteDirectory(WORK_DIR);

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfaceTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfaceTestCase.java
@@ -108,18 +108,14 @@ public class HTTPSManagementInterfaceTestCase {
 
     @BeforeClass
     public static void startAndSetupContainer() throws Exception {
-
-        LOGGER.info("*** starting server");
         controller.start();
 
         ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         ManagementClient managementClient = controller.getClient();
 
-        LOGGER.info("*** will configure server now");
         serverSetup(managementClient);
         managementNativeRealmSetup.setup(client);
 
-        LOGGER.info("*** reloading server");
         // To apply new security realm settings for http interface reload of
         // server is required
         reloadServer();
@@ -199,8 +195,6 @@ public class HTTPSManagementInterfaceTestCase {
 
     @AfterClass
     public static void stopContainer() throws Exception {
-
-        LOGGER.info("*** reseting test configuration");
         ModelControllerClient client = getNativeModelControllerClient();
 
         resetHttpInterfaceConfiguration(client);
@@ -211,10 +205,7 @@ public class HTTPSManagementInterfaceTestCase {
         serverTearDown(client);
         managementNativeRealmSetup.tearDown(client);
 
-        LOGGER.info("*** stopping container");
         controller.stop();
-
-        //FileUtils.deleteDirectory(WORK_DIR);
     }
 
     private static HttpClient getHttpClient(File keystoreFile) {

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/RemoveManagementInterfaceTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/RemoveManagementInterfaceTestCase.java
@@ -1,0 +1,200 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.core.test.standalone.mgmt;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.MANAGEMENT_HTTP_PORT;
+import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.MANAGEMENT_NATIVE_PORT;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import javax.inject.Inject;
+import org.hamcrest.CoreMatchers;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.categories.CommonCriteria;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.management.util.CLITestUtil;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Testing https connection to HTTP Management interface with configured two-way SSL. HTTP client has set client
+ * keystore with valid/invalid certificate, which is used for authentication to management interface. Result of
+ * authentication depends on whether client certificate is accepted in server truststore. HTTP client uses client
+ * truststore with accepted server certificate to authenticate server identity.
+ * <p/>
+ * Keystores and truststores have valid certificates until 25 Octover 2033.
+ *
+ * @author Filip Bogyai
+ * @author Josef Cacek
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+@Category(CommonCriteria.class)
+public class RemoveManagementInterfaceTestCase {
+
+    public static Logger LOGGER = Logger.getLogger(RemoveManagementInterfaceTestCase.class);
+    @Inject
+    protected static ServerController controller;
+
+    @BeforeClass
+    public static void startAndSetupContainer() throws Exception {
+        controller.start();
+        ManagementClient managementClient = controller.getClient();
+        serverSetup(managementClient.getControllerClient());
+        // To have the native management interface ok, we need a reload of the server
+        reloadServer();
+    }
+
+    public static void reloadServer() throws Exception {
+        final CommandContext ctx = CLITestUtil.getCommandContext("remoting", TestSuiteEnvironment.getServerAddress(), MANAGEMENT_NATIVE_PORT);
+        try {
+            ctx.connectController();
+            ctx.handle("reload");
+        } finally {
+            ctx.terminateSession();
+        }
+    }
+
+    @Test
+    public void testRemoveManagementInterface() throws Exception {
+        ModelControllerClient client = getHttpModelControllerClient();
+        ModelNode operation = createOpNode("socket-binding-group=standard-sockets/socket-binding=management-http", ModelDescriptionConstants.READ_RESOURCE_OPERATION);
+        ModelNode response = client.execute(operation);
+        assertThat(response.hasDefined(OUTCOME), is(true));
+        assertThat(response.get(OUTCOME).asString(), is(SUCCESS));
+        operation = createOpNode("core-service=management/management-interface=http-interface", ModelDescriptionConstants.REMOVE);
+        CoreUtils.applyUpdate(operation, client);
+        client.close();
+        reloadServer();
+        client = getNativeModelControllerClient();
+        operation = createOpNode("socket-binding-group=standard-sockets/socket-binding=management-http", ModelDescriptionConstants.READ_RESOURCE_OPERATION);
+        response = client.execute(operation);
+        assertThat(response.hasDefined(OUTCOME), is(true));
+        assertThat(response.get(OUTCOME).asString(), is(SUCCESS));
+        operation = createOpNode("core-service=management/management-interface=native-interface", ModelDescriptionConstants.REMOVE);
+        response = client.execute(operation);
+        assertThat(DomainTestSupport.validateFailedResponse(response).asString(), CoreMatchers.containsString("WFLYRMT0025"));
+        client.close();
+        client = getHttpModelControllerClient();
+        operation = createOpNode("socket-binding-group=standard-sockets/socket-binding=management-http", ModelDescriptionConstants.READ_RESOURCE_OPERATION);
+        try {
+            client.execute(operation);
+            Assert.fail("Shouldn't be able to connect to http management");
+        } catch (IOException ioex) {
+            assertThat(ioex.getMessage(), CoreMatchers.containsString("WFLYPRT0053"));
+        } finally {
+            client.close();
+        }
+    }
+
+    @AfterClass
+    public static void stopContainer() throws Exception {
+        ModelControllerClient client = getNativeModelControllerClient();
+        serverTearDown(client);
+        controller.stop();
+    }
+
+    private static void serverSetup(ModelControllerClient client) throws Exception {
+        // add native socket binding
+        ModelNode operation = createOpNode("socket-binding-group=standard-sockets/socket-binding=management-native", ModelDescriptionConstants.ADD);
+        operation.get("port").set(MANAGEMENT_NATIVE_PORT);
+        operation.get("interface").set("management");
+        CoreUtils.applyUpdate(operation, client);
+
+        // create native interface to control server while http interface will be removed
+        operation = createOpNode("core-service=management/management-interface=native-interface", ModelDescriptionConstants.ADD);
+        operation.get("security-realm").set("ManagementRealm");
+        operation.get("socket-binding").set("management-native");
+        CoreUtils.applyUpdate(operation, client);
+    }
+
+    private static void serverTearDown(final ModelControllerClient client) throws Exception {
+        ModelNode operation = createOpNode("socket-binding-group=standard-sockets/socket-binding=management-http", ModelDescriptionConstants.READ_RESOURCE_OPERATION);
+        ModelNode response = client.execute(operation);
+        if (response.hasDefined(OUTCOME) && FAILED.equals(response.get(OUTCOME).asString())) {
+            // add http-management socket binding
+            operation = createOpNode("socket-binding-group=standard-sockets/socket-binding=management-http", ModelDescriptionConstants.ADD);
+            operation.get("port").set(MANAGEMENT_HTTP_PORT);
+            operation.get("interface").set("management");
+            CoreUtils.applyUpdate(operation, client);
+        }
+        operation = createOpNode("core-service=management/management-interface=http-interface", ModelDescriptionConstants.READ_RESOURCE_OPERATION);
+        response = client.execute(operation);
+        if (response.hasDefined(OUTCOME) && FAILED.equals(response.get(OUTCOME).asString())) {
+            // create http interface to control server
+            operation = createOpNode("core-service=management/management-interface=http-interface", ModelDescriptionConstants.ADD);
+            operation.get("security-realm").set("ManagementRealm");
+            operation.get("socket-binding").set("management-http");
+            operation.get("http-upgrade-enabled").set(true);
+            CoreUtils.applyUpdate(operation, client);
+        }
+        // To recreate http interface, a reload of server is required
+        reloadServer();
+        //Remove native interface
+        operation = createOpNode("core-service=management/management-interface=native-interface", ModelDescriptionConstants.REMOVE);
+        CoreUtils.applyUpdate(operation, client);
+        operation = createOpNode("socket-binding-group=standard-sockets/socket-binding=management-native", ModelDescriptionConstants.REMOVE);
+        CoreUtils.applyUpdate(operation, client);
+    }
+
+    static ModelControllerClient getNativeModelControllerClient() {
+
+        ModelControllerClient client = null;
+        try {
+            client = ModelControllerClient.Factory.create("remote", InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
+                    MANAGEMENT_NATIVE_PORT, new org.wildfly.core.testrunner.Authentication.CallbackHandler());
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+        return client;
+    }
+
+    static ModelControllerClient getHttpModelControllerClient() {
+        ModelControllerClient client = null;
+        try {
+            client = ModelControllerClient.Factory.create("http-remoting", InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
+                    MANAGEMENT_HTTP_PORT, new org.wildfly.core.testrunner.Authentication.CallbackHandler());
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+        return client;
+    }
+}


### PR DESCRIPTION
Removing the management interfaces will put the server in reload mode instead of stopping (and removing) those interfaces at runtime.

Jira: https://issues.jboss.org/browse/WFCORE-949