### PR TITLE
[WFCORE-393] Use a runtime registry on the slave to track if an ignored

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncDomainModelOperationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncDomainModelOperationHandler.java
@@ -25,11 +25,14 @@ package org.jboss.as.domain.controller.operations;
 import java.util.Set;
 
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.transform.Transformers;
 import org.jboss.as.domain.controller.operations.deployment.SyncModelParameters;
 import org.jboss.as.host.controller.mgmt.HostInfo;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Operation handler synchronizing the domain model. This handler will calculate the operations needed to create
@@ -59,4 +62,23 @@ public class SyncDomainModelOperationHandler extends SyncModelHandlerBase {
         return ReadMasterDomainModelUtil.createHostIgnoredRegistry(hostInfo, rc);
     }
 
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        //Indicate to the IgnoredClonedProfileRegistry that we should clear the registry
+        getParameters().getIgnoredResourceRegistry().getIgnoredClonedProfileRegistry().initializeModelSync();
+
+        context.addStep(new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                SyncDomainModelOperationHandler.super.execute(context, operation);
+            }
+        }, OperationContext.Stage.MODEL, true);
+
+        context.completeStep(new OperationContext.ResultHandler() {
+            @Override
+            public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                getParameters().getIgnoredResourceRegistry().getIgnoredClonedProfileRegistry().complete(resultAction == OperationContext.ResultAction.ROLLBACK);
+            }
+        });
+    }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncModelHandlerBase.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncModelHandlerBase.java
@@ -111,4 +111,8 @@ abstract class SyncModelHandlerBase implements OperationStepHandler {
             }
         }, OperationContext.Stage.MODEL, true);
     }
+
+    protected SyncModelParameters getParameters() {
+        return parameters;
+    }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncServerGroupOperationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncServerGroupOperationHandler.java
@@ -60,9 +60,9 @@ public class SyncServerGroupOperationHandler extends SyncModelHandlerBase {
      * For the local model we include both the original as well as the remote model. The diff will automatically remove
      * not used configuration.
      *
-     * @param context             the operation context
-     * @param remote              the remote model
-     * @param remoteExtensions    the extension registry
+     * @param context          the operation context
+     * @param remote           the remote model
+     * @param remoteExtensions the extension registry
      * @return
      */
     @Override
@@ -86,5 +86,4 @@ public class SyncServerGroupOperationHandler extends SyncModelHandlerBase {
         };
         return ReadMasterDomainModelUtil.createServerIgnoredRegistry(rc, delegate);
     }
