### PR TITLE
[WFCORE-1066]: Parameter -Djboss.domain.log.dir does not have effect on HP-UX when directory does not exist.

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/domain.sh
+++ b/core-feature-pack/src/main/resources/content/bin/domain.sh
@@ -193,7 +193,12 @@ if $darwin || $other ; then
              JBOSS_BASE_DIR=`cd ${p#*=} ; pwd -P`
              ;;
         -Djboss.domain.log.dir=*)
-             JBOSS_LOG_DIR=`cd ${p#*=} ; pwd -P`
+             if [ -d "${p#*=}" ]; then
+                JBOSS_LOG_DIR=`cd ${p#*=} ; pwd -P`
+             else
+                #since the specified directory doesn't exist we don't validate it
+                JBOSS_LOG_DIR=${p#*=}
+             fi
              ;;
         -Djboss.domain.config.dir=*)
              JBOSS_CONFIG_DIR=`cd ${p#*=} ; pwd -P`

--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -233,8 +233,13 @@ if $darwin || $freebsd || $other ; then
               JBOSS_BASE_DIR=`cd ${p#*=} ; pwd -P`
               ;;
          -Djboss.server.log.dir=*)
-              JBOSS_LOG_DIR=`cd ${p#*=} ; pwd -P`
-              ;;
+              if [ -d "${p#*=}" ]; then
+                JBOSS_LOG_DIR=`cd ${p#*=} ; pwd -P`
+             else
+                #since the specified directory doesn't exist we don't validate it
+                JBOSS_LOG_DIR=${p#*=}
+             fi
+             ;;
          -Djboss.server.config.dir=*)
               JBOSS_CONFIG_DIR=`cd ${p#*=} ; pwd -P`
               ;;


### PR DESCRIPTION
Checking if the directory exists and avoiding verifying it if not.

Jira: https://issues.jboss.org/browse/WFCORE-1066