### PR TITLE
[WFCORE-1127] Improve handling of unregistering unnamed socket bindings.

### DIFF
--- a/network/src/main/java/org/jboss/as/network/ManagedDatagramSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedDatagramSocketBinding.java
@@ -74,13 +74,15 @@ public class ManagedDatagramSocketBinding extends DatagramSocket implements Mana
 
     @Override
     public void close() {
+        // First unregister, then close. This allows UnnamedRegistryImpl
+        // to get the bind address before it's gone
         try {
-            super.close();
-        } finally {
             // This method might have been called from the super constructor
             if (this.registry != null) {
                 registry.unregisterBinding(this);
             }
+        } finally {
+            super.close();
         }
     }
 }

--- a/network/src/main/java/org/jboss/as/network/ManagedDatagramSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedDatagramSocketBinding.java
@@ -77,7 +77,10 @@ public class ManagedDatagramSocketBinding extends DatagramSocket implements Mana
         try {
             super.close();
         } finally {
-            registry.unregisterBinding(this);
+            // This method might have been called from the super constructor
+            if (this.registry != null) {
+                registry.unregisterBinding(this);
+            }
         }
     }
 }

--- a/network/src/main/java/org/jboss/as/network/ManagedMulticastSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedMulticastSocketBinding.java
@@ -87,13 +87,15 @@ public class ManagedMulticastSocketBinding extends MulticastSocket implements Ma
 
     @Override
     public void close() {
+        // First unregister, then close. This allows UnnamedRegistryImpl
+        // to get the bind address before it's gone
         try {
-            super.close();
-        } finally {
             // This method might have been called from the super constructor
             if (this.socketBindings != null) {
                 socketBindings.unregisterBinding(this);
             }
+        } finally {
+            super.close();
         }
     }
 }

--- a/network/src/main/java/org/jboss/as/network/ManagedMulticastSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedMulticastSocketBinding.java
@@ -90,7 +90,10 @@ public class ManagedMulticastSocketBinding extends MulticastSocket implements Ma
         try {
             super.close();
         } finally {
-            socketBindings.unregisterBinding(this);
+            // This method might have been called from the super constructor
+            if (this.socketBindings != null) {
+                socketBindings.unregisterBinding(this);
+            }
         }
     }
 }

--- a/network/src/main/java/org/jboss/as/network/ManagedServerSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedServerSocketBinding.java
@@ -90,14 +90,16 @@ public class ManagedServerSocketBinding extends ServerSocket implements ManagedB
 
     @Override
     public void close() throws IOException {
+        // First unregister, then close. This allows UnnamedRegistryImpl
+        // to get the bind address before it's gone
         try {
-            super.close();
-        } finally {
             if(name != null) {
                 socketBindings.getNamedRegistry().unregisterBinding(this);
             } else {
                 socketBindings.getUnnamedRegistry().unregisterBinding(this);
             }
+        } finally {
+            super.close();
         }
     }
 

--- a/network/src/main/java/org/jboss/as/network/ManagedSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedSocketBinding.java
@@ -61,10 +61,12 @@ class ManagedSocketBinding extends Socket implements ManagedBinding {
     }
 
     public synchronized void close() throws IOException {
+        // First unregister, then close. This allows UnnamedRegistryImpl
+        // to get the bind address before it's gone
         try {
-            super.close();
-        } finally {
             socketBindings.unregisterBinding(this);
+        } finally {
+            super.close();
         }
     }
 

