### PR TITLE
[WFCORE-628] Transform the 'query' operation for use on slaves running < WildFly 9

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
@@ -29,6 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAI
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.QUERY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
@@ -304,7 +305,9 @@ public class ProxyStepHandler implements OperationStepHandler {
         // so that's proxied controllers running kernel version 1.x or 2.x
         if (proxyController.getKernelModelVersion().getMajor() < 3 && address.size() > 1) {
             String opName = operation.get(OP).asString();
-            if (READ_RESOURCE_OPERATION.equals(opName) || READ_ATTRIBUTE_OPERATION.equals(opName)
+            if (READ_RESOURCE_OPERATION.equals(opName)
+                    || READ_ATTRIBUTE_OPERATION.equals(opName)
+                    || QUERY.equals(opName)
                     || (READ_RESOURCE_DESCRIPTION_OPERATION.equals(opName) && address.size() >= 2)) {
                 PathElement pe = address.getElement(1);
                 return pe.isMultiTarget() && RUNNING_SERVER.equals(pe.getKey());

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3367,4 +3367,13 @@ public interface ControllerLogger extends BasicLogger {
     @LogMessage(level = Level.WARN)
     @Message(id = 405, value = "Couldn't find a transformer to %s, falling back to %s")
     void couldNotFindTransformerRegistryFallingBack(ModelVersion currentVersion, ModelVersion fallbackVersion);
+
+    /**
+     * Creates an exception indicating that an attribute could not be converted to the type required by a query select
+     *
+     * @param attribute the name of the attribute
+     * @param type the required type
+     */
+    @Message(id = 406, value = "Could not convert the attribute '%s' to a %s")
+    OperationFailedException selectFailedCouldNotConvertAttributeToType(String attribute, ModelType type);
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/QueryOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/QueryOperationHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.controller.operations.global;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATOR;
@@ -34,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.MapAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
@@ -47,9 +49,13 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.transform.OperationResultTransformer;
+import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
@@ -155,9 +161,12 @@ public final class QueryOperationHandler extends GlobalOperationHandlers.Abstrac
                                 try {
                                     filterAndReduce(filter, operator, select, result);
                                 } catch (OperationFailedException e) {
-                                    context.getFailureDescription().set(e.getMessage());
+                                    if (!context.hasFailureDescription()) {
+                                        context.getFailureDescription().set(e.getMessage());
+                                    } // else there already was a failure; don't overwrite its message
                                 }
-                            }
+                            } // else there is no filter to run, and 'reduce' will only run when
+                              // the filtered result is defined, so no point calling filterAndReduce
 
                         }
                     }
@@ -274,8 +283,89 @@ public final class QueryOperationHandler extends GlobalOperationHandlers.Abstrac
                     outcome.get(name).set(value);
                 }
             }
-
             return outcome;
