### PR TITLE
[WFCORE-980]:  The capability registry fails to rollback properly

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
@@ -472,18 +472,8 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
             }
             publishedFullRegistry.writeLock.lock();
             try {
-                CapabilityRegistry published = publishedFullRegistry;
-                published.capabilities.clear();
-                published.capabilities.putAll(capabilities);
-
-                published.possibleCapabilities.clear();
-                published.possibleCapabilities.putAll(possibleCapabilities);
-
-                published.requirements.clear();
-                published.requirements.putAll(requirements);
-
-                published.runtimeOnlyRequirements.clear();
-                published.runtimeOnlyRequirements.putAll(runtimeOnlyRequirements);
+                publishedFullRegistry.clear();
+                copy(this, publishedFullRegistry);
                 modified = false;
             } finally {
                 publishedFullRegistry.writeLock.unlock();


### PR DESCRIPTION
The issue is not in the rollback itself but in the publish where we don't deep copy the registry content into the publishedRegistry thus sharing references afterwards.

Jira: https://issues.jboss.org/browse/WFCORE-980