### PR TITLE
[WFCORE-1460] Ensure tests don't leave a running server in reload-required state

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/access/constraint/ApplicationTypeConstraint.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/constraint/ApplicationTypeConstraint.java
@@ -122,17 +122,31 @@ public class ApplicationTypeConstraint extends AllowAllowNotConstraint {
             return false;
         }
 
-        public void addApplicationTypeConfig(ApplicationTypeConfig applicationTypeConfig) {
+        /**
+         * Stores an ApplicationTypeConfig for use in constraints.
+         *
+         * @param applicationTypeConfig the config
+         * @return either the provided confing, or if a compatible one with the same key is already present, that one
+         *
+         * @throws AssertionError if a config with the same key is already register and it is not
+         *           {@linkplain ApplicationTypeConfig#isCompatibleWith(ApplicationTypeConfig)} compatible with} the
+         *           one to be added
+         */
+        public ApplicationTypeConfig addApplicationTypeConfig(ApplicationTypeConfig applicationTypeConfig) {
             ApplicationTypeConfig.Key key = applicationTypeConfig.getKey();
             ApplicationTypeConfig existing = typeConfigs.get(key);
+            ApplicationTypeConfig result;
             if (existing == null) {
                 typeConfigs.put(key, applicationTypeConfig);
+                result = applicationTypeConfig;
             } else {
                 // Check for programming error -- ApplicationTypeConfigs with same key created with
                 // differing default settings
                 assert existing.isCompatibleWith(applicationTypeConfig)
                         : "incompatible " + applicationTypeConfig.getClass().getSimpleName();
+                result = existing;
             }
+            return result;
         }
 
 

--- a/controller/src/main/java/org/jboss/as/controller/access/constraint/SensitiveTargetConstraint.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/constraint/SensitiveTargetConstraint.java
@@ -129,17 +129,31 @@ public class SensitiveTargetConstraint extends AllowAllowNotConstraint {
             return false;
         }
 
-        public final void addSensitivity(SensitivityClassification sensitivity) {
+        /**
+         * Stores a sensitivity classification for use in constraints.
+         *
+         * @param sensitivity the classification
+         * @return either the provided classification, or if a compatible one with the same key is already present, that one
+         *
+         * @throws AssertionError if a classification with the same key is already register and it is not
+         *           {@linkplain SensitivityClassification#isCompatibleWith(AbstractSensitivity) compatible with} the
+         *           one to be added
+         */
+        public final SensitivityClassification addSensitivity(SensitivityClassification sensitivity) {
             SensitivityClassification.Key key = sensitivity.getKey();
             SensitivityClassification existing = sensitivities.get(key);
+            SensitivityClassification result;
             if (existing == null) {
                 sensitivities.put(key, sensitivity);
+                result = sensitivity;
             } else {
                 // Check for programming error -- SensitivityClassification with same key created with
                 // differing default settings
                 assert existing.isCompatibleWith(sensitivity)
                         : "incompatible " + sensitivity.getClass().getSimpleName();
+                result = existing;
             }
+            return result;
         }
 
         public Collection<SensitivityClassification> getSensitivities(){

--- a/controller/src/main/java/org/jboss/as/controller/access/management/ApplicationTypeAccessConstraintDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/management/ApplicationTypeAccessConstraintDefinition.java
@@ -47,10 +47,11 @@ public class ApplicationTypeAccessConstraintDefinition implements AccessConstrai
     private final AccessConstraintKey key;
 
     public ApplicationTypeAccessConstraintDefinition(ApplicationTypeConfig applicationTypeConfig) {
-        this.applicationTypeConfig = applicationTypeConfig;
-        this.key = new AccessConstraintKey(ModelDescriptionConstants.APPLICATION_CLASSIFICATION, applicationTypeConfig.isCore(),
-                applicationTypeConfig.getSubsystem(), applicationTypeConfig.getName());
-        ApplicationTypeConstraint.FACTORY.addApplicationTypeConfig(applicationTypeConfig);
+        // Register this applicationTypeConfig, and if a compatible one is already registered, use that instead
+        ApplicationTypeConfig toUse = ApplicationTypeConstraint.FACTORY.addApplicationTypeConfig(applicationTypeConfig);
+        this.applicationTypeConfig = toUse;
+        this.key = new AccessConstraintKey(ModelDescriptionConstants.APPLICATION_CLASSIFICATION, toUse.isCore(),
+                toUse.getSubsystem(), toUse.getName());
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/access/management/SensitiveTargetAccessConstraintDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/management/SensitiveTargetAccessConstraintDefinition.java
@@ -65,10 +65,11 @@ public class SensitiveTargetAccessConstraintDefinition implements AccessConstrai
     private final AccessConstraintKey key;
 
     public SensitiveTargetAccessConstraintDefinition(SensitivityClassification sensitivity) {
-        this.sensitivity = sensitivity;
-        this.key = new AccessConstraintKey(ModelDescriptionConstants.SENSITIVITY_CLASSIFICATION, sensitivity.isCore(),
-                sensitivity.getSubsystem(), sensitivity.getName());
-        SensitiveTargetConstraint.FACTORY.addSensitivity(sensitivity);
+        // Register this sensitivity, and if a compatible one is already registered, use that instead
+        final SensitivityClassification toUse = SensitiveTargetConstraint.FACTORY.addSensitivity(sensitivity);
+        this.sensitivity = toUse;
+        this.key = new AccessConstraintKey(ModelDescriptionConstants.SENSITIVITY_CLASSIFICATION, toUse.isCore(),
+                toUse.getSubsystem(), toUse.getName());
     }
 
     public SensitivityClassification getSensitivity() {

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/FilteredReadResourceTestCase.java
@@ -87,7 +87,7 @@ public class FilteredReadResourceTestCase extends AbstractRbacTestBase {
         operation = Util.createOperation(ADD, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, BAR));
         executeWithRoles(operation, StandardRole.SUPERUSER);
 
-        MY_SENSITIVITY.setConfiguredRequiresAccessPermission(true);
+        MY_SENSITIVE_CONSTRAINT.getSensitivity().setConfiguredRequiresAccessPermission(true);
     }
 
     @Test
@@ -153,7 +153,7 @@ public class FilteredReadResourceTestCase extends AbstractRbacTestBase {
         assertEquals(1, filteredTypes.asInt());
         assertEquals(SENSITIVE_CONSTRAINED_RESOURCE, filteredTypes.get(0).asString());
 
-        MY_SENSITIVITY.setConfiguredRequiresAccessPermission(false);
+        MY_SENSITIVE_CONSTRAINT.getSensitivity().setConfiguredRequiresAccessPermission(false);
         result = executeWithRole(operation, StandardRole.MONITOR);
         assertEquals(SUCCESS, result.get(OUTCOME).asString());
         assertEquals(ModelType.LIST, result.get(RESULT).getType());
@@ -193,10 +193,8 @@ public class FilteredReadResourceTestCase extends AbstractRbacTestBase {
 
     // model definition
 
-    private static final SensitivityClassification MY_SENSITIVITY
-            = new SensitivityClassification("test", "my-sensitivity", true, true, true);
-    private static final AccessConstraintDefinition MY_SENSITIVE_CONSTRAINT
-            = new SensitiveTargetAccessConstraintDefinition(MY_SENSITIVITY);
+    private static final SensitiveTargetAccessConstraintDefinition MY_SENSITIVE_CONSTRAINT
+            = new SensitiveTargetAccessConstraintDefinition(new SensitivityClassification("test", "my-sensitivity", true, true, true));
 
     @Override
     protected void initModel(ManagementModel managementModel) {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingPreferencesTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/LoggingPreferencesTestCase.java
@@ -42,6 +42,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
@@ -52,6 +53,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author <a href="mailto:pkremens@redhat.com">Petr Kremensky</a>
  */
 @RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
 public class LoggingPreferencesTestCase extends AbstractLoggingTestCase {
 
     private static final String DEPLOYMENT_LOG_MESSAGE = "Deployment logging configuration message.";
@@ -63,17 +65,22 @@ public class LoggingPreferencesTestCase extends AbstractLoggingTestCase {
     private static final String FILE_HANDLER_FILE_NAME = "custom-file-logger.log";
     private static final String PER_DEPLOY_FILE_NAME = "per-deploy-logging.log";
 
-    private static final Path profileLog = getAbsoluteLogFilePath(FILE_HANDLER_FILE_NAME);
-    private static final Path perDeployLog = getAbsoluteLogFilePath(PER_DEPLOY_FILE_NAME);
-
     private static final ModelNode PROFILE_ADDRESS = createAddress("logging-profile", PROFILE_NAME);
     private static final ModelNode ROOT_LOGGER_ADDRESS = createAddress("logging-profile", PROFILE_NAME, "root-logger", "ROOT");
     private static final ModelNode FILE_HANDLER_ADDRESS = createAddress("logging-profile", PROFILE_NAME, FILE_HANDLER, FILE_HANDLER_NAME);
+
+    private Path profileLog;
+    private Path perDeployLog;
 
     @Before
     public void prepareContainer() throws Exception {
         // Start the container
         container.start();
+
+        if (profileLog == null) {
+            profileLog = getAbsoluteLogFilePath(FILE_HANDLER_FILE_NAME);
+            perDeployLog = getAbsoluteLogFilePath(PER_DEPLOY_FILE_NAME);
+        }
 
         final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
         // Create a new logging profile

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ApplicationTypeTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ApplicationTypeTestCase.java
@@ -46,11 +46,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.integration.management.rbac.Outcome;
 import org.jboss.as.test.integration.management.rbac.RbacUtil;
-import org.jboss.as.test.integration.management.util.MgmtOperationException;
-import org.jboss.as.test.integration.mgmt.access.extension.ExtensionSetup;
 import org.jboss.dmr.ModelNode;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
@@ -60,17 +56,8 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author Ladislav Thon <lthon@redhat.com>
  */
 @RunWith(WildflyTestRunner.class)
-@ServerSetup({StandardUsersSetupTask.class, BasicExtensionSetupTask.class})
+@ServerSetup({StandardUsersSetupTask.class, StandardExtensionSetupTask.class})
 public class ApplicationTypeTestCase extends AbstractRbacTestCase {
-    @BeforeClass
-    public static void createResource() throws IOException, MgmtOperationException {
-        ExtensionSetup.addResources(managementClient);
-    }
-
-    @AfterClass
-    public static void removeResources() throws IOException, MgmtOperationException {
-        ExtensionSetup.removeResources(managementClient);
-    }
 
     @Test
     public void testMonitor() throws Exception {

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ConfigurationChangesHistoryTestCase.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ConfigurationChangesHistoryTestCase.java
@@ -78,6 +78,7 @@ import org.jboss.as.domain.management.ConfigurationChangeResourceDefinition;
 import org.jboss.as.test.integration.management.interfaces.CliManagementInterface;
 import org.jboss.as.test.integration.management.interfaces.ManagementInterface;
 import org.jboss.as.test.integration.management.rbac.RbacAdminCallbackHandler;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Before;
@@ -92,7 +93,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
 @RunWith(WildflyTestRunner.class)
-@ServerSetup({StandardUsersSetupTask.class})
+@ServerSetup({ServerReload.SetupTask.class, StandardUsersSetupTask.class})
 public class ConfigurationChangesHistoryTestCase extends AbstractManagementInterfaceRbacTestCase {
 
     private static final int MAX_HISTORY_SIZE = 8;

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/StandardExtensionSetupTask.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/StandardExtensionSetupTask.java
@@ -41,6 +41,7 @@ public class StandardExtensionSetupTask implements ServerSetupTask {
 
     @Override
     public void tearDown(ManagementClient managementClient) throws Exception {
+        ExtensionSetup.removeResources(managementClient);
         ExtensionSetup.removeExtensionAndSubsystem(managementClient);
     }
 }

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
@@ -27,10 +27,10 @@ package org.jboss.as.test.integration.mgmt.access.extension;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -101,7 +101,7 @@ public class ConstrainedResource extends SimpleResourceDefinition {
     public ConstrainedResource(PathElement pathElement) {
         super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
                 .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN))
-                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("rbac", "datasource"))));
     }
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ExtensionSetup.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ExtensionSetup.java
@@ -142,17 +142,20 @@ public class ExtensionSetup {
         PathAddress subsystemAddress = PathAddress.pathAddress(SUBSYSTEM, "rbac");
         ModelNode removeConstrained = Util.createRemoveOperation(subsystemAddress.append("rbac-constrained", "default"));
         removeConstrained.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-        client.getControllerClient().execute(removeConstrained);
+        executeForResult(client.getControllerClient(), removeConstrained);
         ModelNode removeSensitive = Util.createRemoveOperation(subsystemAddress.append("rbac-sensitive", "other"));
         removeSensitive.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-        client.getControllerClient().execute(removeSensitive);
+        executeForResult(client.getControllerClient(), removeSensitive);
     }
 
     public static void removeExtensionAndSubsystem(final ManagementClient client) throws IOException, MgmtOperationException {
-        removeResources(client);
+        //removeResources(client);
+        ModelNode removeSubsystem = Util.createRemoveOperation(PathAddress.pathAddress(SUBSYSTEM, "rbac"));
+        removeSubsystem.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        executeForResult(client.getControllerClient(), removeSubsystem);
         ModelNode removeExtension = Util.createRemoveOperation(PathAddress.pathAddress(EXTENSION, TestExtension.MODULE_NAME));
         removeExtension.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-        client.getControllerClient().execute(removeExtension);
+        executeForResult(client.getControllerClient(), removeExtension);
     }
 
     static StreamExporter createResourceRoot(Class<? extends Extension> extension, Package... additionalPackages) throws IOException {

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/RootResourceDefinition.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/RootResourceDefinition.java
@@ -27,10 +27,10 @@ package org.jboss.as.test.integration.mgmt.access.extension;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
+import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
-import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -49,13 +49,13 @@ public class RootResourceDefinition extends SimpleResourceDefinition {
 
     public RootResourceDefinition(String name) {
         super(PathElement.pathElement(SUBSYSTEM, name), new NonResolvingResourceDescriptionResolver(),
-                new AddSubsystemHandler(), ReloadRequiredRemoveStepHandler.INSTANCE);
+                new AddSubsystemHandler(), ModelOnlyRemoveStepHandler.INSTANCE);
     }
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
-        resourceRegistration.registerReadWriteAttribute(NAME, null, new ReloadRequiredWriteAttributeHandler(NAME));
+        resourceRegistration.registerReadWriteAttribute(NAME, null, new ModelOnlyWriteAttributeHandler(NAME));
     }
 
     @Override

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/SensitiveResource.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/SensitiveResource.java
@@ -26,8 +26,8 @@ package org.jboss.as.test.integration.mgmt.access.extension;
 
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
@@ -42,7 +42,7 @@ public class SensitiveResource extends SimpleResourceDefinition {
     public SensitiveResource(PathElement pathElement) {
         super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
                 .setAddHandler(new AbstractAddStepHandler())
-                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
+                .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN,
                         new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("rbac", "security-domain"))));
     }

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/TestExtension.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/TestExtension.java
@@ -37,16 +37,16 @@ import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
  */
 public class TestExtension implements Extension {
 
-    static final String SUBSYSTEM_NAME = "test-extension";
-    static final String SUBSYSTEM_NAMESPACE = "urn:wildfly:test:test-extension:1.0";
-    public static final String MODULE_NAME = "org.wildfly.test.extension";
+    private static final String SUBSYSTEM_NAME = "rbac";
+    private static final String SUBSYSTEM_NAMESPACE = "urn:wildfly:test:test-extension:1.0";
+    static final String MODULE_NAME = "org.wildfly.test.extension";
 
 
     @Override
     public void initialize(ExtensionContext context) {
         System.out.println("Initializing TestExtension");
         SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1, 0, 0));
-        ManagementResourceRegistration rootRbacRegistration = registration.registerSubsystemModel(new RootResourceDefinition("rbac"));
+        ManagementResourceRegistration rootRbacRegistration = registration.registerSubsystemModel(new RootResourceDefinition(SUBSYSTEM_NAME));
         rootRbacRegistration.registerSubModel(new ConstrainedResource(PathElement.pathElement("rbac-constrained")));
         rootRbacRegistration.registerSubModel(new SensitiveResource(PathElement.pathElement("rbac-sensitive")));
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
@@ -109,7 +110,7 @@ public class BlockerExtension implements Extension {
         private BlockerSubsystemResourceDefinition(boolean forHost) {
             super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver(),
                     new AbstractAddStepHandler(),
-                    ReloadRequiredRemoveStepHandler.INSTANCE);
+                    ModelOnlyRemoveStepHandler.INSTANCE);
             this.forHost = forHost;
         }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -43,7 +43,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -132,7 +131,7 @@ public class BlockerExtension implements Extension {
         }
     }
 
-    public static enum BlockPoint {
+    public enum BlockPoint {
         MODEL,
         RUNTIME,
         SERVICE_START,
@@ -146,6 +145,7 @@ public class BlockerExtension implements Extension {
 
         private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("block", new NonResolvingResourceDescriptionResolver())
                 .setParameters(CALLER, TARGET_HOST, TARGET_SERVER, BLOCK_POINT, BLOCK_TIME)
+                .setRuntimeOnly()
                 .build();
 
         @Override

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/streams/LogStreamExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/streams/LogStreamExtension.java
@@ -35,6 +35,7 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
@@ -42,7 +43,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -98,7 +98,7 @@ public class LogStreamExtension implements Extension {
         private LogStreamSubsystemResourceDefinition() {
             super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver(),
                     new AbstractAddStepHandler(),
-                    ReloadRequiredRemoveStepHandler.INSTANCE);
+                    ModelOnlyRemoveStepHandler.INSTANCE);
             this.handler = new LogStreamHandler();
         }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/ServerReload.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/ServerReload.java
@@ -1,0 +1,182 @@
+/*
+Copyright 2015 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.management.util;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.xnio.IoUtils;
+
+/**
+ * Utilities for handling server reloads.
+ *
+ * @author Stuart Douglas
+ */
+public class ServerReload {
+
+    /** Default time, in ms, to wait for reload to complete. */
+    public static final int TIMEOUT = 100000;
+
+    /**
+     * Executes a {@code reload} operation and waits the {@link #TIMEOUT default timeout}
+     * for the reload to complete.
+     *
+     * @param client the client to use for the request. Cannot be {@code null}
+     *
+     * @throws AssertionError if the reload does not complete within the timeout
+     */
+    public static void executeReloadAndWaitForCompletion(ModelControllerClient client) {
+        executeReloadAndWaitForCompletion(client, TIMEOUT);
+    }
+
+    /**
+     * Executes a {@code reload} operation, optionally putting the server into {@code admin-only}
+     * running mode, and waits the {@link #TIMEOUT default timeout} for the reload to complete.
+     *
+     * @param client the client to use for the request. Cannot be {@code null}
+     * @param adminOnly {@code true} if the server's running mode should be {@code admin-only} when
+     *                              the reload completes
+     *
+     * @throws AssertionError if the reload does not complete within the timeout
+     */
+    public static void executeReloadAndWaitForCompletion(ModelControllerClient client, boolean adminOnly) {
+        executeReloadAndWaitForCompletion(client, TIMEOUT, adminOnly, null, -1);
+    }
+
+    /**
+     * Executes a {@code reload} operation and waits a configurable maximum time for the reload to complete.
+     *
+     * @param client the client to use for the request. Cannot be {@code null}
+     * @param timeout maximum time to wait for the reload to complete, in milliseconds
+     *
+     * @throws AssertionError if the reload does not complete within the specified timeout
+     */
+    public static void executeReloadAndWaitForCompletion(ModelControllerClient client, int timeout) {
+        executeReloadAndWaitForCompletion(client, timeout, false, null, -1);
+    }
+
+    /**
+     * Executes a {@code reload} operation, optionally putting the server into {@code admin-only}
+     * running mode, and waits a configurable maximum time for the reload to complete.
+     *
+     * @param client the client to use for the request. Cannot be {@code null}
+     * @param timeout maximum time to wait for the reload to complete, in milliseconds
+     * @param adminOnly     if {@code true}, the server will be reloaded in admin-only mode
+     * @param serverAddress if {@code null}, use {@code TestSuiteEnvironment.getServerAddress()} to create the ModelControllerClient
+     * @param serverPort    if {@code -1}, use {@code TestSuiteEnvironment.getServerPort()} to create the ModelControllerClient
+     *
+     * @throws AssertionError if the reload does not complete within the specified timeout
+     */
+    public static void executeReloadAndWaitForCompletion(ModelControllerClient client, int timeout, boolean adminOnly, String serverAddress, int serverPort) {
+        executeReload(client, adminOnly);
+        waitForLiveServerToReload(timeout,
+                serverAddress != null ? serverAddress : TestSuiteEnvironment.getServerAddress(),
+                serverPort != -1 ? serverPort : TestSuiteEnvironment.getServerPort());
+    }
+
+    private static void executeReload(ModelControllerClient client, boolean adminOnly) {
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(OP).set("reload");
+        operation.get("admin-only").set(adminOnly);
+        try {
+            ModelNode result = client.execute(operation);
+            Assert.assertEquals("success", result.get(ClientConstants.OUTCOME).asString());
+        } catch (IOException e) {
+            final Throwable cause = e.getCause();
+            if (!(cause instanceof ExecutionException) && !(cause instanceof CancellationException)) {
+                throw new RuntimeException(e);
+            } // else ignore, this might happen if the channel gets closed before we got the response
+        }
+    }
+
+    private static void waitForLiveServerToReload(int timeout, String serverAddress, int serverPort) {
+        long start = System.currentTimeMillis();
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        operation.get(NAME).set("server-state");
+        while (System.currentTimeMillis() - start < timeout) {
+            try {
+                ModelControllerClient liveClient = ModelControllerClient.Factory.create(
+                        serverAddress, serverPort);
+                try {
+                    ModelNode result = liveClient.execute(operation);
+                    if ("running".equals(result.get(RESULT).asString())) {
+                        return;
+                    }
+                } catch (IOException e) {
+                } finally {
+                    IoUtils.safeClose(liveClient);
+                }
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                }
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        fail("Live Server did not reload in the imparted time.");
+    }
+
+    /**
+     * {@link ServerSetupTask} that calls {@link #executeReloadAndWaitForCompletion(ModelControllerClient)}
+     * in the {@code tearDown} method
+     */
+    public static class SetupTask implements ServerSetupTask {
+
+        public static final SetupTask INSTANCE = new SetupTask();
+
+        /**
+         * A no-op.
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        public void setup(ManagementClient managementClient) throws Exception {
+            // no-op;
+        }
+
+        /**
+         * Calls {@link #executeReloadAndWaitForCompletion(ModelControllerClient)}.
+         *
+         * {@inheritDoc}
+         */
+        @Override
+        public void tearDown(ManagementClient managementClient) throws Exception {
+            executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        }
+    }
+}
+

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomFormattersTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomFormattersTestCase.java
@@ -39,16 +39,19 @@ import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
+@ServerSetup(ServerReload.SetupTask.class)
 @RunWith(WildflyTestRunner.class)
 public class CustomFormattersTestCase extends AbstractLoggingOperationsTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
@@ -23,16 +23,19 @@
 package org.jboss.as.test.integration.logging.operations;
 
 import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logmanager.handlers.ConsoleHandler;
 import org.jboss.logmanager.handlers.QueueHandler;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
+@ServerSetup(ServerReload.SetupTask.class)
 @RunWith(WildflyTestRunner.class)
 public class CustomHandlerOperationsTestCase extends AbstractLoggingOperationsTestCase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/LoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/LoggingProfilesTestCase.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuild
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper.ServerDeploymentException;
 import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
 import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceActivator;
@@ -47,7 +48,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.ServerSetupTask;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
@@ -73,7 +73,7 @@ public class LoggingProfilesTestCase extends AbstractLoggingTestCase {
     private static final Path dummyLog2 = Paths.get(LOG_DIR, PROFILE2_LOG_NAME);
     private static final Path dummyLog1Changed = Paths.get(LOG_DIR, CHANGED_LOG_NAME);
 
-    static class LoggingProfilesTestCaseSetup implements ServerSetupTask {
+    static class LoggingProfilesTestCaseSetup extends ServerReload.SetupTask {
 
         @Override
         public void setup(ManagementClient managementClient) throws Exception {
@@ -169,6 +169,8 @@ public class LoggingProfilesTestCase extends AbstractLoggingTestCase {
             Files.deleteIfExists(dummyLog1);
             Files.deleteIfExists(dummyLog2);
             Files.deleteIfExists(dummyLog1Changed);
+
+            super.tearDown(client);
         }
     }
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
@@ -24,7 +24,9 @@ package org.jboss.as.test.integration.logging.syslog;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.productivity.java.syslog4j.SyslogConstants.UDP;
 
 import java.io.IOException;
@@ -37,6 +39,7 @@ import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
 import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
 import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.test.syslogserver.BlockedSyslogServerEventHandler;
@@ -54,7 +57,6 @@ import org.productivity.java.syslog4j.server.SyslogServer;
 import org.productivity.java.syslog4j.server.SyslogServerEventIF;
 import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
-import org.wildfly.core.testrunner.ServerSetupTask;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
@@ -178,7 +180,7 @@ public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
         assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
     }
 
-    static class SyslogHandlerTestCaseSetup implements ServerSetupTask {
+    static class SyslogHandlerTestCaseSetup extends ServerReload.SetupTask {
 
         @Override
         public void setup(final ManagementClient managementClient) throws Exception {
@@ -232,6 +234,8 @@ public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
             op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
             executeOperation(op);
             LOGGER.info("syslog server logging profile removed");
+
+            super.tearDown(managementClient);
         }
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GenericCommandTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GenericCommandTestCase.java
@@ -25,16 +25,19 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
  * Test generic command features of CLI.
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
+@ServerSetup(ServerReload.SetupTask.class)
 @RunWith(WildflyTestRunner.class)
 public class GenericCommandTestCase extends AbstractCliTestBase {
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GlobalOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GlobalOpsTestCase.java
@@ -30,17 +30,20 @@ import java.util.Map;
 
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
+@ServerSetup(ServerReload.SetupTask.class)
 @RunWith(WildflyTestRunner.class)
 public class GlobalOpsTestCase extends AbstractCliTestBase {
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/ChildResourceDefinition.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/ChildResourceDefinition.java
@@ -25,9 +25,9 @@
 package org.wildfly.core.test.standalone.extension.remove;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -46,7 +46,7 @@ public class ChildResourceDefinition extends SimpleResourceDefinition {
     public ChildResourceDefinition() {
         super(PathElement.pathElement("child"), new NonResolvingResourceDescriptionResolver(),
                 new AddChildHandler(),
-                ReloadRequiredRemoveStepHandler.INSTANCE
+                ModelOnlyRemoveStepHandler.INSTANCE
         );
     }
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/RootResourceDefinition.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/extension/remove/RootResourceDefinition.java
@@ -27,9 +27,9 @@ package org.wildfly.core.test.standalone.extension.remove;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -49,7 +49,7 @@ public class RootResourceDefinition extends SimpleResourceDefinition {
 
     public RootResourceDefinition() {
         super(PathElement.pathElement(SUBSYSTEM, TestExtension.SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver(),
-                new AddSubsystemHandler(), ReloadRequiredRemoveStepHandler.INSTANCE);
+                new AddSubsystemHandler(), ModelOnlyRemoveStepHandler.INSTANCE);
     }
 
     @Override

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
@@ -78,11 +78,13 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.test.deployment.trivial.ServiceActivatorDeploymentUtil;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
@@ -90,6 +92,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author Emanuel Muckenhuber
  */
+@ServerSetup(ServerReload.SetupTask.class)
 @RunWith(WildflyTestRunner.class)
 public class BasicOperationsUnitTestCase {
 

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ConfigurationChangesHistoryTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ConfigurationChangesHistoryTestCase.java
@@ -54,12 +54,14 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.domain.management.ConfigurationChangeResourceDefinition;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.test.standalone.base.ContainerResourceMgmtTestBase;
+import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
@@ -67,6 +69,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  *
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
+@ServerSetup(ServerReload.SetupTask.class)
 @RunWith(WildflyTestRunner.class)
 public class ConfigurationChangesHistoryTestCase extends ContainerResourceMgmtTestBase {
 


### PR DESCRIPTION
These changes are part of #1475 since they are required to make the main code change there pass CI, but I decided to submit them separately as well. These are useful on their own and I figure #1475 is a big chunk to review, while these should be more digestible. If they get merged, then #1475 will become more digestible too.

The commits do 3 things:

1) Change some tests such that they don't trigger reload-required.
2) Add a SetupTask that triggers reload in tearDown, and then use it in tests that really need to trigger reload required
3) Change the test runner such that it fails in non-manual control tests that leave the server in reload-required.