+        }
+    }
+
+    /**
+     * Transformer for this operation for slave Host Controllers running versions prior to
+     * WildFly Core 1.0 (i.e. AS 7, EAP 6 and WildFly 8).
+     */
+    public static final OperationTransformer TRANSFORMER = new OperationTransformer() {
+        @Override
+        public TransformedOperation transformOperation(TransformationContext context, PathAddress address, ModelNode operation) throws OperationFailedException {
+            ModelNode transformedOp = Util.createEmptyOperation(READ_RESOURCE_OPERATION, address);
+            transformedOp.get(INCLUDE_RUNTIME).set(true);
+            ResultTransformer rt = new ResultTransformer(operation, address);
+            return new TransformedOperation(transformedOp, rt);
+        }
+    };
+
+    private static class ResultTransformer implements OperationResultTransformer {
+
+        private final boolean multiTarget;
+        private final ModelNode filter;
+        private final Operator operator;
+        private final ModelNode select;
+
+        private ResultTransformer(ModelNode operation, PathAddress address) {
+            this.multiTarget = address.isMultiTarget();
+            try {
+                this.filter = WHERE_ATT.validateOperation(operation);
+                this.select = SELECT_ATT.validateOperation(operation);
+                // Use resolveModelAttribute for OPERATOR_ATT to pull out the default value
+                this.operator = Operator.valueOf(OPERATOR_ATT.resolveModelAttribute(ExpressionResolver.SIMPLE, operation).asString());
+            } catch (OperationFailedException e) {
+                // the validateOperation calls above would have already been invoked in QueryOperationHandler.execute
+                // so this shouldn't happen
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Override
+        public ModelNode transformResult(ModelNode response) {
+            ControllerLogger.MGMT_OP_LOGGER.tracef("Transforming response %s", response);
+            ModelNode transformedResponse;
+            if (response.hasDefined(RESULT)) {
+                transformedResponse = response.clone();
+                if (multiTarget) {
+                    ModelNode transformedResults = transformedResponse.get(RESULT);
+                    for (int i = 0; i < transformedResults.asInt(); i++) {
+                        ModelNode item = transformedResults.get(i);
+                        transformResponseItem(item);
+                        if (!item.hasDefined(RESULT)) {
+                            // An undefined result means this one was filtered
+                            // If "query" had actually run on the remote slave, this
+                            // would not be in response, so we remove it now
+                            transformedResults.remove(i);
+                            i--;
+                            ControllerLogger.MGMT_OP_LOGGER.tracef("Removed response item %s", item);
+                        }
+                    }
+                } else {
+                    transformResponseItem(transformedResponse);
+                }
+                ControllerLogger.MGMT_OP_LOGGER.tracef("Transformed response is %s", transformedResponse);
+            } else {
+                // no transformation is needed
+                transformedResponse = response;
+            }
+            return transformedResponse;
+        }
+
+        private void transformResponseItem(ModelNode responseItem) {
+            if (responseItem.hasDefined(RESULT) || filter.isDefined()) {
+                ModelNode result = responseItem.get(RESULT);
+                try {
+                    FilterReduceHandler.filterAndReduce(filter, operator, select, result);
+                    ControllerLogger.MGMT_OP_LOGGER.tracef("Transformed response item to %s", responseItem);
+                } catch (OperationFailedException e) {
+                    if (!responseItem.hasDefined(FAILURE_DESCRIPTION)) {
+                        responseItem.get(FAILURE_DESCRIPTION).set(e.getMessage());
+                    }  // else there already was a failure; don't overwrite its message
+                }
+            } // else there is no filter to run, and 'reduce' will only run when
+              // the filtered result is defined, so no point calling filterAndReduce
         }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/QueryOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/QueryOperationHandler.java
@@ -69,6 +69,7 @@ public final class QueryOperationHandler extends GlobalOperationHandlers.Abstrac
     public static final PropertiesAttributeDefinition WHERE_ATT = new PropertiesAttributeDefinition.Builder(ModelDescriptionConstants.WHERE, true)
             .setCorrector(MapAttributeDefinition.LIST_TO_MAP_CORRECTOR)
             .setValidator(new StringLengthValidator(1, true, true))
+            .setAllowExpression(true)
             .build();
 
     private static final AttributeDefinition OPERATOR_ATT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.OPERATOR, ModelType.STRING)

--- a/controller/src/main/java/org/jboss/as/controller/transform/OperationResultTransformer.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/OperationResultTransformer.java
@@ -25,7 +25,8 @@ package org.jboss.as.controller.transform;
 import org.jboss.dmr.ModelNode;
 
 /**
- * Transformer for the operation result.
+ * Transformer for the operation response. Despite the name of this interface, the transformation
+ * is applied to the entire response node, not just any {@code result} field in that node.
  *
 * @author Emanuel Muckenhuber
 */
@@ -34,16 +35,16 @@ public interface OperationResultTransformer {
     /**
      * Transform the operation result.
      *
-     * @param result the operation result
-     * @return the transformed result
+     * @param response the operation response, including any {@code outcome}
+     * @return the transformed response
      */
-    ModelNode transformResult(ModelNode result);
+    ModelNode transformResult(ModelNode response);
 
     OperationResultTransformer ORIGINAL_RESULT = new OperationResultTransformer() {
 
         @Override
-        public ModelNode transformResult(ModelNode result) {
-            return result;
+        public ModelNode transformResult(ModelNode response) {
+            return response;
         }
 
     };

--- a/controller/src/main/java/org/jboss/as/controller/transform/TransformationTargetImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/TransformationTargetImpl.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.global.QueryOperationHandler;
 import org.jboss.as.controller.registry.OperationTransformerRegistry;
 import org.jboss.as.controller.registry.OperationTransformerRegistry.PlaceholderResolver;
 
@@ -144,6 +145,9 @@ public class TransformationTargetImpl implements TransformationTarget {
             if(ModelDescriptionConstants.COMPOSITE.equals(operationName)) {
                 return new CompositeOperationTransformer();
             }
+        }
+        if (version.getMajor() < 3 && ModelDescriptionConstants.QUERY.equals(operationName)) { // TODO use transformer inheritance and register this normally
+            return QueryOperationHandler.TRANSFORMER;
         }
         final OperationTransformerRegistry.OperationTransformerEntry entry = registry.resolveOperationTransformer(address, operationName, placeholderResolver);
         return entry.getTransformer();


### PR DESCRIPTION
Legacy slaves will not understand the new 'query' operation added in WF 9 / Core 1.0. This PR fixes this by adding a transformer for legacy kernel version prior to major version 3 (i.e. WF 8 and earlier). The transformer converts the query op to a read-resource and then uses an OperationResultTransformer to do the filter and select work on the DC side that the normal query op does on the remote side.

In the description of WFCORE-628 I mentioned an issue with this task is that the 'query' operation is global, so there would need to be some notion of inherited transformers, with the transformer for this registered that way. It looks like there is already some notion of an inherited transformer (see OperationTransformerEntry.isInherited()) but the hooks to register this transformer that way are not completely in place. To keep this simple, I decided not to deal with that and just did a simple hack to get the transformer in place. See the diff to TransformationTargetImpl.

https://github.com/wildfly/wildfly/pull/8247 is the test part of this work.