### PR TITLE
[WFCORE-1111] Exporse RUNTIME_ONLY methods in JMX

### DIFF
--- a/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
@@ -219,7 +219,7 @@ public class MBeanInfoFactory {
                 }
             }
             final OperationEntry opEntry = entry.getValue();
-            if (mutabilityChecker.mutable(pathAddress) || opEntry.getFlags().contains(OperationEntry.Flag.READ_ONLY)) {
+            if (mutabilityChecker.mutable(pathAddress) || opEntry.getFlags().contains(Flag.READ_ONLY) || opEntry.getFlags().contains(Flag.RUNTIME_ONLY)) {
                 ops.add(getOperation(NameConverter.convertToCamelCase(entry.getKey()), null, opEntry));
             }
         }

--- a/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanHelper.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanHelper.java
@@ -64,6 +64,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.registry.OperationEntry.Flag;
 import org.jboss.as.core.security.AccessMechanism;
 import org.jboss.as.jmx.logging.JmxLogger;
 import org.jboss.as.jmx.model.ChildAddOperationFinder.ChildAddOperationEntry;
@@ -407,7 +408,7 @@ public class ModelControllerMBeanHelper {
     }
 
     private Object invoke(final OperationEntry entry, final String operationName, PathAddress address, Object[] params)  throws InstanceNotFoundException, MBeanException, ReflectionException {
-        if (!mutabilityChecker.mutable(address) && !entry.getFlags().contains(OperationEntry.Flag.READ_ONLY)) {
+        if (!mutabilityChecker.mutable(address) && !(entry.getFlags().contains(Flag.READ_ONLY) || entry.getFlags().contains(Flag.RUNTIME_ONLY))) {
             throw JmxLogger.ROOT_LOGGER.noOperationCalled(operationName);
         }
 

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -354,7 +354,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
 
 
         MBeanOperationInfo[] operations = info.getOperations();
-        Assert.assertEquals(1, operations.length);
+        Assert.assertEquals(2, operations.length);
 
         OpenMBeanOperationInfo op = findOperation(operations, ModelControllerResourceDefinition.VoidOperationNoParams.OPERATION_JMX_NAME);
         Assert.assertEquals(ModelControllerResourceDefinition.VoidOperationNoParams.OPERATION_JMX_NAME, op.getName());
@@ -909,17 +909,11 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         Assert.assertNull(connection.invoke(name, ModelControllerResourceDefinition.VoidOperationNoParams.OPERATION_JMX_NAME, new Object[0], new String[0]));
         Assert.assertTrue(ModelControllerResourceDefinition.VoidOperationNoParams.INSTANCE.invoked);
 
-        try {
-            connection.invoke(
-                    name,
-                    ModelControllerResourceDefinition.IntOperationWithParams.OPERATION_JMX_NAME,
-                    new Object[]{100L, new String[]{"A"}, Collections.singletonMap("test", 3), 5, 5},
-                    new String[]{Long.class.getName(), String[].class.getName(), Map.class.getName(), Integer.class.getName(), Integer.class.getName()});
-            Assert.fail("Should not have been able to invoke method");
-        } catch (Exception expected) {
-            //expected
-        }
-
+        connection.invoke(
+                name,
+                ModelControllerResourceDefinition.IntOperationWithParams.OPERATION_JMX_NAME,
+                new Object[]{100L, new String[]{"A"}, Collections.singletonMap("test", 3), 5, 5},
+                new String[]{Long.class.getName(), String[].class.getName(), Map.class.getName(), Integer.class.getName(), Integer.class.getName()});
     }
 
     @Test


### PR DESCRIPTION
If management operations are flagged with RUNTIME_ONLY, expose them in
JMX even when the resource is not mutable (as is the case for
resources hosted on domain servers).

JIRA: https://issues.jboss.org/browse/WFCORE-1111