### PR TITLE
WFCORE-932 stop-embedded-server stops the embedded host controller and vice versa

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbeddedServerLaunch.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbeddedServerLaunch.java
@@ -65,4 +65,13 @@ public class EmbeddedServerLaunch {
     public HostController getHostController() {
         return server.getHostController();
     }
+
+    public boolean isHostController() {
+        return server.isHostController();
+    }
+
+    public boolean isStandalone() {
+        return !server.isHostController();
+    }
+
 }

--- a/cli/src/main/java/org/jboss/as/cli/embedded/StopEmbeddedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/StopEmbeddedHostControllerHandler.java
@@ -46,7 +46,7 @@ class StopEmbeddedHostControllerHandler extends CommandHandlerWithHelp {
 
     @Override
     public boolean isAvailable(CommandContext ctx) {
-        return hostControllerReference.get() != null;
+        return (hostControllerReference.get() != null && hostControllerReference.get().isHostController());
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/embedded/StopEmbeddedServerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/StopEmbeddedServerHandler.java
@@ -46,7 +46,7 @@ class StopEmbeddedServerHandler extends CommandHandlerWithHelp {
 
     @Override
     public boolean isAvailable(CommandContext ctx) {
-        return serverReference.get() != null;
+        return (serverReference.get() != null && serverReference.get().isStandalone());
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
@@ -97,11 +97,11 @@ public class ShutdownHandler extends BaseOperationCommand {
     protected void doHandle(CommandContext ctx) throws CommandLineException {
         final ModelControllerClient client = ctx.getModelControllerClient();
         if(client == null) {
-            throw new CommandLineException("Connection is now available.");
+            throw new CommandLineException("Connection is not available.");
         }
 
-        if (embeddedServerRef != null && embeddedServerRef.get() != null){
-                embeddedServerRef.get().stop();
+        if (embeddedServerRef != null && embeddedServerRef.get() != null) {
+            embeddedServerRef.get().stop();
             return;
         }
 

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedServerReference.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedServerReference.java
@@ -75,6 +75,10 @@ public final class EmbeddedServerReference implements StandaloneServer, HostCont
         return (HostController) server;
     }
 
+    public boolean isHostController() {
+        return server instanceof HostController;
+    }
+
     private Object invokeOnServer(final Method method, Object... args) {
         try {
             return method.invoke(server, args);


### PR DESCRIPTION
Restrict which server stop commands are available based on the type started.