### PR TITLE
Increase syslog test timeout

### DIFF
--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogSyslogReconnectTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogSyslogReconnectTestCase.java
@@ -49,7 +49,7 @@ public class AuditLogSyslogReconnectTestCase extends AbstractAuditLogHandlerTest
 
     @Test
     public void testAutoReconnect() throws Exception {
-        final int timeoutSeconds = 2;
+        final int timeoutSeconds = 5;
         ModelNode op = createAddSyslogHandlerTcpOperation("syslog", "test-formatter", InetAddress.getByName("localhost"), SYSLOG_PORT, null, MessageTransfer.OCTET_COUNTING);
         op.get(STEPS).asList().get(0).get(SyslogAuditLogHandlerResourceDefinition.MAX_FAILURE_COUNT.getName()).set(3);
         op.get(STEPS).asList().get(1).get(SyslogAuditLogProtocolResourceDefinition.Tcp.RECONNECT_TIMEOUT.getName()).set(timeoutSeconds);

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <version.org.jboss.jboss-vfs>3.2.9.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.logmanager.jboss-logmanager>2.0.0.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.0.2.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>1.4.10.Final</version.org.jboss.marshalling.jboss-marshalling>
         <!-- this is test only dependancy -->


### PR DESCRIPTION
THis includes @jamezp https://github.com/wildfly/wildfly-core/pull/1140 and increase the timeout since with 1140 on its own we saw some problems