### PR TITLE
[WFCORE-1172]:  SimpleResourceDefinition.Parameters should support setting access constraints.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.controller;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -59,6 +60,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
     private volatile DeprecationData deprecationData;
     private final boolean orderedChild;
     private final RuntimeCapability[] capabilities;
+    private final List<AccessConstraintDefinition> accessConstraints;
 
     /**
      * {@link ResourceDefinition} that uses the given {code descriptionProvider} to describe the resource.
@@ -85,6 +87,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
         this.runtime = false;
         this.orderedChild = false;
         this.capabilities = new RuntimeCapability[0];
+        this.accessConstraints = Collections.emptyList();
     }
 
     /**
@@ -274,6 +277,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
         this.runtime = runtime;
         this.orderedChild = false;
         this.capabilities = new RuntimeCapability[0];
+        this.accessConstraints = Collections.emptyList();
     }
 
     /**
@@ -294,6 +298,11 @@ public class SimpleResourceDefinition implements ResourceDefinition {
         this.orderedChild = parameters.orderedChildResource;
         this.descriptionProvider = null;
         this.capabilities = parameters.capabilities;
+        if (parameters.accessConstraints != null) {
+            this.accessConstraints = Arrays.asList(parameters.accessConstraints);
+        } else {
+            this.accessConstraints = Collections.emptyList();
+        }
     }
 
 
@@ -448,7 +457,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
      */
     @Override
     public List<AccessConstraintDefinition> getAccessConstraints() {
-        return Collections.emptyList();
+        return this.accessConstraints;
     }
 
     protected void setDeprecated(ModelVersion since) {
@@ -490,6 +499,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
         private DeprecationData deprecationData;
         private boolean orderedChildResource;
         private RuntimeCapability[] capabilities;
+        private AccessConstraintDefinition[] accessConstraints;
 
         /**
          * Creates a Parameters object
@@ -639,5 +649,14 @@ public class SimpleResourceDefinition implements ResourceDefinition {
             return this;
         }
 
+        /**
+         * set access constraint definitions for this resource
+         * @param accessConstraints access constraint definitions for this resource
+         * @return Parameters object
+         */
+        public Parameters setAccessConstraints(AccessConstraintDefinition ... accessConstraints){
+            this.accessConstraints = accessConstraints;
+            return this;
+        }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionResourceDefinition.java
@@ -24,13 +24,10 @@ package org.jboss.as.controller.extension;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 
-import java.util.List;
-
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
@@ -49,16 +46,14 @@ public class ExtensionResourceDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition MODULE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.MODULE, ModelType.STRING, false)
             .setValidator(new StringLengthValidator(1)).build();
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     public ExtensionResourceDefinition(final ExtensionRegistry extensionRegistry, final boolean parallelBoot,
                                        final ExtensionRegistryType extensionRegistryType, final MutableRootResourceRegistrationProvider rootResourceRegistrationProvider) {
         super(new Parameters(PathElement.pathElement(EXTENSION), ControllerResolver.getResolver(EXTENSION))
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.EXTENSIONS)
                 .setAddHandler(new ExtensionAddHandler(extensionRegistry, parallelBoot, extensionRegistryType, rootResourceRegistrationProvider))
                 .setRemoveHandler(new ExtensionRemoveHandler(extensionRegistry, extensionRegistryType, rootResourceRegistrationProvider))
                 .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
                 .setRemoveRestartLevel(OperationEntry.Flag.RESTART_NONE));
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.EXTENSIONS.wrapAsList();
     }
 
     @Override
@@ -69,10 +64,5 @@ public class ExtensionResourceDefinition extends SimpleResourceDefinition {
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         resourceRegistration.registerSubModel(new ExtensionSubsystemResourceDefinition());
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingGroupResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingGroupResourceDefinition.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.controller.resource;
 
-import java.util.List;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -33,7 +32,6 @@ import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -73,15 +71,13 @@ public abstract class AbstractSocketBindingGroupResourceDefinition extends Simpl
             .setCapabilityReference("org.wildfly.network.interface", SOCKET_BINDING_GROUP_CAPABILITY)
             .build();
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     public AbstractSocketBindingGroupResourceDefinition(final OperationStepHandler addHandler, final OperationStepHandler removeHandler) {
         super(new Parameters(PATH, ControllerResolver.getResolver(ModelDescriptionConstants.SOCKET_BINDING_GROUP))
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_CONFIG)
                 .setAddHandler(addHandler)
                 .setRemoveHandler(removeHandler)
                 .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
                 .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES));
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.SOCKET_CONFIG.wrapAsList();
     }
 
     @Override
@@ -95,11 +91,6 @@ public abstract class AbstractSocketBindingGroupResourceDefinition extends Simpl
             }
         });
 
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 
     public static void validateDefaultInterfaceReference(final OperationContext context, final ModelNode bindingGroup) throws OperationFailedException {

--- a/controller/src/main/java/org/jboss/as/controller/resource/InterfaceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/InterfaceDefinition.java
@@ -28,7 +28,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.Set;
@@ -46,7 +45,6 @@ import org.jboss.as.controller.ReadResourceNameOperationStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleListAttributeDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -178,17 +176,15 @@ public class InterfaceDefinition extends SimpleResourceDefinition {
             MULTICAST, POINT_TO_POINT, PUBLIC_ADDRESS, SITE_LOCAL_ADDRESS, UP, VIRTUAL};*/
 
     private final boolean updateRuntime;
-    private final List<AccessConstraintDefinition> sensitivity;
     private final boolean resolvable;
 
     public InterfaceDefinition(InterfaceAddHandler addHandler, InterfaceRemoveHandler removeHandler, boolean updateRuntime, boolean resolvable) {
-        super(PathElement.pathElement(INTERFACE),
-                ControllerResolver.getResolver(INTERFACE),
-                addHandler,
-                removeHandler);
+        super(new Parameters(PathElement.pathElement(INTERFACE), ControllerResolver.getResolver(INTERFACE))
+                .setAddHandler(addHandler)
+                .setRemoveHandler(removeHandler)
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SOCKET_CONFIG));
         this.updateRuntime = updateRuntime;
         this.resolvable = resolvable;
-        this.sensitivity = SensitiveTargetAccessConstraintDefinition.SOCKET_CONFIG.wrapAsList();
     }
 
     public static String localName(final Element element) {
@@ -231,11 +227,6 @@ public class InterfaceDefinition extends SimpleResourceDefinition {
             registration.registerReadWriteAttribute(def, null, handler);
         }
         registration.registerReadOnlyAttribute(InterfaceDefinition.NAME, ReadResourceNameOperationStepHandler.INSTANCE);
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return sensitivity;
     }
 
     @Deprecated

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
@@ -29,9 +29,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Random;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -488,20 +485,16 @@ public class BasicRbacTestCase extends AbstractRbacTestBase {
     }
 
     private static final class TestResourceDefinition extends SimpleResourceDefinition {
-        private final List<AccessConstraintDefinition> constraintDefinitions;
 
         TestResourceDefinition(String path, AccessConstraintDefinition... constraintDefinitions) {
             this(pathElement(path), constraintDefinitions);
         }
 
         TestResourceDefinition(PathElement element, AccessConstraintDefinition... constraintDefinitions) {
-            super(element,
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {}
-            );
-
-            this.constraintDefinitions = Collections.unmodifiableList(Arrays.asList(constraintDefinitions));
+            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(constraintDefinitions));
         }
 
         @Override
