### PR TITLE
[WFCORE-1008]: Treat ":shutdown" requests similarly to ":reload" in the server-side operation handler.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/ReloadHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ReloadHandler.java
@@ -65,7 +65,7 @@ public class ReloadHandler extends BaseOperationCommand {
     private PerNodeOperationAccess hostReloadPermission;
 
     public ReloadHandler(CommandContext ctx, final AtomicReference<EmbeddedProcessLaunch> embeddedServerRef) {
-        super(ctx, "reload", true);
+        super(ctx, Util.RELOAD, true);
 
         this.embeddedServerRef = embeddedServerRef;
 

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -374,6 +374,7 @@ public class ModelDescriptionConstants {
     public static final String RELATIVE_TO = "relative-to";
     public static final String RELEASE_CODENAME = "release-codename";
     public static final String RELEASE_VERSION = "release-version";
+    public static final String RELOAD = "reload";
     public static final String RELOAD_REQUIRED = "reload-required";
     public static final String REMOVE = "remove";
     public static final String REMOTE = "remote";

--- a/controller/src/main/java/org/jboss/as/controller/remote/ModelControllerClientOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/ModelControllerClientOperationHandler.java
@@ -33,7 +33,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SHUTDOWN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYNC_REMOVED_FOR_READD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.USER;
@@ -45,6 +47,9 @@ import java.io.IOException;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -79,6 +84,7 @@ import org.jboss.dmr.ModelNode;
  */
 public class ModelControllerClientOperationHandler implements ManagementRequestHandlerFactory {
 
+    private static final Set<String> PREPARED_RESPONSE_OPERATIONS = new HashSet<>(Arrays.asList(RELOAD, SHUTDOWN));
     private final ModelController controller;
 
     private final ManagementChannelAssociation channelAssociation;
@@ -128,7 +134,6 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
     }
 
     class ExecuteRequestHandler implements ManagementRequestHandler<ModelNode, Void> {
-
         @Override
         public void handleRequest(final DataInput input, final ActiveOperation.ResultHandler<ModelNode> resultHandler,
                                   final ManagementRequestContext<Void> context) throws IOException {
@@ -239,7 +244,7 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
             final String op = operation.get(OP).asString();
             final int size = address.size();
             if (size == 0) {
-                if ("reload".equals(op)) {
+                if (PREPARED_RESPONSE_OPERATIONS.contains(op)) {
                     return true;
                 } else if (COMPOSITE.equals(op)) {
                     // TODO
@@ -249,7 +254,7 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
                 }
             } else if (size == 1) {
                 if (HOST.equals(address.getLastElement().getKey())) {
-                    return "reload".equals(op);
+                    return PREPARED_RESPONSE_OPERATIONS.contains(op);
                 }
             }
             return false;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/StoppedServerResource.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/StoppedServerResource.java
@@ -49,7 +49,7 @@ public class StoppedServerResource extends SimpleResourceDefinition {
 
     private static final PathElement SERVER = PathElement.pathElement(ModelDescriptionConstants.RUNNING_SERVER);
 
-    private static final OperationDefinition RELOAD = new SimpleOperationDefinitionBuilder("reload", HostResolver.getResolver("host.server"))
+    private static final OperationDefinition RELOAD = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.RELOAD, HostResolver.getResolver("host.server"))
             .setPrivateEntry()
             .build();
 

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.wildfly.core.test.standalone.mgmt;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SHUTDOWN;
+import static org.wildfly.test.shutdown.SlowStopServiceActivator.SHUTDOWN_WAITING_TIME;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import javax.inject.Inject;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.test.shutdown.SlowStopService;
+import org.wildfly.test.shutdown.SlowStopServiceActivator;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class PreparedResponseTestCase {
+
+    public static Logger LOGGER = Logger.getLogger(PreparedResponseTestCase.class);
+
+    public static final String SLOW_STOP_JAR = "slow-stop.jar";
+    private static final long FREQUENCY = TimeoutUtil.adjust(500);
+
+    @Inject
+    protected static ServerController controller;
+
+    @BeforeClass
+    public static void startAndSetupContainer() throws Exception {
+        controller.start();
+        ManagementClient managementClient = controller.getClient();
+        deploy(managementClient);
+    }
+
+    @AfterClass
+    public static void stopContainer() throws Exception {
+        undeploy(controller.getClient());
+        controller.stop();
+    }
+
+    public static void deploy(ManagementClient managementClient) throws Exception {
+        ServerDeploymentHelper helper = new ServerDeploymentHelper(managementClient.getControllerClient());
+        JavaArchive war = ShrinkWrap.create(JavaArchive.class, SLOW_STOP_JAR);
+        war.addPackage(SlowStopService.class.getPackage());
+        war.addClass(TimeoutUtil.class);
+        war.addAsServiceProvider(ServiceActivator.class, SlowStopServiceActivator.class);
+        war.addAsResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.logging, org.jboss.as.controller, org.jboss.as.server,org.wildfly.extension.request-controller, org.jboss.as.network\n"), "META-INF/MANIFEST.MF");
+        helper.deploy(SLOW_STOP_JAR, war.as(ZipExporter.class).exportAsInputStream());
+    }
+
+    public static void undeploy(ManagementClient managementClient) throws ServerDeploymentHelper.ServerDeploymentException {
+        ServerDeploymentHelper helper = new ServerDeploymentHelper(managementClient.getControllerClient());
+        helper.undeploy(SLOW_STOP_JAR);
+    }
+
+    @Test
+    public void reloadServer() throws Exception {
+        ManagementClient mgmtClient = getManagementClient();
+        long timeout = SHUTDOWN_WAITING_TIME + System.currentTimeMillis();
+        mgmtClient.executeForResult(Operations.createOperation(RELOAD, new ModelNode().setEmptyList()));
+        while (System.currentTimeMillis() < timeout) {
+            Thread.sleep(FREQUENCY);
+            try {
+                controller.getClient().isServerInRunningState();
+            } catch (RuntimeException ex) {
+                break;
+            }
+        }
+        Assert.assertFalse(System.currentTimeMillis() < timeout);
+        Thread.sleep(2 * FREQUENCY);
+        Assert.assertTrue(mgmtClient.isServerInRunningState());
+    }
+
+    @Test
+    public void shutdownServer() throws Exception {
+        try (ManagementClient managementClient = getManagementClient()) {
+            long timeout = SHUTDOWN_WAITING_TIME + System.currentTimeMillis();
+            managementClient.executeForResult(Operations.createOperation(SHUTDOWN, new ModelNode().setEmptyList()));
+            while (System.currentTimeMillis() < timeout) {
+                Thread.sleep(FREQUENCY);
+                try {
+                    controller.getClient().isServerInRunningState();
+                } catch (RuntimeException ex) {
+                    break;
+                }
+            }
+            Assert.assertFalse(System.currentTimeMillis() < timeout);
+            Assert.assertFalse(controller.getClient().isServerInRunningState());
+        }
+        Assert.assertFalse(controller.getClient().isServerInRunningState());
+        try {
+            controller.stop(); //Server is already stopped but the ServerController doesn't know it
+        } catch (RuntimeException ex) {
+            //ignore the exception as it is expected
+        }
+        controller.start();
+    }
+
+    static ManagementClient getManagementClient() {
+        ModelControllerClient client = null;
+        try {
+            client = ModelControllerClient.Factory.create("http-remoting", InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
+                    TestSuiteEnvironment.getServerPort(), new org.wildfly.core.testrunner.Authentication.CallbackHandler());
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+        return new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/shutdown/SlowStopService.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/shutdown/SlowStopService.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.shutdown;
+
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2015 Red Hat, inc.
+ */
+
+public class SlowStopService implements Service<SlowStopService> {
+    public static final ServiceName DEFAULT_SERVICE_NAME = ServiceName.JBOSS.append("slow-stopping-service");
+
+    private final long duration;
+
+    public SlowStopService(final long duration) {
+        this.duration = duration;
+    }
+
+    @Override
+    public synchronized void start(final StartContext context) throws StartException {
+        Logger.getLogger(SlowStopService.class).infof("Started with a stop duration of %s ms", duration);
+    }
+
+    @Override
+    public synchronized void stop(final StopContext context) {
+        try {
+            Thread.sleep(duration);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public SlowStopService getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/shutdown/SlowStopServiceActivator.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/shutdown/SlowStopServiceActivator.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.shutdown;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistryException;
+
+/**
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2015 Red Hat, inc.
+ */
+public class SlowStopServiceActivator implements ServiceActivator {
+    public static final long SHUTDOWN_WAITING_TIME = TimeoutUtil.adjust(3000);
+    /**
+     * Class dependencies required to use the {@link org.wildfly.test.undertow.UndertowService}.
+     */
+    public static final Class<?>[] DEPENDENCIES = {
+            SlowStopService.class,
+            SlowStopServiceActivator.class,
+            TimeoutUtil.class
+    };
+
+    @Override
+    public final void activate(final ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        final long duration = getDuration();
+        assert duration > 0 : "duration must be greater than 0";
+        final SlowStopService service = new SlowStopService(duration);
+        serviceActivatorContext.getServiceTarget().addService(getServiceName(), service).install();
+    }
+
+    /**
+     * Returns the service name to use when adding the SlowStopService.
+     *
+     * @return the slow stop service name
+     */
+    protected ServiceName getServiceName() {
+        return SlowStopService.DEFAULT_SERVICE_NAME;
+    }
+
+    protected long getDuration() {
+        return SHUTDOWN_WAITING_TIME;
+    }
+
+}


### PR DESCRIPTION
Shutdown and reload are now treated in the same 'way', sending a prepared response before the services are stopped effectively.

Jira: https://issues.jboss.org/browse/WFCORE-1008