### PR TITLE
[WFCORE-1446] :  EJB thread pool keepalive not honored and is not reusing inactive threads.

### DIFF
--- a/threads/src/main/java/org/jboss/as/threads/ManagedJBossThreadPoolExecutorService.java
+++ b/threads/src/main/java/org/jboss/as/threads/ManagedJBossThreadPoolExecutorService.java
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.jboss.threads.BlockingExecutor;
 import org.jboss.threads.EventListener;
 import org.jboss.threads.JBossExecutors;
-import org.jboss.threads.JBossThreadPoolExecutor;
+import org.jboss.threads.JBossThreadPoolExecutorReuseIdleThreads;
 
 /**
  *
@@ -36,9 +36,9 @@ import org.jboss.threads.JBossThreadPoolExecutor;
  */
 public class ManagedJBossThreadPoolExecutorService extends ManagedExecutorService implements BlockingExecutor {
 
-    private final JBossThreadPoolExecutor executor;
+    private final JBossThreadPoolExecutorReuseIdleThreads executor;
 
-    public ManagedJBossThreadPoolExecutorService(JBossThreadPoolExecutor executor) {
+    public ManagedJBossThreadPoolExecutorService(JBossThreadPoolExecutorReuseIdleThreads executor) {
         super(executor);
         this.executor = executor;
     }

--- a/threads/src/main/java/org/jboss/as/threads/UnboundedQueueThreadPoolService.java
+++ b/threads/src/main/java/org/jboss/as/threads/UnboundedQueueThreadPoolService.java
@@ -32,7 +32,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-import org.jboss.threads.JBossThreadPoolExecutor;
+import org.jboss.threads.JBossThreadPoolExecutorReuseIdleThreads;
 
 /**
  * Service responsible for creating, starting and stopping a thread pool executor with an unbounded queue.
@@ -55,7 +55,7 @@ public class UnboundedQueueThreadPoolService implements Service<ManagedJBossThre
     public synchronized void start(final StartContext context) throws StartException {
         final TimeSpec keepAliveSpec = keepAlive;
         long keepAliveTime = keepAliveSpec == null ? Long.MAX_VALUE : keepAliveSpec.getUnit().toNanos(keepAliveSpec.getDuration());
-        final JBossThreadPoolExecutor jbossExecutor = new JBossThreadPoolExecutor(maxThreads, maxThreads, keepAliveTime, TimeUnit.NANOSECONDS, new LinkedBlockingQueue<Runnable>(), threadFactoryValue.getValue());
+        final JBossThreadPoolExecutorReuseIdleThreads jbossExecutor = new JBossThreadPoolExecutorReuseIdleThreads((int)(maxThreads/2), maxThreads, keepAliveTime, TimeUnit.NANOSECONDS, new LinkedBlockingQueue<Runnable>(), threadFactoryValue.getValue());
         executor = new ManagedJBossThreadPoolExecutorService(jbossExecutor);
     }
 


### PR DESCRIPTION
[WFCORE-1446] : https://issues.jboss.org/browse/WFCORE-1446

Note : The PR will fail till jbossas/jboss-threads#19 is included.
This PR does not include the addition of the core-threads in the management model.