### PR TITLE
[WFLY-4882] Add a phase for the permissions validation.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -525,6 +525,7 @@ public enum Phase {
     public static final int POST_MODULE_UNDERTOW_MODCLUSTER             = 0x3400;
     public static final int POST_MODULE_TRANSACTIONS_EE_CONCURRENCY     = 0x3500;
     public static final int POST_MODULE_EE_COMPONENT_SUSPEND            = 0x3600;
+    public static final int POST_MODULE_PERMISSIONS_VALIDATION          = 0x3700;
 
     // INSTALL
     public static final int INSTALL_SHARED_SESSION_MANAGER              = 0x0100;


### PR DESCRIPTION
The new phase is used to register a DUP in the security manager subsystem that validates the configured permissions (both subsystem and deployment permissions) against the maximum set.

Link to the upstream Jira:
https://issues.jboss.org/browse/WFLY-4882

Link to the WildFly PR that adds the new validator DUP:
https://github.com/wildfly/wildfly/pull/8612