### PR TITLE
WFCORE-1525 ageout-history operations reports failure if it was unabl…

### DIFF
--- a/patching/src/main/java/org/jboss/as/patching/logging/PatchLogger.java
+++ b/patching/src/main/java/org/jboss/as/patching/logging/PatchLogger.java
@@ -238,4 +238,11 @@ public interface PatchLogger extends BasicLogger {
 
     @Message(id = 47, value = "Cannot copy files from %s to %s: %s")
     IOException cannotCopyFiles(String from, String to, String reason, @Cause Throwable cause);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 48, value = "Error when restoring file[%s] - %s")
+    void deleteRollbackError(String path, String message);
+
+    @Message(id = 49, value = "Some backup files were not removed.")
+    IOException failedToDeleteBackup();
 }

--- a/patching/src/main/java/org/jboss/as/patching/management/DeleteOp.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/DeleteOp.java
@@ -1,0 +1,241 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.patching.management;
+
+import org.jboss.as.patching.logging.PatchLogger;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * Recursively removes files from a given directory. If any of the files couldn't be removed, it restores all deleted files.
+ *
+ * @author Bartosz Spyrko-Smietanko
+ */
+class DeleteOp {
+    public static final String BACKUP_FOLDER = ".bkp";
+    private final File fileToDelete;
+    private final FilenameFilter fileFilter;
+    private final File backupRoot;
+
+    DeleteOp(File toDelete, FilenameFilter fileFilter) {
+        this.fileToDelete = toDelete;
+        this.fileFilter = fileFilter;
+
+        backupRoot = new File(toDelete.getParentFile(), BACKUP_FOLDER);
+    }
+
+    /**
+     * remove files from directory. All-or-nothing operation - if any of the files fails to be removed, all deleted files are restored.
+     *
+     * The operation is performed in two steps - first all the files are moved to a backup folder, and afterwards backup folder is removed.
+     * If an error occurs in the first step of the operation, all files are restored and the operation ends with status {@code false}.
+     * If an error occurs in the second step, the operation ends with status {@code false}, but the files are not rolled back.
+     *
+     * @throws IOException if an error occurred
+     */
+    public void execute() throws IOException {
+        try {
+            prepare();
+
+            boolean commitResult = commit();
+            if (commitResult == false) {
+                throw PatchLogger.ROOT_LOGGER.failedToDeleteBackup();
+            }
+        } catch (PrepareException pe){
+            rollback();
+
+            throw PatchLogger.ROOT_LOGGER.failedToDelete(pe.getPath());
+        }
+
+    }
+
+    /**
+     * performs all delete operations together - if error occurs in one of them, all the operations are rolled back.
+     * For details see {@link DeleteOp#execute()}
+     *
+     * @param deleteOps list of {@code DeleteOp} to perform
+     * @throws IOException if an error occurred
+     */
+    public static void execute(Collection<DeleteOp> deleteOps) throws IOException {
+        try {
+            deleteOps.forEach(DeleteOp::prepare);
+
+            // best effort cleanup - delete what's possible and report error if anything remains
+            boolean commitResult = true;
+            for (DeleteOp op : deleteOps) {
+                commitResult &= op.commit();
+            }
+            if (!commitResult) {
+                throw PatchLogger.ROOT_LOGGER.failedToDeleteBackup();
+            }
+
+        } catch (PrepareException pe) {
+            deleteOps.forEach(DeleteOp::rollback);
+
+            throw PatchLogger.ROOT_LOGGER.failedToDelete(pe.getPath());
+        }
+
+    }
+
+    private void prepare() throws PrepareException {
+        backupRoot.mkdir();
+
+        moveToBackup(fileToDelete, backupRoot, fileFilter);
+    }
+
+    private void moveToBackup(File file, File bkp, FilenameFilter fileFilter) throws PrepareException {
+        if (!fileFilter.accept(file.getParentFile(), file.getName())) {
+            // the file is ignored - do nothing
+            return;
+        }
+
+        if (file.isDirectory()) {
+
+            final File backupFolder = createBackupFolder(file, bkp);
+            for (File child : file.listFiles(fileFilter)) {
+                moveToBackup(child, backupFolder, fileFilter);
+            }
+            if (isEmptyFolder(file)) {
+                boolean deleted = file.delete();
+                if (!deleted) {
+                    throw new PrepareException(file);
+                }
+            }
+        } else {
+            final File dest = new File(bkp, file.getName());
+            boolean moved = file.renameTo(dest);
+            if (!moved) {
+                throw new PrepareException(file);
+            }
+        }
+    }
+
+    private File createBackupFolder(File file, File bkp) throws PrepareException {
+        final File backupFolder = new File(bkp, file.getName());
+        if (backupFolder.exists() || !backupFolder.mkdir()) {
+            throw new PrepareException(file);
+        }
+        return backupFolder;
+    }
+
+    private boolean isEmptyFolder(File file) {
+        return file.list().length == 0;
+    }
+
+    private boolean commit() {
+        final File deleteRoot = new File(backupRoot, fileToDelete.getName());
+
+        boolean commitResult = true;
+
+        if (deleteRoot.exists()) {
+            commitResult = doDelete(deleteRoot);
+        }
+
+        if (isEmptyFolder(backupRoot)) {
+            commitResult &= backupRoot.delete();
+        }
+
+        return commitResult;
+    }
+
+    private boolean doDelete(File file) {
+        boolean result = true;
+        if (file.isDirectory()) {
+            for (File child : file.listFiles()) {
+                result &= doDelete(child);
+            }
+        }
+        if (!file.delete()) {
+            PatchLogger.ROOT_LOGGER.cannotDeleteFile(file.getAbsolutePath());
+            result = false;
+        }
+        return result;
+    }
+
+    private void rollback() {
+        try {
+            if (!backupRoot.exists()) {
+                return; // it's OK - no files were originally backed up
+            }
+            final File source = new File(backupRoot, fileToDelete.getName());
+            doRollback(source, fileToDelete);
+
+            if (backupRoot.list().length == 0) {
+                backupRoot.delete();
+            }
+        } catch (RollbackException e) {
+            PatchLogger.ROOT_LOGGER.deleteRollbackError(e.getPath(), e.getMessage());
+        }
+    }
+
+    private static void doRollback(File source, File destination) throws RollbackException {
+        if (source.isDirectory()) {
+            if (!destination.exists()) {
+                destination.mkdir();
+            } else if (!destination.isDirectory()) {
+                throw new RollbackException(source, "file with the same name exists");
+            }
+
+            for (File child : source.listFiles()) {
+                doRollback(child, new File(destination, child.getName()));
+            }
+            if (source.list().length == 0) {
+                if (!source.delete()) {
+                    throw new RollbackException(source, "unable to delete folder");
+                }
+            } else {
+                throw new RollbackException(source, "directory has unexpected files");
+            }
+        } else {
+            if (destination.exists()) {
+                throw new RollbackException(source, "file with the same name already exists");
+            }
+            if (!source.renameTo(destination)) {
+                throw new RollbackException(source, "unable to move file");
+            }
+        }
+    }
+
+    private static class PrepareException extends RuntimeException {
+        private final String path;
+
+        public PrepareException(File file) {
+            this.path = file.getAbsolutePath();
+        }
+
+        public String getPath() {
+            return path;
+        }
+    }
+
+    private static class RollbackException extends Exception {
+        private String path;
+
+        public RollbackException(File source, String msg) {
+            super(msg);
+            this.path = source.getAbsolutePath();
+        }
+
+        public String getPath() {
+            return path;
+        }
+    }
+}

