### PR TITLE
[WFCORE-987]:  java.lang.StringIndexOutOfBoundsException when empty string is used in a resource address value.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PathElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/PathElement.java
@@ -77,7 +77,7 @@ public class PathElement {
             final String element = key + "=" + value;
             throw new OperationClientIllegalArgumentException(ControllerLogger.ROOT_LOGGER.invalidPathElementKey(element, key));
         }
-        if (value == null) {
+        if (value == null || value.isEmpty()) {
             final String element = key + "=" + value;
             throw new OperationClientIllegalArgumentException(ControllerLogger.ROOT_LOGGER.invalidPathElementValue(element, value, ' '));
         }

--- a/controller/src/test/java/org/jboss/as/controller/PathElementTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/PathElementTestCase.java
@@ -77,4 +77,19 @@ public class PathElementTestCase {
             }
     }
 
+    @Test
+    public void invalidValue() {
+        String[] invalidValues = {
+            null,
+            ""
+        };
+        for (String value : invalidValues) {
+            try {
+                PathElement.pathElement("key", value);
+                fail("value " + value + " should be invalid");
+            } catch (IllegalArgumentException e) {
+                // should reach here
+            }
+        }
+    }
 }


### PR DESCRIPTION
Considering empty string as null.

Jira: https://issues.jboss.org/browse/WFCORE-987