### PR TITLE
[WFCORE-1513] Register metrics depends on the server type

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -414,6 +414,14 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
     }
 
     /**
+     * Adds the {@link AttributeAccess.Flag#FORCE_REGISTRATION} flag.
+     *
+     * @return a builder that can be used to continue building the attribute definition
+     */
+    public BUILDER forceRegistration() {
+        return addFlag(AttributeAccess.Flag.FORCE_REGISTRATION);
+    }
+    /**
      * Adds the {@link AttributeAccess.Flag#RESTART_ALL_SERVICES} flag and removes any conflicting flag.
      *
      * @return a builder that can be used to continue building the attribute definition

--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -279,7 +279,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
         final NotificationSupport notificationSupport = NotificationSupport.Factory.create(executorService);
         WritableAuthorizerConfiguration authorizerConfig = authorizer.getWritableAuthorizerConfiguration();
         authorizerConfig.reset();
-        ManagementResourceRegistration rootResourceRegistration = ManagementResourceRegistration.Factory.create(rootResourceDefinition, authorizerConfig, capabilityRegistry);
+        ManagementResourceRegistration rootResourceRegistration = ManagementResourceRegistration.Factory.forProcessType(processType).createRegistration(rootResourceDefinition, authorizerConfig, capabilityRegistry);
         final ModelControllerImpl controller = new ModelControllerImpl(container, target,
                 rootResourceRegistration,
                 new ContainerStateMonitor(container),

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -532,7 +532,7 @@ public class ExtensionRegistry {
                 ControllerLogger.DEPRECATED_LOGGER.extensionDeprecated(name);
             }
             return new SubsystemRegistrationImpl(name, version,
-                    profileRegistration, deploymentsRegistration, extensionRegistryType, extension.extensionModuleName);
+                    profileRegistration, deploymentsRegistration, extensionRegistryType, extension.extensionModuleName, processType);
         }
 
         @Override
@@ -673,12 +673,13 @@ public class ExtensionRegistry {
                                           ManagementResourceRegistration profileRegistration,
                                           ManagementResourceRegistration deploymentsRegistration,
                                           ExtensionRegistryType extensionRegistryType,
-                                          String extensionModuleName) {
+                                          String extensionModuleName,
+                                          ProcessType processType) {
             assert profileRegistration != null;
             this.name = name;
             this.profileRegistration = profileRegistration;
             if (deploymentsRegistration == null){
-                this.deploymentsRegistration = ManagementResourceRegistration.Factory.create(new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE));
+                this.deploymentsRegistration = ManagementResourceRegistration.Factory.forProcessType(processType).createRegistration(new SimpleResourceDefinition(null, NonResolvingResourceDescriptionResolver.INSTANCE));
             }else {
                 this.deploymentsRegistration = deploymentsRegistration;
             }

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/Util.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/Util.java
@@ -25,6 +25,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
@@ -133,6 +134,11 @@ public class Util {
     public static ModelNode getReadAttributeOperation(final PathAddress address, String attributeName) {
         ModelNode op = createEmptyOperation(READ_ATTRIBUTE_OPERATION, address);
         op.get(NAME).set(attributeName);
+        return op;
+    }
+
+    public static ModelNode getReadResourceDescriptionOperation(final PathAddress address) {
+        ModelNode op = createEmptyOperation(READ_RESOURCE_DESCRIPTION_OPERATION, address);
         return op;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
@@ -138,7 +138,11 @@ public final class AttributeAccess {
         /**
          * The attribute is an alias to something else
          */
-        ALIAS
+        ALIAS,
+        /**
+         * Force the registration of the attribute regardless of the actual process type.
+         */
+        FORCE_REGISTRATION
     }
 
     private final AccessType access;

--- a/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
@@ -91,7 +91,7 @@ final class NodeSubregistry {
         boolean ordered = provider.isOrderedChild();
 
         final ConcreteResourceRegistration newRegistry =
-                new ConcreteResourceRegistration(elementValue, this, provider, constraintUtilizationRegistry, ordered, capabilityRegistry);
+                new ConcreteResourceRegistration(elementValue, this, provider, constraintUtilizationRegistry, ordered, capabilityRegistry, parent.processType);
 
         newRegistry.beginInitialization();
         try {

--- a/controller/src/test/java/org/jboss/as/controller/ListAttributeDefinitionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ListAttributeDefinitionTestCase.java
@@ -90,7 +90,7 @@ public class ListAttributeDefinitionTestCase {
             }
         };
 
-        ImmutableManagementResourceRegistration registration = ManagementResourceRegistration.Factory.create(resource);
+        ImmutableManagementResourceRegistration registration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(resource);
         ModelNode modelDescription = resource.getDescriptionProvider(registration).getModelDescription(Locale.ENGLISH);
         assertEquals("incorrect type for description " + modelDescription, LIST, modelDescription.get(ATTRIBUTES, MY_LIST_OF_STRINGS, TYPE).asType());
         assertEquals("incorrect value-type for description " + modelDescription, STRING, modelDescription.get(ATTRIBUTES, MY_LIST_OF_STRINGS, VALUE_TYPE).asType());
@@ -157,7 +157,7 @@ public class ListAttributeDefinitionTestCase {
             }
         };
 
-        ImmutableManagementResourceRegistration registration = ManagementResourceRegistration.Factory.create(resource);
+        ImmutableManagementResourceRegistration registration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(resource);
         ModelNode modelDescription = resource.getDescriptionProvider(registration).getModelDescription(Locale.ENGLISH);
         assertEquals("incorrect type for description " + modelDescription, LIST, modelDescription.get(ATTRIBUTES, MY_LIST_OF_OBJECTS, TYPE).asType());
         assertEquals("incorrect value-type for description " + modelDescription, OBJECT, modelDescription.get(ATTRIBUTES, MY_LIST_OF_OBJECTS, VALUE_TYPE).getType());

