### PR TITLE
[WFCORE-1458] remove extra realm name block check which changes add-user.sh scripts layout after adding a new user.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/UserPropertiesFileLoader.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/UserPropertiesFileLoader.java
@@ -155,36 +155,6 @@ public class UserPropertiesFileLoader extends PropertiesFileLoader {
         }
     }
 
-    /**
-     * Remove the realm name block.
-     *
-     * @see PropertiesFileLoader#addLineContent(java.io.BufferedReader, java.util.List, String)
-     */
-    @Override
-    protected void addLineContent(BufferedReader bufferedFileReader, List<String> content, String line) throws IOException {
-        // Is the line an empty comment "#" ?
-        if (line.startsWith(COMMENT_PREFIX) && line.length() == 1) {
-            String nextLine = bufferedFileReader.readLine();
-            if (nextLine != null) {
-                // Is the next line the realm name "#$REALM_NAME=" ?
-                if (nextLine.startsWith(COMMENT_PREFIX) && nextLine.contains(REALM_COMMENT_PREFIX)) {
-                    // Realm name block detected!
-                    // The next line must be and empty comment "#"
-                    bufferedFileReader.readLine();
-                    // Avoid adding the realm block
-                } else {
-                    // It's a user comment...
-                    content.add(line);
-                    content.add(nextLine);
-                }
-            } else {
-                super.addLineContent(bufferedFileReader, content, line);
-            }
-        } else {
-            super.addLineContent(bufferedFileReader, content, line);
-        }
-    }
-
     private void writeRealm(final BufferedWriter bw, final String realmName) throws IOException {
         bw.append(COMMENT_PREFIX);
         bw.newLine();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1458

Method UserPropertiesFileLoader.addLineContent was added in https://github.com/wildfly/wildfly/pull/4878
This method attempts to remove realm name and rewrite no matter if -r or --realm presents while adding a new user with add-user.sh. This causes problem in jira above. However, you can not define any new realm name if it's not first in properties file due to following exception from DomainManagementLogger.userRealmNotMatchDiscovered

> AddUserFailedException: WFLYDM0065: The user supplied realm name 'AnotherManagementRealm' does not match the realm name discovered from the property file(s) 'ManagementRealm'.
