### PR TITLE
Profile clone transformer and ignores

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/transform/TransformationTarget.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/TransformationTarget.java
@@ -121,6 +121,8 @@ public interface TransformationTarget {
      */
     boolean isIgnoredResourceListAvailableAtRegistration();
 
+    boolean isIgnoreUnaffectedConfig();
+
     enum TransformationTargetType {
 
         DOMAIN,

--- a/controller/src/test/java/org/jboss/as/controller/test/OperationTransformationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/OperationTransformationTestCase.java
@@ -236,7 +236,7 @@ public class OperationTransformationTestCase {
     }
 
     protected TransformationTarget create(final TransformerRegistry registry, ModelVersion version, TransformationTarget.TransformationTargetType type) {
-        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type);
+        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type, false);
     }
 
     protected Resource transform(final TransformationTarget target, final Resource root) throws OperationFailedException {

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/AttributesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/AttributesTestCase.java
@@ -826,7 +826,7 @@ public class AttributesTestCase {
     }
 
     protected TransformationTarget create(final TransformerRegistry registry, ModelVersion version, TransformationTarget.TransformationTargetType type) {
-        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type);
+        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type, false);
     }
 
     private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/BasicResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/BasicResourceTestCase.java
@@ -552,7 +552,7 @@ public class BasicResourceTestCase {
     }
 
     protected TransformationTarget create(final TransformerRegistry registry, ModelVersion version, TransformationTarget.TransformationTargetType type) {
-        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type);
+        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type, false);
     }
 
     private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedOperationBuilderTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedOperationBuilderTestCase.java
@@ -848,7 +848,7 @@ public class ChainedOperationBuilderTestCase {
     }
 
     protected TransformationTarget create(final TransformerRegistry registry, ModelVersion version, TransformationTarget.TransformationTargetType type) {
-        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type);
+        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type, false);
     }
 
     private static ModelNode success() {

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedResourceBuilderTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedResourceBuilderTestCase.java
@@ -1106,7 +1106,7 @@ public class ChainedResourceBuilderTestCase {
     }
 
     protected TransformationTarget create(final TransformerRegistry registry, ModelVersion version, TransformationTarget.TransformationTargetType type) {
-        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type);
+        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type, false);
     }
 
 

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/ChildRedirectTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/ChildRedirectTestCase.java
@@ -168,7 +168,7 @@ public class ChildRedirectTestCase {
     }
 
     protected TransformationTarget create(final TransformerRegistry registry, ModelVersion version, TransformationTarget.TransformationTargetType type) {
-        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type);
+        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type, false);
     }
 
     private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/RecursiveDiscardAndRemoveTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/RecursiveDiscardAndRemoveTestCase.java
@@ -240,7 +240,7 @@ public class RecursiveDiscardAndRemoveTestCase {
     }
 
     protected TransformationTarget create(final TransformerRegistry registry, ModelVersion version, TransformationTarget.TransformationTargetType type) {
-        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type);
+        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), type, false);
     }
 
     private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/MainKernelServicesImpl.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/MainKernelServicesImpl.java
@@ -89,7 +89,7 @@ public class MainKernelServicesImpl extends AbstractKernelServicesImpl {
         OperationTransformerRegistry registry = transformerRegistry.resolveHost(modelVersion, subsystemVersions);
 
         TransformationTarget target = TransformationTargetImpl.create(null, extensionRegistry.getTransformerRegistry(), modelVersion,
-                subsystemVersions, TransformationTarget.TransformationTargetType.DOMAIN);
+                subsystemVersions, TransformationTarget.TransformationTargetType.DOMAIN, false);
         TransformationContext transformationContext = createTransformationContext(target, attachment);
 
         OperationTransformer operationTransformer = registry.resolveOperationTransformer(address, operation.get(OP).asString(), null).getTransformer();
