### PR TITLE
[WFCORE-1161] Provide an MRR-driven CapabilityReferenceRecorder

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -653,6 +653,30 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
      * <p>
      * This method is a convenience method equivalent to calling
      * {@link #setCapabilityReference(CapabilityReferenceRecorder)}
+     * passing in a {@link CapabilityReferenceRecorder.ContextDependencyRecorder}
+     * constructed using the parameters passed to this method.
+     * <p>
+     * <strong>NOTE:</strong> This method of recording capability references is only suitable for use in attributes
+     * only used in resources that themselves expose a single capability. When the capability requirement
+     * is registered, the dependent capability will be that capability.
+     *
+     * @param referencedCapability the name of the dynamic capability the dynamic portion of whose name is
+     *                             represented by the attribute's value
+     * @return the builder
+     * @see SimpleAttributeDefinition#addCapabilityRequirements(OperationContext, ModelNode)
+     * @see SimpleAttributeDefinition#removeCapabilityRequirements(OperationContext, ModelNode)
+     */
+    public BUILDER setCapabilityReference(String referencedCapability) {
+        referenceRecorder = new CapabilityReferenceRecorder.ContextDependencyRecorder(referencedCapability);
+        return (BUILDER) this;
+    }
+
+    /**
+     * Records that this attribute's value represents a reference to an instance of a
+     * {@link org.jboss.as.controller.capability.RuntimeCapability#isDynamicallyNamed() dynamic capability}.
+     * <p>
+     * This method is a convenience method equivalent to calling
+     * {@link #setCapabilityReference(CapabilityReferenceRecorder)}
      * passing in a {@link org.jboss.as.controller.CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder}
      * constructed using the parameters passed to this method.
      *

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ProfileIncludesHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ProfileIncludesHandlerTestCase.java
@@ -75,6 +75,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
     }
 
 
+    @Test
     public void testBadProfileIncludesAdd() throws Exception {
         PathAddress addr = getProfileAddress("test");
         ModelNode op = Util.createAddOperation(addr);


### PR DESCRIPTION
I also enabled a test that I noticed was disabled when I was playing with testing this.

Note that this PR doesn't change any of the usage of setCapabilityReference in core. That's because this method of determining the dependent is more expensive, so I didn't want to change working code to something more expensive.