### PR TITLE
[WFCORE-1262]: Make the /host=* 'domain-controller' attribute writeable in the normal way.

### DIFF
--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
@@ -64,6 +64,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -579,6 +580,13 @@ public class CoreModelTestDelegate {
                 if (opName.equals(LocalDomainControllerAddHandler.OPERATION_NAME) || opName.equals(RemoteDomainControllerAddHandler.OPERATION_NAME)) {
                     dcInBootOps = true;
                     break;
+                }
+                if(WRITE_ATTRIBUTE_OPERATION.equals(opName)) {
+                    String attributeName = op.get(NAME).asString();
+                    if(DOMAIN_CONTROLLER.equals(attributeName)) {
+                        dcInBootOps = true;
+                        break;
+                    }
                 }
             }
             if (!dcInBootOps) {

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -82,6 +82,7 @@ import org.jboss.as.host.controller.HostPathManagerService;
 import org.jboss.as.host.controller.HostRunningModeControl;
 import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
 import org.jboss.as.host.controller.model.host.HostResourceDefinition;
+import org.jboss.as.host.controller.operations.DomainControllerWriteAttributeHandler;
 import org.jboss.as.host.controller.operations.HostModelRegistrationHandler;
 import org.jboss.as.host.controller.operations.LocalDomainControllerAddHandler;
 import org.jboss.as.host.controller.operations.LocalHostControllerInfoImpl;
@@ -565,6 +566,9 @@ class TestModelControllerService extends ModelTestModelControllerService {
             //Swap out the write-local-domain-controller operation with one which only does the model part
             hostReg.unregisterOperationHandler(LocalDomainControllerAddHandler.OPERATION_NAME);
             hostReg.registerOperationHandler(LocalDomainControllerAddHandler.DEFINITION, LocalDomainControllerAddHandler.getTestInstance());
+
+            hostReg.unregisterAttribute(HostResourceDefinition.DOMAIN_CONTROLLER.getName());
+            hostReg.registerReadWriteAttribute(HostResourceDefinition.DOMAIN_CONTROLLER, null, DomainControllerWriteAttributeHandler.getTestInstance());
 
             //Register the ops to initialise the schemalocations and namespaces
             hostReg.registerOperationHandler(AddMissingHostNamespacesAttributeForValidationHandler.DEF, AddMissingHostNamespacesAttributeForValidationHandler.INSTANCE);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
@@ -18,6 +18,7 @@
  */
 package org.jboss.as.host.controller;
 
+
 import org.jboss.as.controller.BootErrorCollector;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ControlledProcessState;
@@ -49,6 +50,8 @@ import org.jboss.as.repository.HostFileRepository;
 import org.jboss.as.server.services.security.AbstractVaultReader;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+
+import org.jboss.as.host.controller.operations.DomainControllerWriteAttributeHandler;
 
 /**
  * Utility for creating the root element and populating the {@link org.jboss.as.controller.registry.ManagementResourceRegistration}
@@ -123,7 +126,9 @@ public class HostModelUtil {
                         hostControllerInfo, serverInventory, remoteFileRepository,
                         contentRepository, domainController, hostExtensionRegistry,
                         vaultReader, ignoredRegistry, processState, pathManager, authorizer, auditLogger, bootErrorCollector));
-
+        hostRegistration.registerReadWriteAttribute(HostResourceDefinition.DOMAIN_CONTROLLER, null,
+                DomainControllerWriteAttributeHandler.getInstance(root, hostControllerInfo, configurationPersister,
+                        localFileRepository, remoteFileRepository, contentRepository, domainController, extensionRegistry, ignoredRegistry, pathManager));
         //TODO See if some of all these parameters can come from domain controller
         LocalDomainControllerAddHandler localDcAddHandler = LocalDomainControllerAddHandler.getInstance(root, hostControllerInfo,
                 configurationPersister, localFileRepository, contentRepository, domainController, extensionRegistry, pathManager);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -289,7 +289,6 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
         hostRegistration.registerReadOnlyAttribute(MANAGEMENT_MINOR_VERSION, null);
         hostRegistration.registerReadOnlyAttribute(MANAGEMENT_MICRO_VERSION, null);
         hostRegistration.registerReadOnlyAttribute(MASTER, IsMasterHandler.INSTANCE);
-        hostRegistration.registerReadOnlyAttribute(DOMAIN_CONTROLLER, null);
         hostRegistration.registerReadOnlyAttribute(ServerRootResourceDefinition.NAMESPACES, null);
         hostRegistration.registerReadOnlyAttribute(ServerRootResourceDefinition.SCHEMA_LOCATIONS, null);
         hostRegistration.registerReadWriteAttribute(HostResourceDefinition.NAME, environment.getProcessNameReadHandler(), environment.getProcessNameWriteHandler());

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/DomainControllerWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/DomainControllerWriteAttributeHandler.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2016 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.host.controller.operations;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_CONTROLLER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOCAL;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.host.controller.operations.RemoteDomainControllerAddHandler.ADMIN_ONLY_POLICY;
+import static org.jboss.as.host.controller.operations.RemoteDomainControllerAddHandler.IGNORE_UNUSED_CONFIG;
+import static org.jboss.as.host.controller.operations.RemoteDomainControllerAddHandler.USERNAME;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.services.path.PathManagerService;
+import org.jboss.as.domain.controller.DomainController;
+import org.jboss.as.host.controller.HostControllerConfigurationPersister;
+import org.jboss.as.host.controller.discovery.StaticDiscovery;
+import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
+import org.jboss.as.host.controller.model.host.AdminOnlyDomainConfigPolicy;
+import org.jboss.as.repository.ContentRepository;
+import org.jboss.as.repository.HostFileRepository;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public abstract class DomainControllerWriteAttributeHandler extends ReloadRequiredWriteAttributeHandler {
+
+    public static DomainControllerWriteAttributeHandler getInstance(final ManagementResourceRegistration rootRegistration,
+                final LocalHostControllerInfoImpl hostControllerInfo,
+                final HostControllerConfigurationPersister overallConfigPersister,
+                final HostFileRepository localFileRepository,
+                final HostFileRepository remoteFileRepository,
+                final ContentRepository contentRepository,
+                final DomainController domainController,
+                final ExtensionRegistry extensionRegistry,
+                final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry,
+                final PathManagerService pathManager) {
+        return new RealLocalDomainControllerAddHandler(rootRegistration, hostControllerInfo, overallConfigPersister,
+                localFileRepository, remoteFileRepository, contentRepository, domainController, extensionRegistry,
+                ignoredDomainResourceRegistry, pathManager);
+    }
+
+    public static DomainControllerWriteAttributeHandler getTestInstance() {
+        return new TestLocalDomainControllerAddHandler();
+    }
+
+    private DomainControllerWriteAttributeHandler() {
+        super(org.jboss.as.host.controller.model.host.HostResourceDefinition.DOMAIN_CONTROLLER);
+    }
+
+    @Override
+    protected boolean requiresRuntime(OperationContext context) {
+        return !context.isBooting();
+    }
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        super.execute(context, operation);
+        final ModelNode model = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel();
+        ModelNode dc = model.get(DOMAIN_CONTROLLER);
+        if (operation.hasDefined(VALUE, LOCAL)) {
+            dc.get(LOCAL).setEmptyObject();
+            if (dc.has(REMOTE)) {
+                dc.remove(REMOTE);
+            }
+            if (context.isBooting()) {
+                initializeLocalDomain();
+            }
+        } else if (operation.hasDefined(VALUE, REMOTE)) {
+            if (dc.has(LOCAL)) {
+                dc.remove(LOCAL);
+            }
+            if (context.isBooting()) {
+                initializeRemoteDomain(context, model);
+            }
+        }
+    }
+
+    protected abstract void initializeLocalDomain();
+
+    protected abstract void initializeRemoteDomain(OperationContext context, ModelNode remoteDC) throws OperationFailedException;
+
+    private static class RealLocalDomainControllerAddHandler extends DomainControllerWriteAttributeHandler {
+
+        private final ManagementResourceRegistration rootRegistration;
+        private final HostControllerConfigurationPersister overallConfigPersister;
+        private final LocalHostControllerInfoImpl hostControllerInfo;
+        private final ContentRepository contentRepository;
+        private final DomainController domainController;
+        private final ExtensionRegistry extensionRegistry;
+        private final PathManagerService pathManager;
+        private final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry;
+        private final HostFileRepository localFileRepository;
+        private final HostFileRepository remoteFileRepository;
+
+        private RealLocalDomainControllerAddHandler(final ManagementResourceRegistration rootRegistration,
+                final LocalHostControllerInfoImpl hostControllerInfo,
+                final HostControllerConfigurationPersister overallConfigPersister,
+                final HostFileRepository localFileRepository,
+                final HostFileRepository remoteFileRepository,
+                final ContentRepository contentRepository,
+                final DomainController domainController,
+                final ExtensionRegistry extensionRegistry,
+                final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry,
+                final PathManagerService pathManager) {
+            this.rootRegistration = rootRegistration;
+            this.overallConfigPersister = overallConfigPersister;
+            this.localFileRepository = localFileRepository;
+            this.remoteFileRepository = remoteFileRepository;
+            this.hostControllerInfo = hostControllerInfo;
+            this.contentRepository = contentRepository;
+            this.domainController = domainController;
+            this.extensionRegistry = extensionRegistry;
+            this.ignoredDomainResourceRegistry = ignoredDomainResourceRegistry;
+            this.pathManager = pathManager;
+        }
+
+        @Override
+        protected void initializeLocalDomain() {
+            hostControllerInfo.setMasterDomainController(true);
+            overallConfigPersister.initializeDomainConfigurationPersister(false);
+            domainController.initializeMasterDomainRegistry(rootRegistration, overallConfigPersister.getDomainPersister(),
+                    contentRepository, localFileRepository, extensionRegistry, pathManager);
+        }
+
+        @Override
+        protected void initializeRemoteDomain(OperationContext context, ModelNode remoteDC) throws OperationFailedException {
+            hostControllerInfo.setMasterDomainController(false);
+            ModelNode protocolNode = RemoteDomainControllerAddHandler.PROTOCOL.resolveModelAttribute(context, remoteDC);
+            ModelNode hostNode = RemoteDomainControllerAddHandler.HOST.resolveModelAttribute(context, remoteDC);
+            ModelNode portNode = RemoteDomainControllerAddHandler.PORT.resolveModelAttribute(context, remoteDC);
+            if (hostNode.isDefined() && portNode.isDefined()) {
+                String host = hostNode.asString();
+                int port = portNode.asInt();
+                String protocol = protocolNode.asString();
+                StaticDiscovery staticDiscoveryOption = new StaticDiscovery(protocol, host, port);
+                hostControllerInfo.addRemoteDomainControllerDiscoveryOption(staticDiscoveryOption);
+            }
+            ModelNode usernameNode = USERNAME.resolveModelAttribute(context, remoteDC);
+            if (usernameNode.isDefined()) {
+                hostControllerInfo.setRemoteDomainControllerUsername(usernameNode.asString());
+            }
+
+            ModelNode ignoreUnusedConfiguration = IGNORE_UNUSED_CONFIG.resolveModelAttribute(context, remoteDC);
+
+            if (!ignoreUnusedConfiguration.isDefined()) {
+                if (hostControllerInfo.isBackupDc()) { // started up with --backup, ignore-unused-configuration not set
+                    hostControllerInfo.setRemoteDomainControllerIgnoreUnaffectedConfiguration(false);
+                } else {
+                    hostControllerInfo.setRemoteDomainControllerIgnoreUnaffectedConfiguration(true);
+                }
+            } else {
+                hostControllerInfo.setRemoteDomainControllerIgnoreUnaffectedConfiguration(ignoreUnusedConfiguration.asBoolean());
+            }
+            AdminOnlyDomainConfigPolicy domainConfigPolicy
+                    = AdminOnlyDomainConfigPolicy.getPolicy(ADMIN_ONLY_POLICY.resolveModelAttribute(context, remoteDC).asString());
+            hostControllerInfo.setAdminOnlyDomainConfigPolicy(domainConfigPolicy);
+            overallConfigPersister.initializeDomainConfigurationPersister(true);
+
+            domainController.initializeSlaveDomainRegistry(rootRegistration, overallConfigPersister.getDomainPersister(), contentRepository, remoteFileRepository,
+                    hostControllerInfo, extensionRegistry, ignoredDomainResourceRegistry, pathManager);
+        }
+    }
+
+    private static class TestLocalDomainControllerAddHandler extends DomainControllerWriteAttributeHandler {
+
+        @Override
+        protected void initializeLocalDomain() {
+        }
+
+        @Override
+        protected void initializeRemoteDomain(OperationContext context, ModelNode remoteDC) throws OperationFailedException {
+        }
+
+    }
+
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalDomainControllerAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/LocalDomainControllerAddHandler.java
@@ -23,6 +23,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOM
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOCAL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE;
 
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
@@ -50,6 +51,7 @@ public abstract class LocalDomainControllerAddHandler implements OperationStepHa
     public static final String OPERATION_NAME = "write-local-domain-controller";
     public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(OPERATION_NAME, HostResolver.getResolver("host"))
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.DOMAIN_CONTROLLER)
+            .setDeprecated(ModelVersion.create(5, 0, 0))
             .build();
 
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/RemoteDomainControllerAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/RemoteDomainControllerAddHandler.java
@@ -24,6 +24,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOTE;
 import static org.jboss.dmr.ModelType.STRING;
 
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
@@ -112,6 +113,7 @@ public class RemoteDomainControllerAddHandler implements OperationStepHandler {
     public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(OPERATION_NAME, HostResolver.getResolver("host"))
             .setParameters(PROTOCOL, PORT, HOST, USERNAME, SECURITY_REALM, IGNORE_UNUSED_CONFIG, ADMIN_ONLY_POLICY)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.DOMAIN_CONTROLLER)
+            .setDeprecated(ModelVersion.create(5, 0, 0))
             .build();
 
     private final ManagementResourceRegistration rootRegistration;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_4.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_4.java
@@ -651,9 +651,9 @@ class HostXml_4 extends CommonXml implements ManagementXmlDelegate {
         }
 
         if (hasLocal) {
-            final ModelNode update = new ModelNode();
-            update.get(OP_ADDR).set(address);
-            update.get(OP).set("write-local-domain-controller");
+            ModelNode localDc = new ModelNode();
+            localDc.get(LOCAL).setEmptyObject() ;
+            final ModelNode update = Util.getWriteAttributeOperation(address, DOMAIN_CONTROLLER, localDc);
             list.add(update);
         }
     }
@@ -724,10 +724,8 @@ class HostXml_4 extends CommonXml implements ManagementXmlDelegate {
     private boolean parseRemoteDomainControllerAttributes(final XMLExtendedStreamReader reader, final ModelNode address,
                                                               final List<ModelNode> list) throws XMLStreamException {
 
-        final ModelNode update = new ModelNode();
-        update.get(OP_ADDR).set(address);
-        update.get(OP).set(RemoteDomainControllerAddHandler.OPERATION_NAME);
-
+        final ModelNode remoteDc = new ModelNode();
+        final ModelNode updateDc = remoteDc.get(REMOTE).setEmptyObject() ;
         // Handle attributes
         AdminOnlyDomainConfigPolicy adminOnlyPolicy = AdminOnlyDomainConfigPolicy.DEFAULT;
         boolean requireDiscoveryOptions = false;
@@ -740,32 +738,32 @@ class HostXml_4 extends CommonXml implements ManagementXmlDelegate {
                 final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
                 switch (attribute) {
                     case HOST: {
-                        RemoteDomainControllerAddHandler.HOST.parseAndSetParameter(value, update, reader);
+                        RemoteDomainControllerAddHandler.HOST.parseAndSetParameter(value, updateDc, reader);
                         break;
                     }
                     case PORT: {
-                        RemoteDomainControllerAddHandler.PORT.parseAndSetParameter(value, update, reader);
+                        RemoteDomainControllerAddHandler.PORT.parseAndSetParameter(value, updateDc, reader);
                         break;
                     }
                     case PROTOCOL: {
-                        RemoteDomainControllerAddHandler.PROTOCOL.parseAndSetParameter(value, update, reader);
+                        RemoteDomainControllerAddHandler.PROTOCOL.parseAndSetParameter(value, updateDc, reader);
                         break;
                     }
                     case SECURITY_REALM: {
-                        RemoteDomainControllerAddHandler.SECURITY_REALM.parseAndSetParameter(value, update, reader);
+                        RemoteDomainControllerAddHandler.SECURITY_REALM.parseAndSetParameter(value, updateDc, reader);
                         break;
                     }
                     case USERNAME: {
-                        RemoteDomainControllerAddHandler.USERNAME.parseAndSetParameter(value, update, reader);
+                        RemoteDomainControllerAddHandler.USERNAME.parseAndSetParameter(value, updateDc, reader);
                         break;
                     }
                     case IGNORE_UNUSED_CONFIG: {
-                        RemoteDomainControllerAddHandler.IGNORE_UNUSED_CONFIG.parseAndSetParameter(value, update, reader);
+                        RemoteDomainControllerAddHandler.IGNORE_UNUSED_CONFIG.parseAndSetParameter(value, updateDc, reader);
                         break;
                     }
                     case ADMIN_ONLY_POLICY: {
-                        RemoteDomainControllerAddHandler.ADMIN_ONLY_POLICY.parseAndSetParameter(value, update, reader);
-                        ModelNode nodeValue = update.get(RemoteDomainControllerAddHandler.ADMIN_ONLY_POLICY.getName());
+                        RemoteDomainControllerAddHandler.ADMIN_ONLY_POLICY.parseAndSetParameter(value, updateDc, reader);
+                        ModelNode nodeValue = updateDc.get(RemoteDomainControllerAddHandler.ADMIN_ONLY_POLICY.getName());
                         if (nodeValue.getType() != ModelType.EXPRESSION) {
                             adminOnlyPolicy = AdminOnlyDomainConfigPolicy.getPolicy(nodeValue.asString());
                         }
@@ -777,13 +775,14 @@ class HostXml_4 extends CommonXml implements ManagementXmlDelegate {
             }
         }
 
-        if (!update.hasDefined(RemoteDomainControllerAddHandler.HOST.getName())) {
+        if (!updateDc.hasDefined(RemoteDomainControllerAddHandler.HOST.getName())) {
             requireDiscoveryOptions = isRequireDiscoveryOptions(adminOnlyPolicy);
         }
-        if (!update.hasDefined(RemoteDomainControllerAddHandler.PORT.getName())) {
+        if (!updateDc.hasDefined(RemoteDomainControllerAddHandler.PORT.getName())) {
             requireDiscoveryOptions = requireDiscoveryOptions || isRequireDiscoveryOptions(adminOnlyPolicy);
         }
 
+        final ModelNode update = Util.getWriteAttributeOperation(address, DOMAIN_CONTROLLER, remoteDc);
         list.add(update);
         return requireDiscoveryOptions;
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SimpleDomainControllerMigrationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SimpleDomainControllerMigrationTestCase.java
@@ -1,0 +1,348 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URL;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.host.controller.operations.RemoteDomainControllerAddHandler;
+import org.jboss.as.test.deployment.trivial.ServiceActivatorDeploymentUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainControllerClientConfig;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.domain.management.util.WildFlyManagedConfiguration;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.jboss.sasl.util.UsernamePasswordHashUtil;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test of migration of the domain controller from one host to another
+ *
+ * @author <a href="dpospisi@redhat.com">Dominik Pospisil</a>
+ */
+public class SimpleDomainControllerMigrationTestCase {
+
+    private static final Logger log = Logger.getLogger(SimpleDomainControllerMigrationTestCase.class.getName());
+
+    private static String[] SERVERS = new String[] {"failover-one", "failover-two", "failover-three"};
+    private static String[] HOSTS = new String[] {"failover-h1", "failover-h2", "failover-h3"};
+    private static int[] MGMT_PORTS = new int[] {9999, 9989, 19999};
+    private static String masterAddress = System.getProperty("jboss.test.host.master.address");
+    private static String slaveAddress = System.getProperty("jboss.test.host.slave.address");
+    private static final String DEPLOYMENT_NAME = "service-activator.jar";
+
+    private static DomainControllerClientConfig domainControllerClientConfig;
+    private static DomainLifecycleUtil[] hostUtils = new DomainLifecycleUtil[3];
+
+    private static File jarFile;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        domainControllerClientConfig = DomainControllerClientConfig.create();
+        for (int k = 0; k<3; k++) {
+            hostUtils[k] = new DomainLifecycleUtil(getHostConfiguration(k+1), domainControllerClientConfig);
+            hostUtils[k].start();
+        }
+
+        String tempDir = System.getProperty("java.io.tmpdir");
+        jarFile = new File(tempDir + File.separator + DEPLOYMENT_NAME);
+        ServiceActivatorDeploymentUtil.createServiceActivatorDeployment(jarFile);
+
+    }
+
+    @AfterClass
+    public static void shutdownDomain() throws IOException {
+        try {
+            int i = 0;
+            for (; i < hostUtils.length; i++) {
+                try {
+                    hostUtils[i].stop();
+                } catch (Exception e) {
+                    log.error("Failed closing host util " + i, e);
+                }
+            }
+        } finally {
+            if (domainControllerClientConfig != null) {
+                domainControllerClientConfig.close();
+            }
+        }
+
+        Assert.assertTrue(jarFile.delete());
+    }
+
+    private static WildFlyManagedConfiguration getHostConfiguration(int host) throws Exception {
+
+        final String testName = SimpleDomainControllerMigrationTestCase.class.getSimpleName();
+        File domains = new File("target" + File.separator + "domains" + File.separator + testName);
+        final File hostDir = new File(domains, "failover" + String.valueOf(host));
+        final File hostConfigDir = new File(hostDir, "configuration");
+        assert hostConfigDir.mkdirs() || hostConfigDir.isDirectory();
+
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        final WildFlyManagedConfiguration hostConfig = new WildFlyManagedConfiguration();
+        hostConfig.setHostControllerManagementAddress(host == 1 ? masterAddress : slaveAddress);
+        hostConfig.setHostCommandLineProperties("-Djboss.test.host.master.address=" + masterAddress + " -Djboss.test.host.slave.address=" + slaveAddress);
+        URL url = tccl.getResource("domain-configs/domain-standard.xml");
+        assert url != null;
+        hostConfig.setDomainConfigFile(new File(url.toURI()).getAbsolutePath());
+        System.out.println(hostConfig.getDomainConfigFile());
+        url = tccl.getResource("host-configs/host-failover" + String.valueOf(host) + ".xml");
+        assert url != null;
+        hostConfig.setHostConfigFile(new File(url.toURI()).getAbsolutePath());
+        System.out.println(hostConfig.getHostConfigFile());
+        hostConfig.setDomainDirectory(hostDir.getAbsolutePath());
+        hostConfig.setHostName("failover-h" + String.valueOf(host));
+        hostConfig.setHostControllerManagementPort(MGMT_PORTS[host - 1]);
+        hostConfig.setStartupTimeoutInSeconds(120);
+        hostConfig.setBackupDC(true);
+        File usersFile = new File(hostConfigDir, "mgmt-users.properties");
+        FileOutputStream fos = new FileOutputStream(usersFile);
+        PrintWriter pw = new PrintWriter(fos);
+        pw.println("slave=" + new UsernamePasswordHashUtil().generateHashedHexURP("slave", "ManagementRealm", "slave_user_password".toCharArray()));
+        pw.close();
+        fos.close();
+
+
+        return hostConfig;
+    }
+
+    @Test
+    /**
+     * Test setup: 3 hosts which each having exactly one server defined - failover-h1, failover-h2, failover-h3
+     * Test scenario:
+     * 1) kill failover-h1 host controller
+     * 2) update failover-h2 configuration to act as the domain controller
+     * 3) reload failover-h2 without restarting server
+     * 4) update failover-h3 config to point to failover-h2 as a new domain controller
+     * 5) reload failover-h3
+     * 6) verify that failover-h2 is the new domain controller managing both failover-h2 and failover-h3 hosts
+     */
+    public void testDCFailover() throws Exception {
+
+        // check that the failover-h1 is acting as domain controller and all three servers are registered
+        Set<String> hosts = getHosts(hostUtils[0]);
+        Assert.assertTrue(hosts.contains(HOSTS[0]));
+        Assert.assertTrue(hosts.contains(HOSTS[1]));
+        Assert.assertTrue(hosts.contains(HOSTS[2]));
+
+        // Add a system property so we can prove it is still there after failover
+        ModelNode addSystemProp = new ModelNode();
+        addSystemProp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.SYSTEM_PROPERTY, "hc-failover-a");
+        addSystemProp.get(ModelDescriptionConstants.OP).set("add");
+        addSystemProp.get(ModelDescriptionConstants.VALUE).set("test-a");
+        hostUtils[0].executeForResult(addSystemProp);
+
+        // WFLY-3418 Add but don't map a deployment so we can prove the backup gets the content
+        Operation addDeployOp = buildDeploymentAddOperation();
+        hostUtils[0].executeForResult(addDeployOp);
+        assertSlaveHostInfo(hostUtils[0].getDomainClient());
+
+        // kill the domain process controller on failover-h1
+        log.info("Stopping the domain controller on failover-h1.");
+        hostUtils[0].stop();
+        log.info("Domain controller on failover-h1 stopped.");
+
+        // check that the failover-h2 hc sees only itself
+        hosts = getHosts(hostUtils[1]);
+        Assert.assertTrue(hosts.contains(HOSTS[1]));
+        Assert.assertEquals(hosts.size(), 1);
+
+        // Reconfigure failover-h2 host so it acts as domain controller
+        ModelNode localDc = new ModelNode();
+        localDc.get("local").setEmptyObject() ;
+        ModelNode becomeMasterOp = Util.getWriteAttributeOperation(PathAddress.EMPTY_ADDRESS.append(ModelDescriptionConstants.HOST, "failover-h2"),
+                 "domain-controller", localDc);
+
+        hostUtils[1].executeForResult(becomeMasterOp);
+
+        ModelNode restartOp = new ModelNode();
+        restartOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.HOST, "failover-h2");
+        restartOp.get(ModelDescriptionConstants.OP).set("reload");
+        restartOp.get(ModelDescriptionConstants.RESTART_SERVERS).set(false);
+
+        log.info("Reloading failover-h2 to act as the domain controller.");
+        hostUtils[1].executeAwaitConnectionClosed(restartOp);
+        log.info("Waiting for Host Controller to be ready");
+        waitUntilHostControllerReady(hostUtils[1]);
+
+        // Read the first system property. This proves we are using the config provided via failover-h1
+        ModelNode readSysPropOp = new ModelNode();
+        readSysPropOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.SYSTEM_PROPERTY, "hc-failover-a");
+        readSysPropOp.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION);
+        readSysPropOp.get(ModelDescriptionConstants.NAME).set(ModelDescriptionConstants.VALUE);
+        Assert.assertEquals("test-a", hostUtils[1].executeForResult(readSysPropOp).asString());
+
+        // Add a 2nd system property so we can prove it is still there after failover-h3 connects
+        addSystemProp = new ModelNode();
+        addSystemProp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.SYSTEM_PROPERTY, "hc-failover-b");
+        addSystemProp.get(ModelDescriptionConstants.OP).set("add");
+        addSystemProp.get(ModelDescriptionConstants.VALUE).set("test-b");
+        hostUtils[1].executeForResult(addSystemProp);
+
+        // Reconfigure failover-h3 to point to the new domain controller
+        ModelNode changeMasterOp = new ModelNode();
+        changeMasterOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.HOST, HOSTS[2]);
+        changeMasterOp.get(ModelDescriptionConstants.OP).set(RemoteDomainControllerAddHandler.OPERATION_NAME);
+        changeMasterOp.get(ModelDescriptionConstants.HOST).set("${jboss.test.host.slave.address}");
+        changeMasterOp.get(ModelDescriptionConstants.PORT).set(MGMT_PORTS[1]);
+        changeMasterOp.get(ModelDescriptionConstants.SECURITY_REALM).set("ManagementRealm");
+
+        hostUtils[2].executeForResult(changeMasterOp);
+
+        restartOp = new ModelNode();
+        restartOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.HOST, HOSTS[2]);
+        restartOp.get(ModelDescriptionConstants.OP).set("reload");
+        restartOp.get(ModelDescriptionConstants.RESTART_SERVERS).set(false);
+
+        log.info("Reloading failover-h3 to register to new domain controller.");
+        hostUtils[2].executeAwaitConnectionClosed(restartOp);
+
+        waitUntilHostControllerReady(hostUtils[2]);
+
+        // Read the second system property. This proves we correctly got the config from failover-h2.
+        readSysPropOp = new ModelNode();
+        readSysPropOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.SYSTEM_PROPERTY, "hc-failover-b");
+        readSysPropOp.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION);
+        readSysPropOp.get(ModelDescriptionConstants.NAME).set(ModelDescriptionConstants.VALUE);
+        Assert.assertEquals("test-b", hostUtils[2].executeForResult(readSysPropOp).asString());
+
+        // test some management ops on failover-h3 using new domain controller on failover-h2
+
+        hosts = getHosts(hostUtils[1]);
+        Assert.assertTrue(hosts.contains(HOSTS[1]));
+        Assert.assertTrue(hosts.contains(HOSTS[2]));
+        Assert.assertEquals(hosts.size(), 2);
+
+        // WFLY-3418 -- map deployment to a server group and validate it gets installed on servers
+        Operation mapDeployOp = buildDeploymentMappingOperation();
+        hostUtils[1].executeForResult(mapDeployOp);
+        checkProperty(hostUtils[1].getDomainClient(), HOSTS[1], SERVERS[1]);
+        checkProperty(hostUtils[1].getDomainClient(), HOSTS[2], SERVERS[2]);
+
+        // stop failover-h3 server using new dc
+        ModelNode stopOp = new ModelNode();
+        stopOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.HOST, HOSTS[2]);
+        stopOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.SERVER_CONFIG, SERVERS[2]);
+        stopOp.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.STOP);
+        hostUtils[1].executeForResult(stopOp);
+        DomainTestUtils.waitUntilState(hostUtils[1].getDomainClient(), HOSTS[2], SERVERS[2], "STOPPED");
+    }
+
+    private Set<String> getHosts(DomainLifecycleUtil hostUtil) throws IOException {
+        ModelNode readOp = new ModelNode();
+        readOp.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.READ_RESOURCE_OPERATION);
+        ModelNode domain = hostUtil.executeForResult(readOp);
+        Assert.assertTrue(domain.get("host").isDefined());
+        return domain.get("host").keys();
+    }
+
+    private void waitUntilHostControllerReady(final DomainLifecycleUtil dcUtil) throws TimeoutException {
+        long now = System.currentTimeMillis();
+        try {
+            dcUtil.awaitHostController(now);
+            dcUtil.awaitServers(now);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Operation buildDeploymentAddOperation() throws IOException, OperationFormatException {
+
+        ModelNode addDeploymentOp = new ModelNode();
+        addDeploymentOp.get(ModelDescriptionConstants.ADDRESS).add(DEPLOYMENT, DEPLOYMENT_NAME);
+        addDeploymentOp.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+        addDeploymentOp.get("content").get(0).get("input-stream-index").set(0);
+
+        OperationBuilder ob = new OperationBuilder(addDeploymentOp, true);
+        ob.addInputStream(new FileInputStream(jarFile));
+
+        return ob.build();
+    }
+
+    private Operation buildDeploymentMappingOperation() throws IOException, OperationFormatException {
+
+        ModelNode deployOp = new ModelNode();
+        deployOp.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+        deployOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.SERVER_GROUP, "main-server-group");
+        deployOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.DEPLOYMENT, DEPLOYMENT_NAME);
+        deployOp.get(ModelDescriptionConstants.ENABLED).set(true);
+
+        OperationBuilder ob = new OperationBuilder(deployOp, true);
+        ob.addInputStream(new FileInputStream(jarFile));
+
+        return ob.build();
+    }
+
+    private void checkProperty(ModelControllerClient client, String host, String server) throws IOException, MgmtOperationException {
+        PathAddress pathAddress = PathAddress.pathAddress(PathElement.pathElement(HOST, host),
+                PathElement.pathElement(SERVER, server));
+        ServiceActivatorDeploymentUtil.validateProperties(client, pathAddress);
+    }
+
+    private void assertSlaveHostInfo(final ModelControllerClient client) throws Exception {
+
+        final ModelNode operation = new ModelNode();
+        operation.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.READ_RESOURCE_OPERATION);
+        operation.get(ModelDescriptionConstants.OP_ADDR)
+                .add(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT)
+                .add(ModelDescriptionConstants.HOST_CONNECTION, "*");
+        operation.get(ModelDescriptionConstants.INCLUDE_RUNTIME).set(true);
+
+        final ModelNode result = DomainTestUtils.executeForResult(operation, client);
+        System.out.println(result);
+        int results = 0;
+        for (final ModelNode node : result.asList()) {
+            results++;
+            for (final ModelNode event : node.get("result", "events").asList()) {
+                Assert.assertTrue(event.hasDefined("type"));
+                Assert.assertTrue(event.hasDefined("address"));
+                Assert.assertTrue(event.hasDefined("timestamp"));
+            }
+        }
+        Assert.assertEquals(3, results);
+    }
+
+}


### PR DESCRIPTION
Using a ReloadRequiredWriteAttributeHandler instead of specific handlers.

Jira: https://issues.jboss.org/browse/WFCORE-1262