--- a/network/src/main/java/org/jboss/as/network/SocketBindingManager.java
+++ b/network/src/main/java/org/jboss/as/network/SocketBindingManager.java
@@ -138,37 +138,235 @@ public interface SocketBindingManager {
      */
     UnnamedBindingRegistry getUnnamedRegistry();
 
-    public interface NamedManagedBindingRegistry extends ManagedBindingRegistry {
+    interface NamedManagedBindingRegistry extends ManagedBindingRegistry {
 
+        /**
+         * Gets the binding registered under the given name.
+         * @param name the name
+         * @return the binding, or {@code null} if there is no binding registered with that name
+         */
         ManagedBinding getManagedBinding(final String name);
+
+        /**
+         * Gets whether there is a binding registered under the given name.
+         * @param name the name
+         * @return {@code true} if there is a binding under that name
+         */
         boolean isRegistered(final String name);
 
+        /**
+         * Registers a binding under the given name based on the given socket.
+         * @param name the name. Cannot be {@code null}
+         * @param socket the socket. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding if {@code close()} is called
+         */
         Closeable registerSocket(String name, Socket socket);
+
+        /**
+         * Registers a binding under the given name based on the given socket.
+         * @param name the name. Cannot be {@code null}
+         * @param socket the socket. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding if {@code close()} is called
+         */
         Closeable registerSocket(String name, ServerSocket socket);
+
+        /**
+         * Registers a binding under the given name based on the given socket.
+         * @param name the name. Cannot be {@code null}
+         * @param socket the socket. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding if {@code close()} is called
+         */
         Closeable registerSocket(String name, DatagramSocket socket);
+
+        /**
+         * Registers a binding under the given name based on the given channel.
+         * @param name the name. Cannot be {@code null}
+         * @param channel the channel. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding if {@code close()} is called
+         */
         Closeable registerChannel(String name, SocketChannel channel);
+
+        /**
+         * Registers a binding under the given name based on the given channel.
+         * @param name the name. Cannot be {@code null}
+         * @param channel the channel. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding if {@code close()} is called
+         */
         Closeable registerChannel(String name, ServerSocketChannel channel);
+
+        /**
+         * Registers a binding under the given name based on the given channel.
+         * @param name the name. Cannot be {@code null}
+         * @param channel the channel. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding if {@code close()} is called
+         */
         Closeable registerChannel(String name, DatagramChannel channel);
 
+        /**
+         * Unregisters the binding with the given name.
+         *
+         * @param name the name
+         */
         void unregisterBinding(String name);
+
+        /**
+         * {@inheritDoc}
+         *
+         * @throws IllegalStateException if {@link ManagedBinding#getSocketBindingName()} returns {@code null}
+         */
+        @Override
+        void registerBinding(final ManagedBinding binding);
+
+        /**
+         * {@inheritDoc}
+         *
+         * @throws IllegalStateException if {@link ManagedBinding#getSocketBindingName()} returns {@code null}
+         */
+        @Override
+        void unregisterBinding(final ManagedBinding binding);
 
     }
 
-    public interface UnnamedBindingRegistry extends ManagedBindingRegistry {
+    interface UnnamedBindingRegistry extends ManagedBindingRegistry {
 
+        /**
+         * Registers an unnamed binding based on the given socket.
+         * @param socket the socket. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding and close the socket
+         *         if {@code close()} is called
+         * @throws IllegalStateException if {@link Socket#getLocalAddress()} returns {@code null}
+         */
         Closeable registerSocket(Socket socket);
+
+        /**
+         * Registers an unnamed binding based on the given socket.
+         * @param socket the socket. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding and close the socket
+         *         if {@code close()} is called
+         * @throws IllegalStateException if {@link Socket#getLocalAddress()} returns {@code null}
+         */
         Closeable registerSocket(ServerSocket socket);
+
+        /**
+         * Registers an unnamed binding based on the given socket.
+         * @param socket the socket. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding and close the socket
+         *         if {@code close()} is called
+         * @throws IllegalStateException if {@link Socket#getLocalAddress()} returns {@code null}
+         */
         Closeable registerSocket(DatagramSocket socket);
+
+        /**
+         * Registers an unnamed binding based on the given channel.
+         * @param channel the channel. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding and close the socket
+         *         if {@code close()} is called
+         * @throws IllegalStateException if calling {@link Socket#getLocalAddress()} on the
+         *          {@link SocketChannel#socket() channel's socket} returns {@code null}
+         */
         Closeable registerChannel(SocketChannel channel);
+
+        /**
+         * Registers an unnamed binding based on the given channel.
+         * @param channel the channel. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding and close the socket
+         *         if {@code close()} is called
+         * @throws IllegalStateException if calling {@link Socket#getLocalAddress()} on the
+         *          {@link ServerSocketChannel#socket() channel's socket} returns {@code null}
+         */
         Closeable registerChannel(ServerSocketChannel channel);
+
+        /**
+         * Registers an unnamed binding based on the given channel.
+         * @param channel the channel. Cannot be {@code null}
+         * @return a {@link Closeable} that will unregister the binding and close the socket
+         *         if {@code close()} is called
+         * @throws IllegalStateException if calling {@link Socket#getLocalAddress()} on the
+         *          {@link DatagramChannel#socket() channel's socket} returns {@code null}
+         */
         Closeable registerChannel(DatagramChannel channel);
 
+        /**
+         * Unregisters a binding previously {@link #registerSocket(Socket) registered for the socket}.
+         * <p>
+         * <strong>For unregistration to work, this method must be called before the socket is closed.</strong>
+         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
+         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
+         *
+         * @param socket the socket. Cannot be {@code null}
+         */
         void unregisterSocket(Socket socket);
+
+        /**
+         * Unregisters a binding previously {@link #registerSocket(ServerSocket) registered for the socket}.
+         * <p>
+         * <strong>For unregistration to work, this method must be called before the socket is closed.</strong>
+         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
+         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
+         *
+         * @param socket the socket. Cannot be {@code null}
+         */
         void unregisterSocket(ServerSocket socket);
+
+        /**
+         * Unregisters a binding previously {@link #registerSocket(DatagramSocket) registered for the socket}.
+         * <p>
+         * <strong>For unregistration to work, this method must be called before the socket is closed.</strong>
+         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
+         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
+         *
+         * @param socket the socket. Cannot be {@code null}
+         */
         void unregisterSocket(DatagramSocket socket);
+
+        /**
+         * Unregisters a binding previously {@link #registerChannel(SocketChannel) registered for the channel}.
+         * <p>
+         * <strong>For unregistration to work, this method must be called before the channel's socket is closed.</strong>
+         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
+         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
+         *
+         * @param channel the channel. Cannot be {@code null}
+         */
         void unregisterChannel(SocketChannel channel);
+
+        /**
+         * Unregisters a binding previously {@link #registerChannel(ServerSocketChannel) registered for the channel}.
+         * <p>
+         * <strong>For unregistration to work, this method must be called before the channel's socket is closed.</strong>
+         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
+         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
+         *
+         * @param channel the channel. Cannot be {@code null}
+         */
         void unregisterChannel(ServerSocketChannel channel);
+
+        /**
+         * Unregisters a binding previously {@link #registerChannel(DatagramChannel) registered for the channel}.
+         * <p>
+         * <strong>For unregistration to work, this method must be called before the channel's socket is closed.</strong>
+         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
+         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
+         *
+         * @param channel the channel. Cannot be {@code null}
+         */
         void unregisterChannel(DatagramChannel channel);
+
+        /**
+         * {@inheritDoc}
+         *
+         * @throws IllegalStateException if {@link ManagedBinding#getBindAddress()} returns {@code null}
+         */
+        @Override
+        void registerBinding(final ManagedBinding binding);
+
+        /**
+         * {@inheritDoc}
+         *
+         * @throws IllegalStateException if {@link ManagedBinding#getBindAddress()} returns {@code null}
+         */
+        @Override
+        void unregisterBinding(final ManagedBinding binding);
 
     }
 

--- a/network/src/main/java/org/jboss/as/network/SocketBindingManagerImpl.java
+++ b/network/src/main/java/org/jboss/as/network/SocketBindingManagerImpl.java
@@ -257,10 +257,12 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
         @Override
         public void close() throws IOException {
+            // First unregister, then close. This allows UnnamedRegistryImpl
+            // to get the bind address before it's gone
             try {
-                closeable.close();
-            } finally {
                 registry.unregisterBinding(this);
+            } finally {
+                closeable.close();
             }
         }
     }
@@ -288,10 +290,12 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
         @Override
         public void close() throws IOException {
+            // First unregister, then close. This allows UnnamedRegistryImpl
+            // to get the bind address before it's gone
             try {
-                socket.close();
-            } finally {
                 registry.unregisterBinding(this);
+            } finally {
+                socket.close();
             }
         }
     }
@@ -313,10 +317,12 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
         @Override
         public void close() throws IOException {
+            // First unregister, then close. This allows UnnamedRegistryImpl
+            // to get the bind address before it's gone
             try {
-                wrapped.close();
-            } finally {
                 registry.unregisterBinding(this);
+            } finally {
+                wrapped.close();
             }
         }
     }
