### PR TITLE
[WFCORE-1397] Fixed XnioWorker service installation in HttpManagementAddHandler for standalone mode

### DIFF
--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
@@ -158,6 +158,8 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler {
         final ServiceName requestProcessorName = UndertowHttpManagementService.SERVICE_NAME.append("requests");
         HttpManagementRequestsService.installService(requestProcessorName, serviceTarget);
 
+        NativeManagementServices.installManagementWorkerService(serviceTarget, context.getServiceRegistry(false));
+
         ServerEnvironment environment = (ServerEnvironment) context.getServiceRegistry(false).getRequiredService(ServerEnvironmentService.SERVICE_NAME).getValue();
         final UndertowHttpManagementService undertowService = new UndertowHttpManagementService(consoleMode, environment.getProductConfig().getConsoleSlot());
         ServiceBuilder<HttpManagement> undertowBuilder = serviceTarget.addService(UndertowHttpManagementService.SERVICE_NAME, undertowService)

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
@@ -75,6 +75,8 @@ public class NativeManagementAddHandler extends AbstractAddStepHandler {
 
         final ServiceName endpointName = ManagementRemotingServices.MANAGEMENT_ENDPOINT;
         final String hostName = WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.NODE_NAME, null);
+
+        NativeManagementServices.installManagementWorkerService(serviceTarget, context.getServiceRegistry(false));
         NativeManagementServices.installRemotingServicesIfNotInstalled(serviceTarget, hostName, context.getServiceRegistry(false));
         installNativeManagementConnector(context, model, endpointName, serviceTarget);
     }

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementServices.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementServices.java
@@ -21,15 +21,19 @@ class NativeManagementServices {
 
     private static final OptionMap OPTIONS = OptionMap.EMPTY;
 
+
+    static synchronized void installManagementWorkerService(final ServiceTarget serviceTarget, final ServiceRegistry serviceContainer) {
+        //install xnio mgmt worker
+        if (serviceContainer.getService(ManagementWorkerService.SERVICE_NAME) == null) {
+            ManagementWorkerService.installService(serviceTarget);
+        }
+    }
+
     static synchronized void installRemotingServicesIfNotInstalled(final ServiceTarget serviceTarget,
                                                                    final String hostName,
                                                                    final ServiceRegistry serviceContainer) {
 
         if (serviceContainer.getService(ManagementRemotingServices.MANAGEMENT_ENDPOINT) == null) {
-
-            //install xnio mgmt worker
-            ManagementWorkerService.installService(serviceTarget);
-
 
             ManagementChannelRegistryService.addService(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT);
 


### PR DESCRIPTION
This commit resolves a problem found with wildfly-core in standalone mode if http-upgrade-enabled configuration is false.

Jira issue link:
https://issues.jboss.org/browse/WFCORE-1397
