### PR TITLE
[WFCORE-1514] Add '!' operator for operation arguments

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandCompleter.java
@@ -124,6 +124,13 @@ public class CommandCompleter implements CommandLineCompleter {
         }
 
         final int result = OperationRequestCompleter.INSTANCE.complete(ctx, candidatesProvider, buffer, cursor, candidates);
+        // Util.NOT_OPERATOR not supported in commands.
+        if (parsedCmd.getFormat() != OperationFormat.INSTANCE) {
+            int notIndex = candidates.indexOf(Util.NOT_OPERATOR);
+            if (notIndex >= 0) {
+                candidates.remove(notIndex);
+            }
+        }
         // if there is nothing else to suggest, check whether it could be a start of a variable
         if(candidates.isEmpty() && buffer.charAt(buffer.length() - 1) == '$' && !ctx.getVariables().isEmpty()) {
             candidates.addAll(ctx.getVariables());

--- a/cli/src/main/java/org/jboss/as/cli/operation/CommandLineParser.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/CommandLineParser.java
@@ -62,6 +62,10 @@ public interface CommandLineParser {
 
         void property(String name, String value, int nameValueSeparatorIndex) throws CommandFormatException;
 
+        void propertyNoValue(int index, String name) throws CommandFormatException;
+
+        void notOperator(int index);
+
         void propertySeparator(int index);
 
         void propertyListEnd(int index);

--- a/cli/src/main/java/org/jboss/as/cli/operation/ParsedCommandLine.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/ParsedCommandLine.java
@@ -54,6 +54,10 @@ public interface ParsedCommandLine {
 
     boolean endsOnPropertyListEnd();
 
+    boolean endsOnNotOperator();
+
+    boolean isLastPropertyNegated();
+
     boolean endsOnAddressOperationNameSeparator();
 
     boolean endsOnNodeSeparator();

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/RolloutPlanCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/RolloutPlanCompleter.java
@@ -144,6 +144,13 @@ public class RolloutPlanCompleter implements CommandLineCompleter {
             candidates.add(Util.MAX_FAILED_SERVERS);
             candidates.add(Util.MAX_FAILURE_PERCENTAGE);
             candidates.add(Util.ROLLING_TO_SERVERS);
+            candidates.add(Util.NOT_OPERATOR);
+            return buffer.length();
+        }
+
+        // Only return the set of boolean properties
+        if (lastGroup.endsOnNotOperator()) {
+            candidates.add(Util.ROLLING_TO_SERVERS);
             return buffer.length();
         }
 
@@ -178,6 +185,7 @@ public class RolloutPlanCompleter implements CommandLineCompleter {
                 }
                 if(!lastGroup.hasProperty(Util.ROLLING_TO_SERVERS)) {
                     candidates.add(Util.ROLLING_TO_SERVERS);
+                    candidates.add(Util.NOT_OPERATOR);
                 }
                 return lastGroup.getLastSeparatorIndex() + 1;
             } else {
@@ -188,11 +196,17 @@ public class RolloutPlanCompleter implements CommandLineCompleter {
                 if(Util.MAX_FAILURE_PERCENTAGE.startsWith(propName)) {
                     candidates.add(Util.MAX_FAILURE_PERCENTAGE + '=');
                 } else if (Util.ROLLING_TO_SERVERS.equals(propName)) {
-                    candidates.add("=" + Util.FALSE);
-                    candidates.add(")");
-                    if (!containsAll) {
-                        candidates.add(",");
+                    if (lastGroup.isLastPropertyNegated() && !containsAll) {
+                        candidates.add(Util.ROLLING_TO_SERVERS + ",");
+                    } else {
+                        candidates.add("=" + Util.FALSE);
+                        if (!containsAll) {
+                            candidates.add(",");
+                        } else {
+                            candidates.add(")");
+                        }
                     }
+
                 } else if (Util.ROLLING_TO_SERVERS.startsWith(propName)) {
                     candidates.add(Util.ROLLING_TO_SERVERS);
                 }

--- a/cli/src/main/java/org/jboss/as/cli/parsing/ParserUtil.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/ParserUtil.java
@@ -200,10 +200,7 @@ public class ParserUtil {
                             }
                         }
                     } else {
-                        handler.propertyName(bufferStartIndex, buffer.toString().trim());
-                        if (nameValueSeparator != -1) {
-                            handler.propertyNameValueSeparator(nameValueSeparator);
-                        }
+                        handler.propertyNoValue(bufferStartIndex, buffer.toString().trim());
                     }
                     if(!ctx.isEndOfContent() || format != null &&
                             // if the char is recognized as the separator but there was an error,

--- a/cli/src/test/java/org/jboss/as/cli/completion/address/test/AbstractAddressCompleterTest.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/address/test/AbstractAddressCompleterTest.java
@@ -56,7 +56,7 @@ public class AbstractAddressCompleterTest {
     protected List<String> fetchCandidates(String buffer) {
         List<String> candidates = new ArrayList<String>();
         try {
-            ctx.parseCommandLine(buffer);
+            ctx.parseCommandLine(buffer, false);
         } catch (CommandFormatException e) {
 //            System.out.println(ctx.getPrefixFormatter().format(ctx.getPrefix()) + ", '" + buffer + "'");
 //            e.printStackTrace();

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -82,9 +82,9 @@ public class MockCommandContext implements CommandContext {
         set(Scope.CONTEXT, "connection_info", connInfo);
     }
 
-    public void parseCommandLine(String buffer) throws CommandFormatException {
+    public void parseCommandLine(String buffer, boolean validate) throws CommandFormatException {
         try {
-            parsedCmd.parse(prefix, buffer);
+            parsedCmd.parse(prefix, buffer, validate);
         } catch (CommandFormatException e) {
             if(!parsedCmd.endsOnAddressOperationNameSeparator() || !parsedCmd.endsOnSeparator()) {
                throw e;

--- a/cli/src/test/java/org/jboss/as/cli/completion/operation/test/OperationNameCompletionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/operation/test/OperationNameCompletionTestCase.java
@@ -90,7 +90,7 @@ public class OperationNameCompletionTestCase {
     protected List<String> fetchCandidates(String buffer) {
         ArrayList<String> candidates = new ArrayList<String>();
         try {
-            ctx.parseCommandLine(buffer);
+            ctx.parseCommandLine(buffer, false);
         } catch (CommandFormatException e) {
             return Collections.emptyList();
         }

--- a/cli/src/test/java/org/jboss/as/cli/completion/operation/test/PropertiesCompletionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/operation/test/PropertiesCompletionTestCase.java
@@ -173,7 +173,7 @@ public class PropertiesCompletionTestCase {
     protected List<String> fetchCandidates(String buffer) {
         ArrayList<String> candidates = new ArrayList<String>();
         try {
-            ctx.parseCommandLine(buffer);
+            ctx.parseCommandLine(buffer, false);
         } catch (CommandFormatException e) {
             return Collections.emptyList();
         }

--- a/cli/src/test/java/org/jboss/as/cli/completion/operation/test/PropertiesWithIndexCompletionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/operation/test/PropertiesWithIndexCompletionTestCase.java
@@ -65,7 +65,7 @@ public class PropertiesWithIndexCompletionTestCase {
     protected List<String> fetchCandidates(String buffer) {
         ArrayList<String> candidates = new ArrayList<String>();
         try {
-            ctx.parseCommandLine(buffer);
+            ctx.parseCommandLine(buffer, false);
         } catch (CommandFormatException e) {
             return Collections.emptyList();
         }

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/CommandLineArgumentsTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/CommandLineArgumentsTestCase.java
@@ -63,7 +63,7 @@ public class CommandLineArgumentsTestCase {
         assertTrue(args.hasProperty("--name"));
         assertEquals("value", args.getPropertyValue("--name"));
         assertTrue(args.hasProperty("--name1"));
-        assertNull(args.getPropertyValue("--name1"));
+        assertTrue(args.getPropertyValue("--name1").equals("true"));
 
         List<String> otherArgs = args.getOtherProperties();
         assertEquals(1, otherArgs.size());

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/CommandTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/CommandTestCase.java
@@ -113,7 +113,7 @@ public class CommandTestCase {
         assertEquals(1, cmd.getPropertyNames().size());
         assertTrue(cmd.getOtherProperties().isEmpty());
         assertTrue(cmd.hasProperty("--arg-name"));
-        assertNull(cmd.getPropertyValue("--arg-name"));
+        assertTrue(cmd.getPropertyValue("--arg-name").equals("true"));
         assertEquals(13, cmd.getLastChunkIndex());
     }
 
@@ -131,7 +131,7 @@ public class CommandTestCase {
         assertEquals(1, cmd.getPropertyNames().size());
         assertTrue(cmd.getOtherProperties().isEmpty());
         assertTrue(cmd.hasProperty("--arg-name"));
-        assertNull(cmd.getPropertyValue("--arg-name"));
+        assertTrue(cmd.getPropertyValue("--arg-name").equals("true"));
         assertEquals(13, cmd.getLastChunkIndex());
     }
 
@@ -232,7 +232,7 @@ public class CommandTestCase {
         assertTrue(cmd.hasProperty("--name"));
         assertEquals("value", cmd.getPropertyValue("--name"));
         assertTrue(cmd.hasProperty("--name1"));
-        assertNull(cmd.getPropertyValue("--name1"));
+        assertTrue(cmd.getPropertyValue("--name1").equals("true"));
 
         List<String> otherArgs = cmd.getOtherProperties();
         assertEquals(1, otherArgs.size());

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/OperationParsingTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/OperationParsingTestCase.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.Util;
 import org.jboss.as.cli.completion.mock.MockCommandContext;
 import org.jboss.as.cli.operation.CommandLineParser;
 import org.jboss.as.cli.operation.OperationFormatException;
@@ -396,17 +397,63 @@ public class OperationParsingTestCase {
     @Test
     public void testImplicitValuesForBooleanProperties() throws Exception {
         DefaultCallbackHandler handler = new DefaultCallbackHandler();
-        parse("/subsystem=logging:read-resource(prop1,prop2,prop3=toto,prop4)",
+        parse("/subsystem=logging:read-resource(prop1,prop2,prop3=toto,prop4,!prop5,prop6=true,!prop7)",
                 handler);
-        assertTrue(handler.getPropertyNames().size() == 4);
+        assertTrue(handler.getPropertyNames().size() == 7);
         assertTrue(handler.getPropertyNames().contains("prop1"));
-        assertTrue(handler.getPropertyValue("prop1") == null);
+        assertTrue(handler.getPropertyValue("prop1").equals(Util.TRUE));
         assertTrue(handler.getPropertyNames().contains("prop2"));
-        assertTrue(handler.getPropertyValue("prop2") == null);
+        assertTrue(handler.getPropertyValue("prop2").equals(Util.TRUE));
         assertTrue(handler.getPropertyNames().contains("prop3"));
         assertTrue(handler.getPropertyValue("prop3").equals("toto"));
         assertTrue(handler.getPropertyNames().contains("prop4"));
-        assertTrue(handler.getPropertyValue("prop4") == null);
+        assertTrue(handler.getPropertyValue("prop4").equals(Util.TRUE));
+        assertTrue(handler.getPropertyNames().contains("prop5"));
+        assertTrue(handler.getPropertyValue("prop5").equals(Util.FALSE));
+        assertTrue(handler.getPropertyNames().contains("prop6"));
+        assertTrue(handler.getPropertyValue("prop6").equals(Util.TRUE));
+        assertTrue(handler.getPropertyNames().contains("prop7"));
+        assertTrue(handler.getPropertyValue("prop7").equals(Util.FALSE));
+    }
+
+    @Test
+    public void testImplicitValuesForBooleanProperties2() throws Exception {
+        DefaultCallbackHandler handler = new DefaultCallbackHandler();
+        parse("/subsystem=logging:read-resource( prop1    , prop2        ",
+                handler);
+        assertTrue(handler.getPropertyNames().size() == 2);
+        assertTrue(handler.getPropertyNames().contains("prop1"));
+        assertTrue(handler.getPropertyValue("prop1").equals(Util.TRUE));
+        assertTrue(handler.getPropertyNames().contains("prop2"));
+        assertTrue(handler.getPropertyValue("prop2").equals(Util.TRUE));
+    }
+
+    @Test
+    public void testImplicitValuesForBooleanProperties3() throws Exception {
+        DefaultCallbackHandler handler = new DefaultCallbackHandler();
+        parse("/subsystem=logging:read-resource( ! prop1    , ! prop2        ",
+                handler);
+        assertTrue(handler.getPropertyNames().size() == 2);
+        assertTrue(handler.getPropertyNames().contains("prop1"));
+        assertTrue(handler.getPropertyValue("prop1").equals(Util.FALSE));
+        assertTrue(handler.getPropertyNames().contains("prop2"));
+        assertTrue(handler.getPropertyValue("prop2").equals(Util.FALSE));
+    }
+
+    @Test
+    public void testImplicitValuesForBooleanProperties4() throws Exception {
+        DefaultCallbackHandler handler = new DefaultCallbackHandler();
+        boolean failed = true;
+        try {
+            parse("/subsystem=logging:read-resource( !! prop1    , ! prop2    ",
+                    handler);
+            failed = false;
+        } catch (CommandFormatException ex) {
+            //OK.
+        }
+        if (!failed) {
+            throw new Exception("Test case should have failed");
+        }
     }
 
     protected void parse(String opReq, DefaultCallbackHandler handler) throws CommandFormatException {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -105,6 +105,73 @@ public class CliCompletionTestCase {
     }
 
     @Test
+    public void testPropertiesNoNegatedValue() throws Exception {
+        CommandContext ctx = CLITestUtil.getCommandContext(testSupport,
+                System.in, System.out);
+        ctx.connectController();
+        try {
+
+            {
+                String cmd = " ";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertFalse(candidates.toString(), candidates.isEmpty());
+                assertFalse(candidates.toString(), candidates.contains(Util.NOT_OPERATOR));
+            }
+
+            {
+                String cmd = ":read-resource(";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.contains("recursive"));
+                assertTrue(candidates.toString(), candidates.contains("recursive-depth"));
+                assertTrue(candidates.toString(), candidates.contains(Util.NOT_OPERATOR));
+            }
+
+            {
+                String cmd = ":read-resource(" + Util.NOT_OPERATOR;
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.contains("recursive"));
+                assertFalse(candidates.toString(), candidates.contains("recursive-depth"));
+            }
+
+            {
+                String cmd = ":read-resource(" + Util.NOT_OPERATOR + "recursive";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertTrue(candidates.size() == 2);
+                assertTrue(candidates.toString(), candidates.contains(","));
+                assertTrue(candidates.toString(), candidates.contains(")"));
+            }
+
+            {
+                String cmd = ":read-resource(" + Util.NOT_OPERATOR + "recursive," + Util.NOT_OPERATOR + "resolve-expressions,";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertFalse(candidates.toString(), candidates.contains("recursive"));
+            }
+
+            {
+                String cmd = ":reload-servers(" + Util.NOT_OPERATOR + "blocking";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertTrue(candidates.size() == 1);
+                assertTrue(candidates.toString(), candidates.contains(")"));
+            }
+
+        } finally {
+            ctx.terminateSession();
+        }
+    }
+
+    @Test
     public void testRolloutGroupPropertiesNoValue() throws Exception {
         CommandContext ctx = CLITestUtil.getCommandContext(testSupport,
                 System.in, System.out);
@@ -115,8 +182,11 @@ public class CliCompletionTestCase {
                 List<String> candidates = new ArrayList<>();
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,
                         cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.size() == 4);
                 assertTrue(candidates.toString(), candidates.contains("rolling-to-servers"));
+                assertTrue(candidates.toString(), candidates.contains("max-failed-servers"));
                 assertTrue(candidates.toString(), candidates.contains("max-failure-percentage"));
+                assertTrue(candidates.toString(), candidates.contains(Util.NOT_OPERATOR));
             }
 
             {
@@ -124,8 +194,8 @@ public class CliCompletionTestCase {
                 List<String> candidates = new ArrayList<>();
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,
                         cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.size() == 2);
                 assertTrue(candidates.toString(), candidates.contains(","));
-                assertTrue(candidates.toString(), candidates.contains(")"));
                 assertTrue(candidates.toString(), candidates.contains("=false"));
             }
 
@@ -134,6 +204,7 @@ public class CliCompletionTestCase {
                 List<String> candidates = new ArrayList<>();
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,
                         cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.size() == 2);
                 assertTrue(candidates.toString(), candidates.contains("max-failed-servers"));
                 assertTrue(candidates.toString(), candidates.contains("max-failure-percentage"));
             }
@@ -143,8 +214,8 @@ public class CliCompletionTestCase {
                 List<String> candidates = new ArrayList<>();
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,
                         cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.size() == 1);
                 assertTrue(candidates.toString(), candidates.contains(")"));
-                assertFalse(candidates.toString(), candidates.contains(","));
             }
 
             {
@@ -152,9 +223,37 @@ public class CliCompletionTestCase {
                 List<String> candidates = new ArrayList<>();
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,
                         cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.size() == 2);
+                assertTrue(candidates.toString(), candidates.contains("=false"));
+                assertTrue(candidates.toString(), candidates.contains(")"));
+            }
+
+            {
+                String cmd = ":reload-servers(blocking){rollout main-server-group(" + Util.NOT_OPERATOR;
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.size() == 1);
+                assertTrue(candidates.toString(), candidates.contains("rolling-to-servers"));
+            }
+
+            {
+                String cmd = ":reload-servers(blocking){rollout main-server-group(" + Util.NOT_OPERATOR + "rolling-to-servers";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.size() == 1);
+                assertTrue(candidates.toString(), candidates.contains("rolling-to-servers,"));
+            }
+
+            {
+                String cmd = ":reload-servers(blocking){rollout main-server-group(max-failed-servers=1,max-failure-percentage=2," + Util.NOT_OPERATOR + "rolling-to-servers";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.size() == 2);
                 assertTrue(candidates.toString(), candidates.contains(")"));
                 assertTrue(candidates.toString(), candidates.contains("=false"));
-                assertFalse(candidates.toString(), candidates.contains(","));
             }
 
         } finally {
@@ -254,6 +353,25 @@ public class CliCompletionTestCase {
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,
                         cmd.length() - 1, candidates);
                 assertFalse(candidates.toString(), candidates.contains("--help"));
+            }
+
+            {
+                String cmd = "reload ";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertFalse(candidates.toString(), candidates.isEmpty());
+                assertFalse(candidates.toString(), candidates.contains(Util.NOT_OPERATOR));
+            }
+
+            {
+                // The parsing will concider the ! as a value and will be not
+                // able to complete a value starting with the not operator
+                String cmd = "reload " + Util.NOT_OPERATOR;
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.isEmpty());
             }
 
             {
@@ -548,6 +666,16 @@ public class CliCompletionTestCase {
                         cmd.length() - 1, candidates);
                 assertTrue(candidates.toString(), candidates.size() == 1);
                 assertTrue(candidates.toString(), candidates.contains("--verbose "));
+            }
+
+            {
+                // The parsing will concider the ! as a value and will be not
+                // able to complete a value starting with the not operator
+                String cmd = "read-attribute " + Util.NOT_OPERATOR;
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length() - 1, candidates);
+                assertTrue(candidates.toString(), candidates.isEmpty());
             }
 
             {


### PR DESCRIPTION
Added support for the "!" operator for operation. 
Removed remote call to retrieve operation description, boolean values are set according to command syntax (implicit value == true, ! == false)
