### PR TITLE
Add missing powershell scripts & fix existing

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/add-user.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/add-user.ps1
@@ -1,0 +1,25 @@
+#############################################################################
+#                                                                          ##
+#    WildFly Startup Script for adding users							   ##
+#                                                                          ##
+#############################################################################
+. ".\common.ps1"
+
+$JAVA_OPTS = @()
+
+# Sample JPDA settings for remote socket debugging
+#$JAVA_OPTS+="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"
+# Uncomment to override standalone and domain user location
+#$JAVA_OPTS+="-Djboss.server.config.user.dir=$JBOSS_HOME/standalone/configuration"
+#$JAVA_OPTS+="-Djboss.domain.config.user.dir=$JBOSS_HOME/domain/configuration"
+
+
+$PROG_ARGS = Get-Java-Arguments -entryModule "org.jboss.as.domain-add-user" -serverOpts $ARGS -logFileProperties $SCRIPTS_HOME\add-user.properties
+
+try{
+	pushd $JBOSS_HOME
+	& $JAVA $PROG_ARGS
+}finally{
+	popd
+	Env-Clean-Up
+}

--- a/core-feature-pack/src/main/resources/content/bin/common.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/common.ps1
@@ -1,0 +1,279 @@
+if($PSVersionTable.PSVersion.Major -lt 2) {
+    Write-Warning "This script requires PowerShell 2.0 or better; you have version $($Host.Version)."
+    return
+}
+
+$SCRIPTS_HOME = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName
+$RESOLVED_JBOSS_HOME = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.Parent.FullName
+
+
+$global:SECMGR = $false
+$global:DEBUG_MODE=$false
+$global:DEBUG_PORT=8787
+$global:RUN_IN_BACKGROUND=$false
+$global:GC_LOG=$false
+#module opts that are passed to jboss modules
+$global:MODULE_OPTS = @()
+
+# A collection of functions that are used by the other scripts
+
+Function Set-Env {
+  $key = $args[0]
+  $value = $args[1]
+  Set-Content -Path env:$key -Value $value
+}
+
+Function Get-Env {
+  $key = $args[0]
+  if( Test-Path env:$key ) {
+    return (Get-ChildItem env:$key).Value
+  }
+  return $args[1]
+}
+
+Function Get-String {
+  $value = ''
+  foreach($k in $args) {
+    $value += $k
+  }
+  return $value
+}
+
+Function String-To-Array($value) {
+  $res = @()
+  if (!$value){
+  	return $res
+  }
+  $tmpArr = $value.split()
+  
+  foreach ($str in $tmpArr) {
+    if ($str) {
+	  $res += $str
+	}
+  }
+  return $res
+}
+
+Function Display-Environment { 
+$JAVA_OPTS = Get-Java-Opts
+# Display our environment
+Write-Host "================================================================================="
+Write-Host ""
+Write-Host "  JBoss Bootstrap Environment"
+Write-Host ""
+Write-Host "  JBOSS_HOME: $JBOSS_HOME"
+Write-Host ""
+Write-Host "  JAVA: $JAVA"
+Write-Host ""
+Write-Host "  MODULE_OPTS: $MODULE_OPTS"
+Write-Host ""
+Write-Host "  JAVA_OPTS: $JAVA_OPTS"
+Write-Host ""
+Write-Host "================================================================================="
+Write-Host ""
+
+}
+
+#todo: bit funky at the moment, should probably be done via global variable
+Function Get-Java-Opts {
+	if($PRESERVE_JAVA_OPTS -ne 'true') { # if not perserve, then check for enviroment variable and use that
+		if( (Test-Path env:JAVA_OPTS)) {
+			$ops = Get-Env JAVA_OPTS
+			# This is Powershell, so split the incoming string on a space into array
+			return String-To-Array -value $ops
+			Write-Host "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
+		}
+	}
+	return $JAVA_OPTS
+}
+
+Function Display-Array($array){
+	for ($i=0; $i -lt $array.length; $i++) {
+		$v =  "$i " + $array[$i]
+		Write-Host $v
+	}
+}
+
+
+Function Get-Java-Arguments {
+Param(
+   [Parameter(Mandatory=$true)]
+   [string]$entryModule,
+   [string]$logFileProperties = "$JBOSS_CONFIG_DIR/logging.properties",
+   [string]$logFile = "$JBOSS_LOG_DIR/server.log",
+   [string[]]$serverOpts
+   
+
+) #end param
+  $JAVA_OPTS = Get-Java-Opts #takes care of looking at defind settings and/or using env:JAVA_OPTS
+
+  $PROG_ARGS = @()
+  if ($JAVA_OPTS -ne $null){
+  	$PROG_ARGS += $JAVA_OPTS
+  }  
+  $PROG_ARGS += "-Dorg.jboss.boot.log.file=$logFile"
+  $PROG_ARGS += "-Dlogging.configuration=file:$logFileProperties"
+  $PROG_ARGS += "-Djboss.home.dir=$JBOSS_HOME"
+  $PROG_ARGS += "-jar"
+  $PROG_ARGS += "$JBOSS_HOME\jboss-modules.jar"
+  if ($MODULE_OPTS -ne $null){
+  	$PROG_ARGS += $MODULE_OPTS
+  }
+  $PROG_ARGS += "-mp"
+  $PROG_ARGS += "$JBOSS_MODULEPATH"
+  $PROG_ARGS += $entryModule
+  if ($serverOpts -ne $null){
+  	$PROG_ARGS += $serverOpts
+  }
+  return $PROG_ARGS
+}
+
+Function Process-Script-Parameters {
+Param(
+   [Parameter(Mandatory=$false)]
+   [string[]]$Params   
+
+) #end param
+    $res = @()
+	for($i=0; $i -lt $Params.Count; $i++){
+		$arg = $Params[$i]
+		if ($arg -eq '--debug'){
+			$global:DEBUG_MODE=$true
+			if ($args[$i+1] -match '\d+'){ #port number can only follow --debug
+				$global:DEBUG_PORT = $Params[$i+1]
+				$i++
+				continue
+			}
+		}elseif ($arg -contains '-Djava.security.manager'){
+			Write-Warning "ERROR: The use of -Djava.security.manager has been removed. Please use the -secmgr command line argument or SECMGR=true environment variable."
+			exit
+		}elseif ($arg -eq '-secmgr'){
+			$global:SECMGR = $true
+		}elseif ($arg -eq '--background'){
+			$global:RUN_IN_BACKGROUND = $true
+		}else{
+			$res+=$arg
+		}
+	}
+	return $res
+}
+
+Function Start-WildFly-Process {
+ Param(
+   [Parameter(Mandatory=$true)]
+   [string[]] $programArguments,
+   [boolean] $runInBackground = $false   
+
+) #end param
+
+	if(($JBOSS_PIDFILE -ne '') -and (Test-Path $JBOSS_PIDFILE)) {
+		$processId = gc $JBOSS_PIDFILE
+		if ($processId -ne $null){
+			$proc = Get-Process -Id $processId -ErrorAction SilentlyContinue
+		}
+		if ($proc -ne $null){
+			Write-Warning "Looks like a server process is already running. If it isn't then, remove the $JBOSS_PIDFILE and try again"
+			return
+		}else{
+			Remove-Item $JBOSS_PIDFILE
+		}
+	}
+
+	if($runInBackground) {	
+		$process = Start-Process -FilePath $JAVA -ArgumentList $programArguments -NoNewWindow -RedirectStandardOutput $global:CONSOLE_LOG -WorkingDirectory $JBOSS_HOME -PassThru
+		$processId = $process.Id;
+		echo "Started process in background, process id: $processId" 
+		if ($JBOSS_PIDFILE -ne $null){
+			$processId >> $JBOSS_PIDFILE  	
+		}
+	} else {
+		try{
+			pushd $JBOSS_HOME
+			& $JAVA $programArguments
+		}finally{
+			popd			
+		}
+	}
+	Env-Clean-Up
+}
+
+Function Set-Global-Variables {
+PARAM(
+[Parameter(Mandatory=$true)]
+   [string]$baseDir
+)
+
+	# determine the default base dir, if not set
+	$global:JBOSS_BASE_DIR = $baseDir;
+	
+	# determine the default log dir, if not set
+	$global:JBOSS_LOG_DIR = Get-Env JBOSS_LOG_DIR $JBOSS_BASE_DIR\log
+	
+	# determine the default configuration dir, if not set
+	$global:JBOSS_CONFIG_DIR = Get-Env JBOSS_CONFIG_DIR $JBOSS_BASE_DIR\configuration
+	
+	$global:CONSOLE_LOG = $JBOSS_LOG_DIR + '\console.log'
+}
+
+Function Set-Global-Variables-Standalone {
+	$dir = Get-Env JBOSS_BASE_DIR $JBOSS_HOME\standalone
+	Set-Global-Variables -baseDir $dir
+}
+
+Function Set-Global-Variables-Domain {
+	$dir = Get-Env JBOSS_BASE_DIR $JBOSS_HOME\domain
+	Set-Global-Variables -baseDir $dir	
+}
+
+Function Env-Clean-Up {
+	[Environment]::SetEnvironmentVariable("JBOSS_HOME", $null, "Process")
+}
+
+Function Rotate-GC-Logs {
+	mv -ErrorAction SilentlyContinue $JBOSS_LOG_DIR/gc.log.0 $JBOSS_LOG_DIR/backupgc.log.0 
+	mv -ErrorAction SilentlyContinue $JBOSS_LOG_DIR/gc.log.1 $JBOSS_LOG_DIR/backupgc.log.1 
+	mv -ErrorAction SilentlyContinue $JBOSS_LOG_DIR/gc.log.2 $JBOSS_LOG_DIR/backupgc.log.2 
+	mv -ErrorAction SilentlyContinue $JBOSS_LOG_DIR/gc.log.3 $JBOSS_LOG_DIR/backupgc.log.3
+	mv -ErrorAction SilentlyContinue $JBOSS_LOG_DIR/gc.log.4 $JBOSS_LOG_DIR/backupgc.log.4
+	mv -ErrorAction SilentlyContinue $JBOSS_LOG_DIR/gc.log.*.current $JBOSS_LOG_DIR/backupgc.log.current
+}
+
+Function Check-For-GC-Log {
+	if ($global:GC_LOG){
+		$args = (,'-verbose:gc',"-Xloggc:$JBOSS_LOG_DIR/gc.log","-XX:+PrintGCDetails","-XX:+PrintGCDateStamps","-XX:+UseGCLogFileRotation","-XX:NumberOfGCLogFiles=5","-XX:GCLogFileSize=3M","-XX:-TraceClassUnloading",'-version')
+		$OutputVariable = (&$JAVA $args )  | Out-String		
+	}
+}
+
+# Setup JBOSS_HOME
+if((Test-Path env:JBOSS_HOME) -and (Test-Path (Get-Item env:JBOSS_HOME))) {# checks if env variable jboss is set and is valid folder
+  $SANITIZED_JBOSS_HOME = (Get-Item env:JBOSS_HOME).FullName
+  if($SANITIZED_JBOSS_HOME -ne $RESOLVED_JBOSS_HOME) {
+    echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
+    echo ""
+  }
+  $JBOSS_HOME=$SANITIZED_JBOSS_HOME
+} else {
+    # get the full path (without any relative bits)
+    $JBOSS_HOME=$RESOLVED_JBOSS_HOME
+}
+
+# Setup the JVM
+if (!(Test-Path env:JAVA)) {
+  if( Test-Path env:JAVA_HOME) {
+    $JAVA = (Get-ChildItem env:JAVA_HOME).Value + "\bin\java"
+  } else {
+    $JAVA = 'java'
+  }
+}
+
+# determine the default module path, if not set
+$JBOSS_MODULEPATH = Get-Env JBOSS_MODULEPATH $JBOSS_HOME\modules
+
+Set-Global-Variables-Standalone
+
+# Determine the default JBoss PID file
+$JBOSS_PIDFILE = Get-Env JBOSS_PIDFILE $SCRIPTS_HOME\process.pid
+
+[Environment]::SetEnvironmentVariable("JBOSS_HOME", $JBOSS_HOME, "Process")
+#$Env:JBOSS_HOME=$JBOSS_HOME

