### PR TITLE
[WFCORE-851] - Remoting Subsystem RemoteOutboundConnectionService is …caching ConnectionURI causing issues when DNS changes

### DIFF
--- a/network/src/main/java/org/jboss/as/network/OutboundSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/OutboundSocketBinding.java
@@ -163,8 +163,7 @@ public class OutboundSocketBinding {
         if (this.resolvedDestinationAddress != null) {
             return this.resolvedDestinationAddress;
         }
-        this.resolvedDestinationAddress = InetAddress.getByName(this.unresolvedDestinationAddress);
-        return this.resolvedDestinationAddress;
+        return InetAddress.getByName(this.unresolvedDestinationAddress);
     }
 
     /**

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
@@ -65,7 +65,6 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
 
     private final String username;
     private final String protocol;
-    private URI connectionURI;
 
     public RemoteOutboundConnectionService(final String connectionName, final OptionMap connectionCreationOptions, final String username, final String protocol) {
         super(connectionName, connectionCreationOptions);
@@ -145,15 +144,12 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
      * @throws URISyntaxException
      */
     private synchronized URI getConnectionURI() throws IOException, URISyntaxException {
-        if (this.connectionURI != null) {
-            return this.connectionURI;
-        }
+        /* WFCORE-851 - do not cache connectionURI else reconnect will fail if DNS changes */
         final OutboundSocketBinding destinationOutboundSocket = this.destinationOutboundSocketBindingInjectedValue.getValue();
         final InetAddress destinationAddress = destinationOutboundSocket.getResolvedDestinationAddress();
         final int port = destinationOutboundSocket.getDestinationPort();
 
-        this.connectionURI = new URI(protocol + "://" + NetworkUtils.formatPossibleIpv6Address(destinationAddress.getHostAddress()) + ":" + port);
-        return this.connectionURI;
+        return new URI(protocol + "://" + NetworkUtils.formatPossibleIpv6Address(destinationAddress.getHostAddress()) + ":" + port);
     }
 
     @Override


### PR DESCRIPTION
Remoting Subsystem RemoteOutboundConnectionService is caching ConnectionURI causing issues when DNS changes

Downstream: https://issues.jboss.org/browse/JBEAP-1960
https://github.com/jbossas/wildfly-core-eap/pull/61