--- a/patching/src/test/java/org/jboss/as/patching/management/DeleteOpTest.java
+++ b/patching/src/test/java/org/jboss/as/patching/management/DeleteOpTest.java
@@ -1,0 +1,348 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.patching.management;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests "safe" delete operation {@link DeleteOp}
+ *
+ * @author Bartosz Spyrko-Smietanko
+ */
+public class DeleteOpTest {
+    public static final boolean NOT_PROTECTED = false;
+    public static final boolean PROTECTED = true;
+    public static final FilenameFilter INCLUDE_ALL = (d,f) -> true;
+    private static String TEST_DIR = "test";
+    public static final String BACKUP_ROOT_FILE_NAME = TEST_DIR + "/" + ".bkp";
+
+    @Before
+    public void setUp() {
+        final File testDir = new File(TEST_DIR);
+        if (testDir.exists()) {
+            recursiveCleanUp(testDir);
+        }
+
+        testDir.mkdir();
+    }
+
+    @After
+    public void tearDown() {
+        final File testDir = new File(TEST_DIR);
+        if (testDir.exists()) {
+            recursiveCleanUp(testDir);
+        }
+    }
+
+    private void recursiveCleanUp(File file) {
+        if (file.isDirectory()) {
+            for (File child : file.listFiles()) {
+                recursiveCleanUp(child);
+            }
+        }
+        file.delete();
+    }
+
+    @Test
+    public void removeNonProtectedFileWithoutErrors() throws Exception {
+        final File origin = createFile("test.txt", NOT_PROTECTED);
+
+        delete(origin, INCLUDE_ALL);
+
+        assertOriginalFileRemoved("test.txt");
+    }
+
+    @Test
+    public void failToDeleteProtectedFile() throws Exception {
+        final File origin = createFile("test.txt", PROTECTED);
+
+        delete(origin, INCLUDE_ALL);
+
+        assertOriginalFileExists("test.txt");
+    }
+
+    @Test
+    public void removeFolderWithUnprotectedFiles() throws Exception {
+        File dir = createDir("parent", createFile("parent/test.txt", NOT_PROTECTED));
+
+        delete(dir, INCLUDE_ALL);
+
+        assertOriginalFileRemoved("parent");
+        assertBackupFolderWasRemoved();
+    }
+
+    @Test
+    public void failToRemoveParentIfChildIsProtected() throws Exception {
+        File dir = createDir("parent", createFile("parent/test.txt", PROTECTED));
+
+        delete(dir, INCLUDE_ALL);
+
+        assertOriginalFileExists("parent");
+        assertOriginalFileExists("parent/test.txt");
+        assertBackupFolderWasRemoved();
+    }
+
+    @Test
+    public void doNotDeleteAnyFilesIfOneFileIsProtected() throws Exception {
+        File dir = createDir("parent", createFile("parent/test2.txt", NOT_PROTECTED), createFile("parent/test.txt", PROTECTED));
+
+        delete(dir, INCLUDE_ALL);
+
+        assertOriginalFileExists("parent");
+        assertOriginalFileExists("parent/test.txt");
+        assertOriginalFileExists("parent/test2.txt");
+        assertBackupFolderWasRemoved();
+    }
+
+    @Test
+    public void executeTwoDeleteOpsWithSameBackupDir() throws Exception {
+        final File dir1 = createDir("dir1", createFile("dir1/test.txt", NOT_PROTECTED));
+        final File dir2 = createDir("dir2", createFile("dir2/test.txt", PROTECTED));
+
+        final DeleteOp op1 = new DeleteOp(dir1, INCLUDE_ALL);
+        final DeleteOp op2 = new DeleteOp(dir2, INCLUDE_ALL);
+        try {
+            DeleteOp.execute(Arrays.asList(op1, op2));
+
+            fail("DeleteOp should throw an exception");
+        } catch(IOException e) {
+            assertOriginalFileExists("dir1/test.txt");
+            assertOriginalFileExists("dir2/test.txt");
+        }
+    }
+
+    @Test
+    public void dontRemoveIgnoredFiles() throws Exception {
+        final File dir = createDir("dir1", createFile("dir1/test1.txt", NOT_PROTECTED), createFile("dir1/test2.txt", NOT_PROTECTED));
+
+        boolean operationResult = delete(dir, exclude("test1.txt"));
+
+        assertTrue("The delete with ignored files should be succesful", operationResult);
+        assertOriginalFileExists("dir1/test1.txt");
+        assertOriginalFileRemoved("dir1/test2.txt");
+    }
+
+    @Test
+    public void dontRemoveIgnoredDirectories() throws Exception {
+        final File dir = createDir("dir1",
+                            createDir("dir2",
+                                    createFile("dir1/dir2/test1.txt", NOT_PROTECTED)),
+                            createFile("dir1/test2.txt", NOT_PROTECTED));
+
+        delete(dir, exclude("dir2"));
+
+        assertOriginalFileExists("dir1/dir2/test1.txt");
+        assertOriginalFileRemoved("dir1/test2.txt");
+    }
+
+    @Test
+    public void completeSuccesfullyIfAllFilesWereIgnored() throws Exception {
+        final File dir = createDir("dir1");
+
+        final DeleteOp op1 = new DeleteOp(dir, (d,f)->false); // exclude all files
+        DeleteOp.execute(Arrays.asList(op1));
+
+        assertOriginalFileExists("dir1");
+        assertBackupFolderWasRemoved();
+    }
+
+    @Test
+    public void removeBackupFolderAfterCommit() throws Exception {
+        file("dir1").mkdir();
+        file("dir1", "test1.txt").createNewFile();
+
+        boolean operationResult = delete(file("dir1"), INCLUDE_ALL);
+
+        assertTrue("The delete should have succeeded", operationResult);
+        assertBackupFolderWasRemoved();
+    }
+
+    @Test
+    public void removeBackupFolderAfterRollback() throws Exception {
+        final File dir1 = createDir("dir1", createFile("dir1/test.txt", PROTECTED));
+
+        boolean operationResult = delete(dir1, INCLUDE_ALL);
+
+        assertFalse("The delete should have failed", operationResult);
+        assertBackupFolderWasRemoved();
+    }
+
+    @Test
+    public void failDeleteIfDeletedFileExistsInBackupFolder() throws Exception {
+        createDir(".bkp", createDir("dir1", createFile(".bkp/dir1/test.txt", NOT_PROTECTED)));
+        final File dir1 = createDir("dir1", createFile("dir1/test.txt", NOT_PROTECTED));
+
+        boolean operationResult = delete(dir1, INCLUDE_ALL);
+
+        assertFalse("The delete should have failed", operationResult);
+    }
+
+    private static void assertOriginalFileExists(String path) {
+        final String fullPath = TEST_DIR + "/" + path;
+        final File file = new File(fullPath);
+
+        assertTrue("Original file [" + fullPath +  "] should not be removed", file.exists());
+    }
+
+    private static void assertOriginalFileRemoved(String path) {
+        final String fullPath = TEST_DIR + "/" + path;
+        final File file = new File(fullPath);
+
+        assertFalse("Original file [" + fullPath +  "] should be removed", file.exists());
+    }
+
+    private static void assertBackupFolderWasRemoved() {
+        final File file = new File(BACKUP_ROOT_FILE_NAME);
+
+        assertFalse("Backup folder [" + BACKUP_ROOT_FILE_NAME  + "] should be removed", file.exists());
+    }
+
+    private boolean delete(File origin, FilenameFilter filter) throws IOException {
+        final DeleteOp op = new DeleteOp(origin, filter);
+        try {
+            DeleteOp.execute(Arrays.asList(op));
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static File file(String... parts) {
+        StringBuilder sb = new StringBuilder(TEST_DIR);
+        for (String part : parts) {
+            sb.append("/").append(part);
+        }
+        return new File(sb.toString());
+    }
+
+    private static FilenameFilter exclude(String fileName) {
+        return (d,f) -> !f.equals(fileName);
+    }
+
+    private static File createDir(String name, File... files) {
+        String fileName = TEST_DIR + "/" + name;
+        File dir = new MockFile(fileName, false, files);
+        if (!dir.exists()) {
+            dir.mkdir();
+        }
+        return dir;
+    }
+
+    private static File createFile(String name, boolean deleteProtected) throws IOException {
+        createParents(name);
+
+        String fileName = TEST_DIR + "/" + name;
+        File origin = new MockFile(fileName, deleteProtected);
+        origin.createNewFile();
+        return origin;
+    }
+
+    private static void createParents(String name) {
+        File parent = new File(TEST_DIR);
+        final String[] split = name.split("/");
+        for (int i = 0; i < split.length - 1; i++) {
+            String p = split[i];
+            parent = new File(parent, p);
+            parent.mkdir();
+        }
+    }
+
+    /*
+    Since exact behaviour of File depends on the underlying platform, File.setReadonly / File.setWritable does not
+    guarantee move protection. MockFile is to help simulate those issues.
+     */
+    private static class MockFile extends File {
+        private File[] children;
+        private boolean protect;
+
+        MockFile(String name, boolean protect) {
+            super(name);
+            this.protect = protect;
+        }
+
+        MockFile(String name, boolean protect, File... children) {
+            this(name, protect);
+            this.children = children;
+        }
+
+        @Override
+        public boolean delete() {
+            if (protect) {
+                return false;
+            } else {
+                return super.delete();
+            }
+        }
+
+        @Override
+        public boolean renameTo(File dest) {
+            if (protect) {
+                return false;
+            } else {
+                return super.renameTo(dest);
+            }
+        }
+
+        @Override
+        public File[] listFiles(FileFilter filter) {
+            final File[] files = super.listFiles(filter);
+
+            // need to return the mock ones, but skip ones that were removed
+            ArrayList<File> filtered = new ArrayList<>();
+            for (File file : files) {
+                for (File child : children) {
+                    if (file.getAbsolutePath().equals(child.getAbsolutePath())) {
+                        filtered.add(child);
+                    }
+                }
+            }
+
+            return filtered.toArray(new File[]{});
+        }
+
+        @Override
+        public File[] listFiles(FilenameFilter filter) {
+            final File[] files = super.listFiles(filter);
+
+            // need to return the mock ones, but skip ones that were removed
+            ArrayList<File> filtered = new ArrayList<>();
+            for (File file : files) {
+                for (File child : children) {
+                    if (file.getAbsolutePath().equals(child.getAbsolutePath())) {
+                        filtered.add(child);
+                    }
+                }
+            }
+
+            return filtered.toArray(new File[]{});
+        }
+    }
+}


### PR DESCRIPTION
…e to remove some history files

https://issues.jboss.org/browse/WFCORE-1525

If ageout-history fails to delete some history files (eg. due to wrong permissions), it returns with 
```
{
  "outcome" => "failed",
  "failure-description" => "WFLYCTL0158: Operation handler failed: java.lang.IllegalStateException: WFLYPAT0048: Unable to     remove some of the history files.",
  "rolled-back" => true
} 
```
In addition offending files are logged at warning level in the patching logger:
```
[33m22:12:47,080 WARN  [org.jboss.as.patching] (management-handler-thread - 3) WFLYPAT0001: Cannot delete file /Users/spyrkob/workspaces/set/wildfly-core/testsuite/patching/target/wildfly-core/.installation/patches/cp0/configuration
[33m22:12:47,081 WARN  [org.jboss.as.patching] (management-handler-thread - 3) WFLYPAT0001: Cannot delete file /Users/spyrkob/workspaces/set/wildfly-core/testsuite/patching/target/wildfly-core/.installation/patches/cp0/timestamp
```