### PR TITLE
[WFCORE-1419] Do not set the recursive attribute on the read-resource operation if not explicitly defined.

### DIFF
--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/Operations.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/Operations.java
@@ -231,7 +231,7 @@ public class Operations {
      * @return the operation
      */
     public static ModelNode createReadResourceOperation(final ModelNode address) {
-        return createReadResourceOperation(address, false);
+        return createOperation(READ_RESOURCE_OPERATION, address);
     }
 
     /**


### PR DESCRIPTION
Removes the `recursive` attribute being defined on a `read-resource` operation if the `createReadResourceOperation(ModelNode address)` is used.
