### PR TITLE
[WFCORE-1013] Allow configuration of the management UUID via system p…

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -209,6 +209,13 @@ public class HostControllerEnvironment extends ProcessEnvironment {
      */
     public static final String JBOSS_HOST_DEFAULT_CONFIG = "jboss.host.default.config";
 
+    /**
+     * The system property used to set the unique identifier for this host exposed via the
+     * {@code uuid} attribute of the root resource of the host's portion of the management resource tree.
+     * If the property is not set any previously persisted UUID will be used; otherwise a random UUID will be generated.
+     */
+    public static final String JBOSS_HOST_MANAGEMENT_UUID = "jboss.host.management.uuid";
+
     private final Map<String, String> hostSystemProperties;
     private final InetAddress processControllerAddress;
     private final Integer processControllerPort;
@@ -241,7 +248,7 @@ public class HostControllerEnvironment extends ProcessEnvironment {
     private volatile String hostControllerName;
     private final HostRunningModeControl runningModeControl;
     private final boolean securityManagerEnabled;
-    private final UUID domainUUID;
+    private final UUID hostControllerUUID;
     private final long startTime;
     private final ProcessType processType;
 
@@ -473,13 +480,14 @@ public class HostControllerEnvironment extends ProcessEnvironment {
             this.defaultJVM = null;
         }
         final Path filePath = this.domainDataDir.toPath().resolve(KERNEL_DIR).resolve(UUID_FILE);
-        UUID uuid = null;
+        UUID uuid;
         try {
-            uuid = obtainProcessUUID(filePath);
+            String sysPropUUID = hostSystemProperties.get(JBOSS_HOST_MANAGEMENT_UUID);
+            uuid = obtainProcessUUID(filePath, sysPropUUID);
         } catch(IOException ex) {
             throw HostControllerLogger.ROOT_LOGGER.couldNotObtainDomainUuid(ex, filePath);
         }
-        this.domainUUID = uuid;
+        this.hostControllerUUID = uuid;
         this.backupDomainFiles = backupDomainFiles;
         this.useCachedDc = useCachedDc;
         this.productConfig = productConfig;
@@ -846,6 +854,6 @@ public class HostControllerEnvironment extends ProcessEnvironment {
 
     @Override
     public UUID getInstanceUuid() {
-        return this.domainUUID;
+        return this.hostControllerUUID;
     }
 }

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -255,6 +255,13 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
     public static final String JBOSS_SERVER_DEFAULT_CONFIG = "jboss.server.default.config";
 
     /**
+     * The system property used to set the unique identifier for this server exposed via the
+     * {@code uuid} attribute of the server's root management resource. If the property is not
+     * set any previously persisted UUID will be used; otherwise a random UUID will be generated.
+     */
+    public static final String JBOSS_SERVER_MANAGEMENT_UUID = "jboss.server.management.uuid";
+
+    /**
      * The system property used to indicate whether the server was configured to persist changes to the configuration
      * files.
      *
@@ -270,7 +277,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
     private static final Set<String> ILLEGAL_PROPERTIES = new HashSet<String>(Arrays.asList(DOMAIN_BASE_DIR,
             DOMAIN_CONFIG_DIR, JAVA_EXT_DIRS, HOME_DIR, "modules.path", SERVER_BASE_DIR, SERVER_CONFIG_DIR,
             SERVER_DATA_DIR, SERVER_DEPLOY_DIR, SERVER_LOG_DIR, BOOTSTRAP_MAX_THREADS, CONTROLLER_TEMP_DIR,
-            JBOSS_SERVER_DEFAULT_CONFIG, JBOSS_PERSIST_SERVER_CONFIG));
+            JBOSS_SERVER_DEFAULT_CONFIG, JBOSS_PERSIST_SERVER_CONFIG, JBOSS_SERVER_MANAGEMENT_UUID));
     /** Properties that can only be set via {@link #systemPropertyUpdated(String, String)} during server boot. */
     private static final Set<String> BOOT_PROPERTIES = new HashSet<String>(Arrays.asList(BUNDLES_DIR, SERVER_TEMP_DIR,
             NODE_NAME, SERVER_NAME, HOST_NAME, QUALIFIED_HOST_NAME));
@@ -554,9 +561,10 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
         }
         allowModelControllerExecutor = allowExecutor;
         final Path filePath = this.serverDataDir.toPath().resolve(KERNEL_DIR).resolve(UUID_FILE);
-        UUID uuid = null;
+        UUID uuid;
         try {
-            uuid = obtainProcessUUID(filePath);
+            String sysPropUUID = props.getProperty(JBOSS_SERVER_MANAGEMENT_UUID);
+            uuid = obtainProcessUUID(filePath, sysPropUUID);
         } catch(IOException ex) {
             throw ServerLogger.ROOT_LOGGER.couldNotObtainServerUuidFile(ex, filePath);
         }


### PR DESCRIPTION
…roperty

This creates two new system properties that can be used to set the value of the 'uuid' attribute returned by a server's root resource or by the root of a particular host's portion of the domain resource tree.

jboss.host.management.uuid -- sets the HC's uuid
jboss.server.management.uuid -- sets a server's uuid

Different properties are used for HCs and servers in order to avoid a problem where setting the property for the HC results in it getting passed to all servers launched by the HC as well, with the affect that multiple processes will have the same id.