### PR TITLE
[WFLY-5928] Avoid NPE

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/registry/OperationTransformerRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/OperationTransformerRegistry.java
@@ -80,7 +80,7 @@ public class OperationTransformerRegistry {
 
             @Override
             public ResourceTransformer getResourceTransformer() {
-                return resourceTransformer.getTransformer();
+                return resourceTransformer == null ? null : resourceTransformer.getTransformer();
             }
         };
     }


### PR DESCRIPTION
GlobalTransformerRegistry.registerTransformer will pass a 'null' into the getOrCreate method that creates a OperationTransformerRegistry, so having this var be 'null' is possible via a normal code path. Why this doesn't regularly fail is a mystery though. Perhaps a different OperationTransformerRegistry instance with the same address/version is created via a different code path in some cases, and there is some timing effect involved. The transformer registration is all single threaded AFAIK though.