### PR TITLE
[WFCORE-1029] Stop using InetSocketAddress as map key in UnnamedBindingRegistry

### DIFF
--- a/network/src/main/java/org/jboss/as/network/ManagedDatagramSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedDatagramSocketBinding.java
@@ -74,8 +74,6 @@ public class ManagedDatagramSocketBinding extends DatagramSocket implements Mana
 
     @Override
     public void close() {
-        // First unregister, then close. This allows UnnamedRegistryImpl
-        // to get the bind address before it's gone
         try {
             // This method might have been called from the super constructor
             if (this.registry != null) {

--- a/network/src/main/java/org/jboss/as/network/ManagedMulticastSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedMulticastSocketBinding.java
@@ -87,8 +87,6 @@ public class ManagedMulticastSocketBinding extends MulticastSocket implements Ma
 
     @Override
     public void close() {
-        // First unregister, then close. This allows UnnamedRegistryImpl
-        // to get the bind address before it's gone
         try {
             // This method might have been called from the super constructor
             if (this.socketBindings != null) {

--- a/network/src/main/java/org/jboss/as/network/ManagedServerSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedServerSocketBinding.java
@@ -90,8 +90,6 @@ public class ManagedServerSocketBinding extends ServerSocket implements ManagedB
 
     @Override
     public void close() throws IOException {
-        // First unregister, then close. This allows UnnamedRegistryImpl
-        // to get the bind address before it's gone
         try {
             if(name != null) {
                 socketBindings.getNamedRegistry().unregisterBinding(this);

--- a/network/src/main/java/org/jboss/as/network/ManagedSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/ManagedSocketBinding.java
@@ -61,8 +61,6 @@ class ManagedSocketBinding extends Socket implements ManagedBinding {
     }
 
     public synchronized void close() throws IOException {
-        // First unregister, then close. This allows UnnamedRegistryImpl
-        // to get the bind address before it's gone
         try {
             socketBindings.unregisterBinding(this);
         } finally {

--- a/network/src/main/java/org/jboss/as/network/SocketBindingManager.java
+++ b/network/src/main/java/org/jboss/as/network/SocketBindingManager.java
@@ -270,7 +270,6 @@ public interface SocketBindingManager {
          * @param socket the socket. Cannot be {@code null}
          * @return a {@link Closeable} that will unregister the binding and close the socket
          *         if {@code close()} is called
-         * @throws IllegalStateException if {@link Socket#getLocalAddress()} returns {@code null}
          */
         Closeable registerSocket(Socket socket);
 
@@ -279,7 +278,6 @@ public interface SocketBindingManager {
          * @param socket the socket. Cannot be {@code null}
          * @return a {@link Closeable} that will unregister the binding and close the socket
          *         if {@code close()} is called
-         * @throws IllegalStateException if {@link Socket#getLocalAddress()} returns {@code null}
          */
         Closeable registerSocket(ServerSocket socket);
 
@@ -288,7 +286,6 @@ public interface SocketBindingManager {
          * @param socket the socket. Cannot be {@code null}
          * @return a {@link Closeable} that will unregister the binding and close the socket
          *         if {@code close()} is called
-         * @throws IllegalStateException if {@link Socket#getLocalAddress()} returns {@code null}
          */
         Closeable registerSocket(DatagramSocket socket);
 
@@ -297,8 +294,6 @@ public interface SocketBindingManager {
          * @param channel the channel. Cannot be {@code null}
          * @return a {@link Closeable} that will unregister the binding and close the socket
          *         if {@code close()} is called
-         * @throws IllegalStateException if calling {@link Socket#getLocalAddress()} on the
-         *          {@link SocketChannel#socket() channel's socket} returns {@code null}
          */
         Closeable registerChannel(SocketChannel channel);
 
@@ -307,8 +302,6 @@ public interface SocketBindingManager {
          * @param channel the channel. Cannot be {@code null}
          * @return a {@link Closeable} that will unregister the binding and close the socket
          *         if {@code close()} is called
-         * @throws IllegalStateException if calling {@link Socket#getLocalAddress()} on the
-         *          {@link ServerSocketChannel#socket() channel's socket} returns {@code null}
          */
         Closeable registerChannel(ServerSocketChannel channel);
 
@@ -317,92 +310,50 @@ public interface SocketBindingManager {
          * @param channel the channel. Cannot be {@code null}
          * @return a {@link Closeable} that will unregister the binding and close the socket
          *         if {@code close()} is called
-         * @throws IllegalStateException if calling {@link Socket#getLocalAddress()} on the
-         *          {@link DatagramChannel#socket() channel's socket} returns {@code null}
          */
         Closeable registerChannel(DatagramChannel channel);
 
         /**
          * Unregisters a binding previously {@link #registerSocket(Socket) registered for the socket}.
-         * <p>
-         * <strong>For unregistration to work, this method must be called before the socket is closed.</strong>
-         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
-         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
          *
-         * @param socket the socket. Cannot be {@code null}
+         * @param socket the socket previously passed to {@link #registerSocket(Socket)}. Cannot be {@code null}
          */
         void unregisterSocket(Socket socket);
 
         /**
          * Unregisters a binding previously {@link #registerSocket(ServerSocket) registered for the socket}.
-         * <p>
-         * <strong>For unregistration to work, this method must be called before the socket is closed.</strong>
-         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
-         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
          *
-         * @param socket the socket. Cannot be {@code null}
+         * @param socket the socket previously passed to {@link #registerSocket(ServerSocket)}. Cannot be {@code null}
          */
         void unregisterSocket(ServerSocket socket);
 
         /**
          * Unregisters a binding previously {@link #registerSocket(DatagramSocket) registered for the socket}.
-         * <p>
-         * <strong>For unregistration to work, this method must be called before the socket is closed.</strong>
-         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
-         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
          *
-         * @param socket the socket. Cannot be {@code null}
+         * @param socket the socket previously passed to {@link #registerSocket(DatagramSocket)}. Cannot be {@code null}
          */
         void unregisterSocket(DatagramSocket socket);
 
         /**
          * Unregisters a binding previously {@link #registerChannel(SocketChannel) registered for the channel}.
-         * <p>
-         * <strong>For unregistration to work, this method must be called before the channel's socket is closed.</strong>
-         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
-         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
          *
-         * @param channel the channel. Cannot be {@code null}
+         * @param channel the channel previously passed to {@link #registerChannel(SocketChannel)}. Cannot be {@code null}
          */
         void unregisterChannel(SocketChannel channel);
 
         /**
          * Unregisters a binding previously {@link #registerChannel(ServerSocketChannel) registered for the channel}.
-         * <p>
-         * <strong>For unregistration to work, this method must be called before the channel's socket is closed.</strong>
-         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
-         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
          *
-         * @param channel the channel. Cannot be {@code null}
+         * @param channel the channel previously passed to {@link #registerChannel(ServerSocketChannel)}. Cannot be {@code null}
          */
         void unregisterChannel(ServerSocketChannel channel);
 
         /**
          * Unregisters a binding previously {@link #registerChannel(DatagramChannel) registered for the channel}.
-         * <p>
-         * <strong>For unregistration to work, this method must be called before the channel's socket is closed.</strong>
-         * The preferred way to handle this is to call {@code close} on the {@link Closeable} returned by the
-         * {@code registerSocket} and let it handle unregistering the binding and closing the socket.
          *
-         * @param channel the channel. Cannot be {@code null}
+         * @param channel the channel previously passed to {@link #registerChannel(DatagramChannel)}. Cannot be {@code null}
          */
         void unregisterChannel(DatagramChannel channel);
-
-        /**
-         * {@inheritDoc}
-         *
-         * @throws IllegalStateException if {@link ManagedBinding#getBindAddress()} returns {@code null}
-         */
-        @Override
-        void registerBinding(final ManagedBinding binding);
-
-        /**
-         * {@inheritDoc}
-         *
-         * @throws IllegalStateException if {@link ManagedBinding#getBindAddress()} returns {@code null}
-         */
-        @Override
-        void unregisterBinding(final ManagedBinding binding);
 
     }
 

--- a/network/src/main/java/org/jboss/as/network/SocketBindingManagerImpl.java
+++ b/network/src/main/java/org/jboss/as/network/SocketBindingManagerImpl.java
@@ -150,7 +150,7 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         return unnamedRegistry;
     }
 
-    class ManagedSocketFactoryImpl extends ManagedSocketFactory {
+    private class ManagedSocketFactoryImpl extends ManagedSocketFactory {
 
         @Override
         public Socket createSocket() {
@@ -214,7 +214,7 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
 
     }
 
-    class ManagedServerSocketFactoryImpl extends ManagedServerSocketFactory {
+    private class ManagedServerSocketFactoryImpl extends ManagedServerSocketFactory {
 
         @Override
         public ServerSocket createServerSocket(String name) throws IOException {
@@ -262,16 +262,57 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
 
     }
 
-    static class CloseableManagedBinding implements ManagedBinding {
+    /**
+     * Base class for internal ManagedBinding implementations that
+     * 'wrap' some other object in order to provide the ManagedBinding contract.
+     * Implementations of this interface can be used as keys in a hash map or
+     * values in a hash set and other instances of the same subclass that have
+     * the same name or wrap the same object will be treated as equivalent by the map/set.
+     *
+     * The equals and hashCode implementations of this class are based either on the binding
+     * name *or* on the wrapped object, but not on the combination. If a binding has a name,
+     * that will be used; otherwise the wrapped object will be used. Both getSocketBindingName()
+     * and getWrappedObject() must always provide the same object.
+     */
+    private abstract static class WrapperBinding implements ManagedBinding {
+
+        /** Gets the wrapped object that provide identity for this binding. */
+        abstract Object getWrappedObject();
+
+        @Override
+        public final int hashCode() {
+            String name = getSocketBindingName();
+            return name != null ? name.hashCode() : System.identityHashCode(getWrappedObject());
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            WrapperBinding that = (WrapperBinding) o;
+            String name = getSocketBindingName();
+            if (name != null) {
+                return name.equals(that.getSocketBindingName());
+            }
+
+            return getWrappedObject() == that.getWrappedObject();
+        }
+    }
+
+    private static class CloseableManagedBinding extends WrapperBinding {
         private final String name;
         private final InetSocketAddress address;
         private final Closeable closeable;
         private final ManagedBindingRegistry registry;
+
         CloseableManagedBinding(final InetSocketAddress address, final Closeable closeable, final ManagedBindingRegistry registry) {
             this(null, address, closeable, registry);
         }
+
         CloseableManagedBinding(final String name, final InetSocketAddress address,
                 final Closeable closeable, final ManagedBindingRegistry registry) {
+            assert closeable != null;
             this.name = name;
             this.address = address;
             this.closeable = closeable;
@@ -287,17 +328,20 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
         @Override
         public void close() throws IOException {
-            // First unregister, then close. This allows UnnamedRegistryImpl
-            // to get the bind address before it's gone
             try {
                 registry.unregisterBinding(this);
             } finally {
                 closeable.close();
             }
         }
+
+        @Override
+        Object getWrappedObject() {
+            return closeable;
+        }
     }
 
-    static class WrappedManagedDatagramSocket implements ManagedBinding {
+    private static class WrappedManagedDatagramSocket extends WrapperBinding {
         private final String name;
         private final DatagramSocket socket;
         private final ManagedBindingRegistry registry;
@@ -305,6 +349,7 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
             this(null, socket, registry);
         }
         public WrappedManagedDatagramSocket(final String name, final DatagramSocket socket, final ManagedBindingRegistry registry) {
+            assert socket != null;
             this.name = name;
             this.socket = socket;
             this.registry = registry;
@@ -320,20 +365,24 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
         @Override
         public void close() throws IOException {
-            // First unregister, then close. This allows UnnamedRegistryImpl
-            // to get the bind address before it's gone
             try {
                 registry.unregisterBinding(this);
             } finally {
                 socket.close();
             }
         }
+
+        @Override
+        Object getWrappedObject() {
+            return socket;
+        }
     }
 
-    static class WrappedManagedBinding implements ManagedBinding {
+    private static class WrappedManagedBinding extends WrapperBinding {
         private final ManagedBinding wrapped;
         private final ManagedBindingRegistry registry;
         public WrappedManagedBinding(final ManagedBinding wrapped, final ManagedBindingRegistry registry) {
+            assert wrapped != null;
             this.wrapped = wrapped;
             this.registry = registry;
         }
@@ -347,17 +396,20 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
         @Override
         public void close() throws IOException {
-            // First unregister, then close. This allows UnnamedRegistryImpl
-            // to get the bind address before it's gone
             try {
                 registry.unregisterBinding(this);
             } finally {
                 wrapped.close();
             }
         }
+
+        @Override
+        Object getWrappedObject() {
+            return wrapped;
+        }
     }
 
-    static class WrappedManagedSocket implements ManagedBinding {
+    private static class WrappedManagedSocket extends WrapperBinding {
         private final String name;
         private final Socket socket;
         private final ManagedBindingRegistry registry;
@@ -365,6 +417,7 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
             this(null, socket, registry);
         }
         public WrappedManagedSocket(final String name, final Socket socket, final ManagedBindingRegistry registry) {
+            assert socket != null;
             this.name = name;
             this.socket = socket;
             this.registry = registry;
@@ -379,17 +432,20 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
         @Override
         public void close() throws IOException {
-            // First unregister, then close. This allows UnnamedRegistryImpl
-            // to get the bind address before it's gone
             try {
                 registry.unregisterBinding(this);
             } finally {
                 socket.close();
             }
         }
+
+        @Override
+        Object getWrappedObject() {
+            return socket;
+        }
     }
 
-    static class WrappedManagedServerSocket implements ManagedBinding {
+    private static class WrappedManagedServerSocket extends WrapperBinding {
         private final String name;
         private final ServerSocket socket;
         private final ManagedBindingRegistry registry;
@@ -397,6 +453,7 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
             this(null, socket, registry);
         }
         public WrappedManagedServerSocket(final String name, final ServerSocket socket, final ManagedBindingRegistry registry) {
+            assert socket != null;
             this.name = name;
             this.socket = socket;
             this.registry = registry;
@@ -411,17 +468,20 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
         @Override
         public void close() throws IOException {
-            // First unregister, then close. This allows UnnamedRegistryImpl
-            // to get the bind address before it's gone
             try {
                 registry.unregisterBinding(this);
             } finally {
                 socket.close();
             }
         }
+
+        @Override
+        Object getWrappedObject() {
+            return socket;
+        }
     }
 
-    static final class NamedRegistryImpl implements NamedManagedBindingRegistry {
+    private static final class NamedRegistryImpl implements NamedManagedBindingRegistry {
         private final Map<String, ManagedBinding> bindings = new ConcurrentHashMap<String, ManagedBinding>();
 
         /** {@inheritDoc} */
@@ -520,36 +580,33 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         }
     }
 
-    static final class UnnamedRegistryImpl implements UnnamedBindingRegistry {
-        private final Map<InetSocketAddress, ManagedBinding> bindings = new ConcurrentHashMap<InetSocketAddress, ManagedBinding>();
+    private static final class UnnamedRegistryImpl implements UnnamedBindingRegistry {
+        // Can't put null in ConcurrentHashMap and I'm too lazy to drop CHM
+        private static final Object VALUE = new Object();
+
+        private final Map<WrapperBinding, Object> bindings = new ConcurrentHashMap<>();
 
         /** {@inheritDoc} */
         @Override
         public void registerBinding(ManagedBinding binding) {
-            final InetSocketAddress address = binding.getBindAddress();
-            if(address == null) {
-                throw new IllegalStateException();
-            }
-            bindings.put(address, new WrappedManagedBinding(binding, this));
+            bindings.put(new WrappedManagedBinding(binding, this), VALUE);
         }
 
         /** {@inheritDoc} */
         @Override
         public void unregisterBinding(ManagedBinding binding) {
-            final InetSocketAddress address = binding.getBindAddress();
-            // WFCORE-1127 - we don't care if there is no address.
-            // This allows us to handle cases where a ManagedSocketBinding
-            // is closed before being bound.
-            //if(address == null) {
-            //    throw new IllegalStateException();
-            //}
-            unregisterBinding(address);
+            if (binding != null) {
+                final WrapperBinding toRemove = binding instanceof WrapperBinding
+                        ? (WrapperBinding) binding
+                        : new WrappedManagedBinding(binding, this);
+                bindings.remove(toRemove);
+            }
         }
 
         /** {@inheritDoc} */
         @Override
         public Collection<ManagedBinding> listActiveBindings() {
-            return new HashSet<ManagedBinding>(bindings.values());
+            return new HashSet<ManagedBinding>(bindings.keySet());
         }
 
         /** {@inheritDoc} */
@@ -603,43 +660,40 @@ public abstract class SocketBindingManagerImpl implements SocketBindingManager {
         /** {@inheritDoc} */
         @Override
         public void unregisterSocket(Socket socket) {
-            unregisterBinding((InetSocketAddress) socket.getLocalSocketAddress());
+            bindings.remove(new WrappedManagedSocket(socket, this));
         }
 
         /** {@inheritDoc} */
         @Override
         public void unregisterSocket(ServerSocket socket) {
-            unregisterBinding((InetSocketAddress) socket.getLocalSocketAddress());
+            bindings.remove(new WrappedManagedServerSocket(socket, this));
         }
 
         /** {@inheritDoc} */
         @Override
         public void unregisterSocket(DatagramSocket socket) {
-            unregisterBinding((InetSocketAddress) socket.getLocalSocketAddress());
+            bindings.remove(new WrappedManagedDatagramSocket(socket, this));
         }
 
         /** {@inheritDoc} */
         @Override
         public void unregisterChannel(SocketChannel channel) {
-            unregisterBinding((InetSocketAddress) channel.socket().getLocalSocketAddress());
+            WrapperBinding wrapper = new CloseableManagedBinding((InetSocketAddress) channel.socket().getLocalSocketAddress(), channel, this);
+            bindings.remove(wrapper);
         }
 
         /** {@inheritDoc} */
         @Override
         public void unregisterChannel(ServerSocketChannel channel) {
-            unregisterBinding((InetSocketAddress) channel.socket().getLocalSocketAddress());
+            WrapperBinding wrapper = new CloseableManagedBinding((InetSocketAddress) channel.socket().getLocalSocketAddress(), channel, this);
+            bindings.remove(wrapper);
         }
 
         /** {@inheritDoc} */
         @Override
         public void unregisterChannel(DatagramChannel channel) {
-            unregisterBinding((InetSocketAddress) channel.socket().getLocalSocketAddress());
-        }
-
-        public void unregisterBinding(final InetSocketAddress address) {
-            if(address != null) {
-                bindings.remove(address);
-            }
+            WrapperBinding wrapper = new CloseableManagedBinding((InetSocketAddress) channel.socket().getLocalSocketAddress(), channel, this);
+            bindings.remove(wrapper);
         }
     }
 


### PR DESCRIPTION
This builds on #1239 but adds an additional commit for https://issues.jboss.org/browse/WFCORE-1029.

I'm using separate PRs for these because the different related issues have, IMO, different degrees of acceptability for inclusion in EAP 7. I believe including the WFCORE-1029 fix is the correct ultimate solution, but having added bake time makes sense to me.