### PR TITLE
[WFCORE-991]: Starting server with config that doesn't end with .xml fails

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -695,17 +696,18 @@ public class ConfigurationFile {
     }
 
     private File addSuffixToFile(final File file, final String suffix) {
-        final String path = file.getAbsolutePath();
-        int index = path.lastIndexOf(".");
+        Path path = file.toPath();
+        final String fileName = path.getFileName().toString();
+        int index = fileName.lastIndexOf('.');
         if (index == -1) {
-            return new File(file.getAbsolutePath() + "." + suffix);
+            return path.resolveSibling(fileName + '.' + suffix).toFile();
         }
         StringBuilder sb = new StringBuilder();
-        sb.append(path.substring(0, index));
-        sb.append(".");
+        sb.append(fileName.substring(0, index));
+        sb.append('.');
         sb.append(suffix);
-        sb.append(path.substring(index));
-        return new File(sb.toString());
+        sb.append(fileName.substring(index));
+        return path.resolveSibling(sb.toString()).toFile();
     }
 
     private Date subtractDays(final Date date, final int days) {


### PR DESCRIPTION
Fixing how the filename is computed.

Jira: https://issues.jboss.org/browse/WFCORE-991