### PR TITLE
[WFCORE-1456] [WFCORE-1471] CLI class to handle offline mode and commands

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContext.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -246,6 +246,13 @@ public interface CommandContext {
      * @return true if the CLI is in the batch mode, false - otherwise.
      */
     boolean isBatchMode();
+
+    /**
+     * Checks whether the CLI is in a workflow mode.
+     *
+     * @return true if the CLI is in a workflow mode, false - otherwise.
+     */
+    boolean isWorkflowMode();
 
     /**
      * Returns batch manager.

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -1346,6 +1346,11 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     }
 
     @Override
+    public boolean isWorkflowMode() {
+        return redirection != null;
+    }
+
+    @Override
     public BatchManager getBatchManager() {
         return batchManager;
     }

--- a/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
+++ b/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2015 Red Hat Inc. and/or its affiliates and other contributors
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
  * as indicated by the @author tags. All rights reserved.
  * See the copyright.txt in the distribution for a
  * full listing of individual contributors.
@@ -21,19 +21,22 @@ package org.jboss.as.cli.scriptsupport;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.concurrent.Callable;
 
 import org.jboss.as.cli.CliInitializationException;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContextFactory;
-import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.impl.CommandContextConfiguration;
+import org.jboss.as.cli.operation.impl.DefaultCallbackHandler;
+import org.jboss.as.cli.parsing.operation.OperationFormat;
 import org.jboss.dmr.ModelNode;
 
 /**
- * This class is intended to be used with JVM-based scripting languages.  It acts as a facade to the CLI public API,
- * providing a single class that can be used to connect, run CLI commands, and disconnect.  It also removes the need
- * to catch checked exceptions.
+ * This class is intended to be used with JVM-based scripting languages. It acts
+ * as a facade to the CLI public API, providing a single class that can be used
+ * to connect, run CLI commands, and disconnect. It also removes the need to
+ * catch checked exceptions.
  *
  * @author Stan Silvert ssilvert@redhat.com (C) 2012 Red Hat Inc.
  */
@@ -41,7 +44,14 @@ public class CLI {
 
     private CommandContext ctx;
 
-    private CLI() {} // only allow new instances from newInstance() method.
+    // This parsedCommand is required in order to determinate if the command
+    // is an operation or a command
+    private final DefaultCallbackHandler handler
+            = new DefaultCallbackHandler(true);
+
+    private CLI() { // only allow new instances from newInstance() method.
+        initOfflineContext();
+    }
 
     /**
      * Create a new CLI instance.
@@ -52,38 +62,26 @@ public class CLI {
         return new CLI();
     }
 
-    private void checkAlreadyConnected() {
-        if (ctx != null) throw new IllegalStateException("Already connected to server.");
-    }
-
-    private void checkNotConnected() {
-        if (ctx == null) throw new IllegalStateException("Not connected to server.");
-        if (ctx.isTerminated()) throw new IllegalStateException("Session is terminated.");
-    }
-
     /**
-     * Return the CLI CommandContext that was created when connected to the server.  This allows a script developer full
-     * access to CLI facilities if needed.
+     * Return the CLI CommandContext. This allows a script developer full access
+     * to CLI facilities if needed. CommandContext can mute during CLI lifetime.
+     * An unconnected CLI instance has a context that handles offline commands.
+     * When connected to a server, the original context is replaced with a
+     * context allowing to interact with the remote server.
      *
-     * @return The CommandContext, or <code>null</code> if not connected.
+     * @return The CommandContext.
      */
     public CommandContext getCommandContext() {
-        return this.ctx;
+        return ctx;
     }
 
     /**
      * Connect to the server using the default host and port.
      */
     public void connect() {
-        checkAlreadyConnected();
-        try {
-            ctx = CommandContextFactory.getInstance().newCommandContext();
-            ctx.connectController();
-        } catch (CliInitializationException e) {
-            throw new IllegalStateException("Unable to initialize command context.", e);
-        } catch (CommandLineException e) {
-            throw new IllegalStateException("Unable to connect to controller.", e);
-        }
+        doConnect(() -> {
+            return CommandContextFactory.getInstance().newCommandContext();
+        });
     }
 
     /**
@@ -93,15 +91,10 @@ public class CLI {
      * @param password The password for logging in.
      */
     public void connect(String username, char[] password) {
-        checkAlreadyConnected();
-        try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(username, password);
-            ctx.connectController();
-        } catch (CliInitializationException e) {
-            throw new IllegalStateException("Unable to initialize command context.", e);
-        } catch (CommandLineException e) {
-            throw new IllegalStateException("Unable to connect to controller.", e);
-        }
+        doConnect(() -> {
+            return CommandContextFactory.getInstance().
+                    newCommandContext(username, password);
+        });
     }
 
     /**
@@ -124,21 +117,17 @@ public class CLI {
      * @param clientBindAddress
      * @param password The password for logging in.
      */
-    public void connect(String controller, String username, char[] password, String clientBindAddress) {
-        checkAlreadyConnected();
-        try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(new CommandContextConfiguration.Builder()
-                    .setController(controller)
+    public void connect(String controller, String username, char[] password,
+            String clientBindAddress) {
+        doConnect(() -> {
+            return CommandContextFactory.getInstance().
+                    newCommandContext(new CommandContextConfiguration.Builder()
+                            .setController(controller)
                     .setUsername(username)
                     .setPassword(password)
                     .setClientBindAddress(clientBindAddress)
                     .build());
-            ctx.connectController();
-        } catch (CliInitializationException e) {
-            throw new IllegalStateException("Unable to initialize command context.", e);
-        } catch (CommandLineException e) {
-            throw new IllegalStateException("Unable to connect to controller.", e);
-        }
+        });
     }
 
     /**
@@ -149,8 +138,10 @@ public class CLI {
      * @param username The user name for logging in.
      * @param password The password for logging in.
      */
-    public void connect(String controllerHost, int controllerPort, String username, char[] password) {
-        connect("http-remoting", controllerHost, controllerPort, username, password, null);
+    public void connect(String controllerHost, int controllerPort,
+            String username, char[] password) {
+        connect("http-remoting", controllerHost, controllerPort,
+                username, password, null);
     }
 
     /**
@@ -162,8 +153,10 @@ public class CLI {
      * @param password The password for logging in.
      * @param clientBindAddress the client bind address.
      */
-    public void connect(String controllerHost, int controllerPort, String username, char[] password, String clientBindAddress) {
-        connect("http-remoting", controllerHost, controllerPort, username, password, clientBindAddress);
+    public void connect(String controllerHost, int controllerPort,
+            String username, char[] password, String clientBindAddress) {
+        connect("http-remoting", controllerHost, controllerPort,
+                username, password, clientBindAddress);
     }
 
     /**
@@ -174,7 +167,8 @@ public class CLI {
      * @param username The user name for logging in.
      * @param password The password for logging in.
      */
-    public void connect(String protocol, String controllerHost, int controllerPort, String username, char[] password) {
+    public void connect(String protocol, String controllerHost,
+            int controllerPort, String username, char[] password) {
         connect(protocol, controllerHost, controllerPort, username, password, null);
     }
 
@@ -186,21 +180,19 @@ public class CLI {
      * @param username The user name for logging in.
      * @param password The password for logging in.
      */
-    public void connect(String protocol, String controllerHost, int controllerPort, String username, char[] password, String clientBindAddress) {
-        checkAlreadyConnected();
-        try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(
-                    new CommandContextConfiguration.Builder().setController(constructUri(protocol, controllerHost, controllerPort))
+    public void connect(String protocol, String controllerHost, int controllerPort,
+            String username, char[] password, String clientBindAddress) {
+        doConnect(() -> {
+            return CommandContextFactory.getInstance().newCommandContext(
+                    new CommandContextConfiguration.Builder().
+                    setController(constructUri(protocol,
+                            controllerHost,
+                            controllerPort))
                     .setUsername(username)
                     .setPassword(password)
                     .setClientBindAddress(clientBindAddress)
                     .build());
-            ctx.connectController();
-        } catch (CliInitializationException e) {
-            throw new IllegalStateException("Unable to initialize command context.", e);
-        } catch (CommandLineException e) {
-            throw new IllegalStateException("Unable to connect to controller.", e);
-        }
+        });
     }
 
     /**
@@ -208,40 +200,52 @@ public class CLI {
      */
     public void disconnect() {
         try {
-            checkNotConnected();
+            if (!isConnected()) {
+                throw new IllegalStateException("Not connected to server.");
+            }
             ctx.terminateSession();
         } finally {
-            ctx = null;
+            // Back to offline context
+            initOfflineContext();
         }
     }
 
     /**
-     * Execute a CLI command.  This can be any command that you might execute on the CLI command line, including both
-     * server-side operations and local commands such as 'cd' or 'cn'.
+     * Execute a CLI command. This can be any command that you might execute on
+     * the CLI command line, including both server-side operations and local
+     * commands such as 'cd' or 'cn'.
      *
      * @param cliCommand A CLI command.
-     * @return A result object that provides all information about the execution of the command.
+     * @return A result object that provides all information about the execution
+     * of the command.
      */
     public Result cmd(String cliCommand) {
-        checkNotConnected();
         try {
-            ModelNode request = ctx.buildRequest(cliCommand);
-            ModelNode response = ctx.getModelControllerClient().execute(request);
-            return new Result(cliCommand, request, response);
-        } catch (CommandFormatException cfe) {
-            // if the command can not be converted to a ModelNode, it might be a local command
-            try {
+            // The intent here is to return a Response when this is doable.
+            if (ctx.isWorkflowMode() || ctx.isBatchMode()) {
                 ctx.handle(cliCommand);
                 return new Result(cliCommand, ctx.getExitCode());
-            } catch (CommandLineException cle) {
-                throw new IllegalArgumentException("Error handling command: " + cliCommand, cle);
             }
+            handler.parse(ctx.getCurrentNodePath(), cliCommand, ctx);
+            if (handler.getFormat() == OperationFormat.INSTANCE) {
+                ModelNode request = ctx.buildRequest(cliCommand);
+                ModelNode response = ctx.getModelControllerClient().execute(request);
+                return new Result(cliCommand, request, response);
+            } else {
+                ctx.handle(cliCommand);
+                return new Result(cliCommand, ctx.getExitCode());
+            }
+        } catch (CommandLineException cfe) {
+            throw new IllegalArgumentException("Error handling command: "
+                    + cliCommand, cfe);
         } catch (IOException ioe) {
-            throw new IllegalStateException("Unable to send command " + cliCommand + " to server.", ioe);
+            throw new IllegalStateException("Unable to send command "
+                    + cliCommand + " to server.", ioe);
         }
     }
 
-    private String constructUri(final String protocol, final String host, final int port) {
+    private String constructUri(final String protocol, final String host,
+            final int port) {
         try {
             URI uri = new URI(protocol, null, host, port, null, null, null);
             // String the leading '//' if there is no protocol.
@@ -251,11 +255,49 @@ public class CLI {
         }
     }
 
+    private void initOfflineContext() {
+        try {
+            ctx = CommandContextFactory.getInstance().newCommandContext();
+        } catch (CliInitializationException e) {
+            throw new IllegalStateException("Unable to initialize "
+                    + "command context.", e);
+        }
+    }
+
+    private boolean isConnected() {
+        return ctx.getConnectionInfo() != null;
+    }
+
+    private void doConnect(Callable<CommandContext> callable) {
+        if (isConnected()) {
+            throw new IllegalStateException("Already connected to server.");
+        }
+        CommandContext newContext = null;
+        try {
+            newContext = callable.call();
+            newContext.connectController();
+        } catch (Exception ex) {
+            if (newContext != null) {
+                newContext.terminateSession();
+            }
+            if (ex instanceof CliInitializationException) {
+                throw new IllegalStateException("Unable to initialize "
+                        + "command context.", ex);
+            }
+            if (ex instanceof CommandLineException) {
+                throw new IllegalStateException("Unable to connect "
+                        + "to controller.", ex);
+            }
+            throw new IllegalStateException(ex);
+        }
+        ctx = newContext;
+    }
+
     /**
      * The Result class provides all information about an executed CLI command.
      */
     public class Result {
-        private String cliCommand;
+        private final String cliCommand;
         private ModelNode request;
         private ModelNode response;
 
@@ -284,37 +326,45 @@ public class CLI {
         }
 
         /**
-         * If the command resulted in a server-side operation, return the ModelNode representation of the operation.
+         * If the command resulted in a server-side operation, return the
+         * ModelNode representation of the operation.
          *
-         * @return The request as a ModelNode, or <code>null</code> if this was a local command.
+         * @return The request as a ModelNode, or <code>null</code> if this was
+         * a local command.
          */
         public ModelNode getRequest() {
             return this.request;
         }
 
         /**
-         * If the command resulted in a server-side operation, return the ModelNode representation of the response.
+         * If the command resulted in a server-side operation, return the
+         * ModelNode representation of the response.
          *
-         * @return The server response as a ModelNode, or <code>null</code> if this was a local command.
+         * @return The server response as a ModelNode, or <code>null</code> if
+         * this was a local command.
          */
         public ModelNode getResponse() {
             return this.response;
         }
 
         /**
-         * Return true if the command was successful.  For a server-side operation, this is determined by the outcome of the
-         * operation on the server side.
+         * Return true if the command was successful. For a server-side
+         * operation, this is determined by the outcome of the operation on the
+         * server side.
          *
-         * @return <code>true</code> if the command was successful, <code>false</code> otherwise.
+         * @return <code>true</code> if the command was successful,
+         * <code>false</code> otherwise.
          */
         public boolean isSuccess() {
             return this.isSuccess;
         }
 
         /**
-         * Return true if the command was only executed locally and did not result in a server-side operation.
+         * Return true if the command was only executed locally and did not
+         * result in a server-side operation.
          *
-         * @return <code>true</code> if the command was only executed locally, <code>false</code> otherwise.
+         * @return <code>true</code> if the command was only executed locally,
+         * <code>false</code> otherwise.
          */
         public boolean isLocalCommand() {
             return this.isLocalCommand;

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -251,6 +251,11 @@ public class MockCommandContext implements CommandContext {
     @Override
     public boolean isBatchMode() {
         // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    public boolean isWorkflowMode() {
         return false;
     }
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIScriptSupportTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIScriptSupportTestCase.java
@@ -1,0 +1,171 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+package org.jboss.as.test.manualmode.management.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import javax.inject.Inject;
+import org.jboss.as.cli.scriptsupport.CLI;
+import org.jboss.as.cli.scriptsupport.CLI.Result;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test various connection states of the CLI class.
+ *
+ * @author Jean-Francois Denise (jdenise@redhat.com)
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class CLIScriptSupportTestCase {
+
+    private static final File ROOT = new File(System.getProperty("jboss.home"));
+    private static final String JBOSS_HOME = " --jboss-home="
+            + ROOT.getAbsolutePath();
+
+    @Inject
+    private ServerController serverController;
+
+    @Test
+    public void testConnectStatus() {
+
+        // Offline instance
+        CLI cli = CLI.newInstance();
+
+        try {
+            copyConfig("standalone.xml", "standalone-cli.xml", true);
+        } catch (IOException ex) {
+            Assert.fail("Exception copying configuration: " + ex);
+        }
+
+        // start an embedded server
+        executeCommand(cli, "embed-server --std-out=echo "
+                + "--server-config=standalone-cli.xml" + JBOSS_HOME);
+        try {
+            // Enable management
+            executeCommand(cli, "reload --admin-only=false");
+
+            // Start a clean CLI
+            CLI cli2 = CLI.newInstance();
+
+            // Make an invalid connect
+            checkFail(() -> cli2.connect(TestSuiteEnvironment.getServerAddress(),
+                    123,
+                    null,
+                    null));
+
+            // Make a valid connect
+            cli2.connect();
+            try {
+                executeCommand(cli2, "version");
+            } finally {
+                cli2.disconnect();
+            }
+        } finally {
+            cli.cmd("stop-embedded-server");
+        }
+    }
+
+    @Test
+    public void testDisconnect() {
+        CLI cli = CLI.newInstance();
+        checkFail(() -> cli.disconnect());
+    }
+
+    @Test
+    public void testBatch() {
+        serverController.start();
+        try {
+            CLI cli = CLI.newInstance();
+            cli.connect(serverController.getClient().getMgmtAddress(),
+                    serverController.getClient().getMgmtPort(), null, null);
+            addProperty(cli, "prop1", "prop1_a");
+            addProperty(cli, "prop2", "prop2_a");
+
+            cli.cmd("batch");
+            writeProperty(cli, "prop1", "prop1_b");
+            writeProperty(cli, "prop2", "prop2_b");
+            cli.cmd("run-batch");
+            assertEquals("prop1_b", readProperty(cli, "prop1"));
+            assertEquals("prop2_b", readProperty(cli, "prop2"));
+        } finally {
+            serverController.stop();
+        }
+    }
+
+    private static void checkFail(Runnable runner) {
+        boolean failed = false;
+        try {
+            runner.run();
+        } catch (RuntimeException ex) {
+            failed = true;
+        }
+        if (!failed) {
+            Assert.fail("Should have failed");
+        }
+    }
+
+    private static void executeCommand(CLI cli, String cmd) {
+        Result res = cli.cmd(cmd);
+        if (!res.isSuccess()) {
+            Assert.fail("Invalid response " + res.getResponse().asString());
+        }
+    }
+
+    private static void addProperty(CLI cli, String name, String value) {
+        cli.cmd("/system-property=" + name + ":add(value=" + value + ")");
+    }
+
+    private static String readProperty(CLI cli, String name) {
+        Result res = cli.cmd("/system-property=" + name
+                + ":read-attribute(name=value)");
+        return res.getResponse().get("result").asString();
+    }
+
+    private static void writeProperty(CLI cli, String name, String value) {
+        cli.cmd("/system-property=" + name
+                + ":write-attribute(name=value,value=" + value + ")");
+    }
+
+    private static void copyConfig(String base, String newName,
+            boolean requiresExists) throws IOException {
+        File configDir = new File(ROOT, "standalone" + File.separatorChar
+                + "configuration");
+        File baseFile = new File(configDir, base);
+        assertTrue(!requiresExists || baseFile.exists());
+        File newFile = new File(configDir, newName);
+        Files.copy(baseFile.toPath(), newFile.toPath(),
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.COPY_ATTRIBUTES);
+    }
+
+}


### PR DESCRIPTION
[WFCORE-1456]
Approach is to make this change compliant with existing CLI class behaviour.
The class can now handle offline mode commands.

 [WFCORE-1471]
The test added for WFCORE-1456 has shown that the CLI class was mixing operations and commands. Furthermore Batch and workflow features were not supported.
Although all could be routed to CommandContext.handle, this fix does its best to allow CLI.cmd to return a response when doable.