### PR TITLE
Provide a better message if testLog detects an unexpected log level

### DIFF
--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
@@ -126,16 +126,16 @@ public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
     /**
      * Tests if the next message in the syslog is the expected one with the given log-level.
      *
-     * @param expectedLevel
+     * @param expectedLevel the expected level of the next log message
      *
      * @throws Exception
      */
     private void testLog(final BlockingQueue<SyslogServerEventIF> queue, final Level expectedLevel) throws Exception {
         SyslogServerEventIF log = queue.poll(15L * ADJUSTED_SECOND, TimeUnit.MILLISECONDS);
         assertNotNull(log);
-        assertEquals("Message with unexpected Syslog event level received.", getSyslogLevel(expectedLevel), log.getLevel());
-        final String expectedMsg = LoggingServiceActivator.formatMessage(MSG, expectedLevel);
         String msg = log.getMessage();
+        assertEquals("Message with unexpected Syslog event level received: " + msg, getSyslogLevel(expectedLevel), log.getLevel());
+        final String expectedMsg = LoggingServiceActivator.formatMessage(MSG, expectedLevel);
         assertEquals("Message with unexpected Syslog event text received.", expectedMsg, msg);
     }
 


### PR DESCRIPTION
There have been a couple intermittent failures of this test, and it would be nice to have better data.

http://brontes.lab.eng.brq.redhat.com/project.html?projectId=WildFlyCore_PullRequest&buildTypeId=&tab=testDetails&testNameId=-785501276856468694&order=TEST_STATUS_DESC&branch_WildFlyCore_PullRequest=__all_branches__&itemsCount=50