### PR TITLE
[WFLY-4882] Ensure the ObjectList attribute is initialized with an em…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
@@ -194,6 +194,10 @@ public abstract class AttributeParser {
                 }
                 ParseUtils.requireNoContent(reader);
             }
+            // the object list element was specified but it is empty, so initialize it with an empty list.
+            if (!operation.get(attribute.getName()).isDefined()) {
+                operation.get(attribute.getName()).setEmptyList();
+            }
         }
     };
 


### PR DESCRIPTION
…pty list when its enclosing element is present but empty. 

This is being done so that in the security manager subsystem we are able to differentiate between an empty and an absent maximum permission set.

Link to the upstream Jira:
https://issues.jboss.org/browse/WFLY-4882
