### PR TITLE
[WFCORE-1209] validate operation request in BatchRunHandler to fix invalid attribute ignoring in batch

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/OperationRequestHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/OperationRequestHandler.java
@@ -21,12 +21,10 @@
  */
 package org.jboss.as.cli.handlers;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.concurrent.CancellationException;
 
 import org.jboss.as.cli.CommandArgument;
@@ -36,12 +34,9 @@ import org.jboss.as.cli.CommandHandler;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.OperationCommand;
 import org.jboss.as.cli.Util;
-import org.jboss.as.cli.operation.OperationFormatException;
 import org.jboss.as.cli.operation.impl.DefaultCallbackHandler;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
-import org.jboss.dmr.Property;
 
 /**
  * The operation request handler.
@@ -74,9 +69,9 @@ public class OperationRequestHandler implements CommandHandler, OperationCommand
         }
 
         if(ctx.getConfig().isValidateOperationRequests()) {
-            ModelNode opDescOutcome = validateRequest(ctx, request);
+            ModelNode opDescOutcome = Util.validateRequest(ctx, request);
             if (opDescOutcome != null) { // operation has params that might need to be replaced
-                replaceFilePathsWithBytes(request, opDescOutcome);
+                Util.replaceFilePathsWithBytes(request, opDescOutcome);
             }
         }
 
@@ -127,91 +122,5 @@ public class OperationRequestHandler implements CommandHandler, OperationCommand
     @Override
     public List<CommandArgument> getArguments(CommandContext ctx) {
         return Collections.emptyList();
-    }
-
-    // returns the READ_OPERATION_DESCRIPTION outcome used to validate the request params
-    // return null if the operation has no params to validate
-    private ModelNode validateRequest(CommandContext ctx, ModelNode request) throws CommandFormatException {
-
-        final ModelControllerClient client = ctx.getModelControllerClient();
-        if(client == null) {
-            throw new CommandFormatException("No connection to the controller.");
-        }
-
-        final Set<String> keys = request.keys();
-
-        if(!keys.contains(Util.OPERATION)) {
-            throw new CommandFormatException("Request is missing the operation name.");
-        }
-        final String operationName = request.get(Util.OPERATION).asString();
-
-        if(!keys.contains(Util.ADDRESS)) {
-            throw new CommandFormatException("Request is missing the address part.");
-        }
-        final ModelNode address = request.get(Util.ADDRESS);
-
-        if(keys.size() == 2) { // no props
-            return null;
-        }
-
-        final ModelNode opDescrReq = new ModelNode();
-        opDescrReq.get(Util.ADDRESS).set(address);
-        opDescrReq.get(Util.OPERATION).set(Util.READ_OPERATION_DESCRIPTION);
-        opDescrReq.get(Util.NAME).set(operationName);
-
-        final ModelNode outcome;
-        try {
-            outcome = client.execute(opDescrReq);
-        } catch(Exception e) {
-            throw new CommandFormatException("Failed to perform " + Util.READ_OPERATION_DESCRIPTION + " to validate the request: " + e.getLocalizedMessage());
-        }
-        if (!Util.isSuccess(outcome)) {
-            throw new CommandFormatException("Failed to get the list of the operation properties: \"" + Util.getFailureDescription(outcome) + '\"');
-        }
-
-        if(!outcome.has(Util.RESULT)) {
-            throw new CommandFormatException("Failed to perform " + Util.READ_OPERATION_DESCRIPTION + " to validate the request: result is not available.");
-        }
-        final ModelNode result = outcome.get(Util.RESULT);
-        final Set<String> definedProps = result.hasDefined(Util.REQUEST_PROPERTIES) ? result.get(Util.REQUEST_PROPERTIES).keys() : Collections.emptySet();
-        if(definedProps.isEmpty()) {
-            if(!(keys.size() == 3 && keys.contains(Util.OPERATION_HEADERS))) {
-                throw new CommandFormatException("Operation '" + operationName + "' does not expect any property.");
-            }
-        } else {
-            int skipped = 0;
-            for(String prop : keys) {
-                if(skipped < 2 && (prop.equals(Util.ADDRESS) || prop.equals(Util.OPERATION))) {
-                    ++skipped;
-                    continue;
-                }
-                if(!definedProps.contains(prop)) {
-                    if(!Util.OPERATION_HEADERS.equals(prop)) {
-                        throw new CommandFormatException("'" + prop + "' is not found among the supported properties: " + definedProps);
-                    }
-                }
-            }
-        }
-        return outcome;
-    }
-
-    // For any request params that are of type BYTES, replace the file path with the bytes from the file
-    private void replaceFilePathsWithBytes(ModelNode request, ModelNode opDescOutcome)  throws CommandFormatException {
-        ModelNode requestProps = opDescOutcome.get("result", "request-properties");
-        for (Property prop : requestProps.asPropertyList()) {
-            ModelNode typeDesc = prop.getValue().get("type");
-            if (typeDesc.getType() == ModelType.TYPE &&
-                    typeDesc.asType() == ModelType.BYTES &&
-                    request.hasDefined(prop.getName())) {
-                String filePath = request.get(prop.getName()).asString();
-                File localFile = new File(filePath);
-                if (!localFile.exists()) continue;
-                try {
-                    request.get(prop.getName()).set(Util.readBytes(localFile));
-                } catch (OperationFormatException e) {
-                    throw new CommandFormatException(e);
-                }
-            }
-        }
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
@@ -75,6 +75,17 @@ public class BatchRunHandler extends BaseOperationCommand {
         try {
             final ModelNode request = buildRequest(ctx);
 
+            if (ctx.getConfig().isValidateOperationRequests() && request.get(Util.OPERATION).asString().equals(Util.COMPOSITE)
+                    && request.hasDefined(Util.STEPS)) {
+                final List<ModelNode> steps = request.get(Util.STEPS).asList();
+                for (ModelNode step : steps) {
+                    ModelNode opDescOutcome = Util.validateRequest(ctx, step);
+                    if (opDescOutcome != null) { // operation has params that might need to be replaced
+                        Util.replaceFilePathsWithBytes(request, opDescOutcome);
+                    }
+                }
+            }
+
             final ModelControllerClient client = ctx.getModelControllerClient();
             try {
                 response = client.execute(request);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1209 "CLI did not throw any error message and just ignored the invalid attribute while using in batch mode.If we use same CLI command in non-batch mode it throws exception."

Move validateRequest() and replaceFilePathsWithBytes() into Util class to allow BatchRunHandler validate operation request in BatchRunHandler as OperationRequestHandler does.