### PR TITLE
[WFCORE-1360] CLI Options missed in WFCORE-1199

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
@@ -43,6 +43,7 @@ import org.jboss.as.cli.Util;
 import org.jboss.as.cli.accesscontrol.AccessRequirement;
 import org.jboss.as.cli.accesscontrol.AccessRequirementBuilder;
 import org.jboss.as.cli.accesscontrol.PerNodeOperationAccess;
+import org.jboss.as.cli.impl.ArgumentWithListValue;
 import org.jboss.as.cli.impl.ArgumentWithValue;
 import org.jboss.as.cli.impl.ArgumentWithoutValue;
 import org.jboss.as.cli.impl.CommaSeparatedCompleter;
@@ -70,7 +71,7 @@ public class DeployHandler extends DeploymentHandler {
     private final ArgumentWithoutValue url;
     private final ArgumentWithoutValue name;
     private final ArgumentWithoutValue rtName;
-    private final ArgumentWithValue serverGroups;
+    private final ArgumentWithListValue serverGroups;
     private final ArgumentWithoutValue allServerGroups;
     private final ArgumentWithoutValue disabled;
     private final ArgumentWithoutValue unmanaged;
@@ -182,7 +183,7 @@ public class DeployHandler extends DeploymentHandler {
         force.addCantAppearAfter(allServerGroups);
         allServerGroups.setAccessRequirement(deployPermission);
 
-        serverGroups = new ArgumentWithValue(this, new CommaSeparatedCompleter() {
+        serverGroups = new ArgumentWithListValue(this, new CommaSeparatedCompleter() {
             @Override
             protected Collection<String> getAllCandidates(CommandContext ctx) {
                 return serverGroupAddPermission.getAllowedOn(ctx);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
@@ -40,6 +40,7 @@ import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.accesscontrol.AccessRequirement;
 import org.jboss.as.cli.accesscontrol.AccessRequirementBuilder;
+import org.jboss.as.cli.impl.ArgumentWithListValue;
 import org.jboss.as.cli.impl.ArgumentWithValue;
 import org.jboss.as.cli.impl.ArgumentWithoutValue;
 import org.jboss.as.cli.impl.CommaSeparatedCompleter;
@@ -63,7 +64,7 @@ public class UndeployHandler extends DeploymentHandler {
     private final ArgumentWithoutValue l;
     private final ArgumentWithoutValue path;
     private final ArgumentWithValue name;
-    private final ArgumentWithValue serverGroups;
+    private final ArgumentWithListValue serverGroups;
     private final ArgumentWithoutValue allRelevantServerGroups;
     private final ArgumentWithoutValue keepContent;
     private final ArgumentWithValue script;
@@ -148,7 +149,7 @@ public class UndeployHandler extends DeploymentHandler {
         allRelevantServerGroups.addRequiredPreceding(name);
         allRelevantServerGroups.setAccessRequirement(undeployPermission);
 
-        serverGroups = new ArgumentWithValue(this, new CommaSeparatedCompleter() {
+        serverGroups = new ArgumentWithListValue(this, new CommaSeparatedCompleter() {
             @Override
             protected Collection<String> getAllCandidates(CommandContext ctx) {
               final String deploymentName = name.getValue(ctx.getParsedCommandLine());

--- a/cli/src/main/java/org/jboss/as/cli/handlers/module/ASModuleHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/module/ASModuleHandler.java
@@ -82,6 +82,10 @@ public class ASModuleHandler extends CommandHandlerWithHelp {
     }
 
     private class AddModuleListArgument extends ArgumentWithListValue {
+        private AddModuleListArgument(String fullname) {
+            super(ASModuleHandler.this, fullname);
+        }
+
         private AddModuleListArgument(String fullname, CommandLineCompleter completer) {
             super(ASModuleHandler.this, completer, fullname);
         }
@@ -112,7 +116,7 @@ public class ASModuleHandler extends CommandHandlerWithHelp {
     private final ArgumentWithValue mainClass;
     private final ArgumentWithValue resources;
     private final ArgumentWithListValue dependencies;
-    private final ArgumentWithValue props;
+    private final ArgumentWithListValue props;
     private final ArgumentWithValue moduleArg;
     private final ArgumentWithValue slot;
     private final ArgumentWithValue resourceDelimiter;
@@ -205,7 +209,7 @@ public class ASModuleHandler extends CommandHandlerWithHelp {
                 }
                 return moduleNameCompleter.complete(ctx, buffer, cursor, candidates);
             }});
-        props = new AddModuleArgument("--properties");
+        props = new AddModuleListArgument("--properties");
 
         moduleArg = new FileSystemPathArgument(this, pathCompleter, "--module-xml") {
             @Override

--- a/cli/src/main/resources/help/deploy.txt
+++ b/cli/src/main/resources/help/deploy.txt
@@ -80,6 +80,9 @@ ARGUMENTS
                     all-server-groups is required in the domain mode. This
                     argument is not applicable in the standalone mode.
 
+                    NOTE: In non-interactive mode, the list must be surrounded
+                    by square brackets e.g. [group1, group2].
+
  --all-server-groups  - indicates that deploy should apply to all the available
                         server groups. Either server-groups or all-server-groups
                         is required in domain mode. This argument is not

--- a/cli/src/main/resources/help/module.txt
+++ b/cli/src/main/resources/help/module.txt
@@ -74,7 +74,8 @@ ARGUMENTS
 
  --properties    - (used with add, optional) a comma-separated list of
                    property_name=property_value pairs that will define module
-                   properties.
+                   properties. NOTE: In non-interactive mode this list must be
+                   surrounded by square brackets, e.g. [prop1=val1,prop2=val2].
                    NOTE: this argument makes sense only when the module.xml file
                    is generated, i.e. when the --module-xml argument isn't
                    specified.

--- a/cli/src/main/resources/help/undeploy.txt
+++ b/cli/src/main/resources/help/undeploy.txt
@@ -20,6 +20,9 @@ ARGUMENTS
                     all-relevant-server-groups is required in the domain mode.
                     This argument is not applicable in the standalone mode.
 
+                    NOTE: In non-interactive mode, the list must be surrounded
+                    by square brackets e.g. [group1, group2].
+
  --all-relevant-server-groups   - indicates that undeploy should apply to all
                                   the server groups in which the deployment is
                     enabled. Either server-groups or all-relevant-server-groups


### PR DESCRIPTION
Now covers --properties option in ASModuleHandler and the --server-groups options in DeployHandler and UndeployHandler.

JIRA: https://issues.jboss.org/browse/WFCORE-1360