### PR TITLE
[WFCORE-307]: When Wildfly fails with JBAS015810: failed to resolve interface management, it should terminate.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -100,6 +100,7 @@ import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.threads.AsyncFuture;
 import org.jboss.threads.AsyncFutureTask;
+import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.security.manager.action.GetAccessControlContextAction;
 
 
@@ -458,11 +459,19 @@ class ModelControllerImpl implements ModelController {
         EnumSet<OperationContextImpl.ContextFlag> contextFlags = rollbackOnRuntimeFailure
                 ? EnumSet.of(AbstractOperationContext.ContextFlag.ROLLBACK_ON_FAIL)
                 : EnumSet.noneOf(OperationContextImpl.ContextFlag.class);
+        //TODO Gigantic HACK to disable the runtime part of this for the core model testing.
+        //The core model testing currently uses RunningMode.ADMIN_ONLY, but in the real world
+        //the http interface needs to be enabled even when that happens.
+        //I don't want to wire up all the services unless I can avoid it, so for now the tests set this system property
+        //@see https://issues.jboss.org/browse/WFCORE-1509
+        EnumSet<OperationContextImpl.ContextFlag> firstBatchFlags = WildFlySecurityManager.getPropertyPrivileged("wildfly.test.boot.disable.rollback", null) == null
+                ? EnumSet.of(AbstractOperationContext.ContextFlag.ROLLBACK_ON_FAIL)
+                : EnumSet.noneOf(OperationContextImpl.ContextFlag.class);
 
         //For the initial operations the model will not be complete, so defer the validation
         final AbstractOperationContext context = new OperationContextImpl(operationID, INITIAL_BOOT_OPERATION, EMPTY_ADDRESS,
                 this, processType, runningModeControl.getRunningMode(),
-                contextFlags, handler, null, managementModel.get(), control, processState, auditLogger, bootingFlag.get(),
+                firstBatchFlags, handler, null, managementModel.get(), control, processState, auditLogger, bootingFlag.get(),
                 hostServerGroupTracker, null, null, notificationSupport, true, extraValidationStepHandler, true);
 
         // Add to the context all ops prior to the first ExtensionAddHandler as well as all ExtensionAddHandlers; save the rest.
@@ -557,7 +566,7 @@ class ModelControllerImpl implements ModelController {
      */
     private BootOperations organizeBootOperations(List<ModelNode> bootList, final int lockPermit, MutableRootResourceRegistrationProvider parallelBootRootResourceRegistrationProvider) {
 
-        final List<ParsedBootOp> initialOps = new ArrayList<ParsedBootOp>();
+        final List<ParsedBootOp> initialOps = new ArrayList<>();
         List<ParsedBootOp> postExtensionOps = null;
         boolean invalid = false;
         boolean sawExtensionAdd = false;
@@ -568,7 +577,6 @@ class ModelControllerImpl implements ModelController {
         ParallelBootOperationStepHandler parallelSubsystemHandler = (executorService != null && processType.isServer() && runningModeControl.getRunningMode() == RunningMode.NORMAL)
                 ? new ParallelBootOperationStepHandler(executorService, rootRegistration, processState, this, lockPermit, extraValidationStepHandler) : null;
         boolean registeredParallelSubsystemHandler = false;
-        int subsystemIndex = 0;
         for (ModelNode bootOp : bootList) {
             final ParsedBootOp parsedOp = new ParsedBootOp(bootOp);
             if (postExtensionOps != null) {
@@ -581,17 +589,20 @@ class ModelControllerImpl implements ModelController {
                         initialOps.add(new ParsedBootOp(parsedOp, stepHandler));
                     }
                 } else {
-                    if (parallelSubsystemHandler == null || !parallelSubsystemHandler.addSubsystemOperation(parsedOp)) {
-                        // Put any interface/socket op before the subsystem op
-                        if (registeredParallelSubsystemHandler && (parsedOp.isInterfaceOperation() || parsedOp.isSocketOperation())) {
-                            postExtensionOps.add(subsystemIndex++, parsedOp);
+                    if (parsedOp.isInterfaceOperation() || parsedOp.isSocketOperation() || parsedOp.isManagementOperation()) {
+                        final OperationStepHandler stepHandler = rootRegistration.getOperationHandler(parsedOp.address, parsedOp.operationName);
+                        if (parsedOp.isManagementOperation()) {
+                            initialOps.add(new ParsedBootOp(parsedOp, stepHandler));
                         } else {
-                            postExtensionOps.add(parsedOp);
+                            initialOps.add(new ParsedBootOp(parsedOp, stepHandler));
                         }
-                    } else if (!registeredParallelSubsystemHandler) {
-                        postExtensionOps.add(parallelSubsystemHandler.getParsedBootOp());
-                        subsystemIndex = postExtensionOps.size() - 1;
-                        registeredParallelSubsystemHandler = true;
+                    } else {
+                        if (parallelSubsystemHandler == null || !parallelSubsystemHandler.addSubsystemOperation(parsedOp)) {
+                            postExtensionOps.add(parsedOp);
+                        } else if (!registeredParallelSubsystemHandler) {
+                            postExtensionOps.add(parallelSubsystemHandler.getParsedBootOp());
+                            registeredParallelSubsystemHandler = true;
+                        }
                     }
                 }
             } else {
@@ -616,9 +627,15 @@ class ModelControllerImpl implements ModelController {
                 } else if (!sawExtensionAdd) {
                     // An operation prior to the first Extension Add
                     initialOps.add(new ParsedBootOp(parsedOp, stepHandler));
+                } else if(parsedOp.isInterfaceOperation() || parsedOp.isSocketOperation() || parsedOp.isManagementOperation()) {
+                    if (parsedOp.isManagementOperation()) {
+                        initialOps.add(new ParsedBootOp(parsedOp, stepHandler));
+                    } else {
+                        initialOps.add(new ParsedBootOp(parsedOp, stepHandler));
+                    }
                 } else {
                     // Start the postExtension list
-                    postExtensionOps = new ArrayList<ParsedBootOp>(32);
+                    postExtensionOps = new ArrayList<>(32);
                     if (parallelSubsystemHandler == null || !parallelSubsystemHandler.addSubsystemOperation(parsedOp)) {
                         postExtensionOps.add(parsedOp);
                     } else {
@@ -629,8 +646,6 @@ class ModelControllerImpl implements ModelController {
                 }
             }
         }
-
-
         return new BootOperations(initialOps, postExtensionOps, invalid);
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/ParsedBootOp.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParsedBootOp.java
@@ -22,9 +22,13 @@
 
 package org.jboss.as.controller;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUDIT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_INTERFACE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
@@ -93,6 +97,23 @@ public class ParsedBootOp {
         return address.size() > 0 && address.getElement(0).getKey().equals(SOCKET_BINDING_GROUP);
     }
 
+    boolean isManagementInterfaceOperation() {
+        return address.size() > 1
+                && MANAGEMENT_INTERFACE.equals(address.getElement(1).getKey());
+    }
+
+    boolean isManagementOperation() {
+        return address.size() > 0
+                && CORE_SERVICE.equals(address.getElement(0).getKey())
+                && !isAuditLogOperation();
+    }
+
+    boolean isAuditLogOperation() {
+        return address.size() > 1
+                && CORE_SERVICE.equals(address.getElement(0).getKey())
+                && ACCESS.equals(address.getElement(1).getKey())
+                && AUDIT.equals(address.getElement(1).getValue());
+    }
     List<ModelNode> getChildOperations() {
         return childOperations == null ? Collections.<ModelNode>emptyList() : childOperations;
     }

--- a/controller/src/main/java/org/jboss/as/controller/audit/ManagedAuditLoggerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/audit/ManagedAuditLoggerImpl.java
@@ -528,6 +528,35 @@ public class ManagedAuditLoggerImpl implements ManagedAuditLogger, ManagedAuditL
         }
     }
 
+    public void copy(ManagedAuditLoggerImpl other) throws IOException {
+        config.lock();
+        try {
+            switch(config.status) {
+                case DISABLED:
+                case DISABLE_NEXT:
+                    break;
+                case LOGGING :
+                    for (AuditLogItem item : other.getQueuedItems()) {
+                        this.writeLogItem(item);
+                    }
+                    break;
+                case QUEUEING:
+                    this.queuedItems.addAll(other.getQueuedItems());
+                    break;
+            }
+        } finally {
+            config.unlock();
+        }
+    }
+
+    private List<AuditLogItem> getQueuedItems() throws IOException {
+        config.lock();
+        try {
+            return new ArrayList<>(this.queuedItems);
+        } finally {
+            config.unlock();
+        }
+    }
 
     /**
      * Abstract base class for core and new configuration

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -183,7 +183,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
     @Override
     protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
         //See server HttpManagementAddHandler
-        System.setProperty("jboss.as.test.disable.runtime", "1");
+        System.setProperty("wildfly.test.boot.disable.rollback", "1");
         if (type == TestModelType.STANDALONE) {
             initializer.initCoreModel(rootResource, rootRegistration, modelControllerResource);
 
@@ -198,7 +198,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
     @Override
     public void stop(StopContext context) {
         super.stop(context);
-        System.clearProperty("jboss.as.test.disable.runtime");
+        System.clearProperty("wildfly.test.boot.disable.rollback");
     }
 
     private ServerEnvironment createStandaloneServerEnvironment() {

--- a/jmx/src/main/java/org/jboss/as/jmx/PluggableMBeanServerImpl.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/PluggableMBeanServerImpl.java
@@ -46,6 +46,7 @@ import static org.jboss.as.jmx.MBeanServerSignature.SET_ATTRIBUTES;
 import static org.jboss.as.jmx.MBeanServerSignature.UNREGISTER_MBEAN;
 import static org.jboss.as.jmx.SecurityActions.createCaller;
 
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.net.InetAddress;
@@ -95,7 +96,9 @@ import org.jboss.as.controller.access.JmxAction;
 import org.jboss.as.controller.access.JmxTarget;
 import org.jboss.as.controller.access.management.JmxAuthorizer;
 import org.jboss.as.controller.audit.AuditLogger;
+import org.jboss.as.controller.audit.AuditLogger.Status;
 import org.jboss.as.controller.audit.ManagedAuditLogger;
+import org.jboss.as.controller.audit.ManagedAuditLoggerImpl;
 import org.jboss.as.controller.security.InetAddressPrincipal;
 import org.jboss.as.core.security.RealmUser;
 import org.jboss.as.jmx.logging.JmxLogger;
@@ -131,9 +134,21 @@ class PluggableMBeanServerImpl implements PluggableMBeanServer {
     PluggableMBeanServerImpl(MBeanServer rootMBeanServer, MBeanServerDelegate rootMBeanServerDelegate) {
         this.rootMBeanServer = new TcclMBeanServer(rootMBeanServer);
         this.rootMBeanServerDelegate = rootMBeanServerDelegate;
+        this.auditLogger = new ManagedAuditLoggerImpl("jmx-boot", false);
+        this.auditLogger.setLogBoot(true);
+        this.auditLogger.setLogReadOnly(false);
+        this.auditLogger.setLoggerStatus(Status.QUEUEING);
     }
 
     void setAuditLogger(ManagedAuditLogger auditLoggerInfo) {
+        if(auditLoggerInfo != null && auditLoggerInfo.isLogBoot()
+                && auditLoggerInfo instanceof ManagedAuditLoggerImpl
+                && auditLogger instanceof ManagedAuditLogger) {
+            try {
+                ((ManagedAuditLoggerImpl)auditLoggerInfo).copy((ManagedAuditLoggerImpl)auditLogger);
+            } catch (IOException ex) {
+            }
+        }
         this.auditLogger = auditLoggerInfo != null ? auditLoggerInfo : AuditLogger.NO_OP_LOGGER;
     }
 

--- a/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
@@ -57,6 +57,7 @@ import org.jboss.as.remoting.EndpointService;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.ServerEnvironmentResourceDescription;
+import org.jboss.as.server.mgmt.ManagementWorkerService;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
@@ -658,6 +659,7 @@ public class JMXSubsystemTestCase extends AbstractSubsystemTest {
 
         @Override
         protected void addExtraServices(final ServiceTarget target) {
+            ManagementWorkerService.installService(target);
             ManagementRemotingServices.installRemotingManagementEndpoint(target, ManagementRemotingServices.MANAGEMENT_ENDPOINT, "localhost", EndpointService.EndpointType.MANAGEMENT);
             ServiceName tmpDirPath = ServiceName.JBOSS.append("server", "path", "jboss.controller.temp.dir");
 

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -92,6 +92,7 @@ import org.jboss.as.network.SocketBinding;
 import org.jboss.as.remoting.EndpointService;
 import org.jboss.as.remoting.RemotingServices;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
+import org.jboss.as.server.mgmt.ManagementWorkerService;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
@@ -1629,6 +1630,7 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
 
         @Override
         protected void addExtraServices(final ServiceTarget target) {
+            ManagementWorkerService.installService(target);
             ManagementRemotingServices.installRemotingManagementEndpoint(target, ManagementRemotingServices.MANAGEMENT_ENDPOINT, "localhost", EndpointService.EndpointType.MANAGEMENT);
             ServiceName tmpDirPath = ServiceName.JBOSS.append("server", "path", "jboss.controller.temp.dir");
 

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
@@ -83,11 +83,7 @@ public class HttpManagementAddHandler extends BaseHttpInterfaceAddStepHandler {
 
     @Override
     protected boolean requiresRuntime(OperationContext context) {
-        //TODO Gigantic HACK to disable the runtime part of this for the core model testing.
-        //The core model testing currently uses RunningMode.ADMIN_ONLY, but in the real world
-        //the http interface needs to be enabled even when that happens.
-        //I don't want to wire up all the services unless I can avoid it, so for now the tests set this system property
-        return WildFlySecurityManager.getPropertyPrivileged("jboss.as.test.disable.runtime", null) == null
+        return WildFlySecurityManager.getPropertyPrivileged("wildfly.test.boot.disable.rollback", null) == null
                 && (context.getProcessType() != ProcessType.EMBEDDED_SERVER || context.getRunningMode() != RunningMode.ADMIN_ONLY);
     }
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/MainKernelServicesImpl.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/MainKernelServicesImpl.java
@@ -82,7 +82,9 @@ class MainKernelServicesImpl extends AbstractKernelServicesImpl {
                 legacyModelVersion, successfulBoot, bootError, registerTransformers);
         this.testClass = testClass;
         //add mgmt worker
-        ManagementWorkerService.installService(container.subTarget());
+        if (container.getService(ManagementWorkerService.SERVICE_NAME) == null) {
+            ManagementWorkerService.installService(container.subTarget());
+        }
     }
 
     /**

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -660,39 +660,44 @@ final class SubsystemTestDelegate {
         }
 
         public KernelServices build() throws Exception {
-            bootOperationBuilder.validateNotAlreadyBuilt();
-            List<ModelNode> bootOperations = bootOperationBuilder.build();
-            AbstractKernelServicesImpl kernelServices = AbstractKernelServicesImpl.create(testClass, mainSubsystemName, additionalInit, ModelTestOperationValidatorFilter.createValidateAll(), cloneExtensionRegistry(additionalInit), bootOperations,
-                    testParser, mainExtension, null, legacyControllerInitializers.size() > 0, true);
-            SubsystemTestDelegate.this.kernelServices.add(kernelServices);
+            System.setProperty("wildfly.test.boot.disable.rollback", "1");
+            try {
+                bootOperationBuilder.validateNotAlreadyBuilt();
+                List<ModelNode> bootOperations = bootOperationBuilder.build();
+                AbstractKernelServicesImpl kernelServices = AbstractKernelServicesImpl.create(testClass, mainSubsystemName, additionalInit, ModelTestOperationValidatorFilter.createValidateAll(), cloneExtensionRegistry(additionalInit), bootOperations,
+                        testParser, mainExtension, null, legacyControllerInitializers.size() > 0, true);
+                SubsystemTestDelegate.this.kernelServices.add(kernelServices);
 
-            validateDescriptionProviders(additionalInit, kernelServices);
-            ImmutableManagementResourceRegistration subsystemReg = kernelServices.getRootRegistration().getSubModel(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, mainSubsystemName)));
-            ModelTestUtils.validateModelDescriptions(PathAddress.EMPTY_ADDRESS, subsystemReg);
+                validateDescriptionProviders(additionalInit, kernelServices);
+                ImmutableManagementResourceRegistration subsystemReg = kernelServices.getRootRegistration().getSubModel(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, mainSubsystemName)));
+                ModelTestUtils.validateModelDescriptions(PathAddress.EMPTY_ADDRESS, subsystemReg);
 
-            for (Map.Entry<ModelVersion, LegacyKernelServiceInitializerImpl> entry : legacyControllerInitializers.entrySet()) {
-                LegacyKernelServiceInitializerImpl legacyInitializer = entry.getValue();
+                for (Map.Entry<ModelVersion, LegacyKernelServiceInitializerImpl> entry : legacyControllerInitializers.entrySet()) {
+                    LegacyKernelServiceInitializerImpl legacyInitializer = entry.getValue();
 
-                List<ModelNode> transformedBootOperations = new ArrayList<ModelNode>();
-                for (ModelNode op : bootOperations) {
+                    List<ModelNode> transformedBootOperations = new ArrayList<ModelNode>();
+                    for (ModelNode op : bootOperations) {
 
-                    TransformedOperation transformedOp = kernelServices.transformOperation(entry.getKey(), op);
-                    if (transformedOp.getTransformedOperation() != null) {
-                        //Since rejected operations now execute on the slave to determine if it has been ignored or not
-                        //we check the reject policy simulating a reject before adding it to the list of boot operations
-                        if (!transformedOp.rejectOperation(SUCCESS)) {
-                            transformedBootOperations.add(transformedOp.getTransformedOperation());
-//                        } else {
-//                            System.out.println(transformedOp.getFailureDescription());
+                        TransformedOperation transformedOp = kernelServices.transformOperation(entry.getKey(), op);
+                        if (transformedOp.getTransformedOperation() != null) {
+                            //Since rejected operations now execute on the slave to determine if it has been ignored or not
+                            //we check the reject policy simulating a reject before adding it to the list of boot operations
+                            if (!transformedOp.rejectOperation(SUCCESS)) {
+                                transformedBootOperations.add(transformedOp.getTransformedOperation());
+                            } else {
+                                System.out.println(transformedOp.getFailureDescription());
+                            }
                         }
                     }
+
+                    LegacyControllerKernelServicesProxy legacyServices = legacyInitializer.install(kernelServices, transformedBootOperations);
+                    kernelServices.addLegacyKernelService(entry.getKey(), legacyServices);
                 }
 
-                LegacyControllerKernelServicesProxy legacyServices = legacyInitializer.install(kernelServices, transformedBootOperations);
-                kernelServices.addLegacyKernelService(entry.getKey(), legacyServices);
+                return kernelServices;
+            } finally {
+                System.clearProperty("wildfly.test.boot.disable.rollback");
             }
-
-            return kernelServices;
         }
 
         @Override

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/HierarchicalCompositionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/HierarchicalCompositionTestCase.java
@@ -158,6 +158,7 @@ public class HierarchicalCompositionTestCase extends AbstractCliTestBase {
         try {
             // create server
             cliRequest("/host=" + HOST + "/server-config=" + SERVER + ":add(group=" + SERVER_GROUP + ",socket-binding-port-offset=550)", true);
+            cliRequest("/host=" + HOST + "/server-config=" + SERVER + "/interface=public:add(inet-address=${jboss.test.host.master.address})", true);
             try {
                 // start server
                 cliRequest("/server-group=" + SERVER_GROUP + ":start-servers(blocking=true)", true);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/AuditLogTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/AuditLogTestCase.java
@@ -222,6 +222,10 @@ public class AuditLogTestCase {
         slaveAuditLog.delete();
         masterServerAuditLog.delete();
         slaveServerAuditLog.delete();
+        Assert.assertFalse(masterAuditLog.exists());
+        Assert.assertFalse(masterServerAuditLog.exists());
+        Assert.assertFalse(slaveAuditLog.exists());
+        Assert.assertFalse(slaveServerAuditLog.exists());
 
         String propertyName = "test" + System.currentTimeMillis();
         ModelNode addOp = Util.createAddOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, propertyName));

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ServerRestartRequiredTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ServerRestartRequiredTestCase.java
@@ -39,6 +39,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.POR
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD_REQUIRED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART_REQUIRED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLOUT_PLAN;
@@ -146,24 +147,32 @@ public class ServerRestartRequiredTestCase {
     @Test
     public void testSocketBinding() throws Exception {
         final DomainClient client = domainMasterLifecycleUtil.getDomainClient();
+            // add a custom socket binding, referencing a non-existent system property
+            final ModelNode socketBinding = new ModelNode();
+            socketBinding.add(SOCKET_BINDING_GROUP, "reload-sockets");
+            socketBinding.add(SOCKET_BINDING, "my-custom-binding");
+        try {
 
-        // add a custom socket binding, referencing a non-existent system property
-        final ModelNode socketBinding = new ModelNode();
-        socketBinding.add(SOCKET_BINDING_GROUP, "reload-sockets");
-        socketBinding.add(SOCKET_BINDING, "my-custom-binding");
+            final ModelNode socketBindingAdd = new ModelNode();
+            socketBindingAdd.get(OP).set(ADD);
+            socketBindingAdd.get(OP_ADDR).set(socketBinding);
+            socketBindingAdd.get(PORT).set(new ValueExpression("${my.custom.socket}"));
 
-        final ModelNode socketBindingAdd = new ModelNode();
-        socketBindingAdd.get(OP).set(ADD);
-        socketBindingAdd.get(OP_ADDR).set(socketBinding);
-        socketBindingAdd.get(PORT).set(new ValueExpression("${my.custom.socket}"));
+            // Don't rollback server failures, rather mark them as restart-required
+            socketBindingAdd.get(OPERATION_HEADERS).get(ROLLOUT_PLAN)
+                    .get(IN_SERIES).add().get(CONCURRENT_GROUPS).get("reload-test-group").get(MAX_FAILURE_PERCENTAGE).set(100);
 
-        // Don't rollback server failures, rather mark them as restart-required
-        socketBindingAdd.get(OPERATION_HEADERS).get(ROLLOUT_PLAN)
-                .get(IN_SERIES).add().get(CONCURRENT_GROUPS).get("reload-test-group").get(MAX_FAILURE_PERCENTAGE).set(100);
+            executeOperation(socketBindingAdd, client);
 
-        executeOperation(socketBindingAdd, client);
-
-        checkRestartOneAndTwo(client);
+            checkRestartOneAndTwo(client);
+        } finally {
+            final ModelNode socketBindingRemove = new ModelNode();
+            socketBindingRemove.get(OP).set(REMOVE);
+            socketBindingRemove.get(OP_ADDR).set(socketBinding);
+            socketBindingRemove.get(OPERATION_HEADERS).get(ROLLOUT_PLAN)
+                    .get(IN_SERIES).add().get(CONCURRENT_GROUPS).get("reload-test-group").get(MAX_FAILURE_PERCENTAGE).set(100);
+            executeOperation(socketBindingRemove, client);
+        }
     }
 
     @Test
@@ -358,10 +367,6 @@ public class ServerRestartRequiredTestCase {
         waitUntilState(client, reloadOneConfigAddress, "STARTED");
         waitUntilState(client, reloadTwoConfigAddress, "STARTED");
 
-    }
-
-    private void checkReloadOneAndTwo(final ModelControllerClient client) throws Exception {
-        checkProcessStateOneAndTwo(client, RELOAD_REQUIRED);
     }
 
     private void checkRestartOneAndTwo(final ModelControllerClient client) throws Exception {


### PR DESCRIPTION
Changing the way a server boots by moving all management and socket related operations to a first batch that will stop the boot process if there is an error.
The other operations subsystems mostly) are in a second batch that won't stop the server from booting.
Fixing some tests according to this new paradigm.
Adding a hack in the ModelControllerImpl for Core Model Tests as we don't have services ready in those tests and they would be breaking with this change.

Jira: https://issues.jboss.org/browse/WFCORE-307