### PR TITLE
[WFCORE-313]: DefaultOperationDescriptionProvider uses incorrect call  to create reply parameter description.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -754,6 +754,53 @@ public abstract class AttributeDefinition {
     }
 
     /**
+     * Creates a returns a basic model node describing a parameter that sets this attribute, after attaching it to the
+     * given overall operation description model node.  The node describing the parameter is returned to make it easy
+     * to perform further modification.
+     *
+     * @param bundle resource bundle to use for text descriptions
+     * @param prefix prefix to prepend to the attribute name key when looking up descriptions
+     * @param operationDescription  the overall resource description
+     * @return  the attribute description node
+     */
+    public ModelNode addOperationReplyDescription(final ResourceBundle bundle, final String prefix, final ModelNode operationDescription) {
+        final ModelNode param = getNoTextDescription(true);
+        param.get(ModelDescriptionConstants.DESCRIPTION).set(getAttributeTextDescription(bundle, prefix));
+        final ModelNode result = operationDescription.get(ModelDescriptionConstants.REPLY_PROPERTIES, getName()).set(param);
+        ModelNode deprecated = addDeprecatedInfo(result);
+        if (deprecated != null) {
+            deprecated.get(ModelDescriptionConstants.REASON).set(getAttributeDeprecatedDescription(bundle, prefix));
+        }
+        return result;
+    }
+
+    /**
+     * Creates a returns a basic model node describing a parameter that sets this attribute, after attaching it to the
+     * given overall operation description model node.  The node describing the parameter is returned to make it easy
+     * to perform further modification.
+     *
+     * @param resourceDescription  the overall resource description
+     * @param operationName the operation name
+     * @param resolver provider of localized text descriptions
+     * @param locale locale to pass to the resolver
+     * @param bundle bundle to pass to the resolver
+     * @return  the attribute description node
+     */
+    public ModelNode addOperationReplyDescription(final ModelNode resourceDescription, final String operationName,
+                                                      final ResourceDescriptionResolver resolver,
+                                                      final Locale locale, final ResourceBundle bundle) {
+        final ModelNode param = getNoTextDescription(true);
+        String description = resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, getName());
+        param.get(ModelDescriptionConstants.DESCRIPTION).set(description);
+        final ModelNode result = resourceDescription.get(ModelDescriptionConstants.REPLY_PROPERTIES, getName()).set(param);
+        ModelNode deprecated = addDeprecatedInfo(result);
+        if (deprecated != null) {
+            deprecated.get(ModelDescriptionConstants.REASON).set(resolver.getOperationParameterDeprecatedDescription(operationName, getName(), locale, bundle));
+        }
+        return result;
+    }
+
+    /**
      * Gets localized text from the given {@link java.util.ResourceBundle} for the attribute.
      *
      * @param bundle the resource bundle. Cannot be {@code null}

--- a/controller/src/main/java/org/jboss/as/controller/ListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ListAttributeDefinition.java
@@ -175,6 +175,15 @@ public abstract class ListAttributeDefinition extends AttributeDefinition {
         return result;
     }
 
+    @Override
+    public ModelNode addOperationReplyDescription(final ModelNode resourceDescription, final String operationName,
+                                                      final ResourceDescriptionResolver resolver,
+                                                      final Locale locale, final ResourceBundle bundle) {
+        final ModelNode result = super.addOperationReplyDescription(resourceDescription, operationName, resolver, locale, bundle);
+        addOperationReplyValueTypeDescription(result, operationName, resolver, locale, bundle);
+        return result;
+    }
+
     protected abstract void addValueTypeDescription(final ModelNode node, final ResourceBundle bundle);
 
     protected abstract void addAttributeValueTypeDescription(final ModelNode node, final ResourceDescriptionResolver resolver,
@@ -183,6 +192,13 @@ public abstract class ListAttributeDefinition extends AttributeDefinition {
     protected abstract void addOperationParameterValueTypeDescription(final ModelNode node, final String operationName,
                                                                       final ResourceDescriptionResolver resolver,
                                                                       final Locale locale, final ResourceBundle bundle);
+
+    protected void addOperationReplyValueTypeDescription(final ModelNode node, final String operationName,
+                                                                      final ResourceDescriptionResolver resolver,
+                                                                      final Locale locale, final ResourceBundle bundle) {
+        //TODO WFCORE-1178: use reply value types description instead of parameter value type
+        addOperationParameterValueTypeDescription(node, operationName, resolver, locale, bundle);
+    }
 
     @Override
     public void marshallAsElement(ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {

--- a/controller/src/main/java/org/jboss/as/controller/MapAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/MapAttributeDefinition.java
@@ -140,6 +140,15 @@ public abstract class MapAttributeDefinition extends AttributeDefinition {
         return result;
     }
 
+        @Override
+    public ModelNode addOperationReplyDescription(ModelNode resourceDescription, String operationName,
+                                                      ResourceDescriptionResolver resolver, Locale locale, ResourceBundle bundle) {
+        final ModelNode result = super.addOperationReplyDescription(resourceDescription, operationName, resolver, locale, bundle);
+        //TODO WFCORE-1178: use reply value types description instead of parameter value type
+        addOperationParameterValueTypeDescription(result, operationName, resolver, locale, bundle);
+        return result;
+    }
+
     protected abstract void addOperationParameterValueTypeDescription(ModelNode result, String operationName, ResourceDescriptionResolver resolver, Locale locale, ResourceBundle bundle);
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/ObjectTypeAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ObjectTypeAttributeDefinition.java
@@ -126,6 +126,7 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
         return result;
     }
 
+    @Override
     public ModelNode addOperationParameterDescription(final ModelNode resourceDescription, final String operationName,
                                                       final ResourceDescriptionResolver resolver,
                                                       final Locale locale, final ResourceBundle bundle) {
@@ -134,6 +135,16 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
         return result;
     }
 
+    @Override
+    public ModelNode addOperationReplyDescription(final ModelNode resourceDescription, final String operationName,
+                                                      final ResourceDescriptionResolver resolver,
+                                                      final Locale locale, final ResourceBundle bundle) {
+        final ModelNode result = super.addOperationReplyDescription(resourceDescription, operationName, resolver, locale, bundle);
+        addValueTypeDescription(result, getName(), bundle, true, resolver, locale);
+        return result;
+    }
+
+    @Override
     public ModelNode addResourceAttributeDescription(final ModelNode resourceDescription, final ResourceDescriptionResolver resolver,
                                                      final Locale locale, final ResourceBundle bundle) {
         final ModelNode result = super.addResourceAttributeDescription(resourceDescription, resolver, locale, bundle);

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultOperationDescriptionProvider.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/DefaultOperationDescriptionProvider.java
@@ -188,13 +188,12 @@ public class DefaultOperationDescriptionProvider implements DescriptionProvider 
                     deprecated.get(ModelDescriptionConstants.REASON).set(attributeDescriptionResolver.getOperationParameterDeprecatedDescription(operationName, ad.getName(), locale, attributeBundle));
                 }*/
                 ModelNode param = new ModelNode();
