### PR TITLE
WFCORE-807 Improve error reporting for missing capabilties

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
@@ -25,12 +25,14 @@ package org.jboss.as.controller;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 import org.jboss.as.controller.capability.Capability;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -437,6 +439,22 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
         } finally {
             readLock.unlock();
         }
+    }
+
+    public Set<PathAddress> getPossibleProviderPoints(CapabilityId capabilityId){
+        Set<PathAddress> result = new LinkedHashSet<>();
+        readLock.lock();
+        try {
+            capabilityId = capabilityId.getScope() == CapabilityScope.GLOBAL?capabilityId: new CapabilityId(capabilityId.getName(), CapabilityScope.GLOBAL);
+            CapabilityRegistration<RuntimeCapability> reg =  possibleCapabilities.get(capabilityId);
+            if (reg!=null){
+                result.addAll(reg.getRegistrationPoints().stream().map(RegistrationPoint::getAddress).collect(Collectors.toList()));
+            }
+
+        } finally {
+            readLock.unlock();
+        }
+        return result;
     }
 
     //end ImmutableCapabilityRegistry methods

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -77,9 +77,9 @@ import org.jboss.as.controller.access.TargetResource;
 import org.jboss.as.controller.audit.AuditLogger;
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.controller.capability.RuntimeCapability;
-import org.jboss.as.controller.capability.registry.CapabilityScope;
 import org.jboss.as.controller.capability.registry.CapabilityId;
 import org.jboss.as.controller.capability.registry.CapabilityResolutionContext;
+import org.jboss.as.controller.capability.registry.CapabilityScope;
 import org.jboss.as.controller.capability.registry.RegistrationPoint;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
@@ -338,7 +338,9 @@ final class OperationContextImpl extends AbstractOperationContext {
                             String formattedCapability = ignoreContext
                                     ? ControllerLogger.ROOT_LOGGER.formattedCapabilityName(reqReq.getRequiredName())
                                     : ControllerLogger.ROOT_LOGGER.formattedCapabilityId(reqReq.getRequiredName(), reqReq.getDependentContext().getName());
-                            unexplainedProblem = unexplainedProblem.append('\n').append(formattedCapability);
+
+                            Set<PathAddress> possiblePoints = managementModel.getCapabilityRegistry().getPossibleProviderPoints(reqReq.getDependentId());
+                            appendPossibleProviderPoints(unexplainedProblem, formattedCapability, possiblePoints);
                         }
                     }
                 }
@@ -358,11 +360,12 @@ final class OperationContextImpl extends AbstractOperationContext {
                     String formattedCapability = ignoreContext
                             ? ControllerLogger.ROOT_LOGGER.formattedCapabilityName(id.getName())
                             : ControllerLogger.ROOT_LOGGER.formattedCapabilityId(id.getName(), id.getScope().getName());
+                    Set<PathAddress> possiblePoints = managementModel.getCapabilityRegistry().getPossibleProviderPoints(id);
                     if (msg != null) {
-                        msg = msg.append('\n').append(formattedCapability);
+                        msg = appendPossibleProviderPoints(msg, formattedCapability, possiblePoints);
                     }
                     if (bootMsg != null) {
-                        bootMsg = bootMsg.append(System.lineSeparator()).append(formattedCapability);
+                        bootMsg = appendPossibleProviderPoints(bootMsg, formattedCapability, possiblePoints);
                     }
                 }
                 if (msg != null) {
@@ -425,6 +428,18 @@ final class OperationContextImpl extends AbstractOperationContext {
         }
         return ok || ignoreFailures;
 
+    }
+    private static StringBuilder appendPossibleProviderPoints(StringBuilder sb, String formattedCapability, Set<PathAddress> possible){
+        //"you wanted X and it doesn't exist; here's where you can add X"
+        sb = sb.append(System.lineSeparator()).append(formattedCapability);
+        if (possible.isEmpty()){
+            return sb.append(ControllerLogger.ROOT_LOGGER.noKnownProviderPoints());
+        }
+        StringBuffer points = new StringBuffer();
+        for (PathAddress c: possible){
+            points = points.append(System.lineSeparator()).append("\t\t").append(c.toCLIStyleString());
+        }
+        return sb.append(ControllerLogger.ROOT_LOGGER.possibleCapabilityProviderPoints(points.toString()));
     }
 
     private Step findCapabilityRemovalStep(CapabilityId missingRequirement, boolean ignoreContext, CapabilityResolutionContext resolutionContext) {

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/ImmutableCapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/ImmutableCapabilityRegistry.java
@@ -21,6 +21,7 @@ package org.jboss.as.controller.capability.registry;
 import java.util.Set;
 
 import org.jboss.as.controller.CapabilityRegistry;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.msc.service.ServiceName;
 
 /**
@@ -84,4 +85,12 @@ public interface ImmutableCapabilityRegistry {
      *             is not {@code null} and the type of the service the capability provides is not assignable from it
      */
     ServiceName getCapabilityServiceName(String capabilityName, CapabilityScope scope, Class<?> serviceType);
+
+    /**
+     * Returns possible provider points for passed capabilityId
+     * @param capabilityId id of capability
+     * @return set of PathAddress-es where capability could be registered, will not return <code>null</code> but can be empty
+     */
+
+    Set<PathAddress> getPossibleProviderPoints(CapabilityId capabilityId);
 }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3242,6 +3242,12 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = NONE, value = "    %s in context '%s'")
     String formattedCapabilityId(String capability, String context);
 