--- a/core-feature-pack/src/main/resources/content/bin/domain.conf.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/domain.conf.ps1
@@ -1,0 +1,74 @@
+## -*- powershell script -*- #################################################
+##                                                                          ##
+##  WildFly domain Script Configuration                                     ##
+##                                                                          ##
+##############################################################################
+#
+# Specify the location of the Java home directory (it is recommended that
+# this always be set). If set, then "%JAVA_HOME%\bin\java" will be used as
+# the Java VM executable; otherwise, "%JAVA%" will be used (see below).
+#
+# $JAVA_HOME="C:\opt\jdk1.8.0"
+
+#
+# Specify the exact Java VM executable to use - only used if JAVA_HOME is
+# not set. Default is "java".
+#
+# $JAVA="C:\opt\jdk1.8.0\bin\java"
+
+#
+# Specify options to pass to the Java VM. Note, there are some additional
+# options that are always passed by run.bat.
+#
+
+if (-Not(test-path env:JBOSS_MODULES_SYSTEM_PKGS )) {
+  $JBOSS_MODULES_SYSTEM_PKGS="org.jboss.byteman"
+}
+
+
+# Uncomment the following line to disable manipulation of JAVA_OPTS (JVM parameters)
+# $PRESERVE_JAVA_OPTS=true
+
+$JAVA_OPTS = @()
+
+# JVM memory allocation pool parameters - modify as appropriate.
+$JAVA_OPTS += '-Xms64M'
+$JAVA_OPTS += '-Xmx512M'
+
+# Reduce the RMI GCs to once per hour for Sun JVMs.
+$JAVA_OPTS += '-Dsun.rmi.dgc.client.gcInterval=3600000'
+$JAVA_OPTS += '-Dsun.rmi.dgc.server.gcInterval=3600000'
+$JAVA_OPTS += '-Djava.net.preferIPv4Stack=true'
+
+# Warn when resolving remote XML DTDs or schemas.
+$JAVA_OPTS += '-Dorg.jboss.resolver.warning=true'
+
+# Make Byteman classes visible in all module loaders
+# This is necessary to inject Byteman rules into AS7 deployments
+$JAVA_OPTS += "-Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS"
+
+# Use JBoss Modules lockless mode
+# $JAVA_OPTS += '-Djboss.modules.lockless=true'
+
+# Uncomment this to run with a security manager enabled
+# $SECMGR=$true
+
+
+
+# The ProcessController process uses its own set of java options
+if ($PROCESS_CONTROLLER_JAVA_OPTS -eq $null) {
+    $PROCESS_CONTROLLER_JAVA_OPTS=$JAVA_OPTS
+}
+
+# The HostController process uses its own set of java options
+if ($HOST_CONTROLLER_JAVA_OPTS -eq $null) {
+    $HOST_CONTROLLER_JAVA_OPTS=$JAVA_OPTS
+}
+
+# Sample JPDA settings for remote socket debuging.
+#PROCESS_CONTROLLER_JAVA_OPTS="$PROCESS_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8788,server=y,suspend=n"
+#HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+
+# Sample JPDA settings for shared memory debugging
+#PROCESS_CONTROLLER_JAVA_OPTS="$PROCESS_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
+#HOST_CONTROLLER_JAVA_OPTS="$HOST_CONTROLLER_JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"

