### PR TITLE
[WFLY-5589] return proper socket address for unnamed socket registrat…

### DIFF
--- a/network/src/main/java/org/jboss/as/network/ManagedDatagramSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedDatagramSocketBinding.java
@@ -35,11 +35,13 @@ import java.net.SocketException;
 public class ManagedDatagramSocketBinding extends DatagramSocket implements ManagedBinding {
 
     private final String name;
+    private final SocketAddress address;
     private final ManagedBindingRegistry registry;
 
     ManagedDatagramSocketBinding(final String name, final ManagedBindingRegistry socketBindings, SocketAddress address) throws SocketException {
         super(address);
         this.name = name;
+        this.address = address;
         this.registry = socketBindings;
         if (this.isBound()) {
             this.registry.registerBinding(this);
@@ -53,7 +55,12 @@ public class ManagedDatagramSocketBinding extends DatagramSocket implements Mana
 
     @Override
     public InetSocketAddress getBindAddress() {
-        return (InetSocketAddress) getLocalSocketAddress();
+        if (name == null) {
+            // unnamed datagram socket
+            return (InetSocketAddress) address;
+        } else {
+            return (InetSocketAddress) getLocalSocketAddress();
+        }
     }
 
     @Override

--- a/network/src/main/java/org/jboss/as/network/ManagedMulticastSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedMulticastSocketBinding.java
@@ -48,11 +48,13 @@ public class ManagedMulticastSocketBinding extends MulticastSocket implements Ma
     }
 
     private final String name;
+    private final SocketAddress address;
     private final ManagedBindingRegistry socketBindings;
 
     private ManagedMulticastSocketBinding(final String name, final ManagedBindingRegistry socketBindings, SocketAddress address) throws IOException {
         super(address);
         this.name = name;
+        this.address = address;
         this.socketBindings = socketBindings;
         if (this.isBound()) {
             this.socketBindings.registerBinding(this);
@@ -66,7 +68,12 @@ public class ManagedMulticastSocketBinding extends MulticastSocket implements Ma
 
     @Override
     public InetSocketAddress getBindAddress() {
-        return (InetSocketAddress) getLocalSocketAddress();
+        if (name == null) {
+            // unnamed multicast socket
+            return (InetSocketAddress) address;
+        } else {
+            return (InetSocketAddress) getLocalSocketAddress();
+        }
     }
 
     @Override


### PR DESCRIPTION
…ion / unregistration since super class getLocalSocketAddress() returns null if socket is closed first.

https://issues.jboss.org/browse/WFCORE-1081