### PR TITLE
Revert "Improve test runner to allow few more things when running in manual s…"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <version.org.jboss.remoting>4.0.18.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>2.0.1.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.sasl>1.0.5.Final</version.org.jboss.sasl>
-        <version.org.jboss.shrinkwrap.shrinkwrap>1.2.3</version.org.jboss.shrinkwrap.shrinkwrap>
+        <version.org.jboss.shrinkwrap.shrinkwrap>1.1.2</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.3.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnHttpTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnHttpTestCase.java
@@ -219,6 +219,8 @@ public class RespawnHttpTestCase {
     @Test
     public void testReloadHc() throws Exception {
 
+        System.out.println("testReloadHc()");
+
         List<RunningProcess> original = waitForAllProcessesFullyStarted();
         Set<String> serverIds = new HashSet<String>();
         for (RunningProcess proc : original) {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/adminonly/auditlog/AdminOnlyAuditLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/adminonly/auditlog/AdminOnlyAuditLogTestCase.java
@@ -31,6 +31,7 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
 import org.jboss.as.domain.management.audit.AuditLogLoggerResourceDefinition;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Assert;
@@ -49,6 +50,7 @@ import org.xnio.IoUtils;
 @RunWith(WildflyTestRunner.class)
 @ServerControl(manual = true)
 public class AdminOnlyAuditLogTestCase {
+    public static final String CONTAINER = "jbossas-admin-only";
 
     @Inject
     private ServerController container;
@@ -58,17 +60,19 @@ public class AdminOnlyAuditLogTestCase {
     @Before
     public void startContainer() throws Exception {
         // Start the server
-        container.startInAdminMode();
-        managementClient = container.getClient();
+        container.start();
+        final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
+        managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
     }
 
     @After
     public void stopContainer() throws Exception {
+        final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         try {
             // Stop the container
             container.stop();
         } finally {
-            IoUtils.safeClose(managementClient);
+            IoUtils.safeClose(client);
         }
     }
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractLoggingTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractLoggingTestCase.java
@@ -42,6 +42,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper.ServerDeploymentException;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
@@ -50,6 +51,7 @@ import org.jboss.msc.service.ServiceActivator;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -159,7 +161,7 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs deploying the archive
      */
-    public void deploy() throws ServerDeploymentException {
+    public static void deploy() throws ServerDeploymentException {
         deploy(createDeployment(), DEPLOYMENT_NAME);
     }
 
@@ -170,7 +172,7 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs deploying the archive
      */
-    public void deploy(final String runtimeName) throws ServerDeploymentException {
+    public static void deploy(final String runtimeName) throws ServerDeploymentException {
         deploy(createDeployment(), runtimeName);
     }
 
@@ -181,7 +183,7 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs deploying the archive
      */
-    public void deploy(final Archive<?> archive) throws ServerDeploymentException {
+    public static void deploy(final Archive<?> archive) throws ServerDeploymentException {
         deploy(archive, DEPLOYMENT_NAME);
     }
 
@@ -193,8 +195,9 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs deploying the archive
      */
-    public void deploy(final Archive<?> archive, final String runtimeName) throws ServerDeploymentException {
-        container.deploy(archive, runtimeName);
+    public static void deploy(final Archive<?> archive, final String runtimeName) throws ServerDeploymentException {
+        final ServerDeploymentHelper helper = new ServerDeploymentHelper(client);
+        helper.deploy(runtimeName, archive.as(ZipExporter.class).exportAsInputStream());
     }
 
     /**
@@ -202,7 +205,7 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs undeploying the application
      */
-    public void undeploy() throws ServerDeploymentException {
+    public static void undeploy() throws ServerDeploymentException {
         undeploy(DEPLOYMENT_NAME);
     }
 
@@ -213,8 +216,9 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs undeploying the application
      */
-    public void undeploy(final String runtimeName) throws ServerDeploymentException {
-        container.undeploy(runtimeName);
+    public static void undeploy(final String runtimeName) throws ServerDeploymentException {
+        final ServerDeploymentHelper helper = new ServerDeploymentHelper(client);
+        helper.undeploy(runtimeName);
     }
 
     public static ModelNode createAddress(final String resourceKey, final String resourceName) {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
@@ -24,6 +24,8 @@ package org.jboss.as.test.manualmode.logging;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.jboss.as.test.integration.security.common.CoreUtils;
+import static org.jboss.as.test.manualmode.logging.AbstractLoggingTestCase.deploy;
+import static org.jboss.as.test.manualmode.logging.AbstractLoggingTestCase.undeploy;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.syslogserver.BlockedAllProtocolsSyslogServerEventHandler;
 import org.junit.After;

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadOpsTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadOpsTestCase.java
@@ -21,28 +21,39 @@
  */
 package org.jboss.as.test.manualmode.management.cli;
 
-import java.util.Map;
-import javax.inject.Inject;
-
-import org.jboss.as.cli.CommandContext;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
-import org.jboss.as.test.integration.management.util.CLIOpResult;
-import org.jboss.as.test.integration.management.util.CLITestUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.ServerControl;
-import org.wildfly.core.testrunner.ServerController;
-import org.wildfly.core.testrunner.WildflyTestRunner;
-
 import static org.hamcrest.CoreMatchers.is;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Map;
+import javax.inject.Inject;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.as.test.integration.management.util.CLITestUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.xnio.IoUtils;
 
 /**
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2013 Red Hat, inc.
@@ -51,7 +62,7 @@ import static org.junit.Assert.assertTrue;
 @ServerControl(manual = true)
 public class ReloadOpsTestCase extends AbstractCliTestBase {
 
-    private static final int TIMEOUT = 10_000;
+    private static final long TIMEOUT = 10_000L;
 
     @Inject
     private static ServerController container;
@@ -70,6 +81,7 @@ public class ReloadOpsTestCase extends AbstractCliTestBase {
 
     @Test
     public void testWriteAttribvuteWithReload() throws Exception {
+        ManagementClient managementClient = container.getClient();
         cli.sendLine("/subsystem=logging:read-attribute(name=add-logging-api-dependencies)");
         CLIOpResult result = cli.readAllAsOpResult();
         assertTrue(result.isIsOutcomeSuccess());
@@ -79,7 +91,7 @@ public class ReloadOpsTestCase extends AbstractCliTestBase {
         result = cli.readAllAsOpResult();
         assertTrue(result.isIsOutcomeSuccess());
         checkResponseHeadersForProcessState(result);
-        executeReload();
+        reloadServer(TIMEOUT);
         cli.sendLine("/subsystem=logging:read-attribute(name=add-logging-api-dependencies)");
         result = cli.readAllAsOpResult();
         assertTrue(result.isIsOutcomeSuccess());
@@ -96,22 +108,9 @@ public class ReloadOpsTestCase extends AbstractCliTestBase {
         assertThat(value, is("false"));
     }
 
-    protected void checkResponseHeadersForProcessState(CLIOpResult result) {
-        assertNotNull("No response headers!", result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS));
-        Map responseHeaders = (Map) result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS);
-        Object processState = responseHeaders.get("process-state");
-        assertNotNull("No process state in response-headers!", processState);
-        assertTrue("Process state is of wrong type!", processState instanceof String);
-        assertEquals("Wrong content of process-state header", "reload-required", processState);
-    }
-
-    protected void assertNoProcessState(CLIOpResult result) {
-        if (result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS) == null) {
-            return;
-        }
-        Map responseHeaders = (Map) result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS);
-        Object processState = responseHeaders.get("process-state");
-        assertNull(processState);
+    private void reloadServer(long timeout) throws Exception {
+        executeReload();
+        waitForLiveServerToReload(timeout);
     }
 
     private static void executeReload() throws Exception {
@@ -122,6 +121,51 @@ public class ReloadOpsTestCase extends AbstractCliTestBase {
         } finally {
             ctx.terminateSession();
         }
+
+    }
+
+    private void waitForLiveServerToReload(long timeout) throws Exception {
+        long start = System.currentTimeMillis();
+        ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        operation.get(NAME).set("server-state");
+        ModelControllerClient liveClient = container.getClient().getControllerClient();
+        while (System.currentTimeMillis() - start < timeout) {
+            try {
+                ModelNode result = liveClient.execute(operation);
+                if ("running".equals(result.get(RESULT).asString())) {
+                    return;
+                }
+            } catch (IOException e) {
+            } finally {
+                IoUtils.safeClose(liveClient);
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
+        }
+        fail("Live Server did not reload in the imparted time.");
+    }
+
+    protected void checkResponseHeadersForProcessState(CLIOpResult result) {
+        assertNotNull("No response headers!", result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS));
+        Map responseHeaders = (Map) result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS);
+        Object processState = responseHeaders.get("process-state");
+        assertNotNull("No process state in response-headers!", processState);
+        assertTrue("Process state is of wrong type!", processState instanceof String);
+        assertEquals("Wrong content of process-state header", "reload-required", (String) processState);
+
+    }
+
+    protected void assertNoProcessState(CLIOpResult result) {
+        if (result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS) == null) {
+            return;
+        }
+        Map responseHeaders = (Map) result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS);
+        Object processState = responseHeaders.get("process-state");
+        assertNull(processState);
 
     }
 }

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
@@ -22,15 +22,23 @@
 
 package org.wildfly.core.test.standalone.mgmt;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.HTTPS_CONTROLLER;
+import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.MANAGEMENT_NATIVE_PORT;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import static org.junit.Assert.assertThat;
+import static org.wildfly.core.test.standalone.mgmt.HTTPSManagementInterfaceTestCase.reloadServer;
+
 import java.io.File;
 import java.io.IOException;
 import javax.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
-import org.jboss.as.cli.CommandContext;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.integration.management.util.CustomCLIExecutor;
 import org.jboss.as.test.integration.security.PicketBoxModuleUtil;
 import org.jboss.as.test.integration.security.common.AbstractBaseSecurityRealmsServerSetupTask;
@@ -53,15 +61,6 @@ import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.ServerSetupTask;
 import org.wildfly.core.testrunner.WildflyTestRunner;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
-import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.HTTPS_CONTROLLER;
-import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.MANAGEMENT_NATIVE_PORT;
-import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
-import static org.junit.Assert.assertThat;
 
 /**
  * Testing https connection to the http management interface with cli console
@@ -102,16 +101,17 @@ public class HTTPSConnectionWithCLITestCase {
 
     @BeforeClass
     public static void prepareServer() throws Exception {
-        containerController.startInAdminMode();
+        containerController.start();
         ManagementClient mgmtClient = containerController.getClient();
         //final ModelControllerClient client = mgmtClient.getControllerClient();
         keystoreFilesSetup.setup(mgmtClient);
         managementNativeRealmSetup.setup(mgmtClient);
 
 
-        picketLinkModule = PicketBoxModuleUtil.createTestModule();
-        // To apply new security realm settings for http interface reload of  server is required
+        // To apply new security realm settings for http interface reload of
+        // server is required
         reloadServer();
+        picketLinkModule = PicketBoxModuleUtil.createTestModule();
     }
 
     /**
@@ -159,7 +159,7 @@ public class HTTPSConnectionWithCLITestCase {
         HTTPSManagementInterfaceTestCase.resetHttpInterfaceConfiguration(client);
 
         // reload to apply changes
-        reloadServer();//reload using CLI
+        reloadServer();
 
         keystoreFilesSetup.tearDown(managementClient);
         managementNativeRealmSetup.tearDown(managementClient);
@@ -169,15 +169,6 @@ public class HTTPSConnectionWithCLITestCase {
         FileUtils.deleteDirectory(WORK_DIR);
     }
 
-    public static void reloadServer() throws Exception {
-        final CommandContext ctx = CLITestUtil.getCommandContext("remoting", TestSuiteEnvironment.getServerAddress(), MANAGEMENT_NATIVE_PORT);
-        try {
-            ctx.connectController();
-            ctx.handle("reload");
-        } finally {
-            ctx.terminateSession();
-        }
-    }
 
     static class ManagementNativeRealmSetup extends AbstractBaseSecurityRealmsServerSetupTask {
 

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfaceTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfaceTestCase.java
@@ -29,7 +29,6 @@ import static org.jboss.as.test.integration.security.common.CoreUtils.makeCallWi
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.wildfly.core.test.standalone.mgmt.HTTPSConnectionWithCLITestCase.reloadServer;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,9 +45,11 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.jboss.as.cli.CommandContext;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.categories.CommonCriteria;
+import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.integration.security.common.AbstractBaseSecurityRealmsServerSetupTask;
 import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.integration.security.common.SSLTruststoreUtil;
@@ -107,7 +108,7 @@ public class HTTPSManagementInterfaceTestCase {
 
     @BeforeClass
     public static void startAndSetupContainer() throws Exception {
-        controller.startInAdminMode();
+        controller.start();
 
         ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         ManagementClient managementClient = controller.getClient();
@@ -118,6 +119,16 @@ public class HTTPSManagementInterfaceTestCase {
         // To apply new security realm settings for http interface reload of
         // server is required
         reloadServer();
+    }
+
+    public static void reloadServer() throws Exception {
+        final CommandContext ctx = CLITestUtil.getCommandContext("remoting", TestSuiteEnvironment.getServerAddress(), 9999);
+        try {
+            ctx.connectController();
+            ctx.handle("reload");
+        } finally {
+            ctx.terminateSession();
+        }
     }
 
     /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.test.integration.management.util;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
@@ -197,6 +198,37 @@ public class CustomCLIExecutor {
             }
         }
         return exitCode + ": " + cliOutput;
+    }
+
+    /**
+     * Waits for server to reload until server-state is running
+     *
+     * @param timeout
+     * @param controller
+     * @throws Exception
+     */
+    public static void waitForServerToReload(int timeout, String controller) throws Exception {
+
+        Thread.sleep(TimeoutUtil.adjust(500));
+        long start = System.currentTimeMillis();
+        long now;
+        do {
+            try {
+                String result = CustomCLIExecutor.execute(null, READ_ATTRIBUTE_OPERATION + " server-state", controller);
+                boolean normal = result.contains("running");
+                if (normal) {
+                    return;
+                }
+            } catch (Exception e) {
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
+            now = System.currentTimeMillis();
+        } while (now - start < timeout);
+
+        fail("Server did not reload in the imparted time.");
     }
 
     private static class ConsoleConsumer implements Runnable {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreUtils.java
@@ -178,7 +178,7 @@ public class CoreUtils {
 
     public static void applyUpdate(ModelNode update, final ModelControllerClient client) throws Exception {
         ModelNode result = client.execute(new OperationBuilder(update).build());
-        if (LOGGER.isDebugEnabled()) {
+        if (LOGGER.isInfoEnabled()) {
             LOGGER.info("Client update: " + update);
             LOGGER.info("Client update result: " + result);
         }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GenericCommandTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GenericCommandTestCase.java
@@ -25,16 +25,19 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
  * Test generic command features of CLI.
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
+@ServerSetup(ServerReload.SetupTask.class)
 @RunWith(WildflyTestRunner.class)
 public class GenericCommandTestCase extends AbstractCliTestBase {
 
@@ -45,7 +48,6 @@ public class GenericCommandTestCase extends AbstractCliTestBase {
 
     @AfterClass
     public static void after() throws Exception {
-        cli.sendLine("reload");
         AbstractCliTestBase.closeCLI();
     }
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GlobalOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GlobalOpsTestCase.java
@@ -30,17 +30,20 @@ import java.util.Map;
 
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
+@ServerSetup(ServerReload.SetupTask.class)
 @RunWith(WildflyTestRunner.class)
 public class GlobalOpsTestCase extends AbstractCliTestBase {
 
@@ -51,7 +54,6 @@ public class GlobalOpsTestCase extends AbstractCliTestBase {
 
     @AfterClass
     public static void after() throws Exception {
-        cli.sendLine("reload");
         AbstractCliTestBase.closeCLI();
     }
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpPostMgmtOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpPostMgmtOpsTestCase.java
@@ -21,6 +21,10 @@
  */
 package org.jboss.as.test.integration.management.http;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
@@ -36,12 +40,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
-import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.WildflyTestRunner;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests all management operation types which are available via HTTP POST requests.
@@ -218,22 +217,6 @@ public class HttpPostMgmtOpsTestCase {
         ModelNode result = ret.get("result");
 
         assertFalse(result.asList().isEmpty());
-    }
-
-    @Inject
-    private static ServerController container;
-
-    //@Test this is prototype for reload testing via http interface
-    public void testReload() throws Exception {
-
-        ModelNode op = HttpMgmtProxy.getOpNode("/", "reload");
-
-        for (int i = 0; i < 10; i++) {
-            ModelNode ret = httpMgmt.sendPostCommand(op);
-            assertTrue("success".equals(ret.get("outcome").asString()));
-            container.waitForLiveServerToReload(10 * 1000); //wait 10 seconds for reload
-            testReadChildrenResources();
-        }
     }
 
     @Test

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
@@ -97,7 +97,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
 public class BasicOperationsUnitTestCase {
 
     @Inject
-    private ManagementClient managementClient;
+    private static ManagementClient managementClient;
 
     @Test
     public void testSocketBindingsWildcards() throws IOException {
@@ -124,16 +124,18 @@ public class BasicOperationsUnitTestCase {
     }
 
     @Test
-    public void testReadResourceRecursiveDepthRecursiveUndefined() throws Exception {
+    public void testReadResourceRecursiveDepthRecursiveUndefined() throws IOException {
         // WFCORE-76
         final ModelNode operation = new ModelNode();
         operation.get(OP).set(READ_RESOURCE_OPERATION);
         operation.get(OP_ADDR).setEmptyList();
         operation.get(RECURSIVE_DEPTH).set(1);
 
-        final ModelNode result = managementClient.executeForResult(operation);
+        final ModelNode result = managementClient.getControllerClient().execute(operation);
+        assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        assertTrue(result.hasDefined(RESULT));
 
-        final ModelNode logging = result.get(SUBSYSTEM, "logging");
+        final ModelNode logging = result.get(RESULT, SUBSYSTEM, "logging");
         assertTrue(logging.hasDefined("logger"));
         final ModelNode rootLogger = result.get(RESULT, SUBSYSTEM, "logging", "root-logger");
         assertFalse(rootLogger.hasDefined("ROOT"));
@@ -447,7 +449,7 @@ public class BasicOperationsUnitTestCase {
         }
     }
 
-    private int countSystemProperties() throws IOException {
+    private static int countSystemProperties() throws IOException {
         ModelNode readProperties = Operations.createOperation(READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS.toModelNode());
         readProperties.get(CHILD_TYPE).set(SYSTEM_PROPERTY);
         ModelNode response = managementClient.getControllerClient().execute(readProperties);
@@ -455,7 +457,7 @@ public class BasicOperationsUnitTestCase {
         return properties.asList().size();
     }
 
-    private void validateSystemProperty(Map<String, String> properties, String propertyName, boolean exist, int origPropCount) throws IOException, MgmtOperationException {
+    private static void validateSystemProperty(Map<String, String> properties, String propertyName, boolean exist, int origPropCount) throws IOException, MgmtOperationException {
         ModelNode readProperties = Operations.createOperation(READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS.toModelNode());
         readProperties.get(CHILD_TYPE).set(SYSTEM_PROPERTY);
         ModelNode response = managementClient.getControllerClient().execute(readProperties);

--- a/testsuite/test-runner/pom.xml
+++ b/testsuite/test-runner/pom.xml
@@ -86,9 +86,5 @@
             <artifactId>junit</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap</groupId>
-            <artifactId>shrinkwrap-api</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -4,38 +4,23 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 
 import org.jboss.as.controller.client.ModelControllerClient;
-import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.client.helpers.Operations;
-import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
-import org.junit.Assert;
 import org.wildfly.core.launcher.Launcher;
 import org.wildfly.core.launcher.ProcessHelper;
 import org.wildfly.core.launcher.StandaloneCommandBuilder;
-
-import static org.jboss.as.controller.client.helpers.ClientConstants.NAME;
-import static org.jboss.as.controller.client.helpers.ClientConstants.OP;
-import static org.jboss.as.controller.client.helpers.ClientConstants.OP_ADDR;
-import static org.jboss.as.controller.client.helpers.ClientConstants.READ_ATTRIBUTE_OPERATION;
-import static org.jboss.as.controller.client.helpers.ClientConstants.RESULT;
-import static org.jboss.as.controller.client.helpers.ClientConstants.SERVER_CONFIG;
-import static org.junit.Assert.fail;
 
 /**
  * encapsulation of a server process
  *
  * @author Stuart Douglas
- * @author Tomaz Cerar
  */
 public class Server {
 
@@ -46,14 +31,13 @@ public class Server {
     private final String javaHome = System.getProperty("java.home", System.getenv("JAVA_HOME"));
     //Use this when specifying an older java to be used for running the server
     private final String legacyJavaHome = System.getProperty("legacy.java.home");
-    private String serverConfig = System.getProperty("server.config", "standalone.xml");
+    private final String serverConfig = System.getProperty("server.config", "standalone.xml");
     private final int managementPort = Integer.getInteger("management.port", 9990);
     private final String managementAddress = System.getProperty("management.address", "localhost");
     private final String managementProtocol = System.getProperty("management.protocol", "http-remoting");
 
     private final String serverDebug = "wildfly.debug";
     private final int serverDebugPort = Integer.getInteger("wildfly.debug.port", 8787);
-    private boolean adminMode = false;
 
     private final Logger log = Logger.getLogger(Server.class.getName());
     private Thread shutdownThread;
@@ -70,18 +54,6 @@ public class Server {
             // good
             return false;
         }
-    }
-
-    /**
-     * Sets server config to use
-     * @param serverConfig
-     */
-    public void setServerConfig(String serverConfig) {
-        this.serverConfig = serverConfig;
-    }
-
-    public void setAdminMode(boolean adminMode) {
-        this.adminMode = adminMode;
     }
 
     protected void start() {
@@ -103,10 +75,6 @@ public class Server {
             }
             if(Boolean.getBoolean(serverDebug)) {
                 commandBuilder.setDebug(true, serverDebugPort);
-            }
-
-            if (this.adminMode) {
-                commandBuilder.setAdminOnly();
             }
 
             //we are testing, of course we want assertions and set-up some other defaults
@@ -131,7 +99,17 @@ public class Server {
             shutdownThread = ProcessHelper.addShutdownHook(proc);
 
 
-            client = createClient();
+            ModelControllerClient modelControllerClient = null;
+            try {
+                modelControllerClient = ModelControllerClient.Factory.create(
+                        managementProtocol,
+                        managementAddress,
+                        managementPort,
+                        Authentication.getCallbackHandler());
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
+            }
+            client = new ManagementClient(modelControllerClient, managementAddress, managementPort, managementProtocol);
 
             long startupTimeout = 30;
             long timeout = startupTimeout * 1000;
@@ -231,20 +209,6 @@ public class Server {
         return client;
     }
 
-    ManagementClient createClient(){
-        ModelControllerClient modelControllerClient = null;
-        try {
-            modelControllerClient = ModelControllerClient.Factory.create(
-                    managementProtocol,
-                    managementAddress,
-                    managementPort,
-                    Authentication.getCallbackHandler());
-        } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
-        }
-        return new ManagementClient(modelControllerClient, managementAddress, managementPort, managementProtocol);
-    }
-
     private void safeCloseClient() {
         try {
             if (client != null) {
@@ -255,79 +219,6 @@ public class Server {
             Logger.getLogger(this.getClass().getName()).warnf(e, "Caught exception closing ModelControllerClient");
         }
     }
-
-    /**
-     * Reload current server
-     * This method makes sure client on server is still operational after reload is done.
-     * @param adminOnly tells server to boot in admin only mode or normal
-     * @param timeout time in miliseconds to wait for server to come back after reload
-     */
-    public void reload(boolean adminOnly, int timeout) {
-        reload(adminOnly, timeout, null);
-    }
-
-    /**
-     * Reload current server
-     * This method makes sure client on server is still operational after reload is done.
-     * @param adminOnly tells server to boot in admin only mode or normal
-     * @param timeout time in miliseconds to wait for server to come back after reload
-     */
-    public void reload(boolean adminOnly, int timeout, String serverConfig) {
-        executeReload(adminOnly, serverConfig);
-        waitForLiveServerToReload(timeout); //30 seconds
-    }
-
-    private void executeReload(boolean adminOnly, String serverConfig) {
-        ModelNode operation = new ModelNode();
-        operation.get(OP_ADDR).setEmptyList();
-        operation.get(OP).set("reload");
-        operation.get("admin-only").set(adminOnly);
-        if (serverConfig != null) {
-            operation.get(SERVER_CONFIG).set(serverConfig);
-        }
-        try {
-            ModelNode result = client.getControllerClient().execute(operation);
-            Assert.assertEquals("success", result.get(ClientConstants.OUTCOME).asString());
-        } catch (IOException e) {
-            final Throwable cause = e.getCause();
-            if (!(cause instanceof ExecutionException) && !(cause instanceof CancellationException) && !(cause instanceof SocketException) ) {
-                throw new RuntimeException(e);
-            } // else ignore, this might happen if the channel gets closed before we got the response
-        }finally {
-            safeCloseClient();//close existing client
-        }
-    }
-
-    private void recreateClient(){
-        safeCloseClient();
-        client = createClient();
-    }
-
-    void waitForLiveServerToReload(int timeout) {
-        long start = System.currentTimeMillis();
-        ModelNode operation = new ModelNode();
-        operation.get(OP_ADDR).setEmptyList();
-        operation.get(OP).set(READ_ATTRIBUTE_OPERATION);
-        operation.get(NAME).set("server-state");
-        while (System.currentTimeMillis() - start < timeout) {
-            recreateClient();
-            ModelControllerClient liveClient = client.getControllerClient();
-            try {
-                ModelNode result = liveClient.execute(operation);
-                if ("running".equals(result.get(RESULT).asString())) {
-                    return;
-                }
-            } catch (IOException e) {
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-            }
-
-        }
-        fail("Live Server did not reload in the imparted time.");
-    }
-
 
     /**
      * Runnable that consumes the output of the process. If nothing consumes the output the AS will hang on some

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ServerController.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ServerController.java
@@ -1,14 +1,6 @@
 package org.wildfly.core.testrunner;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 
 /**
  * @author Tomaz Cerar (c) 2014 Red Hat Inc.
@@ -18,13 +10,9 @@ public class ServerController {
     private static final AtomicBoolean started = new AtomicBoolean(false);
     private static volatile Server server;
 
-    public void start(final String serverConfig, boolean adminMode) {
+    public void start() {
         if (started.compareAndSet(false, true)) {
             server = new Server();
-            if (serverConfig != null) {
-                server.setServerConfig(serverConfig);
-            }
-            server.setAdminMode(adminMode);
             try {
                 server.start();
             } catch (final Throwable t) {
@@ -35,15 +23,6 @@ public class ServerController {
             }
         }
     }
-
-    public void start() {
-        start(null, false);
-    }
-
-    public void startInAdminMode(){
-        start(null, true);
-    }
-
 
     public void stop() {
         if (server != null) {
@@ -62,57 +41,5 @@ public class ServerController {
 
     public ManagementClient getClient() {
         return server.getClient();
-    }
-
-    public ManagementClient createNewManagementClient(){
-        return server.createClient();
-    }
-
-    public ServerDeploymentHelper getDeploymentHelper() {
-        return new ServerDeploymentHelper(server.getClient().getControllerClient());
-    }
-
-    public void deploy(final Archive<?> archive, final String runtimeName) throws ServerDeploymentHelper.ServerDeploymentException {
-        getDeploymentHelper().deploy(runtimeName, archive.as(ZipExporter.class).exportAsInputStream());
-    }
-
-    public void deploy(final Path deployment) throws ServerDeploymentHelper.ServerDeploymentException, IOException {
-        final ServerDeploymentHelper helper = getDeploymentHelper();
-        try (InputStream in = Files.newInputStream(deployment)) {
-            helper.deploy(deployment.getFileName().toString(), in);
-        }
-
-    }
-
-    public void undeploy(final String runtimeName) throws ServerDeploymentHelper.ServerDeploymentException {
-        final ServerDeploymentHelper helper = getDeploymentHelper();
-        helper.undeploy(runtimeName);
-    }
-
-    /**
-     * Reloads server and wait for it to come back
-     */
-    public void reload() {
-        server.reload(false, 30 * 1000); //by default reload in normal mode with timeout of 30 seconds
-    }
-
-    public void reload(int timeout) {
-        server.reload(false, timeout);
-    }
-
-    public void reload(boolean adminMode, int timeout) {
-        server.reload(adminMode, timeout);
-    }
-
-    public void reload(boolean adminMode, int timeout, String serverConfig) {
-        server.reload(adminMode, timeout, serverConfig);
-    }
-
-    public void reload(String serverConfig) {
-        server.reload(false, 30 * 1000, serverConfig);
-    }
-
-    public void waitForLiveServerToReload(int timeout){
-        server.waitForLiveServerToReload(timeout);
     }
 }


### PR DESCRIPTION
Reverts wildfly/wildfly-core#1227

Reverting as we are finding other issues like the one discussed yesterday. We need some sort of cleanup or a way to avoid this problem.

A quick check for scope:

```
git grep "static ManagementClient"
protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementClientChannelStrategy.java:    public static ManagementClientChannelStrategy create(final Channel channel) {
protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementClientChannelStrategy.java:    public static ManagementClientChannelStrategy create(final ProtocolChannelClient setup,
protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementClientChannelStrategy.java:    public static ManagementClientChannelStrategy create(final ProtocolConnectionConfiguration configuration, final Channel.Receiver receiver, final CloseHandler<Channel> closeHandler) {
testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/AbstractManagementInterfaceRbacTestCase.java:    protected static ManagementClient managementClient;
testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/AbstractManagementInterfaceRbacTestCase.java:    protected static ManagementClient getManagementClient() {
testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/AbstractRbacTestCase.java:    protected static ManagementClient managementClient;
testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/DeploymentScannerTestCase.java:    private static ManagementClient managementClient;
testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/AbstractLoggingTestCase.java:    protected static ManagementClient client;
testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/CliExtCommandsTestCase.java:    protected static ManagementClient client;
testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/DuplicateExtCommandTestCase.java:    protected static ManagementClient client;
testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/base/ContainerResourceMgmtTestBase.java:    private static ManagementClient managementClient;
testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/DescribeOperationUnitTestCase.java:    private static ManagementClient managementClient;
```