### PR TITLE
Improve handling of critical errors in domain operation handling

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/BlockingTimeoutImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/BlockingTimeoutImpl.java
@@ -1,0 +1,177 @@
+/*
+Copyright 2015 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING_TIMEOUT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * {@link BlockingTimeout} implementation.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+class BlockingTimeoutImpl implements BlockingTimeout {
+
+    private static final int DEFAULT_TIMEOUT = 300;  // seconds
+    private static final String DEFAULT_TIMEOUT_STRING = Long.toString(DEFAULT_TIMEOUT);
+    private static final int SHORT_TIMEOUT = 5000;
+    // Time to add onto the base timeout to allow a response from a remote
+    // process to propagate back to us after the timeout occurs on that process
+    // This value is arbitrary; meant to be long enough to avoid missing responses
+    // delayed by minor things like short gc pauses. The system is meant to work correctly
+    // even if the response is in transit when this added timeout expires, so there
+    // isn't a great value in making it real high, while there is a cost in added
+    // delay before the system unblocks in cases where there is no remote response coming.
+    private static final int DEFAULT_DOMAIN_TIMEOUT_ADDER = 5000;
+    private static final String DEFAULT_DOMAIN_TIMEOUT_STRING = Long.toString(DEFAULT_DOMAIN_TIMEOUT_ADDER);
+    public static final String DOMAIN_TEST_SYSTEM_PROPERTY = "org.wildfly.unsupported.test.domain-timeout-adder";
+    private static String sysPropLocalValue;
+    private static int defaultLocalValue;
+    private static String sysPropDomainValue;
+    private static int defaultDomainValue;
+
+    private final int blockingTimeout;
+    private final int shortTimeout;
+    private final int domainTimeoutAdder;
+    private volatile boolean localTimeoutDetected;
+    // Guarded by 'this'
+    private Set<PathAddress> domainTimeouts;
+
+
+    BlockingTimeoutImpl(final ModelNode headerValue) {
+        Integer opHeaderValue;
+        if (headerValue != null && headerValue.isDefined()) {
+            opHeaderValue = headerValue.asInt();
+            if (opHeaderValue < 1) {
+                throw ControllerLogger.MGMT_OP_LOGGER.invalidBlockingTimeout(opHeaderValue.longValue(), BLOCKING_TIMEOUT);
+            }
+            blockingTimeout = opHeaderValue * 1000;
+        } else {
+            blockingTimeout = resolveDefaultTimeout();
+        }
+        shortTimeout = Math.min(blockingTimeout, SHORT_TIMEOUT);
+        domainTimeoutAdder = resolveDomainTimeoutAdder();
+    }
+
+    private static int resolveDefaultTimeout() {
+        String propValue = WildFlySecurityManager.getPropertyPrivileged(SYSTEM_PROPERTY, DEFAULT_TIMEOUT_STRING);
+        if (sysPropLocalValue == null || !sysPropLocalValue.equals(propValue)) {
+            // First call or the system property changed
+            sysPropLocalValue = propValue;
+            int number = -1;
+            try {
+                number = Integer.valueOf(sysPropLocalValue);
+            } catch (NumberFormatException nfe) {
+                // ignored
+            }
+
+            if (number > 0) {
+                defaultLocalValue = number * 1000; // seconds to ms
+            } else {
+                ControllerLogger.MGMT_OP_LOGGER.invalidDefaultBlockingTimeout(sysPropLocalValue, SYSTEM_PROPERTY, DEFAULT_TIMEOUT);
+                defaultLocalValue = DEFAULT_TIMEOUT * 1000; // seconds to ms
+            }
+        }
+        return defaultLocalValue;
+    }
+
+    /** Allows testsuites to shorten the domain timeout adder */
+    private static int resolveDomainTimeoutAdder() {
+        String propValue = WildFlySecurityManager.getPropertyPrivileged(DOMAIN_TEST_SYSTEM_PROPERTY, DEFAULT_DOMAIN_TIMEOUT_STRING);
+        if (sysPropDomainValue == null || !sysPropDomainValue.equals(propValue)) {
+            // First call or the system property changed
+            sysPropDomainValue = propValue;
+            int number = -1;
+            try {
+                number = Integer.valueOf(sysPropDomainValue);
+            } catch (NumberFormatException nfe) {
+                // ignored
+            }
+
+            if (number > 0) {
+                defaultDomainValue = number; // this one is in ms
+            } else {
+                ControllerLogger.MGMT_OP_LOGGER.invalidDefaultBlockingTimeout(sysPropDomainValue, DOMAIN_TEST_SYSTEM_PROPERTY, DEFAULT_DOMAIN_TIMEOUT_ADDER);
+                defaultDomainValue = DEFAULT_DOMAIN_TIMEOUT_ADDER;
+            }
+        }
+        return defaultDomainValue;
+    }
+
+    @Override
+    public final int getLocalBlockingTimeout() {
+        return localTimeoutDetected ? shortTimeout : blockingTimeout;
+    }
+
+    @Override
+    public final int getProxyBlockingTimeout(PathAddress targetAddress, ProxyController proxyController) {
+        final PathAddress processAddress = getProcessAddress(targetAddress);
+        // if the proxy address size is less than the process address, that means the timeout
+        // is for a server controlled by a different host, so we have double the normal
+        // domain timeout adder to account for 2 possible delays
+        int multiple = proxyController.getProxyNodeAddress().size() < processAddress.size() ? 2 : 1;
+        return getProcessBaseTimeout(processAddress) + (multiple * domainTimeoutAdder);
+    }
+
+    @Override
+    public int getDomainBlockingTimeout(boolean multipleProxies) {
+        // if we are master, we have double the normal
+        // domain timeout adder to account for 2 possible delays
+        int delayMultiple = multipleProxies ? 2 : 1;
+        return blockingTimeout + (delayMultiple * domainTimeoutAdder);
+    }
+
+    @Override
+    public final void timeoutDetected() {
+        localTimeoutDetected = true;
+    }
+
+    @Override
+    public void proxyTimeoutDetected(PathAddress targetAddress) {
+        final PathAddress processAddress = getProcessAddress(targetAddress);
+        synchronized (this) {
+            if (domainTimeouts == null) {
+                domainTimeouts = new HashSet<>();
+            }
+            domainTimeouts.add(processAddress);
+        }
+    }
+
+    private int getProcessBaseTimeout(PathAddress processAddress) {
+        synchronized (this) {
+            return domainTimeouts != null && domainTimeouts.contains(processAddress) ? shortTimeout : blockingTimeout;
+        }
+    }
+
+    private static PathAddress getProcessAddress(PathAddress targetAddress) {
+        if (targetAddress.size() < 2) {
+            return targetAddress;
+        } else if (RUNNING_SERVER.equals(targetAddress.getElement(1).getKey())) {
+            return targetAddress.subAddress(0, 2);
+        } else {
+            return targetAddress.subAddress(0, 1);
+        }
+
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -467,7 +467,7 @@ final class OperationContextImpl extends AbstractOperationContext {
     void awaitServiceContainerStability() throws InterruptedException, TimeoutException {
         if (affectsRuntime) {
             MGMT_OP_LOGGER.debugf("Entered VERIFY stage; waiting for service container to settle");
-            long timeout = getBlockingTimeout().getBlockingTimeout();
+            long timeout = getBlockingTimeout().getLocalBlockingTimeout();
             ExecutionStatus originalExecutionStatus = executionStatus;
             try {
                 // First wait until any removals we've initiated have begun processing, otherwise
@@ -497,7 +497,7 @@ final class OperationContextImpl extends AbstractOperationContext {
     protected void waitForRemovals() throws InterruptedException, TimeoutException {
         if (affectsRuntime && !cancelled) {
             synchronized (realRemovingControllers) {
-                long waitTime = getBlockingTimeout().getBlockingTimeout();
+                long waitTime = getBlockingTimeout().getLocalBlockingTimeout();
                 long end = System.currentTimeMillis() + waitTime;
                 boolean wait = !realRemovingControllers.isEmpty() && !cancelled;
                 while (wait && waitTime > 0) {
@@ -779,7 +779,7 @@ final class OperationContextImpl extends AbstractOperationContext {
                     throw ControllerLogger.ROOT_LOGGER.invalidModificationAfterCompletedStep();
                 }
                 containerMonitorStep = activeStep;
-                int timeout = getBlockingTimeout().getBlockingTimeout();
+                int timeout = getBlockingTimeout().getLocalBlockingTimeout();
                 ExecutionStatus origStatus = executionStatus;
                 try {
                     executionStatus = ExecutionStatus.AWAITING_STABILITY;
@@ -1136,7 +1136,7 @@ final class OperationContextImpl extends AbstractOperationContext {
                 // will not be cancellable. I (BES 2012/01/24) chose the former as the lesser evil.
                 // Any subsequent step that calls getServiceRegistry/getServiceTarget/removeService
                 // is going to have to await the monitor uninterruptibly anyway before proceeding.
-                long timeout = getBlockingTimeout().getBlockingTimeout();
+                long timeout = getBlockingTimeout().getLocalBlockingTimeout();
                 try {
                     modelController.awaitContainerStability(timeout, TimeUnit.MILLISECONDS, true);
                 }  catch (InterruptedException e) {
@@ -1338,6 +1338,9 @@ final class OperationContextImpl extends AbstractOperationContext {
     @Override
     ResultAction executeOperation() {
         try {
+            if (!isBooting()) {
+                attach(BlockingTimeout.Factory.ATTACHMENT_KEY, getBlockingTimeout());
+            }
             return super.executeOperation();
         } finally {
             synchronized (done) {
@@ -1811,7 +1814,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         if (blockingTimeout == null) {
             synchronized (this) {
                 if (blockingTimeout == null) {
-                    blockingTimeout = new BlockingTimeout(blockingTimeoutConfig);
+                    blockingTimeout = new BlockingTimeoutImpl(blockingTimeoutConfig);
                 }
             }
         }
@@ -2097,7 +2100,7 @@ final class OperationContextImpl extends AbstractOperationContext {
                 boolean intr = false;
                 try {
                     boolean containsKey = realRemovingControllers.containsKey(name);
-                    long timeout = getBlockingTimeout().getBlockingTimeout();
+                    long timeout = getBlockingTimeout().getLocalBlockingTimeout();
                     long waitTime = timeout;
                     long end = System.currentTimeMillis() + waitTime;
                     while (containsKey && waitTime > 0) {

--- a/controller/src/main/java/org/jboss/as/controller/ProxyController.java
+++ b/controller/src/main/java/org/jboss/as/controller/ProxyController.java
@@ -57,13 +57,13 @@ public interface ProxyController {
      * {@link ProxyOperationControl#operationPrepared(ModelController.OperationTransaction, org.jboss.dmr.ModelNode)}
      * or the {@link ProxyOperationControl#operationFailed(org.jboss.dmr.ModelNode)} callbacks on the given  {@code control}
      * will have been invoked.
-     *
-     * @param operation the operation to execute. Cannot be {@code null}
+     *  @param operation the operation to execute. Cannot be {@code null}
      * @param handler the message handler. May be {@code null}
      * @param control the callback handler for this operation. Cannot be {@code null}
      * @param attachments the operation attachments. May be {@code null}
+     * @param blockingTimeout control for maximum period any blocking operations can block. Cannot be {@code null}
      */
-    void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control, OperationAttachments attachments);
+    void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control, OperationAttachments attachments, BlockingTimeout blockingTimeout);
 
     /**
      * Gets the {@link ModelVersion} of the kernel management API exposed by the proxied process.

--- a/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
@@ -76,6 +76,9 @@ public class ProxyStepHandler implements OperationStepHandler {
             executeWFCORE621(context, operation);
             return;
         }
+
+        final BlockingTimeout blockingTimeout = BlockingTimeout.Factory.getProxyBlockingTimeout(context);
+
         OperationMessageHandler messageHandler = new DelegatingMessageHandler(context);
 
         final AtomicReference<ModelController.OperationTransaction> txRef = new AtomicReference<ModelController.OperationTransaction>();
@@ -164,7 +167,8 @@ public class ProxyStepHandler implements OperationStepHandler {
                         proxyControl.operationPrepared(transaction, transformed);
                     }
                 };
-                proxyController.execute(transformedOperation, messageHandler, transformingProxyControl, new DelegatingOperationAttachments(context));
+                proxyController.execute(transformedOperation, messageHandler, transformingProxyControl,
+                        new DelegatingOperationAttachments(context), blockingTimeout);
             } else {
                 // discard the operation
                 final ModelNode transformedResult = resultTransformer.transformResult(new ModelNode());
@@ -175,7 +179,8 @@ public class ProxyStepHandler implements OperationStepHandler {
                 return;
             }
         } else {
-            proxyController.execute(operation, messageHandler, proxyControl, new DelegatingOperationAttachments(context));
+            proxyController.execute(operation, messageHandler, proxyControl, new DelegatingOperationAttachments(context),
+                    blockingTimeout);
         }
         OperationResponse finalResult = finalResultRef.get();
         if (finalResult != null) {

--- a/controller/src/main/java/org/jboss/as/controller/TransformingProxyController.java
+++ b/controller/src/main/java/org/jboss/as/controller/TransformingProxyController.java
@@ -197,9 +197,10 @@ public interface TransformingProxyController extends ProxyController {
             }
 
             @Override
-            public void execute(final ModelNode operation, final OperationMessageHandler handler, final ProxyOperationControl control, final OperationAttachments attachments) {
+            public void execute(final ModelNode operation, final OperationMessageHandler handler, final ProxyOperationControl control,
+                                final OperationAttachments attachments, final BlockingTimeout blockingTimeout) {
                 // Execute untransformed
-                proxy.execute(operation, handler, control, attachments);
+                proxy.execute(operation, handler, control, attachments, blockingTimeout);
             }
 
             @Override

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3384,4 +3384,12 @@ public interface ControllerLogger extends BasicLogger {
     @LogMessage(level = Level.ERROR)
     @Message(id = 408, value = "Failed sending failure response %s for %d")
     void failedSendingFailedResponse(@Cause Throwable cause, ModelNode response, int operationId);
+
+    @Message(id = 409, value = "Execution of operation '%s' on remote process at address '%s' timed out after %d ms while awaiting initial response; remote process has been notified to terminate operation")
+    String proxiedOperationTimedOut(String operation, PathAddress target, long timeout);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 410, value = "Execution of operation '%s' on remote process at address '%s' timed out after %d ms while awaiting final response; remote process has been notified to terminate operation")
+    void timeoutAwaitingFinalResponse(String operation, PathAddress proxyNodeAddress, long timeout);
+
 }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3357,9 +3357,9 @@ public interface ControllerLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     void removeUnsupportedLegacyExtension(List<String> subsystemNames, String extensionName);
 
-    @Message(id = 403, value = "Unexpected exception during execution of the following operation(s): %s")
+    @Message(id = 403, value = "Unexpected failure during execution of the following operation(s): %s")
     @LogMessage(level = ERROR)
-    void unexpectedOperationExecutionException(@Cause RuntimeException e, List<ModelNode> controllerOperations);
+    void unexpectedOperationExecutionException(@Cause Throwable t, List<ModelNode> controllerOperations);
 
     @Message(id = 404, value = "Unexpected exception during execution: %s")
     String unexpectedOperationExecutionFailureDescription(RuntimeException e);
@@ -3376,4 +3376,12 @@ public interface ControllerLogger extends BasicLogger {
      */
     @Message(id = 406, value = "Could not convert the attribute '%s' to a %s")
     OperationFailedException selectFailedCouldNotConvertAttributeToType(String attribute, ModelType type);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 407, value = "Failed sending completed response %s for %d")
+    void failedSendingCompletedResponse(@Cause Throwable cause, ModelNode response, int operationId);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 408, value = "Failed sending failure response %s for %d")
+    void failedSendingFailedResponse(@Cause Throwable cause, ModelNode response, int operationId);
 }

--- a/controller/src/main/java/org/jboss/as/controller/remote/BlockingQueueOperationListener.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/BlockingQueueOperationListener.java
@@ -25,11 +25,8 @@ package org.jboss.as.controller.remote;
 import java.util.Collection;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.jboss.as.controller.client.OperationResponse;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -166,7 +163,7 @@ public class BlockingQueueOperationListener<T extends TransactionalProtocolClien
 
         @Override
         public AsyncFuture<OperationResponse> getFinalResult() {
-            return new CompletedResult<>(OperationResponse.Factory.createSimple(finalResult));
+            return new CompletedFuture<>(OperationResponse.Factory.createSimple(finalResult));
         }
 
         @Override
@@ -179,85 +176,6 @@ public class BlockingQueueOperationListener<T extends TransactionalProtocolClien
             throw new IllegalStateException();
         }
 
-    }
-
-    static class CompletedResult<T> implements AsyncFuture<T> {
-        private final T result;
-        CompletedResult(T result) {
-            this.result = result;
-        }
-
-        @Override
-        public Status await() throws InterruptedException {
-            return Status.COMPLETE;
-        }
-
-        @Override
-        public Status await(long timeout, TimeUnit unit) throws InterruptedException {
-            return Status.COMPLETE;
-        }
-
-        @Override
-        public T getUninterruptibly() throws CancellationException, ExecutionException {
-            return result;
-        }
-
-        @Override
-        public T getUninterruptibly(long timeout, TimeUnit unit) throws CancellationException, ExecutionException, TimeoutException {
-            return result;
-        }
-
-        @Override
-        public Status awaitUninterruptibly() {
-            return Status.COMPLETE;
-        }
-
-        @Override
-        public Status awaitUninterruptibly(long timeout, TimeUnit unit) {
-            return Status.COMPLETE;
-        }
-
-        @Override
-        public Status getStatus() {
-            return Status.COMPLETE;
-        }
-
-        @Override
-        public <A> void addListener(Listener<? super T, A> listener, A attachment) {
-            if(listener != null) {
-                listener.handleComplete(this, attachment);
-            }
-        }
-
-        @Override
-        public boolean cancel(boolean interruptionDesired) {
-            return false;
-        }
-
-        @Override
-        public void asyncCancel(boolean interruptionDesired) {
-            //
-        }
-
-        @Override
-        public boolean isCancelled() {
-            return false;
-        }
-
-        @Override
-        public boolean isDone() {
-            return true;
-        }
-
-        @Override
-        public T get() throws InterruptedException, ExecutionException {
-            return result;
-        }
-
-        @Override
-        public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-            return result;
-        }
     }
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/remote/CompletedFuture.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/CompletedFuture.java
@@ -1,0 +1,114 @@
+/*
+Copyright 2015 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.controller.remote;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.threads.AsyncFuture;
+
+/**
+ * An AsyncFuture that is in {@link org.jboss.threads.AsyncFuture.Status#COMPLETE} as soon as it is instantiated.
+ *
+ * @author Brian Stansberry
+ */
+public final class CompletedFuture<T> implements AsyncFuture<T> {
+
+    private final T result;
+
+    /**
+     * Creates a future that will provide the given value
+     * @param result the value
+     */
+    public CompletedFuture(T result) {
+        this.result = result;
+    }
+
+    @Override
+    public Status await() throws InterruptedException {
+        return Status.COMPLETE;
+    }
+
+    @Override
+    public Status await(long timeout, TimeUnit unit) throws InterruptedException {
+        return Status.COMPLETE;
+    }
+
+    @Override
+    public T getUninterruptibly() throws CancellationException, ExecutionException {
+        return result;
+    }
+
+    @Override
+    public T getUninterruptibly(long timeout, TimeUnit unit) throws CancellationException, ExecutionException, TimeoutException {
+        return result;
+    }
+
+    @Override
+    public Status awaitUninterruptibly() {
+        return Status.COMPLETE;
+    }
+
+    @Override
+    public Status awaitUninterruptibly(long timeout, TimeUnit unit) {
+        return Status.COMPLETE;
+    }
+
+    @Override
+    public Status getStatus() {
+        return Status.COMPLETE;
+    }
+
+    @Override
+    public <A> void addListener(Listener<? super T, A> listener, A attachment) {
+        if (listener != null) {
+            listener.handleComplete(this, attachment);
+        }
+    }
+
+    @Override
+    public boolean cancel(boolean interruptionDesired) {
+        return false;
+    }
+
+    @Override
+    public void asyncCancel(boolean interruptionDesired) {
+        //
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        return true;
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        return result;
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return result;
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/remote/ModelControllerClientOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/ModelControllerClientOperationHandler.java
@@ -44,6 +44,7 @@ import java.io.DataInput;
 import java.io.IOException;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -209,12 +210,13 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
                 responseAttachmentSupport.registerStreams(context.getOperationId(), response.getInputStreams());
 
                 result.set(response.getResponseNode());
-            } catch (Exception e) {
+            } catch (Throwable t) {
                 final ModelNode failure = new ModelNode();
                 failure.get(OUTCOME).set(FAILED);
-                failure.get(FAILURE_DESCRIPTION).set(e.getClass().getName() + ":" + e.getMessage());
+                failure.get(FAILURE_DESCRIPTION).set(t.getClass().getName() + ":" + t.getMessage());
                 result.set(failure);
-                attachmentsProxy.shutdown(e);
+                attachmentsProxy.shutdown();
+                ControllerLogger.MGMT_OP_LOGGER.unexpectedOperationExecutionException(t, Collections.singletonList(operation));
             } finally {
                 ROOT_LOGGER.tracef("Executed client request %d", batchId);
             }

--- a/controller/src/main/java/org/jboss/as/controller/remote/OperationAttachmentsProxy.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/OperationAttachmentsProxy.java
@@ -85,9 +85,9 @@ class OperationAttachmentsProxy implements Operation {
         //
     }
 
-    void shutdown(Exception error) {
+    void shutdown() {
         for (final ProxiedInputStream stream : proxiedStreams) {
-            stream.shutdown(error);
+            stream.shutdown(null);
         }
     }
 
@@ -118,7 +118,7 @@ class OperationAttachmentsProxy implements Operation {
         private final ManagementChannelAssociation channelAssociation;
 
         private boolean initialized;
-        private volatile Exception error;
+        private volatile Throwable error;
 
         ProxiedInputStream(final ManagementChannelAssociation channelAssociation, final int batchId, final int index) {
             this.channelAssociation = channelAssociation;
@@ -217,7 +217,7 @@ class OperationAttachmentsProxy implements Operation {
             }
         }
 
-        private void shutdown(Exception error) {
+        private void shutdown(Throwable error) {
             StreamUtils.safeClose(this);
             this.error = error;
         }

--- a/controller/src/test/java/org/jboss/as/controller/remote/ResponseAttachmentInputStreamSupportTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/remote/ResponseAttachmentInputStreamSupportTestCase.java
@@ -337,7 +337,7 @@ public class ResponseAttachmentInputStreamSupportTestCase {
         }
 
         @Override
-        public boolean failed(Exception e) {
+        public boolean failed(Throwable t) {
             int was = this.result;
             this.result += 10;
             return was == 0;

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadResourceWithRuntimeResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadResourceWithRuntimeResourceTestCase.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.OperationContext;
@@ -158,7 +159,7 @@ public class ReadResourceWithRuntimeResourceTestCase extends AbstractControllerT
         }
 
         @Override
-        public void execute(ModelNode operation, OperationMessageHandler handler, final ProxyOperationControl control, OperationAttachments attachments) {
+        public void execute(ModelNode operation, OperationMessageHandler handler, final ProxyOperationControl control, OperationAttachments attachments, BlockingTimeout blockingTimeout) {
             final ModelNode response = new ModelNode();
             response.get("outcome").set("success");
             response.get("result", "attr").set(true);

--- a/controller/src/test/java/org/jboss/as/controller/test/RegistryProxyControllerTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/RegistryProxyControllerTestCase.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.fail;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProxyController;
@@ -240,7 +241,7 @@ public class RegistryProxyControllerTestCase {
         }
 
         @Override
-        public void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control, OperationAttachments attachments) {
+        public void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control, OperationAttachments attachments, BlockingTimeout blockingTimeout) {
         }
 
     }

--- a/controller/src/test/java/org/jboss/as/controller/test/RemoteProxyControllerProtocolTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/RemoteProxyControllerProtocolTestCase.java
@@ -134,7 +134,7 @@ public class RemoteProxyControllerProtocolTestCase {
                     }
                 },
                 commitControl,
-                null);
+                null, null);
         Assert.assertNotNull(commitControl.tx);
         commitControl.tx.commit();
         assertEquals("123", controller.getOperation().get("test").asString());
@@ -180,7 +180,7 @@ public class RemoteProxyControllerProtocolTestCase {
                         completed.set(true);
                     }
                 },
-                null);
+                null, null);
         ModelNode result = failure.get();
         assertEquals(FAILED, result.get(OUTCOME).asString());
         assertEquals("broken", result.get(FAILURE_DESCRIPTION).asString());
@@ -223,7 +223,7 @@ public class RemoteProxyControllerProtocolTestCase {
                         completed.set(true);
                     }
                 },
-                null);
+                null, null);
         ModelNode result = failure.get();
         assertEquals(FAILED, result.get(OUTCOME).asString());
         assertEquals("java.lang.RuntimeException:Crap", result.get(FAILURE_DESCRIPTION).asString());
@@ -290,7 +290,7 @@ public class RemoteProxyControllerProtocolTestCase {
                         result.done(response);
                     }
                 },
-                null);
+                null, null);
 
         ModelNode preparedResult = prepared.get();
         assertEquals(SUCCESS, preparedResult.get(OUTCOME).asString());
@@ -362,7 +362,7 @@ public class RemoteProxyControllerProtocolTestCase {
                         result.done(response);
                     }
                 },
-                null);
+                null, null);
 
         ModelNode preparedResult = prepared.get();
         assertEquals(SUCCESS, preparedResult.get(OUTCOME).asString());
@@ -405,7 +405,7 @@ public class RemoteProxyControllerProtocolTestCase {
                 result.set(response.getResponseNode());
             }
         };
-        proxyController.execute(node, null, commitControl, null);
+        proxyController.execute(node, null, commitControl, null, null);
         commitControl.tx.commit();
         // Needs to call operation-completed
         Assert.assertEquals(2, commitControl.txCompletionStatus.get());
@@ -501,7 +501,7 @@ public class RemoteProxyControllerProtocolTestCase {
         proxyController.execute(operation,
                 null,
                 commitControl,
-                attachments);
+                attachments, null);
         Assert.assertNotNull(commitControl.tx);
         commitControl.tx.commit();
         assertEquals(3, size.get());
@@ -540,7 +540,7 @@ public class RemoteProxyControllerProtocolTestCase {
         operation.get("test").set("123");
 
         CommitProxyOperationControl commitControl = new CommitProxyOperationControl();
-        proxyController.execute(operation, OperationMessageHandler.DISCARD, commitControl, OperationAttachments.EMPTY);
+        proxyController.execute(operation, OperationMessageHandler.DISCARD, commitControl, OperationAttachments.EMPTY, null);
         Assert.assertNull(errorRef.get());
         latch.await(15, TimeUnit.SECONDS);
         Assert.assertEquals(1, commitControl.txCompletionStatus.get());

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/ServerIdentity.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/ServerIdentity.java
@@ -24,6 +24,10 @@ package org.jboss.as.domain.controller;
 
 import java.io.Serializable;
 
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+
 /**
  * Identifying information for a server in a domain. A bit of a misnomer, as
  * the server's name is sufficient identification since all servers in a
@@ -38,6 +42,7 @@ public class ServerIdentity implements Serializable {
     private final String hostName;
     private final String serverName;
     private final String serverGroupName;
+    private volatile PathAddress pathAddress;
 
     public ServerIdentity(final String hostName, final String serverGroupName, final String serverName) {
         this.hostName = hostName;
@@ -55,6 +60,16 @@ public class ServerIdentity implements Serializable {
 
     public String getServerName() {
         return serverName;
+    }
+
+    public PathAddress toPathAddress() {
+        if (pathAddress == null) {
+            pathAddress = PathAddress.pathAddress(
+                    PathElement.pathElement(ModelDescriptionConstants.HOST, hostName),
+                    PathElement.pathElement(ModelDescriptionConstants.RUNNING_SERVER, serverName)
+            );
+        }
+        return pathAddress;
     }
 
     /**

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
@@ -382,8 +382,9 @@ public interface DomainControllerLogger extends BasicLogger {
      *
      * @return the message.
      */
-    @Message(id = 31, value = "Exception getting result from host %s: %s")
-    String exceptionAwaitingResultFromHost(String name, String message);
+    // Disabled as part of WFCORE-378
+//    @Message(id = 31, value = "Exception getting result from host %s: %s")
+//    String exceptionAwaitingResultFromHost(String name, String message);
 
     /**
      * A message indicating the operation, represented by the {@code operation} parameter, for the {@code address} can
@@ -748,4 +749,23 @@ public interface DomainControllerLogger extends BasicLogger {
             "b) Reload the domain controller into admin-only mode, perform the clone, then reload the domain controller " +
             "into normal mode again, and check whether the slaves need reloading.")
     String cloneOperationNotSupportedOnHost(String hostName);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 79, value = "Timed out after %d ms awaiting host prepared response(s) from hosts %s -- cancelling updates for hosts %s")
+    void timedOutAwaitingHostPreparedResponses(long timeout, Set<String> timeoutHosts, Set<String> allHosts);
+
+    @Message(id = 80, value = "Timed out after %d ms awaiting host prepared response(s) -- remote host %s has been notified to cancel operation")
+    String timedOutAwaitingHostPreparedResponse(long timeout, String host);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 81, value = "Timed out after %d ms awaiting final response from host %s; remote process has been notified to cancel operation")
+    void timedOutAwaitingFinalResponse(long timeout, String hostName);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 82, value = "%s timed out after %d ms awaiting server prepared response(s) -- cancelling updates for servers %s")
+    void timedOutAwaitingPreparedResponse(String callerClass, long timeout, Set<ServerIdentity> servers);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 83, value = "Timed out after %d ms awaiting final response from server %s on host %s; remote process has been notified to cancel operation")
+    void timedOutAwaitingFinalResponse(int patient, String serverName, String hostName);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainFinalResultHandler.java
@@ -118,6 +118,15 @@ class DomainFinalResultHandler implements OperationStepHandler {
                     Map<ServerIdentity, ModelNode> serverResults = multiphaseContext.getServerResults();
                     if (serverResults.size() > 0) {
                         populateServerGroupResults(context, serverResults);
+                        // TODO report post-commit failures on slaves (i.e. in OperationContext.ResultHandler impls).
+                        // Consider enabling this. Problem is this results in the op having
+                        // outcome=failed, but really the model and MSC were updated on all HCs and servers
+                        // so the effect is likely much more like outcome=success
+                        // We don't really know what went wrong.
+//                        if (isDomain) {
+//                            // If there were any post-prepare failures on slaves, report them
+//                            populatePostPrepareHCFailures(context);
+//                        }
                     } else {
                         shouldContinue = collectHostFailures(context, isDomain);
                         if (shouldContinue) {
@@ -361,6 +370,35 @@ class DomainFinalResultHandler implements OperationStepHandler {
             }
         }
     }
+
+    // See TODO above
+//    private void populatePostPrepareHCFailures(OperationContext context) {
+//        ModelNode hostFailureResults = null;
+//        for (Map.Entry<String, ModelNode> entry : multiphaseContext.getHostControllerFinalResults().entrySet()) {
+//            ModelNode hostResult = entry.getValue();
+//            if (hostResult.hasDefined(FAILURE_DESCRIPTION)) {
+//                if (hostFailureResults == null) {
+//                    hostFailureResults = new ModelNode();
+//                }
+//                hostFailureResults.get(entry.getKey()).set(hostResult.get(FAILURE_DESCRIPTION));
+//            }
+//        }
+//
+//        if (hostFailureResults != null) {
+//            //context.getFailureDescription().get(HOST_FAILURE_DESCRIPTIONS).set(hostFailureResults);
+//
+//            //The following is a workaround for AS7-4597
+//            //DomainRolloutStepHandler.pushToServers() puts in a simple string into the failure description, but that might be a red herring.
+//            //If there is a failure description and it is not of type OBJECT, then let's not set it for now
+//            if (!context.getFailureDescription().isDefined() || context.getFailureDescription().getType() == ModelType.OBJECT) {
+//                ModelNode fullFailure = new ModelNode();
+//                fullFailure.get(HOST_FAILURE_DESCRIPTIONS).set(hostFailureResults);
+//                context.getFailureDescription().set(fullFailure);
+//            } else {
+//                DomainControllerLogger.HOST_CONTROLLER_LOGGER.debugf("Failure description is not of type OBJECT '%s'", context.getFailureDescription());
+//            }
+//        }
+//    }
 
     private boolean isDomainOperation(final ModelNode operation) {
         final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainRolloutStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainRolloutStepHandler.java
@@ -59,6 +59,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -78,6 +79,7 @@ import org.jboss.as.domain.controller.plan.RolloutPlanController;
 import org.jboss.as.domain.controller.plan.ServerTaskExecutor;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
+import org.jboss.threads.AsyncFuture;
 
 /**
  * Formulates a rollout plan, invokes the proxies to execute it on the servers.
@@ -125,6 +127,8 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
         // Temporary hack to prevent CompositeOperationHandler throwing away domain failure data
         context.attachIfAbsent(CompositeOperationHandler.DOMAIN_EXECUTION_KEY, Boolean.TRUE);
 
+        final BlockingTimeout blockingTimeout = BlockingTimeout.Factory.getDomainBlockingTimeout(context);
+
         // Confirm no host failures
         boolean pushToServers = !multiphaseContext.hasHostLevelFailures();
         if (pushToServers) {
@@ -160,18 +164,18 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
             final List<ServerTaskExecutor.ServerPreparedResponse> preparedResults = new ArrayList<ServerTaskExecutor.ServerPreparedResponse>();
             boolean completeStepCalled = false;
             try {
-                pushToServers(context, submittedTasks, preparedResults);
+                pushToServers(context, submittedTasks, preparedResults, blockingTimeout);
                 context.completeStep(new OperationContext.ResultHandler() {
                     @Override
                     public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
-                        finalizeOp(context, submittedTasks, preparedResults);
+                        finalizeOp(context, submittedTasks, preparedResults, blockingTimeout);
                     }
                 });
 
                 completeStepCalled = true;
             } finally {
                 if (!completeStepCalled) {
-                    finalizeOp(context, submittedTasks, preparedResults);
+                    finalizeOp(context, submittedTasks, preparedResults, blockingTimeout);
                 }
             }
         } else {
@@ -182,7 +186,7 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
     }
 
     private void finalizeOp(final OperationContext context, final Map<ServerIdentity, ServerTaskExecutor.ExecutedServerRequest> submittedTasks,
-                            final List<ServerTaskExecutor.ServerPreparedResponse> preparedResults) {
+                            final List<ServerTaskExecutor.ServerPreparedResponse> preparedResults, final BlockingTimeout blockingTimeout) {
 
         boolean interrupted = false;
         // Inform the remote hosts whether to commit or roll back their updates
@@ -222,7 +226,7 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
                     // 3) Passing that OperationResponse through the various callbacks related to prepared responses
                     // Doable, but I (BES) am not doing it now for such a corner case
                     OperationResponse originalResponse = OperationResponse.Factory.createSimple(result);
-                    final Future<OperationResponse> future = executorService.submit(new ServerRequireRestartTask(identity, proxy, originalResponse));
+                    final Future<OperationResponse> future = executorService.submit(new ServerRequireRestartTask(identity, proxy, originalResponse, blockingTimeout));
                     // replace the existing future
                     submittedTasks.put(identity, new ServerTaskExecutor.ExecutedServerRequest(identity, future));
                 } catch (Exception ignore) {
@@ -234,7 +238,10 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
         // before we expose the servers to further requests
 
         try {
-            boolean patient = !interrupted;
+            // If we've been interrupted, only wait 50 ms for a final response, otherwise wait the domain blocking timeout
+            // Before WFCORE-996 was analyzed, in the interrupted case we would wait 0 ms. 50 ms is a
+            // workaround attempt to avoid a race
+            int patient = interrupted ? 50 : blockingTimeout.getDomainBlockingTimeout(multiphaseContext.getLocalHostInfo().isMasterDomainController());
             for (Map.Entry<ServerIdentity, ServerTaskExecutor.ExecutedServerRequest> entry : submittedTasks.entrySet()) {
                 final ServerTaskExecutor.ExecutedServerRequest request = entry.getValue();
                 final ServerIdentity sid = entry.getKey();
@@ -242,7 +249,7 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
                 try {
                     final OperationResponse finalResponse = future.isCancelled()
                             ? getCancelledResult()
-                            : patient ? future.get() : future.get(0, TimeUnit.MILLISECONDS);
+                            : future.get(patient, TimeUnit.MILLISECONDS);
 
                     final ModelNode untransformedResponse = finalResponse.getResponseNode();
                     HOST_CONTROLLER_LOGGER.tracef("Final response from %s is %s (untransformed)", sid, untransformedResponse);
@@ -256,19 +263,25 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
 
                     multiphaseContext.addServerResult(sid, transformedResult);
                 } catch (InterruptedException e) {
-                    future.cancel(true);
+                    cancelPreferAsync(future, true);
                     interrupted = true;
                     // We suppressed an interrupt, so don't block indefinitely waiting for other responses;
                     // just grab them if they are already available
-                    patient = false;
+                    patient = patient == 0 ? 0 : 50; // if we were already really impatient, we still are
                     HOST_CONTROLLER_LOGGER.interruptedAwaitingFinalResponse(sid.getServerName(), sid.getHostName());
                 } catch (ExecutionException e) {
-                    future.cancel(true);
+                    cancelPreferAsync(future, true);
                     HOST_CONTROLLER_LOGGER.caughtExceptionAwaitingFinalResponse(e.getCause(), sid.getServerName(), sid.getHostName());
                 } catch (TimeoutException e) {
-                    future.cancel(true);
-                    // This only happens if we were interrupted previously, so treat it that way
-                    HOST_CONTROLLER_LOGGER.interruptedAwaitingFinalResponse(sid.getServerName(), sid.getHostName());
+                    cancelPreferAsync(future, true);
+                    if (interrupted) {
+                        HOST_CONTROLLER_LOGGER.interruptedAwaitingFinalResponse(sid.getServerName(), sid.getHostName());
+                    } else {
+                        HOST_CONTROLLER_LOGGER.timedOutAwaitingFinalResponse(patient, sid.getServerName(), sid.getHostName());
+                    }
+                    // we already waited at least the original 'patient' value since we sent out commit/rollback msgs;
+                    // don't need to wait so long any more
+                    patient = 0;
                 }
             }
         } finally {
@@ -278,14 +291,23 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
         }
     }
 
+    private void cancelPreferAsync(Future<?> future, boolean mayInterruptIfRunning) {
+
+        if (future instanceof AsyncFuture) { // the normal case
+            ((AsyncFuture) future).asyncCancel(mayInterruptIfRunning);
+        } else { // the ServerRequireRestartTask case, where we're interrupting a thread executing an op locally
+            future.cancel(mayInterruptIfRunning);
+        }
+    }
+
     private OperationResponse getCancelledResult() {
         ModelNode cancelled = new ModelNode();
         cancelled.get(OUTCOME).set(CANCELLED);
         return OperationResponse.Factory.createSimple(cancelled);
     }
 
-    private void pushToServers(final OperationContext context, final Map<ServerIdentity,ServerTaskExecutor.ExecutedServerRequest> submittedTasks,
-                               final List<ServerTaskExecutor.ServerPreparedResponse> preparedResults) throws OperationFailedException {
+    private void pushToServers(final OperationContext context, final Map<ServerIdentity, ServerTaskExecutor.ExecutedServerRequest> submittedTasks,
+                               final List<ServerTaskExecutor.ServerPreparedResponse> preparedResults, final BlockingTimeout blockingTimeout) throws OperationFailedException {
 
         final String localHostName = multiphaseContext.getLocalHostInfo().getLocalHostName();
         Map<String, ModelNode> hostResults = new HashMap<String, ModelNode>(multiphaseContext.getHostControllerPreparedResults());
@@ -308,7 +330,7 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
             final ServerTaskExecutor taskExecutor = new ServerTaskExecutor(context, submittedTasks, preparedResults) {
 
                 @Override
-                protected boolean execute(TransactionalProtocolClient.TransactionalOperationListener<ServerTaskExecutor.ServerOperation> listener, ServerIdentity server, ModelNode original) throws OperationFailedException {
+                protected int execute(TransactionalProtocolClient.TransactionalOperationListener<ServerTaskExecutor.ServerOperation> listener, ServerIdentity server, ModelNode original) throws OperationFailedException {
                     final String hostName = server.getHostName();
                     ProxyController proxy = hostProxies.get(hostName);
                     if (proxy == null) {
@@ -320,7 +342,7 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
                             if (trace) {
                                 HOST_CONTROLLER_LOGGER.tracef("No proxy for %s", server);
                             }
-                            return false;
+                            return -1;
                         }
                     }
                     // Transform the server-results
@@ -329,10 +351,15 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
                     final ModelNode transformedOperation = transformed.getTransformedOperation();
                     final OperationResultTransformer resultTransformer = transformed.getResultTransformer();
                     final TransactionalProtocolClient client = remoteProxyController.getProtocolClient();
-                    return executeOperation(listener, client, server, transformedOperation, resultTransformer);
+                    if (executeOperation(listener, client, server, transformedOperation, resultTransformer)) {
+                        return blockingTimeout.getProxyBlockingTimeout(server.toPathAddress(), remoteProxyController);
+                    } else {
+                        return -1;
+                    }
                 }
             };
-            RolloutPlanController rolloutPlanController = new RolloutPlanController(opsByGroup, rolloutPlan, multiphaseContext, taskExecutor, executorService);
+            RolloutPlanController rolloutPlanController = new RolloutPlanController(opsByGroup, rolloutPlan,
+                    multiphaseContext, taskExecutor, executorService, blockingTimeout);
             RolloutPlanController.Result planResult = rolloutPlanController.execute();
             if (trace) {
                 HOST_CONTROLLER_LOGGER.tracef("Rollout plan result is %s", planResult);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.CurrentOperationIdHolder;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -52,7 +53,6 @@ import org.jboss.as.controller.operations.OperationAttachments;
 import org.jboss.as.controller.remote.ResponseAttachmentInputStreamSupport;
 import org.jboss.as.controller.remote.TransactionalProtocolClient;
 import org.jboss.as.controller.transform.Transformers;
-import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -80,6 +80,7 @@ public class DomainSlaveHandler implements OperationStepHandler {
             return;
         }
 
+        final BlockingTimeout blockingTimeout = BlockingTimeout.Factory.getDomainBlockingTimeout(context);
         final Set<String> outstanding = new HashSet<String>(hostProxies.keySet());
         final List<TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation>> results = new ArrayList<TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation>>();
         final Map<String, HostControllerUpdateTask.ExecutedHostRequest> finalResults = new HashMap<String, HostControllerUpdateTask.ExecutedHostRequest>();
@@ -91,8 +92,8 @@ public class DomainSlaveHandler implements OperationStepHandler {
             final TransformingProxyController proxyController = (TransformingProxyController) entry.getValue();
             List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
             ModelNode op = operation;
-            if(transformers != null) {
-                for(final DomainOperationTransformer transformer : transformers) {
+            if (transformers != null) {
+                for (final DomainOperationTransformer transformer : transformers) {
                     op = transformer.transform(context, op);
                     // Set the flag for host controller operations
                     op.get(OPERATION_HEADERS, EXECUTE_FOR_COORDINATOR).set(true);
@@ -112,11 +113,18 @@ public class DomainSlaveHandler implements OperationStepHandler {
         boolean interrupted = false;
         boolean completeStepCalled = false;
         try {
-            try {
-                while(outstanding.size() > 0) {
-                    final TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation> prepared = listener.retrievePreparedOperation();
+            long timeout = 0;
+            while (outstanding.size() > 0) {
+                timeout = blockingTimeout.getDomainBlockingTimeout(false);
+                TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation> prepared = null;
+                try {
+                    prepared = listener.retrievePreparedOperation(timeout, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException ie) {
+                    interrupted = true;
+                }
+                if (prepared != null) {
                     final String hostName = prepared.getOperation().getName();
-                    if(! outstanding.remove(hostName)) {
+                    if (!outstanding.remove(hostName)) {
                         continue;
                     }
                     final ModelNode preparedResult = prepared.getPreparedResult();
@@ -124,7 +132,7 @@ public class DomainSlaveHandler implements OperationStepHandler {
                     // See if we have to reject the result
                     final HostControllerUpdateTask.ExecutedHostRequest request = finalResults.get(hostName);
                     boolean reject = request.rejectOperation(preparedResult);
-                    if(reject) {
+                    if (reject) {
                         if (HOST_CONTROLLER_LOGGER.isDebugEnabled()) {
                             HOST_CONTROLLER_LOGGER.debugf("Rejecting result for remote host %s is %s", hostName, preparedResult);
                         }
@@ -139,45 +147,26 @@ public class DomainSlaveHandler implements OperationStepHandler {
                         multiphaseContext.addHostControllerPreparedResult(hostName, preparedResult);
                     }
                     results.add(prepared);
+                } else {
+                    // Either interrupted or timed out.
+                    handleMissingHostResponses(finalResults, outstanding, !interrupted, timeout);
+                    break;
                 }
-            } catch (InterruptedException ie) {
-                interrupted = true;
-                // Set rollback only
-                multiphaseContext.setFailureReported(true);
-                // Cancel all HCs
-                HOST_CONTROLLER_LOGGER.interruptedAwaitingHostPreparedResponse(finalResults.keySet());
-                for(final HostControllerUpdateTask.ExecutedHostRequest finalResult : finalResults.values()) {
-                    finalResult.asyncCancel();
-                }
-                // Wait that all hosts are rolled back!?
-                for(final Map.Entry<String, HostControllerUpdateTask.ExecutedHostRequest> entry : finalResults.entrySet()) {
-                    final String hostName = entry.getKey();
-                    try {
-                        final HostControllerUpdateTask.ExecutedHostRequest request = entry.getValue();
-                        final ModelNode result = request.getFinalResult().get().getResponseNode();
-                        final ModelNode transformedResult = request.transformResult(result);
-                        multiphaseContext.addHostControllerPreparedResult(hostName, transformedResult);
-                    } catch (Exception e) {
-                        final ModelNode result = new ModelNode();
-                        result.get(OUTCOME).set(FAILED);
-                        if (e instanceof InterruptedException) {
-                            result.get(FAILURE_DESCRIPTION).set(DomainControllerLogger.HOST_CONTROLLER_LOGGER.interruptedAwaitingResultFromHost(entry.getKey()));
-                            interrupted = true;
-                        } else {
-                            result.get(FAILURE_DESCRIPTION).set(DomainControllerLogger.HOST_CONTROLLER_LOGGER.exceptionAwaitingResultFromHost(entry.getKey(), e.getMessage()));
-                        }
-                        multiphaseContext.addHostControllerPreparedResult(hostName, result);
-                    }
-                }
+
             }
 
             if (interrupted) {
+                // Interrupt the thread so the OC can learn the operation was interrupted
+                // when we call completeStep. The OC will then change the outcome of the
+                // op to "cancelled" and prevent further execution of steps. Our
+                // finalizeOp method will still be called, via the ResultHandler we pass in.
                 Thread.currentThread().interrupt();
             }
+
             context.completeStep(new OperationContext.ResultHandler() {
                 @Override
                 public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
-                    finalizeOp(results, finalResults, false, context);
+                    finalizeOp(results, finalResults, false, context, blockingTimeout);
                 }
             });
 
@@ -185,44 +174,85 @@ public class DomainSlaveHandler implements OperationStepHandler {
 
         } finally {
             if (!completeStepCalled) {
-                finalizeOp(results, finalResults, interrupted, context);
+                finalizeOp(results, finalResults, interrupted, context, blockingTimeout);
             }
+        }
+    }
+
+    private void handleMissingHostResponses(Map<String, HostControllerUpdateTask.ExecutedHostRequest> finalResults,
+                                            Set<String> outstanding, boolean timedOut, long timeout) {
+
+        // Set rollback only
+        multiphaseContext.setFailureReported(true);
+
+        // Cancel all HCs
+        if (timedOut) {
+            HOST_CONTROLLER_LOGGER.timedOutAwaitingHostPreparedResponses(timeout, outstanding, finalResults.keySet());
+        } else {
+            HOST_CONTROLLER_LOGGER.interruptedAwaitingHostPreparedResponse(finalResults.keySet());
+        }
+        for (final HostControllerUpdateTask.ExecutedHostRequest finalResult : finalResults.values()) {
+            finalResult.asyncCancel();
+        }
+
+        // Record "prepared" responses
+        for (String hostName : outstanding) {
+            ModelNode failureResponse;
+            if (timedOut) {
+                failureResponse = getTimeoutResponse(timeout, hostName);
+                // Store this locally created response as the final response, since
+                // as far as this operation is concerned this slave is non-responsive,
+                // what we do here is what rules (i.e. the op failed due to timeout) and
+                // we have no idea if any final response from the remote node will make sense
+                finalResults.put(hostName, finalResults.get(hostName).toFailedRequest(failureResponse));
+            } else {
+                failureResponse = getInterruptedResponse(hostName);
+                // Here we don't regard this as the final response as we are willing to wait
+                // for a final response from the cancelled slave. The slave didn't time out,
+                // rather the user cancelled. So we want to report the slave's reaction to that,
+                // as that is an aspect of cancellation.
+            }
+            multiphaseContext.addHostControllerPreparedResult(hostName, failureResponse);
         }
     }
 
     private void finalizeOp(final List<TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation>> results,
                             final Map<String, HostControllerUpdateTask.ExecutedHostRequest> finalResults,
-                            final boolean interrupted, final OperationContext context) {
+                            final boolean interrupted, final OperationContext context, final BlockingTimeout blockingTimeout) {
+
+        // If an interrupt occurred, either in our execute method or after it called completeStep,
+        // we will be less patient in waiting for final responses, as the user has indicated
+        // they want the op ended. Quite likely that is because the op is taking too long.
         boolean interruptThread = Thread.interrupted() || interrupted;
         try {
             // Inform the remote hosts whether to commit or roll back their updates
-            // Do this in parallel
+            // The slaves will then being doing the commit/rollback in parallel
             boolean rollback = multiphaseContext.isCompleteRollback();
-            for(final TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation> prepared : results) {
+            for (final TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation> prepared : results) {
 
                 // Clear any thread interrupted status so we know the commit/rollback message will go out
                 interruptThread = Thread.interrupted() || interruptThread;
 
-                if(prepared.isDone()) {
+                if (prepared.isDone()) {
                     continue;
                 }
-                if(! rollback) {
+                if (!rollback) {
                     prepared.commit();
                 } else {
                     prepared.rollback();
                 }
             }
             // Now get the final results from the hosts
-            // If we've been interrupted, only wait 50 ms for a final response, otherwise wait indefinitely
+            // If we've been interrupted, only wait 50 ms for a final response, otherwise wait the domain blocking timeout
             // Before WFCORE-996 was analyzed, in the interrupted case we would wait 0 ms. 50 ms is a
             // workaround attempt to avoid a race
-            int patient = interruptThread ? 50 : -1;
-            for(final TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation> prepared : results) {
+            int patient = interruptThread ? 50 : blockingTimeout.getDomainBlockingTimeout(false);
+            for (final TransactionalProtocolClient.PreparedOperation<HostControllerUpdateTask.ProxyOperation> prepared : results) {
                 final String hostName = prepared.getOperation().getName();
                 final HostControllerUpdateTask.ExecutedHostRequest request = finalResults.get(hostName);
                 final Future<OperationResponse> future = prepared.getFinalResult();
                 try {
-                    final OperationResponse finalResponse = patient < 0 ? future.get() : future.get(patient, TimeUnit.MILLISECONDS);
+                    final OperationResponse finalResponse = future.get(patient, TimeUnit.MILLISECONDS);
                     final ModelNode transformedResult = request.transformResult(finalResponse.getResponseNode());
                     multiphaseContext.addHostControllerFinalResult(hostName, transformedResult);
 
@@ -243,10 +273,15 @@ public class DomainSlaveHandler implements OperationStepHandler {
                 } catch (ExecutionException e) {
                     HOST_CONTROLLER_LOGGER.caughtExceptionAwaitingFinalResponse(e.getCause(), hostName);
                 } catch (TimeoutException e) {
-                    // This only happens if we were interrupted previously, so treat it that way
                     future.cancel(true);
-                    patient = 0; // we already waited 50 ms since we sent out commit/rollback msgs; don't need to wait so long any more
-                    HOST_CONTROLLER_LOGGER.interruptedAwaitingFinalResponse(hostName);
+                    if (interruptThread) {
+                        HOST_CONTROLLER_LOGGER.interruptedAwaitingFinalResponse(hostName);
+                    } else {
+                        HOST_CONTROLLER_LOGGER.timedOutAwaitingFinalResponse(patient, hostName);
+                    }
+                    // we already waited at least the original 'patient' value since we sent out commit/rollback msgs;
+                    // don't need to wait so long any more
+                    patient = 0;
                 }
             }
         } finally {
@@ -254,6 +289,22 @@ public class DomainSlaveHandler implements OperationStepHandler {
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    private static ModelNode getTimeoutResponse(long timeout, String hostName) {
+        String msg = HOST_CONTROLLER_LOGGER.timedOutAwaitingHostPreparedResponse(timeout, hostName);
+        final ModelNode response = new ModelNode();
+        response.get(OUTCOME).set(FAILED);
+        response.get(FAILURE_DESCRIPTION).set(msg);
+        return response;
+    }
+
+    private static ModelNode getInterruptedResponse(String hostName) {
+        String msg = HOST_CONTROLLER_LOGGER.interruptedAwaitingResultFromHost(hostName);
+        final ModelNode response = new ModelNode();
+        response.get(OUTCOME).set(FAILED);
+        response.get(FAILURE_DESCRIPTION).set(msg);
+        return response;
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerUpdateTask.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerUpdateTask.java
@@ -53,6 +53,7 @@ import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.OperationResponse;
 import org.jboss.as.controller.remote.BlockingQueueOperationListener;
+import org.jboss.as.controller.remote.CompletedFuture;
 import org.jboss.as.controller.remote.TransactionalOperationImpl;
 import org.jboss.as.controller.remote.TransactionalProtocolClient;
 import org.jboss.as.controller.transform.OperationRejectionPolicy;
@@ -218,6 +219,11 @@ class HostControllerUpdateTask {
 
         public void asyncCancel() {
             futureResult.asyncCancel(true);
+        }
+
+        ExecutedHostRequest toFailedRequest(ModelNode finalResponse) {
+            OperationResponse simpleResponse = OperationResponse.Factory.createSimple(finalResponse);
+            return new ExecutedHostRequest(new CompletedFuture<>(simpleResponse), resultTransformer, rejectPolicy);
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerRequireRestartTask.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerRequireRestartTask.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.domain.controller.operations.coordination;
 
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.client.OperationAttachments;
@@ -57,11 +58,13 @@ class ServerRequireRestartTask implements Callable<OperationResponse> {
     private final ServerIdentity identity;
     private final ProxyController controller;
     private final OperationResponse originalResult;
+    private final BlockingTimeout blockingTimeout;
 
-    public ServerRequireRestartTask(final ServerIdentity identity, ProxyController controller, final OperationResponse originalResult) {
+    public ServerRequireRestartTask(final ServerIdentity identity, ProxyController controller, final OperationResponse originalResult, BlockingTimeout blockingTimeout) {
         this.identity = identity;
         this.controller = controller;
         this.originalResult = originalResult;
+        this.blockingTimeout = blockingTimeout;
     }
 
     @Override
@@ -88,7 +91,7 @@ class ServerRequireRestartTask implements Callable<OperationResponse> {
             };
             // Execute
             final ModelNode operation = createOperation(identity);
-            controller.execute(operation, OperationMessageHandler.DISCARD, proxyControl, OperationAttachments.EMPTY);
+            controller.execute(operation, OperationMessageHandler.DISCARD, proxyControl, OperationAttachments.EMPTY, blockingTimeout);
             final ModelController.OperationTransaction tx = txRef.get();
             if(tx != null) {
                 // Commit right away

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/plan/AbstractServerGroupRolloutTask.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/plan/AbstractServerGroupRolloutTask.java
@@ -22,15 +22,24 @@
 
 package org.jboss.as.domain.controller.plan;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+
 import java.security.PrivilegedAction;
 import java.util.List;
 
 import javax.security.auth.Subject;
 
 import org.jboss.as.controller.AccessAuditContext;
+import org.jboss.as.controller.BlockingTimeout;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.remote.BlockingQueueOperationListener;
 import org.jboss.as.controller.remote.TransactionalProtocolClient;
-import org.jboss.as.domain.controller.logging.DomainControllerLogger;
+import org.jboss.as.controller.transform.OperationResultTransformer;
 import org.jboss.as.domain.controller.ServerIdentity;
+import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -45,12 +54,14 @@ abstract class AbstractServerGroupRolloutTask implements Runnable {
     protected final ServerUpdatePolicy updatePolicy;
     protected final ServerTaskExecutor executor;
     protected final Subject subject;
+    protected final BlockingTimeout blockingTimeout;
 
-    public AbstractServerGroupRolloutTask(List<ServerUpdateTask> tasks, ServerUpdatePolicy updatePolicy, ServerTaskExecutor executor, Subject subject) {
+    public AbstractServerGroupRolloutTask(List<ServerUpdateTask> tasks, ServerUpdatePolicy updatePolicy, ServerTaskExecutor executor, Subject subject, BlockingTimeout blockingTimeout) {
         this.tasks = tasks;
         this.updatePolicy = updatePolicy;
         this.executor = executor;
         this.subject = subject;
+        this.blockingTimeout = blockingTimeout;
     }
 
     @Override
@@ -92,5 +103,23 @@ abstract class AbstractServerGroupRolloutTask implements Runnable {
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{server-group=" + updatePolicy.getServerGroupName() + "}";
+    }
+
+    void handlePreparePhaseTimeout(ServerIdentity identity, ServerUpdateTask task, long timeout) {
+
+        blockingTimeout.proxyTimeoutDetected(identity.toPathAddress());
+
+        // Record a synthetic prepared result so the timeout can impact the updatePolicy and
+        // possibly trigger a ServerRequestRestartTask if the overall rollout isn't rolled back
+        final ServerTaskExecutor.ServerOperation serverOperation = new ServerTaskExecutor.ServerOperation(identity, task.getOperation(), null, null, OperationResultTransformer.ORIGINAL_RESULT);
+        final String failureMsg = ControllerLogger.ROOT_LOGGER.proxiedOperationTimedOut(task.getOperation().get(OP).asString(), identity.toPathAddress(), timeout);
+        final ModelNode failureNode = new ModelNode();
+        failureNode.get(OUTCOME).set(FAILED);
+        failureNode.get(FAILURE_DESCRIPTION).set(failureMsg);
+        final BlockingQueueOperationListener.FailedOperation<ServerTaskExecutor.ServerOperation> prepared = new BlockingQueueOperationListener.FailedOperation<>(serverOperation, failureNode);
+
+        final ModelNode preparedResult = prepared.getPreparedResult();
+        updatePolicy.recordServerResult(identity, preparedResult);
+        executor.recordOperationPrepareTimeout(prepared);
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/plan/RolloutPlanController.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/plan/RolloutPlanController.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutorService;
 
 import javax.security.auth.Subject;
 
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.domain.controller.ServerIdentity;
 import org.jboss.as.domain.controller.operations.coordination.MultiphaseOverallContext;
 import org.jboss.dmr.ModelNode;
@@ -74,7 +75,8 @@ public class RolloutPlanController {
                                  final ModelNode rolloutPlan,
                                  final MultiphaseOverallContext domainOperationContext,
                                  final ServerTaskExecutor taskExecutor,
-                                 final ExecutorService executor) {
+                                 final ExecutorService executor,
+                                 final BlockingTimeout blockingTimeout) {
         this.domainOperationContext = domainOperationContext;
 
         this.rollbackAcrossGroups = !rolloutPlan.hasDefined(ROLLBACK_ACROSS_GROUPS) || rolloutPlan.get(ROLLBACK_ACROSS_GROUPS).asBoolean();
@@ -131,8 +133,8 @@ public class RolloutPlanController {
                     }
                     ServerUpdatePolicy policy = new ServerUpdatePolicy(parent, serverGroupName, servers, maxFailures);
 
-                    seriesTasks.add(rollingGroup ? new RollingServerGroupUpdateTask(groupTasks, policy, taskExecutor, subject)
-                        : new ConcurrentServerGroupUpdateTask(groupTasks, policy, taskExecutor, subject));
+                    seriesTasks.add(rollingGroup ? new RollingServerGroupUpdateTask(groupTasks, policy, taskExecutor, subject, blockingTimeout)
+                        : new ConcurrentServerGroupUpdateTask(groupTasks, policy, taskExecutor, subject, blockingTimeout));
 
                     updatePolicies.put(serverGroupName, policy);
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -69,6 +69,7 @@ import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.UnsupportedCallbackException;
 
 import org.jboss.as.controller.AbstractControllerService;
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.BootContext;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ExpressionResolver;
@@ -1399,17 +1400,18 @@ public class DomainModelControllerService extends AbstractControllerService impl
 
             @Override
             public ProxyController serverCommunicationRegistered(String serverProcessName, ManagementChannelHandler channelHandler) {
-                ProxyController proxy = new ProxyController() {
+                return new ProxyController() {
                     @Override
                     public PathAddress getProxyNodeAddress() {
                         return null;
                     }
 
                     @Override
-                    public void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control, OperationAttachments attachments) {
+                    public void execute(ModelNode operation, OperationMessageHandler handler,
+                                        ProxyOperationControl control, OperationAttachments attachments,
+                                        BlockingTimeout blockingTimeout) {
                     }
                 };
-                return proxy;
             }
 
             @Override

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.NoopOperationStepHandler;
 import org.jboss.as.controller.NotificationDefinition;
@@ -996,7 +997,7 @@ public abstract class AbstractOperationTestCase {
                         return null;
                     }
 
-                    public void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control, OperationAttachments attachments) {
+                    public void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control, OperationAttachments attachments, BlockingTimeout blockingTimeout) {
                     }
                 };
             }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReloadRequiredServerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReloadRequiredServerTestCase.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -507,7 +508,7 @@ public class ReloadRequiredServerTestCase extends AbstractOperationTestCase {
 
         @Override
         public void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control,
-                OperationAttachments attachments) {
+                            OperationAttachments attachments, BlockingTimeout blockingTimeout) {
         }
 
     }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SyncModelServerStateTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SyncModelServerStateTestCase.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.BootErrorCollector;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ControlledProcessState;
@@ -808,7 +809,7 @@ public class SyncModelServerStateTestCase extends AbstractControllerTestBase  {
 
         @Override
         public void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control,
-                            OperationAttachments attachments) {
+                            OperationAttachments attachments, BlockingTimeout blockingTimeout) {
         }
 
         @Override

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperation.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperation.java
@@ -98,9 +98,9 @@ public interface ActiveOperation<T, A> {
          * Mark the operation as failed.
          *
          * @return {@code true} if the result was successfully set, or {@code false} if a result was already set
-         * @param e the exception
+         * @param t the exception
          */
-        boolean failed(Exception e);
+        boolean failed(Throwable t);
 
         /**
          * Cancel the operation.

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperationSupport.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperationSupport.java
@@ -319,11 +319,11 @@ class ActiveOperationSupport {
             }
 
             @Override
-            public boolean failed(Exception e) {
+            public boolean failed(Throwable t) {
                 try {
-                    boolean failed = ActiveOperationImpl.this.setFailed(e);
+                    boolean failed = ActiveOperationImpl.this.setFailed(t);
                     if(failed) {
-                        ProtocolLogger.ROOT_LOGGER.debugf(e, "active-op (%d) failed %s", operationId, attachment);
+                        ProtocolLogger.ROOT_LOGGER.debugf(t, "active-op (%d) failed %s", operationId, attachment);
                     }
                     return failed;
                 } finally {

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementRequestContext.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementRequestContext.java
@@ -79,7 +79,7 @@ public interface ManagementRequestContext<A> {
      * <p>
      * If the executor {@link java.util.concurrent.RejectedExecutionException rejects} the task, or if the task itself
      * throws an exception during execution, the
-     * {@link org.jboss.as.protocol.mgmt.ActiveOperation.ResultHandler#failed(Exception) failed method} of the
+     * {@link ActiveOperation.ResultHandler#failed(Throwable) failed method} of the
      * {@code ResultHander} associated with the request will be invoked, and if it returns {@code true} a failure
      * message will be sent to the remote client.
      * </p>
@@ -95,7 +95,7 @@ public interface ManagementRequestContext<A> {
      * <p>
      * If the executor {@link java.util.concurrent.RejectedExecutionException rejects} the task, or if the task itself
      * throws an exception during execution, the
-     * {@link org.jboss.as.protocol.mgmt.ActiveOperation.ResultHandler#failed(Exception) failed method} of the
+     * {@link ActiveOperation.ResultHandler#failed(Throwable) failed method} of the
      * {@code ResultHander} associated with the request will be invoked, and if it returns {@code true} a failure
      * message will be sent to the remote client.
      * </p>
@@ -113,7 +113,7 @@ public interface ManagementRequestContext<A> {
      * <p>
      * If the executor {@link java.util.concurrent.RejectedExecutionException rejects} the task, or if the task itself
      * throws an exception during execution, the
-     * {@link org.jboss.as.protocol.mgmt.ActiveOperation.ResultHandler#failed(Exception) failed method} of the
+     * {@link ActiveOperation.ResultHandler#failed(Throwable) failed method} of the
      * {@code ResultHander} associated with the request will be invoked, and if it returns {@code true} a failure
      * message will be sent to the remote client.
      * </p>
@@ -131,7 +131,7 @@ public interface ManagementRequestContext<A> {
      * <p>
      * If the executor {@link java.util.concurrent.RejectedExecutionException rejects} the task, or if the task itself
      * throws an exception during execution, the
-     * {@link org.jboss.as.protocol.mgmt.ActiveOperation.ResultHandler#failed(Exception) failed method} of the
+     * {@link ActiveOperation.ResultHandler#failed(Throwable) failed method} of the
      * {@code ResultHander} associated with the request will be invoked, and if it returns {@code true} a failure
      * message will be sent to the remote client.
      * </p>
@@ -160,7 +160,7 @@ public interface ManagementRequestContext<A> {
          * Execute the task.
          * <p>
          * If the task throws an exception during execution, the
-         * {@link org.jboss.as.protocol.mgmt.ActiveOperation.ResultHandler#failed(Exception) failed method} of the
+         * {@link ActiveOperation.ResultHandler#failed(Throwable) failed method} of the
          * {@code ResultHander} associated with the request will be invoked, and if it returns {@code true} a failure
          * message will be sent to the remote client.
          * </p>
@@ -170,5 +170,24 @@ public interface ManagementRequestContext<A> {
          */
         void execute(final ManagementRequestContext<A> context) throws Exception;
 
+    }
+
+    /**
+     * {@link org.jboss.as.protocol.mgmt.ManagementRequestContext.AsyncTask} subinterface implemented
+     * by tasks where the appropriate request header to use for notifying a remote process of a
+     * failure varies through the course of the task.
+     *
+     * @deprecated this is a bit of a hack, plus we can move this method into AsyncTask with a default impl
+     *             once this module no longer requires JDK 6 source level
+     */
+    @Deprecated
+    interface MultipleResponseAsyncTask<A> extends AsyncTask<A> {
+        /**
+         * Gets the current request header for which an error response should be sent
+         * @return the header, or {@code null} if the
+         * {@linkplain ManagementRequestContext#getRequestHeader() default header for the request context}
+         * should be used
+         */
+        ManagementProtocolHeader getCurrentRequestHeader();
     }
 }

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementResponseHeader.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementResponseHeader.java
@@ -126,7 +126,7 @@ public class ManagementResponseHeader extends ManagementProtocolHeader {
         return create(header, header.getRequestId());
     }
 
-    public static ManagementResponseHeader create(final ManagementRequestHeader header, Exception error) {
+    public static ManagementResponseHeader create(final ManagementRequestHeader header, Throwable error) {
         final int workingVersion = Math.min(ManagementProtocol.VERSION, header.getVersion());
         return new ManagementResponseHeader(workingVersion, header.getRequestId(), error != null ? error.getClass().getName() + ':' + error.getMessage() : null);
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OperationTimeoutTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OperationTimeoutTestCase.java
@@ -1,0 +1,448 @@
+/*
+Copyright 2015 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACTIVE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXECUTION_STATUS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PLATFORM_MBEAN;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.BLOCK_POINT;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.CALLER;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.TARGET_HOST;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.TARGET_SERVER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.extension.ExtensionSetup;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.domain.suites.OperationCancellationTestCase;
+import org.jboss.as.test.integration.management.extension.blocker.BlockerExtension;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests that the domain responds appropriately to hang situations on remote processes.
+ *
+ * @author Brian Stansberry
+ */
+public class OperationTimeoutTestCase {
+
+    private static final Logger log = Logger.getLogger(OperationCancellationTestCase.class);
+
+    private static final PathAddress SUBSYSTEM_ADDRESS = PathAddress.pathAddress(
+            PathElement.pathElement(PROFILE, "default"),
+            PathElement.pathElement(SUBSYSTEM, BlockerExtension.SUBSYSTEM_NAME));
+    private static final ModelNode BLOCK_OP = Util.createEmptyOperation("block", SUBSYSTEM_ADDRESS);
+    private static final ModelNode WRITE_FOO_OP = Util.getWriteAttributeOperation(SUBSYSTEM_ADDRESS, BlockerExtension.FOO.getName(), true);
+    private static final PathAddress MGMT_CONTROLLER = PathAddress.pathAddress(
+            PathElement.pathElement(CORE_SERVICE, MANAGEMENT),
+            PathElement.pathElement(SERVICE, MANAGEMENT_OPERATIONS)
+    );
+    private static final PathAddress RUNTIME_MXBEAN = PathAddress.pathAddress(
+            PathElement.pathElement(CORE_SERVICE, PLATFORM_MBEAN),
+            PathElement.pathElement(TYPE, "runtime")
+    );
+    private static final String TIMEOUT_CONFIG = "-Djboss.as.management.blocking.timeout=1";
+    private static final String TIMEOUT_ADDER_CONFIG = "-Dorg.wildfly.unsupported.test.domain-timeout-adder=1000";
+
+    private static final long GET_TIMEOUT = TimeoutUtil.adjust(10000);
+
+    private static DomainTestSupport testSupport;
+    private static DomainClient masterClient;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+
+        // We can't use the standard config or make this part of a TestSuite because we need to
+        // set TIMEOUT_ADDER_CONFIG on the HC processes. There's no management API to do this post-boot
+        final DomainTestSupport.Configuration configuration = DomainTestSupport.Configuration.create(OperationTimeoutTestCase.class.getSimpleName(),
+            "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
+        configuration.getMasterConfiguration().addHostCommandLineProperty(TIMEOUT_CONFIG);
+        configuration.getMasterConfiguration().addHostCommandLineProperty(TIMEOUT_ADDER_CONFIG);
+        configuration.getSlaveConfiguration().addHostCommandLineProperty(TIMEOUT_CONFIG);
+        configuration.getSlaveConfiguration().addHostCommandLineProperty(TIMEOUT_ADDER_CONFIG);
+
+        testSupport = DomainTestSupport.create(configuration);
+
+        testSupport.start();
+        masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+
+        // Initialize the test extension
+        ExtensionSetup.initializeBlockerExtension(testSupport);
+
+        ModelNode addExtension = Util.createAddOperation(PathAddress.pathAddress(PathElement.pathElement(EXTENSION, BlockerExtension.MODULE_NAME)));
+
+        executeForResult(addExtension, masterClient);
+
+        ModelNode addSubsystem = Util.createAddOperation(PathAddress.pathAddress(
+                PathElement.pathElement(PROFILE, "default"),
+                PathElement.pathElement(SUBSYSTEM, BlockerExtension.SUBSYSTEM_NAME)));
+        executeForResult(addSubsystem, masterClient);
+
+        restoreServerTimeouts("master", "main-one");
+        restoreServerTimeouts("slave", "main-three");
+
+        // Confirm that the timeout properties are what we expect on each process
+        validateTimeoutProperties("master", null, "1", "1000");
+        validateTimeoutProperties("slave", null, "1", "1000");
+        validateTimeoutProperties("master", "main-one", "300", "5000");
+        validateTimeoutProperties("slave", "main-three", "300", "5000");
+    }
+
+    private static void restoreServerTimeouts(String host, String server) throws IOException, MgmtOperationException {
+        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, host), PathElement.pathElement(SERVER_CONFIG, server));
+        ModelNode op = Util.createAddOperation(pa.append(PathAddress.pathAddress(SYSTEM_PROPERTY, "jboss.as.management.blocking.timeout")));
+        op.get(VALUE).set("300");
+        executeForResult(op, masterClient);
+
+        op.get(OP_ADDR).set(pa.append(PathAddress.pathAddress(SYSTEM_PROPERTY, "org.wildfly.unsupported.test.domain-timeout-adder")).toModelNode());
+        op.get(VALUE).set("5000");
+        executeForResult(op, masterClient);
+    }
+
+    private static void validateTimeoutProperties(String host, String server, String baseTimeout, String domainAdder) throws IOException, MgmtOperationException {
+        PathAddress pa = PathAddress.pathAddress(HOST, host);
+        if (server != null) {
+            pa = pa.append(RUNNING_SERVER, server);
+        }
+        ModelNode op = Util.getReadAttributeOperation(pa.append(RUNTIME_MXBEAN), "system-properties");
+        ModelNode props = executeForResult(op, masterClient);
+        if (baseTimeout == null) {
+            assertFalse(props.toString(), props.hasDefined("jboss.as.management.blocking.timeout"));
+        } else {
+            assertEquals(props.toString(), baseTimeout, props.get("jboss.as.management.blocking.timeout").asString());
+        }
+        if (domainAdder == null) {
+            assertFalse(props.toString(), props.hasDefined("org.wildfly.unsupported.test.domain-timeout-adder"));
+        } else {
+            assertEquals(props.toString(), domainAdder, props.get("org.wildfly.unsupported.test.domain-timeout-adder").asString());
+        }
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        ModelNode removeSubsystem = Util.createEmptyOperation(REMOVE, PathAddress.pathAddress(
+                PathElement.pathElement(PROFILE, "default"),
+                PathElement.pathElement(SUBSYSTEM, BlockerExtension.SUBSYSTEM_NAME)));
+        executeForResult(removeSubsystem, masterClient);
+
+        ModelNode removeExtension = Util.createEmptyOperation(REMOVE, PathAddress.pathAddress(PathElement.pathElement(EXTENSION, BlockerExtension.MODULE_NAME)));
+        executeForResult(removeExtension, masterClient);
+
+        testSupport.stop();
+        testSupport = null;
+        masterClient = null;
+    }
+
+    @After
+    public void awaitCompletion() throws Exception {
+        // Start from the leaves of the domain process tree and work inward validating
+        // that all block ops are cleared locally. This ensures that a later test doesn't
+        // mistakenly cancel a completing op from an earlier test
+        validateNoActiveOperation(masterClient, "master", "main-one");
+        validateNoActiveOperation(masterClient, "slave", "main-three");
+        validateNoActiveOperation(masterClient, "slave", null);
+        validateNoActiveOperation(masterClient, "master", null);
+    }
+
+    @Test
+    public void testPrePrepareHangOnSlaveHC() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.RUNTIME);
+        String id = findActiveOperation(masterClient, "slave", null, "block", null, start);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        System.out.println(response);
+        assertTrue(response.asString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYDC0080"));
+        validateNoActiveOperation(masterClient, "slave", null, id, true);
+    }
+
+    @Test
+    public void testPrePrepareHangOnSlaveServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.asString(), response.get(FAILURE_DESCRIPTION).asString().contains("main-three"));
+        assertTrue(response.asString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0409"));
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    public void testPrePrepareHangOnMasterServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.RUNTIME);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", null, start);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.asString(), response.get(FAILURE_DESCRIPTION).asString().contains("main-one"));
+        assertTrue(response.asString(), response.get(FAILURE_DESCRIPTION).asString().contains("WFLYCTL0409"));
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    @Test
+    public void testPostCommitHangOnSlaveHC() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.COMMIT);
+        String id = findActiveOperation(masterClient, "slave", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // cancelling on the slave during Stage.DONE should not result in a prepare-phase failure sent to master,
+        // so result should always be SUCCESS
+        assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, id, true);
+    }
+
+    @Test
+    public void testPostCommitHangOnSlaveServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.COMMIT);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // cancelling on the server during Stage.DONE should not result in a prepare-phase failure sent to master,
+        // so result should always be SUCCESS
+        assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    public void testPostCommitHangOnMasterServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.COMMIT);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // cancelling on the server during Stage.DONE should not result in a prepare-phase failure sent to master,
+        // so result should always be SUCCESS
+        assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    private Future<ModelNode> block(String host, String server, BlockerExtension.BlockPoint blockPoint) {
+        ModelNode op = BLOCK_OP.clone();
+        op.get(TARGET_HOST.getName()).set(host);
+        if (server != null) {
+            op.get(TARGET_SERVER.getName()).set(server);
+        }
+        op.get(BLOCK_POINT.getName()).set(blockPoint.toString());
+        op.get(CALLER.getName()).set(getTestMethod());
+        return masterClient.executeAsync(op, OperationMessageHandler.DISCARD);
+    }
+
+    private static String getTestMethod() {
+        final StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+        for (StackTraceElement ste : stack) {
+            String method = ste.getMethodName();
+            if (method.startsWith("test")) {
+                return method;
+            }
+        }
+        return "unknown";
+    }
+
+    private static ModelNode executeForResult(final ModelNode op, final ModelControllerClient modelControllerClient) throws IOException, MgmtOperationException {
+        try {
+            return DomainTestUtils.executeForResult(op, modelControllerClient);
+        } catch (MgmtOperationException e) {
+            System.out.println(" Op failed:");
+            System.out.println(e.getOperation());
+            System.out.println("with result");
+            System.out.println(e.getResult());
+            throw e;
+        }
+    }
+
+    private static ModelNode executeForFailure(final ModelNode op, final ModelControllerClient modelControllerClient) throws IOException, MgmtOperationException {
+        try {
+            return DomainTestUtils.executeForFailure(op, modelControllerClient);
+        } catch (MgmtOperationException e) {
+            System.out.println(" Op that incorrectly succeeded:");
+            System.out.println(e.getOperation());
+            throw e;
+        }
+    }
+
+    private String findActiveOperation(DomainClient client, String host, String server, String opName,
+                                       OperationContext.ExecutionStatus targetStatus, long executionStart) throws Exception {
+        PathAddress address = getManagementControllerAddress(host, server);
+        return findActiveOperation(client, address, opName, targetStatus, executionStart, false);
+    }
+
+    private String findActiveOperation(DomainClient client, PathAddress address, String opName, OperationContext.ExecutionStatus targetStatus, long executionStart, boolean serverOpOnly) throws Exception {
+        ModelNode op = Util.createEmptyOperation(READ_CHILDREN_RESOURCES_OPERATION, address);
+        op.get(CHILD_TYPE).set(ACTIVE_OPERATION);
+        long maxTime = TimeoutUtil.adjust(5000);
+        long timeout = executionStart + maxTime;
+        List<String> activeOps = new ArrayList<String>();
+        String opToCancel = null;
+        do {
+            activeOps.clear();
+            ModelNode result = executeForResult(op, client);
+            if (result.isDefined()) {
+                assertEquals(result.asString(), ModelType.OBJECT, result.getType());
+                for (Property prop : result.asPropertyList()) {
+                    if (prop.getValue().get(OP).asString().equals(opName)) {
+                        PathAddress pa = PathAddress.pathAddress(prop.getValue().get(OP_ADDR));
+                        if (!serverOpOnly || pa.size() > 2 && pa.getElement(1).getKey().equals(SERVER)) {
+                            activeOps.add(prop.getName() + " -- " + prop.getValue().toString());
+                            if (targetStatus == null || prop.getValue().get(EXECUTION_STATUS).asString().equals(targetStatus.toString())) {
+                                opToCancel = prop.getName();
+                            }
+                        }
+                    }
+                }
+            }
+            if (opToCancel == null) {
+                Thread.sleep(50);
+            }
+
+        } while ((opToCancel == null || activeOps.size() > 1) && System.currentTimeMillis() <= timeout);
+
+        assertTrue(opName + " not present after " + maxTime + " ms", activeOps.size() > 0);
+        assertEquals("Multiple instances of " + opName + " present: " + activeOps, 1, activeOps.size());
+        assertNotNull(opName + " not in status " + targetStatus + " after " + maxTime + " ms", opToCancel);
+
+        return opToCancel;
+    }
+
+    private String findActiveOperation(DomainClient client, PathAddress address, String opName) throws Exception {
+        ModelNode op = Util.createEmptyOperation(READ_CHILDREN_RESOURCES_OPERATION, address);
+        op.get(CHILD_TYPE).set(ACTIVE_OPERATION);
+        ModelNode result = executeForResult(op, client);
+        if (result.isDefined()) {
+            assertEquals(result.asString(), ModelType.OBJECT, result.getType());
+            for (Property prop : result.asPropertyList()) {
+                if (prop.getValue().get(OP).asString().equals(opName)) {
+                    return prop.getName();
+                }
+            }
+        }
+        return null;
+    }
+
+    private void validateNoActiveOperation(DomainClient client, String host, String server) throws Exception {
+
+        PathAddress baseAddress = getManagementControllerAddress(host, server);
+
+        // The op should clear w/in a few ms but we'll wait up to 5 secs just in case
+        // something strange is happening on the machine is overloaded
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(5000);
+        MgmtOperationException failure;
+        do {
+            String id = findActiveOperation(client, baseAddress, "block");
+            if (id == null) {
+                return;
+            }
+            failure = null;
+            PathAddress address = baseAddress.append(PathElement.pathElement(ACTIVE_OPERATION, id));
+            ModelNode op = Util.createEmptyOperation(READ_ATTRIBUTE_OPERATION, address);
+            op.get(NAME).set(OP);
+            try {
+                executeForFailure(op, client);
+            } catch (MgmtOperationException moe) {
+                failure = moe;
+            }
+            Thread.sleep(50);
+        } while (System.currentTimeMillis() < timeout);
+
+        throw failure;
+    }
+
+    private void validateNoActiveOperation(DomainClient client, String host, String server, String id,
+                                           boolean patient) throws Exception {
+        PathAddress address = getManagementControllerAddress(host, server);
+        address = address.append(PathElement.pathElement(ACTIVE_OPERATION, id));
+        ModelNode op = Util.createEmptyOperation(READ_ATTRIBUTE_OPERATION, address);
+        op.get(NAME).set(OP);
+
+        // The op should clear w/in a few ms but we'll wait up to 5 secs just in case
+        // something strange is happening on the machine is overloaded
+        long timeout = patient ? System.currentTimeMillis() + TimeoutUtil.adjust(5000) : 0;
+        MgmtOperationException failure;
+        do {
+            try {
+                executeForFailure(op, client);
+                return;
+            } catch (MgmtOperationException moe) {
+                if (!patient) {
+                    throw moe;
+                }
+                failure = moe;
+            }
+            Thread.sleep(50);
+        } while (System.currentTimeMillis() < timeout);
+
+        throw failure;
+    }
+
+
+    private static PathAddress getManagementControllerAddress(String host, String server) {
+        PathAddress address = PathAddress.pathAddress(PathElement.pathElement(HOST, host));
+        if (server != null) {
+            address = address.append(PathElement.pathElement(SERVER, server));
+        }
+        address = address.append(MGMT_CONTROLLER);
+        return address;
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ExtensionSetup.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ExtensionSetup.java
@@ -35,6 +35,7 @@ import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
 import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
 import org.jboss.as.test.integration.management.extension.blocker.BlockerExtension;
+import org.jboss.as.test.integration.management.extension.error.ErrorExtension;
 import org.jboss.as.test.integration.management.extension.streams.LogStreamExtension;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
@@ -117,6 +118,14 @@ public class ExtensionSetup {
         StreamExporter exporter = createResourceRoot(BlockerExtension.class, EmptySubsystemParser.class.getPackage());
         Map<String, StreamExporter> content = Collections.singletonMap("blocker-extension.jar", exporter);
         support.addTestModule(BlockerExtension.MODULE_NAME, moduleXml, content);
+    }
+
+    public static void initializeErrorExtension(final DomainTestSupport support) throws IOException {
+        // Get module.xml, create modules.jar and add to test config
+        final InputStream moduleXml = getModuleXml("error-module.xml");
+        StreamExporter exporter = createResourceRoot(ErrorExtension.class, EmptySubsystemParser.class.getPackage());
+        Map<String, StreamExporter> content = Collections.singletonMap("error-extension.jar", exporter);
+        support.addTestModule(ErrorExtension.MODULE_NAME, moduleXml, content);
     }
 
     public static void initializeLogStreamExtension(final DomainTestSupport support) throws IOException {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -53,6 +53,7 @@ import org.junit.runners.Suite;
         ManagementVersionTestCase.class,
         ModuleLoadingManagementTestCase.class,
         OperationCancellationTestCase.class,
+        OperationErrorTestCase.class,
         OperationTransformationTestCase.class,
         ResponseStreamTestCase.class,
         ServerRestartRequiredTestCase.class,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationErrorTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationErrorTestCase.java
@@ -1,0 +1,528 @@
+/*
+Copyright 2015 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACTIVE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST_FAILURE_DESCRIPTIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IN_SERIES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX_FAILED_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLOUT_PLAN;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.CALLER;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.TARGET_HOST;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.TARGET_SERVER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.extension.ExtensionSetup;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.management.extension.error.ErrorExtension;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test of handling of java.lang.Error thrown while running operations in a domain.
+ *
+ * @author Brian Stansberry (c) 2015 Red Hat Inc.
+ */
+public class OperationErrorTestCase {
+
+    private static final Logger log = Logger.getLogger(OperationErrorTestCase.class);
+
+    private static final PathAddress SUBSYSTEM_ADDRESS = PathAddress.pathAddress(
+            PathElement.pathElement(PROFILE, "default"),
+            PathElement.pathElement(SUBSYSTEM, ErrorExtension.SUBSYSTEM_NAME));
+    private static final ModelNode ERROR_OP = Util.createEmptyOperation("error", SUBSYSTEM_ADDRESS);
+    private static final PathAddress MGMT_CONTROLLER = PathAddress.pathAddress(
+            PathElement.pathElement(CORE_SERVICE, MANAGEMENT),
+            PathElement.pathElement(SERVICE, MANAGEMENT_OPERATIONS)
+    );
+
+    private static final long GET_TIMEOUT = TimeoutUtil.adjust(10000);
+
+    private static final ModelNode ROLLOUT_HEADER;
+
+    static {
+        ROLLOUT_HEADER = new ModelNode();
+        ModelNode groupHeader = ROLLOUT_HEADER.get(ROLLOUT_PLAN, IN_SERIES).add();
+        groupHeader.get(SERVER_GROUP, "main-server-group", MAX_FAILED_SERVERS).set(1);
+        ROLLOUT_HEADER.protect();
+    }
+
+    private static DomainTestSupport testSupport;
+    private static DomainClient masterClient;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(OperationCancellationTestCase.class.getSimpleName());
+        masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+
+        // Initialize the test extension
+        ExtensionSetup.initializeErrorExtension(testSupport);
+
+        ModelNode addExtension = Util.createAddOperation(PathAddress.pathAddress(PathElement.pathElement(EXTENSION, ErrorExtension.MODULE_NAME)));
+
+        executeForResponse(addExtension, masterClient);
+
+        ModelNode addSubsystem = Util.createAddOperation(PathAddress.pathAddress(
+                PathElement.pathElement(PROFILE, "default"),
+                PathElement.pathElement(SUBSYSTEM, ErrorExtension.SUBSYSTEM_NAME)));
+        executeForResponse(addSubsystem, masterClient);
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        ModelNode removeSubsystem = Util.createEmptyOperation(REMOVE, PathAddress.pathAddress(
+                PathElement.pathElement(PROFILE, "default"),
+                PathElement.pathElement(SUBSYSTEM, ErrorExtension.SUBSYSTEM_NAME)));
+        executeForResponse(removeSubsystem, masterClient);
+
+        ModelNode removeExtension = Util.createEmptyOperation(REMOVE, PathAddress.pathAddress(PathElement.pathElement(EXTENSION, ErrorExtension.MODULE_NAME)));
+        executeForResponse(removeExtension, masterClient);
+
+        testSupport = null;
+        masterClient = null;
+        DomainTestSuite.stopSupport();
+    }
+
+    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+    @After
+    public void awaitCompletion() throws Exception {
+        // Start from the leaves of the domain process tree and work inward validating
+        // that all error ops are cleared locally. This ensures that a later test doesn't
+        // mistakenly cancel a completing op from an earlier test
+        validateNoActiveOperation(masterClient, "master", "main-one");
+        validateNoActiveOperation(masterClient, "slave", "main-three");
+        validateNoActiveOperation(masterClient, "slave", null);
+        MgmtOperationException moe = validateNoActiveOperation(masterClient, "master", null);
+        if (moe != null) {
+            throw moe;
+        }
+    }
+
+    @Test
+    public void testMasterServerStageModel() throws Exception {
+        // The server fails in pre-prepare so whether overall outcome=failed depends on the rollout plan
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.MODEL, false, true);
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.MODEL, true, false);
+    }
+
+    @Test
+    public void testSlaveServerStageModel() throws Exception {
+        // The server fails in pre-prepare so whether overall outcome=failed depends on the rollout plan
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.MODEL, false, true);
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.MODEL, true, false);
+    }
+
+    @Test
+    public void testMasterHCStageModel() throws Exception {
+        // A pre-prepare failure on an HC always means outcome=failed
+        errorTest("master", null, ErrorExtension.ErrorPoint.MODEL, false, true);
+        errorTest("master", null, ErrorExtension.ErrorPoint.MODEL, true, true);
+    }
+
+    @Test
+    public void testSlaveHCStageModel() throws Exception {
+        // A pre-prepare failure on an HC always means outcome=failed
+        errorTest("slave", null, ErrorExtension.ErrorPoint.MODEL, false, true);
+        errorTest("slave", null, ErrorExtension.ErrorPoint.MODEL, true, true);
+    }
+
+    @Test
+    public void testMasterServerStageRuntime() throws Exception {
+        // The server fails in pre-prepare so whether overall outcome=failed depends on the rollout plan
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.RUNTIME, false, true);
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.RUNTIME, true, false);
+    }
+
+    @Test
+    public void testSlaveServerStageRuntime() throws Exception {
+        // The server fails in pre-prepare so whether overall outcome=failed depends on the rollout plan
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.RUNTIME, false, true);
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.RUNTIME, true, false);
+    }
+
+    @Test
+    public void testMasterHCStageRuntime() throws Exception {
+        // A pre-prepare failure on an HC always means outcome=failed
+        errorTest("master", null, ErrorExtension.ErrorPoint.RUNTIME, false, true);
+        errorTest("master", null, ErrorExtension.ErrorPoint.RUNTIME, true, true);
+    }
+
+    @Test
+    public void testSlaveHCStageRuntime() throws Exception {
+        // A pre-prepare failure on an HC always means outcome=failed
+        errorTest("slave", null, ErrorExtension.ErrorPoint.RUNTIME, false, true);
+        errorTest("slave", null, ErrorExtension.ErrorPoint.RUNTIME, true, true);
+    }
+
+    @Test
+    public void testMasterServerServiceStart() throws Exception {
+        // The server fails in pre-prepare so whether overall outcome=failed depends on the rollout plan
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.SERVICE_START, false, true);
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.SERVICE_START, true, false);
+    }
+
+    @Test
+    public void testSlaveServerServiceStart() throws Exception {
+        // The server fails in pre-prepare so whether overall outcome=failed depends on the rollout plan
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.SERVICE_START, false, true);
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.SERVICE_START, true, false);
+    }
+
+    @Test
+    public void testMasterHCServiceStart() throws Exception {
+        // A pre-prepare failure on an HC always means outcome=failed
+        errorTest("master", null, ErrorExtension.ErrorPoint.SERVICE_START, false, true);
+        errorTest("master", null, ErrorExtension.ErrorPoint.SERVICE_START, true, true);
+    }
+
+    @Test
+    public void testSlaveHCServiceStart() throws Exception {
+        // A pre-prepare failure on an HC always means outcome=failed
+        errorTest("slave", null, ErrorExtension.ErrorPoint.SERVICE_START, false, true);
+        errorTest("slave", null, ErrorExtension.ErrorPoint.SERVICE_START, true, true);
+    }
+
+    @Test
+    public void testMasterServerServiceStop() throws Exception {
+        // MSC only logs a WARN for service.stop() errors and stops the service regardless.
+        // So the op should succeed.
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.SERVICE_STOP, false, false);
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.SERVICE_STOP, true, false);
+    }
+
+    @Test
+    public void testSlaveServerServiceStop() throws Exception {
+        // MSC only logs a WARN for service.stop() errors and stops the service regardless.
+        // So the op should succeed.
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.SERVICE_STOP, false, false);
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.SERVICE_STOP, true, false);
+    }
+
+    @Test
+    public void testMasterHCServiceStop() throws Exception {
+        // MSC only logs a WARN for service.stop() errors and stops the service regardless.
+        // So the op should succeed.
+        errorTest("master", null, ErrorExtension.ErrorPoint.SERVICE_STOP, false, false);
+        errorTest("master", null, ErrorExtension.ErrorPoint.SERVICE_STOP, true, false);
+    }
+
+    @Test
+    public void testSlaveHCServiceStop() throws Exception {
+        // MSC only logs a WARN for service.stop() errors and stops the service regardless.
+        // So the op should succeed.
+        errorTest("slave", null, ErrorExtension.ErrorPoint.SERVICE_STOP, false, false);
+        errorTest("slave", null, ErrorExtension.ErrorPoint.SERVICE_STOP, true, false);
+    }
+
+    @Test
+    public void testMasterServerStageVerify() throws Exception {
+        // The server fails in pre-prepare so whether overall outcome=failed depends on the rollout plan
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.VERIFY, false, true);
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.VERIFY, true, false);
+    }
+
+    @Test
+    public void testSlaveServerStageVerify() throws Exception {
+        // The server fails in pre-prepare so whether overall outcome=failed depends on the rollout plan
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.VERIFY, false, true);
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.VERIFY, true, false);
+    }
+
+    @Test
+    public void testMasterHCStageVerify() throws Exception {
+        // A pre-prepare failure on an HC always means outcome=failed
+        errorTest("master", null, ErrorExtension.ErrorPoint.VERIFY, false, true);
+        errorTest("master", null, ErrorExtension.ErrorPoint.VERIFY, true, true);
+    }
+
+    @Test
+    public void testSlaveHCStageVerify() throws Exception {
+        // A pre-prepare failure on an HC always means outcome=failed
+        errorTest("slave", null, ErrorExtension.ErrorPoint.VERIFY, false, true);
+        errorTest("slave", null, ErrorExtension.ErrorPoint.VERIFY, true, true);
+    }
+
+    @Test
+    public void testMasterServerStageCommit() throws Exception {
+        // Post commit failure does not result in outcome=failed
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.COMMIT, false, false);
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.COMMIT, true, false);
+    }
+
+    @Test
+    public void testSlaveServerStageCommit() throws Exception {
+        // Post commit failure does not result in outcome=failed
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.COMMIT, false, false);
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.COMMIT, true, false);
+    }
+
+    @Test
+    public void testMasterHCStageCommit() throws Exception {
+        // Here the failure blows away the normal domain response and results in reporting a failure
+        // TODO this isn't ideal as the DC's model, MSC and the rest of the domain are changed
+        errorTest("master", null, ErrorExtension.ErrorPoint.COMMIT, false, true);
+        errorTest("master", null, ErrorExtension.ErrorPoint.COMMIT, true, true);
+    }
+
+    @Test
+    public void testSlaveHCStageCommit() throws Exception {
+        // Post commit failure does not result in outcome=failed
+        errorTest("slave", null, ErrorExtension.ErrorPoint.COMMIT, false, false);
+        errorTest("slave", null, ErrorExtension.ErrorPoint.COMMIT, true, false);
+    }
+
+    @Test
+    public void testMasterServerStageRollback() throws Exception {
+        // The server fails in pre-prepare (to trigger the rollback that throws Error),
+        // so whether overall outcome=failed depends on the rollout plan
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.ROLLBACK, false, true);
+        errorTest("master", "main-one", ErrorExtension.ErrorPoint.ROLLBACK, true, false);
+    }
+
+    @Test
+    public void testSlaveServerStageRollback() throws Exception {
+        // The server fails in pre-prepare (to trigger the rollback that throws Error),
+        // so whether overall outcome=failed depends on the rollout plan
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.ROLLBACK, false, true);
+        errorTest("slave", "main-three", ErrorExtension.ErrorPoint.ROLLBACK, true, false);
+    }
+
+    @Test
+    public void testMasterHCStageRollback() throws Exception {
+        // A pre-prepare failure (used to trigger the rollback that throws Error) on an HC always means outcome=failed
+        errorTest("master", null, ErrorExtension.ErrorPoint.ROLLBACK, false, true);
+        errorTest("master", null, ErrorExtension.ErrorPoint.ROLLBACK, true, true);
+    }
+
+    @Test
+    public void testSlaveHCStageRollback() throws Exception {
+        // A pre-prepare failure (used to trigger the rollback that throws Error) on an HC always means outcome=failed
+        errorTest("slave", null, ErrorExtension.ErrorPoint.ROLLBACK, false, true);
+        errorTest("slave", null, ErrorExtension.ErrorPoint.ROLLBACK, true, true);
+    }
+
+    private void errorTest(String host, String server, ErrorExtension.ErrorPoint errorPoint, boolean addRolloutPlan, boolean expectFailure) throws Exception {
+        ModelNode op = ERROR_OP.clone();
+        op.get(TARGET_HOST.getName()).set(host);
+        if (server != null) {
+            op.get(TARGET_SERVER.getName()).set(server);
+        }
+        op.get(ErrorExtension.ERROR_POINT.getName()).set(errorPoint.toString());
+        op.get(CALLER.getName()).set(getTestMethod());
+        if (addRolloutPlan) {
+            op.get(OPERATION_HEADERS).set(ROLLOUT_HEADER);
+        }
+
+        ModelNode response;
+        if (expectFailure) {
+            response = executeForFailure(op, masterClient);
+        } else {
+            response = executeForResponse(op, masterClient);
+        }
+        if (errorPoint != ErrorExtension.ErrorPoint.SERVICE_STOP) {
+            validateResponseDetails(response, host, server, errorPoint);
+        } // else it's a success and I'm too lazy to write the code to verify the response
+    }
+
+    private void validateResponseDetails(ModelNode response, String host, String server, ErrorExtension.ErrorPoint errorPoint) {
+        ModelNode unmodified = response.clone();
+        ModelNode fd;
+        if (server != null) {
+            ModelNode serverResp = response.get(SERVER_GROUPS, "main-server-group", HOST, host, server, RESPONSE);
+            assertEquals(unmodified.toString(), FAILED, serverResp.get(OUTCOME).asString());
+            fd = serverResp.get(FAILURE_DESCRIPTION);
+        } else if ("master".equals(host)) {
+            if (errorPoint == ErrorExtension.ErrorPoint.COMMIT || errorPoint == ErrorExtension.ErrorPoint.ROLLBACK) {
+                // In this case the late error destroys the normal response structure and we
+                // get a simple failure. This isn't ideal. I'm writing the test to specifically assert
+                // this simple failure structure mostly so it can assert the more complex
+                // structure in the other cases, not because I'm explicitly ruling out any change to this
+                // simple structure and want this test to enforce that. OTOH it shouldn't be changed lightly
+                // as it would be easy to mess up.
+                fd = response.get(FAILURE_DESCRIPTION);
+            } else {
+                fd = response.get(FAILURE_DESCRIPTION, DOMAIN_FAILURE_DESCRIPTION);
+            }
+        } else {
+            if (errorPoint == ErrorExtension.ErrorPoint.COMMIT) {
+                // post-commit failure currently does not produce a failure-description
+                assertFalse(unmodified.toString(), response.hasDefined(FAILURE_DESCRIPTION));
+                return;
+            }
+            fd = response.get(FAILURE_DESCRIPTION, HOST_FAILURE_DESCRIPTIONS, host);
+        }
+        ModelType errorType = errorPoint == ErrorExtension.ErrorPoint.SERVICE_START ? ModelType.OBJECT : ModelType.STRING;
+        assertEquals(unmodified.toString(), errorType, fd.getType());
+        assertTrue(unmodified.toString(), fd.asString().contains(ErrorExtension.ERROR_MESSAGE));
+    }
+
+    private MgmtOperationException validateNoActiveOperation(DomainClient client, String host, String server) throws Exception {
+
+        PathAddress baseAddress = getManagementControllerAddress(host, server);
+
+        // The op should clear w/in a few ms but we'll wait up to 5 secs just in case
+        // something strange is happening on the machine is overloaded
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(5000);
+        MgmtOperationException failure;
+        String id;
+        do {
+            id = findActiveOperation(client, baseAddress, "error");
+            if (id == null) {
+                return null;
+            }
+            failure = null;
+            PathAddress address = baseAddress.append(PathElement.pathElement(ACTIVE_OPERATION, id));
+            ModelNode op = Util.createEmptyOperation(READ_ATTRIBUTE_OPERATION, address);
+            op.get(NAME).set(OP);
+            try {
+                executeForFailure(op, client);
+            } catch (MgmtOperationException moe) {
+                failure = moe;
+            }
+            Thread.sleep(50);
+        } while (System.currentTimeMillis() < timeout);
+
+        if (failure != null) {
+            PathAddress address = baseAddress.append(PathElement.pathElement(ACTIVE_OPERATION, id));
+
+            if (!executeForResponse(Util.createEmptyOperation("cancel", address), client).get(RESULT).asBoolean()) {
+                return failure;
+            }
+        }
+        return null;
+    }
+
+    private String findActiveOperation(DomainClient client, PathAddress address, String opName) throws Exception {
+        ModelNode op = Util.createEmptyOperation(READ_CHILDREN_RESOURCES_OPERATION, address);
+        op.get(CHILD_TYPE).set(ACTIVE_OPERATION);
+        ModelNode result = executeForResponse(op, client).get(RESULT);
+        if (result.isDefined()) {
+            assertEquals(result.asString(), ModelType.OBJECT, result.getType());
+            for (Property prop : result.asPropertyList()) {
+                if (prop.getValue().get(OP).asString().equals(opName)) {
+                    return prop.getName();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static ModelNode execute(final ModelNode op, final ModelControllerClient modelControllerClient) throws Exception {
+        Future<ModelNode> future =  modelControllerClient.executeAsync(op, OperationMessageHandler.DISCARD);
+        try {
+            return future.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            future.cancel(true);
+            throw e;
+        } catch (Exception e) {
+            future.cancel(true);
+            throw e;
+        }
+    }
+
+    private static ModelNode executeForResponse(final ModelNode op, final ModelControllerClient modelControllerClient) throws Exception {
+        final ModelNode ret = execute(op, modelControllerClient);
+
+        if (! SUCCESS.equals(ret.get(OUTCOME).asString())) {
+            System.out.println("Failed operation:");
+            System.out.println(op);
+            System.out.println("Response:");
+            System.out.println(ret);
+            throw new MgmtOperationException("Management operation failed.", op, ret);
+        }
+        return ret;
+    }
+
+    private static ModelNode executeForFailure(final ModelNode op, final ModelControllerClient modelControllerClient) throws Exception {
+        final ModelNode ret = execute(op, modelControllerClient);
+
+        if (! FAILED.equals(ret.get(OUTCOME).asString())) {
+            System.out.println("Unexpectedly successful operation:");
+            System.out.println(op);
+            System.out.println("Response:");
+            System.out.println(ret);
+            throw new MgmtOperationException("Management operation succeeded.", op, ret);
+        }
+
+        return ret;
+    }
+
+    private static String getTestMethod() {
+        final StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+        for (StackTraceElement ste : stack) {
+            String method = ste.getMethodName();
+            if (method.startsWith("test")) {
+                return method;
+            }
+        }
+        return "unknown";
+    }
+
+    private static PathAddress getManagementControllerAddress(String host, String server) {
+        PathAddress address = PathAddress.pathAddress(PathElement.pathElement(HOST, host));
+        if (server != null) {
+            address = address.append(PathElement.pathElement(SERVER, server));
+        }
+        address = address.append(MGMT_CONTROLLER);
+        return address;
+    }
+}

--- a/testsuite/domain/src/test/resources/extension/error-module.xml
+++ b/testsuite/domain/src/test/resources/extension/error-module.xml
@@ -1,0 +1,16 @@
+<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.error-test">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="error-extension.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.msc"/>
+    </dependencies>
+</module>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/error/ErrorExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/error/ErrorExtension.java
@@ -1,0 +1,330 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.management.extension.error;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Logger;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * Extension that throws {@link Error}.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class ErrorExtension implements Extension {
+
+    public static final String MODULE_NAME = "org.wildfly.extension.error-test";
+    public static final String SUBSYSTEM_NAME = "error-test";
+    public static final AttributeDefinition CALLER = SimpleAttributeDefinitionBuilder.create("caller", ModelType.STRING, true)
+            .setDefaultValue(new ModelNode("unknown")).build();
+    public static final AttributeDefinition TARGET_HOST = SimpleAttributeDefinitionBuilder.create(HOST, ModelType.STRING, true).build();
+    public static final AttributeDefinition TARGET_SERVER = SimpleAttributeDefinitionBuilder.create(SERVER, ModelType.STRING, true).build();
+    public static final AttributeDefinition ERROR_POINT = SimpleAttributeDefinitionBuilder.create("error-point", ModelType.STRING)
+            .setValidator(EnumValidator.create(ErrorPoint.class, false, false))
+            .build();
+
+    public static final String REGISTERED_MESSAGE = "Registered error-test operations";
+    public static final String ERROR_MESSAGE = "Deliberate failure to test java.lang.Error handling";
+
+    private static final EmptySubsystemParser PARSER = new EmptySubsystemParser("urn:wildfly:extension:error-test:1.0");
+    private static final Logger log = Logger.getLogger(ErrorExtension.class.getCanonicalName());
+
+    private static final StringBuilder oomeSB = new StringBuilder();
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
+        subsystem.registerSubsystemModel(new BlockerSubsystemResourceDefinition(context.getProcessType() == ProcessType.HOST_CONTROLLER));
+        subsystem.registerXMLElementWriter(PARSER);
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, PARSER.getNamespace(), PARSER);
+    }
+
+    private static class BlockerSubsystemResourceDefinition extends SimpleResourceDefinition {
+
+        private final boolean forHost;
+        private BlockerSubsystemResourceDefinition(boolean forHost) {
+            super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver(),
+                    new AbstractAddStepHandler(),
+                    ReloadRequiredRemoveStepHandler.INSTANCE);
+            this.forHost = forHost;
+        }
+
+        @Override
+        public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+            super.registerOperations(resourceRegistration);
+            resourceRegistration.registerOperationHandler(ErroringHandler.DEFINITION, new ErroringHandler());
+            if (forHost) {
+                resourceRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+            }
+            // Don't remove this as some tests check for it in the log
+            log.info(REGISTERED_MESSAGE);
+        }
+
+        @Override
+        public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+            super.registerAttributes(resourceRegistration);
+        }
+    }
+
+    public enum ErrorPoint {
+        MODEL,
+        RUNTIME,
+        SERVICE_START,
+        SERVICE_STOP,
+        VERIFY,
+        COMMIT,
+        ROLLBACK
+    }
+
+    private static void error() {
+        log.info("erroring");
+        throw new Error(ERROR_MESSAGE);
+    }
+
+    private static class ErroringHandler implements OperationStepHandler {
+
+        private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("error", new NonResolvingResourceDescriptionResolver())
+                .setParameters(CALLER, TARGET_HOST, TARGET_SERVER, ERROR_POINT)
+                .build();
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            ModelNode targetServer = TARGET_SERVER.resolveModelAttribute(context, operation);
+            ModelNode targetHost = TARGET_HOST.resolveModelAttribute(context, operation);
+            final ErrorPoint errorPoint = ErrorPoint.valueOf(ERROR_POINT.resolveModelAttribute(context, operation).asString());
+            log.info("error requested by " + CALLER.resolveModelAttribute(context, operation).asString() + " for " +
+                targetHost.asString() + "/" + targetServer.asString() + "(" + errorPoint + ")");
+            boolean forMe = false;
+            if (context.getProcessType() == ProcessType.STANDALONE_SERVER) {
+                forMe = true;
+            } else {
+                Resource rootResource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
+                if (targetServer.isDefined()) {
+                    if (context.getProcessType().isServer()) {
+                        String name = System.getProperty(ServerEnvironment.SERVER_NAME);
+                        forMe = targetServer.asString().equals(name);
+                    }
+                } else if (context.getProcessType() == ProcessType.HOST_CONTROLLER) {
+                    Set<String> hosts = rootResource.getChildrenNames(HOST);
+                    String name;
+                    if (hosts.size() > 1) {
+                        name = "master";
+                    } else {
+                        name = hosts.iterator().next();
+                    }
+                    if (!targetHost.isDefined()) {
+                        throw new OperationFailedException("target-host required");
+                    }
+                    forMe = targetHost.asString().equals(name);
+                }
+            }
+            if (forMe) {
+                log.info("will error at " + errorPoint);
+                switch (errorPoint) {
+                    case MODEL: {
+                        error();
+                        break;
+                    }
+                    case RUNTIME: {
+                        context.addStep(new ErrorStep(), OperationContext.Stage.RUNTIME);
+                        break;
+                    }
+                    case SERVICE_START:
+                    case SERVICE_STOP: {
+                        context.addStep(new OperationStepHandler() {
+                            @Override
+                            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+                                // We always add the service, regardless of whether we want it to fail in start or stop
+                                // Otherwise it's not there to fail in stop!
+                                boolean induceOOME = false; // = context.getProcessType().isServer() && !"master".equals(targetHost.asString());
+                                final ErroringService service = new ErroringService(errorPoint == ErrorPoint.SERVICE_START, induceOOME);
+
+                                final ServiceController<?> serviceController =
+                                        context.getServiceTarget().addService(ErroringService.SERVICE_NAME, service).install();
+
+                                if (errorPoint == ErrorPoint.SERVICE_STOP) {
+                                    // Add a separate step to remove the service, triggering stop
+                                    context.addStep(new OperationStepHandler() {
+                                        @Override
+                                        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                                            // Make sure the service has started
+                                            long timeout = System.currentTimeMillis() + 30000;
+                                            boolean started;
+                                            do {
+                                                started = serviceController.getState() == ServiceController.State.UP;
+                                                if (!started) {
+                                                    try {
+                                                        Thread.sleep(10);
+                                                    } catch (InterruptedException e) {
+                                                        Thread.currentThread().interrupt();
+                                                        break;
+                                                    }
+                                                }
+                                            } while (!started && System.currentTimeMillis() < timeout);
+
+                                            if (started) {
+                                                context.removeService(ErroringService.SERVICE_NAME);
+                                            } else {
+                                                // Something's wrong.
+                                                // Tell the service not to fail any more so we can successfully
+                                                // clean it up in the rollback handler
+                                                service.errored.set(true);
+                                                throw new IllegalStateException(ErroringService.SERVICE_NAME + " service did not start; state is " + serviceController.getState());
+                                            }
+                                        }
+                                    }, OperationContext.Stage.RUNTIME);
+                                }
+
+                                // Always try and remove the service on rollback
+                                context.completeStep(new OperationContext.RollbackHandler() {
+                                    @Override
+                                    public void handleRollback(OperationContext context, ModelNode operation) {
+                                        context.removeService(ErroringService.SERVICE_NAME);
+                                    }
+                                });
+                            }
+                        }, OperationContext.Stage.RUNTIME);
+                        break;
+                    }
+                    case VERIFY: {
+                        context.addStep(new ErrorStep(), OperationContext.Stage.VERIFY);
+                        break;
+                    }
+                    case ROLLBACK:
+                        context.addStep(new OperationStepHandler() {
+                            @Override
+                            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                                context.getFailureDescription().set("rollback");
+                                context.setRollbackOnly();
+                            }
+                        }, OperationContext.Stage.MODEL);
+                        break;
+                    case COMMIT:
+                        break;
+                    default:
+                        throw new IllegalStateException(errorPoint.toString());
+                }
+                context.completeStep(new OperationContext.ResultHandler() {
+                    @Override
+                    public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                        if ((errorPoint == ErrorPoint.COMMIT && resultAction == OperationContext.ResultAction.KEEP)
+                            || (errorPoint == ErrorPoint.ROLLBACK && resultAction == OperationContext.ResultAction.ROLLBACK)) {
+                            error();
+                        }
+                    }
+                });
+            }
+        }
+
+        private static class ErrorStep implements OperationStepHandler {
+
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                error();
+            }
+        }
+    }
+
+    private static class ErroringService implements Service<ErroringService> {
+
+        private static final ServiceName SERVICE_NAME = ServiceName.of("jboss", "test", "erroring-service");
+        private final boolean errorInStart;
+        private final boolean induceOOME;
+        private final AtomicBoolean errored = new AtomicBoolean();
+
+        private ErroringService(boolean errorInStart, boolean induceOOME) {
+            this.errorInStart = errorInStart;
+            this.induceOOME = induceOOME;
+        }
+
+        @Override
+        public void start(final StartContext context) throws StartException {
+            if (errorInStart) {
+                if (induceOOME) {  // this will only be true if ErroringHandler is edited to make it possible
+                    while (System.currentTimeMillis() > 1) {
+                        oomeSB.append("more and more and more");
+                    }
+                    log.info(oomeSB.toString());
+                } else {
+                    error();
+                }
+            }
+        }
+
+        @Override
+        public void stop(final StopContext context) {
+            log.info("ErroringService Stopping");
+            if (!errorInStart && errored.compareAndSet(false, true)) {
+                error();
+            }
+        }
+
+        @Override
+        public ErroringService getValue() throws IllegalStateException, IllegalArgumentException {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
Two commits related to better handling domain operation errors:

1) WFCORE-1134 which improves how the management op execution handles java.lang.Error. The most meaningful bit is TransactionalProtocolOperationHandler now attempts to communicate the Error to the remote caller (i.e. the HC that made the call.)

This may not prove all that helpful in practice, particularly in OOME cases, as the attempt to notify the remote caller may itself fail due to the OOME condition. But it is better behavior for Errors that do not prevent further work, as the test case in the commit shows.

2) WFCORE-378. This is the more significant change. It introduces timeouts into various blocking calls used in domain op execution, preventing a non-responsive process from locking up the domain indefinitely.