### PR TITLE
WFCORE-950 - allow changing of --jboss-home in non-modular

### DIFF
--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
@@ -144,7 +144,7 @@ public class EmbeddedHostControllerFactory {
             props.put(HostControllerEnvironment.DOMAIN_BASE_DIR, tempRoot.getAbsolutePath());
             props.put(HostControllerEnvironment.DOMAIN_CONFIG_DIR, configDir.getAbsolutePath());
             props.put(HostControllerEnvironment.DOMAIN_DATA_DIR, dataDir.getAbsolutePath());
-        }  catch (IOException e) {
+        } catch (IOException e) {
             throw EmbeddedLogger.ROOT_LOGGER.cannotSetupEmbeddedServer(e);
         }
 
@@ -220,8 +220,7 @@ public class EmbeddedHostControllerFactory {
                 throw ServerLogger.ROOT_LOGGER.errorCopyingFile(srcFile.getAbsolutePath(), destFile.getAbsolutePath(), e);
             }
         }
-
-}
+    }
 
     private static class HostControllerImpl implements HostController {
 
@@ -443,9 +442,7 @@ public class EmbeddedHostControllerFactory {
 
         private static HostControllerEnvironment createHostControllerEnvironment(File jbossHome, String[] cmdargs, String hostName, long startTime) {
             try {
-                // for SecurityActions.getSystemProperty("jboss.home.dir") in InstallationManagerService
-                System.setProperty("jboss.home.dir", jbossHome.getAbsolutePath());
-                WildFlySecurityManager.setPropertyPrivileged("jboss.home.dir", jbossHome.getAbsolutePath());
+                WildFlySecurityManager.setPropertyPrivileged(HostControllerEnvironment.HOME_DIR, jbossHome.getAbsolutePath());
 
                 Map<String, String> props = new HashMap<String, String>();
                 props.put(HostControllerEnvironment.HOME_DIR, jbossHome.getAbsolutePath());

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
@@ -201,6 +201,7 @@ public class EmbeddedStandaloneServerFactory {
         }
     }
 
+
     private static class StandaloneServerImpl implements StandaloneServer {
 
         private final PropertyChangeListener processStateListener;

--- a/embedded/src/main/java/org/wildfly/core/embedded/logging/EmbeddedLogger.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/logging/EmbeddedLogger.java
@@ -193,4 +193,8 @@ public interface EmbeddedLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 25, value = "Unable to configure embedded server logging from %s")
     void cannotConfigureBootLogging(File loggingProperties);
+
+    @Message(id = 26, value = "Cannot create host controller using factory: %s")
+    IllegalStateException cannotCreateHostController(@Cause Throwable cause, Method createMethod);
+
 }


### PR DESCRIPTION
The should help if a user enters an incorrect --jboss-home or restarts with a different --jboss-home.