### PR TITLE
[WFCORE-1042]: ExtensionRemoveHandler logs client mistakes.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRemoveHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRemoveHandler.java
@@ -65,7 +65,11 @@ public class ExtensionRemoveHandler implements OperationStepHandler {
         context.removeResource(PathAddress.EMPTY_ADDRESS);
 
         final ManagementResourceRegistration rootRegistration = rootResourceRegistrationProvider.getRootResourceRegistrationForUpdate(context);
-        extensionRegistry.removeExtension(context.readResourceFromRoot(rootRegistration.getPathAddress()), module, rootRegistration);
+        try {
+            extensionRegistry.removeExtension(context.readResourceFromRoot(rootRegistration.getPathAddress()), module, rootRegistration);
+        } catch(IllegalStateException isex) {
+            throw new OperationFailedException(isex.getMessage());
+        }
 
         context.completeStep(new OperationContext.RollbackHandler() {
             @Override


### PR DESCRIPTION
Catching the IllegalStateException and transforming it into an OperationFailedException.

Jira: https://issues.jboss.org/browse/WFCORE-1042