### PR TITLE
[WFCORE-937] Ensure that System.out is used instead of System.console() for console logging

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -259,7 +259,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
         File standaloneDir =  new File(jbossHome, "domain");
         File configDir =  new File(standaloneDir, "configuration");
         File logDir =  new File(standaloneDir, "log");
-        File bootLog = new File(logDir, "boot.log");
+        File bootLog = new File(logDir, "server.log");
         File loggingProperties = new File(configDir, "logging.properties");
         if (loggingProperties.exists()) {
 

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
@@ -275,7 +275,7 @@ class EmbedServerHandler extends CommandHandlerWithHelp {
         File standaloneDir =  new File(jbossHome, "standalone");
         File configDir =  new File(standaloneDir, "configuration");
         File logDir =  new File(standaloneDir, "log");
-        File bootLog = new File(logDir, "boot.log");
+        File bootLog = new File(logDir, "server.log");
         File loggingProperties = new File(configDir, "logging.properties");
         if (loggingProperties.exists()) {
 

--- a/core-feature-pack/src/main/resources/content/domain/configuration/logging.properties
+++ b/core-feature-pack/src/main/resources/content/domain/configuration/logging.properties
@@ -30,10 +30,11 @@ logger.handlers=BOOT_FILE,CONSOLE
 
 # Console handler configuration
 handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
-handler.CONSOLE.properties=autoFlush
+handler.CONSOLE.properties=autoFlush,target
 handler.CONSOLE.level=${jboss.boot.server.log.console.level:INFO}
 handler.CONSOLE.autoFlush=true
 handler.CONSOLE.formatter=COLOR-PATTERN
+handler.CONSOLE.target=SYSTEM_OUT
 
 # File handler configuration
 handler.BOOT_FILE=org.jboss.logmanager.handlers.PeriodicRotatingFileHandler


### PR DESCRIPTION
Using `SYSTEM_OUT` as the target ensures that the `embed-host-controller` CLI command will not use the `System.console()` to write log messages.

The second commit just changes the `boot.log` to `server.log` for consistency. 