### PR TITLE
Improve test runner to allow few more things when running in manual server mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <version.org.jboss.remoting>4.0.18.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>2.0.1.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.sasl>1.0.5.Final</version.org.jboss.sasl>
-        <version.org.jboss.shrinkwrap.shrinkwrap>1.1.2</version.org.jboss.shrinkwrap.shrinkwrap>
+        <version.org.jboss.shrinkwrap.shrinkwrap>1.2.3</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.3.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnHttpTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnHttpTestCase.java
@@ -219,8 +219,6 @@ public class RespawnHttpTestCase {
     @Test
     public void testReloadHc() throws Exception {
 
-        System.out.println("testReloadHc()");
-
         List<RunningProcess> original = waitForAllProcessesFullyStarted();
         Set<String> serverIds = new HashSet<String>();
         for (RunningProcess proc : original) {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/adminonly/auditlog/AdminOnlyAuditLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/adminonly/auditlog/AdminOnlyAuditLogTestCase.java
@@ -31,7 +31,6 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
 import org.jboss.as.domain.management.audit.AuditLogLoggerResourceDefinition;
-import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.Assert;
@@ -50,7 +49,6 @@ import org.xnio.IoUtils;
 @RunWith(WildflyTestRunner.class)
 @ServerControl(manual = true)
 public class AdminOnlyAuditLogTestCase {
-    public static final String CONTAINER = "jbossas-admin-only";
 
     @Inject
     private ServerController container;
@@ -60,19 +58,17 @@ public class AdminOnlyAuditLogTestCase {
     @Before
     public void startContainer() throws Exception {
         // Start the server
-        container.start();
-        final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
-        managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+        container.startInAdminMode();
+        managementClient = container.getClient();
     }
 
     @After
     public void stopContainer() throws Exception {
-        final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         try {
             // Stop the container
             container.stop();
         } finally {
-            IoUtils.safeClose(client);
+            IoUtils.safeClose(managementClient);
         }
     }
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractLoggingTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractLoggingTestCase.java
@@ -42,7 +42,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.helpers.Operations;
-import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper.ServerDeploymentException;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
@@ -51,7 +50,6 @@ import org.jboss.msc.service.ServiceActivator;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -161,7 +159,7 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs deploying the archive
      */
-    public static void deploy() throws ServerDeploymentException {
+    public void deploy() throws ServerDeploymentException {
         deploy(createDeployment(), DEPLOYMENT_NAME);
     }
 
@@ -172,7 +170,7 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs deploying the archive
      */
-    public static void deploy(final String runtimeName) throws ServerDeploymentException {
+    public void deploy(final String runtimeName) throws ServerDeploymentException {
         deploy(createDeployment(), runtimeName);
     }
 
@@ -183,7 +181,7 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs deploying the archive
      */
-    public static void deploy(final Archive<?> archive) throws ServerDeploymentException {
+    public void deploy(final Archive<?> archive) throws ServerDeploymentException {
         deploy(archive, DEPLOYMENT_NAME);
     }
 
@@ -195,9 +193,8 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs deploying the archive
      */
-    public static void deploy(final Archive<?> archive, final String runtimeName) throws ServerDeploymentException {
-        final ServerDeploymentHelper helper = new ServerDeploymentHelper(client);
-        helper.deploy(runtimeName, archive.as(ZipExporter.class).exportAsInputStream());
+    public void deploy(final Archive<?> archive, final String runtimeName) throws ServerDeploymentException {
+        container.deploy(archive, runtimeName);
     }
 
     /**
@@ -205,7 +202,7 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs undeploying the application
      */
-    public static void undeploy() throws ServerDeploymentException {
+    public void undeploy() throws ServerDeploymentException {
         undeploy(DEPLOYMENT_NAME);
     }
 
@@ -216,9 +213,8 @@ public abstract class AbstractLoggingTestCase {
      *
      * @throws ServerDeploymentException if an error occurs undeploying the application
      */
-    public static void undeploy(final String runtimeName) throws ServerDeploymentException {
-        final ServerDeploymentHelper helper = new ServerDeploymentHelper(client);
-        helper.undeploy(runtimeName);
+    public void undeploy(final String runtimeName) throws ServerDeploymentException {
+        container.undeploy(runtimeName);
     }
 
     public static ModelNode createAddress(final String resourceKey, final String resourceName) {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
@@ -24,8 +24,6 @@ package org.jboss.as.test.manualmode.logging;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.jboss.as.test.integration.security.common.CoreUtils;
-import static org.jboss.as.test.manualmode.logging.AbstractLoggingTestCase.deploy;
-import static org.jboss.as.test.manualmode.logging.AbstractLoggingTestCase.undeploy;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.syslogserver.BlockedAllProtocolsSyslogServerEventHandler;
 import org.junit.After;

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
@@ -22,23 +22,15 @@
 
 package org.wildfly.core.test.standalone.mgmt;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
-import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.HTTPS_CONTROLLER;
-import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.MANAGEMENT_NATIVE_PORT;
-import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
-import static org.junit.Assert.assertThat;
-import static org.wildfly.core.test.standalone.mgmt.HTTPSManagementInterfaceTestCase.reloadServer;
-
 import java.io.File;
 import java.io.IOException;
 import javax.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
+import org.jboss.as.cli.CommandContext;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.integration.management.util.CustomCLIExecutor;
 import org.jboss.as.test.integration.security.PicketBoxModuleUtil;
 import org.jboss.as.test.integration.security.common.AbstractBaseSecurityRealmsServerSetupTask;
@@ -61,6 +53,15 @@ import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.ServerSetupTask;
 import org.wildfly.core.testrunner.WildflyTestRunner;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.HTTPS_CONTROLLER;
+import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.MANAGEMENT_NATIVE_PORT;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import static org.junit.Assert.assertThat;
 
 /**
  * Testing https connection to the http management interface with cli console
@@ -101,17 +102,16 @@ public class HTTPSConnectionWithCLITestCase {
 
     @BeforeClass
     public static void prepareServer() throws Exception {
-        containerController.start();
+        containerController.startInAdminMode();
         ManagementClient mgmtClient = containerController.getClient();
         //final ModelControllerClient client = mgmtClient.getControllerClient();
         keystoreFilesSetup.setup(mgmtClient);
         managementNativeRealmSetup.setup(mgmtClient);
 
 
-        // To apply new security realm settings for http interface reload of
-        // server is required
-        reloadServer();
         picketLinkModule = PicketBoxModuleUtil.createTestModule();
+        // To apply new security realm settings for http interface reload of  server is required
+        reloadServer();
     }
 
     /**
@@ -159,7 +159,7 @@ public class HTTPSConnectionWithCLITestCase {
         HTTPSManagementInterfaceTestCase.resetHttpInterfaceConfiguration(client);
 
         // reload to apply changes
-        reloadServer();
+        reloadServer();//reload using CLI
 
         keystoreFilesSetup.tearDown(managementClient);
         managementNativeRealmSetup.tearDown(managementClient);
@@ -169,6 +169,15 @@ public class HTTPSConnectionWithCLITestCase {
         FileUtils.deleteDirectory(WORK_DIR);
     }
 
+    public static void reloadServer() throws Exception {
+        final CommandContext ctx = CLITestUtil.getCommandContext("remoting", TestSuiteEnvironment.getServerAddress(), MANAGEMENT_NATIVE_PORT);
+        try {
+            ctx.connectController();
+            ctx.handle("reload");
+        } finally {
+            ctx.terminateSession();
+        }
+    }
 
     static class ManagementNativeRealmSetup extends AbstractBaseSecurityRealmsServerSetupTask {
 

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfaceTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfaceTestCase.java
@@ -29,6 +29,7 @@ import static org.jboss.as.test.integration.security.common.CoreUtils.makeCallWi
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.wildfly.core.test.standalone.mgmt.HTTPSConnectionWithCLITestCase.reloadServer;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,11 +46,9 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.jboss.as.cli.CommandContext;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.categories.CommonCriteria;
-import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.integration.security.common.AbstractBaseSecurityRealmsServerSetupTask;
 import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.integration.security.common.SSLTruststoreUtil;
@@ -108,7 +107,7 @@ public class HTTPSManagementInterfaceTestCase {
 
     @BeforeClass
     public static void startAndSetupContainer() throws Exception {
-        controller.start();
+        controller.startInAdminMode();
 
         ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         ManagementClient managementClient = controller.getClient();
@@ -119,16 +118,6 @@ public class HTTPSManagementInterfaceTestCase {
         // To apply new security realm settings for http interface reload of
         // server is required
         reloadServer();
-    }
-
-    public static void reloadServer() throws Exception {
-        final CommandContext ctx = CLITestUtil.getCommandContext("remoting", TestSuiteEnvironment.getServerAddress(), 9999);
-        try {
-            ctx.connectController();
-            ctx.handle("reload");
-        } finally {
-            ctx.terminateSession();
-        }
     }
 
     /**

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/RemoveManagementInterfaceTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/RemoveManagementInterfaceTestCase.java
@@ -25,6 +25,7 @@ import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.MA
 import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.MANAGEMENT_NATIVE_PORT;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
 import static org.junit.Assert.assertThat;
+import static org.wildfly.core.test.standalone.mgmt.HTTPSConnectionWithCLITestCase.reloadServer;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -33,16 +34,13 @@ import java.net.UnknownHostException;
 import javax.inject.Inject;
 import org.hamcrest.CoreMatchers;
 
-import org.jboss.as.cli.CommandContext;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.categories.CommonCriteria;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
-import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -70,27 +68,16 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
 @Category(CommonCriteria.class)
 public class RemoveManagementInterfaceTestCase {
 
-    public static Logger LOGGER = Logger.getLogger(RemoveManagementInterfaceTestCase.class);
     @Inject
     protected static ServerController controller;
 
     @BeforeClass
     public static void startAndSetupContainer() throws Exception {
-        controller.start();
+        controller.startInAdminMode();
         ManagementClient managementClient = controller.getClient();
         serverSetup(managementClient.getControllerClient());
         // To have the native management interface ok, we need a reload of the server
-        reloadServer();
-    }
-
-    public static void reloadServer() throws Exception {
-        final CommandContext ctx = CLITestUtil.getCommandContext("remoting", TestSuiteEnvironment.getServerAddress(), MANAGEMENT_NATIVE_PORT);
-        try {
-            ctx.connectController();
-            ctx.handle("reload");
-        } finally {
-            ctx.terminateSession();
-        }
+        controller.reload();
     }
 
     @Test
@@ -167,7 +154,7 @@ public class RemoveManagementInterfaceTestCase {
             CoreUtils.applyUpdate(operation, client);
         }
         // To recreate http interface, a reload of server is required
-        reloadServer();
+        controller.reload();
         //Remove native interface
         operation = createOpNode("core-service=management/management-interface=native-interface", ModelDescriptionConstants.REMOVE);
         CoreUtils.applyUpdate(operation, client);

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.test.integration.management.util;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
@@ -198,37 +197,6 @@ public class CustomCLIExecutor {
             }
         }
         return exitCode + ": " + cliOutput;
-    }
-
-    /**
-     * Waits for server to reload until server-state is running
-     *
-     * @param timeout
-     * @param controller
-     * @throws Exception
-     */
-    public static void waitForServerToReload(int timeout, String controller) throws Exception {
-
-        Thread.sleep(TimeoutUtil.adjust(500));
-        long start = System.currentTimeMillis();
-        long now;
-        do {
-            try {
-                String result = CustomCLIExecutor.execute(null, READ_ATTRIBUTE_OPERATION + " server-state", controller);
-                boolean normal = result.contains("running");
-                if (normal) {
-                    return;
-                }
-            } catch (Exception e) {
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-            }
-            now = System.currentTimeMillis();
-        } while (now - start < timeout);
-
-        fail("Server did not reload in the imparted time.");
     }
 
     private static class ConsoleConsumer implements Runnable {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreUtils.java
@@ -178,7 +178,7 @@ public class CoreUtils {
 
     public static void applyUpdate(ModelNode update, final ModelControllerClient client) throws Exception {
         ModelNode result = client.execute(new OperationBuilder(update).build());
-        if (LOGGER.isInfoEnabled()) {
+        if (LOGGER.isDebugEnabled()) {
             LOGGER.info("Client update: " + update);
             LOGGER.info("Client update result: " + result);
         }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GenericCommandTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GenericCommandTestCase.java
@@ -25,19 +25,16 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
-import org.jboss.as.test.integration.management.util.ServerReload;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
  * Test generic command features of CLI.
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@ServerSetup(ServerReload.SetupTask.class)
 @RunWith(WildflyTestRunner.class)
 public class GenericCommandTestCase extends AbstractCliTestBase {
 
@@ -48,6 +45,7 @@ public class GenericCommandTestCase extends AbstractCliTestBase {
 
     @AfterClass
     public static void after() throws Exception {
+        cli.sendLine("reload");
         AbstractCliTestBase.closeCLI();
     }
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GlobalOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/GlobalOpsTestCase.java
@@ -30,20 +30,17 @@ import java.util.Map;
 
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
-import org.jboss.as.test.integration.management.util.ServerReload;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
  *
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
-@ServerSetup(ServerReload.SetupTask.class)
 @RunWith(WildflyTestRunner.class)
 public class GlobalOpsTestCase extends AbstractCliTestBase {
 
@@ -54,6 +51,7 @@ public class GlobalOpsTestCase extends AbstractCliTestBase {
 
     @AfterClass
     public static void after() throws Exception {
+        cli.sendLine("reload");
         AbstractCliTestBase.closeCLI();
     }
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpPostMgmtOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpPostMgmtOpsTestCase.java
@@ -21,10 +21,6 @@
  */
 package org.jboss.as.test.integration.management.http;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
@@ -40,7 +36,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.WildflyTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests all management operation types which are available via HTTP POST requests.
@@ -217,6 +218,22 @@ public class HttpPostMgmtOpsTestCase {
         ModelNode result = ret.get("result");
 
         assertFalse(result.asList().isEmpty());
+    }
+
+    @Inject
+    private static ServerController container;
+
+    //@Test this is prototype for reload testing via http interface
+    public void testReload() throws Exception {
+
+        ModelNode op = HttpMgmtProxy.getOpNode("/", "reload");
+
+        for (int i = 0; i < 10; i++) {
+            ModelNode ret = httpMgmt.sendPostCommand(op);
+            assertTrue("success".equals(ret.get("outcome").asString()));
+            container.waitForLiveServerToReload(10 * 1000); //wait 10 seconds for reload
+            testReadChildrenResources();
+        }
     }
 
     @Test

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
@@ -97,7 +97,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
 public class BasicOperationsUnitTestCase {
 
     @Inject
-    private static ManagementClient managementClient;
+    private ManagementClient managementClient;
 
     @Test
     public void testSocketBindingsWildcards() throws IOException {
@@ -124,18 +124,16 @@ public class BasicOperationsUnitTestCase {
     }
 
     @Test
-    public void testReadResourceRecursiveDepthRecursiveUndefined() throws IOException {
+    public void testReadResourceRecursiveDepthRecursiveUndefined() throws Exception {
         // WFCORE-76
         final ModelNode operation = new ModelNode();
         operation.get(OP).set(READ_RESOURCE_OPERATION);
         operation.get(OP_ADDR).setEmptyList();
         operation.get(RECURSIVE_DEPTH).set(1);
 
-        final ModelNode result = managementClient.getControllerClient().execute(operation);
-        assertEquals(SUCCESS, result.get(OUTCOME).asString());
-        assertTrue(result.hasDefined(RESULT));
+        final ModelNode result = managementClient.executeForResult(operation);
 
-        final ModelNode logging = result.get(RESULT, SUBSYSTEM, "logging");
+        final ModelNode logging = result.get(SUBSYSTEM, "logging");
         assertTrue(logging.hasDefined("logger"));
         final ModelNode rootLogger = result.get(RESULT, SUBSYSTEM, "logging", "root-logger");
         assertFalse(rootLogger.hasDefined("ROOT"));
@@ -449,7 +447,7 @@ public class BasicOperationsUnitTestCase {
         }
     }
 
-    private static int countSystemProperties() throws IOException {
+    private int countSystemProperties() throws IOException {
         ModelNode readProperties = Operations.createOperation(READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS.toModelNode());
         readProperties.get(CHILD_TYPE).set(SYSTEM_PROPERTY);
         ModelNode response = managementClient.getControllerClient().execute(readProperties);
@@ -457,7 +455,7 @@ public class BasicOperationsUnitTestCase {
         return properties.asList().size();
     }
 
-    private static void validateSystemProperty(Map<String, String> properties, String propertyName, boolean exist, int origPropCount) throws IOException, MgmtOperationException {
+    private void validateSystemProperty(Map<String, String> properties, String propertyName, boolean exist, int origPropCount) throws IOException, MgmtOperationException {
         ModelNode readProperties = Operations.createOperation(READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS.toModelNode());
         readProperties.get(CHILD_TYPE).set(SYSTEM_PROPERTY);
         ModelNode response = managementClient.getControllerClient().execute(readProperties);

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/ReloadWithConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/ReloadWithConfigTestCase.java
@@ -25,7 +25,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHI
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DIRECTORY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAMES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 
@@ -37,12 +36,11 @@ import javax.inject.Inject;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
@@ -54,8 +52,9 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
 public class ReloadWithConfigTestCase {
     private static final String RELOAD_TEST_CASE_ONE = "reload-test-case-one";
     private static final String RELOAD_TEST_CASE_TWO = "reload-test-case-two";
+
     @Inject
-    private static ManagementClient managementClient;
+    private static ServerController container;
 
     private File snapshotDir;
 
@@ -66,19 +65,17 @@ public class ReloadWithConfigTestCase {
         addSystemProperty(RELOAD_TEST_CASE_ONE, "1");
         try {
 
-            managementClient.executeForResult(Util.createEmptyOperation("take-snapshot", PathAddress.EMPTY_ADDRESS));
+            executeForResult(Util.createEmptyOperation("take-snapshot", PathAddress.EMPTY_ADDRESS));
             addSystemProperty(RELOAD_TEST_CASE_TWO, "2");
 
-            final ModelNode reloadOp = Util.createEmptyOperation("reload", PathAddress.EMPTY_ADDRESS);
             List<File> snapshots = listSnapshots();
             Assert.assertEquals(1, snapshots.size());
-            reloadOp.get(SERVER_CONFIG).set(snapshots.get(0).getName());
-            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), reloadOp);
+            container.reload(snapshots.get(0).getName());
             wasReloaded = true;
 
             final ModelNode readChildrenNames = Util.createEmptyOperation(READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS);
             readChildrenNames.get(CHILD_TYPE).set(SYSTEM_PROPERTY);
-            List<ModelNode> list = managementClient.executeForResult(readChildrenNames).asList();
+            List<ModelNode> list = executeForResult(readChildrenNames).asList();
             Assert.assertEquals(1, list.size());
             Assert.assertEquals(RELOAD_TEST_CASE_ONE, list.get(0).asString());
         } finally {
@@ -87,8 +84,7 @@ public class ReloadWithConfigTestCase {
             cleanSnapshotDirectory();
             if (wasReloaded) {
                 //Reset the config file
-                final ModelNode reloadOp = Util.createEmptyOperation("reload", PathAddress.EMPTY_ADDRESS);
-                ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient(), reloadOp);
+                container.reload();
             }
         }
     }
@@ -96,12 +92,12 @@ public class ReloadWithConfigTestCase {
     private void addSystemProperty(String name, String value) throws Exception {
         ModelNode op = Util.createAddOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, name));
         op.get(VALUE).set(value);
-        managementClient.executeForResult(op);
+        executeForResult(op);
     }
 
     private List<File> listSnapshots() throws Exception {
         final ModelNode op = Util.createEmptyOperation("list-snapshots", PathAddress.EMPTY_ADDRESS);
-        final ModelNode result = managementClient.executeForResult(op);
+        final ModelNode result = executeForResult(op);
         String dir = result.get(DIRECTORY).asString();
         ModelNode names = result.get(NAMES);
         List<File> snapshotFiles = new ArrayList<>();
@@ -117,10 +113,14 @@ public class ReloadWithConfigTestCase {
         }
     }
 
+    private ModelNode executeForResult(ModelNode op)throws Exception{
+        return container.getClient().executeForResult(op);
+    }
+
     private File getSnapshotDir() throws Exception {
         if (snapshotDir == null) {
             final ModelNode op = Util.createEmptyOperation("list-snapshots", PathAddress.EMPTY_ADDRESS);
-            final ModelNode result = managementClient.executeForResult(op);
+            final ModelNode result = executeForResult(op);
             final String dir = result.get(DIRECTORY).asString();
             snapshotDir = new File(dir);
         }
@@ -129,7 +129,7 @@ public class ReloadWithConfigTestCase {
 
     private void removeSystemProperty(String name, boolean safe) throws Exception {
         try {
-            managementClient.executeForResult(Util.createRemoveOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, name)));
+            executeForResult(Util.createRemoveOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, name)));
         } catch (Exception e) {
             if (safe) {
                 e.printStackTrace();

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/suspend/web/SuspendResumeTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/suspend/web/SuspendResumeTestCase.java
@@ -36,14 +36,13 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 import org.wildfly.test.suspendresumeendpoint.SuspendResumeHandler;
 import org.wildfly.test.suspendresumeendpoint.TestSuspendServiceActivator;
@@ -58,24 +57,25 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
 public class SuspendResumeTestCase {
 
     public static final String WEB_SUSPEND_JAR = "web-suspend.jar";
+
     @Inject
-    private static ManagementClient managementClient;
+    private static ServerController serverController;
 
     @BeforeClass
     public static void deploy() throws Exception {
-        ServerDeploymentHelper helper = new ServerDeploymentHelper(managementClient.getControllerClient());
+        //ServerDeploymentHelper helper = new ServerDeploymentHelper(managementClient.getControllerClient());
         JavaArchive war = ShrinkWrap.create(JavaArchive.class, WEB_SUSPEND_JAR);
         war.addPackage(SuspendResumeHandler.class.getPackage());
         war.addAsServiceProvider(ServiceActivator.class, TestSuspendServiceActivator.class);
         war.addAsResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller, io.undertow.core, org.jboss.as.server,org.wildfly.extension.request-controller, org.jboss.as.network\n"), "META-INF/MANIFEST.MF");
-        helper.deploy(WEB_SUSPEND_JAR, war.as(ZipExporter.class).exportAsInputStream());
+        //helper.deploy(WEB_SUSPEND_JAR, war.as(ZipExporter.class).exportAsInputStream());
+        serverController.deploy(war, WEB_SUSPEND_JAR);
 
     }
 
     @AfterClass
     public static void undeploy() throws ServerDeploymentHelper.ServerDeploymentException {
-        ServerDeploymentHelper helper = new ServerDeploymentHelper(managementClient.getControllerClient());
-        helper.undeploy(WEB_SUSPEND_JAR);
+        serverController.undeploy(WEB_SUSPEND_JAR);
     }
 
     @Test
@@ -96,16 +96,16 @@ public class SuspendResumeTestCase {
 
             ModelNode op = new ModelNode();
             op.get(OP).set("suspend");
-            managementClient.getControllerClient().execute(op);
+            serverController.getClient().getControllerClient().execute(op);
 
             op = new ModelNode();
             op.get(OP).set(READ_ATTRIBUTE_OPERATION);
             op.get(NAME).set(SUSPEND_STATE);
-            Assert.assertEquals("SUSPENDING", managementClient.executeForResult(op).asString());
+            Assert.assertEquals("SUSPENDING", serverController.getClient().executeForResult(op).asString());
 
             HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", 10, TimeUnit.SECONDS);
             Assert.assertEquals(SuspendResumeHandler.TEXT, result.get());
-            Assert.assertEquals("SUSPENDED", managementClient.executeForResult(op).asString());
+            Assert.assertEquals("SUSPENDED", serverController.getClient().executeForResult(op).asString());
 
             final HttpURLConnection conn = (HttpURLConnection) new URL(address).openConnection();
             try {
@@ -118,7 +118,7 @@ public class SuspendResumeTestCase {
 
             op = new ModelNode();
             op.get(OP).set("resume");
-            managementClient.getControllerClient().execute(op);
+            serverController.getClient().getControllerClient().execute(op);
 
             Assert.assertEquals(SuspendResumeHandler.TEXT, HttpRequest.get(address, 60, TimeUnit.SECONDS));
         } finally {
@@ -127,9 +127,7 @@ public class SuspendResumeTestCase {
 
             ModelNode op = new ModelNode();
             op.get(OP).set("resume");
-            managementClient.getControllerClient().execute(op);
+            serverController.getClient().getControllerClient().execute(op);
         }
-
-
     }
 }

--- a/testsuite/test-runner/pom.xml
+++ b/testsuite/test-runner/pom.xml
@@ -86,5 +86,9 @@
             <artifactId>junit</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ServerController.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ServerController.java
@@ -1,6 +1,14 @@
 package org.wildfly.core.testrunner;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 
 /**
  * @author Tomaz Cerar (c) 2014 Red Hat Inc.
@@ -10,9 +18,13 @@ public class ServerController {
     private static final AtomicBoolean started = new AtomicBoolean(false);
     private static volatile Server server;
 
-    public void start() {
+    public void start(final String serverConfig, boolean adminMode) {
         if (started.compareAndSet(false, true)) {
             server = new Server();
+            if (serverConfig != null) {
+                server.setServerConfig(serverConfig);
+            }
+            server.setAdminMode(adminMode);
             try {
                 server.start();
             } catch (final Throwable t) {
@@ -23,6 +35,15 @@ public class ServerController {
             }
         }
     }
+
+    public void start() {
+        start(null, false);
+    }
+
+    public void startInAdminMode(){
+        start(null, true);
+    }
+
 
     public void stop() {
         if (server != null) {
@@ -41,5 +62,57 @@ public class ServerController {
 
     public ManagementClient getClient() {
         return server.getClient();
+    }
+
+    public ManagementClient createNewManagementClient(){
+        return server.createClient();
+    }
+
+    public ServerDeploymentHelper getDeploymentHelper() {
+        return new ServerDeploymentHelper(server.getClient().getControllerClient());
+    }
+
+    public void deploy(final Archive<?> archive, final String runtimeName) throws ServerDeploymentHelper.ServerDeploymentException {
+        getDeploymentHelper().deploy(runtimeName, archive.as(ZipExporter.class).exportAsInputStream());
+    }
+
+    public void deploy(final Path deployment) throws ServerDeploymentHelper.ServerDeploymentException, IOException {
+        final ServerDeploymentHelper helper = getDeploymentHelper();
+        try (InputStream in = Files.newInputStream(deployment)) {
+            helper.deploy(deployment.getFileName().toString(), in);
+        }
+
+    }
+
+    public void undeploy(final String runtimeName) throws ServerDeploymentHelper.ServerDeploymentException {
+        final ServerDeploymentHelper helper = getDeploymentHelper();
+        helper.undeploy(runtimeName);
+    }
+
+    /**
+     * Reloads server and wait for it to come back
+     */
+    public void reload() {
+        server.reload(false, 30 * 1000); //by default reload in normal mode with timeout of 30 seconds
+    }
+
+    public void reload(int timeout) {
+        server.reload(false, timeout);
+    }
+
+    public void reload(boolean adminMode, int timeout) {
+        server.reload(adminMode, timeout);
+    }
+
+    public void reload(boolean adminMode, int timeout, String serverConfig) {
+        server.reload(adminMode, timeout, serverConfig);
+    }
+
+    public void reload(String serverConfig) {
+        server.reload(false, 30 * 1000, serverConfig);
+    }
+
+    public void waitForLiveServerToReload(int timeout){
+        server.waitForLiveServerToReload(timeout);
     }
 }

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/WildflyTestRunner.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/WildflyTestRunner.java
@@ -52,7 +52,7 @@ public class WildflyTestRunner extends BlockJUnit4ClassRunner {
             while (c != null && c != Object.class) {
                 for (Field field : c.getDeclaredFields()) {
                     if ((instance == null && Modifier.isStatic(field.getModifiers()) ||
-                            instance != null && !Modifier.isStatic(field.getModifiers()))) {
+                            instance != null )) {//we want to do injection even on static fields before test run, so we make sure that client is correct for current state of server
                         if (field.isAnnotationPresent(Inject.class)) {
                             field.setAccessible(true);
                             if (field.getType() == ManagementClient.class && controller.isStarted()) {


### PR DESCRIPTION
fixed version of #1227 

- allows us to not use arquillian in manual tests in full.
- adds support for deploy/undeploy operations on container.
- adds reload() method on server

