### PR TITLE
[WFCORE-1311] Limit the WFCORE-1311 assistance to the server case

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -193,7 +193,13 @@ public class RemotingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_2_0.getUriString(), RemotingSubsystem20Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_3_0.getUriString(), RemotingSubsystem30Parser.INSTANCE);
 
-        context.setProfileParsingCompletionHandler(new IOCompletionHandler());
+        // For servers only as a migration aid we'll install io if it is missing.
+        // It is invalid to do this on an HC as the HC needs to support profiles running legacy
+        // slaves that will not understand the io extension
+        // See also WFCORE-778 and the description of the pull request for it
+        if (context.getProcessType().isServer()) {
+            context.setProfileParsingCompletionHandler(new IOCompletionHandler());
+        }
     }
 
     private static class IOCompletionHandler implements ProfileParsingCompletionHandler {


### PR DESCRIPTION
This can go in 2.0.8 or in 3.x; I'm fine either way.

WFCORE-963 added registration of an io subsystem by the parser if a legacy remoting xsd version was used. That's a migration aid, but it breaks mixed domain use cases by introducing a subsystem that legacy slaves can't understand to profiles meant for legacy.

This PR limits this migration behavior to servers to avoid this problem.

@dmlloyd made a good point in a discussion suggesting that in new releases capabilities should not add new *hard* requirements, but only optional ones, and if the optional capability is not present fall back on some non-capability based mechanism for getting required services. I agree with this. But digging into this issue I saw that with WFCORE-778, we already largely have this kind of behavior. The presence of an endpoint resource triggers the requirement for an io capability. If no such resource is added, which it won't be with a legacy config, then no requirement is added. For details see description of #836. So that's great. That means we can just limit this fix to not being "helpful" with domain configs. Easy, peasy. :)