@@ -119,7 +119,7 @@ public class MainKernelServicesImpl extends AbstractKernelServicesImpl {
         checkIsMainController();
 
         final TransformationTarget target = TransformationTargetImpl.create(null, extensionRegistry.getTransformerRegistry(), modelVersion,
-                Collections.<PathAddress, ModelVersion>emptyMap(), TransformationTarget.TransformationTargetType.DOMAIN);
+                Collections.<PathAddress, ModelVersion>emptyMap(), TransformationTarget.TransformationTargetType.DOMAIN, false);
         final Transformers transformers = Transformers.Factory.create(target);
 
         ModelNode fakeOP = new ModelNode();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
@@ -740,4 +740,7 @@ public interface DomainControllerLogger extends BasicLogger {
 
     @Message(id = 77, value = "Duplicate included socket binding group '%s'")
     XMLStreamException duplicateSocketBindingGroupInclude(String s);
+
+    @Message(id = 78, value = "The profile clone operation is not available on the host '%s'")
+    String cloneOperationNotSupportedOnHost(String hostName);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/FetchMissingConfigurationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/FetchMissingConfigurationHandler.java
@@ -67,7 +67,7 @@ public class FetchMissingConfigurationHandler implements OperationStepHandler {
             ReadMasterDomainModelUtil.processServerConfig(context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS), rc, serverConfig, extensionRegistry);
         }
         final Transformers.ResourceIgnoredTransformationRegistry manualExcludes = HostInfo.createIgnoredRegistry(operation);
-        final Transformers.ResourceIgnoredTransformationRegistry ignoredTransformationRegistry = ReadMasterDomainModelUtil.createServerIgnoredRegistry(rc, false, manualExcludes);
+        final Transformers.ResourceIgnoredTransformationRegistry ignoredTransformationRegistry = ReadMasterDomainModelUtil.createServerIgnoredRegistry(rc, manualExcludes);
 
         final ReadDomainModelHandler handler = new ReadDomainModelHandler(ignoredTransformationRegistry, transformers);
         context.addStep(handler, OperationContext.Stage.MODEL);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandler.java
@@ -66,7 +66,7 @@ public class ReadMasterDomainModelHandler implements OperationStepHandler {
             ignoredTransformationRegistry = Transformers.DEFAULT;
         } else {
             final ReadMasterDomainModelUtil.RequiredConfigurationHolder rc = ReadMasterDomainModelUtil.populateHostResolutionContext(hostInfo, resource, extensionRegistry);
-            ignoredTransformationRegistry = ReadMasterDomainModelUtil.createHostIgnoredRegistry(hostInfo, rc, false);
+            ignoredTransformationRegistry = ReadMasterDomainModelUtil.createHostIgnoredRegistry(hostInfo, rc);
         }
 
         final OperationStepHandler handler = new ReadDomainModelHandler(ignoredTransformationRegistry, transformers);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelUtil.java
