### PR TITLE
https://issues.jboss.org/browse/WFCORE-970 Deploying a CLI archive th…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/gui/CommandExecutor.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/CommandExecutor.java
@@ -120,6 +120,12 @@ public class CommandExecutor {
     }
 
     private OperationResponse execute(ModelNode request, boolean useWaitCursor) throws IOException {
+
+        if(request.get(Util.OPERATION).asString().equals(Util.COMPOSITE) &&
+                (!request.get(Util.STEPS).isDefined() || request.get(Util.STEPS).asList().isEmpty())) {
+            return OperationResponse.Factory.createSimple(new ModelNode("WARN: no request was sent as there were no server-side operations to execute"));
+        }
+
         try {
             if (useWaitCursor) {
                 cliGuiCtx.getMainWindow().setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));


### PR DESCRIPTION
…at contains 'module add' commands results in 'WFLYCTL0155: steps may not be null' when using the CLI GUI

This commit instead of sending an empty composite request and displaying the error, logs a warning explaining that the request was not sent because there were no server-side operations to execute.

@ssilvert could you please review this too?

Thanks,
Alexey