### PR TITLE
WFCORE-1469 - Support match-comparison operation for if-command

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/ifelse/ConditionArgument.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ifelse/ConditionArgument.java
@@ -94,6 +94,12 @@ public class ConditionArgument extends ArgumentWithValue {
             return new NotLesserThanOperation();
         }
     };
+    private static final ParsingState MCH = new OperationParsingState(MatchOperation.SYMBOL) {
+        @Override
+        BaseOperation createOperation() {
+            return new MatchOperation();
+        }
+    };
 
     private DefaultParsingState parenthesisState;
     private ExpressionBaseState exprState;
@@ -115,6 +121,8 @@ public class ConditionArgument extends ArgumentWithValue {
                     signalState(ctx, OR, true);
                 } else if(c == '=' && isFollowingChar(ctx, '=')) {
                     signalState(ctx, EQ, true);
+                } else if(c == '~' && isFollowingChar(ctx, '=')) {
+                    signalState(ctx, MCH, true);
                 } else if(c == '!' && isFollowingChar(ctx, '=')) {
                     signalState(ctx, NEQ, true);
                 } else if(c == '>' && isFollowingChar(ctx, '=')) {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ifelse/MatchOperation.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ifelse/MatchOperation.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.handlers.ifelse;
+
+import java.util.regex.Pattern;
+
+/**
+ *
+ * @author Thomas Darimont
+ */
+public class MatchOperation extends SameTypeOperation {
+
+    static final String SYMBOL = "~=";
+
+    MatchOperation() {
+        super(SYMBOL);
+    }
+
+    @Override
+    protected boolean doCompare(Object left, Object right) {
+
+        if(left == null) {
+            return right == null;
+        }
+
+        String text = String.valueOf(left);
+        String pattern = String.valueOf(right);
+
+        Pattern compiledPattern = Pattern.compile(pattern);
+
+        return compiledPattern.matcher(text).matches();
+    }
+}

--- a/cli/src/test/java/org/jboss/as/cli/parsing/ifelse/test/MatchTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/ifelse/test/MatchTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.parsing.ifelse.test;
+
+
+import org.jboss.dmr.ModelNode;
+import org.junit.Test;
+
+
+/**
+ *
+ * @author Thomas Darimont
+ */
+public class MatchTestCase extends ComparisonTestBase {
+
+    @Test
+    public void testExactStringPatternPatching() throws Exception {
+
+        ModelNode node = new ModelNode();
+
+        node.get("result").set("foo");
+        assertTrue(node, "result ~= \"foo\"");
+
+        node.get("result").set("foo");
+        assertFalse(node, "result ~= \"bar\"");
+    }
+
+    @Test
+    public void testFuzzyStringPatternMatching() throws Exception {
+
+        ModelNode node = new ModelNode();
+
+        String featureList = "feature1 feature2";
+
+        node.get("result").set(featureList);
+        assertTrue(node, "result ~= \".*feature1.*\"");
+
+        node.get("result").set(featureList);
+        assertTrue(node, "result ~= \".*feature2.*\"");
+
+        node.get("result").set(featureList);
+        assertFalse(node, "result ~= \".*feature3.*\"");
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/BasicIfElseTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/BasicIfElseTestCase.java
@@ -51,6 +51,24 @@ public class BasicIfElseTestCase extends CLISystemPropertyTestBase {
             cliOut.reset();
         }
     }
+
+    @Test
+    public void testIfMatchComparison() throws Exception {
+
+        final CommandContext ctx = CLITestUtil.getCommandContext(cliOut);
+        try {
+            ctx.connectController();
+            ctx.handle(this.getAddPropertyReq("match-test-values", "\"AAA BBB\""));
+            assertEquals("true", runIfWithMatchComparison("match-test-values", "AAA", ctx));
+            assertEquals("true", runIfWithMatchComparison("match-test-values", "BBB", ctx));
+            assertEquals("false", runIfWithMatchComparison("match-test-values", "CCC", ctx));
+        } finally {
+            ctx.handleSafe(this.getRemovePropertyReq("match-test-values"));
+            ctx.terminateSession();
+            cliOut.reset();
+        }
+    }
+
     protected String runIf(CommandContext ctx) throws Exception {
         ctx.handle("if result.value==\"true\" of " + this.getReadPropertyReq());
         ctx.handle(this.getWritePropertyReq("\"false\""));
@@ -60,5 +78,21 @@ public class BasicIfElseTestCase extends CLISystemPropertyTestBase {
         cliOut.reset();
         ctx.handle(getReadPropertyReq());
         return getValue();
+    }
+
+    protected String runIfWithMatchComparison(String propertyName, String lookupValue, CommandContext ctx) throws Exception {
+
+        ctx.handle("set match=false");
+
+        ctx.handle("if result.value~=\".*" + lookupValue + ".*\" of " + this.getReadPropertyReq(propertyName));
+        ctx.handle("set match=true");
+        ctx.handle("else");
+        ctx.handle("set match=false");
+        ctx.handle("end-if");
+        cliOut.reset();
+
+        ctx.handle("echo $match");
+
+        return cliOut.toString().trim();
     }
 }


### PR DESCRIPTION
Introduced regex based match comparison-operation for if-commands.
The match operation is denoted by the symbol `~=`.
The left operand is a string to match against the right operand
which is a regex string.

This enables a simple way to do feature flag detection
via partial regex matches.

E.g. given the system property "features" which contains a space
separated list of enabled "features".
```
-Dfeatures="activemq jgroups"
```

One could conditionally configure wildfly components via CLI
in one generic CLI script, e.g.:
```
if (features ~= ".*activemq.*") of /:resolve-expression(expression=${features})
echo configuring activemq
end-if

if (features ~= ".*jgroups.*") of /:resolve-expression(expression=${features})
echo configuring jgroups
end-if

if (features ~= ".*postgres.*") of /:resolve-expression(expression=${features})
echo configuring postgres
end-if
```