--- a/controller/src/test/java/org/jboss/as/controller/MetricsRegistrationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/MetricsRegistrationTestCase.java
@@ -175,7 +175,7 @@ public class MetricsRegistrationTestCase {
         public ManagementResourceRegistration managementControllerResource;
 
         public ModelControllerService(ProcessType processType, TestResourceDefinition resourceDefinition) {
-            super(processType, new RunningModeControl(RunningMode.NORMAL));
+            super(processType);
             this.resourceDefinition = resourceDefinition;
         }
 

--- a/controller/src/test/java/org/jboss/as/controller/MetricsRegistrationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/MetricsRegistrationTestCase.java
@@ -1,0 +1,219 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ *
+ */
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests cases for metrics registration.
+ *
+ * Depending on the server environment (process type and running mode), resource metrics
+ * may not be actually registered on the MMR (even if registerMetric is always called).
+ */
+public class MetricsRegistrationTestCase {
+
+    private static final PathElement ELEMENT = PathElement.pathElement("testing", "resource");
+    private static final PathAddress ADDRESS = PathAddress.pathAddress(ELEMENT);
+    private static final String TEST_METRIC = "test-metric";
+    private static final String FORCED_TEST_METRIC = "forced-test-metric";
+
+    private static final Executor executor = Executors.newCachedThreadPool();
+
+    private ServiceContainer container;
+    private ModelController controller;
+    private ModelControllerClient client;
+
+    private void checkMetricRegistration(ProcessType processType, boolean metricIsRegistered) throws Exception {
+        setupController(processType, new TestResourceDefinition());
+        ModelNode description = getResult(client.execute(Util.getReadResourceDescriptionOperation(ADDRESS)));
+        assertEquals(description.toJSONString(false), metricIsRegistered, description.hasDefined(ATTRIBUTES, TEST_METRIC));
+        if (metricIsRegistered) {
+            checkTestMetric(TEST_METRIC, 1000);
+        }
+        // forced test metric is always registered
+        assertTrue(description.hasDefined(ATTRIBUTES, FORCED_TEST_METRIC));
+        checkTestMetric(FORCED_TEST_METRIC, 2000);
+    }
+
+    @Test
+    public void registerMetricOnEmbeddedServerRegistersTheMetric() throws Exception {
+        checkMetricRegistration(ProcessType.EMBEDDED_SERVER, true);
+    }
+
+    @Test
+    public void registerMetricOnStandaloneServerRegistersTheMetric() throws Exception {
+        checkMetricRegistration(ProcessType.STANDALONE_SERVER, true);
+    }
+
+    @Test
+    public void registerMetricOnDomainServerRegistersTheMetric() throws Exception {
+        checkMetricRegistration(ProcessType.DOMAIN_SERVER, true);
+    }
+
+    @Test
+    public void registerMetricOnHostControllerDoesNotRegisterTheMetric() throws Exception {
+        checkMetricRegistration(ProcessType.HOST_CONTROLLER, false);
+    }
+    @Test
+    public void registerMetricOnEmbeddedHostControllerDoesNotRegisterTheMetric() throws Exception {
+        checkMetricRegistration(ProcessType.EMBEDDED_HOST_CONTROLLER, false);
+    }
+
+    private void checkTestMetric(String metric, int expectedValue) throws Exception {
+        ModelNode result = getResult(client.execute(Util.getReadAttributeOperation(ADDRESS, metric)));
+        assertEquals(expectedValue, result.asInt());
+
+        ModelNode rr = Util.createEmptyOperation(READ_RESOURCE_OPERATION, ADDRESS);
+        rr.get(INCLUDE_RUNTIME).set(true);
+        result = getResult(client.execute(rr));
+        Assert.assertTrue(result.hasDefined(metric));
+        assertEquals(expectedValue, result.get(metric).asInt());
+    }
+
+    private ModelNode getResult(ModelNode result) {
+        assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        return result.get(RESULT);
+    }
+
+
+    @After
+    public void shutdownServiceContainer() {
+
+        if (client != null) {
+            try {
+                client.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (container != null) {
+            container.shutdown();
+            try {
+                container.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } finally {
+                container = null;
+            }
+        }
+    }
+
+    private ManagementResourceRegistration setupController(ProcessType processType, TestResourceDefinition resourceDefinition) throws InterruptedException {
+
+        System.out.println("=========  New Test \n");
+        container = ServiceContainer.Factory.create(TEST_METRIC);
+        ServiceTarget target = container.subTarget();
+        ModelControllerService svc = new ModelControllerService(processType, resourceDefinition);
+        ServiceBuilder<ModelController> builder = target.addService(ServiceName.of("ModelController"), svc);
+        builder.install();
+        svc.awaitStartup(30, TimeUnit.SECONDS);
+        controller = svc.getValue();
+        ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
+        controller.execute(setup, null, null, null);
+
+        client = controller.createClient(executor);
+
+        return svc.managementControllerResource;
+    }
+
+    private static class ModelControllerService extends TestModelControllerService {
+
+        private final TestResourceDefinition resourceDefinition;
+        public ManagementResourceRegistration managementControllerResource;
+
+        public ModelControllerService(ProcessType processType, TestResourceDefinition resourceDefinition) {
+            super(processType, new RunningModeControl(RunningMode.NORMAL));
+            this.resourceDefinition = resourceDefinition;
+        }
+
+        @Override
+        protected void initModel(ManagementModel managementModel, Resource modelControllerResource) {
+            ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
+            GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+            GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
+            managementControllerResource = rootRegistration.registerSubModel(resourceDefinition);
+
+            Resource rootResource = managementModel.getRootResource();
+            rootResource.registerChild(resourceDefinition.getPathElement(), Resource.Factory.create());
+        }
+    }
+
+
+    private static class TestResourceDefinition extends SimpleResourceDefinition {
+
+        // metric is registered depending on the type of server for the MMR
+        private static final SimpleAttributeDefinition METRIC = new SimpleAttributeDefinitionBuilder(TEST_METRIC, ModelType.INT)
+                .setStorageRuntime()
+                .setUndefinedMetricValue(new ModelNode(0))
+                .build();
+        // metric is always registered
+        private static final SimpleAttributeDefinition FORCED_METRIC = new SimpleAttributeDefinitionBuilder(FORCED_TEST_METRIC, ModelType.INT)
+                .forceRegistration()
+                .setUndefinedMetricValue(new ModelNode(0))
+                .build();
+
+        public TestResourceDefinition() {
+            super(ELEMENT, new NonResolvingResourceDescriptionResolver(),
+                    new ModelOnlyAddStepHandler(), new ModelOnlyRemoveStepHandler());
+        }
+
+        @Override
+        public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+            resourceRegistration.registerMetric(METRIC, (context, operation) -> context.getResult().set(1000));
+            resourceRegistration.registerMetric(FORCED_METRIC, (context, operation) -> context.getResult().set(2000));
+        }
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
+++ b/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
@@ -48,22 +48,41 @@ public abstract class TestModelControllerService extends AbstractControllerServi
     private final CapabilityRegistry capabilityRegistry;
 
     protected TestModelControllerService() {
-        this(new NullConfigurationPersister(), new ControlledProcessState(true));
+        this(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.NORMAL), new NullConfigurationPersister(), new ControlledProcessState(true));
+    }
+
+    protected TestModelControllerService(ProcessType processType, RunningModeControl runningModeControl) {
+        this(processType, runningModeControl, new NullConfigurationPersister(), new ControlledProcessState(true));
+    }
+
+    protected TestModelControllerService(ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
+        this(processType, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState,
+                ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
+    }
+
+    protected TestModelControllerService(ProcessType processType, RunningModeControl runningModeControl, final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
+        this(processType, runningModeControl, configurationPersister, processState,
+                ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
     }
 
     protected TestModelControllerService(final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
-        this(ProcessType.EMBEDDED_SERVER, configurationPersister, processState,
+        this(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState,
                 ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
     }
 
     protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
                                          final ResourceDefinition rootResourceDefinition) {
-        this(processType, configurationPersister, processState, rootResourceDefinition, new CapabilityRegistry(processType.isServer()));
+        this(processType, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState, rootResourceDefinition, new CapabilityRegistry(processType.isServer()));
     }
 
-    protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
+    protected TestModelControllerService(final ProcessType processType, RunningModeControl runningModeControl, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
+                                         final ResourceDefinition rootResourceDefinition) {
+        this(processType, runningModeControl, configurationPersister, processState, rootResourceDefinition, new CapabilityRegistry(processType.isServer()));
+    }
+
+    protected TestModelControllerService(final ProcessType processType, RunningModeControl runningModeControl, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
                                              final ResourceDefinition rootResourceDefinition, final CapabilityRegistry capabilityRegistry) {
-        super(processType, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState, rootResourceDefinition, null, ExpressionResolver.TEST_RESOLVER,
+        super(processType, runningModeControl, configurationPersister, processState, rootResourceDefinition, null, ExpressionResolver.TEST_RESOLVER,
                         AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer(), capabilityRegistry);
         this.processState = processState;
         this.capabilityRegistry = capabilityRegistry;

--- a/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
+++ b/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
@@ -48,41 +48,31 @@ public abstract class TestModelControllerService extends AbstractControllerServi
     private final CapabilityRegistry capabilityRegistry;
 
     protected TestModelControllerService() {
-        this(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.NORMAL), new NullConfigurationPersister(), new ControlledProcessState(true));
+        this(ProcessType.EMBEDDED_SERVER, new NullConfigurationPersister(), new ControlledProcessState(true));
     }
 
-    protected TestModelControllerService(ProcessType processType, RunningModeControl runningModeControl) {
-        this(processType, runningModeControl, new NullConfigurationPersister(), new ControlledProcessState(true));
+    protected TestModelControllerService(ProcessType processType) {
+        this(processType, new NullConfigurationPersister(), new ControlledProcessState(true));
     }
 
     protected TestModelControllerService(ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
-        this(processType, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState,
-                ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
-    }
-
-    protected TestModelControllerService(ProcessType processType, RunningModeControl runningModeControl, final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
-        this(processType, runningModeControl, configurationPersister, processState,
+        this(processType, configurationPersister, processState,
                 ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
     }
 
     protected TestModelControllerService(final ConfigurationPersister configurationPersister, final ControlledProcessState processState) {
-        this(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState,
+        this(ProcessType.EMBEDDED_SERVER, configurationPersister, processState,
                 ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
     }
 
     protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
                                          final ResourceDefinition rootResourceDefinition) {
-        this(processType, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState, rootResourceDefinition, new CapabilityRegistry(processType.isServer()));
+        this(processType, configurationPersister, processState, rootResourceDefinition, new CapabilityRegistry(processType.isServer()));
     }
 
-    protected TestModelControllerService(final ProcessType processType, RunningModeControl runningModeControl, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
-                                         final ResourceDefinition rootResourceDefinition) {
-        this(processType, runningModeControl, configurationPersister, processState, rootResourceDefinition, new CapabilityRegistry(processType.isServer()));
-    }
-
-    protected TestModelControllerService(final ProcessType processType, RunningModeControl runningModeControl, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
-                                             final ResourceDefinition rootResourceDefinition, final CapabilityRegistry capabilityRegistry) {
-        super(processType, runningModeControl, configurationPersister, processState, rootResourceDefinition, null, ExpressionResolver.TEST_RESOLVER,
+    protected TestModelControllerService(final ProcessType processType, final ConfigurationPersister configurationPersister, final ControlledProcessState processState,
+                                         final ResourceDefinition rootResourceDefinition, final CapabilityRegistry capabilityRegistry) {
+        super(processType, new RunningModeControl(RunningMode.NORMAL), configurationPersister, processState, rootResourceDefinition, null, ExpressionResolver.TEST_RESOLVER,
                         AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer(), capabilityRegistry);
         this.processState = processState;
         this.capabilityRegistry = capabilityRegistry;

--- a/controller/src/test/java/org/jboss/as/controller/access/constraint/ApplicationTypeConstraintUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/constraint/ApplicationTypeConstraintUnitTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.as.controller.NoopOperationStepHandler;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -93,7 +94,7 @@ public class ApplicationTypeConstraintUnitTestCase {
                 return rootResourceConstraints;
             }
         };
-        ManagementResourceRegistration rootRegistration = ManagementResourceRegistration.Factory.create(rootRd);
+        ManagementResourceRegistration rootRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(rootRd);
         rootRegistration.registerOperationHandler(WRITE_CONFIG_DEF, NoopOperationStepHandler.WITHOUT_RESULT, true);
 
         PathElement childPE = PathElement.pathElement("child");

--- a/controller/src/test/java/org/jboss/as/controller/access/constraint/SensitiveTargetConstraintUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/constraint/SensitiveTargetConstraintUnitTestCase.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.NoopOperationStepHandler;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -95,7 +96,7 @@ public class SensitiveTargetConstraintUnitTestCase {
                 return rootResourceConstraints;
             }
         };
-        ManagementResourceRegistration rootRegistration = ManagementResourceRegistration.Factory.create(rootRd);
+        ManagementResourceRegistration rootRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(rootRd);
         rootRegistration.registerOperationHandler(READ_CONFIG_DEF, NoopOperationStepHandler.WITH_RESULT, true);
         PathElement childPE = PathElement.pathElement("child");
         ResourceDefinition childRd = new SimpleResourceDefinition(childPE, new NonResolvingResourceDescriptionResolver()) {

--- a/controller/src/test/java/org/jboss/as/controller/access/permission/ManagementPermissionAuthorizerTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/permission/ManagementPermissionAuthorizerTestCase.java
@@ -54,7 +54,7 @@ import org.junit.Test;
  */
 public class ManagementPermissionAuthorizerTestCase {
 
-    private static final ManagementResourceRegistration ROOT_RR = ManagementResourceRegistration.Factory.create(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()) {
+    private static final ManagementResourceRegistration ROOT_RR = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()) {
         @Override
         public List<AccessConstraintDefinition> getAccessConstraints() {
             return Collections.emptyList();

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/DefaultPermissionFactoryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/DefaultPermissionFactoryTestCase.java
@@ -62,7 +62,7 @@ import org.junit.Test;
  */
 public class DefaultPermissionFactoryTestCase {
 
-    private static final ManagementResourceRegistration ROOT_RR = ManagementResourceRegistration.Factory.create(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()) {
+    private static final ManagementResourceRegistration ROOT_RR = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()) {
         @Override
         public List<AccessConstraintDefinition> getAccessConstraints() {
             return Collections.emptyList();

--- a/controller/src/test/java/org/jboss/as/controller/registry/CoreManagementResourceRegistrationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/registry/CoreManagementResourceRegistrationUnitTestCase.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -68,7 +69,7 @@ public class CoreManagementResourceRegistrationUnitTestCase {
 
     @Before
     public void setup() {
-        rootRegistration = ManagementResourceRegistration.Factory.create(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()));
+        rootRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()));
     }
 
     @Test
@@ -336,7 +337,7 @@ public class CoreManagementResourceRegistrationUnitTestCase {
 
         ResourceDefinition rootRd = new SimpleResourceDefinition(new Parameters(null, new NonResolvingResourceDescriptionResolver())
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.EXTENSIONS, ApplicationTypeAccessConstraintDefinition.DEPLOYMENT));
-        ManagementResourceRegistration root = ManagementResourceRegistration.Factory.create(rootRd);
+        ManagementResourceRegistration root = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(rootRd);
 
         List<AccessConstraintDefinition> acds = root.getAccessConstraints();
         assertEquals(2, acds.size());

--- a/controller/src/test/java/org/jboss/as/controller/registry/ExtendWildCardRegistrationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/registry/ExtendWildCardRegistrationUnitTestCase.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
@@ -87,7 +88,7 @@ public class ExtendWildCardRegistrationUnitTestCase {
 
     @BeforeClass
     public static void setup() {
-        registration = ManagementResourceRegistration.Factory.create(new SimpleResourceDefinition(PathElement.pathElement("root","root"), new NonResolvingResourceDescriptionResolver()));
+        registration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(new SimpleResourceDefinition(PathElement.pathElement("root","root"), new NonResolvingResourceDescriptionResolver()));
 
         parentWildReg = registration.registerSubModel(new SimpleResourceDefinition(parentWild, new NonResolvingResourceDescriptionResolver()));
         parentWildReg.registerReadOnlyAttribute(wildAttr, parentWildAttr);

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
@@ -45,6 +45,8 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ResourceBuilder;
 import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.TestModelControllerService;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
@@ -196,13 +198,13 @@ public abstract class AbstractControllerTestBase {
     public class ModelControllerService extends TestModelControllerService {
 
         public ModelControllerService(final ProcessType processType) {
-            super(processType, new EmptyConfigurationPersister(), new ControlledProcessState(true),
+            super(processType, new RunningModeControl(RunningMode.NORMAL), new EmptyConfigurationPersister(), new ControlledProcessState(true),
                     ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build()
             );
         }
 
         public ModelControllerService(final ProcessType processType, ResourceDefinition resourceDefinition){
-            super(processType, new EmptyConfigurationPersister(), new ControlledProcessState(true), resourceDefinition);
+            super(processType, new RunningModeControl(RunningMode.NORMAL), new EmptyConfigurationPersister(), new ControlledProcessState(true), resourceDefinition);
         }
 
         @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
@@ -45,8 +45,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ResourceBuilder;
 import org.jboss.as.controller.ResourceDefinition;
-import org.jboss.as.controller.RunningMode;
-import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.TestModelControllerService;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
@@ -198,13 +196,13 @@ public abstract class AbstractControllerTestBase {
     public class ModelControllerService extends TestModelControllerService {
 
         public ModelControllerService(final ProcessType processType) {
-            super(processType, new RunningModeControl(RunningMode.NORMAL), new EmptyConfigurationPersister(), new ControlledProcessState(true),
+            super(processType, new EmptyConfigurationPersister(), new ControlledProcessState(true),
                     ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build()
             );
         }
 
         public ModelControllerService(final ProcessType processType, ResourceDefinition resourceDefinition){
-            super(processType, new RunningModeControl(RunningMode.NORMAL), new EmptyConfigurationPersister(), new ControlledProcessState(true), resourceDefinition);
+            super(processType, new EmptyConfigurationPersister(), new ControlledProcessState(true), resourceDefinition);
         }
 
         @Override

--- a/controller/src/test/java/org/jboss/as/controller/test/OperationTransformationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/OperationTransformationTestCase.java
@@ -81,7 +81,7 @@ public class OperationTransformationTestCase {
 
     private final Resource resourceRoot = Resource.Factory.create();
     private final GlobalTransformerRegistry registry = new GlobalTransformerRegistry();
-    private final ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+    private final ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
     private final OperationTransformer NOOP_TRANSFORMER = new OperationTransformer() {
         @Override
         public TransformedOperation transformOperation(TransformationContext context, PathAddress address, ModelNode operation) {

--- a/controller/src/test/java/org/jboss/as/controller/test/RegistryProxyControllerTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/RegistryProxyControllerTestCase.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import org.jboss.as.controller.BlockingTimeout;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.ResourceBuilder;
 import org.jboss.as.controller.ResourceDefinition;
@@ -66,7 +67,7 @@ public class RegistryProxyControllerTestCase {
 
     @Before
     public void setup() {
-        root = ManagementResourceRegistration.Factory.create(rootResource);
+        root = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(rootResource);
         assertNotNull(root);
 
         profileAReg = registerSubModel(root, profileA);

--- a/controller/src/test/java/org/jboss/as/controller/transform/ModelDescriptionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/ModelDescriptionTestCase.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.registry.LegacyResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -23,7 +24,7 @@ public class ModelDescriptionTestCase {
 
     @BeforeClass
     public static void setup() {
-        registration = ManagementResourceRegistration.Factory.create(RootSubsystemResource.INSTANCE);
+        registration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(RootSubsystemResource.INSTANCE);
         registration.registerSubModel(SessionDefinition.INSTANCE);
 
     }
@@ -37,7 +38,7 @@ public class ModelDescriptionTestCase {
     public void testManagementResourceSerialization() {
         ModelNode model = SubsystemDescriptionDump.readFullModelDescription(PathAddress.EMPTY_ADDRESS, registration);
         ResourceDefinition definition = new LegacyResourceDefinition(model);
-        ManagementResourceRegistration loaded = ManagementResourceRegistration.Factory.create(definition);
+        ManagementResourceRegistration loaded = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(definition);
         validate(registration, loaded);
 
 

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/AliasTransformerTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/AliasTransformerTestCase.java
@@ -70,7 +70,7 @@ public class AliasTransformerTestCase {
 
     private Resource resourceRoot = Resource.Factory.create();
     private TransformerRegistry registry = TransformerRegistry.Factory.create();
-    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+    private ManagementResourceRegistration resourceRegistration;
     private TransformersSubRegistration transformersSubRegistration;
 
     @Before
@@ -78,7 +78,7 @@ public class AliasTransformerTestCase {
         // Cleanup
         resourceRoot = Resource.Factory.create();
         registry = TransformerRegistry.Factory.create();
-        resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+        resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
         ManagementResourceRegistration ss = resourceRegistration.registerSubModel(new AbstractChildResourceDefinition(PATH));
         ManagementResourceRegistration target = ss.registerSubModel(new AbstractChildResourceDefinition(CHILD));
         ss.registerAlias(CHILD_ALIAS, new AliasEntry(target) {

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/AttributesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/AttributesTestCase.java
@@ -77,7 +77,7 @@ public class AttributesTestCase {
 
     private Resource resourceRoot = Resource.Factory.create();
     private TransformerRegistry registry = TransformerRegistry.Factory.create();
-    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+    private ManagementResourceRegistration resourceRegistration;
     private TransformersSubRegistration transformersSubRegistration;
     private ModelNode resourceModel;
 
@@ -86,7 +86,7 @@ public class AttributesTestCase {
         // Cleanup
         resourceRoot = Resource.Factory.create();
         registry = TransformerRegistry.Factory.create();
-        resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+        resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
         // test
         final Resource toto = Resource.Factory.create();
         resourceRoot.registerChild(PATH, toto);

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/BasicResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/BasicResourceTestCase.java
@@ -82,7 +82,7 @@ public class BasicResourceTestCase {
 
     private Resource resourceRoot = Resource.Factory.create();
     private TransformerRegistry registry = TransformerRegistry.Factory.create();
-    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
 
     private static final TransformationDescription description;
 
@@ -206,7 +206,7 @@ public class BasicResourceTestCase {
         // Cleanup
         resourceRoot = Resource.Factory.create();
         registry = TransformerRegistry.Factory.create();
-        resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+        resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
         // test
         final Resource toto = Resource.Factory.create();
         toto.getModel().get("test").set("onetwothree");

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedOperationBuilderTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedOperationBuilderTestCase.java
@@ -77,7 +77,7 @@ public class ChainedOperationBuilderTestCase {
     private Resource resourceRoot = Resource.Factory.create();
     private Resource toto;
     private TransformerRegistry registry = TransformerRegistry.Factory.create();
-    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
     private TransformersSubRegistration transformersSubRegistration;
     private ModelNode resourceModel;
 
@@ -86,7 +86,7 @@ public class ChainedOperationBuilderTestCase {
         // Cleanup
         resourceRoot = Resource.Factory.create();
         registry = TransformerRegistry.Factory.create();
-        resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+        resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
         // test
         toto = Resource.Factory.create();
         resourceRoot.registerChild(PATH, toto);

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedResourceBuilderTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/ChainedResourceBuilderTestCase.java
@@ -71,7 +71,7 @@ public class ChainedResourceBuilderTestCase {
     private Resource resourceRoot = Resource.Factory.create();
     private Resource toto;
     private TransformerRegistry registry = TransformerRegistry.Factory.create();
-    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
     private TransformersSubRegistration transformersSubRegistration;
     private ModelNode resourceModel;
 
@@ -80,7 +80,7 @@ public class ChainedResourceBuilderTestCase {
         // Cleanup
         resourceRoot = Resource.Factory.create();
         registry = TransformerRegistry.Factory.create();
-        resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+        resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
         // test
         toto = Resource.Factory.create();
         resourceRoot.registerChild(PATH, toto);

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/ChildRedirectTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/ChildRedirectTestCase.java
@@ -70,7 +70,7 @@ public class ChildRedirectTestCase {
 
     private Resource resourceRoot = Resource.Factory.create();
     private TransformerRegistry registry = TransformerRegistry.Factory.create();
-    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
     private TransformersSubRegistration transformersSubRegistration;
 
     @Before
@@ -78,7 +78,7 @@ public class ChildRedirectTestCase {
         // Cleanup
         resourceRoot = Resource.Factory.create();
         registry = TransformerRegistry.Factory.create();
-        resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+        resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
         // test
         final Resource toto = Resource.Factory.create();
         resourceRoot.registerChild(PATH, toto);

--- a/controller/src/test/java/org/jboss/as/controller/transform/description/RecursiveDiscardAndRemoveTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/transform/description/RecursiveDiscardAndRemoveTestCase.java
@@ -65,7 +65,7 @@ public class RecursiveDiscardAndRemoveTestCase {
 
     private Resource resourceRoot = Resource.Factory.create();
     private TransformerRegistry registry = TransformerRegistry.Factory.create();
-    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+    private ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
     private TransformersSubRegistration transformersSubRegistration;
     private ModelNode resourceModel;
 
@@ -74,7 +74,7 @@ public class RecursiveDiscardAndRemoveTestCase {
         // Cleanup
         resourceRoot = Resource.Factory.create();
         registry = TransformerRegistry.Factory.create();
-        resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+        resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
         // test
         final Resource toto = Resource.Factory.create();
         resourceRoot.registerChild(PATH, toto);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
@@ -117,6 +117,8 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     public static final SimpleAttributeDefinition STATUS = SimpleAttributeDefinitionBuilder.create(ServerStatusHandler.ATTRIBUTE_NAME, ModelType.STRING)
+            .setStorageRuntime()
+            .forceRegistration()
             .setValidator(new EnumValidator<ServerStatus>(ServerStatus.class, false, false))
             .build();
 

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandlerTestCase.java
@@ -71,7 +71,7 @@ public class ReadMasterDomainModelHandlerTestCase {
     public void testResourceTransformation() throws Exception {
         Resource resourceRoot = Resource.Factory.create();
         TransformerRegistry registry = TransformerRegistry.Factory.create();
-        ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.create(ROOT);
+        ManagementResourceRegistration resourceRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(ROOT);
 
         final Resource extension = Resource.Factory.create();
         extension.getModel().get("attr").set("value");

--- a/jmx/src/test/java/org/jboss/as/jmx/model/ObjectNameAddressUtilTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/model/ObjectNameAddressUtilTestCase.java
@@ -32,6 +32,7 @@ import javax.management.ObjectName;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ResourceBuilder;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -101,7 +102,7 @@ public class ObjectNameAddressUtilTestCase {
 
         NonResolvingResourceDescriptionResolver resolver = new NonResolvingResourceDescriptionResolver();
 
-        ManagementResourceRegistration rootRegistration = ManagementResourceRegistration.Factory.create(rootResourceDef);
+        ManagementResourceRegistration rootRegistration = ManagementResourceRegistration.Factory.forProcessType(ProcessType.EMBEDDED_SERVER).createRegistration(rootResourceDef);
         ManagementResourceRegistration subsystemRegistration = rootRegistration.registerSubModel(new SimpleResourceDefinition(pathElement("subsystem", "foo"), resolver));
         ManagementResourceRegistration resourceRegistration = subsystemRegistration.registerSubModel(new SimpleResourceDefinition(pathElement("resource", "resourceA"), resolver));
         ManagementResourceRegistration subresourceRegistration = resourceRegistration.registerSubModel(new SimpleResourceDefinition(pathElement("subresource", "resourceB"), resolver));

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/BufferPoolResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/BufferPoolResourceDefinition.java
@@ -47,15 +47,18 @@ class BufferPoolResourceDefinition extends SimpleResourceDefinition {
 
     private static AttributeDefinition MEMORY_USED_NAME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.MEMORY_USED_NAME, ModelType.LONG, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .build();
     private static AttributeDefinition TOTAL_CAPACITY = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.TOTAL_CAPACITY, ModelType.LONG, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .build();
 
     private static AttributeDefinition COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COUNT, ModelType.LONG, false)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
 
     private static final List<AttributeDefinition> METRICS = Arrays.asList(

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ClassLoadingResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ClassLoadingResourceDefinition.java
@@ -17,14 +17,17 @@ class ClassLoadingResourceDefinition extends SimpleResourceDefinition {
     //metrics
     private static SimpleAttributeDefinition TOTAL_LOADED_CLASS_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.TOTAL_LOADED_CLASS_COUNT, ModelType.LONG, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
     private static SimpleAttributeDefinition LOADED_CLASS_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.LOADED_CLASS_COUNT, ModelType.INT, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
     private static SimpleAttributeDefinition UNLOADED_CLASS_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.UNLOADED_CLASS_COUNT, ModelType.LONG, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
     //r+w attributes

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CompilationResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CompilationResourceDefinition.java
@@ -26,6 +26,7 @@ class CompilationResourceDefinition extends SimpleResourceDefinition {
     static SimpleAttributeDefinition TOTAL_COMPILATION_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.TOTAL_COMPILATION_TIME, ModelType.LONG, true)
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
     protected static final List<String> COMPILATION_READ_ATTRIBUTES = Arrays.asList(
             NAME.getName(),

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/GarbageCollectorResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/GarbageCollectorResourceDefinition.java
@@ -46,10 +46,12 @@ class GarbageCollectorResourceDefinition extends SimpleResourceDefinition {
     //metrics
     private static SimpleAttributeDefinition COLLECTION_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_COUNT, ModelType.LONG, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
     private static SimpleAttributeDefinition COLLECTION_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_TIME, ModelType.LONG, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .build();
     private static AttributeDefinition MEMORY_POOL_NAMES = new StringListAttributeDefinition.Builder(PlatformMBeanConstants.MEMORY_POOL_NAMES)

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryManagerResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryManagerResourceDefinition.java
@@ -45,14 +45,16 @@ import org.jboss.dmr.ModelType;
 class MemoryManagerResourceDefinition extends SimpleResourceDefinition {
     private static SimpleAttributeDefinition VALID = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.VALID, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
     private static AttributeDefinition MEMORY_POOL_NAMES = new StringListAttributeDefinition.Builder(PlatformMBeanConstants.MEMORY_POOL_NAMES)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
 
 
     private static final List<AttributeDefinition> METRICS = Arrays.asList(
-            NAME,
+            NAME, // TODO is name really a metric? It seems to be a runtime r/o attibute
             VALID,
             MEMORY_POOL_NAMES
     );

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolResourceDefinition.java
@@ -62,12 +62,14 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
 
     private static AttributeDefinition USAGE_THRESHOLD = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.USAGE_THRESHOLD, ModelType.LONG, true)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .setValidator(new IntRangeValidator(0))
             .build();
 
     private static AttributeDefinition USAGE_THRESHOLD_EXCEEDED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.USAGE_THRESHOLD_EXCEEDED, ModelType.BOOLEAN, true)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
 
     private static AttributeDefinition USAGE_THRESHOLD_SUPPORTED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.USAGE_THRESHOLD_SUPPORTED, ModelType.BOOLEAN, false)
@@ -76,11 +78,13 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
 
     private static AttributeDefinition USAGE_THRESHOLD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.USAGE_THRESHOLD_COUNT, ModelType.LONG, true)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     private static AttributeDefinition COLLECTION_USAGE_THRESHOLD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_USAGE_THRESHOLD_COUNT, ModelType.LONG, true)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
@@ -95,6 +99,7 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
             .build();
     private static AttributeDefinition COLLECTION_USAGE_THRESHOLD_EXCEEDED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_USAGE_THRESHOLD_EXCEEDED, ModelType.BOOLEAN, true)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
 
 
@@ -116,6 +121,7 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
             PlatformMBeanConstants.MEMORY_COMMITTED,
             PlatformMBeanConstants.MEMORY_MAX)
             .setStorageRuntime()
+            .forceRegistration()
             .setAllowNull(false)
             .build();
 
@@ -126,6 +132,7 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
             PlatformMBeanConstants.MEMORY_COMMITTED,
             PlatformMBeanConstants.MEMORY_MAX)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
 
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryResourceDefinition.java
@@ -47,6 +47,7 @@ class MemoryResourceDefinition extends SimpleResourceDefinition {
     //metrics
     private static SimpleAttributeDefinition OBJECT_PENDING_FINALIZATION_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.OBJECT_PENDING_FINALIZATION_COUNT, ModelType.INT, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
@@ -59,6 +60,7 @@ class MemoryResourceDefinition extends SimpleResourceDefinition {
             PlatformMBeanConstants.MEMORY_MAX
     )
             .setStorageRuntime()
+            .forceRegistration()
             .setAllowNull(false)
             .build();
 
@@ -69,6 +71,7 @@ class MemoryResourceDefinition extends SimpleResourceDefinition {
             PlatformMBeanConstants.MEMORY_COMMITTED,
             PlatformMBeanConstants.MEMORY_MAX)
             .setStorageRuntime()
+            .forceRegistration()
             .setAllowNull(false)
             .build();
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/OperatingSystemResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/OperatingSystemResourceDefinition.java
@@ -46,12 +46,14 @@ class OperatingSystemResourceDefinition extends SimpleResourceDefinition {
 
     private static SimpleAttributeDefinition AVAILABLE_PROCESSORS = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.AVAILABLE_PROCESSORS, ModelType.INT, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     private static SimpleAttributeDefinition SYSTEM_LOAD_AVERAGE = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.SYSTEM_LOAD_AVERAGE, ModelType.DOUBLE, false)
             .setMeasurementUnit(MeasurementUnit.PERCENTAGE)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
 
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/RuntimeResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/RuntimeResourceDefinition.java
@@ -49,6 +49,7 @@ class RuntimeResourceDefinition extends SimpleResourceDefinition {
     private static AttributeDefinition UPTIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.UPTIME, ModelType.LONG, false)
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
 
     private static AttributeDefinition START_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.START_TIME, ModelType.LONG, false)

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadResourceDefinition.java
@@ -49,11 +49,13 @@ class ThreadResourceDefinition extends SimpleResourceDefinition {
     static AttributeDefinition CURRENT_THREAD_CPU_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.CURRENT_THREAD_CPU_TIME, ModelType.LONG, false)
             .setMeasurementUnit(MeasurementUnit.NANOSECONDS)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
 
     static AttributeDefinition CURRENT_THREAD_USER_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.CURRENT_THREAD_USER_TIME, ModelType.LONG, false)
             .setMeasurementUnit(MeasurementUnit.NANOSECONDS)
             .setStorageRuntime()
+            .forceRegistration()
             .build();
 
 
@@ -63,21 +65,25 @@ class ThreadResourceDefinition extends SimpleResourceDefinition {
 
     static AttributeDefinition THREAD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.THREAD_COUNT, ModelType.INT, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     static AttributeDefinition PEAK_THREAD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.PEAK_THREAD_COUNT, ModelType.INT, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     static AttributeDefinition TOTAL_STARTED_THREAD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.TOTAL_STARTED_THREAD_COUNT, ModelType.LONG, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     static AttributeDefinition DAEMON_THREAD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.DAEMON_THREAD_COUNT, ModelType.INT, false)
             .setStorageRuntime()
+            .forceRegistration()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 

--- a/server/src/main/java/org/jboss/as/server/services/net/BindingMetricHandlers.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingMetricHandlers.java
@@ -30,7 +30,6 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.network.ManagedBinding;
@@ -79,7 +78,11 @@ public final class BindingMetricHandlers {
     public static class BoundHandler extends AbstractBindingMetricsHandler {
 
         public static final String ATTRIBUTE_NAME = "bound";
-        public static final AttributeDefinition ATTRIBUTE_DEFINITION = new SimpleAttributeDefinition(ATTRIBUTE_NAME, ModelType.BOOLEAN, true);
+        public static final AttributeDefinition ATTRIBUTE_DEFINITION = SimpleAttributeDefinitionBuilder.create(ATTRIBUTE_NAME, ModelType.BOOLEAN)
+                .setAllowNull(true)
+                .setStorageRuntime()
+                .forceRegistration()
+                .build();
         public static final OperationStepHandler INSTANCE = new BoundHandler();
 
         private BoundHandler() {
@@ -101,7 +104,11 @@ public final class BindingMetricHandlers {
     public static class BoundAddressHandler extends AbstractBindingMetricsHandler {
 
         public static final String ATTRIBUTE_NAME = "bound-address";
-        public static final AttributeDefinition ATTRIBUTE_DEFINITION = new SimpleAttributeDefinition(ATTRIBUTE_NAME, ModelType.STRING, true);
+        public static final AttributeDefinition ATTRIBUTE_DEFINITION = SimpleAttributeDefinitionBuilder.create(ATTRIBUTE_NAME, ModelType.STRING)
+                .setAllowNull(true)
+                .setStorageRuntime()
+                .forceRegistration()
+                .build();
         public static final OperationStepHandler INSTANCE = new BoundAddressHandler();
 
         private BoundAddressHandler() {
@@ -125,9 +132,12 @@ public final class BindingMetricHandlers {
     public static class BoundPortHandler extends AbstractBindingMetricsHandler {
 
         public static final String ATTRIBUTE_NAME = "bound-port";
-        public static final AttributeDefinition ATTRIBUTE_DEFINITION =
-                new SimpleAttributeDefinitionBuilder(ATTRIBUTE_NAME, ModelType.INT, true)
-                        .setValidator(new IntRangeValidator(1, Integer.MAX_VALUE, true, false)).build();
+        public static final AttributeDefinition ATTRIBUTE_DEFINITION = SimpleAttributeDefinitionBuilder.create(ATTRIBUTE_NAME, ModelType.INT)
+                .setAllowNull(true)
+                .setValidator(new IntRangeValidator(1, Integer.MAX_VALUE, true, false))
+                .setStorageRuntime()
+                .forceRegistration()
+                .build();
 
         public static final OperationStepHandler INSTANCE = new BoundPortHandler();
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -519,7 +519,7 @@ final class SubsystemTestDelegate {
         //2) Check that the transformed model is valid according to the resource definition in the legacy subsystem controller
         ResourceDefinition rd = getResourceDefinition(kernelServices, modelVersion);
         Assert.assertNotNull("Could not load legacy dmr for subsystem '" + mainSubsystemName + "' version: '" + modelVersion + "' please add it", rd);
-        ManagementResourceRegistration rr = ManagementResourceRegistration.Factory.create(rd);
+        ManagementResourceRegistration rr = ManagementResourceRegistration.Factory.forEnvironment(getProcessType(), RunningMode.NORMAL).createRegistry(rd);
         ModelTestUtils.checkModelAgainstDefinition(transformed, rr);
         return legacyModel;
     }

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -519,7 +519,7 @@ final class SubsystemTestDelegate {
         //2) Check that the transformed model is valid according to the resource definition in the legacy subsystem controller
         ResourceDefinition rd = getResourceDefinition(kernelServices, modelVersion);
         Assert.assertNotNull("Could not load legacy dmr for subsystem '" + mainSubsystemName + "' version: '" + modelVersion + "' please add it", rd);
-        ManagementResourceRegistration rr = ManagementResourceRegistration.Factory.forEnvironment(getProcessType(), RunningMode.NORMAL).createRegistry(rd);
+        ManagementResourceRegistration rr = ManagementResourceRegistration.Factory.forProcessType(getProcessType()).createRegistration(rd);
         ModelTestUtils.checkModelAgainstDefinition(transformed, rr);
         return legacyModel;
     }


### PR DESCRIPTION
* register metrics in the ConcreteResourceRegistration only when they are
  meaningful (for the given ProcessType/RunningMode).
* add the AttibuteAccess.Flag.FORCE_REGISTRATION to override this
  behaviour and always force the registration of the metric. This is
  meant for metrics that are *always* relevant (eg MBean metrics that
  are computed by the JVM)
* add this flag to MBean metrics, service-config's status and
  socket-binding metrics
* add the ManagementResourceRegistration.Factory#forEnvironment  API to
  create a ManagementResourceRegistration aware of the process type and
  running mode.s type/running mode) by the new ones in the tests
* replace deprecated ManagementResourceRegistration.Factory calls
  (without process type/running mode) by the new ones in the tests

JIRA: https://issues.jboss.org/browse/WFCORE-1513