--- a/core-feature-pack/src/main/resources/content/bin/domain.conf.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/domain.conf.ps1
@@ -36,12 +36,14 @@ $JAVA_OPTS += '-Xms64M'
 $JAVA_OPTS += '-Xmx512M'
 
 # Reduce the RMI GCs to once per hour for Sun JVMs.
-$JAVA_OPTS += '-Dsun.rmi.dgc.client.gcInterval=3600000'
-$JAVA_OPTS += '-Dsun.rmi.dgc.server.gcInterval=3600000'
+# $JAVA_OPTS += '-Dsun.rmi.dgc.client.gcInterval=3600000'
+# $JAVA_OPTS += '-Dsun.rmi.dgc.server.gcInterval=3600000'
+
+#prefer ipv4 stack
 $JAVA_OPTS += '-Djava.net.preferIPv4Stack=true'
 
 # Warn when resolving remote XML DTDs or schemas.
-$JAVA_OPTS += '-Dorg.jboss.resolver.warning=true'
+# $JAVA_OPTS += '-Dorg.jboss.resolver.warning=true'
 
 # Make Byteman classes visible in all module loaders
 # This is necessary to inject Byteman rules into AS7 deployments

--- a/core-feature-pack/src/main/resources/content/bin/domain.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/domain.ps1
@@ -4,5 +4,77 @@
 #                                                                          ##
 #############################################################################
 
