### PR TITLE
Execute the server reload op that the test creates

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/AuditLogTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/AuditLogTestCase.java
@@ -367,6 +367,7 @@ public class AuditLogTestCase {
                 final PathAddress serverAddress = PathAddress.pathAddress(baseAddress.getElement(0)).append(SERVER_CONFIG, servers.get(0));
                 final ModelNode restartOp = Util.createEmptyOperation("reload", serverAddress);
                 restartOp.get(BLOCKING).set(true);
+                masterLifecycleUtil.executeForResult(restartOp);
                 expectNoSyslogData();
 
                 //Now enable the server logger again


### PR DESCRIPTION
Just noticed this test isn't doing what it says because it never executes this op.