+    @Message(id = NONE, value = "; Possible registration points for this capability: %s")
+    String possibleCapabilityProviderPoints(String providerPoints);
+
+    @Message(id = NONE, value = "; There are no known registration points which can provide this capability.")
+    String noKnownProviderPoints();
+
     @Message(id = 370, value="Incomplete expression: %s")
     OperationFailedException incompleteExpression(String expression);
 

--- a/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
@@ -72,6 +72,7 @@ abstract class AbstractCapabilityResolutionTestCase {
     protected static final PathElement SBG_B = PathElement.pathElement(SOCKET_BINDING_GROUP, "b");
     protected static final PathElement SBG_C = PathElement.pathElement(SOCKET_BINDING_GROUP, "c");
     protected static final PathElement SBG_D = PathElement.pathElement(SOCKET_BINDING_GROUP, "d");
+    protected static final PathElement SBG_F = PathElement.pathElement(SUBSYSTEM, "only-registered");
     protected static final PathAddress GLOBAL_A = PathAddress.pathAddress(PathElement.pathElement(GLOBAL, "a"));
     protected static final PathAddress SUBSYSTEM_A_1 = PathAddress.pathAddress(PROFILE_A, PathElement.pathElement(SUBSYSTEM, "1"));
     protected static final PathAddress SUBSYSTEM_A_2 = PathAddress.pathAddress(PROFILE_A, PathElement.pathElement(SUBSYSTEM, "2"));
@@ -116,6 +117,8 @@ abstract class AbstractCapabilityResolutionTestCase {
             }
         }
     }
