### PR TITLE
[WFCORE-1322] Make the org.jboss.log4j.logmanager module private

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/log4j/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/log4j/main/module.xml
@@ -22,4 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.3" name="org.apache.log4j" target-name="org.jboss.log4j.logmanager"/>
+<module xmlns="urn:jboss:module:1.3" name="org.apache.log4j">
+
+    <properties>
+        <property name="jboss.api" value="public"/>
+    </properties>
+
+    <dependencies>
+        <!-- This allows the org.jboss.log4j.logmanager module to be private while keeping this module public -->
+        <module name="org.jboss.log4j.logmanager" export="true"/>
+    </dependencies>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
@@ -23,6 +23,10 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.jboss.log4j.logmanager">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
     <resources>
         <artifact name="${org.jboss.logmanager:log4j-jboss-logmanager}"/>
     </resources>


### PR DESCRIPTION
In an effort to make the the `org.jboss.log4j.logmanager` a private module the `org.apache.log4j` module is no longer aliased. It now delegates to the `org.jboss.log4j.logmanager` my export the packages.