### PR TITLE
WFCORE-1319 - Defaults for Metasize and Java 8

### DIFF
--- a/core-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/core-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -74,7 +74,7 @@
             <heap size="64m" max-size="256m"/>
             <jvm-options>
                 <option value="-server"/>
-                <option value="-XX:MetaspaceSize=256m"/>
+                <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
             </jvm-options>
         </jvm>

--- a/core-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/core-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -84,7 +84,7 @@
             <heap size="64m" max-size="256m"/>
             <jvm-options>
                 <option value="-server"/>
-                <option value="-XX:MetaspaceSize=256m"/>
+                <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
             </jvm-options>
         </jvm>

--- a/core-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/core-feature-pack/src/main/resources/configuration/host/host.xml
@@ -80,7 +80,7 @@
             <heap size="64m" max-size="256m"/>
             <jvm-options>
                 <option value="-server"/>
-                <option value="-XX:MetaspaceSize=256m"/>
+                <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
             </jvm-options>
         </jvm>

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf
@@ -47,7 +47,7 @@ fi
 # Specify options to pass to the Java VM.
 #
 if [ "x$JAVA_OPTS" = "x" ]; then
-   JAVA_OPTS="-Xms64m -Xmx512m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true"
+   JAVA_OPTS="-Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true"
    JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true"
 else
    echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf.bat
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf.bat
@@ -46,7 +46,7 @@ rem # options that are always passed by run.bat.
 rem #
 
 rem # JVM memory allocation pool parameters - modify as appropriate.
-set "JAVA_OPTS=-Xms64M -Xmx512M -XX:MaxMetaspaceSize=256m"
+set "JAVA_OPTS=-Xms64M -Xmx512M -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m"
 
 rem # Prefer IPv4
 set "JAVA_OPTS=%JAVA_OPTS% -Djava.net.preferIPv4Stack=true"

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf.ps1
@@ -41,6 +41,7 @@ $JAVA_OPTS = @()
 # JVM memory allocation pool parameters - modify as appropriate.
 $JAVA_OPTS += '-Xms64M'
 $JAVA_OPTS += '-Xmx512M'
+$JAVA_OPTS += '-XX:MetaspaceSize=96M'
 $JAVA_OPTS += '-XX:MaxMetaspaceSize=256m'
 
 # Reduce the RMI GCs to once per hour for Sun JVMs.


### PR DESCRIPTION
Initial change for standalone, possibly another change to follow for jvm defaults (currently 256m).