### PR TITLE
[WFCORE-1473] Improve inter-process handling for suspend servers operation using a blocking timeout

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/BlockingTimeout.java
+++ b/controller/src/main/java/org/jboss/as/controller/BlockingTimeout.java
@@ -102,7 +102,7 @@ public interface BlockingTimeout {
          * @param context the context. Cannot e {@code null}
          * @return the blocking timeout. Will not return {@code null}
          */
-        static BlockingTimeout getProxyBlockingTimeout(OperationContext context) {
+        public static BlockingTimeout getProxyBlockingTimeout(OperationContext context) {
             return context.getAttachment(ATTACHMENT_KEY);
         }
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -1179,8 +1179,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
         }
 
         @Override
-        public boolean awaitServerSuspend(Set<String> waitForServers, int timeout) {
-            return getServerInventory().awaitServerSuspend(waitForServers, timeout);
+        public List<ModelNode> awaitServerSuspend(Set<String> waitForServers, int timeout, BlockingTimeout blockingTimeout) {
+            return getServerInventory().awaitServerSuspend(waitForServers, timeout, blockingTimeout);
         }
     }
 
@@ -1512,8 +1512,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
             }
 
             @Override
-            public boolean awaitServerSuspend(Set<String> waitForServers, int timeout) {
-                return false;
+            public List<ModelNode> awaitServerSuspend(Set<String> waitForServers, int timeout, BlockingTimeout blockingTimeout) {
+                return Collections.emptyList();
             }
         };
         future.setInventory(inventory);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
@@ -46,6 +46,7 @@ import org.jboss.as.controller.ProxyOperationAddressTranslator;
 import org.jboss.as.controller.TransformingProxyController;
 import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.client.OperationResponse;
 import org.jboss.as.controller.client.helpers.domain.ServerStatus;
 import org.jboss.as.controller.remote.BlockingQueueOperationListener;
 import org.jboss.as.controller.remote.TransactionalProtocolClient;
@@ -64,6 +65,7 @@ import org.jboss.marshalling.Marshalling;
 import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.SimpleClassResolver;
 import org.jboss.msc.service.ServiceActivator;
+import org.jboss.threads.AsyncFuture;
 
 /**
  * Represents a managed server.
@@ -125,6 +127,8 @@ class ManagedServer {
     private volatile int operationID = CurrentOperationIdHolder.getCurrentOperationID();
     private volatile ManagedServerBootConfiguration bootConfiguration;
 
+    private final PathAddress address;
+
     ManagedServer(final String hostControllerName, final String serverName, final String authKey,
                   final ProcessControllerClient processControllerClient, final URI managementURI,
                   final TransformationTarget transformationTarget) {
@@ -144,7 +148,7 @@ class ManagedServer {
 
         // Setup the proxy controller
         final PathElement serverPath = PathElement.pathElement(RUNNING_SERVER, serverName);
-        final PathAddress address = PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement(HOST, hostControllerName), serverPath);
+        address = PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement(HOST, hostControllerName), serverPath);
         this.protocolClient = new ManagedServerProxy(this);
         this.proxyController = TransformingProxyController.Factory.create(protocolClient,
                 Transformers.Factory.create(transformationTarget), address, ProxyOperationAddressTranslator.SERVER);
@@ -718,15 +722,13 @@ class ManagedServer {
         return true;
     }
 
-    BlockingQueueOperationListener<?> suspend(int timeoutInSeconds) throws IOException {
+    AsyncFuture<OperationResponse> suspend(int timeoutInSeconds, final BlockingQueueOperationListener<TransactionalProtocolClient.Operation> listener) throws IOException {
         final ModelNode operation = new ModelNode();
         operation.get(OP).set(SUSPEND);
         operation.get(OP_ADDR).setEmptyList();
         operation.get(TIMEOUT).set(timeoutInSeconds);
 
-        BlockingQueueOperationListener<TransactionalProtocolClient.Operation> listener = new BlockingQueueOperationListener<>();
-        protocolClient.execute(listener, operation, OperationMessageHandler.DISCARD, OperationAttachments.EMPTY);
-        return listener;
+        return protocolClient.execute(listener, operation, OperationMessageHandler.DISCARD, OperationAttachments.EMPTY);
     }
 
     static enum InternalState {
@@ -938,6 +940,10 @@ class ManagedServer {
             }
         }
         return result;
+    }
+
+    PathAddress getAddress(){
+        return address;
     }
 
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
@@ -23,11 +23,13 @@
 package org.jboss.as.host.controller;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import javax.security.auth.callback.CallbackHandler;
 
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.client.helpers.domain.ServerStatus;
 import org.jboss.as.process.ProcessInfo;
@@ -315,11 +317,14 @@ public interface ServerInventory {
     void resumeServer(String serverName);
 
     /**
-     * Suspends and waits for the given set of servers to suspend up to the timeout
+     * Suspends and waits for the given set of servers to suspend up to the timeout.
+     *
      * @param waitForServers The servers to wait for
      * @param timeoutInSeconds The maximum amount of time to wait in seconds, with -1 meaning indefinitly
-     * @return <code>true</code> if all the servers suspended in time
+     * @param blockingTimeout  control for maximum period any blocking operations can block. Cannot be {@code null}
+     * @return An empty {@link Collection} if no errors were returned suspending the servers, otherwise it will contain
+     * all error responses. Will not be {@code null}
      */
