### PR TITLE
[WFCORE-1522] PersistanceResourceTestCase fails if defaultPermissions contain only groups

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistanceResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistanceResourceTestCase.java
@@ -697,8 +697,10 @@ public class PersistanceResourceTestCase {
         AclFileAttributeView aclDefaultCreatedFilePermissionView = Files.getFileAttributeView(testPermissions, AclFileAttributeView.class);
         assert aclDefaultCreatedFilePermissionView != null;
         List<AclEntry> defaultPermissions = aclDefaultCreatedFilePermissionView.getAcl();
-        Set<AclEntryPermission> ownerPermissions = getOwnerPermissions(defaultPermissions, owner);
-        assertThat(ownerPermissions.toString(), ownerPermissions, hasItem(AclEntryPermission.WRITE_OWNER));
+        Set<AclEntryPermission> ownerPermissions = getOwnerPermissions(defaultPermissions, aclDefaultCreatedFilePermissionView.getOwner());
+        if (!ownerPermissions.isEmpty()) {
+            assertThat(ownerPermissions.toString(), ownerPermissions, hasItem(AclEntryPermission.WRITE_OWNER));
+        }
         Files.delete(testPermissions);
         configurationFile.successfulBoot();
         List<AclEntry> configurationFilePermissions = aclStandardFileView.getAcl();


### PR DESCRIPTION
PersistanceResourceTestCase fails on Windows 10 (out-of-box configuration), where
defaultPermissins list contain only groups, ownerPermissions is empty set thus assertion fail

This is a follow-up to https://github.com/wildfly/wildfly-core/pull/1513

Jira:
https://issues.jboss.org/browse/WFCORE-1522