### PR TITLE
[WFCORE-1062]:  Deployments from the domain/data/content folder goes missing after few minutes if the Host controller is started with --backup option.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
@@ -128,7 +128,7 @@ class FilePersistenceUtils {
     }
 
     private static List<FileAttribute<Set<PosixFilePermission>>> getPosixAttributes(Path file) throws IOException {
-        if (Files.getFileStore(file).supportsFileAttributeView(PosixFileAttributeView.class)) {
+        if (Files.exists(file) && Files.getFileStore(file).supportsFileAttributeView(PosixFileAttributeView.class)) {
             PosixFileAttributeView posixView = Files.getFileAttributeView(file, PosixFileAttributeView.class);
             if (posixView != null) {
                 return Collections.singletonList(PosixFilePermissions.asFileAttribute(posixView.readAttributes().permissions()));
@@ -138,7 +138,7 @@ class FilePersistenceUtils {
     }
 
     private static List<FileAttribute<List<AclEntry>>> getAclAttributes(Path file) throws IOException {
-        if (Files.getFileStore(file).supportsFileAttributeView(AclFileAttributeView.class)) {
+        if (Files.exists(file) && Files.getFileStore(file).supportsFileAttributeView(AclFileAttributeView.class)) {
             AclFileAttributeView aclView = Files.getFileAttributeView(file, AclFileAttributeView.class);
             if (aclView != null) {
                 final List<AclEntry> entries = aclView.getAcl();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
@@ -56,8 +56,8 @@ public class DeploymentAddHandler implements OperationStepHandler {
     private final HostFileRepository fileRepository;
 
     /** Constructor for a slave Host Controller */
-    public DeploymentAddHandler(final HostFileRepository fileRepository) {
-        this.contentRepository = null;
+    public DeploymentAddHandler(final HostFileRepository fileRepository, final ContentRepository contentRepository) {
+        this.contentRepository = contentRepository;
         this.fileRepository = fileRepository;
     }
 
@@ -104,7 +104,7 @@ public class DeploymentAddHandler implements OperationStepHandler {
             // If we are the master, validate that we actually have this content. If we're not the master
             // we do not need the content until it's added to a server group we care about, so we defer
             // pulling it until then
-            if (contentRepository != null && !contentRepository.hasContent(hash)) {
+            if (fileRepository == null && contentRepository != null && !contentRepository.hasContent(hash)) {
                 if (context.isBooting()) {
                     if (context.getRunningMode() == RunningMode.ADMIN_ONLY) {
                         // The deployment content is missing, which would be a fatal boot error if we were going to actually
@@ -121,7 +121,7 @@ public class DeploymentAddHandler implements OperationStepHandler {
                 fileRepository.getDeploymentFiles(ModelContentReference.fromModelAddress(address, hash));
             }
         } else if (DeploymentHandlerUtils.hasValidContentAdditionParameterDefined(contentItemNode)) {
-            if (contentRepository == null) {
+            if (fileRepository != null || contentRepository == null) {
                 // This is a slave DC. We can't handle this operation; it should have been fixed up on the master DC
                 throw createFailureException(DomainControllerLogger.ROOT_LOGGER.slaveCannotAcceptUploads());
             }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainDeploymentResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainDeploymentResourceDefinition.java
@@ -55,7 +55,7 @@ class DomainDeploymentResourceDefinition extends DeploymentResourceDefinition {
     public static DomainDeploymentResourceDefinition createForDomainSlave(boolean backupDC, HostFileRepository fileRepository, ContentRepository contentRepository) {
         return new DomainDeploymentResourceDefinition(DeploymentResourceParent.DOMAIN,
                 DeploymentAttributes.DOMAIN_DEPLOYMENT_ADD_DEFINITION,
-                new DeploymentAddHandler(backupDC ? fileRepository : null),
+                backupDC ? new DeploymentAddHandler(fileRepository, contentRepository) :  new DeploymentAddHandler(null, null),
                 DeploymentRemoveHandler.createForSlave(fileRepository, contentRepository));
     }
 

--- a/server/src/main/java/org/jboss/as/server/deployment/ContentCleanerService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/ContentCleanerService.java
@@ -21,6 +21,11 @@
 package org.jboss.as.server.deployment;
 
 
+import static java.lang.Long.getLong;
+import static java.lang.System.getSecurityManager;
+import static java.security.AccessController.doPrivileged;
+
+import java.security.PrivilegedAction;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -41,10 +46,18 @@ import org.jboss.as.server.Services;
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2014 Red Hat, inc.
  */
 public class ContentCleanerService implements Service<Void> {
+
+   /**
+     * For testing purpose only.
+     *
+     * @deprecated DON'T USE IT.
+     */
+    @Deprecated
+    private static final String UNSUPPORTED_PROPERTY = "org.wildfly.unsupported.content.repository.obsolescence";
     /**
      * The conten repository cleaner will test content for clean-up every 5 minutes.
      */
-    public static final long DEFAULT_INTERVAL = 300000L;
+    public static final long DEFAULT_INTERVAL = getSecurityManager() == null ? getLong(UNSUPPORTED_PROPERTY, 300000L) : doPrivileged((PrivilegedAction<Long>) () -> getLong(UNSUPPORTED_PROPERTY, 300000L));
     /**
      * Standard ServiceName under which a service controller for an instance of
      * @code Service<ContentRepository> would be registered.


### PR DESCRIPTION
When the HC is in backup mode it needs to reference every content it downloads from the DC otherwise those would get deleted by the GC.
Thus we provide the ContentRepository of the HC in the DeploymentAddHandler with the RemoteFileRepository when we have a backup.

Jira: https://issues.jboss.org/browse/WFCORE-1062