### PR TITLE
[WFCORE-997] Override the optional createSocket methods and pass these calls onto the delegate.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/connections/ldap/ThreadLocalSSLSocketFactory.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/connections/ldap/ThreadLocalSSLSocketFactory.java
@@ -22,6 +22,7 @@
 package org.jboss.as.domain.management.connections.ldap;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 
@@ -109,6 +110,14 @@ public class ThreadLocalSSLSocketFactory extends SSLSocketFactory {
     @Override
     public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
         return delegate.createSocket(address, port, localAddress, localPort);
+    }
+
+    public Socket createSocket(Socket s, InputStream consumed, boolean autoClose) throws IOException {
+        return delegate.createSocket(s, consumed, autoClose);
+    }
+
+    public Socket createSocket() throws IOException {
+        return delegate.createSocket();
     }
 
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/WrapperSSLContext.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/WrapperSSLContext.java
@@ -23,6 +23,7 @@
 package org.jboss.as.domain.management.security;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -162,6 +163,18 @@ class WrapperSSLContext extends SSLContext {
             public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
                     throws IOException {
                 Socket socket = wrapped.createSocket(address, port, localAddress, localPort);
+                setSslParams(socket);
+                return socket;
+            }
+
+            public Socket createSocket(Socket s, InputStream consumed, boolean autoClose) throws IOException {
+                Socket socket = wrapped.createSocket(s, consumed, autoClose);
+                setSslParams(socket);
+                return socket;
+            }
+
+            public Socket createSocket() throws IOException {
+                Socket socket = wrapped.createSocket();
                 setSslParams(socket);
                 return socket;
             }


### PR DESCRIPTION
This enables the use of standard timeout settings for outbound LDAPS connections.