### PR TITLE
[WFCORE-1444]: Fix schema as native-interface shouldn't be mandatory for host-management-interfaces

### DIFF
--- a/server/src/main/resources/schema/wildfly-config_4_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_4_0.xsd
@@ -1989,7 +1989,7 @@
 
     <xs:complexType name="host-management-interfacesType">
         <xs:sequence>
-            <xs:element name="native-interface" type="host-native-management-interfaceType" />
+            <xs:element name="native-interface" type="host-native-management-interfaceType" minOccurs="0"/>
             <xs:element name="http-interface" type="host-http-management-interfaceType" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>

--- a/server/src/main/resources/schema/wildfly-config_4_1.xsd
+++ b/server/src/main/resources/schema/wildfly-config_4_1.xsd
@@ -1990,7 +1990,7 @@
 
     <xs:complexType name="host-management-interfacesType">
         <xs:sequence>
-            <xs:element name="native-interface" type="host-native-management-interfaceType" />
+            <xs:element name="native-interface" type="host-native-management-interfaceType" minOccurs="0"/>
             <xs:element name="http-interface" type="host-http-management-interfaceType" minOccurs="0"/>
         </xs:sequence>
     </xs:complexType>


### PR DESCRIPTION
Adding minOccurs="0" for native-interface.

Jira: https://issues.jboss.org/browse/WFCORE-1444