@@ -365,7 +365,7 @@ public class ReadMasterDomainModelUtil {
      * @param local    whether the operation is executed on the slave host locally
      * @return
      */
-    public static Transformers.ResourceIgnoredTransformationRegistry createHostIgnoredRegistry(final HostInfo hostInfo, final RequiredConfigurationHolder rc, final boolean local) {
+    public static Transformers.ResourceIgnoredTransformationRegistry createHostIgnoredRegistry(final HostInfo hostInfo, final RequiredConfigurationHolder rc) {
         return new Transformers.ResourceIgnoredTransformationRegistry() {
             @Override
             public boolean isResourceTransformationIgnored(PathAddress address) {
@@ -416,7 +416,7 @@ public class ReadMasterDomainModelUtil {
      * @param delegate the delegate ignored resource transformation registry for manually ignored resources
      * @return
      */
-    public static Transformers.ResourceIgnoredTransformationRegistry createServerIgnoredRegistry(final RequiredConfigurationHolder rc, final boolean local, final Transformers.ResourceIgnoredTransformationRegistry delegate) {
+    public static Transformers.ResourceIgnoredTransformationRegistry createServerIgnoredRegistry(final RequiredConfigurationHolder rc, final Transformers.ResourceIgnoredTransformationRegistry delegate) {
         return new Transformers.ResourceIgnoredTransformationRegistry() {
             @Override
             public boolean isResourceTransformationIgnored(PathAddress address) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncDomainModelOperationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncDomainModelOperationHandler.java
@@ -56,7 +56,7 @@ public class SyncDomainModelOperationHandler extends SyncModelHandlerBase {
     Transformers.ResourceIgnoredTransformationRegistry createRegistry(OperationContext context, Resource remoteModel, Set<String> remoteExtensions) {
         final ReadMasterDomainModelUtil.RequiredConfigurationHolder rc =
                 ReadMasterDomainModelUtil.populateHostResolutionContext(hostInfo, remoteModel, extensionRegistry);
-        return ReadMasterDomainModelUtil.createHostIgnoredRegistry(hostInfo, rc, true);
+        return ReadMasterDomainModelUtil.createHostIgnoredRegistry(hostInfo, rc);
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncServerGroupOperationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncServerGroupOperationHandler.java
@@ -84,7 +84,7 @@ public class SyncServerGroupOperationHandler extends SyncModelHandlerBase {
                 return parameters.getIgnoredResourceRegistry().isResourceExcluded(address);
             }
         };
-        return ReadMasterDomainModelUtil.createServerIgnoredRegistry(rc, true, delegate);
+        return ReadMasterDomainModelUtil.createServerIgnoredRegistry(rc, delegate);
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -303,7 +303,7 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
         final ManagementResourceRegistration coreMgmt = resourceRegistration.registerSubModel(CoreManagementResourceDefinition.forDomain(authorizer));
         coreMgmt.registerSubModel(new HostConnectionResourceDefinition(hostRegistrations));
 
-        resourceRegistration.registerSubModel(new ProfileResourceDefinition(extensionRegistry));
+        resourceRegistration.registerSubModel(new ProfileResourceDefinition(hostControllerInfo, ignoredDomainResourceRegistry));
         resourceRegistration.registerSubModel(PathResourceDefinition.createNamed(pathManager));
         ResourceDefinition domainDeploymentDefinition = isMaster
                 ? DomainDeploymentResourceDefinition.createForDomainMaster(contentRepo)

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ProfileResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ProfileResourceDefinition.java
@@ -37,9 +37,9 @@ import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.domain.controller.operations.DomainIncludesValidationWriteAttributeHandler;
 import org.jboss.as.domain.controller.operations.GenericModelDescribeOperationHandler;
 import org.jboss.as.domain.controller.operations.ProfileAddHandler;
@@ -47,6 +47,7 @@ import org.jboss.as.domain.controller.operations.ProfileCloneHandler;
 import org.jboss.as.domain.controller.operations.ProfileDescribeHandler;
 import org.jboss.as.domain.controller.operations.ProfileModelDescribeHandler;
 import org.jboss.as.domain.controller.operations.ProfileRemoveHandler;
+import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -83,18 +84,22 @@ public class ProfileResourceDefinition extends SimpleResourceDefinition {
 
     public static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {INCLUDES};
 
-    private final ExtensionRegistry extensionRegistry;
+    private final LocalHostControllerInfo hostInfo;
 
-    public ProfileResourceDefinition(ExtensionRegistry extensionRegistry) {
+    private final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry;
+
+
+    public ProfileResourceDefinition(LocalHostControllerInfo hostInfo, IgnoredDomainResourceRegistry ignoredDomainResourceRegistry) {
         super(PATH, DomainResolver.getResolver(PROFILE, false), ProfileAddHandler.INSTANCE, ProfileRemoveHandler.INSTANCE);
-        this.extensionRegistry = extensionRegistry;
+        this.hostInfo = hostInfo;
+        this.ignoredDomainResourceRegistry = ignoredDomainResourceRegistry;
     }
 
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
         resourceRegistration.registerOperationHandler(DESCRIBE, ProfileDescribeHandler.INSTANCE);
-        resourceRegistration.registerOperationHandler(ProfileCloneHandler.DEFINITION, ProfileCloneHandler.INSTANCE);
+        resourceRegistration.registerOperationHandler(ProfileCloneHandler.DEFINITION, new ProfileCloneHandler(hostInfo, ignoredDomainResourceRegistry));
         resourceRegistration.registerOperationHandler(GenericModelDescribeOperationHandler.DEFINITION, ProfileModelDescribeHandler.INSTANCE);
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -25,6 +25,13 @@ package org.jboss.as.domain.controller.transformers;
 import java.util.Map;
 
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.transform.OperationRejectionPolicy;
+import org.jboss.as.controller.transform.OperationResultTransformer;
+import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.TransformerRegistry;
 import org.jboss.as.controller.transform.TransformersSubRegistration;
 import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
@@ -33,9 +40,11 @@ import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.TransformationDescription;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.as.domain.controller.operations.DomainServerLifecycleHandlers;
 import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
 import org.jboss.as.version.Version;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Global transformation rules for the domain, host and server-config model.
@@ -57,6 +66,12 @@ public class DomainTransformers {
     static final ModelVersion VERSION_2_0 = ModelVersion.create(2, 0, 0);
     //WF 8.1.0.Final
     static final ModelVersion VERSION_2_1 = ModelVersion.create(2, 1, 0);
+    //WF 9.0.0 and 9.0.1
+    static final ModelVersion VERSION_3_0 = ModelVersion.create(3, 0, 0);
+
+    //All versions before WildFly 10/EAP 7, which do not understand /profile=xxx:clone
+    private static final ModelVersion[] PRE_PROFILE_CLONE_VERSIONS = new ModelVersion[]{VERSION_3_0, VERSION_2_1, VERSION_2_0, VERSION_1_7, VERSION_1_6, VERSION_1_5};
+
     //Current
     static final ModelVersion CURRENT = ModelVersion.create(Version.MANAGEMENT_MAJOR_VERSION, Version.MANAGEMENT_MINOR_VERSION, Version.MANAGEMENT_MICRO_VERSION);
 
@@ -105,14 +120,18 @@ public class DomainTransformers {
     private static void registerProfileTransformers(TransformerRegistry registry, ModelVersion currentVersion) {
         //Do NOT use chained transformers for the profile. The placeholder registry takes precedence over the actual
         //transformer registry, which means we would not get subsystem transformation
-        ModelVersion[] versions = new ModelVersion[]{VERSION_1_7, VERSION_1_6, VERSION_1_5};
-        for (ModelVersion version : versions) {
+
+        //Registering for all previous WF versions (as well as the required EAP ones) isn't strictly necessary,
+        //but it is very handy for testing the 'clone' behaviour
+        for (ModelVersion version : PRE_PROFILE_CLONE_VERSIONS) {
             ResourceTransformationDescriptionBuilder builder =
                     ResourceTransformationDescriptionBuilder.Factory.createInstance(ProfileResourceDefinition.PATH);
             builder.getAttributeBuilder()
                     .addRejectCheck(RejectAttributeChecker.DEFINED, ProfileResourceDefinition.INCLUDES)
                     .setDiscard(DiscardAttributeChecker.UNDEFINED, ProfileResourceDefinition.INCLUDES)
                     .end();
+            builder.addOperationTransformationOverride(ModelDescriptionConstants.CLONE)
+                    .setCustomOperationTransformer(ProfileCloneOperationTransformer.INSTANCE);
             TransformersSubRegistration domain = registry.getDomainRegistration(version);
             TransformationDescription.Tools.register(builder.build(), domain);
         }
@@ -127,6 +146,30 @@ public class DomainTransformers {
         for (Map.Entry<ModelVersion, TransformationDescription> entry : builder.build(versions).entrySet()) {
             TransformersSubRegistration domain = registry.getDomainRegistration(entry.getKey());
             TransformationDescription.Tools.register(entry.getValue(), domain);
+        }
+    }
+
+    private static class ProfileCloneOperationTransformer implements OperationTransformer {
+        static ProfileCloneOperationTransformer INSTANCE = new ProfileCloneOperationTransformer();
+        @Override
+        public TransformedOperation transformOperation(final TransformationContext context, final PathAddress address, final ModelNode operation) throws OperationFailedException {
+            if (context.getTarget().isIgnoreUnaffectedConfig()) {
+                //Since the cloned profile is a new one it will definitely be ignored on the host with this setting,
+                //so we can just discard it
+                return OperationTransformer.DISCARD.transformOperation(context, address, operation);
+            }
+
+            return new TransformedOperation(operation, new OperationRejectionPolicy() {
+                @Override
+                public boolean rejectOperation(ModelNode preparedResult) {
+                    return true;
+                }
+
+                @Override
+                public String getFailureDescription() {
+                    return DomainControllerLogger.ROOT_LOGGER.cloneOperationNotSupportedOnHost(context.getTarget().getHostName());
+                }
+            }, OperationResultTransformer.ORIGINAL_RESULT);
         }
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
@@ -25,13 +25,6 @@ package org.jboss.as.host.controller;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.host.controller.logging.HostControllerLogger.ROOT_LOGGER;
 
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.NameCallback;
-import javax.security.auth.callback.PasswordCallback;
-import javax.security.auth.callback.UnsupportedCallbackException;
-import javax.security.sasl.AuthorizeCallback;
-import javax.security.sasl.RealmCallback;
 import java.io.IOException;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
@@ -49,6 +42,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.AuthorizeCallback;
+import javax.security.sasl.RealmCallback;
 
 import org.jboss.as.controller.CurrentOperationIdHolder;
 import org.jboss.as.controller.ModelVersion;
@@ -618,7 +619,7 @@ public class ServerInventoryImpl implements ServerInventory {
         final ModelVersion modelVersion = ModelVersion.create(Version.MANAGEMENT_MAJOR_VERSION, Version.MANAGEMENT_MINOR_VERSION, Version.MANAGEMENT_MICRO_VERSION);
         //We don't need any transformation between host and server
         final TransformationTarget target = TransformationTargetImpl.create(hostControllerName, extensionRegistry.getTransformerRegistry(),
-                modelVersion, subsystems, TransformationTarget.TransformationTargetType.SERVER);
+                modelVersion, subsystems, TransformationTarget.TransformationTargetType.SERVER, false);
         return new ManagedServer(hostControllerName, serverName, authKey, processControllerClient, managementURI, target);
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
@@ -304,7 +304,7 @@ public class HostControllerRegistrationHandler implements ManagementRequestHandl
             }
             // Initialize the transformers
             final TransformationTarget target = TransformationTargetImpl.create(hostInfo.getHostName(), transformerRegistry, ModelVersion.create(major, minor, micro),
-                    Collections.<PathAddress, ModelVersion>emptyMap(), TransformationTarget.TransformationTargetType.HOST);
+                    Collections.<PathAddress, ModelVersion>emptyMap(), TransformationTarget.TransformationTargetType.HOST, hostInfo.isIgnoreUnaffectedConfig());
             final Transformers transformers = Transformers.Factory.create(target);
             try {
                 SlaveChannelAttachments.attachSlaveInfo(handler.getChannel(), registrationContext.hostName, transformers);

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOrderedChildResourceSyncModelTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOrderedChildResourceSyncModelTestCase.java
@@ -147,7 +147,8 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
 
         registration.registerSubModel(SocketBindingGroupResourceDefinition.INSTANCE);
 
-        ManagementResourceRegistration profileReg = registration.registerSubModel(new ProfileResourceDefinition(extensionRegistry));
+        ignoredDomainResourceRegistry = new IgnoredDomainResourceRegistry(hostControllerInfo);
+        ManagementResourceRegistration profileReg = registration.registerSubModel(new ProfileResourceDefinition(hostControllerInfo, ignoredDomainResourceRegistry));
 
         profileReg.registerSubModel(new SubsystemResourceDefinition());
 
@@ -155,7 +156,6 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
 
         registerCommonChildren(managementModel.getRootResource(), localIndexedAdd);
 
-        ignoredDomainResourceRegistry = new IgnoredDomainResourceRegistry(hostControllerInfo);
     }
 
     void executeTriggerSyncOperation(Resource rootResource) throws Exception {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandlerTestCase.java
@@ -145,7 +145,7 @@ public class ReadMasterDomainModelHandlerTestCase {
     }
 
     protected TransformationTarget create(final TransformerRegistry registry, ModelVersion version) {
-        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), TransformationTargetType.DOMAIN);
+        return TransformationTargetImpl.create(null, registry, version, Collections.<PathAddress, ModelVersion>emptyMap(), TransformationTargetType.DOMAIN, false);
     }
 
     private static final ResourceDefinition ROOT = new SimpleResourceDefinition(PathElement.pathElement("test"), new NonResolvingResourceDescriptionResolver());

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/MainKernelServicesImpl.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/MainKernelServicesImpl.java
@@ -105,7 +105,7 @@ class MainKernelServicesImpl extends AbstractKernelServicesImpl {
 
             final Map<PathAddress, ModelVersion> subsystem = Collections.singletonMap(PathAddress.EMPTY_ADDRESS.append(pathElement), modelVersion);
             final TransformationTarget transformationTarget = TransformationTargetImpl.create(null, extensionRegistry.getTransformerRegistry(), getCoreModelVersionByLegacyModelVersion(modelVersion),
-                    subsystem, TransformationTarget.TransformationTargetType.SERVER);
+                    subsystem, TransformationTarget.TransformationTargetType.SERVER, false);
 
             final Transformers transformers = Transformers.Factory.create(transformationTarget);
             final TransformationContext transformationContext = createTransformationContext(transformationTarget, attachment);

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ReadTransformedResourceOperation.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ReadTransformedResourceOperation.java
@@ -75,7 +75,8 @@ class ReadTransformedResourceOperation implements OperationStepHandler {
         Map<PathAddress, ModelVersion> subsystemVersions = new HashMap<>();
         subsystemVersions.put(PathAddress.EMPTY_ADDRESS.append(ModelDescriptionConstants.SUBSYSTEM, subsystem), subsystemModelVersion);
 
-        final TransformationTarget target = TransformationTargetImpl.create(null, transformerRegistry, coreModelVersion, subsystemVersions, TransformationTarget.TransformationTargetType.SERVER);
+        final TransformationTarget target = TransformationTargetImpl.create(null, transformerRegistry, coreModelVersion,
+                subsystemVersions, TransformationTarget.TransformationTargetType.SERVER, false);
         final Transformers transformers = Transformers.Factory.create(target);
 
         final ImmutableManagementResourceRegistration rr = context.getRootResourceRegistration();


### PR DESCRIPTION
This currently has no test, I am planning on adding one tomorrow.

When executing /profile-clone=ignored(to-profile=new) in a mixed domain, if 
a) the slave has set ignore-unused-configuration=true (and the ignored profile is not used) the operation goes through the transformer.
b) the slave has not set ignore-unused-configuration=true (or does not support it) the operation should be rejected with a message (this still needs to be improved) saying they need to 
-reload the DC into admin-only mode 
-perform the clone 
-ignore the profile on slaves which cannot support, or are not interested, in the new profile 
-reload the DC into normal mode 
-reload any slaves needing reload