### PR TITLE
[WFCORE-1281] NPE in LDAP principal to group loading

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
@@ -1145,6 +1145,15 @@ public interface DomainManagementLogger extends BasicLogger {
     StartException keyTabFileNotFound(String fileName);
 
     /**
+     * The error to indicate where it has not been possible to load a distinguished name for a group.
+     *
+     * @param distinguishedName the distinguished name of the group that failed to load.
+     * @return The exception for the error.
+     */
+    @Message(id = 110, value = "Unable to load a simple name for group '%s'")
+    NamingException unableToLoadSimpleNameForGroup(String distinguishedName);
+
+    /**
      * Information message saying the username and password must be different.
      *
      * @return an {@link String} for the error.

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -524,7 +524,7 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
             iterative = PrincipalToGroupResourceDefinition.ITERATIVE.resolveModelAttribute(context, principalToGroup).asBoolean();
             boolean skipMissingGroups = PrincipalToGroupResourceDefinition.SKIP_MISSING_GROUPS.resolveModelAttribute(context, principalToGroup).asBoolean();
 
-            groupSearcher = LdapGroupSearcherFactory.createForPrincipalToGroup(groupAttribute, groupNameAttribute, preferOriginalConnection, skipMissingGroups);
+            groupSearcher = LdapGroupSearcherFactory.createForPrincipalToGroup(groupAttribute, groupNameAttribute, preferOriginalConnection, skipMissingGroups, GroupName.SIMPLE == groupName);
         }
 
         LdapCacheService<LdapEntry[], LdapEntry> groupCacheService = createCacheService(context, groupSearcher, groupCache);

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/realms/LdapTestSuite.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/realms/LdapTestSuite.java
@@ -57,6 +57,7 @@ import org.junit.runners.Suite;
     LdapAuthenticationSuiteTest.class,
     GroupToPrincipalLdapSuiteTest.class,
     PrincipalToGroupLdapSuiteTest.class,
+    PrincipalToGroupMissingNameLdapSuiteTest.class,
     LdapAuthenticationFollowSuiteTest.class,
     LdapAuthenticationThrowSuiteTest.class,
     GroupLoadingReferralsSuiteTest.class

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/realms/PrincipalToGroupMissingNameLdapSuiteTest.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/realms/PrincipalToGroupMissingNameLdapSuiteTest.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.domain.management.security.realms;
+
+import org.jboss.as.domain.management.security.operations.SecurityRealmAddBuilder;
+import org.jboss.as.domain.management.security.operations.CacheBuilder.By;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * An alternative principal to group test to verify a group with a missing simple name can be ignored.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class PrincipalToGroupMissingNameLdapSuiteTest extends BaseLdapSuiteTest {
+
+    private static boolean initialised;
+
+    @BeforeClass
+    public static void startLdapServer() throws Exception {
+        initialised = LdapTestSuite.startLdapServers(false);
+    }
+
+    @AfterClass
+    public static void stopLdapServer() throws Exception {
+        if (initialised) {
+            LdapTestSuite.stopLdapServers();
+        }
+    }
+
+    private static final String BASE_DN = "ou=users,dc=principal-to-group,dc=wildfly,dc=org";
+    private static final String USERNAME_FILTER = "uid";
+    private static final String GROUP_NAME_ATTRIBUTE = "name";
+
+    @Override
+    protected void initialiseRealm(SecurityRealmAddBuilder builder) throws Exception {
+        builder.authentication()
+        .ldap()
+        .setConnection(MASTER_CONNECTION_NAME)
+        .setBaseDn(BASE_DN)
+        .setUsernameFilter(USERNAME_FILTER)
+        .cache()
+        .setBy(By.SEARCH_TIME)
+        .setEvictionTime(1)
+        .setMaxCacheSize(1)
+        .build().build().build()
+        .authorization().ldap()
+        .setConnection(MASTER_CONNECTION_NAME)
+        .usernameFilter()
+        .setBaseDn(BASE_DN)
+        .setRecursive(false)
+        .setAttribute(USERNAME_FILTER)
+        .cache()
+        .setBy(By.ACCESS_TIME)
+        .setEvictionTime(1)
+        .setMaxCacheSize(1)
+        .build().build()
+        .principalToGroup()
+        .setIterative(true)
+        .setSkipMissingGroups(true)
+        .setGroupNameAttribute(GROUP_NAME_ATTRIBUTE)
+        .cache()
+        .setBy(By.SEARCH_TIME)
+        .setEvictionTime(1)
+        .setMaxCacheSize(1)
+        .build().build().build().build();
+    }
+
+    /**
+     * Expected membership (GroupTwo)
+     *
+     * This user is also a member of a group missing the 'uid' attribute so should be treated as a missing group and ignored.
+     */
+    @Test
+    public void testTestUserTwelve() throws Exception {
+        verifyGroupMembership(TEST_REALM, "TestUserTwelve", "passwordTwelve", "GroupTen");
+    }
+
+}

--- a/domain-management/src/test/resources/org/jboss/as/domain/management/security/realms/principal-to-group.ldif
+++ b/domain-management/src/test/resources/org/jboss/as/domain/management/security/realms/principal-to-group.ldif
@@ -240,3 +240,38 @@ memberOf: uid=GroupTwo,ou=groups,dc=principal-to-group,dc=wildfly,dc=org
 memberOf: uid=MissingGroup,ou=groups,dc=principal-to-group,dc=wildfly,dc=org
 userPassword: passwordEleven
 
+# Entries for a user referencing two groups, one of which is missing the attribute that holds it's simple name.
+
+dn: uid=TestUserTwelve,ou=users,dc=principal-to-group,dc=wildfly,dc=org
+objectClass: top
+objectClass: groupMember
+objectClass: inetOrgPerson
+objectClass: uidObject
+objectClass: person
+objectClass: organizationalPerson
+cn: Test User Twelve
+sn: Test User Twelve
+uid: TestUserTwelve
+memberOf: uid=GroupTen,ou=groups,dc=principal-to-group,dc=wildfly,dc=org
+memberOf: uid=GroupEleven,ou=groups,dc=principal-to-group,dc=wildfly,dc=org
+userPassword: passwordTwelve
+
+dn: uid=GroupTen,ou=groups,dc=principal-to-group,dc=wildfly,dc=org
+objectClass: top
+objectClass: groupMember
+objectClass: group
+objectClass: uidObject
+objectClass: extensibleObject
+uid: GroupTen
+name: GroupTen
+
+dn: uid=GroupEleven,ou=groups,dc=principal-to-group,dc=wildfly,dc=org
+objectClass: top
+objectClass: groupMember
+objectClass: group
+objectClass: uidObject
+uid: GroupEleven
+
+
+
+


### PR DESCRIPTION
Check that the simple name attribute can be loaded for the group and if it is required, not loaded and missing group skipping disabled - log an error.