### PR TITLE
[WFCORE-1272] Clean up the deployment resource on deployment unit service stop

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentHandlerUtil.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentHandlerUtil.java
@@ -172,7 +172,7 @@ public class DeploymentHandlerUtil {
                 .addDependency(Services.JBOSS_DEPLOYMENT_CHAINS, DeployerChains.class, service.getDeployerChainsInjector())
                 .addDependency(DeploymentMountProvider.SERVICE_NAME, DeploymentMountProvider.class, service.getServerDeploymentRepositoryInjector())
                 .addDependency(PathManagerService.SERVICE_NAME, PathManager.class, service.getPathManagerInjector())
-                .addDependency(contentsServiceName, VirtualFile.class, service.contentsInjector)
+                .addDependency(contentsServiceName, VirtualFile.class, service.getContentsInjector())
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
 

--- a/server/src/main/java/org/jboss/as/server/deployment/RootDeploymentUnitService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/RootDeploymentUnitService.java
@@ -32,7 +32,6 @@ import org.jboss.as.server.deploymentoverlay.DeploymentOverlayIndex;
 import org.jboss.as.server.services.security.AbstractVaultReader;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceRegistry;
-import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.vfs.VirtualFile;
 
@@ -44,22 +43,10 @@ import org.jboss.vfs.VirtualFile;
 final class RootDeploymentUnitService extends AbstractDeploymentUnitService {
     private final InjectedValue<DeploymentMountProvider> serverDeploymentRepositoryInjector = new InjectedValue<DeploymentMountProvider>();
     private final InjectedValue<PathManager> pathManagerInjector = new InjectedValue<PathManager>();
+    private final InjectedValue<VirtualFile> contentsInjector = new InjectedValue<VirtualFile>();
     private final String name;
     private final String managementName;
-    final InjectedValue<VirtualFile> contentsInjector = new InjectedValue<VirtualFile>();
     private final DeploymentUnit parent;
-    private final ImmutableManagementResourceRegistration registration;
-    private final ManagementResourceRegistration mutableRegistration;
-    private final Resource resource;
-
-    @Override
-    public synchronized void stop(StopContext context) {
-        super.stop(context);
-        DeploymentResourceSupport.cleanup(resource);
-    }
-
-    private final CapabilityServiceSupport capabilityServiceSupport;
-    private final AbstractVaultReader vaultReader;
     private final DeploymentOverlayIndex deploymentOverlays;
 
     /**
@@ -78,15 +65,11 @@ final class RootDeploymentUnitService extends AbstractDeploymentUnitService {
                                      final ImmutableManagementResourceRegistration registration, final ManagementResourceRegistration mutableRegistration,
                                      final Resource resource, final CapabilityServiceSupport capabilityServiceSupport,
                                      final AbstractVaultReader vaultReader, DeploymentOverlayIndex deploymentOverlays) {
+        super(registration, mutableRegistration, resource, capabilityServiceSupport, vaultReader);
         assert name != null : "name is null";
         this.name = name;
         this.managementName = managementName;
         this.parent = parent;
-        this.registration = registration;
-        this.mutableRegistration = mutableRegistration;
-        this.resource = resource;
-        this.capabilityServiceSupport = capabilityServiceSupport;
-        this.vaultReader = vaultReader;
         this.deploymentOverlays = deploymentOverlays;
     }
 
@@ -119,6 +102,10 @@ final class RootDeploymentUnitService extends AbstractDeploymentUnitService {
 
     InjectedValue<PathManager> getPathManagerInjector() {
         return pathManagerInjector;
+    }
+
+    InjectedValue<VirtualFile> getContentsInjector() {
+        return contentsInjector;
     }
 
     @SuppressWarnings("deprecation")

--- a/server/src/main/java/org/jboss/as/server/deployment/RootDeploymentUnitService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/RootDeploymentUnitService.java
@@ -32,6 +32,7 @@ import org.jboss.as.server.deploymentoverlay.DeploymentOverlayIndex;
 import org.jboss.as.server.services.security.AbstractVaultReader;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.vfs.VirtualFile;
 
@@ -50,6 +51,13 @@ final class RootDeploymentUnitService extends AbstractDeploymentUnitService {
     private final ImmutableManagementResourceRegistration registration;
     private final ManagementResourceRegistration mutableRegistration;
     private final Resource resource;
+
+    @Override
+    public synchronized void stop(StopContext context) {
+        super.stop(context);
+        DeploymentResourceSupport.cleanup(resource);
+    }
+
     private final CapabilityServiceSupport capabilityServiceSupport;
     private final AbstractVaultReader vaultReader;
     private final DeploymentOverlayIndex deploymentOverlays;

--- a/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentUnitService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentUnitService.java
@@ -42,24 +42,15 @@ import org.jboss.msc.service.ServiceRegistry;
 public class SubDeploymentUnitService extends AbstractDeploymentUnitService {
     private final ResourceRoot deploymentRoot;
     private final DeploymentUnit parent;
-    private final ImmutableManagementResourceRegistration registration;
-    private final ManagementResourceRegistration mutableRegistration;
-    private Resource resource;
-    private final CapabilityServiceSupport capabilityServiceSupport;
-    private final AbstractVaultReader vaultReader;
     private final PathManager pathManager;
 
     public SubDeploymentUnitService(ResourceRoot deploymentRoot, DeploymentUnit parent, ImmutableManagementResourceRegistration registration, final ManagementResourceRegistration mutableRegistration, Resource resource, CapabilityServiceSupport capabilityServiceSupport, final AbstractVaultReader vaultReader, PathManager pathManager) {
+        super(registration, mutableRegistration, resource, capabilityServiceSupport, vaultReader);
         this.pathManager = pathManager;
         if (deploymentRoot == null) throw ServerLogger.ROOT_LOGGER.deploymentRootRequired();
         this.deploymentRoot = deploymentRoot;
         if (parent == null) throw ServerLogger.ROOT_LOGGER.subdeploymentsRequireParent();
         this.parent = parent;
-        this.registration = registration;
-        this.mutableRegistration = mutableRegistration;
-        this.resource = resource;
-        this.capabilityServiceSupport = capabilityServiceSupport;
-        this.vaultReader = vaultReader;
     }
 
     protected DeploymentUnit createAndInitializeDeploymentUnit(ServiceRegistry registry) {
@@ -79,7 +70,6 @@ public class SubDeploymentUnitService extends AbstractDeploymentUnitService {
         // For compatibility only
         addSVH(deploymentUnit);
 
-        this.resource = null;
         return deploymentUnit;
     }
 


### PR DESCRIPTION
Bit of a convenience in case DUPs don't undo in undeploy what the do in deploy and then the deployment unit service gets bounced due to some MSC dependency bouncing, e.g. WFLY-4908.

@scottmarlow not critical but I'm curious if this fixes PR the WFLY-4908 issue without the need for your patch. Your patch is still correct though as a DUP should undo in undeploy what it does in deploy; this PR is just a 2nd line of defense.