### PR TITLE
[WFCORE-1309] Applying patch - "no space available" not specific enough

### DIFF
--- a/patching/src/main/java/org/jboss/as/patching/HashUtils.java
+++ b/patching/src/main/java/org/jboss/as/patching/HashUtils.java
@@ -87,17 +87,14 @@ public class HashUtils {
             if (file.getName().endsWith(".jar.index")) {
                 return;
             }
-            FileInputStream fis = new FileInputStream(file);
-            try {
+            try (FileInputStream fis = new FileInputStream(file);
+                 BufferedInputStream bis = new BufferedInputStream(fis)){
 
-                BufferedInputStream bis = new BufferedInputStream(fis);
                 byte[] bytes = new byte[8192];
                 int read;
                 while ((read = bis.read(bytes)) > -1) {
                     digest.update(bytes, 0, read);
                 }
-            } finally {
-                IoUtils.safeClose(fis);
             }
 
         }
@@ -107,9 +104,10 @@ public class HashUtils {
         byte[] sha1Bytes;
         synchronized (DIGEST) {
             DIGEST.reset();
-            BufferedInputStream bis = new BufferedInputStream(is);
-            DigestOutputStream dos = new DigestOutputStream(os, DIGEST);
-            IoUtils.copyStream(bis, dos);
+            try (BufferedInputStream bis = new BufferedInputStream(is);
+                 DigestOutputStream dos = new DigestOutputStream(os, DIGEST)) {
+                IoUtils.copyStream(bis, dos);
+            }
             sha1Bytes = DIGEST.digest();
         }
         return sha1Bytes;

--- a/patching/src/main/java/org/jboss/as/patching/IoUtils.java
+++ b/patching/src/main/java/org/jboss/as/patching/IoUtils.java
@@ -29,6 +29,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.zip.ZipFile;
 
 import org.jboss.as.patching.logging.PatchLogger;
@@ -112,9 +114,7 @@ public class IoUtils {
                 }
             }
             try {
-                final InputStream is = new FileInputStream(sourceFile);
-                final OutputStream os = new FileOutputStream(targetFile);
-                copyStreamAndClose(is, os);
+                Files.copy(sourceFile.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException e) {
                 throw PatchLogger.ROOT_LOGGER.cannotCopyFiles(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath(),
                         e.getMessage(), e);
@@ -143,27 +143,17 @@ public class IoUtils {
         if(! target.getParentFile().exists()) {
             target.getParentFile().mkdirs(); // Hmm
         }
-        final OutputStream os = new FileOutputStream(target);
-        try {
-            byte[] nh = HashUtils.copyAndGetHash(is, os);
-            os.close();
-            return nh;
+        try (final OutputStream os = new FileOutputStream(target)){
+            return HashUtils.copyAndGetHash(is, os);
         } catch (IOException e) {
             throw PatchLogger.ROOT_LOGGER.cannotCopyFiles(is.toString(), target.getAbsolutePath(),
                     e.getMessage(), e);
-        } finally {
-            safeClose(os);
         }
     }
 
     public static byte[] copy(File source, File target) throws IOException {
-        final FileInputStream is = new FileInputStream(source);
-        try {
-            byte[] backupHash = copy(is, target);
-            is.close();
-            return backupHash;
-        } finally {
-            safeClose(is);
+        try (final FileInputStream is = new FileInputStream(source)){
+            return copy(is, target);
         }
     }
 

--- a/patching/src/main/java/org/jboss/as/patching/IoUtils.java
+++ b/patching/src/main/java/org/jboss/as/patching/IoUtils.java
@@ -111,9 +111,14 @@ public class IoUtils {
                     throw PatchLogger.ROOT_LOGGER.cannotCreateDirectory(parent.getAbsolutePath());
                 }
             }
-            final InputStream is = new FileInputStream(sourceFile);
-            final OutputStream os = new FileOutputStream(targetFile);
-            copyStreamAndClose(is, os);
+            try {
+                final InputStream is = new FileInputStream(sourceFile);
+                final OutputStream os = new FileOutputStream(targetFile);
+                copyStreamAndClose(is, os);
+            } catch (IOException e) {
+                throw PatchLogger.ROOT_LOGGER.cannotCopyFiles(sourceFile.getAbsolutePath(), targetFile.getAbsolutePath(),
+                        e.getMessage(), e);
+            }
         }
     }
 
@@ -143,6 +148,9 @@ public class IoUtils {
             byte[] nh = HashUtils.copyAndGetHash(is, os);
             os.close();
             return nh;
+        } catch (IOException e) {
+            throw PatchLogger.ROOT_LOGGER.cannotCopyFiles(is.toString(), target.getAbsolutePath(),
+                    e.getMessage(), e);
         } finally {
             safeClose(os);
         }

--- a/patching/src/main/java/org/jboss/as/patching/installation/InstallationManagerImpl.java
+++ b/patching/src/main/java/org/jboss/as/patching/installation/InstallationManagerImpl.java
@@ -11,7 +11,6 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jboss.as.patching.Constants;
-import org.jboss.as.patching.IoUtils;
 import org.jboss.as.patching.PatchingException;
 import org.jboss.as.patching.logging.PatchLogger;
 import org.jboss.as.version.ProductConfig;
@@ -126,16 +125,11 @@ public class InstallationManagerImpl extends InstallationManager {
 
     private Properties loadProductConf(File productConf) throws PatchingException {
         final Properties props = new Properties();
-        FileInputStream fis = null;
-        try {
-            fis = new FileInputStream(productConf);
+
+        try (FileInputStream fis = new FileInputStream(productConf)){
             props.load(fis);
         } catch(IOException e) {
             throw new PatchingException(PatchLogger.ROOT_LOGGER.failedToLoadInfo(productConf.getAbsolutePath()), e);
-        } finally {
-            if(fis != null) {
-                IoUtils.safeClose(fis);
-            }
         }
         return props;
     }

--- a/patching/src/main/java/org/jboss/as/patching/logging/PatchLogger.java
+++ b/patching/src/main/java/org/jboss/as/patching/logging/PatchLogger.java
@@ -232,4 +232,10 @@ public interface PatchLogger extends BasicLogger {
 
     @Message(id = 45, value = "Unrecognized condition format '%s'")
     PatchingException unrecognizedConditionFormat(String condition);
+
+    @Message(id = 46, value = "Cannot copy files to temporary directory %s: %s. Note that '-Djava.io.tmpdir' switch can be used to set different temporary directory.")
+    PatchingException cannotCopyFilesToTempDir(String tempDir, String reason, @Cause Throwable cause);
+
+    @Message(id = 47, value = "Cannot copy files from %s to %s: %s")
+    IOException cannotCopyFiles(String from, String to, String reason, @Cause Throwable cause);
 }

--- a/patching/src/main/java/org/jboss/as/patching/metadata/PatchMerger.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/PatchMerger.java
@@ -84,14 +84,10 @@ public class PatchMerger {
 
             patch = merge(patch, patch2Metadata);
 
-            FileWriter writer = null;
-            try {
-                writer = new FileWriter(new File(mergedDir, f.getName()));
+            try (FileWriter writer = new FileWriter(new File(mergedDir, f.getName()))){
                 PatchXml.marshal(writer, patch);
             } catch (Exception e) {
                 throw new PatchingException("Failed to marshal merged metadata into " + f.getName(), e);
-            } finally {
-                IoUtils.safeClose(writer);
             }
 
         }
@@ -100,14 +96,10 @@ public class PatchMerger {
         copyFile(new File(patch2Dir, PatchXml.PATCH_XML), new File(mergedDir, patch2Metadata.getIdentity().getVersion() +  PATCH_XML_SUFFIX));
 
         // merged patch.xml is the metadata from the earliest version to the latest
-        FileWriter writer = null;
-        try {
-            writer = new FileWriter(new File(mergedDir, PatchXml.PATCH_XML));
+        try (FileWriter writer = new FileWriter(new File(mergedDir, PatchXml.PATCH_XML))){
             PatchXml.marshal(writer, mergedMetadata);
         } catch (Exception e) {
             throw new PatchingException("Failed to marshal merged metadata into " + PatchXml.PATCH_XML, e);
-        } finally {
-            IoUtils.safeClose(writer);
         }
 
         try {

--- a/patching/src/main/java/org/jboss/as/patching/runner/IdentityPatchContext.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/IdentityPatchContext.java
@@ -996,11 +996,8 @@ class IdentityPatchContext implements PatchContentProvider {
             }
         }
         try {
-            final OutputStream os = new FileOutputStream(file);
-            try {
+            try (final OutputStream os = new FileOutputStream(file)){
                 PatchXml.marshal(os, rollbackPatch);
-            } finally {
-                IoUtils.safeClose(os);
             }
         } catch (XMLStreamException e) {
             throw new IOException(e);

--- a/patching/src/main/java/org/jboss/as/patching/runner/ModuleRemoveTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/ModuleRemoveTask.java
@@ -28,7 +28,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 
-import org.jboss.as.patching.IoUtils;
 import org.jboss.as.patching.logging.PatchLogger;
 import org.jboss.as.patching.metadata.ContentModification;
 import org.jboss.as.patching.metadata.ModificationType;
@@ -59,11 +58,8 @@ class ModuleRemoveTask extends AbstractModuleTask {
             throw PatchLogger.ROOT_LOGGER.cannotCreateDirectory(targetDir.getAbsolutePath());
         }
         final File moduleXml = new File(targetDir, MODULE_XML);
-        final ByteArrayInputStream is = new ByteArrayInputStream(PatchUtils.getAbsentModuleContent(contentItem));
-        try {
+        try (final ByteArrayInputStream is = new ByteArrayInputStream(PatchUtils.getAbsentModuleContent(contentItem))){
             return copy(is, moduleXml);
-        } finally {
-            IoUtils.safeClose(is);
         }
     }
 

--- a/patching/src/main/java/org/jboss/as/patching/runner/ModuleUpdateTask.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/ModuleUpdateTask.java
@@ -22,11 +22,12 @@
 
 package org.jboss.as.patching.runner;
 
-import static org.jboss.as.patching.IoUtils.copy;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 
 import org.jboss.as.patching.HashUtils;
@@ -83,13 +84,10 @@ class ModuleUpdateTask extends AbstractModuleTask {
             if(!targetDir.exists() && ! targetDir.mkdirs()) {
                 throw PatchLogger.ROOT_LOGGER.cannotCreateDirectory(targetDir.getAbsolutePath());
             }
-            final File moduleXml = new File(targetDir, MODULE_XML);
+
+            final Path moduleXml = targetDir.toPath().resolve(MODULE_XML);
             final ByteArrayInputStream is = new ByteArrayInputStream(PatchUtils.getAbsentModuleContent(contentItem));
-            try {
-                return copy(is, moduleXml);
-            } finally {
-                IoUtils.safeClose(is);
-            }
+            Files.copy(is, moduleXml, StandardCopyOption.REPLACE_EXISTING);
         }
         // return contentItem.getContentHash();
         return HashUtils.hashFile(targetDir);

--- a/patching/src/main/java/org/jboss/as/patching/runner/PatchToolImpl.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/PatchToolImpl.java
@@ -186,11 +186,15 @@ public class PatchToolImpl implements PatchTool {
             // Create a working dir
             workDir = parentWorkDir == null ? IdentityPatchRunner.createTempDir() : IdentityPatchRunner.createTempDir(parentWorkDir);
 
-            // Save the content
-            final File cachedContent = new File(workDir, "content");
-            IoUtils.copy(is, cachedContent);
-            // Unpack to the work dir
-            ZipUtils.unzip(cachedContent, workDir);
+            try {
+                // Save the content
+                final File cachedContent = new File(workDir, "content");
+                IoUtils.copy(is, cachedContent);
+                // Unpack to the work dir
+                ZipUtils.unzip(cachedContent, workDir);
+            } catch (IOException e) {
+                throw PatchLogger.ROOT_LOGGER.cannotCopyFilesToTempDir(workDir.getAbsolutePath(), e.getMessage(), e); // add info that temp dir is involved
+            }
 
             // Execute
             return execute(workDir, contentPolicy);

--- a/patching/src/main/java/org/jboss/as/patching/runner/PatchToolImpl.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/PatchToolImpl.java
@@ -26,14 +26,14 @@ import static org.jboss.as.patching.IoUtils.safeClose;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.patching.Constants;
@@ -142,15 +142,9 @@ public class PatchToolImpl implements PatchTool {
                     return execute(file, contentPolicy);
                 }
             }
-            final InputStream is = new FileInputStream(file);
-            try {
+
+            try (final InputStream is = new FileInputStream(file)) {
                 return applyPatch(is, contentPolicy);
-            } finally {
-                if(is != null) try {
-                    is.close();
-                } catch (IOException e) {
-                    PatchLogger.ROOT_LOGGER.debugf(e, "failed to close input stream");
-                }
             }
         } catch (Exception e) {
             throw rethrowException(e);
@@ -188,10 +182,10 @@ public class PatchToolImpl implements PatchTool {
 
             try {
                 // Save the content
-                final File cachedContent = new File(workDir, "content");
-                IoUtils.copy(is, cachedContent);
+                Path cachedContent = workDir.toPath().resolve("content");
+                Files.copy(is, cachedContent);
                 // Unpack to the work dir
-                ZipUtils.unzip(cachedContent, workDir);
+                ZipUtils.unzip(cachedContent.toFile(), workDir);
             } catch (IOException e) {
                 throw PatchLogger.ROOT_LOGGER.cannotCopyFilesToTempDir(workDir.getAbsolutePath(), e.getMessage(), e); // add info that temp dir is involved
             }
@@ -295,8 +289,7 @@ public class PatchToolImpl implements PatchTool {
         }
     }
 
-    private PatchMetadataResolver parsePatchXml(final File patchXml)
-            throws FileNotFoundException, XMLStreamException, IOException {
+    private PatchMetadataResolver parsePatchXml(final File patchXml) throws XMLStreamException, IOException {
         InputStream patchIS = null;
         try {
             patchIS = new FileInputStream(patchXml);

--- a/patching/src/test/java/org/jboss/as/patching/cli/CLIPatchInfoUtil.java
+++ b/patching/src/test/java/org/jboss/as/patching/cli/CLIPatchInfoUtil.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.jboss.as.patching.IoUtils;
 import org.junit.Assert;
 
 /**
@@ -50,13 +49,12 @@ public class CLIPatchInfoUtil {
 
     public static void assertPatchInfo(byte[] info, String patchId, String link, boolean oneOff, String targetName, String targetVersion,
             String description) {
-        final ByteArrayInputStream bis = new ByteArrayInputStream(info);
-        final InputStreamReader reader = new InputStreamReader(bis);
-        final BufferedReader buf = new BufferedReader(reader);
-        try {
+        try (final ByteArrayInputStream bis = new ByteArrayInputStream(info);
+                final InputStreamReader reader = new InputStreamReader(bis);
+                final BufferedReader buf = new BufferedReader(reader)){
             assertPatchInfo(buf, patchId, link, oneOff, targetName, targetVersion, description);
         } catch (IOException e) {
-            IoUtils.safeClose(buf);
+            //
         }
     }
 
@@ -79,11 +77,9 @@ public class CLIPatchInfoUtil {
     public static void assertPatchInfo(byte[] info, String patchId, String link, boolean oneOff, String targetName, String targetVersion,
             String description, List<Map<String,String>> elements) {
 
-        final ByteArrayInputStream bis = new ByteArrayInputStream(info);
-        final InputStreamReader reader = new InputStreamReader(bis);
-        final BufferedReader buf = new BufferedReader(reader);
-
-        try {
+        try (final ByteArrayInputStream bis = new ByteArrayInputStream(info);
+                final InputStreamReader reader = new InputStreamReader(bis);
+                final BufferedReader buf = new BufferedReader(reader)){
             assertPatchInfo(buf, patchId, link, oneOff, targetName, targetVersion, description, elements);
             if (buf.ready()) {
                 final StringBuilder str = new StringBuilder();
@@ -95,8 +91,6 @@ public class CLIPatchInfoUtil {
             }
         } catch (IOException e) {
             throw new IllegalStateException("Failed to read the input", e);
-        } finally {
-            IoUtils.safeClose(buf);
         }
     }
 
@@ -138,13 +132,10 @@ public class CLIPatchInfoUtil {
     }
 
     public static Map<String, String> parseTable(byte[] table) throws IOException {
-        final ByteArrayInputStream bis = new ByteArrayInputStream(table);
-        final InputStreamReader reader = new InputStreamReader(bis);
-        final BufferedReader buf = new BufferedReader(reader);
-        try {
+        try (final ByteArrayInputStream bis = new ByteArrayInputStream(table);
+             final InputStreamReader reader = new InputStreamReader(bis);
+             final BufferedReader buf = new BufferedReader(reader)) {
             return parseTable(buf);
-        } finally {
-            IoUtils.safeClose(buf);
         }
     }
 

--- a/patching/src/test/java/org/jboss/as/patching/installation/BaseLayerTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/installation/BaseLayerTestCase.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.patching.installation;
 
+import static org.jboss.as.patching.logging.PatchLogger.ROOT_LOGGER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.jboss.as.patching.Constants.LAYERS;
@@ -97,7 +98,6 @@ public class BaseLayerTestCase extends AbstractTaskTestCase {
                 .build();
 
         createPatchXMLFile(patchDir, patch);
-        System.out.println("patch =>>");
         File zippedPatch = createZippedPatchFile(patchDir, patchID);
 
         // apply patch
@@ -107,8 +107,10 @@ public class BaseLayerTestCase extends AbstractTaskTestCase {
         assertInstallationIsPatched(patch, patchedInstalledIdentity.getIdentity().loadTargetInfo());
         assertFileExists(env.getInstalledImage().getJbossHome(), "bin", fileAdded.getItem().getName());
 
-        System.out.println("installation =>>");
-        tree(env.getInstalledImage().getJbossHome());
+        if (ROOT_LOGGER.isDebugEnabled()) {
+            System.out.println("installation =>>");
+            tree(env.getInstalledImage().getJbossHome());
+        }
 
         DirectoryStructure layerDirStructure = installedIdentity.getLayers().get(0).loadTargetInfo().getDirectoryStructure();
         File modulesPatchDir = layerDirStructure.getModulePatchDirectory(layerPatchId);

--- a/patching/src/test/java/org/jboss/as/patching/metadata/PatchBundleXmlUnitTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/metadata/PatchBundleXmlUnitTestCase.java
@@ -41,10 +41,11 @@ public class PatchBundleXmlUnitTestCase {
     @Test
     public void testBasic() throws Exception {
 
-        final InputStream is = getResource("multi-patch-01.xml");
-        final BundledPatch bundledPatch = PatchBundleXml.parse(is);
-        Assert.assertNotNull(bundledPatch);
-        Assert.assertFalse(bundledPatch.getPatches().isEmpty());
+        try (final InputStream is = getResource("multi-patch-01.xml")) {
+            final BundledPatch bundledPatch = PatchBundleXml.parse(is);
+            Assert.assertNotNull(bundledPatch);
+            Assert.assertFalse(bundledPatch.getPatches().isEmpty());
+        }
 
     }
 
@@ -56,17 +57,15 @@ public class PatchBundleXmlUnitTestCase {
     static void doMarshall(final String fileName) throws Exception {
         final String original = toString(fileName);
 
-        final InputStream is = getResource(fileName);
-        final BundledPatch patch = PatchBundleXml.parse(is);
+        try (final InputStream is = getResource(fileName)) {
+            final BundledPatch patch = PatchBundleXml.parse(is);
 
-        final StringWriter writer = new StringWriter();
-        PatchBundleXml.marshal(writer, patch);
-        final String marshalled = writer.toString();
+            final StringWriter writer = new StringWriter();
+            PatchBundleXml.marshal(writer, patch);
+            final String marshalled = writer.toString();
 
-        System.out.println(original);
-        System.out.println(marshalled);
-
-        XMLUtils.compareXml(original, marshalled, false);
+            XMLUtils.compareXml(original, marshalled, false);
+        }
     }
 
     static InputStream getResource(final String name) throws IOException {
@@ -76,9 +75,8 @@ public class PatchBundleXmlUnitTestCase {
     }
 
     static String toString(final String fileName) throws Exception {
-        final InputStream is = getResource(fileName);
-        assertNotNull(is);
-        try {
+        try (final InputStream is = getResource(fileName)){
+            assertNotNull(is);
             is.mark(0);
             String out = new Scanner(is).useDelimiter("\\A").next();
             is.reset();

--- a/patching/src/test/java/org/jboss/as/patching/metadata/PatchXmlUnitTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/metadata/PatchXmlUnitTestCase.java
@@ -143,9 +143,8 @@ public class PatchXmlUnitTestCase {
     }
 
     private String toString(String fileName) throws Exception {
-        final InputStream is = getResource(fileName);
-        assertNotNull(is);
-        try {
+        try (final InputStream is = getResource(fileName)){
+            assertNotNull(is);
             is.mark(0);
             String out = new Scanner(is).useDelimiter("\\A").next();
             is.reset();

--- a/patching/src/test/java/org/jboss/as/patching/runner/AbstractTaskTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/runner/AbstractTaskTestCase.java
@@ -149,12 +149,8 @@ public abstract class AbstractTaskTestCase {
                 str.append(layers[i]);
             }
             props.put(Constants.LAYERS, str.toString());
-            //props.put(Constants.EXCLUDE_LAYER_BASE, "true");
-            final FileOutputStream os = new FileOutputStream(layerConf);
-            try {
+            try (final FileOutputStream os = new FileOutputStream(layerConf)){
                 props.store(os, "");
-            } finally {
-                IoUtils.safeClose(os);
             }
         }
     }

--- a/patching/src/test/java/org/jboss/as/patching/runner/PatchingAssert.java
+++ b/patching/src/test/java/org/jboss/as/patching/runner/PatchingAssert.java
@@ -24,10 +24,10 @@ package org.jboss.as.patching.runner;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
 import static org.jboss.as.patching.HashUtils.bytesToHexString;
 import static org.jboss.as.patching.HashUtils.hashFile;
 import static org.jboss.as.patching.metadata.Patch.PatchType.CUMULATIVE;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -38,8 +38,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Scanner;
 
-import org.junit.Assert;
-
 import org.jboss.as.patching.ContentConflictsException;
 import org.jboss.as.patching.DirectoryStructure;
 import org.jboss.as.patching.IoUtils;
@@ -49,6 +47,7 @@ import org.jboss.as.patching.installation.PatchableTarget;
 import org.jboss.as.patching.metadata.ContentItem;
 import org.jboss.as.patching.metadata.Patch;
 import org.jboss.as.patching.tool.PatchingResult;
+import org.junit.Assert;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2012, Red Hat Inc
@@ -205,8 +204,10 @@ public class PatchingAssert {
     }
 
     private static void assertFileContains(File f, String string) throws Exception {
-        String content = new Scanner(f, "UTF-8").useDelimiter("\\Z").next();
-        assertTrue(string + " not found in " + f + " with content=" + content, content.contains(string));
+        try (Scanner scanner = new Scanner(f, "UTF-8").useDelimiter("\\Z")) {
+            String content = scanner.next();
+            assertTrue(string + " not found in " + f + " with content=" + content, content.contains(string));
+        }
     }
 
     public static void assertPatchHasBeenApplied(PatchingResult result, Patch patch) {

--- a/patching/src/test/java/org/jboss/as/patching/runner/TestUtils.java
+++ b/patching/src/test/java/org/jboss/as/patching/runner/TestUtils.java
@@ -55,7 +55,6 @@ import java.util.jar.Manifest;
 
 import org.jboss.as.patching.Constants;
 import org.jboss.as.patching.DirectoryStructure;
-import org.jboss.as.patching.IoUtils;
 import org.jboss.as.patching.ZipUtils;
 import org.jboss.as.patching.installation.InstalledImage;
 import org.jboss.as.patching.installation.PatchableTarget;
@@ -75,10 +74,12 @@ public class TestUtils {
     }
 
     public static void tree(File dir) {
+        if (!ROOT_LOGGER.isTraceEnabled()){
+            return;
+        }
         StringBuilder out = new StringBuilder();
-        out.append(dir.getParentFile().getAbsolutePath() + "\n");
+        out.append(dir.getParentFile().getAbsolutePath()).append("\n");
         tree0(out, dir, 1, "  ");
-        System.out.println(out);
         ROOT_LOGGER.trace(out.toString());
     }
 
@@ -108,12 +109,8 @@ public class TestUtils {
     }
 
     public static void dump(File f, String content) throws IOException {
-        final OutputStream os = new FileOutputStream(f);
-        try {
+        try (final OutputStream os = new FileOutputStream(f)){
             os.write(content.getBytes(StandardCharsets.UTF_8));
-            os.close();
-        } finally {
-            IoUtils.safeClose(os);
         }
     }
 
@@ -229,14 +226,10 @@ public class TestUtils {
         }
 
         if(logContent) {
-            java.io.FileInputStream fis = null;
-            try {
-                fis = new java.io.FileInputStream(new java.io.File(dir, "patch.xml"));
+            try (java.io.FileInputStream fis = new java.io.FileInputStream(new java.io.File(dir, "patch.xml"))){
                 final byte[] bytes = new byte[fis.available()];
                 fis.read(bytes);
                 System.out.println(new String(bytes));
-            } finally {
-                StreamUtils.safeClose(fis);
             }
         }
     }

--- a/patching/src/test/java/org/jboss/as/patching/tests/MergingPatchContentTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/MergingPatchContentTestCase.java
@@ -392,35 +392,4 @@ public class MergingPatchContentTestCase extends AbstractTaskTestCase {
         createPatchXMLFile(cp1Dir, cp1);
         cp1Zip = createZippedPatchFile(cp1Dir, cp1ID);
     }
-
-/*    private static void ls(final File f) {
-        System.out.println(f.getAbsolutePath());
-        for(File c : f.listFiles()) {
-            ls(c, "  ");
-        }
-    }
-
-    private static void ls(final File f, String offset) {
-        System.out.println(offset + f.getName());
-        if(f.isDirectory()) {
-            for(File c : f.listFiles()) {
-                ls(c, offset + "  ");
-            }
-        }
-    }
-
-    private static void less(File f) throws Exception {
-
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new FileReader(f));
-            String line = reader.readLine();
-            while(line != null) {
-                System.out.println(line);
-                line = reader.readLine();
-            }
-        } finally {
-            IoUtils.safeClose(reader);
-        }
-    }
-*/}
+}

--- a/patching/src/test/java/org/jboss/as/patching/tests/MergingPatchMetadataTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/MergingPatchMetadataTestCase.java
@@ -76,16 +76,6 @@ public class MergingPatchMetadataTestCase {
         final Patch cp2 = generateCP("cp1", "cp2", ModificationType.MODIFY);
         final Patch merged = PatchMerger.merge(cp1, cp2);
 
-//        StringWriter writer = new StringWriter();
-//        PatchXml.marshal(writer, cp1);
-//        System.out.println(writer.getBuffer().toString());
-//        writer = new StringWriter();
-//        PatchXml.marshal(writer, cp2);
-//        System.out.println(writer.getBuffer().toString());
-//        writer = new StringWriter();
-//        PatchXml.marshal(writer, merged);
-//        System.out.println(writer.getBuffer().toString());
-
         assertEquals("cp2", merged.getPatchId());
         assertEquals("cp2" + " description", merged.getDescription());
 
@@ -127,16 +117,6 @@ public class MergingPatchMetadataTestCase {
         final Patch cp2 = generateCP("cp1", "cp2", ModificationType.REMOVE);
         final Patch merged = PatchMerger.merge(cp1, cp2);
 
-//        StringWriter writer = new StringWriter();
-//        PatchXml.marshal(writer, cp1);
-//        System.out.println(writer.getBuffer().toString());
-//        writer = new StringWriter();
-//        PatchXml.marshal(writer, cp2);
-//        System.out.println(writer.getBuffer().toString());
-//        writer = new StringWriter();
-//        PatchXml.marshal(writer, merged);
-//        System.out.println(writer.getBuffer().toString());
-
         assertEquals("cp2", merged.getPatchId());
         assertEquals("cp2" + " description", merged.getDescription());
 
@@ -170,16 +150,6 @@ public class MergingPatchMetadataTestCase {
         final Patch cp1 = generateCP("base", "cp1", ModificationType.MODIFY);
         final Patch cp2 = generateCP("cp1", "cp2", ModificationType.REMOVE);
         final Patch merged = PatchMerger.merge(cp1, cp2);
-
-//        StringWriter writer = new StringWriter();
-//        PatchXml.marshal(writer, cp1);
-//        System.out.println(writer.getBuffer().toString());
-//        writer = new StringWriter();
-//        PatchXml.marshal(writer, cp2);
-//        System.out.println(writer.getBuffer().toString());
-//        writer = new StringWriter();
-//        PatchXml.marshal(writer, merged);
-//        System.out.println(writer.getBuffer().toString());
 
         assertEquals("cp2", merged.getPatchId());
         assertEquals("cp2" + " description", merged.getDescription());
@@ -221,16 +191,6 @@ public class MergingPatchMetadataTestCase {
         final Patch cp1 = generateCP("base", "cp1", ModificationType.REMOVE);
         final Patch cp2 = generateCP("cp1", "cp2", ModificationType.ADD);
         final Patch merged = PatchMerger.merge(cp1, cp2);
-
-//        StringWriter writer = new StringWriter();
-//        PatchXml.marshal(writer, cp1);
-//        System.out.println(writer.getBuffer().toString());
-//        writer = new StringWriter();
-//        PatchXml.marshal(writer, cp2);
-//        System.out.println(writer.getBuffer().toString());
-//        writer = new StringWriter();
-//        PatchXml.marshal(writer, merged);
-//        System.out.println(writer.getBuffer().toString());
 
         assertEquals("cp2", merged.getPatchId());
         assertEquals("cp2" + " description", merged.getDescription());
@@ -274,16 +234,6 @@ public class MergingPatchMetadataTestCase {
         final Patch cp1 = generateCP("base", "cp1", ModificationType.MODIFY);
         final Patch cp2 = generateCP("cp1", "cp2", ModificationType.MODIFY);
         final Patch merged = PatchMerger.merge(cp1, cp2);
-
-//        StringWriter writer = new StringWriter();
-//        PatchXml.marshal(writer, cp1);
-//        System.out.println(writer.getBuffer().toString());
-//        writer = new StringWriter();
-//        PatchXml.marshal(writer, cp2);
-//        System.out.println(writer.getBuffer().toString());
-//        writer = new StringWriter();
-//        PatchXml.marshal(writer, merged);
-//        System.out.println(writer.getBuffer().toString());
 
         assertEquals("cp2", merged.getPatchId());
         assertEquals("cp2" + " description", merged.getDescription());

--- a/patching/src/test/java/org/jboss/as/patching/tests/ModificationConditionTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/ModificationConditionTestCase.java
@@ -132,21 +132,4 @@ public class ModificationConditionTestCase extends AbstractPatchingTest {
         Assert.assertFalse(builder.hasFile(OTHER, MANUAL));
         Assert.assertFalse(builder.hasFile(DOCS, NOT_INSTALLED, MANUAL));
     }
-
-/*    private void printPatch(PatchingTestStepBuilder cp2) throws Exception {
-        writePatch(cp2.getPatchDir(), cp2.build());
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new FileReader(new File(cp2.getPatchDir(), "patch.xml")));
-            String line = reader.readLine();
-            while(line != null) {
-                System.out.println(line);
-                line = reader.readLine();
-            }
-        } finally {
-            if(reader != null) {
-                reader.close();
-            }
-        }
-    }
-*/}
+}

--- a/patching/src/test/java/org/jboss/as/patching/tests/MultipleStreamsPatchingTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/MultipleStreamsPatchingTestCase.java
@@ -43,12 +43,6 @@ public class MultipleStreamsPatchingTestCase extends AbstractPatchingTest {
     static final String[] FILE_EXISTING = {"bin", "test"};
 
 
-/*    @After
-    public void tearDown() {
-        System.out.println("finished " + tempDir.getAbsolutePath());
-        //super.tearDown();
-    }
-*/
     @Test
     public void testOne() throws Exception {
 


### PR DESCRIPTION
superceeds https://github.com/wildfly/wildfly-core/pull/1368

it adds NIO methods usage for copying which produce better error messages.
Also fixes lots of file leaks in the patching / patching ts.