### PR TITLE
WFCORE-1467 This commit avoids call two times a suspend operation when suspend-servers is used with a timeout parameter different than 0

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
@@ -346,16 +346,19 @@ public class DomainServerLifecycleHandlers {
                     context.getServiceRegistry(true);
                     Map<String, ProcessInfo> processes = serverInventory.determineRunningProcesses(true);
                     final Set<String> serversInGroup = getServersForGroup(model, group);
-                    final Set<String> waitForServers = new HashSet<String>();
+                    final Set<String> waitForServers = new HashSet<>();
                     for (String serverName : processes.keySet()) {
                         final String serverModelName = serverInventory.getProcessServerName(serverName);
                         if (group == null || serversInGroup.contains(serverModelName)) {
-                            serverInventory.suspendServer(serverModelName);
                             waitForServers.add(serverModelName);
                         }
                     }
                     if (timeout != 0) {
                         serverInventory.awaitServerSuspend(waitForServers, timeout > 0 ? timeout * 1000 : timeout);
+                    } else {
+                        for (String serverModelName : waitForServers){
+                            serverInventory.suspendServer(serverModelName);
+                        }
                     }
                     context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }


### PR DESCRIPTION
In a domain mode :suspend-servers command with a timeout parameter different than 0 executes two suspend operations for each server in the domain. It first executes a suspend with 0ms and later a suspend with the timeout specified.

Jira issue:
https://issues.jboss.org/browse/WFCORE-1467