### PR TITLE
[WFCORE-857]: A read-resource on a subsystem resource of a missing deployment returns a successful completion

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -778,6 +778,7 @@ public class GlobalOperationHandlers {
             }
         }
 
+        @Override
         protected void executeSingleTargetChild(PathAddress base, PathElement currentElement, PathAddress newRemaining, OperationContext context, boolean ignoreMissing) {
             final PathAddress next = base.append(currentElement);
             // Either require the child or a remote target
@@ -785,6 +786,10 @@ public class GlobalOperationHandlers {
             final ImmutableManagementResourceRegistration nr = context.getResourceRegistration().getSubModel(next);
             if (resource.hasChild(currentElement) || (nr != null && nr.isRemote())) {
                 safeExecute(next, newRemaining, context, nr, ignoreMissing);
+            }
+            //if we are on the wrong host no need to do anything
+            else if(!resource.hasChild(currentElement)) {
+               throw new Resource.NoSuchResourceException(currentElement);
             }
         }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/WildCardReadsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/WildCardReadsTestCase.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.test.integration.domain.management.cli;
 
+
 import java.io.IOException;
 
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -113,6 +114,42 @@ public class WildCardReadsTestCase extends AbstractCliTestBase {
             Assert.assertTrue(result.hasDefined(ModelDescriptionConstants.OP_ADDR));
             Assert.assertTrue(result.hasDefined(ModelDescriptionConstants.RESULT));
         }
+    }
+
+    @Test
+    public void testSlaveAllServersReadRootAttribute() throws IOException {
+        cli.sendLine("/host=slave/server=*:read-attribute(name=\"server-state\")");
+        CLIOpResult opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        ModelNode generic = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+        Assert.assertEquals(ModelType.LIST, generic.getType());
+        Assert.assertEquals(4, generic.asInt());
+        cli.sendLine("/host=slave/server=*/interface=*:read-resource()");
+        opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        generic = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+        Assert.assertEquals(ModelType.LIST, generic.getType());
+        Assert.assertEquals(4, generic.asInt());
+    }
+
+    @Test
+    public void testSlaveAllServersReadResource() throws IOException {
+        cli.sendLine("/host=slave/server=*/interface=*:read-resource()");
+        CLIOpResult opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        ModelNode generic = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+        Assert.assertEquals(ModelType.LIST, generic.getType());
+        Assert.assertEquals(4, generic.asInt());
+    }
+
+    @Test
+    public void testSlaveAllServersReadResourceDescription() throws IOException {
+        cli.sendLine("/host=slave/server=*/interface=public:read-resource-description()");
+        CLIOpResult opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        ModelNode generic = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+        Assert.assertEquals(ModelType.LIST, generic.getType());
+        Assert.assertEquals(2, generic.asInt());
     }
 
 }

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
@@ -159,6 +159,18 @@ public class BasicOperationsUnitTestCase {
     }
 
     @Test
+    public void testReadResourceWithSubsystem() throws IOException {
+        // WFCORE-857
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set(READ_RESOURCE_OPERATION);
+        operation.get(OP_ADDR).set(PathAddress.parseCLIStyleAddress("/deployment=foo.war/subsystem=*").toModelNode());
+        operation.get(RECURSIVE).set(false);
+
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        assertEquals(FAILED, result.get(OUTCOME).asString());
+    }
+
+    @Test
     public void testReadResourceRecursiveDepthGt1RecursiveTrue() throws IOException {
         // WFCORE-76
         final ModelNode operation = new ModelNode();


### PR DESCRIPTION
For a global operation check that if the address doesn't resolve in the middle of it we fail.
Jira: https://issues.jboss.org/browse/WFCORE-857