### PR TITLE
Remove deprecated annotation that appears to have been mistakenly added.

### DIFF
--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
@@ -30,7 +30,6 @@ public class ClientConstants {
     public static final String ADD = "add";
     public static final String ADDRESS = "address";
     public static final String ATTACHED_STREAMS = "attached-streams";
-    @Deprecated
     public static final String AUTO_START = "auto-start";
     public static final String CHILD_TYPE = "child-type";
     public static final String COMPOSITE = "composite";


### PR DESCRIPTION
The `@Deprecated` annotation appears to have been mistakenly added to the `ClientConstants.AUTO_START` constants. This just simply removes the `@Deprecated` annotation.