### PR TITLE
[WFCORE-1026] Upgrade jboss-logmanager from 2.0.0.Final to 2.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <version.org.jboss.jboss-vfs>3.2.9.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.logmanager.jboss-logmanager>2.0.0.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.0.1.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>1.4.10.Final</version.org.jboss.marshalling.jboss-marshalling>
         <!-- this is test only dependancy -->


### PR DESCRIPTION
The new version contains a single fix for https://issues.jboss.org/browse/LOGMGR-122.