### PR TITLE
[WFCORE-1304] fix StringIndexOutOfBoundsException when clean an obsolete system added content

### DIFF
--- a/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -362,7 +363,14 @@ public interface ContentRepository {
                         contentHashReferences.remove(reference.getHexHash());
                     }
                 }
-                Path file = getDeploymentContentFile(reference.getHash(), true);
+
+                Path file;
+                if (!HashUtil.isEachHexHashInTable(reference.getHexHash())) {
+                    String identifier = reference.getContentIdentifier();
+                    file = Paths.get(identifier);
+                } else
+                    file = getDeploymentContentFile(reference.getHash(), true);
+
                 try {
                     Files.deleteIfExists(file);
                 } catch (IOException ex) {

--- a/deployment-repository/src/main/java/org/jboss/as/repository/HashUtil.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/HashUtil.java
@@ -18,6 +18,8 @@
  */
 package org.jboss.as.repository;
 
+import java.util.Arrays;
+
 /**
  * Utilities related to deployment content hashes.
  *
@@ -66,4 +68,13 @@ class HashUtil {
         return data;
     }
 
+    public static boolean isEachHexHashInTable(String s) {
+        // WFLY-6018, check each char is in table, otherwise, there will be StringIndexOutOfBoundsException due to illegal char
+        char[] array = s.toCharArray();
+        for (char c : array) {
+            if (Arrays.binarySearch(table, c) < 0)
+                return false;
+        }
+        return true;
+    }
 }

--- a/deployment-repository/src/test/java/org/jboss/as/repository/ContentRepositoryTest.java
+++ b/deployment-repository/src/test/java/org/jboss/as/repository/ContentRepositoryTest.java
@@ -226,6 +226,30 @@ public class ContentRepositoryTest {
     }
 
     /**
+     * Test that an empty dir with a system metadata file .DS_Store will be removed during cleaning.
+     */
+    @Test
+    public void testCleanEmptyParentDirWithSystemMetaDataFile() throws Exception {
+        File emptyGrandParent = new File(rootDir, "ae");
+        emptyGrandParent.mkdir();
+        File metaDataFile = new File(emptyGrandParent, ".DS_Store");
+        metaDataFile.createNewFile();
+        assertThat(emptyGrandParent.exists(), is(true));
+        assertThat(metaDataFile.exists(), is(true));
+        Map<String, Set<String>> result = repository.cleanObsoleteContent(); // To mark content for deletion
+        assertThat(result.get(ContentRepository.MARKED_CONTENT).size(), is(1));
+        assertThat(result.get(ContentRepository.DELETED_CONTENT).size(), is(0));
+        assertThat(result.get(ContentRepository.MARKED_CONTENT).contains(metaDataFile.getAbsolutePath()), is(true));
+        Thread.sleep(10);
+        result = repository.cleanObsoleteContent();
+        assertThat(emptyGrandParent.exists(), is(false));
+        assertThat(metaDataFile.exists(), is(false));
+        assertThat(result.get(ContentRepository.MARKED_CONTENT).size(), is(0));
+        assertThat(result.get(ContentRepository.DELETED_CONTENT).size(), is(1));
+        assertThat(result.get(ContentRepository.DELETED_CONTENT).contains(metaDataFile.getAbsolutePath()), is(true));
+    }
+
+    /**
      * Test that an empty dir will be removed during cleaning.
      */
     @Test


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1304

Mac OS can add a hidden file .DS_Store to deployment content repository. This causes an unexpected StringIndexOutOfBoundsException when it calls HashUtil.hexStringToByteArray() to clean obsolete content.

It should exam each char inside hexString is among 0 to f for such system added file, in this case ".DS.Store".

As reported, It's also reproducible in Linux by creating a file under the content dir, but I think it's incorrect behavior to manually create any customer file in this directory.