### PR TITLE
[WFCORE-1133] JDK 1.8 on Mac causes javax.script.ScriptEngineFactory:…

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/sun/scripting/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/sun/scripting/main/module.xml
@@ -33,6 +33,7 @@
     <dependencies>
         <system export="true">
             <paths>
+                <path name="apple/applescript"/>
                 <path name="com/sun/script/javascript"/>
                 <path name="jdk/nashorn/api/scripting"/>
                 <path name="jdk/nashorn/api/scripting/resources"/>


### PR DESCRIPTION
… Provider apple.applescript.AppleScriptEngineFactory not found

https://issues.jboss.org/browse/WFCORE-1133