### PR TITLE
WFCORE-1136 Subsystem parser tests fail when woodstox parser is on classpath

### DIFF
--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestParser.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestParser.java
@@ -71,6 +71,8 @@ public final class TestParser implements  ModelTestParser {
                 if (subsystemWriter != null) {
                     subsystemWriter.writeContent(writer, new SubsystemMarshallingContext(subsystem, writer));
                 }
+            }else{
+                writer.writeEmptyElement(Element.SUBSYSTEM.getLocalName());
             }
         }catch (Throwable t){
             Assert.fail("could not marshal subsystem xml: "+t.getMessage()+":\n"+ Arrays.toString(t.getStackTrace()).replaceAll(", ","\n"));

--- a/subsystem-test/tests/pom.xml
+++ b/subsystem-test/tests/pom.xml
@@ -63,5 +63,10 @@
            <artifactId>junit</artifactId>
            <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <scope>test</scope> <!-- here to test WFCORE-1136 -->
+        </dependency>
     </dependencies>
 </project>

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/map_to_child_resource/TransformerAttachmentAndInspectModelSubsystemTestCase.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/map_to_child_resource/TransformerAttachmentAndInspectModelSubsystemTestCase.java
@@ -92,6 +92,7 @@ public class TransformerAttachmentAndInspectModelSubsystemTestCase extends Abstr
         builder.createLegacyKernelServicesBuilder(null, ModelTestControllerVersion.MASTER, oldVersion)
                 .setExtensionClassName(OldExtension.class.getName())
                 .addSimpleResourceURL("target/legacy-archive.jar")
+                .dontPersistXml()//don't test xml persistence as woodstox parser for legacy test will break it
                 .skipReverseControllerCheck();
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(oldVersion);


### PR DESCRIPTION

probably breaks also with other parsers. 