### PR TITLE
WFCORE-1012 Remove Tomcat modeler log configuration

### DIFF
--- a/core-feature-pack/src/main/resources/content/domain/configuration/default-server-logging.properties
+++ b/core-feature-pack/src/main/resources/content/domain/configuration/default-server-logging.properties
@@ -21,7 +21,7 @@
 #
 
 # Additional loggers to configure (the root logger is always configured)
-loggers=com.arjuna,org.jboss.as.config,org.apache.tomcat.util.modeler,sun.rmi
+loggers=com.arjuna,org.jboss.as.config,sun.rmi
 
 logger.level=INFO
 logger.handlers=CONSOLE,FILE
@@ -31,9 +31,6 @@ logger.com.arjuna.useParentHandlers=true
 
 logger.org.jboss.as.config.level=DEBUG
 logger.org.jboss.as.config.useParentHandlers=true
-
-logger.org.apache.tomcat.util.modeler.level=WARN
-logger.org.apache.tomcat.util.modeler.useParentHandlers=true
 
 logger.sun.rmi.level=WARN
 logger.sun.rmi.useParentHandlers=true

--- a/core-feature-pack/src/main/resources/content/standalone/configuration/logging.properties
+++ b/core-feature-pack/src/main/resources/content/standalone/configuration/logging.properties
@@ -21,7 +21,7 @@
 #
 
 # Additional loggers to configure (the root logger is always configured)
-loggers=com.arjuna,org.jboss.as.config,org.apache.tomcat.util.modeler,sun.rmi
+loggers=com.arjuna,org.jboss.as.config,sun.rmi
 
 logger.level=INFO
 logger.handlers=CONSOLE,FILE
@@ -31,9 +31,6 @@ logger.com.arjuna.useParentHandlers=true
 
 logger.org.jboss.as.config.level=DEBUG
 logger.org.jboss.as.config.useParentHandlers=true
-
-logger.org.apache.tomcat.util.modeler.level=WARN
-logger.org.apache.tomcat.util.modeler.useParentHandlers=true
 
 logger.sun.rmi.level=WARN
 logger.sun.rmi.useParentHandlers=true

--- a/logging/src/main/resources/subsystem-templates/logging.xml
+++ b/logging/src/main/resources/subsystem-templates/logging.xml
@@ -38,9 +38,6 @@
 	      <logger category="com.arjuna">
 	          <level name="WARN"/>
 	      </logger>
-	      <logger category="org.apache.tomcat.util.modeler">
-	          <level name="WARN"/>
-	      </logger>
 	      <logger category="org.jboss.as.config">
 	          <level name="DEBUG"/>
 	      </logger>

--- a/logging/src/test/resources/default-subsystem.xml
+++ b/logging/src/test/resources/default-subsystem.xml
@@ -38,9 +38,6 @@
     <logger category="com.arjuna">
         <level name="WARN"/>
     </logger>
-    <logger category="org.apache.tomcat.util.modeler">
-        <level name="WARN"/>
-    </logger>
     <logger category="org.jboss.as.config">
         <level name="DEBUG"/>
     </logger>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-auto-ignore.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-auto-ignore.xml
@@ -58,9 +58,6 @@
                 <logger category="com.arjuna">
                     <level name="WARN"/>
                 </logger>
-                <logger category="org.apache.tomcat.util.modeler">
-                    <level name="WARN"/>
-                </logger>
                 <logger category="org.jboss.as.config">
                     <level name="DEBUG"/>
                 </logger>
@@ -99,9 +96,6 @@
                     <append value="true"/>
                 </periodic-rotating-file-handler>
                 <logger category="com.arjuna">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="org.apache.tomcat.util.modeler">
                     <level name="WARN"/>
                 </logger>
                 <logger category="org.jboss.as.config">
@@ -153,9 +147,6 @@
                     <append value="true"/>
                 </periodic-rotating-file-handler>
                 <logger category="com.arjuna">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="org.apache.tomcat.util.modeler">
                     <level name="WARN"/>
                 </logger>
                 <logger category="org.jboss.as.config">

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
@@ -379,7 +379,6 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
         cli.sendLine("/subsystem=logging/console-handler=CONSOLE:add(level=INFO,named-formatter=COLOR-PATTERN)");
         cli.sendLine("/subsystem=logging/periodic-rotating-file-handler=FILE:add(autoflush=true,named-formatter=PATTERN,file={relative-to=jboss.server.log.dir,path=server.log},suffix=.yyyy-MM-dd,append=true)");
         cli.sendLine("/subsystem=logging/logger=com.arjuna:add(level=WARN)");
-        cli.sendLine("/subsystem=logging/logger=org.apache.tomcat.util.modeler:add(level=WARN)");
         cli.sendLine("/subsystem=logging/logger=org.jboss.as.config:add(level=DEBUG)");
         cli.sendLine("/subsystem=logging/logger=sun.rmi:add(level=WARN)");
         cli.sendLine("/subsystem=logging/logger=jacorb:add(level=WARN)");


### PR DESCRIPTION
The org.apache.tomcat.util.modeler logger is still configured in
several places. This seems to be a leftover from the days when WildFly
used Tomcat as a servlet implementation.

Issue: WFCORE-1012
https://issues.jboss.org/browse/WFCORE-1012