+
+
 
     protected static ModelNode getCapabilityOperation(PathAddress pathAddress, String capability) {
         return getCapabilityOperation(pathAddress, capability, null);
@@ -240,12 +243,24 @@ abstract class AbstractCapabilityResolutionTestCase {
 
             // Add capabilities for each of the profiles and sbgs
             RuntimeCapabilityRegistry capabilityRegistry = managementModel.getCapabilityRegistry();
-            capabilityRegistry.registerCapability(getCapabilityRegistration(PROFILE_A));
-            capabilityRegistry.registerCapability(getCapabilityRegistration(PROFILE_B));
-            capabilityRegistry.registerCapability(getCapabilityRegistration(SBG_A));
-            capabilityRegistry.registerCapability(getCapabilityRegistration(SBG_B));
-            capabilityRegistry.registerCapability(getCapabilityRegistration(SBG_C));
-            capabilityRegistry.registerCapability(getCapabilityRegistration(SBG_D));
+            registerCapability(capabilityRegistry, PROFILE_A);
+            registerCapability(capabilityRegistry, PROFILE_B);
+            registerCapability(capabilityRegistry, SBG_A);
+            registerCapability(capabilityRegistry, SBG_B);
+            registerCapability(capabilityRegistry, SBG_C);
+            registerCapability(capabilityRegistry, SBG_D);
+            registerCapability(capabilityRegistry, SBG_F, false);
+        }
+    }
+    private static void registerCapability(RuntimeCapabilityRegistry registry, PathElement element){
+         registerCapability(registry, element, true);
+    }
+
+    private static void registerCapability(RuntimeCapabilityRegistry registry, PathElement element, boolean registerRuntime){
+        RuntimeCapabilityRegistration registration = getCapabilityRegistration(element);
+        ((CapabilityRegistry)registry).registerPossibleCapability(registration.getCapability(), registration.getOldestRegistrationPoint().getAddress());
+        if (registerRuntime) {
+            registry.registerCapability(registration);
         }
     }
 
@@ -279,7 +294,7 @@ abstract class AbstractCapabilityResolutionTestCase {
                 context.getResult().set(true);
             }
             if (capName != null) {
-                context.registerCapability(rcb.build(), null);
+                context.registerCapability(rcb.build());
             }
         }
     }

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityResolutionErrorTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityResolutionErrorTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+/**
+ * Test of the specialized capability resolution logic for socket-bindings that
+ * is necessary in a managed domain.
+ *
+ * @author Tomaz Cerar
+ */
+public class CapabilityResolutionErrorTestCase extends AbstractCapabilityResolutionTestCase {
+
+    @Test
+    public void testMissingGlobalRef() {
+        ModelNode op = getCompositeOperation(getCapabilityOperation(SOCKET_A_1, "cap_b"), getCapabilityOperation(GLOBAL_A, "dep_a", "subsystem.only-registered"));
+        ModelNode response = controller.execute(op, null, null, null);
+        validateMissingFailureDesc(response, "step-2", "cap_a", "global", true);
+    }
+
+    @Test
+    public void testMissingProfileRef() {
+        ModelNode op = getCompositeOperation(getCapabilityOperation(SOCKET_A_1, "cap_b"), getCapabilityOperation(SUBSYSTEM_A_1, "dep_a", "cap_a"));
+        ModelNode response = controller.execute(op, null, null, null);
+        validateMissingFailureDesc(response, "step-2", "cap_a", "profile=a", false);
+    }
+
+    protected static void validateMissingFailureDesc(ModelNode response, String step, String cap, String context, boolean expectedPossible) {
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.hasDefined(FAILURE_DESCRIPTION));
+        String failDesc = response.get(FAILURE_DESCRIPTION).asString();
+        int loc = -1;
+        if (step != null) {
+            loc = failDesc.indexOf(step);
+            assertTrue(response.toString(), loc > 0);
+        }
+        int lastLoc = loc;
+        loc = failDesc.indexOf("WFLYCTL0369");
+        assertTrue(response.toString(), loc > lastLoc);
+        if (expectedPossible) {
+            assertTrue(failDesc.contains("Possible registration points for this"));
+        } else {
+            assertTrue(failDesc.contains("There are no known registration points"));
+        }
+
+    }
+
+
+}

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
@@ -74,7 +74,7 @@ public abstract class AbstractControllerTestBase {
     protected abstract void initModel(ManagementModel managementModel);
 
     private ServiceContainer container;
-    private ModelController controller;
+    protected ModelController controller;
     protected final ProcessType processType;
     protected CapabilityRegistry capabilityRegistry;
 


### PR DESCRIPTION
messages like this now:
```
WFLYCTL0369: Required capabilities are not available:
        cap_a in context 'profile=a'; There are no known registration points which can provide this capability.

```
and
```
WFLYCTL0369: Required capabilities are not available:
     cap_a in context 'profile=a'; Possible registration points for this capability:
       /subsystem=bah/
```