-# for now just call domain.bat, so we can have complete set of ps scripts
-& .\domain.bat
+. ".\common.ps1"
+
+$SERVER_OPTS = Process-Script-Parameters -Params $ARGS
+
+# Read an optional running configuration file
+$DOMAIN_CONF = '.\domain.conf.ps1'
+$DOMAIN_CONF = Get-Env RUN_CONF $DOMAIN_CONF
+. $DOMAIN_CONF
+
+Set-Global-Variables-Domain
+
+# consolidate the host-controller and command line opts
+$HOST_CONTROLLER_OPTS=$HOST_CONTROLLER_JAVA_OPTS+$SERVER_OPTS
+# process the host-controller options
+foreach($p in $HOST_CONTROLLER_OPTS){
+	if ($p -eq $null){# odd but could happen
+		continue
+	}
+	$arg = $p.Trim()
+	if ($arg.StartsWith('-Djboss.domain.base.dir')){
+		$JBOSS_BASE_DIR=$p.Substring('-Djboss.domain.base.dir='.Length)
+	}elseif ($arg.StartsWith('-Djboss.domain.log.dir')){
+		$JBOSS_LOG_DIR=$p.Substring('-Djboss.domain.log.dir='.Length)
+	}elseif ($arg.StartsWith('-Djboss.domain.config.dir')){
+		$JBOSS_CONFIG_DIR=$p.Substring('-Djboss.domain.config.dir='.Length)
+	}
+}
+
+# If the -Djava.security.manager is found, enable the -secmgr and include a bogus security manager for JBoss Modules to replace
+# Note that HOST_CONTROLLER_JAVA_OPTS will not need to be handled here
+
+if ( $PROCESS_CONTROLLER_JAVA_OPTS -contains 'java.security.manager') {
+    echo "ERROR: The use of -Djava.security.manager has been removed. Please use the -secmgr command line argument or SECMGR=true environment variable."
+    exit
+}
+
+Display-Environment
+
+$MODULE_OPTS += "-jvm"
+$MODULE_OPTS += "$JAVA"
+$MODULE_OPTS += "-jboss-home"
+$MODULE_OPTS += "$JBOSS_HOME"
+         
+
+$PROG_ARGS = @()
+$PROG_ARGS +='-DProcessController' 
+$PROG_ARGS += $PROCESS_CONTROLLER_JAVA_OPTS
+$PROG_ARGS += "-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR\process-controller.log"
+$PROG_ARGS += "-Dlogging.configuration=file:$JBOSS_CONFIG_DIR\logging.properties"
+$PROG_ARGS += "-Djboss.home.dir=$JBOSS_HOME"
+$PROG_ARGS += "-jar"
+$PROG_ARGS += "$JBOSS_HOME\jboss-modules.jar"
+$PROG_ARGS += "-mp"
+$PROG_ARGS += $JBOSS_MODULEPATH
+$PROG_ARGS += "org.jboss.as.process-controller"
+if ($MODULE_OPTS -ne $null){
+	$PROG_ARGS += $MODULE_OPTS
+}
+$PROG_ARGS += "--"  
+$PROG_ARGS += "-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR\host-controller.log"
+$PROG_ARGS += "-Dlogging.configuration=file:$JBOSS_CONFIG_DIR\logging.properties"
+$PROG_ARGS += $HOST_CONTROLLER_JAVA_OPTS
+$PROG_ARGS += "--"  
+$PROG_ARGS += "-default-jvm"
+$PROG_ARGS += $JAVA
+if ($SERVER_OPTS -ne $null){
+	$PROG_ARGS += $SERVER_OPTS
+}
+
+ 
+$backgroundProcess = Get-Env LAUNCH_JBOSS_IN_BACKGROUND 'false'
+$runInBackGround = $global:RUN_IN_BACKGROUND -or ($backgroundProcess -eq 'true')
+
+Start-WildFly-Process -programArguments $PROG_ARGS -runInBackground $runInBackGround

