### PR TITLE
WFCORE-310 

### DIFF
--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesImpl.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/LegacyKernelServicesImpl.java
@@ -281,6 +281,11 @@ public class LegacyKernelServicesImpl extends AbstractKernelServicesImpl {
                 return Collections.EMPTY_LIST;
             }
 
+            @Override
+            public boolean isBackupDc() {
+                return false;
+            }
+
         });
 
         for (IgnoreDomainResourceTypeResource resource : ignoredResources) {

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager.xml
@@ -28,7 +28,8 @@
     </management>
 
     <domain-controller>
-       <remote host="${jboss.domain.master.address:127.0.0.1}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm" protocol="http-remoting" />
+       <!-- ignore-unused-configuration is set here so the XML comparision test with pass when this file is loaded with .getResource() and compared to the built model -->
+       <remote host="${jboss.domain.master.address:127.0.0.1}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm" protocol="http-remoting" ignore-unused-configuration="true"/>
     </domain-controller>
 
     <interfaces>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-remote-domain-manager.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-remote-domain-manager.xml
@@ -28,7 +28,9 @@
     </management>
 
     <domain-controller>
-       <remote host="${jboss.domain.master.address:127.0.0.1}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm" protocol="remote" />
+       <!-- ignore-unused-configuration is set here so the XML comparision test with pass w
+hen this file is loaded with .getResource() and compared to the built model -->
+       <remote host="${jboss.domain.master.address:127.0.0.1}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm" protocol="remote" ignore-unused-configuration="true"/>
     </domain-controller>
 
     <interfaces>

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/LocalHostControllerInfo.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/LocalHostControllerInfo.java
@@ -54,6 +54,14 @@ public interface LocalHostControllerInfo {
      boolean isMasterDomainController();
 
     /**
+     * Whether we are acting as a backup DC or not (started with the --backup option)
+     *
+     * @return {@code true} if we intend to be able to take over as DC
+     *
+     */
+    boolean isBackupDc();
+
+    /**
      * Gets the name of the interface on which the host listens for native management requests.
      *
      * @return the logical interface name

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostControllerInfoImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalHostControllerInfoImpl.java
@@ -153,6 +153,12 @@ public class LocalHostControllerInfoImpl implements LocalHostControllerInfo {
         return remoteIgnoreUnaffectedConfiguration;
     }
 
+    @Override
+    // started with --backup
+    public boolean isBackupDc() {
+        return hostEnvironment.isBackupDomainFiles();
+    }
+
     public AdminOnlyDomainConfigPolicy getAdminOnlyDomainConfigPolicy() {
         return adminOnlyDomainConfigPolicy;
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_4.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_4.java
@@ -688,7 +688,6 @@ class HostXml_4 extends CommonXml implements ManagementXmlDelegate {
 
         requireDiscoveryOptions = parseRemoteDomainControllerAttributes(reader, address, list);
 
-
         Set<String> types = new HashSet<String>();
         Set<String> staticDiscoveryOptionNames = new HashSet<String>();
         Set<String> discoveryOptionNames = new HashSet<String>();

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -168,6 +168,11 @@ public abstract class AbstractOperationTestCase {
         public Collection<String> getAllowedOrigins() {
             return Collections.EMPTY_LIST;
         }
+
+        @Override
+        public boolean isBackupDc() {
+            return false;
+        }
     };
 
     MockOperationContext getOperationContext() {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -530,6 +530,11 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         public Collection<String> getAllowedOrigins() {
             return Collections.EMPTY_LIST;
         }
+
+        @Override
+        public boolean isBackupDc() {
+            return false;
+        }
     }
 
     private static class ServerInventoryMock implements ServerInventory {

--- a/server/src/main/resources/schema/wildfly-config_4_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_4_0.xsd
@@ -2337,11 +2337,17 @@
         </xs:attribute>
         <xs:attribute name="security-realm" type="xs:string" use="optional" />
         <xs:attribute name="username" type="xs:string" use="optional" />
-        <xs:attribute name="ignore-unused-configuration" type="xs:boolean" default="false">
+        <xs:attribute name="ignore-unused-configuration" type="xs:boolean" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    Set to true to instruct the master Host Controller to automatically not forward configuration and
+                    When set to true, this instructs the master Host Controller to not forward configuration and
                     operations for profiles, socket binding groups and server groups which do not affect our servers.
+                    Setting to false will ensure that all of this configuration information is copied. Note that using
+                    the '--backup' startup option on the command line will set this to false if the value is unspecified
+                    in host.xml. If the value is specified in host.xml, then using '--backup' will not override the
+                    specified value (for example: setting ignore-unused-configuration="true" and using --backup will
+                    not override the value of ignore-unused-configuration, which will remain true). If --backup is not
+                    used, this value will be true at runtime.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>


### PR DESCRIPTION
- change ignore-unused-configuration default runtime value to true, unless --backup is used on the command line, or a value is available for use in host.xml