### PR TITLE
modified script to allow special characters in username and Password

### DIFF
--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/service/service.bat
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/service/service.bat
@@ -63,6 +63,8 @@ if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
   set PRUNSRV="%JBOSS_HOME%\bin\service\wildfly-service"
 )
 
+setlocal DisableDelayedExpansion
+
 if /I "%1" == "install"   goto cmdInstall
 if /I "%1" == "uninstall" goto cmdUninstall
 if /I "%1" == "start"     goto cmdStart


### PR DESCRIPTION
The original service.bat stripped out special characters like '!' in passwords. This was due to the delayed expansion of variables which is only necessary to determine JBOSS_HOME.
