### PR TITLE
WFCORE-1011 jboss-cli.ps1 uses wrong logging config

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
@@ -115,7 +115,7 @@ echo ""
 $PROG_ARGS = @()
 $PROG_ARGS += $JAVA_OPTS
 $PROG_ARGS += "-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/boot.log"
-$PROG_ARGS += "-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties"
+$PROG_ARGS += "-Dlogging.configuration=file:$JBOSS_HOME/bin/jboss-cli-logging.properties"
 $PROG_ARGS += "-Djboss.home.dir=$JBOSS_HOME"
 $PROG_ARGS += "-jar"
 $PROG_ARGS += "$JBOSS_HOME/jboss-modules.jar"


### PR DESCRIPTION
jboss-cli.ps1 uses logging.properties but should use
jboss-cli-logging.properties.

Issue: WFCORE-1011
https://issues.jboss.org/browse/WFCORE-1011