### PR TITLE
Revert "Update Remoting to 4.0.11.Final"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <version.org.jboss.metadata.jboss-metadata-common>10.0.0.CR1</version.org.jboss.metadata.jboss-metadata-common>
         <version.org.jboss.modules.jboss-modules>1.4.4.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.6.Final</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.remoting>4.0.11.Final</version.org.jboss.remoting>
+        <version.org.jboss.remoting>4.0.10.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>2.0.1.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.sasl>1.0.5.Final</version.org.jboss.sasl>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.1.2</version.org.jboss.shrinkwrap.shrinkwrap>


### PR DESCRIPTION
This reverts commit 613d6f8375b9f2bc006514099376a1cf0de0f623.

With 4.0.11 we've found testsuite hangs a la http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=72351&buildTypeId=WildFlyCore_PullRequest