### PR TITLE
[WFCORE-935] Allow byteman tests to run on IPv6 addresses.

### DIFF
--- a/deployment-scanner/pom.xml
+++ b/deployment-scanner/pom.xml
@@ -36,6 +36,11 @@
 
     <name>WildFly: Deployment Scanner</name>
 
+    <properties>
+        <byteman.host>127.0.0.1</byteman.host>
+        <byteman.port>9091</byteman.port>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -53,10 +58,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar}</argLine>
+                    <argLine>-javaagent:${org.jboss.byteman:byteman:jar}=port:${byteman.port},address:${byteman.host},boot:${org.jboss.byteman:byteman:jar}</argLine>
                     <systemPropertyVariables>
                         <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
-                        <org.jboss.byteman.contrib.bmunit.agent.port>9091</org.jboss.byteman.contrib.bmunit.agent.port>
+                        <org.jboss.byteman.debug>true</org.jboss.byteman.debug>
+                        <org.jboss.byteman.contrib.bmunit.agent.host>${byteman.host}</org.jboss.byteman.contrib.bmunit.agent.host>
+                        <org.jboss.byteman.contrib.bmunit.agent.port>${byteman.port}</org.jboss.byteman.contrib.bmunit.agent.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -138,5 +145,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- profile is the same name as the test IPv6 profile for consistency and in case the profile is enabled via
+        the profile name rather than the system property. -->
+        <profile>
+            <id>ts.ipv6</id>
+            <activation>
+                <property>
+                    <name>ipv6</name>
+                </property>
+            </activation>
+            <properties>
+                <byteman.host>::1</byteman.host>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -37,6 +37,11 @@
 
     <name>WildFly: Logging Subsystem</name>
 
+    <properties>
+        <byteman.host>127.0.0.1</byteman.host>
+        <byteman.port>9091</byteman.port>
+    </properties>
+
     <build>
         <plugins>
             <!-- this is only needed on windows -->
@@ -58,11 +63,14 @@
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <!-- the log manager needs to be setup before the agent this is only needed on windows!-->
                     <argLine>-Xbootclasspath/a:"${org.jboss.logmanager:jboss-logmanager:jar}"
-                        -javaagent:"${org.jboss.byteman:byteman:jar}"=port:9091,boot:"${org.jboss.byteman:byteman:jar}"
+                        -javaagent:"${org.jboss.byteman:byteman:jar}"=port:${byteman.port},address:${byteman.host},boot:"${org.jboss.byteman:byteman:jar}"
                     </argLine>
                     <systemPropertyVariables>
                         <jboss.server.log.dir>${project.build.directory}${file.separator}logs</jboss.server.log.dir>
                         <jboss.server.config.dir>${project.build.directory}${file.separator}config</jboss.server.config.dir>
+                        <org.jboss.byteman.debug>true</org.jboss.byteman.debug>
+                        <org.jboss.byteman.contrib.bmunit.agent.host>${byteman.host}</org.jboss.byteman.contrib.bmunit.agent.host>
+                        <org.jboss.byteman.contrib.bmunit.agent.port>${byteman.port}</org.jboss.byteman.contrib.bmunit.agent.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -206,5 +214,21 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <!-- profile is the same name as the test IPv6 profile for consistency and in case the profile is enabled via
+        the profile name rather than the system property. -->
+        <profile>
+            <id>ts.ipv6</id>
+            <activation>
+                <property>
+                    <name>ipv6</name>
+                </property>
+            </activation>
+            <properties>
+                <byteman.host>::1</byteman.host>
+            </properties>
+        </profile>
+    </profiles>
 
 </project>

--- a/patching/pom.xml
+++ b/patching/pom.xml
@@ -36,6 +36,11 @@
 
     <name>WildFly: Patching Core</name>
 
+    <properties>
+        <byteman.host>127.0.0.1</byteman.host>
+        <byteman.port>9091</byteman.port>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -64,11 +69,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                     <argLine>-javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar} -Dorg.jboss.byteman.debug=true</argLine>
+                     <argLine>-javaagent:${org.jboss.byteman:byteman:jar}=port:${byteman.port},address:${byteman.host},boot:${org.jboss.byteman:byteman:jar} -Dorg.jboss.byteman.debug=true</argLine>
                     <systemPropertyVariables>
                         <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
                         <org.jboss.byteman.debug>true</org.jboss.byteman.debug>
-                        <org.jboss.byteman.contrib.bmunit.agent.port>9091</org.jboss.byteman.contrib.bmunit.agent.port>
+                        <org.jboss.byteman.contrib.bmunit.agent.host>${byteman.host}</org.jboss.byteman.contrib.bmunit.agent.host>
+                        <org.jboss.byteman.contrib.bmunit.agent.port>${byteman.port}</org.jboss.byteman.contrib.bmunit.agent.port>
                         <org.wildfly.patching.jar.invalidation>true</org.wildfly.patching.jar.invalidation>
                     </systemPropertyVariables>
                 </configuration>
@@ -158,4 +164,20 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <!-- profile is the same name as the test IPv6 profile for consistency and in case the profile is enabled via
+        the profile name rather than the system property. -->
+        <profile>
+            <id>ts.ipv6</id>
+            <activation>
+                <property>
+                    <name>ipv6</name>
+                </property>
+            </activation>
+            <properties>
+                <byteman.host>::1</byteman.host>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Allows tests to run in IPv6 only environments. Used the same `ts.ipv6` profile and `ipv6` property to enable to the profile.