### PR TITLE
[WFCORE-1092]:  ConfigurationChangeResourceRemoveHandler makes its changes in the constructor not in execute.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/ConfigurationChangeResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/ConfigurationChangeResourceDefinition.java
@@ -108,15 +108,20 @@ public class ConfigurationChangeResourceDefinition extends SimpleResourceDefinit
     }
 
     private static class ConfigurationChangeResourceRemoveHandler extends AbstractRemoveStepHandler {
+        @Override
+        protected boolean requiresRuntime(OperationContext context) {
+            return true;
+        }
 
-        public ConfigurationChangeResourceRemoveHandler() {
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+            super.performRuntime(context, operation, model);
             ConfigurationChangesCollector.INSTANCE.deactivate();
         }
     }
 
     private static class MaxHistoryWriteHandler extends AbstractWriteAttributeHandler<Integer> {
 
-        private static final MaxHistoryWriteHandler INSTANCE = new MaxHistoryWriteHandler(ConfigurationChangesCollector.INSTANCE);
         private final ConfigurationChangesCollector collector;
 
         private MaxHistoryWriteHandler(ConfigurationChangesCollector collector) {


### PR DESCRIPTION
Moving the code in the performRuntime method where it should have been.

Jira: https://issues.jboss.org/browse/WFCORE-1092
https://issues.jboss.org/browse/JBEAP-1748