### PR TITLE
WFCORE-1448 AttributeParser for ObjectListAttributeDefinitions doesn'…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AttributeMarshaller.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeMarshaller.java
@@ -205,4 +205,8 @@ public abstract class AttributeMarshaller {
 
 
     public static final AttributeMarshaller OBJECT_LIST_MARSHALLER = new ObjectListMarshaller();
+
+    public static final AttributeMarshaller PROPERTIES_MARSHALLER = new AttributeMarshallers.PropertiesAttributeMarshaller();
+
+    public static final AttributeMarshaller PROPERTIES_MARSHALLER_UNWRAPPED = new AttributeMarshallers.PropertiesAttributeMarshaller(null, false);
 }

--- a/controller/src/main/java/org/jboss/as/controller/AttributeMarshallers.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeMarshallers.java
@@ -55,12 +55,15 @@ public interface AttributeMarshallers {
 
         @Override
         public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
-            if (!resourceModel.hasDefined(attribute.getName())) {
+            String wrapper =  wrapperElement == null ? attribute.getName() : wrapperElement;
+            resourceModel = resourceModel.get(attribute.getName());
+            if (!resourceModel.isDefined()){//this is scenario to handle WFCORE-1448 cases
+                writer.writeEmptyElement(wrapper);
                 return;
             }
-            resourceModel = resourceModel.get(attribute.getName());
+
             if (wrapElement) {
-                writer.writeStartElement(wrapperElement == null ? attribute.getName() : wrapperElement);
+                writer.writeStartElement(wrapper);
             }
             for (ModelNode property : resourceModel.asList()) {
                 writer.writeEmptyElement(elementName);

--- a/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
@@ -174,9 +174,11 @@ public abstract class AttributeParser {
             Map<String, AttributeDefinition> attributes = Arrays.asList(valueTypes).stream()
                     .collect(Collectors.toMap(AttributeDefinition::getXmlName,
                             Function.identity()));
+            ModelNode listValue = new ModelNode();
+            listValue.setEmptyList();
             while (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT) {
                 if (objectType.getXmlName().equals(reader.getLocalName())){
-                    ModelNode op = operation.get(attribute.getName()).add();
+                    ModelNode op = listValue.add();
                     for (int i = 0; i < reader.getAttributeCount(); i++) {
                         String attributeName = reader.getAttributeLocalName(i);
                         String value = reader.getAttributeValue(i);
@@ -194,6 +196,7 @@ public abstract class AttributeParser {
                 }
                 ParseUtils.requireNoContent(reader);
             }
+            operation.get(attribute.getName()).set(listValue);
         }
     };
 
@@ -252,5 +255,9 @@ public abstract class AttributeParser {
             return new ModelNode();
         }
     }
+
+    public static final AttributeParser PROPERTIES_PARSER = new AttributeParsers.PropertiesParser();
+
+    public static final AttributeParser PROPERTIES_PARSER_UNWRAPPED = new AttributeParsers.PropertiesParser(false);
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/AttributeParsers.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeParsers.java
@@ -76,7 +76,7 @@ public interface AttributeParsers {
             assert attribute instanceof PropertiesAttributeDefinition;
             PropertiesAttributeDefinition property = (PropertiesAttributeDefinition) attribute;
             String wrapper = wrapperElement == null ? property.getName() : wrapperElement;
-
+            operation.get(attribute.getName()).setEmptyObject();//create empty attribute to address WFCORE-1448
             if (wrapElement) {
                 if (!reader.getLocalName().equals(wrapper)) {
                     throw ParseUtils.unexpectedElement(reader, Collections.singleton(wrapper));
@@ -98,7 +98,7 @@ public interface AttributeParsers {
             } while (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT && reader.getLocalName().equals(elementName));
 
             if (wrapElement) {
-                if (!reader.getLocalName().equals(wrapperElement)) {
+                if (!reader.getLocalName().equals(wrapper)) {
                     ParseUtils.requireNoContent(reader);
                 }
             }

--- a/controller/src/main/java/org/jboss/as/controller/ExpressionResolverImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExpressionResolverImpl.java
@@ -90,6 +90,7 @@ public class ExpressionResolverImpl implements ExpressionResolver {
         } else if (type == ModelType.LIST) {
             resolved = node.clone();
             ModelNode list = new ModelNode();
+            list.setEmptyList();
             for (ModelNode current : resolved.asList()) {
                 list.add(resolveExpressionsRecursively(current));
             }

--- a/controller/src/main/java/org/jboss/as/controller/ObjectListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ObjectListAttributeDefinition.java
@@ -134,11 +134,11 @@ public class ObjectListAttributeDefinition extends ListAttributeDefinition {
         if (superResult.getType() != ModelType.LIST) {
             return superResult;
         }
-
         // Resolve each element.
         // Don't mess with the original value
         ModelNode clone = superResult == value ? value.clone() : superResult;
         ModelNode result = new ModelNode();
+        result.setEmptyList();
         for (ModelNode element : clone.asList()) {
             result.add(valueType.resolveValue(resolver, element));
         }
@@ -228,6 +228,7 @@ public class ObjectListAttributeDefinition extends ListAttributeDefinition {
     ObjectTypeAttributeDefinition getValueType() {
         return valueType;
     }
+
 
     public static final class Builder extends ListAttributeDefinition.Builder<Builder, ObjectListAttributeDefinition> {
         private final ObjectTypeAttributeDefinition valueType;

--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -1,16 +1,5 @@
 package org.jboss.as.controller;
 
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.logging.ControllerLogger;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.parsing.Element;
-import org.jboss.as.controller.parsing.ParseUtils;
-import org.jboss.dmr.ModelNode;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
-import org.jboss.staxmapper.XMLExtendedStreamWriter;
-
-import javax.xml.stream.XMLStreamConstants;
-import javax.xml.stream.XMLStreamException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -22,6 +11,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.Element;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
@@ -41,7 +41,7 @@ public final class PersistentResourceXMLDescription {
     protected final String xmlWrapperElement;
     protected final LinkedHashMap<String, LinkedHashMap<String, AttributeDefinition>> attributesByGroup;
     protected final List<PersistentResourceXMLDescription> children;
-    protected final Map<String,AttributeDefinition> attributeElements =  new HashMap<>();
+    protected final Map<String, AttributeDefinition> attributeElements = new HashMap<>();
     protected final boolean useValueAsElementName;
     protected final boolean noAddOperation;
     protected final AdditionalOperationsGenerator additionalOperationsGenerator;
@@ -80,15 +80,15 @@ public final class PersistentResourceXMLDescription {
                 }
                 forGroup.put(ad.getXmlName(), ad);
 
-                if (ad.getParser()!=null&&ad.getParser().isParseAsElement()){
+                if (ad.getParser() != null && ad.getParser().isParseAsElement()) {
                     attributeElements.put(ad.getParser().getXmlName(ad), ad);
                 }
 
             }
         } else {
-            LinkedHashMap<String,AttributeDefinition> attrs = new LinkedHashMap<>();
+            LinkedHashMap<String, AttributeDefinition> attrs = new LinkedHashMap<>();
             for (AttributeDefinition ad : builder.attributeList) {
-                    attrs.put(ad.getXmlName(), ad);
+                attrs.put(ad.getXmlName(), ad);
             }
             // Ignore attribute-group, treat all as if they are in the default group
             this.attributesByGroup.put(null, attrs);
@@ -139,17 +139,17 @@ public final class PersistentResourceXMLDescription {
 
     private String parseAttributeGroups(final XMLExtendedStreamReader reader, ModelNode op, boolean wildcard) throws XMLStreamException {
         String name = parseAttributes(reader, op, attributesByGroup.get(null), wildcard); //parse attributes not belonging to a group
-        if (!attributeGroups.isEmpty()){
+        if (!attributeGroups.isEmpty()) {
             while (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT) {
                 boolean element = attributeElements.containsKey(reader.getLocalName());
                 //it can be a group or element attribute
-                if (attributeGroups.contains(reader.getLocalName()) ||element) {
+                if (attributeGroups.contains(reader.getLocalName()) || element) {
                     if (element) {
                         AttributeDefinition ad = attributeElements.get(reader.getLocalName());
                         ad.getParser().parseElement(ad, reader, op);
-                        if (attributeGroups.contains(reader.getLocalName()) ){
+                        if (attributeGroups.contains(reader.getLocalName())) {
                             parseGroup(reader, op, wildcard);
-                        }else if (reader.isEndElement() && !attributeGroups.contains(reader.getLocalName())&& !attributeElements.containsKey(reader.getLocalName())){
+                        } else if (reader.isEndElement() && !attributeGroups.contains(reader.getLocalName()) && !attributeElements.containsKey(reader.getLocalName())) {
                             childAlreadyRead = true;
                             break;
                         }
@@ -174,6 +174,7 @@ public final class PersistentResourceXMLDescription {
             if (reader.nextTag() == START_ELEMENT && attributeElements.containsKey(reader.getLocalName())) {
                 AttributeDefinition ad = attributeElements.get(reader.getLocalName());
                 ad.getParser().parseElement(ad, reader, op);
+                ParseUtils.requireNoContent(reader);
             } else if (reader.getEventType() != END_ELEMENT) {
                 throw ParseUtils.unexpectedElement(reader);
             }
@@ -197,7 +198,7 @@ public final class PersistentResourceXMLDescription {
             }
         }
         //only pare attribute elements here if there are no attribute groups defined
-        if (attributeGroups.isEmpty()&&!attributeElements.isEmpty()&&reader.isStartElement()) {
+        if (attributeGroups.isEmpty() && !attributeElements.isEmpty() && reader.isStartElement()) {
             String originalStartElement = reader.getLocalName();
             if (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT) {
                 do {
@@ -205,13 +206,12 @@ public final class PersistentResourceXMLDescription {
                         AttributeDefinition ad = attributeElements.get(reader.getLocalName());
                         ad.getParser().parseElement(ad, reader, op);
                     } else {
-                        throw ParseUtils.unexpectedElement(reader, attributeElements.keySet());
+                        return name;  //this means we only have children left, return so child handling logic can take over
                     }
                     childAlreadyRead = true;
                 } while (!reader.getLocalName().equals(originalStartElement) && reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT);
             }
         }
-
 
 
         return name;
@@ -257,7 +257,7 @@ public final class PersistentResourceXMLDescription {
                             child.parse(reader, parentAddress, list);
                         }
 
-                    } else if (attributeElements.containsKey(reader.getLocalName())){
+                    } else if (attributeElements.containsKey(reader.getLocalName())) {
                         AttributeDefinition ad = attributeElements.get(reader.getLocalName());
                         ad.getParser().parseElement(ad, reader, op);
                     } else {
@@ -352,13 +352,13 @@ public final class PersistentResourceXMLDescription {
     }
 
     private void persistAttributes(XMLExtendedStreamWriter writer, ModelNode model) throws XMLStreamException {
-        marshallAttributes(writer,model,attributesByGroup.get(null).values(), null);
+        marshallAttributes(writer, model, attributesByGroup.get(null).values(), null);
         if (useElementsForGroups) {
             for (Map.Entry<String, LinkedHashMap<String, AttributeDefinition>> entry : attributesByGroup.entrySet()) {
                 if (entry.getKey() == null) {
                     continue;
                 }
-                marshallAttributes(writer,model,entry.getValue().values(), entry.getKey());
+                marshallAttributes(writer, model, entry.getValue().values(), entry.getKey());
             }
         }
     }
@@ -514,6 +514,7 @@ public final class PersistentResourceXMLDescription {
 
         /**
          * If set to false, default attribute values won't be persisted
+         *
          * @param marshallDefault weather default values should be persisted or not.
          * @return builder
          */
@@ -526,6 +527,7 @@ public final class PersistentResourceXMLDescription {
          * Sets name for "name" attribute that is used for wildcard resources.
          * It defines name of attribute one resource xml element to be used for such identifier
          * If not set it defaults to "name"
+         *
          * @param nameAttributeName xml attribute name to be used for resource name
          * @return builder
          */

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/mail-parser.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/mail-parser.xml
@@ -18,6 +18,7 @@
 
 <subsystem xmlns="urn:jboss:domain:test:1.0">
     <mail-session session-name="custom" >
+        <properties />
         <custom-server name="smtp" buffer-size="10">
             <property name="host" value="mail.example.com"/>
         </custom-server>

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/server-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/server-subsystem.xml
@@ -17,11 +17,12 @@
   -->
 
 <subsystem xmlns="urn:jboss:domain:test:1.0">
-    <server name="default" >
-            <security enabled="${security.enabled:false}" />
-            <statistics enabled="${statistics.enabled:true}" />
-            <buffer-cache name="default" buffer-size="1025" buffers-per-region="1054" max-regions="15" alias="entry1 entry2 entry3" />
-      </server>
-  <server name="bar"> <!-- we are testing if parsing empty tags works properly -->
-  </server>
+    <server name="default">
+        <interceptors />
+        <security enabled="${security.enabled:false}"/>
+        <statistics enabled="${statistics.enabled:true}"/>
+        <buffer-cache name="default" buffer-size="1025" buffers-per-region="1054" max-regions="15" alias="entry1 entry2 entry3"/>
+    </server>
+    <server name="bar"> <!-- we are testing if parsing empty tags works properly -->
+    </server>
 </subsystem>


### PR DESCRIPTION
…t differentiate between empty and absent object lists

- also fixes WFCORE-1440 Expression resolver breaks return value for empty lists
- fixes rare scenario in which wrapped properties attribute without group would fail if same element also had child resources
- make sure that same thing applys also to maps
- add convinence method ObjectListAttributeDefinition.unwarp

downstream jiras JBEAP-3924 JBEAP-408