--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
@@ -3,125 +3,13 @@
 #    WildFly CLI Script for interacting with the server                    ##
 #                                                                          ##
 #############################################################################
-
 $PROGNAME=$MyInvocation.MyCommand.Name
-$RESOLVED_JBOSS_HOME = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.Parent.FullName
+. ".\common.ps1"
 
+$SERVER_OPTS = Process-Script-Parameters -Params $ARGS
 
-# Common functions
-
-Function Set-Env {
-  $key = $args[0]
-  $value = $args[1]
-  Set-Content -Path env:$key -Value $value
-}
-
-Function Get-Env {
-  $key = $args[0]
-  if( Test-Path env:$key ) {
-    return (Get-ChildItem env:$key).Value
-  }
-  return $args[1]
-}
-
-Function Get-String {
-  $value = ''
-  foreach($k in $args) {
-    $value += $k
-  }
-  return $value
-}
-
-# Setup JBOSS_HOME
-if(Test-Path env:JBOSS_HOME) {
-  $SANITIZED_JBOSS_HOME = (Get-Item env:JBOSS_HOME).FullName
-  if( $SANITIZED_JBOSS_HOME -ne $RESOLVED_JBOSS_HOME) {
-    echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
-    echo ""
-  }
-  $JBOSS_HOME=$SANITIZED_JBOSS_HOME
-} else {
-    # get the full path (without any relative bits)
-    $JBOSS_HOME=$RESOLVED_JBOSS_HOME
-}
-Set-Env JBOSS_HOME $JBOSS_HOME
-
-# Read an optional running configuration file
-$STANDALONE_CONF_FILE = $JBOSS_HOME + '\bin\standalone.conf.ps1'
-$STANDALONE_CONF_FILE = Get-Env RUN_CONF $STANDALONE_CONF_FILE
-. $STANDALONE_CONF_FILE
-
-
-# Setup the JVM
-if (!(Test-Path env:JAVA)) {
-  if( Test-Path env:JAVA_HOME) {
-    $JAVA = (Get-ChildItem env:JAVA_HOME).Value + "\bin\java"
-  } else {
-    $JAVA = 'java'
-  }
-}
-
-# determine the default module path, if not set
-$JBOSS_MODULEPATH = Get-Env JBOSS_MODULEPATH $JBOSS_HOME\modules
-
-# determine the default base dir, if not set
-$JBOSS_BASE_DIR = Get-Env JBOSS_BASE_DIR $JBOSS_HOME\standalone
-
-# determine the default log dir, if not set
-$JBOSS_LOG_DIR = Get-Env JBOSS_LOG_DIR $JBOSS_BASE_DIR\log
-
-# determine the default configuration dir, if not set
-$JBOSS_CONFIG_DIR = Get-Env JBOSS_CONFIG_DIR $JBOSS_BASE_DIR\configuration
-
-# Determine the default JBoss PID file
-$JBOSS_PIDFILE = Get-Env JBOSS_PIDFILE ''
-
-$PRESERVE_JAVA_OPTS = Get-Env PRESERVE_JAVA_OPTS false
-$PREPEND_JAVA_OPTS = Get-Env PREPEND_JAVA_OPTS false
-
-
-if($PRESERVE_JAVA_OPTS -ne 'true') {
-  $JVM_OPTVERSION = ''
-
-  # Get the Java options as a string
-  $JAVA_OPTS_STRING = Get-String $JAVA_OPTS
-
-  if($JAVA_OPTS_STRING.Contains('-d64')) {
-    $JVM_OPTVERSION = '-d64'
-  } elseif ($JAVA_OPTS_STRING.Contains('-d32')) {
-    $JVM_OPTVERSION = '-d32'
-  }
-}
-
-
-# Display our environment
-echo "========================================================================="
-echo ""
-echo "  WildFly Bootstrap Environment"
-echo ""
-echo "  JBOSS_HOME: $JBOSS_HOME"
-echo ""
-echo "  JBOSS_BASE_DIR: $JBOSS_BASE_DIR"
-echo ""
-echo "  JAVA: $JAVA"
-echo ""
-echo "  JAVA_OPTS: $JAVA_OPTS"
-echo ""
-echo "  JBOSS_MODULEPATH: $JBOSS_MODULEPATH"
-echo ""
-echo "========================================================================="
-echo ""
-
-$PROG_ARGS = @()
-$PROG_ARGS += $JAVA_OPTS
-$PROG_ARGS += "-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/boot.log"
-$PROG_ARGS += "-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties"
-$PROG_ARGS += "-Djboss.home.dir=$JBOSS_HOME"
-$PROG_ARGS += "-jar"
-$PROG_ARGS += "$JBOSS_HOME/jboss-modules.jar"
-$PROG_ARGS += "-mp"
-$PROG_ARGS += "$JBOSS_MODULEPATH"
-$PROG_ARGS += "org.jboss.as.cli"
-$PROG_ARGS += $ARGS
+$PROG_ARGS = Get-Java-Arguments -entryModule "org.jboss.as.cli" -serverOpts $SERVER_OPTS -logFileProperties "$JBOSS_HOME/bin/jboss-cli-logging.properties"
 
 & $JAVA $PROG_ARGS