@@ -512,11 +505,6 @@ public class BasicRbacTestCase extends AbstractRbacTestBase {
                     new TestOperationStepHandler(false));
             resourceRegistration.registerOperationHandler(TestOperationStepHandler.RW_DEFINITION,
                     new TestOperationStepHandler(true));
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraintDefinitions;
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
@@ -596,20 +596,16 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
     }
 
     private static final class TestResourceDefinition extends SimpleResourceDefinition {
-        private final List<AccessConstraintDefinition> constraintDefinitions;
 
         TestResourceDefinition(String path, AccessConstraintDefinition... constraintDefinitions) {
             this(pathElement(path), constraintDefinitions);
         }
 
         TestResourceDefinition(PathElement element, AccessConstraintDefinition... constraintDefinitions) {
-            super(element,
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {}
-            );
-
-            this.constraintDefinitions = Collections.unmodifiableList(Arrays.asList(constraintDefinitions));
+            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(constraintDefinitions));
         }
 
         @Override
@@ -642,11 +638,6 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
                     new TestOperationStepHandler(Action.ActionEffect.READ_RUNTIME, Action.ActionEffect.WRITE_CONFIG));
             resourceRegistration.registerOperationHandler(TestOperationStepHandler.WRITE_RUNTIME_WRITE_CONFIG_DEFINITION,
                     new TestOperationStepHandler(Action.ActionEffect.WRITE_RUNTIME, Action.ActionEffect.WRITE_CONFIG));
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraintDefinitions;
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenNamesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenNamesTestCase.java
@@ -36,15 +36,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUC
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition.Parameters;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -167,30 +164,16 @@ public class FilteredReadChildrenNamesTestCase extends AbstractRbacTestBase {
     protected void initModel(ManagementModel managementModel) {
         ManagementResourceRegistration registration = managementModel.getRootResourceRegistration();
         GlobalOperationHandlers.registerGlobalOperations(registration, ProcessType.EMBEDDED_SERVER);
-
         GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
-        registration.registerSubModel(new TestResourceDefinition(UNCONSTRAINED_RESOURCE));
-        registration.registerSubModel(new TestResourceDefinition(SENSITIVE_CONSTRAINED_RESOURCE,
-                MY_SENSITIVE_CONSTRAINT));
-    }
-
-    private static final class TestResourceDefinition extends SimpleResourceDefinition {
-        private final List<AccessConstraintDefinition> constraintDefinitions;
-
-        TestResourceDefinition(String path, AccessConstraintDefinition... constraintDefinitions) {
-            super(pathElement(path),
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {}
-            );
-
-            this.constraintDefinitions = Collections.unmodifiableList(Arrays.asList(constraintDefinitions));
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraintDefinitions;
-        }
+        registration.registerSubModel(new SimpleResourceDefinition(
+                new Parameters(pathElement(UNCONSTRAINED_RESOURCE), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})));
+        registration.registerSubModel(new SimpleResourceDefinition(
+                new Parameters(pathElement(SENSITIVE_CONSTRAINED_RESOURCE), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(MY_SENSITIVE_CONSTRAINT)));
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenResourcesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadChildrenResourcesTestCase.java
@@ -36,15 +36,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUC
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition.Parameters;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -161,27 +158,14 @@ public class FilteredReadChildrenResourcesTestCase extends AbstractRbacTestBase 
 
         GlobalNotifications.registerGlobalNotifications(registration, ProcessType.EMBEDDED_SERVER);
 
-        registration.registerSubModel(new TestResourceDefinition(UNCONSTRAINED_RESOURCE));
-        registration.registerSubModel(new TestResourceDefinition(SENSITIVE_CONSTRAINED_RESOURCE,
-                MY_SENSITIVE_CONSTRAINT));
-    }
-
-    private static final class TestResourceDefinition extends SimpleResourceDefinition {
-        private final List<AccessConstraintDefinition> constraintDefinitions;
-
-        TestResourceDefinition(String path, AccessConstraintDefinition... constraintDefinitions) {
-            super(pathElement(path),
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {}
-            );
-
-            this.constraintDefinitions = Collections.unmodifiableList(Arrays.asList(constraintDefinitions));
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraintDefinitions;
-        }
+        registration.registerSubModel(new SimpleResourceDefinition(
+                new Parameters(pathElement(UNCONSTRAINED_RESOURCE), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})));
+        registration.registerSubModel(new SimpleResourceDefinition(
+                new Parameters(pathElement(SENSITIVE_CONSTRAINED_RESOURCE), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(MY_SENSITIVE_CONSTRAINT)));
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadResourceTestCase.java
@@ -39,9 +39,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -213,21 +211,12 @@ public class FilteredReadResourceTestCase extends AbstractRbacTestBase {
     }
 
     private static final class TestResourceDefinition extends SimpleResourceDefinition {
-        private final List<AccessConstraintDefinition> constraintDefinitions;
 
         TestResourceDefinition(String path, AccessConstraintDefinition... constraintDefinitions) {
-            super(pathElement(path),
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {}
-            );
-
-            this.constraintDefinitions = Collections.unmodifiableList(Arrays.asList(constraintDefinitions));
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraintDefinitions;
+             super(new Parameters(pathElement(path), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(constraintDefinitions));
         }
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadAttributeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadAttributeTestCase.java
@@ -31,10 +31,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RES
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -292,18 +288,15 @@ public class ReadAttributeTestCase extends AbstractRbacTestBase {
     }
 
     private static final class TestResourceDefinition extends SimpleResourceDefinition {
-        private final List<AccessConstraintDefinition> constraintDefinitions;
         private final boolean useDefaultReadAttributeHandler;
 
         TestResourceDefinition(String path, boolean useDefaultReadAttributeHandler, AccessConstraintDefinition... constraintDefinitions) {
-            super(pathElement(path),
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {}
-            );
+             super(new Parameters(pathElement(path), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(constraintDefinitions));
 
             this.useDefaultReadAttributeHandler = useDefaultReadAttributeHandler;
-            this.constraintDefinitions = Collections.unmodifiableList(Arrays.asList(constraintDefinitions));
         }
 
         @Override
@@ -344,11 +337,6 @@ public class ReadAttributeTestCase extends AbstractRbacTestBase {
                     .setAccessConstraints(MY_APPLICATION_CONSTRAINT)
                     .build();
             resourceRegistration.registerReadOnlyAttribute(attributeDefinition, readAttributeHandler);
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraintDefinitions;
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationDescriptionAccessControlTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationDescriptionAccessControlTestCase.java
@@ -263,18 +263,11 @@ public class ReadOperationDescriptionAccessControlTestCase extends AbstractContr
         this.rootRegistration = managementModel.getRootResourceRegistration();
     }
 
-    private static class TestResourceDefinition extends SimpleResourceDefinition {
-        TestResourceDefinition(PathElement pathElement) {
-            super(pathElement,
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {});
-        }
-    }
-
-    private static class RootResourceDefinition extends TestResourceDefinition {
+    private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
-            super(PathElement.pathElement("root"));
+            super(new Parameters(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
 
         @Override
@@ -284,15 +277,16 @@ public class ReadOperationDescriptionAccessControlTestCase extends AbstractContr
         }
     }
 
-    private static class ChildResourceDefinition extends TestResourceDefinition implements ResourceDefinition {
-        private final List<AccessConstraintDefinition> constraints;
+    private static class ChildResourceDefinition extends SimpleResourceDefinition implements ResourceDefinition {
         private final List<AttributeDefinition> attributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
         private final List<AttributeDefinition> readOnlyAttributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
         private final List<OperationDefinition> operations = Collections.synchronizedList(new ArrayList<OperationDefinition>());
 
         ChildResourceDefinition(PathElement element, AccessConstraintDefinition...constraints){
-            super(element);
-            this.constraints = Collections.unmodifiableList(Arrays.asList(constraints));
+            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(constraints));
         }
 
         void addOperation(String name, boolean readOnly, boolean runtimeOnly, AccessConstraintDefinition...constraints) {
@@ -325,11 +319,6 @@ public class ReadOperationDescriptionAccessControlTestCase extends AbstractContr
             for (OperationDefinition op : operations) {
                 resourceRegistration.registerOperationHandler(op, TestOperationStepHandler.INSTANCE);
             }
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraints;
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationNamesRbacTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadOperationNamesRbacTestCase.java
@@ -287,18 +287,11 @@ public class ReadOperationNamesRbacTestCase extends AbstractControllerTestBase {
         return op;
     }
 
-    private static class TestResourceDefinition extends SimpleResourceDefinition {
-        TestResourceDefinition(PathElement pathElement) {
-            super(pathElement,
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {});
-        }
-    }
-
-    private static class RootResourceDefinition extends TestResourceDefinition {
+    private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
-            super(PathElement.pathElement("root"));
+            super(new Parameters(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
 
         @Override
@@ -308,15 +301,16 @@ public class ReadOperationNamesRbacTestCase extends AbstractControllerTestBase {
         }
     }
 
-    private static class ChildResourceDefinition extends TestResourceDefinition implements ResourceDefinition {
-        private final List<AccessConstraintDefinition> constraints;
+    private static class ChildResourceDefinition extends SimpleResourceDefinition implements ResourceDefinition {
         private final List<AttributeDefinition> attributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
         private final List<AttributeDefinition> readOnlyAttributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
         private final List<OperationDefinition> operations = Collections.synchronizedList(new ArrayList<OperationDefinition>());
 
         ChildResourceDefinition(PathElement element, AccessConstraintDefinition...constraints){
-            super(element);
-            this.constraints = Collections.unmodifiableList(Arrays.asList(constraints));
+            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(constraints));
         }
 
         void addOperation(String name, boolean readOnly, boolean runtimeOnly, AccessConstraintDefinition...constraints) {
@@ -349,11 +343,6 @@ public class ReadOperationNamesRbacTestCase extends AbstractControllerTestBase {
             for (OperationDefinition op : operations) {
                 resourceRegistration.registerOperationHandler(op, TestOperationStepHandler.INSTANCE);
             }
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraints;
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessConstraintDefinitionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessConstraintDefinitionTestCase.java
@@ -34,7 +34,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SENSITIVE;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
@@ -232,18 +231,11 @@ public class ReadResourceDescriptionAccessConstraintDefinitionTestCase extends A
     protected void initModel(ManagementModel managementModel) {
     }
 
-    private static class TestResourceDefinition extends SimpleResourceDefinition {
-        TestResourceDefinition(PathElement pathElement) {
-            super(pathElement,
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {});
-        }
-    }
-
-    private static class RootResourceDefinition extends TestResourceDefinition {
+    private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
-            super(PathElement.pathElement("root"));
+            super(new Parameters(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
 
         @Override
@@ -265,9 +257,12 @@ public class ReadResourceDescriptionAccessConstraintDefinitionTestCase extends A
         }
     }
 
-    private static class ConstrainedChildResourceDefinition extends TestResourceDefinition implements ResourceDefinition {
+    private static class ConstrainedChildResourceDefinition extends SimpleResourceDefinition implements ResourceDefinition {
         ConstrainedChildResourceDefinition(){
-            super(PathElement.pathElement("constrained-resource"));
+            super(new Parameters(PathElement.pathElement("constrained-resource"), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(SOCKET_CONFIG_SENSITIVE_CONSTRAINT));
         }
 
         @Override
@@ -286,16 +281,13 @@ public class ReadResourceDescriptionAccessConstraintDefinitionTestCase extends A
                 }
             });
         }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return Collections.singletonList(SOCKET_CONFIG_SENSITIVE_CONSTRAINT);
-        }
     }
 
-    private static class NonConstrainedChildResourceDefinition extends TestResourceDefinition {
+    private static class NonConstrainedChildResourceDefinition extends SimpleResourceDefinition {
         NonConstrainedChildResourceDefinition(){
-            super(PathElement.pathElement("nonconstrained-resource"));
+            super(new Parameters(PathElement.pathElement("nonconstrained-resource"), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
 
         @Override
@@ -304,21 +296,18 @@ public class ReadResourceDescriptionAccessConstraintDefinitionTestCase extends A
         }
     }
 
-    private static class ApplicationChildResourceDefinition extends TestResourceDefinition implements ResourceDefinition {
+    private static class ApplicationChildResourceDefinition extends SimpleResourceDefinition implements ResourceDefinition {
         ApplicationChildResourceDefinition(){
-            super(PathElement.pathElement("application-resource"));
+            super(new Parameters(PathElement.pathElement("application-resource"), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(DEPLOYMENT_APPLICATION_CONSTRAINT));
         }
 
         @Override
         public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
             resourceRegistration.registerReadWriteAttribute(STANDARD_ATTR, null, new TestWriteAttributeHandler(STANDARD_ATTR));
             resourceRegistration.registerReadWriteAttribute(APPLICATION_ATTR, null, new TestWriteAttributeHandler(APPLICATION_ATTR));
-        }
-
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return Collections.singletonList(DEPLOYMENT_APPLICATION_CONSTRAINT);
         }
 
     }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
@@ -2020,18 +2020,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         return op;
     }
 
-    private static class TestResourceDefinition extends SimpleResourceDefinition {
-        TestResourceDefinition(PathElement pathElement) {
-            super(pathElement,
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {});
-        }
-    }
-
-    private static class RootResourceDefinition extends TestResourceDefinition {
+    private static class RootResourceDefinition extends SimpleResourceDefinition {
         RootResourceDefinition() {
-            super(PathElement.pathElement("root"));
+            super(new Parameters(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {}));
         }
 
         @Override
@@ -2041,15 +2034,16 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         }
     }
 
-    private static class ChildResourceDefinition extends TestResourceDefinition implements ResourceDefinition {
-        private final List<AccessConstraintDefinition> constraints;
+    private static class ChildResourceDefinition extends SimpleResourceDefinition implements ResourceDefinition {
         private final List<AttributeDefinition> attributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
         private final List<AttributeDefinition> readOnlyAttributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
         private final List<OperationDefinition> operations = Collections.synchronizedList(new ArrayList<OperationDefinition>());
 
         ChildResourceDefinition(PathElement element, AccessConstraintDefinition...constraints){
-            super(element);
-            this.constraints = Collections.unmodifiableList(Arrays.asList(constraints));
+            super(new Parameters(element, new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(constraints));
         }
 
         void addAttribute(String name, AccessConstraintDefinition...constraints) {
@@ -2098,11 +2092,6 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
             for (OperationDefinition op : operations) {
                 resourceRegistration.registerOperationHandler(op, TestOperationStepHandler.INSTANCE);
             }
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraints;
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/WriteAttributeTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/WriteAttributeTestCase.java
@@ -32,10 +32,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -313,16 +309,12 @@ public class WriteAttributeTestCase extends AbstractRbacTestBase {
     }
 
     private static final class TestResourceDefinition extends SimpleResourceDefinition {
-        private final List<AccessConstraintDefinition> constraintDefinitions;
 
         TestResourceDefinition(String path, AccessConstraintDefinition... constraintDefinitions) {
-            super(pathElement(path),
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {}
-            );
-
-            this.constraintDefinitions = Collections.unmodifiableList(Arrays.asList(constraintDefinitions));
+            super(new Parameters(pathElement(path), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(constraintDefinitions));
         }
 
         @Override
@@ -351,11 +343,6 @@ public class WriteAttributeTestCase extends AbstractRbacTestBase {
                     .build();
             resourceRegistration.registerReadWriteAttribute(attributeDefinition, null,
                     new ModelOnlyWriteAttributeHandler(attributeDefinition));
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraintDefinitions;
         }
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/registry/CoreManagementResourceRegistrationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/registry/CoreManagementResourceRegistrationUnitTestCase.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -41,6 +40,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition.Parameters;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -334,15 +334,8 @@ public class CoreManagementResourceRegistrationUnitTestCase {
     @Test
     public void testInheritedAccessConstraints() {
 
-        ResourceDefinition rootRd = new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()) {
-            @Override
-            public List<AccessConstraintDefinition> getAccessConstraints() {
-                return Arrays.asList(
-                        SensitiveTargetAccessConstraintDefinition.EXTENSIONS,
-                        ApplicationTypeAccessConstraintDefinition.DEPLOYMENT
-                );
-            }
-        };
+        ResourceDefinition rootRd = new SimpleResourceDefinition(new Parameters(null, new NonResolvingResourceDescriptionResolver())
+            .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.EXTENSIONS, ApplicationTypeAccessConstraintDefinition.DEPLOYMENT));
         ManagementResourceRegistration root = ManagementResourceRegistration.Factory.create(rootRd);
 
         List<AccessConstraintDefinition> acds = root.getAccessConstraints();
@@ -350,15 +343,9 @@ public class CoreManagementResourceRegistrationUnitTestCase {
         assertTrue(acds.contains(SensitiveTargetAccessConstraintDefinition.EXTENSIONS));
         assertTrue(acds.contains(ApplicationTypeAccessConstraintDefinition.DEPLOYMENT));
 
-        ResourceDefinition childRd = new SimpleResourceDefinition(PathElement.pathElement("child"), new NonResolvingResourceDescriptionResolver()) {
-            @Override
-            public List<AccessConstraintDefinition> getAccessConstraints() {
-                return Arrays.asList(
-                        SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN,
-                        ApplicationTypeAccessConstraintDefinition.DEPLOYMENT
-                );
-            }
-        };
+        ResourceDefinition childRd = new SimpleResourceDefinition(
+                new Parameters(PathElement.pathElement("child"), new NonResolvingResourceDescriptionResolver())
+                    .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN, ApplicationTypeAccessConstraintDefinition.DEPLOYMENT));
         ManagementResourceRegistration child = root.registerSubModel(childRd);
         acds = child.getAccessConstraints();
         assertEquals(4, acds.size());

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationResourceDefinition.java
@@ -36,7 +36,6 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.access.CombinationPolicy;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintUtilizationRegistry;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -116,14 +115,12 @@ public class AccessAuthorizationResourceDefinition extends SimpleResourceDefinit
 
     private final boolean isDomain;
     private final boolean isHostController;
-    private final List<AccessConstraintDefinition> accessConstraints;
 
     private AccessAuthorizationResourceDefinition(DelegatingConfigurableAuthorizer configurableAuthorizer, boolean domain, boolean hostController) {
-        super(PATH_ELEMENT, DomainManagementResolver.getResolver("core.access-control"));
+        super(new Parameters(PATH_ELEMENT, DomainManagementResolver.getResolver("core.access-control")).setAccessConstraints(SensitiveTargetAccessConstraintDefinition.ACCESS_CONTROL));
         this.configurableAuthorizer = configurableAuthorizer;
         isDomain = domain;
         isHostController = hostController;
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.ACCESS_CONTROL.wrapAsList();
     }
 
     @Override
@@ -177,11 +174,6 @@ public class AccessAuthorizationResourceDefinition extends SimpleResourceDefinit
             resourceRegistration.registerOperationHandler(AccessAuthorizationDomainSlaveConfigHandler.DEFINITION,
                     new AccessAuthorizationDomainSlaveConfigHandler(configurableAuthorizer));
         }
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 
     public static Resource createResource(AccessConstraintUtilizationRegistry registry) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmResourceDefinition.java
@@ -24,8 +24,6 @@ package org.jboss.as.domain.management.security;
 
 import static org.jboss.as.domain.management.ModelDescriptionConstants.SECURITY_REALM;
 
-import java.util.List;
-
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.PathElement;
@@ -33,7 +31,6 @@ import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
@@ -61,17 +58,14 @@ public class SecurityRealmResourceDefinition extends SimpleResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
-    private final List<AccessConstraintDefinition> sensitivity;
-
     private SecurityRealmResourceDefinition() {
-        super(PathElement.pathElement(SECURITY_REALM),
-                ControllerResolver.getResolver(DEPRECATED_PARENT_CATEGORY),
-                SecurityRealmAddHandler.INSTANCE,
-                SecurityRealmRemoveHandler.INSTANCE,
-                OperationEntry.Flag.RESTART_NONE,
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        sensitivity = SensitiveTargetAccessConstraintDefinition.SECURITY_REALM.wrapAsList();
-        setDeprecated(ModelVersion.create(1, 7));
+        super(new Parameters(PathElement.pathElement(SECURITY_REALM), ControllerResolver.getResolver(DEPRECATED_PARENT_CATEGORY))
+                .setAddHandler(SecurityRealmAddHandler.INSTANCE)
+                .setRemoveHandler(SecurityRealmRemoveHandler.INSTANCE)
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_REALM)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override
@@ -102,10 +96,5 @@ public class SecurityRealmResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(new PropertiesAuthorizationResourceDefinition());
         resourceRegistration.registerSubModel(new PlugInAuthorizationResourceDefinition());
         resourceRegistration.registerSubModel(new LdapAuthorizationResourceDefinition());
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return sensitivity;
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/HttpManagementResourceDefinition.java
@@ -25,8 +25,6 @@ package org.jboss.as.host.controller.resources;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HTTP_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_INTERFACE;
 
-import java.util.List;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.ModelVersion;
@@ -35,7 +33,6 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -136,17 +133,15 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, HTTP_PORT, HTTPS_PORT, SECURE_INTERFACE, SECURITY_REALM,
                                                                                                  CONSOLE_ENABLED, HTTP_UPGRADE_ENABLED, SASL_PROTOCOL, SERVER_NAME, ALLOWED_ORIGINS};
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     public HttpManagementResourceDefinition(final LocalHostControllerInfoImpl hostControllerInfo,
                                              final HostControllerEnvironment environment) {
-        super(RESOURCE_PATH,
-                HostModelUtil.getResourceDescriptionResolver("core", "management", "http-interface"),
-                new HttpManagementAddHandler(hostControllerInfo, environment),
-                HttpManagementRemoveHandler.INSTANCE,
-                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES.wrapAsList();
-        setDeprecated(ModelVersion.create(1, 7));
+        super(new Parameters(RESOURCE_PATH, HostModelUtil.getResourceDescriptionResolver("core", "management", "http-interface"))
+                .setAddHandler(new HttpManagementAddHandler(hostControllerInfo, environment))
+                .setRemoveHandler(HttpManagementRemoveHandler.INSTANCE)
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override
@@ -155,10 +150,5 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
         for (AttributeDefinition attr : ATTRIBUTE_DEFINITIONS) {
             resourceRegistration.registerReadWriteAttribute(attr, null, HttpManagementWriteAttributeHandler.INSTANCE);
         }
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/NativeManagementResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/NativeManagementResourceDefinition.java
@@ -25,15 +25,12 @@ package org.jboss.as.host.controller.resources;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NATIVE_INTERFACE;
 
-import java.util.List;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -98,15 +95,14 @@ public class NativeManagementResourceDefinition extends SimpleResourceDefinition
 
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = new AttributeDefinition[] {INTERFACE, NATIVE_PORT, SECURITY_REALM, SERVER_NAME, SASL_PROTOCOL };
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     public NativeManagementResourceDefinition(final LocalHostControllerInfoImpl hostControllerInfo) {
-        super(RESOURCE_PATH,
-                HostModelUtil.getResourceDescriptionResolver("core","management","native-interface"),
-                new NativeManagementAddHandler(hostControllerInfo), NativeManagementRemoveHandler.INSTANCE,
-                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES.wrapAsList();
-        setDeprecated(ModelVersion.create(1, 7));
+        super(new Parameters(RESOURCE_PATH,  HostModelUtil.getResourceDescriptionResolver("core","management","native-interface"))
+                .setAddHandler(new NativeManagementAddHandler(hostControllerInfo))
+                .setRemoveHandler(NativeManagementRemoveHandler.INSTANCE)
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override
@@ -114,11 +110,6 @@ public class NativeManagementResourceDefinition extends SimpleResourceDefinition
         for (AttributeDefinition attr : ATTRIBUTE_DEFINITIONS) {
             resourceRegistration.registerReadWriteAttribute(attr, null, NativeManagementWriteAttributeHandler.INSTANCE);
         }
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 
     @Override

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
@@ -23,7 +23,6 @@ package org.jboss.as.jmx.rbac;
 
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
@@ -819,23 +818,21 @@ public class JmxFacadeRbacEnabledTestCase extends AbstractControllerTestBase {
     }
 
     private static class TestResourceDefinition extends SimpleResourceDefinition {
-        TestResourceDefinition(PathElement pathElement) {
-            super(pathElement,
-                    new NonResolvingResourceDescriptionResolver(),
-                    new AbstractAddStepHandler() {},
-                    new AbstractRemoveStepHandler() {});
+        TestResourceDefinition(PathElement pathElement, AccessConstraintDefinition...constraints) {
+            super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new AbstractAddStepHandler() {})
+                    .setRemoveHandler(new AbstractRemoveStepHandler() {})
+                    .setAccessConstraints(constraints));
         }
     }
 
     private static class ChildResourceDefinition extends TestResourceDefinition implements ResourceDefinition {
-        private final List<AccessConstraintDefinition> constraints;
         private final List<AttributeDefinition> attributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
         private final List<AttributeDefinition> readOnlyAttributes = Collections.synchronizedList(new ArrayList<AttributeDefinition>());
         private final List<OperationDefinition> operations = Collections.synchronizedList(new ArrayList<OperationDefinition>());
 
         ChildResourceDefinition(PathElement element, AccessConstraintDefinition...constraints){
-            super(element);
-            this.constraints = Collections.unmodifiableList(Arrays.asList(constraints));
+            super(element, constraints);
         }
 
         void addAttribute(String name, AccessConstraintDefinition...constraints) {
@@ -887,11 +884,6 @@ public class JmxFacadeRbacEnabledTestCase extends AbstractControllerTestBase {
                 }
 
             }
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return constraints;
         }
     }
 

--- a/logging/src/main/java/org/jboss/as/logging/LogFileResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/LogFileResourceDefinition.java
@@ -123,8 +123,8 @@ class LogFileResourceDefinition extends SimpleResourceDefinition {
     private final PathManager pathManager;
 
     protected LogFileResourceDefinition(final PathManager pathManager) {
-        super(new Parameters(LOG_FILE_PATH,
-                LoggingExtension.getResourceDescriptionResolver("log-file")).setRuntime());
+        super(new Parameters(LOG_FILE_PATH, LoggingExtension.getResourceDescriptionResolver("log-file"))
+                .setRuntime().setAccessConstraints(VIEW_SERVER_LOGS));
         assert pathManager != null : "PathManager cannot be null";
         this.pathManager = pathManager;
     }
@@ -172,11 +172,6 @@ class LogFileResourceDefinition extends SimpleResourceDefinition {
             }
         };
         resourceRegistration.registerReadOnlyAttribute(STREAM, streamHandler);
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return Collections.singletonList(VIEW_SERVER_LOGS);
     }
 
     private abstract class ReadAttributeOperationStepHandler implements OperationStepHandler {

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -34,9 +34,9 @@ import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition.Parameters;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -182,17 +182,11 @@ public class LoggingExtension implements Extension {
 
         // Register logging profile sub-models
         ApplicationTypeConfig atc = new ApplicationTypeConfig(SUBSYSTEM_NAME, CommonAttributes.LOGGING_PROFILE);
-        final List<AccessConstraintDefinition> accessConstraints = new ApplicationTypeAccessConstraintDefinition(atc).wrapAsList();
-        ResourceDefinition profile = new SimpleResourceDefinition(LOGGING_PROFILE_PATH,
-                getResourceDescriptionResolver(),
-                new LoggingProfileAdd(pathManager),
-                LoggingProfileOperations.REMOVE_PROFILE) {
-
-            @Override
-            public List<AccessConstraintDefinition> getAccessConstraints() {
-                return accessConstraints;
-            }
-        };
+        ResourceDefinition profile = new SimpleResourceDefinition(
+                new Parameters(LOGGING_PROFILE_PATH, getResourceDescriptionResolver())
+                        .setAddHandler(new LoggingProfileAdd(pathManager))
+                        .setRemoveHandler(LoggingProfileOperations.REMOVE_PROFILE)
+                        .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(atc)));
 
         registerLoggingProfileSubModels(registration.registerSubModel(profile), pathManager);
 

--- a/logging/src/main/java/org/jboss/as/logging/TransformerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/TransformerResourceDefinition.java
@@ -15,17 +15,24 @@ import org.jboss.as.controller.transform.description.ResourceTransformationDescr
 abstract class TransformerResourceDefinition extends SimpleResourceDefinition {
 
     protected TransformerResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver) {
-        super(pathElement, descriptionResolver);
+        super(new Parameters(pathElement, descriptionResolver));
     }
 
     protected TransformerResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver, final OperationStepHandler addHandler, final OperationStepHandler removeHandler) {
-        super(pathElement, descriptionResolver, addHandler, removeHandler);
+        super(new Parameters(pathElement, descriptionResolver).setAddHandler(addHandler).setRemoveHandler(removeHandler));
     }
 
     protected TransformerResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver, final OperationStepHandler addHandler, final OperationStepHandler removeHandler, final Flag addRestartLevel, final Flag removeRestartLevel) {
-        super(pathElement, descriptionResolver, addHandler, removeHandler, addRestartLevel, removeRestartLevel);
+        super(new Parameters(pathElement, descriptionResolver)
+                .setAddHandler(addHandler)
+                .setRemoveHandler(removeHandler)
+                .setAddRestartLevel(addRestartLevel)
+                .setRemoveRestartLevel(removeRestartLevel));
     }
 
+    protected TransformerResourceDefinition(final Parameters parameters) {
+        super(parameters);
+    }
     /**
      * Register the transformers for the resource.
      *

--- a/patching/src/main/java/org/jboss/as/patching/management/PatchResourceDefinition.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/PatchResourceDefinition.java
@@ -23,7 +23,6 @@
 package org.jboss.as.patching.management;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectListAttributeDefinition;
@@ -36,7 +35,6 @@ import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -167,11 +165,9 @@ class PatchResourceDefinition extends SimpleResourceDefinition {
 
     static final ResourceDefinition INSTANCE = new PatchResourceDefinition();
 
-    private final List<AccessConstraintDefinition> sensitivity;
-
     private PatchResourceDefinition() {
-        super(PATH, getResourceDescriptionResolver(NAME));
-        sensitivity = SensitiveTargetAccessConstraintDefinition.PATCHING.wrapAsList();
+        super(new Parameters(PATH, getResourceDescriptionResolver(NAME))
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.PATCHING));
     }
 
     @Override
@@ -181,7 +177,8 @@ class PatchResourceDefinition extends SimpleResourceDefinition {
         registerPatchingAttributes(registry);
 
         final StandardResourceDescriptionResolver resolver = new StandardResourceDescriptionResolver("patching.patch-stream", RESOURCE_NAME, PatchResourceDefinition.class.getClassLoader());
-        registry.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement("patch-stream"), resolver) {
+        registry.registerSubModel(new SimpleResourceDefinition(new Parameters(PathElement.pathElement("patch-stream"), resolver)
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.PATCHING)) {
 
             @Override
             public void registerAttributes(final ManagementResourceRegistration resource) {
@@ -193,11 +190,6 @@ class PatchResourceDefinition extends SimpleResourceDefinition {
             public void registerOperations(ManagementResourceRegistration registry) {
                 PatchResourceDefinition.this.registerPatchingOperations(registry, false);
             }
-
-            @Override
-            public List<AccessConstraintDefinition> getAccessConstraints() {
-                return sensitivity;
-            }
         });
     }
 
@@ -205,11 +197,6 @@ class PatchResourceDefinition extends SimpleResourceDefinition {
     public void registerOperations(ManagementResourceRegistration registry) {
         super.registerOperations(registry);
         registerPatchingOperations(registry, true);
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return sensitivity;
     }
 
     protected void registerPatchingOperations(ManagementResourceRegistration registry, boolean patchOp) {
@@ -248,7 +235,8 @@ class PatchResourceDefinition extends SimpleResourceDefinition {
         });
 
         StandardResourceDescriptionResolver resolver = new StandardResourceDescriptionResolver("patching.layer", "org.jboss.as.patching.management.LocalDescriptions", PatchResourceDefinition.class.getClassLoader());
-        registry.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement("layer"), resolver) {
+        registry.registerSubModel(new SimpleResourceDefinition(new Parameters(PathElement.pathElement("layer"), resolver)
+            .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.PATCHING)){
 
             @Override
             public void registerAttributes(final ManagementResourceRegistration resource) {
@@ -276,15 +264,11 @@ class PatchResourceDefinition extends SimpleResourceDefinition {
                     }
                 });
             }
-
-            @Override
-            public List<AccessConstraintDefinition> getAccessConstraints() {
-                return sensitivity;
-            }
         });
 
         resolver = new StandardResourceDescriptionResolver("patching.addon", "org.jboss.as.patching.management.LocalDescriptions", PatchResourceDefinition.class.getClassLoader());
-        registry.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement("addon"), resolver) {
+        registry.registerSubModel(new SimpleResourceDefinition(new Parameters(PathElement.pathElement("addon"), resolver)
+            .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.PATCHING)) {
             @Override
             public void registerAttributes(final ManagementResourceRegistration resource) {
                 resource.registerReadOnlyAttribute(CUMULATIVE_PATCH_ID, new ElementProviderAttributeReadHandler.AddOnAttributeReadHandler() {
@@ -310,11 +294,6 @@ class PatchResourceDefinition extends SimpleResourceDefinition {
                         }
                     }
                 });
-            }
-
-            @Override
-            public List<AccessConstraintDefinition> getAccessConstraints() {
-                return sensitivity;
             }
         });
     }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorChildResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/ConnectorChildResource.java
@@ -38,9 +38,12 @@ import org.jboss.msc.service.ServiceName;
 abstract class ConnectorChildResource extends SimpleResourceDefinition {
 
     public ConnectorChildResource(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, OperationStepHandler addHandler, OperationStepHandler removeHandler) {
-        super(pathElement, descriptionResolver, addHandler, removeHandler);
+        this(new Parameters(pathElement, descriptionResolver).setAddHandler(addHandler).setRemoveHandler(removeHandler));
     }
 
+    public ConnectorChildResource(Parameters parameters) {
+        super(parameters);
+    }
     static void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel) throws OperationFailedException {
         ConnectorAdd.INSTANCE.launchServices(context, parentAddress.getLastElement().getValue(), parentModel);
     }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/PropertyResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/PropertyResource.java
@@ -50,7 +50,7 @@ public class PropertyResource extends ConnectorChildResource {
 
     private final String parent;
 
-    protected PropertyResource(String parent) {
+     protected PropertyResource(String parent) {
         super(PATH,
                 RemotingExtension.getResourceDescriptionResolver(PROPERTY),
                 new AddResourceConnectorRestartHandler(parent, PropertyResource.VALUE),

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/SaslResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/SaslResource.java
@@ -43,7 +43,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.operations.validation.AllowedValuesValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -94,14 +93,11 @@ class SaslResource extends ConnectorChildResource {
     static final SaslResource INSTANCE_CONNECTOR = new SaslResource(CONNECTOR);
     static final SaslResource INSTANCE_HTTP_CONNECTOR = new SaslResource(HTTP_CONNECTOR);
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     private SaslResource(final String parent) {
-        super(SASL_CONFIG_PATH,
-                RemotingExtension.getResourceDescriptionResolver(SASL),
-                new AddResourceConnectorRestartHandler(parent, ATTRIBUTES),
-                new RemoveResourceConnectorRestartHandler(parent));
-        this.accessConstraints = RemotingExtension.REMOTING_SECURITY_DEF.wrapAsList();
+        super(new Parameters(SASL_CONFIG_PATH, RemotingExtension.getResourceDescriptionResolver(SASL))
+                .setAddHandler(new AddResourceConnectorRestartHandler(parent, ATTRIBUTES))
+                .setRemoveHandler(new RemoveResourceConnectorRestartHandler(parent))
+                .setAccessConstraints(RemotingExtension.REMOTING_SECURITY_DEF));
         this.parent = parent;
     }
 
@@ -114,11 +110,6 @@ class SaslResource extends ConnectorChildResource {
         resourceRegistration.registerReadWriteAttribute(STRENGTH_ATTRIBUTE, null, writeHandler);
         resourceRegistration.registerReadWriteAttribute(REUSE_SESSION_ATTRIBUTE, null, writeHandler);
         resourceRegistration.registerReadWriteAttribute(SERVER_AUTH_ATTRIBUTE, null, writeHandler);
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 
     private static class SaslAttributeMarshaller extends AttributeMarshaller {

--- a/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentResourceDefinition.java
@@ -21,9 +21,7 @@
 */
 package org.jboss.as.server.controller.resources;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 
-import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.NotificationDefinition;
@@ -31,8 +29,8 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReadResourceNameOperationStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.server.deployment.DeploymentStatusHandler;
@@ -47,10 +45,10 @@ public abstract class DeploymentResourceDefinition extends SimpleResourceDefinit
     private DeploymentResourceParent parent;
 
     protected DeploymentResourceDefinition(DeploymentResourceParent parent, OperationStepHandler addHandler, OperationStepHandler removeHandler) {
-        super(PathElement.pathElement(DEPLOYMENT),
-                DeploymentAttributes.DEPLOYMENT_RESOLVER,
-                addHandler,
-                removeHandler);
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.DEPLOYMENT), DeploymentAttributes.DEPLOYMENT_RESOLVER)
+                .setAddHandler(addHandler)
+                .setRemoveHandler(removeHandler)
+                .setAccessConstraints(ApplicationTypeAccessConstraintDefinition.DEPLOYMENT));
         this.parent = parent;
     }
 
@@ -66,11 +64,6 @@ public abstract class DeploymentResourceDefinition extends SimpleResourceDefinit
                 resourceRegistration.registerReadOnlyAttribute(attr, null);
             }
         }
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return ApplicationTypeAccessConstraintDefinition.DEPLOYMENT_AS_LIST;
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ModuleLoadingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ModuleLoadingResourceDefinition.java
@@ -46,7 +46,6 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleListAttributeDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.server.controller.descriptions.ServerDescriptions;
@@ -72,14 +71,12 @@ public class ModuleLoadingResourceDefinition extends SimpleResourceDefinition {
 
     private static final AttributeDefinition MODULE_NAME = new SimpleAttributeDefinitionBuilder(MODULE, ModelType.STRING).build();
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     public static final ModuleLoadingResourceDefinition INSTANCE = new ModuleLoadingResourceDefinition();
 
     private ModuleLoadingResourceDefinition() {
-        super(PathElement.pathElement(CORE_SERVICE, MODULE_LOADING),
-                ServerDescriptions.getResourceDescriptionResolver("core", MODULE_LOADING));
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.MODULE_LOADING.wrapAsList();
+        super(new Parameters(PathElement.pathElement(CORE_SERVICE, MODULE_LOADING),
+                ServerDescriptions.getResourceDescriptionResolver("core", MODULE_LOADING))
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.MODULE_LOADING));
     }
 
     @Override
@@ -108,11 +105,6 @@ public class ModuleLoadingResourceDefinition extends SimpleResourceDefinition {
 
          resourceRegistration.registerOperationHandler(definition, new ModuleLocationHandler());
          resourceRegistration.registerOperationHandler(ModuleInfoHandler.DEFINITION, ModuleInfoHandler.INSTANCE);
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 
     /** Read attribute handler for "module-roots" */

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServiceContainerResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServiceContainerResourceDefinition.java
@@ -25,11 +25,8 @@ package org.jboss.as.server.controller.resources;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE_CONTAINER;
 
-import java.util.List;
-
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.server.controller.descriptions.ServerDescriptions;
@@ -43,22 +40,15 @@ import org.jboss.as.server.operations.DumpServicesHandler;
 
 class ServiceContainerResourceDefinition extends SimpleResourceDefinition {
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     ServiceContainerResourceDefinition() {
-        super(PathElement.pathElement(CORE_SERVICE, SERVICE_CONTAINER),
-                ServerDescriptions.getResourceDescriptionResolver("core", SERVICE_CONTAINER));
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.SERVICE_CONTAINER.wrapAsList();
+        super(new Parameters(PathElement.pathElement(CORE_SERVICE, SERVICE_CONTAINER),
+                ServerDescriptions.getResourceDescriptionResolver("core", SERVICE_CONTAINER))
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SERVICE_CONTAINER));
     }
 
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
         resourceRegistration.registerOperationHandler(DumpServicesHandler.DEFINITION, DumpServicesHandler.INSTANCE);
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 }

--- a/server/src/main/java/org/jboss/as/server/controller/resources/SystemPropertyResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/SystemPropertyResourceDefinition.java
@@ -23,8 +23,6 @@ package org.jboss.as.server.controller.resources;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
@@ -35,7 +33,6 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
@@ -78,17 +75,13 @@ public class SystemPropertyResourceDefinition extends SimpleResourceDefinition {
     final ProcessEnvironmentSystemPropertyUpdater systemPropertyUpdater;
     final boolean useBoottime;
 
-    private final List<AccessConstraintDefinition> sensitivity;
-
     private SystemPropertyResourceDefinition(Location location, ProcessEnvironmentSystemPropertyUpdater systemPropertyUpdater, boolean useBoottime) {
-        super(PATH,
-                new ReplaceResourceNameResourceDescriptionResolver(location, SYSTEM_PROPERTY),
-                new SystemPropertyAddHandler(systemPropertyUpdater, useBoottime ? ALL_ATTRIBUTES : SERVER_ATTRIBUTES),
-                new SystemPropertyRemoveHandler(systemPropertyUpdater));
+        super(new Parameters(PATH, new ReplaceResourceNameResourceDescriptionResolver(location, SYSTEM_PROPERTY))
+                .setAddHandler(new SystemPropertyAddHandler(systemPropertyUpdater, useBoottime ? ALL_ATTRIBUTES : SERVER_ATTRIBUTES))
+                .setRemoveHandler(new SystemPropertyRemoveHandler(systemPropertyUpdater))
+                .setAccessConstraints(new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SYSTEM_PROPERTY)));
         this.systemPropertyUpdater = systemPropertyUpdater;
         this.useBoottime = useBoottime;
-        AccessConstraintDefinition acd = new SensitiveTargetAccessConstraintDefinition(SensitivityClassification.SYSTEM_PROPERTY);
-        sensitivity = Collections.singletonList(acd);
     }
 
     public static SystemPropertyResourceDefinition createForStandaloneServer(ServerEnvironment processEnvironment) {
@@ -137,10 +130,4 @@ public class SystemPropertyResourceDefinition extends SimpleResourceDefinition {
             return suffix;
         }
     }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return sensitivity;
-    }
-
 }

--- a/server/src/main/java/org/jboss/as/server/controller/resources/VaultResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/VaultResourceDefinition.java
@@ -24,8 +24,6 @@ package org.jboss.as.server.controller.resources;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAULT;
 
-import java.util.List;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.MapAttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
@@ -34,7 +32,6 @@ import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
@@ -78,15 +75,12 @@ public class VaultResourceDefinition extends SimpleResourceDefinition {
 
     public static AttributeDefinition[] ALL_ATTRIBUTES = new AttributeDefinition[]{CODE, MODULE, VAULT_OPTIONS};
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     public VaultResourceDefinition(AbstractVaultReader vaultReader) {
-        super(PATH,
-                ServerDescriptions.getResourceDescriptionResolver(VAULT),
-                new VaultAddHandler(vaultReader),
-                new VaultRemoveHandler(vaultReader));
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.SECURITY_VAULT.wrapAsList();
-        setDeprecated(ModelVersion.create(1, 7));
+        super(new Parameters(PATH, ServerDescriptions.getResourceDescriptionResolver(VAULT))
+                .setAddHandler(new VaultAddHandler(vaultReader))
+                .setRemoveHandler(new VaultRemoveHandler(vaultReader))
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_VAULT)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override
@@ -95,10 +89,5 @@ public class VaultResourceDefinition extends SimpleResourceDefinition {
         for (AttributeDefinition def : ALL_ATTRIBUTES) {
             resourceRegistration.registerReadWriteAttribute(def, null, write);
         }
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDefinition.java
@@ -22,12 +22,10 @@
 
 package org.jboss.as.server.deploymentoverlay;
 
-import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
@@ -52,10 +50,11 @@ public class DeploymentOverlayDefinition extends SimpleResourceDefinition {
 
 
     public DeploymentOverlayDefinition(boolean domainLevel,ContentRepository contentRepo, DeploymentFileRepository fileRepository) {
-        super(DeploymentOverlayModel.DEPLOYMENT_OVERRIDE_PATH,
-                ControllerResolver.getResolver(ModelDescriptionConstants.DEPLOYMENT_OVERLAY),
-                DeploymentOverlayAdd.INSTANCE,
-                ModelOnlyRemoveStepHandler.INSTANCE);
+        super(new Parameters(DeploymentOverlayModel.DEPLOYMENT_OVERRIDE_PATH,
+                ControllerResolver.getResolver(ModelDescriptionConstants.DEPLOYMENT_OVERLAY))
+                .setAddHandler(DeploymentOverlayAdd.INSTANCE)
+                .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE)
+                .setAccessConstraints(ApplicationTypeAccessConstraintDefinition.DEPLOYMENT));
         this.contentRepo = contentRepo;
         this.fileRepository = fileRepository;
         this.domainLevel = domainLevel;
@@ -76,10 +75,5 @@ public class DeploymentOverlayDefinition extends SimpleResourceDefinition {
         if (!domainLevel) {
             resourceRegistration.registerSubModel(new DeploymentOverlayDeploymentDefinition());
         }
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return ApplicationTypeAccessConstraintDefinition.DEPLOYMENT_AS_LIST;
     }
 }

--- a/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/HttpManagementResourceDefinition.java
@@ -25,8 +25,6 @@ package org.jboss.as.server.mgmt;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HTTP_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_INTERFACE;
 
-import java.util.List;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.ModelVersion;
@@ -38,7 +36,6 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -125,15 +122,15 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
 
     public static final HttpManagementResourceDefinition INSTANCE = new HttpManagementResourceDefinition();
 
-    private final List<AccessConstraintDefinition> accessConstraints;
 
     private HttpManagementResourceDefinition() {
-        super(RESOURCE_PATH,
-                ServerDescriptions.getResourceDescriptionResolver("core.management.http-interface"),
-                HttpManagementAddHandler.INSTANCE, HttpManagementRemoveHandler.INSTANCE,
-                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES.wrapAsList();
-        setDeprecated(ModelVersion.create(1, 7));
+        super(new Parameters(RESOURCE_PATH, ServerDescriptions.getResourceDescriptionResolver("core.management.http-interface"))
+                .setAddHandler(HttpManagementAddHandler.INSTANCE)
+                .setRemoveHandler(HttpManagementRemoveHandler.INSTANCE)
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override
@@ -142,11 +139,6 @@ public class HttpManagementResourceDefinition extends SimpleResourceDefinition {
         for (AttributeDefinition attr : ATTRIBUTE_DEFINITIONS) {
             resourceRegistration.registerReadWriteAttribute(attr, null, writeAttributeHandler);
         }
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/mgmt/NativeManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/NativeManagementResourceDefinition.java
@@ -25,8 +25,6 @@ package org.jboss.as.server.mgmt;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NATIVE_INTERFACE;
 
-import java.util.List;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationStepHandler;
@@ -36,7 +34,6 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -98,15 +95,15 @@ public class NativeManagementResourceDefinition extends SimpleResourceDefinition
 
     public static final NativeManagementResourceDefinition INSTANCE = new NativeManagementResourceDefinition();
 
-    private final List<AccessConstraintDefinition> accessConstraints;
 
     private NativeManagementResourceDefinition() {
-        super(RESOURCE_PATH,
-                ServerDescriptions.getResourceDescriptionResolver("core.management.native-interface"),
-                NativeManagementAddHandler.INSTANCE, NativeManagementRemoveHandler.INSTANCE,
-                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES.wrapAsList();
-        setDeprecated(ModelVersion.create(3));
+        super(new Parameters(RESOURCE_PATH, ServerDescriptions.getResourceDescriptionResolver("core.management.native-interface"))
+                .setAddHandler(NativeManagementAddHandler.INSTANCE)
+                .setRemoveHandler(NativeManagementRemoveHandler.INSTANCE)
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES)
+                .setDeprecatedSince(ModelVersion.create(3)));
     }
 
     @Override
@@ -115,11 +112,6 @@ public class NativeManagementResourceDefinition extends SimpleResourceDefinition
         for (AttributeDefinition attr : ATTRIBUTE_DEFINITIONS) {
             resourceRegistration.registerReadWriteAttribute(attr, null, writeHandler);
         }
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/mgmt/NativeRemotingManagementResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/NativeRemotingManagementResourceDefinition.java
@@ -25,12 +25,9 @@ package org.jboss.as.server.mgmt;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NATIVE_REMOTING_INTERFACE;
 
-import java.util.List;
-
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.server.controller.descriptions.ServerDescriptions;
@@ -49,19 +46,13 @@ public class NativeRemotingManagementResourceDefinition extends SimpleResourceDe
 
     public static final NativeRemotingManagementResourceDefinition INSTANCE = new NativeRemotingManagementResourceDefinition();
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     private NativeRemotingManagementResourceDefinition() {
-        super(RESOURCE_PATH,
-                ServerDescriptions.getResourceDescriptionResolver("core.management.native-remoting-interface"),
-                NativeRemotingManagementAddHandler.INSTANCE, NativeRemotingManagementRemoveHandler.INSTANCE,
-                OperationEntry.Flag.RESTART_NONE, OperationEntry.Flag.RESTART_NONE);
-        this.accessConstraints = SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES.wrapAsList();
-        setDeprecated(ModelVersion.create(1, 7));
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
+        super(new Parameters(RESOURCE_PATH, ServerDescriptions.getResourceDescriptionResolver("core.management.native-remoting-interface"))
+                .setAddHandler(NativeRemotingManagementAddHandler.INSTANCE)
+                .setRemoveHandler(NativeRemotingManagementRemoveHandler.INSTANCE)
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_NONE)
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.MANAGEMENT_INTERFACES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ConstrainedResource.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ConstrainedResource.java
@@ -24,7 +24,6 @@
 
 package org.jboss.as.test.integration.domain.extension;
 
-import java.util.List;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.PathElement;
@@ -34,7 +33,6 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
@@ -63,19 +61,11 @@ public class ConstrainedResource extends SimpleResourceDefinition {
             .build();
 
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     public ConstrainedResource(PathElement pathElement) {
-        super(pathElement, new NonResolvingResourceDescriptionResolver(),
-                new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN), ReloadRequiredRemoveStepHandler.INSTANCE);
-
-        ApplicationTypeConfig atc = new ApplicationTypeConfig("datasources", "datasource");
-        accessConstraints = new ApplicationTypeAccessConstraintDefinition(atc).wrapAsList();
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
+        super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
+                .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("datasources", "datasource"))));
     }
 
     @Override

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/SensitiveResource.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/SensitiveResource.java
@@ -24,15 +24,12 @@
 
 package org.jboss.as.test.integration.domain.extension;
 
-import java.util.Arrays;
-import java.util.List;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
@@ -41,20 +38,12 @@ import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResol
  * @author Tomaz Cerar (c) 2014 Red Hat Inc.
  */
 public class SensitiveResource extends SimpleResourceDefinition {
-    private final List<AccessConstraintDefinition> accessConstraints;
-
 
     public SensitiveResource(PathElement pathElement) {
-        super(pathElement, new NonResolvingResourceDescriptionResolver(),
-                new AbstractAddStepHandler(), ReloadRequiredRemoveStepHandler.INSTANCE);
-
-        ApplicationTypeConfig atc = new ApplicationTypeConfig("security", "security-domain");
-        AccessConstraintDefinition acd = new ApplicationTypeAccessConstraintDefinition(atc);
-        this.accessConstraints = Arrays.asList(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN, acd);
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
+        super(new  Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
+                .setAddHandler(new AbstractAddStepHandler())
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN,
+                        new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("security", "security-domain"))));
     }
 }

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
@@ -23,7 +23,6 @@
  */
 package org.jboss.as.test.integration.mgmt.access.extension;
 
-import java.util.List;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
@@ -37,7 +36,6 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
@@ -100,18 +98,11 @@ public class ConstrainedResource extends SimpleResourceDefinition {
             })
             .build();
 
-    private final List<AccessConstraintDefinition> accessConstraints;
-
     public ConstrainedResource(PathElement pathElement) {
-        super(pathElement, new NonResolvingResourceDescriptionResolver(),
-                new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN), ReloadRequiredRemoveStepHandler.INSTANCE);
-        ApplicationTypeConfig atc = new ApplicationTypeConfig("rbac", "datasource");
-        accessConstraints = new ApplicationTypeAccessConstraintDefinition(atc).wrapAsList();
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
+        super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
+                .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("rbac", "datasource"))));
     }
 
     @Override

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/SensitiveResource.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/SensitiveResource.java
@@ -24,15 +24,12 @@
 
 package org.jboss.as.test.integration.mgmt.access.extension;
 
-import java.util.Arrays;
-import java.util.List;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
@@ -41,20 +38,12 @@ import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResol
  * @author Tomaz Cerar (c) 2014 Red Hat Inc.
  */
 public class SensitiveResource extends SimpleResourceDefinition {
-    private final List<AccessConstraintDefinition> accessConstraints;
-
 
     public SensitiveResource(PathElement pathElement) {
-        super(pathElement, new NonResolvingResourceDescriptionResolver(),
-                new AbstractAddStepHandler(), ReloadRequiredRemoveStepHandler.INSTANCE);
-
-        ApplicationTypeConfig atc = new ApplicationTypeConfig("rbac", "security-domain");
-        AccessConstraintDefinition acd = new ApplicationTypeAccessConstraintDefinition(atc);
-        this.accessConstraints = Arrays.asList(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN, acd);
-    }
-
-    @Override
-    public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
+        super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
+                .setAddHandler(new AbstractAddStepHandler())
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN,
+                        new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("rbac", "security-domain"))));
     }
 }


### PR DESCRIPTION
Adding support for AccessContraintDefinition in the SimpleResourceDefinition.Parameters constructor and removing useless subclasses.

Jira: https://issues.jboss.org/browse/WFCORE-1172