### PR TITLE
WFCORE 1467 Avoids calling suspend twice when a timeout is used with suspend.

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
@@ -346,16 +346,19 @@ public class DomainServerLifecycleHandlers {
                     context.getServiceRegistry(true);
                     Map<String, ProcessInfo> processes = serverInventory.determineRunningProcesses(true);
                     final Set<String> serversInGroup = getServersForGroup(model, group);
-                    final Set<String> waitForServers = new HashSet<String>();
+                    final Set<String> waitForServers = new HashSet<>();
                     for (String serverName : processes.keySet()) {
                         final String serverModelName = serverInventory.getProcessServerName(serverName);
                         if (group == null || serversInGroup.contains(serverModelName)) {
-                            serverInventory.suspendServer(serverModelName);
                             waitForServers.add(serverModelName);
                         }
                     }
                     if (timeout != 0) {
                         serverInventory.awaitServerSuspend(waitForServers, timeout > 0 ? timeout * 1000 : timeout);
+                    } else {
+                        for (String serverModelName : waitForServers){
+                            serverInventory.suspendServer(serverModelName);
+                        }
                     }
                     context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
@@ -354,7 +354,7 @@ public class DomainServerLifecycleHandlers {
                         }
                     }
                     if (timeout != 0) {
-                        serverInventory.awaitServerSuspend(waitForServers, timeout > 0 ? timeout * 1000 : timeout);
+                        serverInventory.awaitServerSuspend(waitForServers, timeout);
                     } else {
                         for (String serverModelName : waitForServers){
                             serverInventory.suspendServer(serverModelName);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
@@ -25,7 +25,9 @@ package org.jboss.as.host.controller;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESUME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUSPEND;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TIMEOUT;
 import static org.jboss.as.host.controller.logging.HostControllerLogger.ROOT_LOGGER;
 
@@ -42,7 +44,10 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProxyOperationAddressTranslator;
 import org.jboss.as.controller.TransformingProxyController;
+import org.jboss.as.controller.client.OperationAttachments;
+import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.helpers.domain.ServerStatus;
+import org.jboss.as.controller.remote.BlockingQueueOperationListener;
 import org.jboss.as.controller.remote.TransactionalProtocolClient;
 import org.jboss.as.controller.remote.TransactionalProtocolHandlers;
 import org.jboss.as.controller.transform.TransformationTarget;
@@ -677,7 +682,7 @@ class ManagedServer {
     boolean suspend() {
 
         final ModelNode operation = new ModelNode();
-        operation.get(OP).set("suspend");
+        operation.get(OP).set(SUSPEND);
         operation.get(OP_ADDR).setEmptyList();
 
         try {
@@ -697,7 +702,7 @@ class ManagedServer {
     boolean resume() {
 
         final ModelNode operation = new ModelNode();
-        operation.get(OP).set("resume");
+        operation.get(OP).set(RESUME);
         operation.get(OP_ADDR).setEmptyList();
 
         try {
@@ -713,25 +718,15 @@ class ManagedServer {
         return true;
     }
 
-    void awaitSuspended(long timeout) {
-
-        //we just re-suspend, but this time give a timeout
+    BlockingQueueOperationListener<?> suspend(int timeoutInSeconds) throws IOException {
         final ModelNode operation = new ModelNode();
-        operation.get(OP).set("suspend");
+        operation.get(OP).set(SUSPEND);
         operation.get(OP_ADDR).setEmptyList();
-        operation.get(TIMEOUT).set(timeout);
+        operation.get(TIMEOUT).set(timeoutInSeconds);
 
-        try {
-            final TransactionalProtocolClient.PreparedOperation<?> prepared = TransactionalProtocolHandlers.executeBlocking(operation, protocolClient);
-            if (prepared.isFailed()) {
-                return;
-            }
-            prepared.commit();
-            prepared.getFinalResult().get();
-        } catch (Exception ignore) {
-            return;
-        }
-        return;
+        BlockingQueueOperationListener<TransactionalProtocolClient.Operation> listener = new BlockingQueueOperationListener<>();
+        protocolClient.execute(listener, operation, OperationMessageHandler.DISCARD, OperationAttachments.EMPTY);
+        return listener;
     }
 
     static enum InternalState {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
@@ -315,11 +315,11 @@ public interface ServerInventory {
     void resumeServer(String serverName);
 
     /**
-     * Waits for the given set of servers to suspend
+     * Suspends and waits for the given set of servers to suspend up to the timeout
      * @param waitForServers The servers to wait for
-     * @param timeout The maximum amount of time to wait in milliseconds, with -1 meaning indefinitly
+     * @param timeoutInSeconds The maximum amount of time to wait in seconds, with -1 meaning indefinitly
      * @return <code>true</code> if all the servers suspended in time
      */
-    boolean awaitServerSuspend(Set<String> waitForServers, int timeout);
+    boolean awaitServerSuspend(Set<String> waitForServers, int timeoutInSeconds);
 
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import javax.security.sasl.SaslException;
 import javax.xml.stream.Location;
@@ -1256,4 +1257,12 @@ public interface HostControllerLogger extends BasicLogger {
 
     @Message(id = 170, value = "Error releasing shared lock after host registration for operationID: %s")
     String hostRegistrationCannotReleaseSharedLock(int operationID);
+
+    @LogMessage(level = Level.ERROR)
+    @Message( id = 171, value = "Failed getting the response from the suspend listener for server: %s")
+    void suspendListenerFailed(@Cause ExecutionException cause, String serverName);
+
+    @LogMessage(level = Level.ERROR)
+    @Message( id = 172, value = "Failed executing the suspend operation for server: %s")
+    void suspendExecutionFailed(@Cause IOException cause, String serverName);
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerSuspendHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/ServerSuspendHandler.java
@@ -82,9 +82,10 @@ public class ServerSuspendHandler implements OperationStepHandler {
                 // WFLY-2189 trigger a write-runtime authz check
                 context.getServiceRegistry(true);
 
-                serverInventory.suspendServer(serverName);
-                if(timeout!= 0) {
-                    serverInventory.awaitServerSuspend(Collections.singleton(serverName), timeout > 0 ? timeout * 1000 : timeout);
+                if (timeout != 0) {
+                    serverInventory.awaitServerSuspend(Collections.singleton(serverName), timeout);
+                } else {
+                    serverInventory.suspendServer(serverName);
                 }
             }
         }, OperationContext.Stage.RUNTIME);

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1060,7 +1060,7 @@ public interface ServerLogger extends BasicLogger {
     IllegalStateException serverAlreadyPaused();
 
     @LogMessage(level = INFO)
-    @Message(id = 211, value = "Suspending server with %dms timeout.")
+    @Message(id = 211, value = "Suspending server with %d ms timeout.")
     void suspendingServer(long timeoutMillis);
 
     @LogMessage(level = INFO)
@@ -1173,4 +1173,7 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 235, value = "Security Manager is enabled")
     void securityManagerEnabled();
 
+    @LogMessage(level = INFO)
+    @Message(id = 236, value = "Suspending server with no timeout.")
+    void suspendingServerWithNoTimeout();
 }

--- a/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
+++ b/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
@@ -48,7 +48,11 @@ public class SuspendController implements Service<SuspendController> {
     };
 
     public synchronized void suspend(long timeoutMillis) {
-        ServerLogger.ROOT_LOGGER.suspendingServer(timeoutMillis);
+        if (timeoutMillis > 0) {
+            ServerLogger.ROOT_LOGGER.suspendingServer(timeoutMillis);
+        } else {
+            ServerLogger.ROOT_LOGGER.suspendingServerWithNoTimeout();
+        }
         state = State.PRE_SUSPEND;
         //we iterate a copy, in case a listener tries to register a new listener
         for(OperationListener listener: new ArrayList<>(operationListeners)) {


### PR DESCRIPTION
Attempt at following Brian's suggestions on https://github.com/wildfly/wildfly-core/pull/1489.

I wasn't familiar with BlockingQueueOperationListener, but hopefully if something needs tweaking this will help.

https://issues.jboss.org/browse/WFCORE-1467