+
+Env-Clean-Up

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf.ps1
@@ -43,12 +43,13 @@ $JAVA_OPTS += '-Xms64M'
 $JAVA_OPTS += '-Xmx512M'
 
 # Reduce the RMI GCs to once per hour for Sun JVMs.
-$JAVA_OPTS += '-Dsun.rmi.dgc.client.gcInterval=3600000'
-$JAVA_OPTS += '-Dsun.rmi.dgc.server.gcInterval=3600000'
+#$JAVA_OPTS += '-Dsun.rmi.dgc.client.gcInterval=3600000'
+#$JAVA_OPTS += '-Dsun.rmi.dgc.server.gcInterval=3600000'
+# prefer ipv4 stack
 $JAVA_OPTS += '-Djava.net.preferIPv4Stack=true'
 
 # Warn when resolving remote XML DTDs or schemas.
-$JAVA_OPTS += '-Dorg.jboss.resolver.warning=true'
+# $JAVA_OPTS += '-Dorg.jboss.resolver.warning=true'
 
 # Make Byteman classes visible in all module loaders
 # This is necessary to inject Byteman rules into AS7 deployments

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf.ps1
@@ -9,43 +9,33 @@
 # variables that standalone.ps1 uses. It is recommended to use this file to
 # configure these variables, rather than modifying standalone.ps1 itself.
 #
-
-
-# Uncomment the following line to disable manipulation of JAVA_OPTS (JVM parameters)
-# Set-Env PRESERVE_JAVA_OPTS true
-
-if( Test-Path env:JAVA_OPTS ) {
-  $JAVA_OPTS = Get-Env JAVA_OPTS
-  echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
-
-  # This is Powershell, so split the incoming string on a space.
-  $tmpArr = $JAVA_OPTS.split()
-  $JAVA_OPTS = @('')
-  foreach ($str in $tmpArr) {
-    if ($str -ne '') {
-	  $JAVA_OPTS += $str
-	}
-  }
-  return
-}
-
 #
 # Specify the location of the Java home directory (it is recommended that
 # this always be set). If set, then "%JAVA_HOME%\bin\java" will be used as
 # the Java VM executable; otherwise, "%JAVA%" will be used (see below).
 #
-# Set-Env JAVA_HOME C:\opt\jdk1.8.0
+# $JAVA_HOME="C:\opt\jdk1.8.0"
 
 #
 # Specify the exact Java VM executable to use - only used if JAVA_HOME is
 # not set. Default is "java".
 #
-# Set-Env JAVA C:\opt\jdk1.8.0\bin\java
+# $JAVA="C:\opt\jdk1.8.0\bin\java"
 
 #
 # Specify options to pass to the Java VM. Note, there are some additional
 # options that are always passed by run.bat.
 #
+
+
+# Uncomment the following line to disable manipulation of JAVA_OPTS (JVM parameters)
+# $PRESERVE_JAVA_OPTS=true
+
+if (-Not(test-path env:JBOSS_MODULES_SYSTEM_PKGS )) {
+  $JBOSS_MODULES_SYSTEM_PKGS="org.jboss.byteman"
+}
+
+
 $JAVA_OPTS = @()
 
 # JVM memory allocation pool parameters - modify as appropriate.
