### PR TITLE
[WFCORE-701] Apply changes to get a consistence between the HC's view state and server's own view state when the server process is stopped

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
@@ -454,8 +454,13 @@ class ManagedServer {
         if(required == InternalState.STOPPED && state == InternalState.PROCESS_STOPPING) {
             finishTransition(InternalState.PROCESS_STOPPING, InternalState.PROCESS_STOPPED);
         } else {
-            this.requiredState = InternalState.FAILED;
-            internalSetState(null, state, InternalState.PROCESS_STOPPED);
+            this.requiredState = InternalState.STOPPED;
+            if ( !(internalSetState(getTransitionTask(InternalState.PROCESS_STOPPING), internalState, InternalState.PROCESS_STOPPING)
+                    && internalSetState(getTransitionTask(InternalState.PROCESS_REMOVING), internalState, InternalState.PROCESS_REMOVING)
+                    && internalSetState(getTransitionTask(InternalState.STOPPED), internalState, InternalState.STOPPED)) ){
+                this.requiredState = InternalState.FAILED;
+                internalSetState(null, internalState, InternalState.PROCESS_STOPPED);
+            }
         }
     }
 


### PR DESCRIPTION
The status reported by the HC's view of server management lifecycle is different from the status reported by the server's itself. This commit tries to avoid that discrepancy if the server was stopped by an action, which wasn't initialized by the HC. In that case instead of report FAILED from the HC's view, now STOPPED is reported if the server was successful stopped.

Jira issue:
https://issues.jboss.org/browse/WFCORE-701
