### PR TITLE
[WFCORE-1226] undeploying disabled deployment stops service for same …

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentUndeployHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentUndeployHandler.java
@@ -46,12 +46,14 @@ public class DeploymentUndeployHandler implements OperationStepHandler {
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         ModelNode model = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel();
-        final String runtimeName = RUNTIME_NAME.resolveModelAttribute(context, model).asString();
-        model.get(ENABLED.getName()).set(false);
+        if (model.hasDefined(ENABLED.getName()) && model.get(ENABLED.getName()).asBoolean()) {
+            final String runtimeName = RUNTIME_NAME.resolveModelAttribute(context, model).asString();
+            model.get(ENABLED.getName()).set(false);
 
-        final String managementName = context.getCurrentAddressValue();
+            final String managementName = context.getCurrentAddressValue();
 
-        DeploymentHandlerUtil.undeploy(context, operation, managementName, runtimeName, vaultReader);
+            DeploymentHandlerUtil.undeploy(context, operation, managementName, runtimeName, vaultReader);
+        }
         DeploymentUtils.disableAttribute(model);
     }
 }


### PR DESCRIPTION
…runtime-name in DeploymentUndeployHandler

https://issues.jboss.org/browse/WFCORE-1226
DeploymentUndeployHandler checks that deployment is enabled before stopping the relevant service.

A test in DeployWithRuntimeNameTestCase.java is available in WFCORE-1226 attachment, I'll send another WildFly PR once we include this fix in next wildfly-core upgrade. 