### PR TITLE
[WFCORE-1007] Warnings about missing notification descriptions

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3190,9 +3190,8 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = 356, value = "Failed to emit notification %s")
     void failedToEmitNotification(Notification notification, @Cause Throwable cause);
 
-    @LogMessage(level = WARN)
     @Message(id = 357, value = "Notification of type %s is not described for the resource at the address %s")
-    void notificationIsNotDescribed(String type, PathAddress source);
+    String notificationIsNotDescribed(String type, PathAddress source);
 
     @Message(id = 358, value = "The resource was added at the address %s.")
     String resourceWasAdded(PathAddress address);


### PR DESCRIPTION
check that the notification is described by the resource registry at
the time emit(Notification) is called and buffer the eventual
warnings. These warnings will be logged only at the end of the operation
execution if it actually successful.

JIRA: https://issues.jboss.org/browse/WFCORE-1007