-                ad.addOperationParameterDescription(param, operationName, attributeDescriptionResolver, locale, attributeBundle);
-                reply.set(param.get(REQUEST_PROPERTIES).get(ad.getName()));
-
+                ad.addOperationReplyDescription(param, operationName, attributeDescriptionResolver, locale, attributeBundle);
+                reply.set(param.get(REPLY_PROPERTIES).get(ad.getName()));
             } else {
                 reply.get(TYPE).set(replyType == null ? ModelType.OBJECT : replyType);
                 for (AttributeDefinition ad : replyParameters) {
-                    final ModelNode param = ad.addOperationParameterDescription(new ModelNode(), operationName, attributeDescriptionResolver, locale, bundle);
+                    final ModelNode param = ad.addOperationReplyDescription(new ModelNode(), operationName, attributeDescriptionResolver, locale, bundle);
                     reply.get(VALUE_TYPE, ad.getName()).set(param);
                 }
             }

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/StandardResourceDescriptionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/StandardResourceDescriptionResolver.java
@@ -219,9 +219,13 @@ public class StandardResourceDescriptionResolver implements ResourceDescriptionR
     @Override
     public String getOperationReplyValueTypeDescription(String operationName, Locale locale, ResourceBundle bundle, String... suffixes) {
         try {
-            return bundle.getString(getVariableBundleKey(new String[] {operationName, REPLY}, suffixes));
+            return bundle.getString(getVariableBundleKey(new String[]{operationName, REPLY}, suffixes));
         } catch (MissingResourceException e) {
-            return null;
+            try {
+                return getOperationParameterValueTypeDescription(operationName, suffixes[0], locale, bundle);
+            } catch (MissingResourceException ex) {
+                throw e;
+            }
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/OperationDefinitionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationDefinitionTestCase.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2015 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPRECATED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REASON;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REPLY_PROPERTIES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUEST_PROPERTIES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SINCE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE_TYPE;
+
+import java.util.Locale;
+import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.MissingResourceException;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class OperationDefinitionTestCase {
+
+    @Test
+    public void testSimpleOperationDefinition() {
+        SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder("operation",
+                new StandardResourceDescriptionResolver("simple", OperationDefinitionTestCase.class.getName(), Thread.currentThread().getContextClassLoader()));
+        builder.addParameter(create("parameter", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.addParameter(create("deprecated-parameter", ModelType.STRING, true).setDeprecated(ModelVersion.CURRENT).setAllowExpression(true).build());
+        builder.addParameter(create("duplicated", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.setReplyParameters(create("duplicated", ModelType.STRING, true).setAllowExpression(true).build(),
+                create("deprecated-parameter", ModelType.STRING, true).build());
+        ModelNode description = builder.build().getDescriptionProvider().getModelDescription(Locale.ROOT);
+        assertThat(description.get(OPERATION_NAME).asString(), is("operation"));
+        assertThat(description.get(DESCRIPTION).asString(), is("Simple operation test"));
+        assertTrue(description.hasDefined(REQUEST_PROPERTIES));
+        ModelNode parameters = description.get(REQUEST_PROPERTIES);
+        assertTrue(parameters.hasDefined("parameter"));
+        assertThat(parameters.get("parameter", DESCRIPTION).asString(), is("Simple operation parameter"));
+        assertTrue(parameters.hasDefined("deprecated-parameter"));
+        assertThat(parameters.get("deprecated-parameter", DESCRIPTION).asString(), is("Simple operation deprecated parameter"));
+        assertThat(parameters.get("deprecated-parameter", DEPRECATED, SINCE).asString(), is(ModelVersion.CURRENT.toString()));
+        assertThat(parameters.get("deprecated-parameter", DEPRECATED, REASON).asString(), is("The simple operation deprecated parameter is deprecated and may be removed in the near future."));
+        assertTrue(parameters.hasDefined("duplicated"));
+        assertThat(parameters.get("duplicated", DESCRIPTION).asString(), is("Simple operation parameter"));
+        assertTrue(description.hasDefined(REPLY_PROPERTIES));
+        ModelNode replies = description.get(REPLY_PROPERTIES, VALUE_TYPE);
+        assertTrue(replies.hasDefined("deprecated-parameter"));
+        assertThat(replies.get("deprecated-parameter", DESCRIPTION).asString(), is("Simple operation reply parameter not deprecated"));
+        assertFalse(replies.hasDefined("deprecated-parameter", DEPRECATED));
+        assertTrue(replies.hasDefined("duplicated"));
+        assertThat(replies.get("duplicated", DESCRIPTION).asString(), is("Simple operation reply parameter"));
+    }
+
+    @Test
+    public void testReplyValueTypeOperationDefinition() {
+        SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder("operation",
+                new StandardResourceDescriptionResolver("simple", OperationDefinitionTestCase.class.getName(), Thread.currentThread().getContextClassLoader()));
+        builder.addParameter(create("parameter", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.addParameter(create("deprecated-parameter", ModelType.STRING, true).setDeprecated(ModelVersion.CURRENT).setAllowExpression(true).build());
+        builder.addParameter(create("duplicated", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.setReplyType(ModelType.LIST);
+        builder.setReplyValueType(ModelType.STRING);
+        ModelNode description = builder.build().getDescriptionProvider().getModelDescription(Locale.ROOT);
+        assertThat(description.get(OPERATION_NAME).asString(), is("operation"));
+        assertThat(description.get(DESCRIPTION).asString(), is("Simple operation test"));
+        assertTrue(description.hasDefined(REQUEST_PROPERTIES));
+        ModelNode parameters = description.get(REQUEST_PROPERTIES);
+        assertTrue(parameters.hasDefined("parameter"));
+        assertThat(parameters.get("parameter", DESCRIPTION).asString(), is("Simple operation parameter"));
+        assertTrue(parameters.hasDefined("deprecated-parameter"));
+        assertThat(parameters.get("deprecated-parameter", DESCRIPTION).asString(), is("Simple operation deprecated parameter"));
+        assertThat(parameters.get("deprecated-parameter", DEPRECATED, SINCE).asString(), is(ModelVersion.CURRENT.toString()));
+        assertThat(parameters.get("deprecated-parameter", DEPRECATED, REASON).asString(), is("The simple operation deprecated parameter is deprecated and may be removed in the near future."));
+        assertTrue(parameters.hasDefined("duplicated"));
+        assertThat(parameters.get("duplicated", DESCRIPTION).asString(), is("Simple operation parameter"));
+        assertTrue(description.hasDefined(REPLY_PROPERTIES, TYPE));
+        assertTrue(description.hasDefined(REPLY_PROPERTIES, VALUE_TYPE));
+    }
+
+    @Test
+    public void testListOperationDefinition() {
+        SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder("operation",
+                new StandardResourceDescriptionResolver("simple", OperationDefinitionTestCase.class.getName(), Thread.currentThread().getContextClassLoader()));
+        builder.addParameter(create("parameter", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.addParameter(create("deprecated-parameter", ModelType.STRING, true).setDeprecated(ModelVersion.CURRENT).setAllowExpression(true).build());
+        builder.addParameter(create("duplicated", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.setReplyType(ModelType.LIST);
+        builder.setReplyParameters(new SimpleListAttributeDefinition.Builder("reply-list",
+                create("parameter", ModelType.STRING, true).setAllowExpression(true).build()).build());
+        ModelNode description = builder.build().getDescriptionProvider().getModelDescription(Locale.ROOT);
+        assertThat(description.get(OPERATION_NAME).asString(), is("operation"));
+        assertThat(description.get(DESCRIPTION).asString(), is("Simple operation test"));
+        assertTrue(description.hasDefined(REQUEST_PROPERTIES));
+        ModelNode parameters = description.get(REQUEST_PROPERTIES);
+        assertTrue(parameters.hasDefined("parameter"));
+        assertThat(parameters.get("parameter", DESCRIPTION).asString(), is("Simple operation parameter"));
+        assertTrue(parameters.hasDefined("deprecated-parameter"));
+        assertThat(parameters.get("deprecated-parameter", DESCRIPTION).asString(), is("Simple operation deprecated parameter"));
+        assertThat(parameters.get("deprecated-parameter", DEPRECATED, SINCE).asString(), is(ModelVersion.CURRENT.toString()));
+        assertThat(parameters.get("deprecated-parameter", DEPRECATED, REASON).asString(), is("The simple operation deprecated parameter is deprecated and may be removed in the near future."));
+        assertTrue(parameters.hasDefined("duplicated"));
+        assertThat(parameters.get("duplicated", DESCRIPTION).asString(), is("Simple operation parameter"));
+        assertTrue(description.hasDefined(REPLY_PROPERTIES, TYPE));
+        assertTrue(description.hasDefined(REPLY_PROPERTIES, VALUE_TYPE, "reply-list", DESCRIPTION));
+        assertThat(description.get(REPLY_PROPERTIES, VALUE_TYPE, "reply-list", DESCRIPTION).asString(), is("Simple operation reply list of parameters"));
+    }
+
+    @Test
+    public void testObjectListOperationDefinition() {
+        SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder("operation",
+                new StandardResourceDescriptionResolver("simple", OperationDefinitionTestCase.class.getName(), Thread.currentThread().getContextClassLoader()));
+        builder.addParameter(create("parameter", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.addParameter(create("deprecated-parameter", ModelType.STRING, true).setDeprecated(ModelVersion.CURRENT).setAllowExpression(true).build());
+        builder.addParameter(create("duplicated", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.setReplyType(ModelType.LIST);
+        builder.setReplyParameters(new ObjectListAttributeDefinition.Builder("object-list",
+                ObjectTypeAttributeDefinition.Builder.of("object",
+                        create("attribute", ModelType.STRING, true).setAllowExpression(true).build())
+                        .build()).build());
+        ModelNode description = builder.build().getDescriptionProvider().getModelDescription(Locale.ROOT);
+        assertThat(description.get(OPERATION_NAME).asString(), is("operation"));
+        assertThat(description.get(DESCRIPTION).asString(), is("Simple operation test"));
+        assertTrue(description.hasDefined(REQUEST_PROPERTIES));
+        ModelNode parameters = description.get(REQUEST_PROPERTIES);
+        assertTrue(parameters.hasDefined("parameter"));
+        assertThat(parameters.get("parameter", DESCRIPTION).asString(), is("Simple operation parameter"));
+        assertTrue(parameters.hasDefined("deprecated-parameter"));
+        assertThat(parameters.get("deprecated-parameter", DESCRIPTION).asString(), is("Simple operation deprecated parameter"));
+        assertThat(parameters.get("deprecated-parameter", DEPRECATED, SINCE).asString(), is(ModelVersion.CURRENT.toString()));
+        assertThat(parameters.get("deprecated-parameter", DEPRECATED, REASON).asString(), is("The simple operation deprecated parameter is deprecated and may be removed in the near future."));
+        assertTrue(parameters.hasDefined("duplicated"));
+        assertThat(parameters.get("duplicated", DESCRIPTION).asString(), is("Simple operation parameter"));
+        assertTrue(description.hasDefined(REPLY_PROPERTIES, TYPE));
+        assertTrue(description.hasDefined(REPLY_PROPERTIES, VALUE_TYPE, "object-list", DESCRIPTION));
+        assertThat(description.get(REPLY_PROPERTIES, VALUE_TYPE, "object-list", DESCRIPTION).asString(), is("Simple operation reply list of objects"));
+    }
+
+    @Test
+    public void testSimpleOperationDefinitionFallBack() {
+        SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder("operation",
+                new StandardResourceDescriptionResolver("simple", OperationDefinitionTestCase.class.getName(), Thread.currentThread().getContextClassLoader()));
+        builder.addParameter(create("parameter", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.addParameter(create("deprecated-parameter", ModelType.STRING, true).setDeprecated(ModelVersion.CURRENT).setAllowExpression(true).build());
+        builder.addParameter(create("duplicated", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.setReplyParameters(create("parameter", ModelType.STRING, true).setAllowExpression(true).build());
+        ModelNode description = builder.build().getDescriptionProvider().getModelDescription(Locale.ROOT);
+        assertThat(description.get(OPERATION_NAME).asString(), is("operation"));
+        assertThat(description.get(DESCRIPTION).asString(), is("Simple operation test"));
+        assertTrue(description.hasDefined(REQUEST_PROPERTIES));
+        ModelNode parameters = description.get(REQUEST_PROPERTIES);
+        assertTrue(parameters.hasDefined("parameter"));
+        assertThat(parameters.get("parameter", DESCRIPTION).asString(), is("Simple operation parameter"));
+        assertTrue(parameters.hasDefined("deprecated-parameter"));
+        assertThat(parameters.get("deprecated-parameter", DESCRIPTION).asString(), is("Simple operation deprecated parameter"));
+        assertThat(parameters.get("deprecated-parameter", DEPRECATED, SINCE).asString(), is(ModelVersion.CURRENT.toString()));
+        assertThat(parameters.get("deprecated-parameter", DEPRECATED, REASON).asString(), is("The simple operation deprecated parameter is deprecated and may be removed in the near future."));
+        assertTrue(parameters.hasDefined("duplicated"));
+        assertThat(parameters.get("duplicated", DESCRIPTION).asString(), is("Simple operation parameter"));
+        assertTrue(description.hasDefined(REPLY_PROPERTIES));
+        ModelNode replies = description.get(REPLY_PROPERTIES);
+        assertTrue(replies.hasDefined(DESCRIPTION));
+        assertThat(replies.get(DESCRIPTION).asString(), is("Simple operation parameter"));
+    }
+
+    @Test
+    public void testNotDefinedSimpleOperationDefinition() {
+        SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder("operation",
+                new StandardResourceDescriptionResolver("simple", OperationDefinitionTestCase.class.getName(), Thread.currentThread().getContextClassLoader()));
+        builder.addParameter(create("parameter", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.addParameter(create("deprecated-parameter", ModelType.STRING, true).setDeprecated(ModelVersion.CURRENT).setAllowExpression(true).build());
+        builder.addParameter(create("duplicated", ModelType.STRING, true).setAllowExpression(true).build());
+        builder.setReplyParameters(create("not-defined-parameter", ModelType.STRING, true).setAllowExpression(true).build());
+        try {
+            builder.build().getDescriptionProvider().getModelDescription(Locale.ROOT);
+            Assert.fail("The description for \"not-defined-parameter\" isn't existing, htis should have failed");
+        } catch(MissingResourceException e) {
+            assertThat(e.getMessage(), CoreMatchers.containsString("simple.operation.reply.not-defined-parameter"));
+        }
+    }
+}

--- a/controller/src/test/resources/org/jboss/as/controller/OperationDefinitionTestCase.properties
+++ b/controller/src/test/resources/org/jboss/as/controller/OperationDefinitionTestCase.properties
@@ -1,0 +1,28 @@
+# Copyright (C) 2015 Red Hat, inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301  USA
+simple.operation=Simple operation test
+simple.operation.parameter=Simple operation parameter
+simple.operation.deprecated-parameter=Simple operation deprecated parameter
+simple.operation.deprecated-parameter.deprecated=The simple operation deprecated parameter is deprecated and may be removed in the near future.
+simple.operation.duplicated=Simple operation parameter
+simple.operation.reply.duplicated=Simple operation reply parameter
+simple.operation.reply.deprecated-parameter=Simple operation reply parameter not deprecated
+simple.operation.reply.reply-list=Simple operation reply list of parameters
+simple.operation.reply.object-list=Simple operation reply list of objects
+simple.object-list.attribute=Attribute of the reply object.


### PR DESCRIPTION
Adding support for reply parameter description using a different text from the parameter.

Jira: https://issues.jboss.org/browse/WFCORE-313

https://github.com/wildfly/wildfly/pull/8440 is needed to have integration builds green.

http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=80520&tab=buildResultsDiv&buildTypeId=WildFlyCore_PullRequest_WildFlyCoreFullIntegration
http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=80523&tab=buildResultsDiv&buildTypeId=WildFlyCore_PullRequest_WildFlyCoreFullIntegration