@@ -343,10 +349,12 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
         @Override
         public void close() throws IOException {
+            // First unregister, then close. This allows UnnamedRegistryImpl
+            // to get the bind address before it's gone
             try {
-                socket.close();
-            } finally {
                 registry.unregisterBinding(this);
+            } finally {
+                socket.close();
             }
         }
     }
@@ -373,10 +381,12 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
         @Override
         public void close() throws IOException {
+            // First unregister, then close. This allows UnnamedRegistryImpl
+            // to get the bind address before it's gone
             try {
-                socket.close();
-            } finally {
                 registry.unregisterBinding(this);
+            } finally {
+                socket.close();
             }
         }
     }
@@ -497,9 +507,12 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         @Override
         public void unregisterBinding(ManagedBinding binding) {
             final InetSocketAddress address = binding.getBindAddress();
-            if(address == null) {
-                throw new IllegalStateException();
-            }
+            // WFCORE-1127 - we don't care if there is no address.
+            // This allows us to handle cases where a ManagedSocketBinding
+            // is closed before being bound.
+            //if(address == null) {
+            //    throw new IllegalStateException();
+            //}
             unregisterBinding(address);
         }
 


### PR DESCRIPTION
Also includes the commit for WFCORE-1119 from #1237 as that commit would conflict with this one.