@@ -62,7 +52,7 @@ $JAVA_OPTS += '-Dorg.jboss.resolver.warning=true'
 
 # Make Byteman classes visible in all module loaders
 # This is necessary to inject Byteman rules into AS7 deployments
-$JAVA_OPTS += '-Djboss.modules.system.pkgs=org.jboss.byteman'
+$JAVA_OPTS += "-Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS"
 
 # Set the default configuration file to use if -c or --server-config are not used
 #$JAVA_OPTS += '-Djboss.server.default.config=standalone.xml'
@@ -75,3 +65,8 @@ $JAVA_OPTS += '-Djboss.modules.system.pkgs=org.jboss.byteman'
 
 # Use JBoss Modules lockless mode
 # $JAVA_OPTS += '-Djboss.modules.lockless=true'
+
+# Uncomment this to run with a security manager enabled
+# $SECMGR=$true
+
+# $GC_LOG=$true

--- a/core-feature-pack/src/main/resources/content/bin/standalone.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.ps1
@@ -4,151 +4,35 @@
 #                                                                          ##
 #############################################################################
 
-$PROGNAME=$MyInvocation.MyCommand.Name
-$RESOLVED_JBOSS_HOME = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.Parent.FullName
-
-
-# A collection of functions that are used by the other scripts
-
-Function Set-Env {
-  $key = $args[0]
-  $value = $args[1]
-  Set-Content -Path env:$key -Value $value
-}
-
-Function Get-Env {
-  $key = $args[0]
-  if( Test-Path env:$key ) {
-    return (Get-ChildItem env:$key).Value
-  }
-  return $args[1]
-}
-
-Function Get-String {
-  $value = ''
-  foreach($k in $args) {
-    $value += $k
-  }
-  return $value
-}
-
-# Setup JBOSS_HOME
-if( Test-Path env:JBOSS_HOME) {
-  $SANITIZED_JBOSS_HOME = (Get-Item env:JBOSS_HOME).FullName
-  if( $SANITIZED_JBOSS_HOME -ne $RESOLVED_JBOSS_HOME) {
-    echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
-    echo ""
-  }
-  $JBOSS_HOME=$SANITIZED_JBOSS_HOME
-} else {
-    # get the full path (without any relative bits)
-    $JBOSS_HOME=$RESOLVED_JBOSS_HOME
-}
-
+. ".\common.ps1"
+$SERVER_OPTS = Process-Script-Parameters -Params $ARGS
 
 # Read an optional running configuration file
-$STANDALONE_CONF_FILE = $JBOSS_HOME + '\bin\standalone.conf.ps1'
+$STANDALONE_CONF_FILE = '.\standalone.conf.ps1'
 $STANDALONE_CONF_FILE = Get-Env RUN_CONF $STANDALONE_CONF_FILE
 . $STANDALONE_CONF_FILE
 
+Write-Debug "debug is: $global:DEBUG_MODE"
+Write-Debug "debug port: $global:DEBUG_PORT"
+Write-Debug "sec mgr: $global:SECMGR"
 