-
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationSlaveStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationSlaveStepHandler.java
@@ -80,10 +80,15 @@ class OperationSlaveStepHandler {
 
         final MultiPhaseLocalContext localContext = new MultiPhaseLocalContext(false);
         final HostControllerExecutionSupport hostControllerExecutionSupport = addSteps(context, operation, localContext);
+        final boolean reloadRequired = hostControllerExecutionSupport.isReloadRequired();
+        if (reloadRequired) {
+            context.reloadRequired();
+        }
 
         context.completeStep(new OperationContext.ResultHandler() {
             @Override
             public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                hostControllerExecutionSupport.complete(resultAction == OperationContext.ResultAction.ROLLBACK);
 
                 if (resultAction == OperationContext.ResultAction.KEEP) {
 
@@ -96,6 +101,9 @@ class OperationSlaveStepHandler {
                     ModelNode domainFormatted = hostControllerExecutionSupport.getFormattedDomainResult(localContext.getLocalResponse().get(RESULT));
                     result.get(DOMAIN_RESULTS).set(domainFormatted);
                 } else {
+                    if (reloadRequired) {
+                        context.revertReloadRequired();
+                    }
                     // The actual operation failed but make sure the result still gets formatted
                     if (hostControllerExecutionSupport.getDomainOperation() != null) {
                         ModelNode localResponse = localContext.getLocalResponse();
@@ -118,7 +126,7 @@ class OperationSlaveStepHandler {
         final ModelNode localResponse = multiPhaseLocalContext.getLocalResponse();
 
         final HostControllerExecutionSupport hostControllerExecutionSupport =
-                HostControllerExecutionSupport.Factory.create(operation, localHostControllerInfo.getLocalHostName(),
+                HostControllerExecutionSupport.Factory.create(context, operation, localHostControllerInfo.getLocalHostName(),
                         new LazyDomainModelProvider(context), ignoredDomainResourceRegistry, !localHostControllerInfo.isMasterDomainController() && localHostControllerInfo.isRemoteDomainControllerIgnoreUnaffectedConfiguration(),
                         extensionRegistry);
         ModelNode domainOp = hostControllerExecutionSupport.getDomainOperation();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ignored/IgnoredDomainResourceRegistry.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ignored/IgnoredDomainResourceRegistry.java
@@ -22,6 +22,17 @@
 
 package org.jboss.as.host.controller.ignored;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CLONE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TO_PROFILE;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -44,6 +55,7 @@ public class IgnoredDomainResourceRegistry {
 
     private final LocalHostControllerInfo localHostControllerInfo;
     private volatile IgnoredDomainResourceRoot rootResource;
+    private IgnoredClonedProfileRegistry ignoredClonedProfileRegistry = new IgnoredClonedProfileRegistry();
 
     public IgnoredDomainResourceRegistry(LocalHostControllerInfo localHostControllerInfo) {
         this.localHostControllerInfo = localHostControllerInfo;
@@ -95,6 +107,10 @@ public class IgnoredDomainResourceRegistry {
         return localHostControllerInfo.isMasterDomainController();
     }
 
+    public IgnoredClonedProfileRegistry getIgnoredClonedProfileRegistry() {
+        return ignoredClonedProfileRegistry;
+    }
+
     private class ResourceDefinition extends SimpleResourceDefinition {
 
         public ResourceDefinition() {
@@ -105,5 +121,126 @@ public class IgnoredDomainResourceRegistry {
         public void registerChildren(ManagementResourceRegistration resourceRegistration) {
             resourceRegistration.registerSubModel(new IgnoredDomainTypeResourceDefinition());
         }
+    }
+
+    /**
+     * <p>This class is for internal use only.</p>
+     *
+     * <p>The main purpose of this registry is to deal with the situation where a profile is explicitly ignored on the slave,
+     * and that profile is cloned. So say that the {@code ignored} profile is ignored on the slave, and a call comes to
+     * {@code /profile=ignore:clone(to-profile=new)}. Since the {@code ignored} profile is ignored on the slave, the
+     * {@code clone} operation never gets called, so no {@code new} profile gets created on the slave. Hence, we need
+     * to ignore all subsequent operation invocations on the slave for the {@code new} profile. This class maintains the
+     * runtime registry of profiles resulting from clone operations on profiles that were ignored on this slave.</p>
+     *
+     * <p>The situation above where the {@code new} profile does not get created on the slave due to the {@ignored} profile
+     * being explicitly ignored on the slave, will result in the server being put into the {@code reload-required} state
+     * since according to the explicit ignores it should really be part of the slave's domain model, and a reload of the
+     * slave will download that.
+     *
+     * <p>If the {@new} profile was also explicitly ignored, we do not add it to the runtime registry and do not put the
+     * server into the {@code reload-required} state. The settings in the slave model deal with the ignores for us in
+     * that case.</p>
+     *
+     * <p>Finally in the example above, a call to {@code /profile=new:remove} will remove the {@code new} profile from the
+     * runtime registry of profiles resulting from clone operations on profiles that were ignored on this slave.</p>
+     *
+     * <p>The registry is transactional, using a transaction local copy of the changes made, and should be published/rolled back
+     * on transaction completion.</p>
+     */
+    public class IgnoredClonedProfileRegistry {
+        private volatile Set<String> ignoredClonedProfiles = Collections.synchronizedSet(new HashSet<>());
+        private volatile Set<String> currentTxIgnoredClonedProfiles;
+        private volatile boolean reloadRequired;
+
+        private IgnoredClonedProfileRegistry() {
+        }
+
+        /**
+         * Checks if an operation should be ignored, and updates the runtime registry and host state as required. Use
+         * {@link #isReloadRequired()} to check if the host state should be set to {@code reload-required}.
+         *
+         * @param operation the operation to check
+         * @return whether the operation should be ignored
+         */
+        public boolean checkIgnoredProfileClone(ModelNode operation) {
+            if (!localHostControllerInfo.isMasterDomainController()) {
+                PathAddress addr = PathAddress.pathAddress(operation.get(OP_ADDR));
+                if (addr.size() > 0) {
+                    PathElement first = addr.getElement(0);
+                    if (first.getKey().equals(PROFILE)) {
+                        String name = operation.get(OP).asString();
+                        if (name.equals(CLONE) && isResourceExcluded(addr)) {
+                            //We are cloning an ignored profile
+                            final String profileName = operation.get(TO_PROFILE).asString();
+
+                            if (!isResourceExcluded(PathAddress.pathAddress(PROFILE, profileName))) {
+                                //The new profile is not explicitly ignored, so  add the new profile to the runtime registry
+                                //and indicate that the host should be put into the reload-required state.
+                                getIgnoredClonedProfiles(true).add(profileName);
+                                reloadRequired = true;
+                                return true;
+                            }
+                        } else if (name.equals(REMOVE) && addr.size() == 1) {
+                            //We are removing a profile, remove it from the runtime registry if it is there
+                            return getIgnoredClonedProfiles(true).remove(first.getValue());
+                        } else {
+                            //Ignore depending on if it is in the runtime registry
+                            return getIgnoredClonedProfiles(false).contains(first.getValue());
+                        }
+                    }
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Callback for starting applying a fresh domain model from the DC. This will clear the runtime registry
+         */
+        public void initializeModelSync() {
+            if (!localHostControllerInfo.isMasterDomainController()) {
+                //We are resyncing the model, so clear the runtime registry
+                getIgnoredClonedProfiles(true).clear();
+            }
+        }
+
+        /**
+         * Callback for when the controller transaction completes. This will publish the changes to the runtime registry
+         * if the transaction was committed, and roll them back if it was rolled back.
+         *
+         * @param rollback {@code true} if the changes should be rolled back, {@code false} if they should be committed.
+         */
+        public void complete(boolean rollback) {
+            if (!localHostControllerInfo.isMasterDomainController()) {
+                if (!rollback) {
+                    if (currentTxIgnoredClonedProfiles != null) {
+                        ignoredClonedProfiles = currentTxIgnoredClonedProfiles;
+                    }
+                }
+                currentTxIgnoredClonedProfiles = null;
+                reloadRequired = false;
+            }
+        }
+
+        /**
+         * Check if the changes to the registry should cause the slave to be put into the {@code reload-required} state.
+         *
+         * @return {@code true} if the host should be put into the {@code reload-required} state, {@code false} otherwise.
+         */
+        public boolean isReloadRequired() {
+            return reloadRequired;
+        }
+
+        private Set<String> getIgnoredClonedProfiles(boolean write) {
+            if (currentTxIgnoredClonedProfiles != null) {
+                return currentTxIgnoredClonedProfiles;
+            }
+            if (write) {
+                currentTxIgnoredClonedProfiles = Collections.synchronizedSet(new HashSet<>(ignoredClonedProfiles));
+                return currentTxIgnoredClonedProfiles;
+            }
+            return ignoredClonedProfiles;
+        }
+
     }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -37,6 +37,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses ({
         AuditLogTestCase.class,
+        IgnoredResourcesProfileCloneTestCase.class,
         CompositeOperationTestCase.class,
         CoreResourceManagementTestCase.class,
         DeploymentRolloutFailureTestCase.class,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/IgnoredResourcesProfileCloneTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/IgnoredResourcesProfileCloneTestCase.java
@@ -1,0 +1,346 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADMIN_ONLY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CLONE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_CONTROLLER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IGNORED_RESOURCES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IGNORED_RESOURCE_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IGNORE_UNUSED_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAMES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TO_PROFILE;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+import org.xnio.IoUtils;
+
+
+/**
+ * Tests effect of ignoring profiles when profiles are cloned
+ *
+ * @author Kabir Khan
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class IgnoredResourcesProfileCloneTestCase {
+
+    private static final String ORIGINAL_PROFILE = "default";
+
+    ///The testsuite host-slave.xml is set up to ignore this profile
+    private static final String IGNORED_PROFILE = "ignored";
+
+    //This test sets up another profile which should be ignored
+    private static final String IGNORE_TO_PROFILE = "ignore-to";
+
+    private static final String CLONED_PROFILE = "cloned-profile";
+
+    private static final PathAddress SLAVE_ADDR = PathAddress.pathAddress(HOST, "slave");
+    /**
+     * Domain configuration
+     */
+    private static File domainCfg;
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil masterLifecycleUtil;
+    private static DomainLifecycleUtil slaveLifecycleUtil;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        testSupport = DomainTestSuite.createSupport(IgnoredResourcesProfileCloneTestCase.class.getSimpleName());
+        masterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        slaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
+
+        File masterDir = new File(testSupport.getDomainMasterConfiguration().getDomainDirectory());
+        domainCfg = new File(masterDir, "configuration"
+                + File.separator + "testing-domain-standard.xml");
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        testSupport = null;
+        masterLifecycleUtil = null;
+        slaveLifecycleUtil = null;
+        DomainTestSuite.stopSupport();
+    }
+
+    @Test
+    public void test01_ProfileCloneIgnoredWithIgnoreUnusedConfiguration() throws Exception {
+        final DomainClient masterClient = masterLifecycleUtil.getDomainClient();
+        final DomainClient slaveClient = slaveLifecycleUtil.getDomainClient();
+
+        try {
+            final ModelNode originalSlaveDc = DomainTestUtils.executeForResult(
+                    Util.getReadAttributeOperation(SLAVE_ADDR, DOMAIN_CONTROLLER),
+                    masterClient).get(REMOTE);
+            originalSlaveDc.protect();
+            Assert.assertFalse(originalSlaveDc.hasDefined(IGNORE_UNUSED_CONFIG));
+            try {
+                //TODO Remove this - Once the default for ignore-unused-configuration is true, we don't need to set it to true
+                ModelNode newSlaveDc = originalSlaveDc.clone();
+                newSlaveDc.get(IGNORE_UNUSED_CONFIG).set(true);
+                writeSlaveDomainController(slaveClient, newSlaveDc);
+                reloadSlave(slaveLifecycleUtil);
+
+                // clone profile
+                ModelNode clone = Util.createEmptyOperation(CLONE, PathAddress.pathAddress(PROFILE, ORIGINAL_PROFILE));
+                clone.get(TO_PROFILE).set(CLONED_PROFILE);
+                DomainTestUtils.executeForResult(clone, masterClient);
+                try {
+                    // get and check submodules
+                    List<String> originalSubsystems = getSubsystems(ORIGINAL_PROFILE, masterClient);
+                    List<String> newSubsystems = getSubsystems(CLONED_PROFILE, masterClient);
+                    assertEquals(originalSubsystems, newSubsystems);
+
+                    //Since the slave ignores unused config, the new profile should not exist on the slave
+                    List<String> slaveSubsystems = getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, slaveClient);
+                    Assert.assertTrue(slaveSubsystems.contains(ORIGINAL_PROFILE));
+                    Assert.assertFalse(slaveSubsystems.contains(CLONED_PROFILE));
+                } finally {
+                    DomainTestUtils.executeForResult(Util.createRemoveOperation(PathAddress.pathAddress(PROFILE, CLONED_PROFILE)), masterClient);
+                }
+            } finally {
+                //TODO Remove this - Once the default for ignore-unused-configuration is true, we don't need to set it to true
+                //above and so don't need to reset it here
+                writeSlaveDomainController(slaveClient, originalSlaveDc);
+                reloadSlave(slaveLifecycleUtil);
+            }
+        } finally {
+            IoUtils.safeClose(slaveClient);
+            IoUtils.safeClose(masterClient);
+        }
+    }
+
+    @Test
+    public void test02_ProfileCloneIgnoredWithoutIgnoreUnusedConfiguration() throws Exception {
+        final DomainClient masterClient = masterLifecycleUtil.getDomainClient();
+        DomainClient slaveClient = slaveLifecycleUtil.getDomainClient();
+        try {
+            final ModelNode originalSlaveDc = DomainTestUtils.executeForResult(
+                    Util.getReadAttributeOperation(SLAVE_ADDR, DOMAIN_CONTROLLER),
+                    masterClient).get(REMOTE);
+            originalSlaveDc.protect();
+            final PathAddress profileIgnoreAddress = PathAddress.pathAddress(SLAVE_ADDR.append(CORE_SERVICE, IGNORED_RESOURCES).append(IGNORED_RESOURCE_TYPE, PROFILE));
+            final ModelNode originalIgnores = DomainTestUtils.executeForResult(Util.getReadAttributeOperation(profileIgnoreAddress, NAMES), slaveClient);
+            originalIgnores.protect();
+
+            try {
+                //Turn off the slave's ignore-unused-config setting, add an ignore for 'ignore-to' and reload it
+                ModelNode newSlaveDc = originalSlaveDc.clone();
+                newSlaveDc.get(IGNORE_UNUSED_CONFIG).set(false);
+                writeSlaveDomainController(slaveClient, newSlaveDc);
+                DomainTestUtils.executeForResult(
+                        Util.getWriteAttributeOperation(profileIgnoreAddress, NAMES, originalIgnores.clone().add(IGNORE_TO_PROFILE)), slaveClient);
+                reloadSlave(slaveLifecycleUtil);
+                slaveClient = slaveLifecycleUtil.getDomainClient();
+
+                ////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //Clone profile which is not ignored
+                //It should appear on the slave, and the host state should be running
+                ModelNode clone = Util.createEmptyOperation(CLONE, PathAddress.pathAddress(PROFILE, ORIGINAL_PROFILE));
+                clone.get(TO_PROFILE).set(CLONED_PROFILE);
+                DomainTestUtils.executeForResult(clone, masterClient);
+                try {
+                    List<String> masterProfiles = getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, masterClient);
+                    Assert.assertTrue(masterProfiles.remove(IGNORED_PROFILE));
+                    Assert.assertEquals(masterProfiles, getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, slaveClient));
+                    Assert.assertEquals(getSubsystems(ORIGINAL_PROFILE, masterClient), getSubsystems(ORIGINAL_PROFILE, slaveClient));
+                    Assert.assertEquals(getSubsystems(CLONED_PROFILE, masterClient), getSubsystems(CLONED_PROFILE, slaveClient));
+
+                    DomainTestUtils.executeForResult(
+                            Util.getWriteAttributeOperation(
+                                    PathAddress.pathAddress(PROFILE, CLONED_PROFILE).append(SUBSYSTEM, "jmx"),
+                                    "non-core-mbean-sensitivity",
+                                    new ModelNode(true)),
+                            masterClient);
+
+                } finally {
+                    DomainTestUtils.executeForResult(Util.createRemoveOperation(PathAddress.pathAddress(PROFILE, CLONED_PROFILE)), masterClient);
+                }
+                Assert.assertEquals("running", getSlaveState(slaveClient));
+
+
+                ////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //Clone profile which is ignored
+                //It should not appear on the slave and the slave should be reload-required
+                clone = Util.createEmptyOperation(CLONE, PathAddress.pathAddress(PROFILE, IGNORED_PROFILE));
+                clone.get(TO_PROFILE).set(CLONED_PROFILE);
+                DomainTestUtils.executeForResult(clone, masterClient);
+                try {
+                    Assert.assertEquals("reload-required", getSlaveState(slaveClient));
+                    List<String> masterProfiles = getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, masterClient);
+                    Assert.assertTrue(masterProfiles.remove(IGNORED_PROFILE));
+                    Assert.assertTrue(masterProfiles.remove(CLONED_PROFILE));
+                    Assert.assertEquals(masterProfiles, getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, slaveClient));
+
+                    DomainTestUtils.executeForResult(
+                            Util.getWriteAttributeOperation(
+                                    PathAddress.pathAddress(PROFILE, CLONED_PROFILE).append(SUBSYSTEM, "jmx"),
+                                    "non-core-mbean-sensitivity",
+                                    new ModelNode(true)),
+                            masterClient);
+                } finally {
+                    DomainTestUtils.executeForResult(Util.createRemoveOperation(PathAddress.pathAddress(PROFILE, CLONED_PROFILE)), masterClient);
+                }
+
+                reloadSlave(slaveLifecycleUtil);
+                //Clone profile which is ignored again, it should not appear on the slave and the slave should be reload-required
+                DomainTestUtils.executeForResult(clone, masterClient);
+                try {
+                    Assert.assertEquals("reload-required", getSlaveState(slaveClient));
+                    List<String> masterProfiles = getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, masterClient);
+                    Assert.assertTrue(masterProfiles.remove(IGNORED_PROFILE));
+                    Assert.assertTrue(masterProfiles.remove(CLONED_PROFILE));
+                    Assert.assertEquals(masterProfiles, getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, slaveClient));
+
+                    //The reload should bring down the new profile
+                    reloadSlave(slaveLifecycleUtil);
+                    masterProfiles = getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, masterClient);
+                    Assert.assertTrue(masterProfiles.remove(IGNORED_PROFILE));
+                    Assert.assertEquals(masterProfiles, getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, slaveClient));
+                    DomainTestUtils.executeForResult(
+                            Util.getWriteAttributeOperation(
+                                    PathAddress.pathAddress(PROFILE, CLONED_PROFILE).append(SUBSYSTEM, "jmx"),
+                                    "non-core-mbean-sensitivity",
+                                    new ModelNode(true)),
+                            masterClient);
+
+                } finally {
+                    DomainTestUtils.executeForResult(Util.createRemoveOperation(PathAddress.pathAddress(PROFILE, CLONED_PROFILE)), masterClient);
+                }
+                Assert.assertEquals("running", getSlaveState(slaveClient));
+
+
+                ////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //Clone profile where the to-profile is ignored
+                //It should not appear on the slave, and the slave should be in the running state
+                clone = Util.createEmptyOperation(CLONE, PathAddress.pathAddress(PROFILE, ORIGINAL_PROFILE));
+                clone.get(TO_PROFILE).set(IGNORE_TO_PROFILE);
+                DomainTestUtils.executeForResult(clone, masterClient);
+                try {
+                    List<String> masterProfiles = getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, masterClient);
+                    Assert.assertTrue(masterProfiles.remove(IGNORED_PROFILE));
+                    Assert.assertTrue(masterProfiles.remove(IGNORE_TO_PROFILE));
+                    Assert.assertEquals(masterProfiles, getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, slaveClient));
+                    DomainTestUtils.executeForResult(
+                            Util.getWriteAttributeOperation(
+                                    PathAddress.pathAddress(PROFILE, IGNORE_TO_PROFILE).append(SUBSYSTEM, "jmx"),
+                                    "non-core-mbean-sensitivity",
+                                    new ModelNode(true)),
+                            masterClient);
+                } finally {
+                    DomainTestUtils.executeForResult(Util.createRemoveOperation(PathAddress.pathAddress(PROFILE, IGNORE_TO_PROFILE)), masterClient);
+                }
+                Assert.assertEquals("running", getSlaveState(slaveClient));
+
+                ////////////////////////////////////////////////////////////////////////////////////////////////////////
+                //Clone profile where both the original and the to profiles are cloned.
+                //It should not appear on the slave, and the slave should be in the running state
+                clone = Util.createEmptyOperation(CLONE, PathAddress.pathAddress(PROFILE, IGNORED_PROFILE));
+                clone.get(TO_PROFILE).set(IGNORE_TO_PROFILE);
+                DomainTestUtils.executeForResult(clone, masterClient);
+                try {
+                    List<String> masterProfiles = getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, masterClient);
+                    Assert.assertTrue(masterProfiles.remove(IGNORED_PROFILE));
+                    Assert.assertTrue(masterProfiles.remove(IGNORE_TO_PROFILE));
+                    Assert.assertEquals(masterProfiles, getChildNames(PathAddress.EMPTY_ADDRESS, PROFILE, slaveClient));
+                    DomainTestUtils.executeForResult(
+                            Util.getWriteAttributeOperation(
+                                    PathAddress.pathAddress(PROFILE, IGNORE_TO_PROFILE).append(SUBSYSTEM, "jmx"),
+                                    "non-core-mbean-sensitivity",
+                                    new ModelNode(true)),
+                            masterClient);
+                } finally {
+                    DomainTestUtils.executeForResult(Util.createRemoveOperation(PathAddress.pathAddress(PROFILE, IGNORE_TO_PROFILE)), masterClient);
+                }
+                Assert.assertEquals("running", getSlaveState(slaveClient));
+            } finally {
+                writeSlaveDomainController(slaveClient, originalSlaveDc);
+                DomainTestUtils.executeForResult(Util.getWriteAttributeOperation(profileIgnoreAddress, NAMES, originalIgnores), slaveClient);
+                reloadSlave(slaveLifecycleUtil);
+            }
+        } finally {
+            IoUtils.safeClose(slaveClient);
+            IoUtils.safeClose(masterClient);
+        }
+    }
+
+    private static void reloadSlave(DomainLifecycleUtil slaveLifecycleUtil) throws Exception {
+        ModelNode reload = Util.createEmptyOperation("reload", PathAddress.pathAddress(HOST, "slave"));
+        reload.get(RESTART_SERVERS).set(false);
+        reload.get(ADMIN_ONLY).set(false);
+        slaveLifecycleUtil.executeAwaitConnectionClosed(reload);
+        slaveLifecycleUtil.connect();
+        slaveLifecycleUtil.awaitHostController(System.currentTimeMillis());
+    }
+
+    private List<String> getSubsystems(String profile, DomainClient client) throws Exception {
+        return getChildNames(PathAddress.pathAddress(PROFILE, profile), SUBSYSTEM, client);
+    }
+
+    private List<String> getChildNames(PathAddress parent, String childType, DomainClient client) throws Exception {
+        ModelNode readChildrenNames = Util.createEmptyOperation(READ_CHILDREN_NAMES_OPERATION, parent);
+        readChildrenNames.get(CHILD_TYPE).set(childType);
+        ModelNode result = DomainTestUtils.executeForResult(readChildrenNames, client);
+        List<String> list = new ArrayList<>();
+        for (ModelNode element : result.asList()) {
+            list.add(element.asString());
+        }
+        return list;
+    }
+
+    private void writeSlaveDomainController(DomainClient slaveClient, ModelNode remoteDc) throws Exception{
+        DomainTestUtils.executeForResult(Util.createEmptyOperation("remove-remote-domain-controller", SLAVE_ADDR), slaveClient);
+        ModelNode writeRemoteDc = Util.createEmptyOperation("write-remote-domain-controller", SLAVE_ADDR);
+        for (String key : remoteDc.keys()) {
+            writeRemoteDc.get(key).set(remoteDc.get(key));
+        }
+        DomainTestUtils.executeForResult(writeRemoteDc, slaveClient);
+    }
+
+    private String getSlaveState(DomainClient slaveClient) throws Exception {
+        return DomainTestUtils.executeForResult(Util.getReadAttributeOperation(SLAVE_ADDR, "host-state"), slaveClient).asString();
+    }
+}


### PR DESCRIPTION
profile is being cloned. In this case, the clone operation does not get
executed on the slave. Track this, and ignore any subsequent operations
on that profile on the slave, and put the slave in the requires-reload
state.