### PR TITLE
[WFCORE-1274] CLI resolve-parameter-values set to true does not recognize vaulted strings

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/util/CLIExpressionResolver.java
+++ b/cli/src/main/java/org/jboss/as/cli/util/CLIExpressionResolver.java
@@ -105,6 +105,9 @@ public class CLIExpressionResolver {
                 }
             } else if(c == '{') {
                 if(state == DOLLAR) {
+                    if (i - 2 >= 0 && input.charAt(i - 2) == '\\') {
+                        return input;
+                    }
                     state = INITIAL;
                     final String[] inputRef = new String[]{input};
                     if(i - 2 == resolveProperty2(inputRef, i - 2, exceptionIfNotResolved)) {

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/ParameterValueResolutionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/ParameterValueResolutionTestCase.java
@@ -196,6 +196,22 @@ public class ParameterValueResolutionTestCase {
         assertEquals("the value is valuable", value.asString());
     }
 
+    @Test
+    public void testSecurityVaultString() throws Exception {
+        final CommandContext ctx = new MockCommandContext();
+        ctx.setResolveParameterValues(true);
+
+        ModelNode value = parseObject(ctx, "the value is $\\{VAULT::text::password::1\\}");
+        assertNotNull(value);
+        assertEquals(ModelType.STRING, value.getType());
+        assertEquals("the value is ${VAULT::text::password::1}", value.asString());
+
+        value = parseObject(ctx, "the value is ${VAULT::text::password::1}");
+        assertNotNull(value);
+        assertEquals(ModelType.STRING, value.getType());
+        assertEquals("the value is :text::password::1", value.asString());
+    }
+
     protected void setProperty(final String name, final String value) {
         if(System.getSecurityManager() == null) {
             System.setProperty(name, value);


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-1274

The format of security vault: `${VAULT::xxx::yyy::zzz}` is like system property: `${propName:defaultValue}`. I prefer to let user send escaped string: `$\{VAULT::xxx::yyy::zzz\}`, instead of let CLI distinguish the input for this special case.