-# Setup the JVM
-if (!(Test-Path env:JAVA)) {
-  if( Test-Path env:JAVA_HOME) {
-    $JAVA = (Get-ChildItem env:JAVA_HOME).Value + "\bin\java"
-  } else {
-    $JAVA = 'java'
-  }
+if ($global:SECMGR) {
+    $MODULE_OPTS +="-secmgr";
 }
-
-# determine the default module path, if not set
-$JBOSS_MODULEPATH = Get-Env JBOSS_MODULEPATH $JBOSS_HOME\modules
-
-# determine the default base dir, if not set
-$JBOSS_BASE_DIR = Get-Env JBOSS_BASE_DIR $JBOSS_HOME\standalone
-
-# determine the default log dir, if not set
-$JBOSS_LOG_DIR = Get-Env JBOSS_LOG_DIR $JBOSS_BASE_DIR\log
-
-# determine the default configuration dir, if not set
-$JBOSS_CONFIG_DIR = Get-Env JBOSS_CONFIG_DIR $JBOSS_BASE_DIR\configuration
-
-# Determine the default JBoss PID file
-$JBOSS_PIDFILE = Get-Env JBOSS_PIDFILE ''
-
-$PRESERVE_JAVA_OPTS = Get-Env PRESERVE_JAVA_OPTS false
-$PREPEND_JAVA_OPTS = Get-Env PREPEND_JAVA_OPTS false
-
-
-if($PRESERVE_JAVA_OPTS -ne 'true') {
-  $JVM_OPTVERSION = ''
-
-  # Get the Java options as a string
-  $JAVA_OPTS_STRING = Get-String $JAVA_OPTS
-
-  if($JAVA_OPTS_STRING.Contains('-d64')) {
-    $JVM_OPTVERSION = '-d64'
-  } elseif ($JAVA_OPTS_STRING.Contains('-d32')) {
-    $JVM_OPTVERSION = '-d32'
-  }
+# Set debug settings if not already set
+if ($global:DEBUG_MODE){
+    if ($JAVA_OPTS -notcontains ('-agentlib:jdwp')){
+        $JAVA_OPTS+= "-agentlib:jdwp=transport=dt_socket,address=$global:DEBUG_PORT,server=y,suspend=n"
+    }else{
+        echo "Debug already enabled in JAVA_OPTS, ignoring --debug argument"
+    }
 }
-
-
-# Display our environment
-echo "================================================================================="
-echo ""
-echo "  WildFly Bootstrap Environment"
-echo ""
-echo "  JBOSS_HOME: $JBOSS_HOME"
-echo ""
-echo "  JBOSS_BASE_DIR: $JBOSS_BASE_DIR"
-echo ""
-echo "  JAVA: $JAVA"
-echo ""
-echo "  JAVA_OPTS: $JAVA_OPTS"
-echo ""
-echo "  JBOSS_MODULEPATH: $JBOSS_MODULEPATH"
-echo ""
-echo "================================================================================="
-echo ""
 
 $backgroundProcess = Get-Env LAUNCH_JBOSS_IN_BACKGROUND 'false'
+$runInBackGround = $global:RUN_IN_BACKGROUND -or ($backgroundProcess -eq 'true')
 
-  $PROG_ARGS = @()
-  $PROG_ARGS += $JAVA_OPTS
-  $PROG_ARGS += "-Dorg.jboss.boot.log.file=$JBOSS_LOG_DIR/server.log"
-  $PROG_ARGS += "-Dlogging.configuration=file:$JBOSS_CONFIG_DIR/logging.properties"
-  $PROG_ARGS += "-Djboss.home.dir=$JBOSS_HOME"
-  $PROG_ARGS += "-jar"
-  $PROG_ARGS += "$JBOSS_HOME\jboss-modules.jar"
-  $PROG_ARGS += "-mp"
-  $PROG_ARGS += "$JBOSS_MODULEPATH"
-  $PROG_ARGS += "org.jboss.as.standalone"
-  $PROG_ARGS += $ARGS
+Display-Environment
 
-if($JBOSS_PIDFILE -ne '') {
-  # Create the file if it doesn't exist
-  if(Test-Path $JBOSS_PIDFILE) {
-    throw "Looks like a server process is already running. If it isn't then, remove the $JBOSS_PIDFILE and try again"
-    return
-  }
+$PROG_ARGS = Get-Java-Arguments -entryModule "org.jboss.as.standalone" -serverOpts $SERVER_OPTS
 
-  New-Item $JBOSS_PIDFILE -type file
-}
-
-if($backgroundProcess -eq 'true') {
-
-  # Export the Java program so that the background job can pick that up.
-  Set-Env JB_JAVA_EXE $JAVA
-  $j = Start-Job -ScriptBlock { & $env:JB_JAVA_EXE $ARGS } -ArgumentList $PROG_ARGS
-
-}
-else {
-  & $JAVA $PROG_ARGS
-}
-
-if($JBOSS_PIDFILE -ne '') {
-  if(Test-Path $JBOSS_PIDFILE) {
-    Remove-Item $JBOSS_PIDFILE
-  }
-}
+Start-WildFly-Process -programArguments $PROG_ARGS -runInBackground $runInBackGround

--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -285,7 +285,7 @@ fi
 # Display our environment
 echo "========================================================================="
 echo ""
-echo "  JBoss Bootstrap Environment"
+echo "  WildFly Bootstrap Environment"
 echo ""
 echo "  JBOSS_HOME: $JBOSS_HOME"
 echo ""

--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -285,7 +285,7 @@ fi
 # Display our environment
 echo "========================================================================="
 echo ""
-echo "  WildFly Bootstrap Environment"
+echo "  JBoss Bootstrap Environment"
 echo ""
 echo "  JBOSS_HOME: $JBOSS_HOME"
 echo ""

--- a/core-feature-pack/src/main/resources/content/bin/vault.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/vault.ps1
@@ -1,0 +1,16 @@
+##################################################################
+#                                                               ##
+#    Vault tool script for Windows                              ##
+#                                                               ##
+##################################################################
+. ".\common.ps1"
+
+$JAVA_OPTS = @()
+
+# Sample JPDA settings for remote socket debugging
+#$JAVA_OPTS+="-agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"
+
+$PROG_ARGS = Get-Java-Arguments -entryModule "org.jboss.as.vault-tool" -serverOpts $ARGS
+& $JAVA $PROG_ARGS
+
+Env-Clean-Up


### PR DESCRIPTION
- WFCORE-745 Standalone powershell script does't support --debug and -secmgr option
- WFCORE-742 Unify linux and PowerShell scripts for jboss-cli in printing environment information
- WFCORE-744 Unify add-user script functionality in windows (powershell, bat) and linux
- WFCORE-737 PowerShell script "vault.ps1" is missing
- WFCORE-1030 PS1 scripts for standalone and domain do not survive :shutdown(restart=true)