### PR TITLE
[WFCORE-1508]

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -1465,10 +1465,15 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                     + " 'help' for the list of supported commands.");
         }
 
+        console.setPrompt(getPrompt());
         if(!console.running()) {
             console.start();
         }
-        console.setPrompt(getPrompt());
+        // if console is already running before we have started interacting, we need to
+        // make sure that the prompt is correctly displayed
+        else {
+            console.redrawPrompt();
+        }
         if(console.isControlled()) {
             console.continuous();
         }

--- a/cli/src/main/java/org/jboss/as/cli/impl/Console.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Console.java
@@ -108,6 +108,8 @@ public interface Console {
 
     void setPrompt(String prompt, Character mask);
 
+    void redrawPrompt();
+
     static final class Factory {
 
         public static Console getConsole(CommandContext ctx, Settings settings) throws CliInitializationException {
@@ -222,7 +224,8 @@ public interface Console {
                         Prompt origPrompt = null;
                         if(!console.getPrompt().getPromptAsString().equals(prompt)) {
                             origPrompt = console.getPrompt();
-                            console.updatePrompt(new Prompt(prompt, mask));
+                            console.setPrompt(new Prompt(prompt, mask));
+                            redrawPrompt();
                         }
                         try {
                             return console.getInputLine();
@@ -230,7 +233,7 @@ public interface Console {
                             e.printStackTrace();
                         } finally {
                             if(origPrompt != null) {
-                                console.updatePrompt(origPrompt);
+                                console.setPrompt(origPrompt);
                             }
                         }
                     } finally {
@@ -309,11 +312,15 @@ public interface Console {
                 }
 
                 @Override
-                public void
-                setPrompt(String prompt, Character mask) {
+                public void setPrompt(String prompt, Character mask) {
                     if(!prompt.equals(console.getPrompt().getPromptAsString())) {
-                        console.updatePrompt(new Prompt(prompt, mask));
+                        console.setPrompt(new Prompt(prompt, mask));
                     }
+                }
+
+                @Override
+                public void redrawPrompt() {
+                    console.clearBufferAndDisplayPrompt();
                 }
 
                 class HistoryImpl implements CommandHistory {


### PR DESCRIPTION
make sure the prompt is always displayed
if the console is started from other methods than CommandContextImpl.interact
we need to make sure that we redisplay the prompt when interact is eventually
called.