### PR TITLE
[WFCORE-1144] Space before JVM argument in <jvm-options> causes failure

### DIFF
--- a/process-controller/src/main/java/org/jboss/as/process/ManagedProcess.java
+++ b/process-controller/src/main/java/org/jboss/as/process/ManagedProcess.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import org.jboss.as.process.logging.ProcessLogger;
 import org.jboss.as.process.protocol.StreamUtils;
@@ -201,7 +202,7 @@ final class ManagedProcess {
         }
         log.startingProcess(processName);
         log.debugf("Process name='%s' command='%s' workingDirectory='%s'", processName, command, workingDirectory);
-        final ProcessBuilder builder = new ProcessBuilder(command);
+        final ProcessBuilder builder = new ProcessBuilder(command.stream().map(c -> c.trim()).collect(Collectors.toList()));
         builder.environment().putAll(env);
         builder.directory(new File(workingDirectory));
         final Process process;


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-1144

trims spaces of each line in commands to construct ProcessBuilder