### PR TITLE
[WFCORE-892] Set timeout parameter for cli client

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
@@ -130,6 +130,7 @@ public class CustomCLIExecutor {
             cliConfigPath = Paths.get(jbossDist, "bin", "jboss-cli.xml");
         }
         commandBuilder.addJavaOption("-Djboss.cli.config=" + cliConfigPath);
+        commandBuilder.addCliArgument("--timeout="+CLI_PROC_TIMEOUT);
 
         // Note that this only allows for a single system property
         if (System.getProperty("cli.args") != null) {


### PR DESCRIPTION
Default value (5s) is not enough sometimes, especially on java IBM8. Parameter --timeout has to be same as in with waiting mechanism in CustomCLIExecutor.

JIRA: https://issues.jboss.org/browse/WFCORE-892