-    boolean awaitServerSuspend(Set<String> waitForServers, int timeoutInSeconds);
+    List<ModelNode> awaitServerSuspend(Set<String> waitForServers, int timeoutInSeconds, BlockingTimeout blockingTimeout);
 
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1303,5 +1303,23 @@ public interface HostControllerLogger extends BasicLogger {
     @Message(id = 181, value = "Host Controller shutdown has been requested via an OS signal")
     void shutdownHookInvoked();
 
+    @LogMessage(level = Level.INFO)
+    @Message(id = 182, value = "Timed out after %d ms awaiting server suspend response(s) for server: %s")
+    void timedOutAwaitingSuspendResponse(int blockingTimeout, String serverName);
 
+    @Message(id = 183, value = "Timed out after %d ms awaiting server suspend response(s) for server: %s")
+    String timedOutAwaitingSuspendResponseMsg(int blockingTimeout, String serverName);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 184, value = "%s interrupted awaiting server suspend response(s)")
+    void interruptedAwaitingSuspendResponse(@Cause InterruptedException cause, String serverName);
+
+    @Message(id = 185, value = "%s interrupted awaiting server suspend response(s)")
+    String interruptedAwaitingSuspendResponseMsg(String serverName);
+
+    @Message( id = 186, value = "Failed executing the suspend operation for server: %s")
+    String suspendExecutionFailedMsg(String serverName);
+
+    @Message( id = 187, value = "Failed getting the response from the suspend listener for server: %s")
+    String suspendListenerFailedMsg(String serverName);
 }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -48,6 +48,7 @@ import java.util.concurrent.TimeoutException;
 
 import javax.security.auth.callback.CallbackHandler;
 
+import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ControlledProcessState.State;
 import org.jboss.as.controller.OperationContext;
@@ -688,7 +689,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         }
 
         @Override
-        public boolean awaitServerSuspend(Set<String> waitForServers, int timeout) {
+        public List<ModelNode> awaitServerSuspend(Set<String> waitForServers, int timeout, BlockingTimeout blockingTimeout) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
     }


### PR DESCRIPTION
This issue has been created from @bstansberry comments on https://github.com/wildfly/wildfly-core/pull/1490. 
It adds a blocking timout for the calls done by the HC when :suspend-servers operation is executed.

Jira issue is:
https://issues.jboss.org/browse/WFCORE-1473