### PR TITLE
https://issues.jboss.org/browse/WFCORE-1359 Exiting the CLI after dis…

### DIFF
--- a/cli/src/main/resources/help/history.txt
+++ b/cli/src/main/resources/help/history.txt
@@ -17,4 +17,4 @@ ARGUMENTS
  --enable     - will re-enable history expansion (starting from the last
                 recorded command before the history expansion was disabled);
 
- --clear      - will clear the in-memory history (but not the file one).
+ --clear      - will clear the history (in-memory and persisted).


### PR DESCRIPTION
…abling and clearing history will clear content of .jboss-cli-history

The help content describes outdated behavior, probably back from jline days.

Thanks,
Alexey