### PR TITLE
Fix HSM-based SSL

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeystore.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeystore.java
@@ -123,7 +123,7 @@ final class FileKeystore {
             if (alias == null) {
                 this.setKeyStore(loadedKeystore);
             } else {
-                KeyStore newKeystore = KeyStore.getInstance("JKS");
+                KeyStore newKeystore = KeyStore.getInstance(provider);
                 newKeystore.load(null);
 
                 KeyStore.ProtectionParameter passParam = new KeyStore.PasswordProtection(keyPassword == null ? keystorePassword


### PR DESCRIPTION
Using a KeyStore provider that does not allow or returns empty from getEncoded() on private keys causes a KeyStoreException at SSL startup. This is common in HSM-backed key operations.

When creating a reduced KeyStore, use the same provider as the source KeyStore to
minimize incompatibilities.

While it's still not guaranteed to work with all KeyStore providers, switching `KeyStore.getInstance("JKS")` to `KeyStore.getInstance(provider)` fixes the issue for SafeNet "Luna" and SunPKCS11 "PKCS11" KeyStore implementations while not breaking the "PKCS12" and "JKS" cases.