### PR TITLE
Fix problems revealed when domain testsuite runs with assertions enabled.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -388,6 +388,7 @@ class ModelControllerImpl implements ModelController {
                     }
 
                     context.addStep(responseNode, operation, prepareStep, OperationContext.Stage.MODEL);
+                    ControllerLogger.MGMT_OP_LOGGER.tracef("Executing %s", operation);
                     context.executeOperation();
                     responseStreams = context.getResponseStreams();
                 } finally {

--- a/controller/src/main/java/org/jboss/as/controller/TransformingProxyController.java
+++ b/controller/src/main/java/org/jboss/as/controller/TransformingProxyController.java
@@ -69,13 +69,45 @@ public interface TransformingProxyController extends ProxyController {
      */
     OperationTransformer.TransformedOperation transformOperation(OperationContext context, ModelNode operation) throws OperationFailedException;
 
-    public static class Factory {
+    /**
+     * Transform the operation.
+     *
+     * @param parameters parameters that drive the transformation
+     * @param operation the operation to transform.
+     * @return the transformed operation
+     * @throws OperationFailedException
+     */
+    OperationTransformer.TransformedOperation transformOperation(Transformers.TransformationInputs parameters, ModelNode operation) throws OperationFailedException;
 
+
+    /**
+     * Factory methods for creating a {@link TransformingProxyController}
+     */
+    class Factory {
+
+        /**
+         * Creates a {@link TransactionalProtocolClient} based on the given {@code channelAssociation} and then
+         * uses that to create a {@link TransformingProxyController}.
+         *
+         * @param channelAssociation the channel handler. Cannot be {@code null}
+         * @param transformers transformers to use for transforming resources and operations. Cannot be {@code null}
+         * @param pathAddress address under which the proxy controller is registered in the resource tree
+         * @param addressTranslator translator to use for converting local addresses to addresses appropriate for the target process
+         * @return the proxy controller. Will not be {@code null}
+         */
         public static TransformingProxyController create(final ManagementChannelHandler channelAssociation, final Transformers transformers, final PathAddress pathAddress, final ProxyOperationAddressTranslator addressTranslator) {
             final TransactionalProtocolClient client = TransactionalProtocolHandlers.createClient(channelAssociation);
             return create(client, transformers, pathAddress, addressTranslator);
         }
 
+        /**
+         * Creates a {@link TransformingProxyController} based on the given {@link TransactionalProtocolClient}.
+         * @param client the client for communicating with the target process. Cannot be {@code null}
+         * @param transformers transformers to use for transforming resources and operations. Cannot be {@code null}
+         * @param pathAddress address under which the proxy controller is registered in the resource tree
+         * @param addressTranslator translator to use for converting local addresses to addresses appropriate for the target process
+         * @return the proxy controller. Will not be {@code null}
+         */
         public static TransformingProxyController create(final TransactionalProtocolClient client, final Transformers transformers, final PathAddress pathAddress, final ProxyOperationAddressTranslator addressTranslator) {
             final ModelVersion targetKernelVersion = transformers.getTarget().getVersion();
             final RemoteProxyController proxy = RemoteProxyController.create(client, pathAddress, addressTranslator, targetKernelVersion);
@@ -97,19 +129,19 @@ public interface TransformingProxyController extends ProxyController {
                 }
 
                 @Override
-                public OperationTransformer.TransformedOperation transformOperation(OperationContext operationContext, ModelNode original) throws OperationFailedException {
+                public OperationTransformer.TransformedOperation transformOperation(TransformationInputs transformationParameters, ModelNode original) throws OperationFailedException {
                     final ModelNode operation = proxy.translateOperationForProxy(original);
-                    return transformers.transformOperation(operationContext, operation);
+                    return transformers.transformOperation(transformationParameters, operation);
                 }
 
                 @Override
-                public Resource transformRootResource(OperationContext operationContext, Resource resource) throws OperationFailedException {
-                    return transformers.transformRootResource(operationContext, resource);
+                public Resource transformRootResource(TransformationInputs transformationParameters, Resource resource) throws OperationFailedException {
+                    return transformers.transformRootResource(transformationParameters, resource);
                 }
 
                 @Override
-                public Resource transformRootResource(OperationContext operationContext, Resource resource, ResourceIgnoredTransformationRegistry ignoredTransformationRegistry) throws OperationFailedException {
-                    return transformers.transformRootResource(operationContext, resource, ignoredTransformationRegistry);
+                public Resource transformRootResource(TransformationInputs transformationParameters, Resource resource, ResourceIgnoredTransformationRegistry ignoredTransformationRegistry) throws OperationFailedException {
+                    return transformers.transformRootResource(transformationParameters, resource, ignoredTransformationRegistry);
                 }
             };
             return create(proxy, delegating);
@@ -119,58 +151,63 @@ public interface TransformingProxyController extends ProxyController {
             return new TransformingProxyControllerImpl(transformers, delegate);
         }
 
-    }
+        private static class TransformingProxyControllerImpl implements TransformingProxyController {
 
-    static class TransformingProxyControllerImpl implements TransformingProxyController {
+            private final RemoteProxyController proxy;
+            private final Transformers transformers;
 
-        private final RemoteProxyController proxy;
-        private final Transformers transformers;
-
-        public TransformingProxyControllerImpl(Transformers transformers, RemoteProxyController proxy) {
-            this.transformers = transformers;
-            this.proxy = proxy;
-        }
-
-        @Override
-        public TransactionalProtocolClient getProtocolClient() {
-            return proxy.getTransactionalProtocolClient();
-        }
-
-        @Override
-        public Transformers getTransformers() {
-            return transformers;
-        }
-
-        @Override
-        public PathAddress getProxyNodeAddress() {
-            return proxy.getProxyNodeAddress();
-        }
-
-        @Override
-        public OperationTransformer.TransformedOperation transformOperation(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-            //Some transformers don't propagate the headers, back them up here and add them again
-            ModelNode operationHeaders = operation.hasDefined(OPERATION_HEADERS) ? operation.get(OPERATION_HEADERS) : null;
-            OperationTransformer.TransformedOperation transformed = transformers.transformOperation(context, operation);
-
-            if (operationHeaders != null) {
-                ModelNode transformedOp = transformed.getTransformedOperation();
-                if (transformedOp != null && !transformedOp.hasDefined(OPERATION_HEADERS)) {
-                    transformedOp.get(OPERATION_HEADERS).set(operationHeaders);
-                }
+            public TransformingProxyControllerImpl(Transformers transformers, RemoteProxyController proxy) {
+                this.transformers = transformers;
+                this.proxy = proxy;
             }
-            return transformed;
+
+            @Override
+            public TransactionalProtocolClient getProtocolClient() {
+                return proxy.getTransactionalProtocolClient();
+            }
+
+            @Override
+            public Transformers getTransformers() {
+                return transformers;
+            }
+
+            @Override
+            public PathAddress getProxyNodeAddress() {
+                return proxy.getProxyNodeAddress();
+            }
+
+            @Override
+            public OperationTransformer.TransformedOperation transformOperation(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+                return transformOperation(Transformers.TransformationInputs.getOrCreate(context), operation);
+            }
+
+            @Override
+            public OperationTransformer.TransformedOperation transformOperation(Transformers.TransformationInputs parameters, ModelNode operation) throws OperationFailedException {
+                //Some transformers don't propagate the headers, back them up here and add them again
+                ModelNode operationHeaders = operation.hasDefined(OPERATION_HEADERS) ? operation.get(OPERATION_HEADERS) : null;
+                OperationTransformer.TransformedOperation transformed = transformers.transformOperation(parameters, operation);
+
+                if (operationHeaders != null) {
+                    ModelNode transformedOp = transformed.getTransformedOperation();
+                    if (transformedOp != null && !transformedOp.hasDefined(OPERATION_HEADERS)) {
+                        transformedOp.get(OPERATION_HEADERS).set(operationHeaders);
+                    }
+                }
+                return transformed;
+            }
+
+            @Override
+            public void execute(final ModelNode operation, final OperationMessageHandler handler, final ProxyOperationControl control, final OperationAttachments attachments) {
+                // Execute untransformed
+                proxy.execute(operation, handler, control, attachments);
+            }
+
+            @Override
+            public ModelVersion getKernelModelVersion() {
+                return proxy.getKernelModelVersion();
+            }
         }
 
-        @Override
-        public void execute(final ModelNode operation, final OperationMessageHandler handler, final ProxyOperationControl control, final OperationAttachments attachments) {
-            // Execute untransformed
-            proxy.execute(operation, handler, control, attachments);
-        }
-
-        @Override
-        public ModelVersion getKernelModelVersion() {
-            return proxy.getKernelModelVersion();
-        }
     }
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolOperationHandler.java
@@ -272,6 +272,7 @@ public class TransactionalProtocolOperationHandler implements ManagementRequestH
                     ControllerLogger.MGMT_OP_LOGGER.tracef("aborting (cancel received before request) for %d", context.getOperationId());
                     ModelNode response = new ModelNode();
                     response.get(OUTCOME).set(CANCELLED);
+                    context.getAttachment().initialize(context);
                     context.getAttachment().failed(response);
                 }
             } else {

--- a/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolOperationHandler.java
@@ -29,16 +29,16 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUT
 import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
 import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
 
-import javax.security.auth.Subject;
 import java.io.DataInput;
 import java.io.IOException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.concurrent.CountDownLatch;
 
+import javax.security.auth.Subject;
+
 import org.jboss.as.controller.AccessAuditContext;
 import org.jboss.as.controller.ModelController;
-import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.OperationResponse;
@@ -176,17 +176,18 @@ public class TransactionalProtocolOperationHandler implements ManagementRequestH
                 final ModelNode failure = new ModelNode();
                 failure.get(OUTCOME).set(FAILED);
                 failure.get(FAILURE_DESCRIPTION).set(e.getClass().getName() + ":" + e.getMessage());
-                control.operationFailed(failure);
+                executeRequestContext.failed(failure);
                 attachmentsProxy.shutdown(e);
                 return;
             }
 
-            if (result.getResponseNode().hasDefined(FAILURE_DESCRIPTION)) {
-                control.operationFailed(result.getResponseNode());
+            // At this point the transactional request either failed prior to preparing the transaction,
+            // or it has completed.
+            if (!executeRequestContext.prepared) {
+                // If internalExecute did not result in a prepare, it failed
+                executeRequestContext.failed(result.getResponseNode());
             } else {
-                // controller.execute() will block in OperationControl.prepared until the {@code ProxyController}
-                // sent a CompleteTxRequest, which will either commit or rollback the operation
-                control.operationCompleted(result);
+                executeRequestContext.completed(result);
             }
         }
     }
@@ -228,7 +229,7 @@ public class TransactionalProtocolOperationHandler implements ManagementRequestH
      * @param control the operation transaction control
      * @return the result of the executed operation
      */
-    protected OperationResponse internalExecute(final Operation operation, final ManagementRequestContext<?> context, final OperationMessageHandler messageHandler, final ProxyController.ProxyOperationControl control) {
+    protected OperationResponse internalExecute(final Operation operation, final ManagementRequestContext<?> context, final OperationMessageHandler messageHandler, final ModelController.OperationTransactionControl control) {
         // Execute the operation
         return controller.execute(
                 operation,
@@ -288,25 +289,17 @@ public class TransactionalProtocolOperationHandler implements ManagementRequestH
 
     }
 
-    static class ProxyOperationControlProxy implements ProxyController.ProxyOperationControl {
+    static class ProxyOperationControlProxy implements ModelController.OperationTransactionControl {
 
         private final ExecuteRequestContext requestContext;
+
         ProxyOperationControlProxy(ExecuteRequestContext requestContext) {
             this.requestContext = requestContext;
         }
 
         @Override
-        public void operationFailed(final ModelNode response) {
-            requestContext.failed(response);
-        }
-
-        @Override
-        public void operationCompleted(final OperationResponse response) {
-            requestContext.completed(response);
-        }
-
-        @Override
         public void operationPrepared(final ModelController.OperationTransaction transaction, final ModelNode result) {
+
             requestContext.prepare(transaction, result);
             try {
                 // Wait for the commit or rollback message
@@ -391,20 +384,26 @@ public class TransactionalProtocolOperationHandler implements ManagementRequestH
             assert activeTx == null;
             // 1) initialize (set the response information)
             this.responseChannel = context;
+            ControllerLogger.MGMT_OP_LOGGER.tracef("Initialized for %d", getOperationId());
+
         }
 
         synchronized void prepare(final ModelController.OperationTransaction tx, final ModelNode result) {
+            assert !prepared;
             if(rollbackOnPrepare) {
+                prepared = true; // we count as prepared no matter what. Prepare was invoked
+                                 // and the other side has told us it's not expecting a prepare message,
+                                 // so the 'prepare' communication work this object tracks is done
                 try {
                     tx.rollback();
+                    ControllerLogger.MGMT_OP_LOGGER.tracef("rolled back on prepare for %d  --- interrupted: %s", getOperationId(), (Object) Thread.currentThread().isInterrupted());
                 } finally {
                     txCompletedLatch.countDown();
                 }
 
-                // TODO send response ?
+                // no response to remote side here; the response will come when the now rolled-back op returns
 
             } else {
-                assert !prepared;
                 assert activeTx == null;
                 assert responseChannel != null;
                 ControllerLogger.MGMT_OP_LOGGER.tracef("sending prepared response for %d  --- interrupted: %s", getOperationId(), (Object) Thread.currentThread().isInterrupted());
@@ -412,7 +411,7 @@ public class TransactionalProtocolOperationHandler implements ManagementRequestH
                     // 2) send the operation-prepared notification (just clear response info)
                     sendResponse(responseChannel, ModelControllerProtocol.PARAM_OPERATION_PREPARED, result);
                     activeTx = tx;
-                    prepared = true;
+                    prepared = true; // Here we only mark the op prepared once the message the other side expects has gone out
                 } catch (IOException e) {
                     getResultHandler().failed(e);
                 } finally {
@@ -471,9 +470,10 @@ public class TransactionalProtocolOperationHandler implements ManagementRequestH
         }
 
         synchronized void completed(final OperationResponse response) {
+
             assert prepared;
             assert responseChannel != null;
-            ControllerLogger.MGMT_OP_LOGGER.tracef("sending completed response for %d  --- interrupted: %s", getOperationId(), (Object) Thread.currentThread().isInterrupted());
+            ControllerLogger.MGMT_OP_LOGGER.tracef("sending completed response %s for %d  --- interrupted: %s", response.getResponseNode(), getOperationId(), (Object) Thread.currentThread().isInterrupted());
 
             streamSupport.registerStreams(operation.getOperationId(), response.getInputStreams());
 

--- a/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolOperationHandler.java
@@ -433,7 +433,6 @@ public class TransactionalProtocolOperationHandler implements ManagementRequestH
             } else if (txCompleted) {
                 // A 2nd call means a cancellation from the remote side after the tx was committed/rolled back
                 // This would usually mean the completion of the request is hanging for some reason
-                assert !commit; // can only be rollback if this has already been called
                 ControllerLogger.MGMT_OP_LOGGER.tracef("completeTx (post-commit cancel) for %d", getOperationId());
                 cancel(context);
             } else {

--- a/controller/src/main/java/org/jboss/as/controller/transform/ResourceTransformationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/ResourceTransformationContextImpl.java
@@ -405,7 +405,7 @@ class ResourceTransformationContextImpl implements ResourceTransformationContext
         private final ImmutableManagementResourceRegistration registration;
 
         OriginalModel(Resource original, RunningMode mode, ProcessType type, TransformationTarget target, ImmutableManagementResourceRegistration registration) {
-            this.original = original;
+            this.original = original.clone();
             this.mode = mode;
             this.type = type;
             this.target = target;

--- a/controller/src/main/java/org/jboss/as/controller/transform/ResourceTransformationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/ResourceTransformationContextImpl.java
@@ -52,14 +52,12 @@ class ResourceTransformationContextImpl implements ResourceTransformationContext
     private final TransformerOperationAttachment transformerOperationAttachment;
     private final Transformers.ResourceIgnoredTransformationRegistry ignoredTransformationRegistry;
 
-    static ResourceTransformationContext create(final OperationContext context, final TransformationTarget target,
+    static ResourceTransformationContext create(final Transformers.TransformationInputs tp, final TransformationTarget target,
                                                 final PathAddress current, final PathAddress read,
                                                 final Transformers.ResourceIgnoredTransformationRegistry ignoredTransformationRegistry) {
         final Resource root = Resource.Factory.create();
-        final Resource original = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, true);
-        final ImmutableManagementResourceRegistration registration = context.getRootResourceRegistration().getSubModel(PathAddress.EMPTY_ADDRESS);
-        final OriginalModel originalModel = new OriginalModel(original, context.getRunningMode(), context.getProcessType(), target, registration);
-        final TransformerOperationAttachment attachment = context.getAttachment(TransformerOperationAttachment.KEY);
+        final OriginalModel originalModel = new OriginalModel(tp.getRootResource(), tp.getRunningMode(), tp.getProcessType(), target, tp.getRootRegistration());
+        final TransformerOperationAttachment attachment = tp.getTransformerOperationAttachment();
         return new ResourceTransformationContextImpl(root, current, read, originalModel, attachment, ignoredTransformationRegistry);
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/transform/ResourceTransformationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/ResourceTransformationContextImpl.java
@@ -53,11 +53,6 @@ class ResourceTransformationContextImpl implements ResourceTransformationContext
     private final Transformers.ResourceIgnoredTransformationRegistry ignoredTransformationRegistry;
 
     static ResourceTransformationContext create(final OperationContext context, final TransformationTarget target,
-                                                final Transformers.ResourceIgnoredTransformationRegistry ignoredTransformationRegistry) {
-        return create(context, target, PathAddress.EMPTY_ADDRESS, PathAddress.EMPTY_ADDRESS, ignoredTransformationRegistry);
-    }
-
-    static ResourceTransformationContext create(final OperationContext context, final TransformationTarget target,
                                                 final PathAddress current, final PathAddress read,
                                                 final Transformers.ResourceIgnoredTransformationRegistry ignoredTransformationRegistry) {
         final Resource root = Resource.Factory.create();

--- a/controller/src/main/java/org/jboss/as/controller/transform/TransformersImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/TransformersImpl.java
@@ -28,7 +28,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import java.util.Iterator;
 import java.util.List;
 
-import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.logging.ControllerLogger;
@@ -75,7 +74,7 @@ public class TransformersImpl implements Transformers {
     }
 
     @Override
-    public OperationTransformer.TransformedOperation transformOperation(final OperationContext operationContext, final ModelNode operation) throws OperationFailedException {
+    public OperationTransformer.TransformedOperation transformOperation(final TransformationInputs transformationInputs, final ModelNode operation) throws OperationFailedException {
 
         final PathAddress original = PathAddress.pathAddress(operation.require(OP_ADDR));
         final String operationName = operation.require(OP).asString();
@@ -85,7 +84,7 @@ public class TransformersImpl implements Transformers {
         // Update the operation using the new path address
         operation.get(OP_ADDR).set(transformed.toModelNode()); // TODO should this happen by default?
 
-        final TransformationContext context = ResourceTransformationContextImpl.create(operationContext, target, transformed, original, Transformers.DEFAULT);
+        final TransformationContext context = ResourceTransformationContextImpl.create(transformationInputs, target, transformed, original, Transformers.DEFAULT);
         final OperationTransformer transformer = target.resolveTransformer(context, original, operationName);
         if (transformer == null) {
             ControllerLogger.ROOT_LOGGER.tracef("operation %s does not need transformation", operation);
@@ -97,18 +96,19 @@ public class TransformersImpl implements Transformers {
     }
 
     @Override
-    public Resource transformRootResource(OperationContext operationContext, Resource resource) throws OperationFailedException {
-        return transformRootResource(operationContext, resource, Transformers.DEFAULT);
+    public Resource transformRootResource(TransformationInputs transformationInputs, Resource resource) throws OperationFailedException {
+        return transformRootResource(transformationInputs, resource, Transformers.DEFAULT);
     }
 
     @Override
-    public Resource transformRootResource(OperationContext operationContext, Resource resource, ResourceIgnoredTransformationRegistry ignoredTransformationRegistry) throws OperationFailedException {
+    public Resource transformRootResource(TransformationInputs transformationInputs, Resource resource, ResourceIgnoredTransformationRegistry ignoredTransformationRegistry) throws OperationFailedException {
         // Transform the path address
         final PathAddress original = PathAddress.EMPTY_ADDRESS;
         final PathAddress transformed = transformAddress(original, target);
-        final ResourceTransformationContext context = ResourceTransformationContextImpl.create(operationContext, target, transformed, original, ignoredTransformationRegistry);
+        final ResourceTransformationContext context = ResourceTransformationContextImpl.create(transformationInputs, target, transformed, original, ignoredTransformationRegistry);
         final ResourceTransformer transformer = target.resolveTransformer(context, original);
         if(transformer == null) {
+
             ControllerLogger.ROOT_LOGGER.tracef("resource %s does not need transformation", resource);
             return resource;
         }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadDomainModelHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadDomainModelHandler.java
@@ -25,8 +25,6 @@ package org.jboss.as.domain.controller.operations;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.transform.Transformers;
 import org.jboss.dmr.ModelNode;
 
@@ -49,8 +47,9 @@ class ReadDomainModelHandler implements OperationStepHandler {
         // Acquire the lock to make sure that nobody can modify the model before the slave has applied it
         context.acquireControllerLock();
 
-        final Resource rootResource = context.readResource(PathAddress.EMPTY_ADDRESS, true);
-        final ReadMasterDomainModelUtil readUtil = ReadMasterDomainModelUtil.readMasterDomainResourcesForInitialConnect(context, transformers, rootResource, ignoredTransformationRegistry);
+        final Transformers.TransformationInputs transformationInputs = new Transformers.TransformationInputs(context);
+        final ReadMasterDomainModelUtil readUtil = ReadMasterDomainModelUtil.readMasterDomainResourcesForInitialConnect(transformers,
+                transformationInputs, ignoredTransformationRegistry, transformationInputs.getRootResource());
         context.getResult().set(readUtil.getDescribedResources());
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelUtil.java
@@ -36,7 +36,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -75,15 +74,18 @@ public class ReadMasterDomainModelUtil {
     /**
      * Used to read the domain model when a slave host connects to the DC
      *
-     *  @param context the operation context
      *  @param transformers the transformers for the host
-     *  @param domainRoot the domain root resource
-     *  @return a read master domain model util instance
+     *  @param transformationInputs parameters for the transformation
+     *  @param ignoredTransformationRegistry registry of resources ignored by the transformation target
+     *  @param domainRoot the root resource for the domain resource tree
+     * @return a read master domain model util instance
      */
-    static ReadMasterDomainModelUtil readMasterDomainResourcesForInitialConnect(
-            final OperationContext context, final Transformers transformers, final Resource domainRoot, final Transformers.ResourceIgnoredTransformationRegistry ignoredTransformationRegistry) throws OperationFailedException {
+    static ReadMasterDomainModelUtil readMasterDomainResourcesForInitialConnect(final Transformers transformers,
+                                                                                final Transformers.TransformationInputs transformationInputs,
+                                                                                final Transformers.ResourceIgnoredTransformationRegistry ignoredTransformationRegistry,
+                                                                                final Resource domainRoot) throws OperationFailedException {
 
-        Resource transformedResource = transformers.transformRootResource(context, domainRoot, ignoredTransformationRegistry);
+        Resource transformedResource = transformers.transformRootResource(transformationInputs, domainRoot, ignoredTransformationRegistry);
         ReadMasterDomainModelUtil util = new ReadMasterDomainModelUtil();
         util.describedResources = util.describeAsNodeList(PathAddress.EMPTY_ADDRESS, transformedResource, false);
         return util;
@@ -362,7 +364,6 @@ public class ReadMasterDomainModelUtil {
      *
      * @param hostInfo the host info
      * @param rc       the resolution context
-     * @param local    whether the operation is executed on the slave host locally
      * @return
      */
     public static Transformers.ResourceIgnoredTransformationRegistry createHostIgnoredRegistry(final HostInfo hostInfo, final RequiredConfigurationHolder rc) {
@@ -412,7 +413,6 @@ public class ReadMasterDomainModelUtil {
      * to a server-config.
      *
      * @param rc       the resolution context
-     * @param local    whether the operation is executed on the slave host locally
      * @param delegate the delegate ignored resource transformation registry for manually ignored resources
      * @return
      */

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainRolloutStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainRolloutStepHandler.java
@@ -68,6 +68,7 @@ import org.jboss.as.controller.remote.ResponseAttachmentInputStreamSupport;
 import org.jboss.as.controller.remote.TransactionalProtocolClient;
 import org.jboss.as.controller.transform.OperationResultTransformer;
 import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.controller.transform.Transformers;
 import org.jboss.as.domain.controller.ServerIdentity;
 import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.as.domain.controller.plan.RolloutPlanController;
@@ -292,6 +293,7 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
                 HOST_CONTROLLER_LOGGER.tracef("Rollout plan is %s", rolloutPlan);
             }
 
+            final Transformers.TransformationInputs transformationInputs = Transformers.TransformationInputs.getOrCreate(context);
             final ServerTaskExecutor taskExecutor = new ServerTaskExecutor(context, submittedTasks, preparedResults) {
 
                 @Override
@@ -312,7 +314,7 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
                     }
                     // Transform the server-results
                     final TransformingProxyController remoteProxyController = (TransformingProxyController) proxy;
-                    final OperationTransformer.TransformedOperation transformed = multiphaseContext.transformServerOperation(hostName, remoteProxyController, context, original);
+                    final OperationTransformer.TransformedOperation transformed = multiphaseContext.transformServerOperation(hostName, remoteProxyController, transformationInputs, original);
                     final ModelNode transformedOperation = transformed.getTransformedOperation();
                     final OperationResultTransformer resultTransformer = transformed.getResultTransformer();
                     final TransactionalProtocolClient client = remoteProxyController.getProtocolClient();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
@@ -51,6 +51,7 @@ import org.jboss.as.controller.operations.DomainOperationTransformer;
 import org.jboss.as.controller.operations.OperationAttachments;
 import org.jboss.as.controller.remote.ResponseAttachmentInputStreamSupport;
 import org.jboss.as.controller.remote.TransactionalProtocolClient;
+import org.jboss.as.controller.transform.Transformers;
 import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.dmr.ModelNode;
 
@@ -83,6 +84,7 @@ public class DomainSlaveHandler implements OperationStepHandler {
         final List<TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation>> results = new ArrayList<TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation>>();
         final Map<String, HostControllerUpdateTask.ExecutedHostRequest> finalResults = new HashMap<String, HostControllerUpdateTask.ExecutedHostRequest>();
         final HostControllerUpdateTask.ProxyOperationListener listener = new HostControllerUpdateTask.ProxyOperationListener();
+        final Transformers.TransformationInputs transformationInputs = Transformers.TransformationInputs.getOrCreate(context);
         for (Map.Entry<String, ProxyController> entry : hostProxies.entrySet()) {
             // Create the proxy task
             final String host = entry.getKey();
@@ -99,7 +101,7 @@ public class DomainSlaveHandler implements OperationStepHandler {
 
             ModelNode clonedOp = op.clone();
             clonedOp.get(OPERATION_HEADERS, DomainControllerLockIdUtils.DOMAIN_CONTROLLER_LOCK_ID).set(CurrentOperationIdHolder.getCurrentOperationID());
-            final HostControllerUpdateTask task = new HostControllerUpdateTask(host, clonedOp, context, proxyController);
+            final HostControllerUpdateTask task = new HostControllerUpdateTask(host, clonedOp, context, proxyController, transformationInputs);
             // Execute the operation on the remote host
             final HostControllerUpdateTask.ExecutedHostRequest finalResult = task.execute(listener);
             multiphaseContext.recordHostRequest(host, finalResult);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerUpdateTask.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerUpdateTask.java
@@ -74,13 +74,16 @@ class HostControllerUpdateTask {
     private final ModelNode operation;
     private final OperationContext context;
     private final TransformingProxyController proxyController;
+    private final Transformers.TransformationInputs transformationInputs;
 
     public HostControllerUpdateTask(final String name, final ModelNode operation, final OperationContext context,
-                                    final TransformingProxyController proxyController) {
+                                    final TransformingProxyController proxyController,
+                                    final Transformers.TransformationInputs transformationInputs) {
         this.name = name;
         this.context = context;
         this.operation = operation;
         this.proxyController = proxyController;
+        this.transformationInputs = transformationInputs;
     }
 
     public ExecutedHostRequest execute(final ProxyOperationListener listener) {
@@ -91,7 +94,7 @@ class HostControllerUpdateTask {
         final SubsystemInfoOperationListener subsystemListener = new SubsystemInfoOperationListener(listener, proxyController.getTransformers());
         try {
 
-            final OperationTransformer.TransformedOperation transformationResult = proxyController.transformOperation(context, operation);
+            final OperationTransformer.TransformedOperation transformationResult = proxyController.transformOperation(transformationInputs, operation);
             final ModelNode transformedOperation = transformationResult.getTransformedOperation();
             final ProxyOperation proxyOperation = new ProxyOperation(name, transformedOperation, messageHandler, operationAttachments);
             try {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/MultiphaseOverallContext.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/MultiphaseOverallContext.java
@@ -34,11 +34,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.TransformingProxyController;
 import org.jboss.as.controller.transform.OperationResultTransformer;
 import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.controller.transform.Transformers;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.domain.controller.ServerIdentity;
 import org.jboss.as.domain.controller.logging.DomainControllerLogger;
@@ -172,8 +172,10 @@ public final class MultiphaseOverallContext {
     /*
      * Transform an operation for a server. This will also delegate to the host-controller result-transformer.
      */
-    public OperationTransformer.TransformedOperation transformServerOperation(final String hostName, final TransformingProxyController remoteProxyController, final OperationContext context, final ModelNode original) throws OperationFailedException {
-        final OperationTransformer.TransformedOperation transformed = remoteProxyController.transformOperation(context, original);
+    public OperationTransformer.TransformedOperation transformServerOperation(final String hostName, final TransformingProxyController remoteProxyController,
+                                                                              final Transformers.TransformationInputs transformationInputs,
+                                                                              final ModelNode original) throws OperationFailedException {
+        final OperationTransformer.TransformedOperation transformed = remoteProxyController.transformOperation(transformationInputs, original);
         final HostControllerUpdateTask.ExecutedHostRequest hostRequest = finalResultFutures.get(hostName);
         if(hostRequest == null) {
             // in case it's local hosts-controller

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
@@ -276,8 +276,6 @@ public class ServerInventoryImpl implements ServerInventory {
         if(running) {
             if(!stopping) {
                  server.reconnectServerProcess(createBootFactory(serverName, domainModel));
-                 // Register the server proxy at the domain controller
-                 domainController.registerRunningServer(server.getProxyController());
             } else {
                  server.setServerProcessStopping();
             }
@@ -477,6 +475,8 @@ public class ServerInventoryImpl implements ServerInventory {
         serverCommunicationRegistered(serverProcessName, channelHandler);
         // Mark the server as started
         serverStarted(serverProcessName);
+        // Register the server proxy at the domain controller
+        domainController.registerRunningServer(server.getProxyController());
         // If the server requires a reload, means we are out of sync
         return server.isRequiresReload() == false;
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/HostControllerRegistrationHandler.java
@@ -313,7 +313,8 @@ public class HostControllerRegistrationHandler implements ManagementRequestHandl
             }
             // Build the extensions list
             final ModelNode extensions = new ModelNode();
-            final Resource transformed = transformers.transformRootResource(context, root);
+            final Transformers.TransformationInputs transformationInputs = Transformers.TransformationInputs.getOrCreate(context);
+            final Resource transformed = transformers.transformRootResource(transformationInputs, root);
             final Collection<Resource.ResourceEntry> resources = transformed.getChildren(EXTENSION);
             for(final Resource.ResourceEntry entry : resources) {
                 extensions.add(entry.getName());

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
@@ -32,7 +32,6 @@ import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.ProxyController.ProxyOperationControl;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.OperationResponse;
@@ -116,7 +115,7 @@ public class MasterDomainControllerOperationHandlerService extends AbstractModel
         }
 
         @Override
-        protected OperationResponse internalExecute(final Operation operation, final ManagementRequestContext<?> context, final OperationMessageHandler messageHandler, final ProxyOperationControl control) {
+        protected OperationResponse internalExecute(final Operation operation, final ManagementRequestContext<?> context, final OperationMessageHandler messageHandler, final ModelController.OperationTransactionControl control) {
 
             final ModelNode operationNode = operation.getOperation();
             final OperationStepHandler handler;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/ServerToHostProtocolHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/ServerToHostProtocolHandler.java
@@ -268,6 +268,10 @@ public class ServerToHostProtocolHandler implements ManagementRequestHandlerFact
                             // Acquire controller lock
                             context.acquireControllerLock();
                             // Check if the server is still in sync with the domain model
+                            // TODO WFCORE-990 this should involve shipping the resource tree to the server, which then compares
+                            // its local model. This would be done in the prepare phase of a transactional request.
+                            // The ResultHandler of this step would then publish the server's state, and register
+                            // the server's proxy controller with DomainModelControllerService
                             final byte param;
                             if(serverInventory.serverReconnected(serverName, channelHandler)) {
                                 param = DomainServerProtocol.PARAM_OK;

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOrderedChildResourceSyncModelTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOrderedChildResourceSyncModelTestCase.java
@@ -159,7 +159,7 @@ public class AbstractOrderedChildResourceSyncModelTestCase extends AbstractContr
     }
 
     void executeTriggerSyncOperation(Resource rootResource) throws Exception {
-        ReadMasterDomainModelUtil util = ReadMasterDomainModelUtil.readMasterDomainResourcesForInitialConnect(null, new NoopTransformers(), rootResource, null);
+        ReadMasterDomainModelUtil util = ReadMasterDomainModelUtil.readMasterDomainResourcesForInitialConnect(new NoopTransformers(), null, null, rootResource);
         ModelNode op = Util.createEmptyOperation(TRIGGER_SYNC.getName(), PathAddress.EMPTY_ADDRESS);
         op.get(DOMAIN_MODEL).set(util.getDescribedResources());
         executeForResult(op);

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SyncModelServerStateTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SyncModelServerStateTestCase.java
@@ -142,7 +142,7 @@ public class SyncModelServerStateTestCase extends AbstractControllerTestBase  {
     }
 
     private void executeTriggerSyncOperation(Resource rootResource) throws Exception {
-        ReadMasterDomainModelUtil util = ReadMasterDomainModelUtil.readMasterDomainResourcesForInitialConnect(null, new NoopTransformers(), rootResource, null);
+        ReadMasterDomainModelUtil util = ReadMasterDomainModelUtil.readMasterDomainResourcesForInitialConnect(new NoopTransformers(), null, null, rootResource);
         ModelNode op = Util.createEmptyOperation(TRIGGER_SYNC.getName(), PathAddress.EMPTY_ADDRESS);
         op.get(DOMAIN_MODEL).set(util.getDescribedResources());
         executeForResult(op);

--- a/host-controller/src/test/java/org/jboss/as/host/controller/util/AbstractControllerTestBase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/util/AbstractControllerTestBase.java
@@ -49,7 +49,6 @@ import org.jboss.as.controller.DelegatingResourceDefinition;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelController;
-import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -254,7 +253,7 @@ public abstract class AbstractControllerTestBase {
         }
 
         @Override
-        public OperationTransformer.TransformedOperation transformOperation(OperationContext operationContext, ModelNode operation)
+        public OperationTransformer.TransformedOperation transformOperation(TransformationInputs transformationInputs, ModelNode operation)
                 throws OperationFailedException {
             return new OperationTransformer.TransformedOperation(operation, OperationTransformer.TransformedOperation.ORIGINAL_RESULT);
         }
@@ -266,13 +265,13 @@ public abstract class AbstractControllerTestBase {
         }
 
         @Override
-        public Resource transformRootResource(OperationContext operationContext, Resource resource)
+        public Resource transformRootResource(TransformationInputs transformationInputs, Resource resource)
                 throws OperationFailedException {
             return resource;
         }
 
         @Override
-        public Resource transformRootResource(OperationContext operationContext, Resource resource, ResourceIgnoredTransformationRegistry ignoredTransformationRegistry) throws OperationFailedException {
+        public Resource transformRootResource(TransformationInputs transformationInputs, Resource resource, ResourceIgnoredTransformationRegistry ignoredTransformationRegistry) throws OperationFailedException {
             return resource;
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
 
         <!-- Surefire args -->
         <surefire.jpda.args/>
-        <surefire.system.args>-da ${surefire.jpda.args}</surefire.system.args>
+        <surefire.system.args>-ea ${surefire.jpda.args}</surefire.system.args>
 
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperationSupport.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperationSupport.java
@@ -149,7 +149,10 @@ class ActiveOperationSupport {
     protected <T, A> ActiveOperation<T, A> registerActiveOperation(final Integer id, A attachment, ActiveOperation.CompletedCallback<T> callback) {
         lock.lock(); try {
             // Check that we still allow registration
-            assert ! shutdown;
+            // TODO WFCORE-199 distinguish client uses from server uses and limit this check to server uses
+            // Using id==null may be one way to do this, but we need to consider ops that involve multiple requests
+            // TODO WFCORE-845 consider using an IllegalStateException for this
+            //assert ! shutdown;
             final Integer operationId;
             if(id == null) {
                 // If we did not get an operationId, create a new one

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ReadTransformedResourceOperation.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ReadTransformedResourceOperation.java
@@ -81,7 +81,8 @@ class ReadTransformedResourceOperation implements OperationStepHandler {
 
         final ImmutableManagementResourceRegistration rr = context.getRootResourceRegistration();
         Resource root = TransformationUtils.modelToResource(rr, rootData, true);
-        Resource transformed = transformers.transformRootResource(context, root);
+        Transformers.TransformationInputs transformationInputs = Transformers.TransformationInputs.getOrCreate(context);
+        Resource transformed = transformers.transformRootResource(transformationInputs, root);
 
         return Resource.Tools.readModel(transformed);
     }

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -86,13 +86,13 @@
             <groupId>org.apache.directory.api</groupId>
             <artifactId>api-ldap-codec-standalone</artifactId>
             <scope>test</scope>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>org.apache.directory.jdbm</groupId>
             <artifactId>apacheds-jdbm1</artifactId>
             <type>bundle</type>
             <scope>test</scope>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-core-annotations</artifactId>
@@ -103,12 +103,12 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-interceptor-kerberos</artifactId>
             <scope>test</scope>
-        </dependency>    
+        </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-server-annotations</artifactId>
@@ -178,7 +178,7 @@
                     <argLine>${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
 
                     <systemPropertyVariables>
-                        <jboss.options>${surefire.system.args}</jboss.options>
+                        <jboss.options>-ea ${surefire.system.args}</jboss.options>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <jboss.home>${project.basedir}/target/wildfly-core</jboss.home>
                         <module.path>${jboss.dist}/modules</module.path>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
@@ -75,6 +75,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
         </jvm>
     </jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
@@ -75,6 +75,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
         </jvm>
     </jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-master.xml
@@ -69,10 +69,11 @@
 
  	<jvms>
  	   <jvm name="default">
-          <heap size="64m" max-size="128m"/>
-          <environment-variables>
-              <variable name="DOMAIN_TEST_JVM" value="jvm"/>
-          </environment-variables>
+           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
+           <environment-variables>
+               <variable name="DOMAIN_TEST_JVM" value="jvm"/>
+           </environment-variables>
             <!--
             <jvm-options>
                 <option value="-Xdebug"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-slave.xml
@@ -90,7 +90,8 @@
 
  	<jvms>
  	   <jvm name="default">
-          <heap size="64m" max-size="128m"/>
+           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
        </jvm>
  	</jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-default-interface.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-default-interface.xml
@@ -73,6 +73,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
         </jvm>
     </jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -70,6 +70,7 @@
  	<jvms>
  	   <jvm name="default">
           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
        </jvm>
  	</jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -75,7 +75,8 @@
 
  	<jvms>
  	   <jvm name="default">
-          <heap size="64m" max-size="128m"/>
+           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
        </jvm>
  	</jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -92,7 +92,8 @@
 
  	<jvms>
  	   <jvm name="default">
-          <heap size="64m" max-size="128m"/>
+           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
        </jvm>
  	</jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-master-auto-start.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-auto-start.xml
@@ -86,6 +86,7 @@
 	<jvms>
 	   <jvm name="default">
           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
           <environment-variables>
               <variable name="DOMAIN_TEST_JVM" value="jvm"/>
           </environment-variables>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -92,6 +92,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>
             </environment-variables>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -89,6 +89,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>
             </environment-variables>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-ssl.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-ssl.xml
@@ -86,6 +86,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>
             </environment-variables>

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -91,6 +91,7 @@
  	<jvms>
  	   <jvm name="default">
           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
           <environment-variables>
               <variable name="DOMAIN_TEST_JVM" value="jvm"/>
           </environment-variables>
@@ -155,7 +156,7 @@
             <jvm name="default" />
         </server>
     </servers>
-    
+
     <profile>
         <subsystem xmlns="urn:jboss:domain:jmx:1.3">
             <expose-resolved-model/>

--- a/testsuite/domain/src/test/resources/host-configs/host-minimal.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-minimal.xml
@@ -75,6 +75,7 @@
  	<jvms>
  	   <jvm name="default">
           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
        </jvm>
  	</jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-outbound-ldap-connection.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-outbound-ldap-connection.xml
@@ -103,6 +103,7 @@
  	<jvms>
  	   <jvm name="default">
           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
           <environment-variables>
               <variable name="DOMAIN_TEST_JVM" value="jvm"/>
           </environment-variables>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-auto-start.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-auto-start.xml
@@ -109,6 +109,7 @@
 	<jvms>
 	   <jvm name="default">
           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
        </jvm>
 	</jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -97,6 +97,7 @@
  	<jvms>
  	   <jvm name="default">
           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
        </jvm>
  	</jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-failure.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-failure.xml
@@ -97,6 +97,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
         </jvm>
     </jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -113,6 +113,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
         </jvm>
     </jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -110,6 +110,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
         </jvm>
     </jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-1way.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-1way.xml
@@ -118,6 +118,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
         </jvm>
     </jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-2way.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-2way.xml
@@ -120,6 +120,7 @@
     <jvms>
         <jvm name="default">
             <heap size="64m" max-size="128m"/>
+            <jvm-options><option value="-ea"/></jvm-options>
         </jvm>
     </jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -115,6 +115,7 @@
  	<jvms>
  	   <jvm name="default">
           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
        </jvm>
  	</jvms>
 
@@ -144,7 +145,7 @@
         </server>
     </servers>
 
-    
+
     <profile>
         <subsystem xmlns="urn:jboss:domain:jmx:1.3">
             <expose-resolved-model/>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master-http.xml
@@ -61,6 +61,7 @@
 	<jvms>
 	   <jvm name="default">
           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
        </jvm>
 	</jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -64,6 +64,7 @@
  	<jvms>
  	   <jvm name="default">
           <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
        </jvm>
  	</jvms>
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
@@ -149,6 +149,13 @@ public class DomainLifecycleUtil {
                         .addProcessControllerJavaOptions(javaOpts);
             }
 
+            if (configuration.isEnableAssertions()) {
+                commandBuilder.addProcessControllerJavaOption("-ea");
+                commandBuilder.addHostControllerJavaOption("-ea");
+                // This doesn't work; the HC Main class treats this as an invalid param
+                //commandBuilder.addServerArgument("-ea");
+            }
+
             final String jbossArgs = System.getProperty("jboss.domain.server.args");
             if (jbossArgs != null) {
                 commandBuilder.addServerArguments(jbossArgs.split("\\s+"));

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/WildFlyManagedConfiguration.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/WildFlyManagedConfiguration.java
@@ -105,6 +105,11 @@ public class WildFlyManagedConfiguration {
 
     private boolean cachedDC;
 
+    // TODO MixedDomainTestSuite in full fails with this enabled as the legacy HC is broken with -ea
+    // So, turn this off by default for now, until MixedDomainTestSupport can use the setter to disable
+    // assertions for the slave HC
+    private boolean enableAssertions;
+
     public WildFlyManagedConfiguration(String jbossHome) {
         if (jbossHome != null) {
             this.jbossHome = jbossHome;
@@ -348,5 +353,13 @@ public class WildFlyManagedConfiguration {
 
     public void setCachedDC(boolean cachedDC) {
         this.cachedDC = cachedDC;
+    }
+
+    public boolean isEnableAssertions() {
+        return enableAssertions;
+    }
+
+    public void setEnableAssertions(boolean enableAssertions) {
+        this.enableAssertions = enableAssertions;
     }
 }

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -169,7 +169,7 @@ public class Server {
                 try {
                     // AS7-6620: Create the shutdown operation and run it asynchronously and wait for process to terminate
                     client.getControllerClient().executeAsync(Operations.createOperation("shutdown"), null);
-                } catch (AssertionError e) {
+                } catch (AssertionError | RuntimeException e) {
                     //ignore as this can only fail if shutdown is already in progress
                 }
 


### PR DESCRIPTION
This PR does two main things:

1) Turns on assertions in the build.
2) Fixes domain mode issues that are revealed thereby.

We can skip part 1) for now if it's considered too risky for CR2. But I wanted it on for now to get CI tests of this work with assertions now. I can back out those commits before merging if that's the decision.

The details on 2) are:

a) Fix WFCORE-988
b) Fix WFCORE-989
c) Fix an issue where in some situations request tracking wasn't recording that an operation had been 'prepared' even though it had, plus some related code cleanup to help make the intended behavior clearer.