### PR TITLE
WFCORE-794 IPv6ScopeIdMatchUnitTestCase fails with link-local subinterfaces

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/interfaces/IPv6ScopeIdMatchUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/interfaces/IPv6ScopeIdMatchUnitTestCase.java
@@ -125,7 +125,7 @@ public class IPv6ScopeIdMatchUnitTestCase {
                 }
 
                 matchCriteriaTest(hostAddress, nif, address, true);
-                if (address.isLinkLocalAddress() || address.isSiteLocalAddress()) {
+                if (!nif.isVirtual() && (address.isLinkLocalAddress() || address.isSiteLocalAddress())) {
                     matchCriteriaTest(hostAddress + "%" + nif.getName(), nif, address, true);
                     matchCriteriaTest(hostAddress + "%" + address.getScopeId(), nif, address, true);
                     matchCriteriaTest(hostAddress + "%" + (address.getScopeId() + 1), nif, address, false);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-794 - IPv6ScopeIdMatchUnitTestCase fails if some IPv6 subinterface exists

InetAddress.getByName(subInterface.getName()) returns null for virtual interfaces making the IPv6ScopeIdMatchUnitTestCase fail on servers with link-local IPv6 addressed sub-interfaces