### PR TITLE
WFCORE-1010 standalone.sh hard codes boot log

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
@@ -114,7 +114,6 @@ echo ""
 
 $PROG_ARGS = @()
 $PROG_ARGS += $JAVA_OPTS
-$PROG_ARGS += "-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/boot.log"
 $PROG_ARGS += "-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties"
 $PROG_ARGS += "-Djboss.home.dir=$JBOSS_HOME"
 $PROG_ARGS += "-jar"

--- a/core-feature-pack/src/main/resources/content/bin/standalone.bat
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.bat
@@ -248,7 +248,6 @@ echo.
 :RESTART
 rem if x%XLOGGC% == x (
   "%JAVA%" %JAVA_OPTS% ^
-   "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\server.log" ^
    "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
       -jar "%JBOSS_HOME%\jboss-modules.jar" ^
       %MODULE_OPTS% ^
@@ -258,7 +257,6 @@ rem if x%XLOGGC% == x (
        %SERVER_OPTS%
 rem ) else (
   rem "%JAVA%" -Xloggc:%XLOGGC% %JAVA_OPTS% ^
-   rem "-Dorg.jboss.boot.log.file=%JBOSS_LOG_DIR%\server.log" ^
    rem "-Dlogging.configuration=file:%JBOSS_CONFIG_DIR%/logging.properties" ^
       rem -jar "%JBOSS_HOME%\jboss-modules.jar" ^
       rem %MODULE_OPTS% ^

--- a/core-feature-pack/src/main/resources/content/bin/standalone.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.ps1
@@ -116,7 +116,6 @@ $backgroundProcess = Get-Env LAUNCH_JBOSS_IN_BACKGROUND 'false'
 
   $PROG_ARGS = @()
   $PROG_ARGS += $JAVA_OPTS
-  $PROG_ARGS += "-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/server.log"
   $PROG_ARGS += "-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties"
   $PROG_ARGS += "-Djboss.home.dir=$JBOSS_HOME"
   $PROG_ARGS += "-jar"

--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -300,7 +300,6 @@ while true; do
    if [ "x$LAUNCH_JBOSS_IN_BACKGROUND" = "x" ]; then
       # Execute the JVM in the foreground
       eval \"$JAVA\" -D\"[Standalone]\" $JAVA_OPTS \
-         \"-Dorg.jboss.boot.log.file="$JBOSS_LOG_DIR"/server.log\" \
          \"-Dlogging.configuration=file:"$JBOSS_CONFIG_DIR"/logging.properties\" \
          -jar \""$JBOSS_HOME"/jboss-modules.jar\" \
          $MODULE_OPTS \
@@ -313,7 +312,6 @@ while true; do
    else
       # Execute the JVM in the background
       eval \"$JAVA\" -D\"[Standalone]\" $JAVA_OPTS \
-         \"-Dorg.jboss.boot.log.file="$JBOSS_LOG_DIR"/server.log\" \
          \"-Dlogging.configuration=file:"$JBOSS_CONFIG_DIR"/logging.properties\" \
          -jar \""$JBOSS_HOME"/jboss-modules.jar\" \
          $MODULE_OPTS \


### PR DESCRIPTION
The standalone.sh file hard codes the org.jboss.boot.log.file property
to server.log. This is inconvenient because it overrides the dynamic
configuration in logging.properties which is set to
${org.jboss.boot.log.file:boot.log}.

 - remove hard coding

Issue: WFCORE-1010
https://issues.jboss.org/browse/WFCORE-1010