### PR TITLE
WFCORE-937 - --std-out=discard for embedded host controller doesn't work

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/logmanager/ConfigurationPersistence.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/ConfigurationPersistence.java
@@ -377,6 +377,9 @@ public class ConfigurationPersistence implements Configurator, LogContextConfigu
                 loggingConfig = FileResolver.resolvePath(context, "jboss.server.data.dir", PROPERTIES_FILE);
                 break;
             }
+            case EMBEDDED_SERVER: {
+                return;
+            }
             default: {
                 loggingConfig = FileResolver.resolvePath(context, "jboss.server.config.dir", PROPERTIES_FILE);
             }


### PR DESCRIPTION
Starting embeded standalone would overwrite standalone/configuration/logging.properties, quitting and starting after would start with an empty logging.properties.

@bstansberry can you have a look and tell me if you think this is the right thing to do here?