### PR TITLE
[WFCORE-1261]: Changing the max-history attribute value for configuration-changes fails.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/ConfigurationChangeResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/ConfigurationChangeResourceDefinition.java
@@ -66,7 +66,7 @@ import org.jboss.dmr.ModelType;
 public class ConfigurationChangeResourceDefinition extends SimpleResourceDefinition {
 
     public static final SimpleAttributeDefinition MAX_HISTORY = SimpleAttributeDefinitionBuilder.create(
-            ModelDescriptionConstants.MAX_HISTORY, ModelType.INT)
+            ModelDescriptionConstants.MAX_HISTORY, ModelType.INT, true)
             .setDefaultValue(new ModelNode(10))
             .build();
     public static final PathElement PATH = PathElement.pathElement(SERVICE, CONFIGURATION_CHANGES);
@@ -125,19 +125,18 @@ public class ConfigurationChangeResourceDefinition extends SimpleResourceDefinit
         private final ConfigurationChangesCollector collector;
 
         private MaxHistoryWriteHandler(ConfigurationChangesCollector collector) {
+            super(MAX_HISTORY);
             this.collector = collector;
         }
 
         @Override
         protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Integer> handbackHolder) throws OperationFailedException {
-            MAX_HISTORY.validateAndSet(operation, context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel());
             collector.setMaxHistory(resolvedValue.asInt());
             return true;
         }
 
         @Override
         protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode valueToRestore, ModelNode valueToRevert, Integer handback) throws OperationFailedException {
-            MAX_HISTORY.validateAndSet(operation, context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel());
             collector.setMaxHistory(valueToRestore.asInt());
         }
     }


### PR DESCRIPTION
Moving the update of the model to the MODEL phase instead of the RUNTIME one.

Jira: https://issues.jboss.org/browse/WFCORE-1261