### PR TITLE
[WFCORE-992] fix memory leak in host controller

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerProxy.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerProxy.java
@@ -114,19 +114,21 @@ class ManagedServerProxy implements TransactionalProtocolClient {
             futures.add(future);
 
             // Make sure we clean up
+            // ignore the 1st parameter of handle* callbacks, that's the _underlying_ future,
+            // not the one just added to the "futures" set
             future.addListener(new AsyncFuture.Listener<OperationResponse, TransactionalProtocolClient>() {
                 @Override
-                public void handleComplete(AsyncFuture<? extends OperationResponse> future, TransactionalProtocolClient attachment) {
+                public void handleComplete(AsyncFuture<? extends OperationResponse> ignored, TransactionalProtocolClient attachment) {
                     futureDone(attachment, future);
                 }
 
                 @Override
-                public void handleFailed(AsyncFuture<? extends OperationResponse> future, Throwable cause, TransactionalProtocolClient attachment) {
+                public void handleFailed(AsyncFuture<? extends OperationResponse> ignored, Throwable cause, TransactionalProtocolClient attachment) {
                     futureDone(attachment, future);
                 }
 
                 @Override
-                public void handleCancelled(AsyncFuture<? extends OperationResponse> future, TransactionalProtocolClient attachment) {
+                public void handleCancelled(AsyncFuture<? extends OperationResponse> ignored, TransactionalProtocolClient attachment) {
                     futureDone(attachment, future);
                 }
             }, remoteClient);


### PR DESCRIPTION
This commit makes sure that the Future objects added to Sets inside
the ManagedServerProxy.activeRequests Map are also properly removed.
The problem was that a delegating Future calls addListener directly
on the underlying Future, so that the callbacks don't get the original
Future, but the underlying one. And this underlying future was
"removed" from the Set (which is a noop, because the underlying Future
was never in the Set in the first place).