### PR TITLE
[WFCORE-1442] Remove -XX:MaxMetaspaceSize=256m

### DIFF
--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/OldVersionTestRunner.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/OldVersionTestRunner.java
@@ -250,6 +250,11 @@ public class OldVersionTestRunner extends Suite {
                             " home from either -D" + prop);
                 }
                 System.setProperty("legacy.java.home", jdkHome);
+
+                //Server has this
+                //    private final String jvmArgs = System.getProperty("jvm.args", "-Xmx512m -XX:MaxMetaspaceSize=256m");
+                //-XX:MaxMetaspaceSize is not available < JDK 8, so remove it:
+                System.setProperty("jvm.args", "-Xmx512m");
             }
         }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1442

This only affects the client old server tests which have been failing for a while.

This branch now passes the test: https://ci.wildfly.org/viewLog.html?buildId=13333&tab=buildResultsDiv&buildTypeId=WildFlyCore_ClientOldServerLinux