### PR TITLE
Clean some cruft

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainControllerLockIdUtils.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainControllerLockIdUtils.java
@@ -43,12 +43,6 @@ public final class DomainControllerLockIdUtils {
      */
     public static final AttachmentKey<Integer> DOMAIN_CONTROLLER_LOCK_ID_ATTACHMENT = AttachmentKey.create(Integer.class);
 
-    /**
-     * The slave controller lock id header sent by the slaves to the DC. This is used to group several
-     * slave requuests onto one DC request.
-     */
-    public static final String SLAVE_CONTROLLER_LOCK_ID = "slave-controller-lock-id";
-
     private DomainControllerLockIdUtils() {
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
@@ -50,7 +50,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.net.ssl.SSLHandshakeException;
 import javax.security.sasl.SaslException;
 
-import org.jboss.as.controller.CurrentOperationIdHolder;
 import org.jboss.as.controller.HashUtil;
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.OperationContext;
@@ -401,7 +400,6 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
                 if (domainControllerLock != null) {
                     fetchContentOp.get(OPERATION_HEADERS, DomainControllerLockIdUtils.DOMAIN_CONTROLLER_LOCK_ID).set(domainControllerLock);
                 }
-                fetchContentOp.get(OPERATION_HEADERS, DomainControllerLockIdUtils.SLAVE_CONTROLLER_LOCK_ID).set(CurrentOperationIdHolder.getCurrentOperationID());
 
                 // execute the operation blocking
                 final TransactionalProtocolClient.PreparedOperation<TransactionalProtocolClient.Operation> preparedOperation;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
@@ -137,7 +137,6 @@ public class MasterDomainControllerOperationHandlerService extends AbstractModel
                 domainControllerLockId = null;
             }
 
-            final Integer slaveLockId = operationNode.get(OPERATION_HEADERS, DomainControllerLockIdUtils.SLAVE_CONTROLLER_LOCK_ID).asInt();
             if (domainControllerLockId == null) {
                 synchronized (this) {
                     SlaveRequest slaveRequest = this.activeSlaveRequest;
@@ -146,8 +145,6 @@ public class MasterDomainControllerOperationHandlerService extends AbstractModel
                         slaveRequest.refCount.incrementAndGet();
                     }
                 }
-                //TODO https://issues.jboss.org/browse/AS7-6809 If there are many slaves calling back many of these threads will be blocked, and I
-                //believe they are a finite resource
             }
 
             try {


### PR DESCRIPTION
This slave-controller-lock-id has never done anything since my first commit where it appeared. Javadoc says it "is used to group several slave requuests onto one DC request" but there aren't several slave requests.

Given the javadoc on slave-controller-lock-id, I didn't believe my original addition of that had anything to do with the following, but before deciding to remove this cruft I was concerned about a missing "lock". So I analyzed what happens, and it looks ok, details as follows:

If a slave request comes in without a domain-controller-lock-id, that means the user op went directly to the slave, e.g. a direct CLI connection to the slave adding a new server-config requiring a pull down of data. In that case domain-controller-lock-id will be null on the master, and it will drop into the block where it tries to acquire the controller lock before executing (call to executor.executeAndAttemptLock). That call will failing promptly without blocking if the lock is held by some other op on the master. So, that prevents deadlocks by having the slave-originated op fail in the presence of a concurrent master-originated op.