### PR TITLE
[WFCORE-515] Unable to create create backup copies of configuration file if main file folder is unwritable by the WildFly process.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFile.java
@@ -444,21 +444,28 @@ public class ConfigurationFile {
         return mainFile;
     }
 
+    File getConfigurationDir(){
+        return configurationDir;
+    }
+
+
     /** Notification that boot has completed successfully and the configuration history should be updated */
     void successfulBoot() throws ConfigurationPersistenceException {
         synchronized (this) {
             if (doneBootup.get()) {
                 return;
             }
-
             final File copySource;
             if (!interactionPolicy.isReadOnly()) {
                 copySource = mainFile;
             } else {
-                // TODO WFCORE-515 in the !persistOriginal case, mainFile may not be in the
-                // configuration dir and writing to its dir may not be legal.
-                // Why not use the configuration dir?
-                copySource = new File(mainFile.getParentFile(), mainFile.getName() + ".boot");
+
+                if ( FilePersistenceUtils.isParentFolderWritable(mainFile) ) {
+                    copySource = new File(mainFile.getParentFile(), mainFile.getName() + ".boot");
+                } else{
+                    copySource = new File(configurationDir, mainFile.getName() + ".boot");
+                }
+
                 FilePersistenceUtils.deleteFile(copySource);
             }
 

--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFilePersistenceResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFilePersistenceResource.java
@@ -49,7 +49,14 @@ public class ConfigurationFilePersistenceResource extends AbstractFilePersistenc
 
     @Override
     public void doCommit(ExposedByteArrayOutputStream marshalled) {
-        final File tempFileName = FilePersistenceUtils.createTempFile(fileName);
+        final File tempFileName;
+
+        if ( FilePersistenceUtils.isParentFolderWritable(fileName) ){
+            tempFileName = FilePersistenceUtils.createTempFile(fileName);
+        }else{
+            tempFileName = FilePersistenceUtils.createTempFile(configurationFile.getConfigurationDir(), fileName.getName());
+        }
+
         try {
             try {
                 FilePersistenceUtils.writeToTempFile(marshalled, tempFileName, fileName);

--- a/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
@@ -49,7 +49,11 @@ import org.xnio.IoUtils;
 class FilePersistenceUtils {
 
     static File createTempFile(File fileName) {
-        return new File(fileName.getParentFile(), fileName.getName() + ".tmp");
+        return createTempFile(fileName.getParentFile(), fileName.getName());
+    }
+
+    static File createTempFile(File fileFolder, String fileName) {
+        return new File(fileFolder, fileName + ".tmp");
     }
 
     static ExposedByteArrayOutputStream marshalXml(final AbstractConfigurationPersister persister, final ModelNode model) throws ConfigurationPersistenceException {
@@ -156,5 +160,12 @@ class FilePersistenceUtils {
             }
         }
         return Collections.emptyList();
+    }
+
+    static boolean isParentFolderWritable(File file){
+        if ( !file.exists() || file.getParentFile() == null ){
+            return false;
+        }
+        return  file.getParentFile().canWrite();
     }
 }


### PR DESCRIPTION
Server is unable to start if it is started with --read-only-domain-config or --read-only-server-config using a folder unwritable by the Wildfly process. This commit resolves this issue using the configuration dir to create the configuration file backup

Jira issue:
https://issues.jboss.org/browse/WFCORE-515