### PR TITLE
WFLY-4959 add a log message at INFO level that SM is enabled

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -110,6 +110,9 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
         final ProductConfig config = environment.getProductConfig();
         final String prettyVersion = config.getPrettyVersionString();
         ServerLogger.AS_ROOT_LOGGER.serverStarting(prettyVersion);
+        if (System.getSecurityManager() != null) {
+            ServerLogger.AS_ROOT_LOGGER.securityManagerEnabled();
+        }
         if (ServerLogger.CONFIG_LOGGER.isDebugEnabled()) {
             final Properties properties = System.getProperties();
             final StringBuilder b = new StringBuilder(8192);

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -99,6 +99,9 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         final ProductConfig config = serverEnvironment.getProductConfig();
         final String prettyVersion = config.getPrettyVersionString();
         ServerLogger.AS_ROOT_LOGGER.serverStarting(prettyVersion);
+        if (System.getSecurityManager() != null) {
+            ServerLogger.AS_ROOT_LOGGER.securityManagerEnabled();
+        }
         if (ServerLogger.CONFIG_LOGGER.isDebugEnabled()) {
             final Properties properties = System.getProperties();
             final StringBuilder b = new StringBuilder(8192);

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1165,4 +1165,12 @@ public interface ServerLogger extends BasicLogger {
 
     @Message(id = 234, value = "Deployed \"%s\" (runtime-name : \"%s\")")
     String deploymentDeployedNotification(String managementName, String deploymentUnitName);
+
+    /**
+     * Logs an informational message indicating the Security Manager is in force.
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 235, value = "Security Manager is enabled")
+    void securityManagerEnabled();
+
 }


### PR DESCRIPTION
This introduces a new INFO log message that Security Manager is enabled.

https://issues.jboss.org/browse/WFLY-4959