### PR TITLE
WFCORE-1229 - Reloading the embed host controller logs ERROR messages

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/PrepareStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/PrepareStepHandler.java
@@ -126,10 +126,12 @@ public class PrepareStepHandler  implements OperationStepHandler {
             context.addStep(stepHandler, OperationContext.Stage.MODEL);
         } else {
             PathAddress pathAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
-            if (registration == null) {
-                context.getFailureDescription().set(ControllerLogger.ROOT_LOGGER.noSuchResourceType(pathAddress));
-            } else {
-                context.getFailureDescription().set(ControllerLogger.ROOT_LOGGER.noHandlerForOperation(operationName, pathAddress));
+            if (! context.isBooting()) {
+                if (registration == null) {
+                    context.getFailureDescription().set(ControllerLogger.ROOT_LOGGER.noSuchResourceType(pathAddress));
+                } else {
+                    context.getFailureDescription().set(ControllerLogger.ROOT_LOGGER.noHandlerForOperation(operationName, pathAddress));
+                }
             }
         }
     }


### PR DESCRIPTION
This stops the logging of the host controller not being registered during polling by ReloadHandler.ensureServerRebootComplete(). I'm not sure if this is actually correct in all cases, @bstansberry thoughts? Is this too broad here or are their other things that could fail to report errors during boot because of this?