### PR TITLE
Pull #1198 plus WFCORE-1080

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -104,12 +104,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- added here as it is dep of wildfly-embedded any only needs 2 constants at compile time -->
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-process-controller</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <!-- added here as it is dep of embedded and needs to be included in shaded jar-->
         <dependency>
             <groupId>org.jboss.msc</groupId>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -96,6 +96,24 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-embedded</artifactId>
+            <exclusions>
+                <!-- so its dependencies are not included in shaded jar -->
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- added here as it is dep of wildfly-embedded any only needs 2 constants at compile time -->
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-process-controller</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- added here as it is dep of embedded and needs to be included in shaded jar-->
+        <dependency>
+            <groupId>org.jboss.msc</groupId>
+            <artifactId>jboss-msc</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
@@ -146,11 +164,18 @@
            <groupId>org.jboss</groupId>
            <artifactId>jboss-vfs</artifactId>
         </dependency>
+        <!-- here so it is included in shaded jar-->
+        <dependency>
+            <groupId>org.jboss.stdio</groupId>
+            <artifactId>jboss-stdio</artifactId>
+        </dependency>
 
         <dependency>
-           <groupId>org.picketbox</groupId>
-           <artifactId>picketbox</artifactId>
+            <groupId>org.picketbox</groupId>
+            <artifactId>picketbox</artifactId>
             <optional>true</optional>
+            <!-- so it is not included in shaded jar  -->
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -47,7 +47,6 @@ import org.jboss.as.cli.impl.FileSystemPathArgument;
 import org.jboss.as.cli.operation.ParsedCommandLine;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.ClientConstants;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.process.CommandLineConstants;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.dmr.ModelNode;
@@ -194,9 +193,9 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
 
                 final ModelNode getStateOp = new ModelNode();
                 getStateOp.get(ClientConstants.OP).set(ClientConstants.READ_ATTRIBUTE_OPERATION);
-                ModelNode address = getStateOp.get(ModelDescriptionConstants.ADDRESS);
+                ModelNode address = getStateOp.get(ClientConstants.ADDRESS);
                 address.add(ClientConstants.HOST, localName);
-                getStateOp.get(ClientConstants.NAME).set(ModelDescriptionConstants.HOST_STATE);
+                getStateOp.get(ClientConstants.NAME).set(ClientConstants.HOST_STATE);
                 do {
                     try {
                         final ModelNode nameResponse = mcc.execute(getNameOp);

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -47,7 +47,6 @@ import org.jboss.as.cli.impl.FileSystemPathArgument;
 import org.jboss.as.cli.operation.ParsedCommandLine;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.ClientConstants;
-import org.jboss.as.process.CommandLineConstants;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logmanager.LogContext;
@@ -68,6 +67,8 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
 
     private static final String ECHO = "echo";
     private static final String DISCARD_STDOUT = "discard";
+    private static final String DOMAIN_CONFIG = "--domain-config";
+    private static final String HOST_CONFIG = "--host-config";
 
     private final AtomicReference<EmbeddedServerLaunch> hostControllerReference;
     private ArgumentWithValue jbossHome;
@@ -84,8 +85,8 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
             result.jbossHome = new FileSystemPathArgument(result, pathCompleter, "--jboss-home");
         }
         result.stdOutHandling = new ArgumentWithValue(result, new SimpleTabCompleter(new String[]{ECHO, DISCARD_STDOUT}), "--std-out");
-        result.domainConfig = new ArgumentWithValue(result, "--domain-config");
-        result.hostConfig = new ArgumentWithValue(result, "--host-config");
+        result.domainConfig = new ArgumentWithValue(result, DOMAIN_CONFIG);
+        result.hostConfig = new ArgumentWithValue(result, HOST_CONFIG);
         result.dashC = new ArgumentWithValue(result, "-c");
         result.dashC.addCantAppearAfter(result.domainConfig);
         result.domainConfig.addCantAppearAfter(result.dashC);
@@ -158,12 +159,12 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
 
             List<String> cmdsList = new ArrayList<>();
             if (domainXml != null && domainXml.trim().length() > 0) {
-                cmdsList.add(CommandLineConstants.DOMAIN_CONFIG);
+                cmdsList.add(DOMAIN_CONFIG);
                 cmdsList.add(domainXml.trim());
             }
 
             if (hostXml != null && hostXml.trim().length() > 0) {
-                cmdsList.add(CommandLineConstants.HOST_CONFIG);
+                cmdsList.add(HOST_CONFIG);
                 cmdsList.add(hostXml.trim());
             }
 

--- a/cli/src/main/java/org/jboss/as/cli/handlers/report/InstallationReportHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/report/InstallationReportHandler.java
@@ -20,10 +20,10 @@
  */
 package org.jboss.as.cli.handlers.report;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTACHED_STREAMS;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UUID;
+import static org.jboss.as.controller.client.helpers.ClientConstants.ATTACHED_STREAMS;
+import static org.jboss.as.controller.client.helpers.ClientConstants.FILE;
+import static org.jboss.as.controller.client.helpers.ClientConstants.RESPONSE_HEADERS;
+import static org.jboss.as.controller.client.helpers.ClientConstants.UUID;
 
 import java.io.File;
 import java.io.IOException;

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
@@ -28,6 +28,7 @@ package org.jboss.as.controller.client.helpers;
  */
 public class ClientConstants {
     public static final String ADD = "add";
+    public static final String ADDRESS = "address";
     public static final String ATTACHED_STREAMS = "attached-streams";
     @Deprecated
     public static final String AUTO_START = "auto-start";
@@ -42,9 +43,11 @@ public class ClientConstants {
     public static final String DEPLOYMENT_REPLACE_OPERATION = "replace-deployment";
     public static final String DEPLOYMENT_UNDEPLOY_OPERATION = "undeploy";
     public static final String EXTENSION = "extension";
+    public static final String FILE = "file";
     public static final String FAILURE_DESCRIPTION = "failure-description";
     public static final String GROUP = "group";
     public static final String HOST = "host";
+    public static final String HOST_STATE = "host-state";
     public static final String INCLUDE_RUNTIME = "include-runtime";
     public static final String INPUT_STREAM_INDEX = "input-stream-index";
     public static final String NAME = "name";
@@ -76,6 +79,7 @@ public class ClientConstants {
     public static final String SUCCESS = "success";
     public static final String TO_REPLACE = "to-replace";
     public static final String UNDEFINE_ATTRIBUTE_OPERATION = "undefine-attribute";
+    public static final String UUID = "uuid";
     public static final String VALUE = "value";
     public static final String WRITE_ATTRIBUTE_OPERATION = "write-attribute";
 

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -52,7 +52,6 @@
         <module name="org.jboss.vfs"/>
         <module name="org.picketbox" optional="true"/>
         <module name="org.wildfly.embedded"/>
-        <module name="org.jboss.as.process-controller"/>
         <module name="javax.api"/>
         <module name="ibm.jdk" />
         <module name="sun.jdk" />


### PR DESCRIPTION
This follows up on #1198 by adding a commit to remove the compile time dep of cli module on process-controller.

The only link dep from the client side modules to the server side ones should be wildfly-embedded, so I want to be really strict about that.