### PR TITLE
WFCORE-1394 remove permgen defaults when started with no jvm configured

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmElement.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/jvm/JvmElement.java
@@ -73,7 +73,6 @@ public class JvmElement {
         if(name == null) {
             heapSize = "64m";
             maxHeap = "256m";
-            maxPermgen = "128m";
         }
         for(final ModelNode node : toCombine) {
             if(node == null) {


### PR DESCRIPTION
Note, we should probably add support for MetaSpacesize here too so we can get the current value from /host=foo/jvm, I experimented with this earlier, looks easy enough, I'll open as a separate Jira.