### PR TITLE
https://issues.jboss.org/browse/WFCORE-1188 Exiting CLI requires stty…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -1477,7 +1477,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
             console.start();
         }
 
-        while(!isTerminated() && console.running()){
+        while(/*!isTerminated() && */console.running()){
             try {
                 Thread.sleep(10);
             } catch (InterruptedException e) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/Console.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Console.java
@@ -283,8 +283,8 @@ public interface Console {
                 }
 
                 @Override
-                public boolean running(){
-                    return console != null && console.isRunning();
+                public boolean running() {
+                    return console != null && (console.isRunning() || console.hasRunningProcesses());
                 }
 
                 @Override


### PR DESCRIPTION
… sane command to be issued on Linux

The fix is in waiting for the Aesh processes to finish before leaving the interactive mode and terminating the JVM process.

Thanks,
Alexey