### PR TITLE
[WFCORE-1535] Avoid a potential blocking forever for ManagedServer suspend() and resume()

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainServerLifecycleHandlers.java
@@ -340,7 +340,7 @@ public class DomainServerLifecycleHandlers {
             context.readResource(PathAddress.EMPTY_ADDRESS, false);
             final ModelNode model = Resource.Tools.readModel(context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, true));
             final String group = getServerGroupName(operation);
-            final int suspendTimeout = TIMEOUT.resolveModelAttribute(context, operation).asInt();
+            final int suspendTimeout = TIMEOUT.resolveModelAttribute(context, operation).asInt(); // timeout in seconds, by default is 0
             final BlockingTimeout blockingTimeout = BlockingTimeout.Factory.getProxyBlockingTimeout(context);
 
 
@@ -358,15 +358,9 @@ public class DomainServerLifecycleHandlers {
                             waitForServers.add(serverModelName);
                         }
                     }
-                    if (suspendTimeout != 0) {
-                        final List<ModelNode> errorResponses = serverInventory.awaitServerSuspend(waitForServers, suspendTimeout, blockingTimeout);
-                        if ( !errorResponses.isEmpty() ){
-                            context.getFailureDescription().set(errorResponses);
-                        }
-                    } else {
-                        for (String serverModelName : waitForServers){
-                            serverInventory.suspendServer(serverModelName);
-                        }
+                    final List<ModelNode> errorResponses  = serverInventory.suspendServers(waitForServers, suspendTimeout, blockingTimeout);
+                    if ( !errorResponses.isEmpty() ){
+                        context.getFailureDescription().set(errorResponses);
                     }
                     context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
                 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -1169,8 +1169,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
         }
 
         @Override
-        public void suspendServer(String serverName) {
-            getServerInventory().suspendServer(serverName);
+        public List<ModelNode> suspendServers(Set<String> serverNames, BlockingTimeout blockingTimeout) {
+            return getServerInventory().suspendServers(serverNames, blockingTimeout);
         }
 
         @Override
@@ -1179,8 +1179,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
         }
 
         @Override
-        public List<ModelNode> awaitServerSuspend(Set<String> waitForServers, int timeout, BlockingTimeout blockingTimeout) {
-            return getServerInventory().awaitServerSuspend(waitForServers, timeout, blockingTimeout);
+        public List<ModelNode> suspendServers(Set<String> serverNames, int timeout, BlockingTimeout blockingTimeout) {
+            return getServerInventory().suspendServers(serverNames, timeout, blockingTimeout);
         }
     }
 
@@ -1504,7 +1504,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
             }
 
             @Override
-            public void suspendServer(String serverName) {
+            public List<ModelNode> suspendServers(Set<String> serverName, BlockingTimeout blockingTimeout) {
+                return Collections.emptyList();
             }
 
             @Override
@@ -1512,7 +1513,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
             }
 
             @Override
-            public List<ModelNode> awaitServerSuspend(Set<String> waitForServers, int timeout, BlockingTimeout blockingTimeout) {
+            public List<ModelNode> suspendServers(Set<String> serverName, int timeout, BlockingTimeout blockingTimeout) {
                 return Collections.emptyList();
             }
         };

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -1174,8 +1174,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
         }
 
         @Override
-        public void resumeServer(String serverName) {
-            getServerInventory().resumeServer(serverName);
+        public List<ModelNode> resumeServers(Set<String> serverNames, BlockingTimeout blockingTimeout) {
+            return getServerInventory().resumeServers(serverNames, blockingTimeout);
         }
 
         @Override
@@ -1504,16 +1504,17 @@ public class DomainModelControllerService extends AbstractControllerService impl
             }
 
             @Override
-            public List<ModelNode> suspendServers(Set<String> serverName, BlockingTimeout blockingTimeout) {
+            public List<ModelNode> suspendServers(Set<String> serverNames, BlockingTimeout blockingTimeout) {
                 return Collections.emptyList();
             }
 
             @Override
-            public void resumeServer(String serverName) {
+            public List<ModelNode> resumeServers(Set<String> serverNames, BlockingTimeout blockingTimeout) {
+                return Collections.emptyList();
             }
 
             @Override
-            public List<ModelNode> suspendServers(Set<String> serverName, int timeout, BlockingTimeout blockingTimeout) {
+            public List<ModelNode> suspendServers(Set<String> serverNames, int timeout, BlockingTimeout blockingTimeout) {
                 return Collections.emptyList();
             }
         };

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
@@ -683,23 +683,12 @@ class ManagedServer {
         return null;
     }
 
-    boolean resume() {
-
+    AsyncFuture<OperationResponse> resume(final BlockingQueueOperationListener<TransactionalProtocolClient.Operation> listener) throws IOException {
         final ModelNode operation = new ModelNode();
         operation.get(OP).set(RESUME);
         operation.get(OP_ADDR).setEmptyList();
 
-        try {
-            final TransactionalProtocolClient.PreparedOperation<?> prepared = TransactionalProtocolHandlers.executeBlocking(operation, protocolClient);
-            if (prepared.isFailed()) {
-                return false;
-            }
-            prepared.commit();
-            prepared.getFinalResult().get();
-        } catch (Exception ignore) {
-            return false;
-        }
-        return true;
+        return protocolClient.execute(listener, operation, OperationMessageHandler.DISCARD, OperationAttachments.EMPTY);
     }
 
     AsyncFuture<OperationResponse> suspend(int timeoutInSeconds, final BlockingQueueOperationListener<TransactionalProtocolClient.Operation> listener) throws IOException {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
@@ -683,26 +683,6 @@ class ManagedServer {
         return null;
     }
 
-    boolean suspend() {
-
-        final ModelNode operation = new ModelNode();
-        operation.get(OP).set(SUSPEND);
-        operation.get(OP_ADDR).setEmptyList();
-
-        try {
-            final TransactionalProtocolClient.PreparedOperation<?> prepared = TransactionalProtocolHandlers.executeBlocking(operation, protocolClient);
-            if (prepared.isFailed()) {
-                return false;
-            }
-            prepared.commit();
-            prepared.getFinalResult().get();
-        } catch (Exception ignore) {
-            return false;
-        }
-        return true;
-    }
-
-
     boolean resume() {
 
         final ModelNode operation = new ModelNode();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
@@ -302,13 +302,17 @@ public interface ServerInventory {
      */
     void awaitServersState(Collection<String> serverNames, boolean started);
 
+
     /**
-     * Suspends a server, allowing current requests to finish and blocking any new requests
+     * Suspend the servers, allowing current requests to finish and blocking any new requests
      * from starting.
+     * @param serverNames The server names to suspend, can be an immutable collection.
+     * @param blockingTimeout control for maximum period any blocking operations can block. Cannot be {@code null}
      *
-     * @param serverName The server name
+     * @return An empty {@link Collection} if no errors were returned suspending the servers, otherwise it will contain
+     * all error responses. Will not be {@code null}
      */
-    void suspendServer(String serverName);
+    List<ModelNode> suspendServers(Set<String> serverNames, BlockingTimeout blockingTimeout);
 
     /**
      * Resumes a server, allowing it to begin processing requests normally
@@ -317,14 +321,15 @@ public interface ServerInventory {
     void resumeServer(String serverName);
 
     /**
-     * Suspends and waits for the given set of servers to suspend up to the timeout.
+     * Suspend the servers up to the timeout, allowing current requests to finish and blocking any new requests from starting.
      *
-     * @param waitForServers The servers to wait for
-     * @param timeoutInSeconds The maximum amount of time to wait in seconds, with -1 meaning indefinitly
-     * @param blockingTimeout  control for maximum period any blocking operations can block. Cannot be {@code null}
+     * @param serverNames The servers to wait for, can be an immutable collection.
+     * @param timeoutInSeconds The maximum amount of time to wait in seconds, with -1 meaning wait indefinitely, 0 meaning
+     *                         return immediately and with a value bigger than 0 meaning wait n seconds.
+     * @param blockingTimeout control for maximum period any blocking operations can block. Cannot be {@code null}
+     *
      * @return An empty {@link Collection} if no errors were returned suspending the servers, otherwise it will contain
      * all error responses. Will not be {@code null}
      */
-    List<ModelNode> awaitServerSuspend(Set<String> waitForServers, int timeoutInSeconds, BlockingTimeout blockingTimeout);
-
+    List<ModelNode> suspendServers(Set<String> serverNames, int timeoutInSeconds, BlockingTimeout blockingTimeout);
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
@@ -302,7 +302,6 @@ public interface ServerInventory {
      */
     void awaitServersState(Collection<String> serverNames, boolean started);
 
-
     /**
      * Suspend the servers, allowing current requests to finish and blocking any new requests
      * from starting.
@@ -315,10 +314,14 @@ public interface ServerInventory {
     List<ModelNode> suspendServers(Set<String> serverNames, BlockingTimeout blockingTimeout);
 
     /**
-     * Resumes a server, allowing it to begin processing requests normally
-     * @param serverName The server name
+     * Resume the servers, allowing them to begin processing requests normally
+     * @param serverNames The server names to resume. It allows an immutable collection.
+     * @param blockingTimeout control for maximum period any blocking operations can block. Cannot be {@code null}
+     *
+     * @return An empty {@link Collection} if no errors were returned resuming the servers, otherwise it will contain
+     * all error responses. Will not be {@code null}
      */
-    void resumeServer(String serverName);
+    List<ModelNode> resumeServers(Set<String> serverNames, BlockingTimeout blockingTimeout);
 
     /**
      * Suspend the servers up to the timeout, allowing current requests to finish and blocking any new requests from starting.

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
@@ -388,13 +388,10 @@ public class ServerInventoryImpl implements ServerInventory {
         }
     }
 
+
     @Override
-    public void suspendServer(String serverName) {
-        final ManagedServer server = servers.get(serverName);
-        if(server == null) {
-            return;
-        }
-        server.suspend();
+    public List<ModelNode> suspendServers(Set<String> serverNames, BlockingTimeout blockingTimeout) {
+        return suspendServers(serverNames, 0, blockingTimeout);
     }
 
     @Override
@@ -407,7 +404,7 @@ public class ServerInventoryImpl implements ServerInventory {
     }
 
     @Override
-    public List<ModelNode> awaitServerSuspend(Set<String> waitForServers, int timeoutInSeconds, BlockingTimeout blockingTimeout) {
+    public List<ModelNode> suspendServers(Set<String> serverNames, int timeoutInSeconds, BlockingTimeout blockingTimeout) {
         List<ModelNode> errorResults = new ArrayList<>();
 
         class OperationData {
@@ -423,7 +420,7 @@ public class ServerInventoryImpl implements ServerInventory {
         }
 
         Map<String, OperationData> operationDataMap = new HashMap<>();
-        for (String serverName : waitForServers) {
+        for (String serverName : serverNames) {
             final ManagedServer server = servers.get(serverName);
             if (server != null) {
                 try {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1322,4 +1322,32 @@ public interface HostControllerLogger extends BasicLogger {
 
     @Message( id = 187, value = "Failed getting the response from the suspend listener for server: %s")
     String suspendListenerFailedMsg(String serverName);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 188, value = "Timed out after %d ms awaiting server resume response(s) for server: %s")
+    void timedOutAwaitingResumeResponse(int blockingTimeout, String serverName);
+
+    @Message(id = 189, value = "Timed out after %d ms awaiting server resume response(s) for server: %s")
+    String timedOutAwaitingResumeResponseMsg(int blockingTimeout, String serverName);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 190, value = "%s interrupted awaiting server resume response(s)")
+    void interruptedAwaitingResumeResponse(@Cause InterruptedException cause, String serverName);
+
+    @Message(id = 191, value = "%s interrupted awaiting server resume response(s)")
+    String interruptedAwaitingResumeResponseMsg(String serverName);
+
+    @Message( id = 192, value = "Failed executing the resume operation for server: %s")
+    String resumeExecutionFailedMsg(String serverName);
+
+    @Message( id = 193, value = "Failed getting the response from the resume listener for server: %s")
+    String resumeListenerFailedMsg(String serverName);
+
+    @LogMessage(level = Level.ERROR)
+    @Message( id = 194, value = "Failed executing the resume operation for server: %s")
+    void resumeExecutionFailed(@Cause IOException cause, String serverName);
+
+    @LogMessage(level = Level.ERROR)
+    @Message( id = 195, value = "Failed getting the response from the resume listener for server: %s")
+    void resumeListenerFailed(@Cause ExecutionException cause, String serverName);
 }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -679,7 +679,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         }
 
         @Override
-        public void suspendServer(String serverName) {
+        public List<ModelNode> suspendServers(Set<String> serverNames, BlockingTimeout blockingTimeout) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
@@ -689,7 +689,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         }
 
         @Override
-        public List<ModelNode> awaitServerSuspend(Set<String> waitForServers, int timeout, BlockingTimeout blockingTimeout) {
+        public List<ModelNode> suspendServers(Set<String> serverNames, int timeout, BlockingTimeout blockingTimeout) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
     }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -684,7 +684,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         }
 
         @Override
-        public void resumeServer(String serverName) {
+        public List<ModelNode> resumeServers(Set<String> serverNames, BlockingTimeout blockingTimeout) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 


### PR DESCRIPTION
Basically this PR continues previous changes done in WFCORE-1473 applying them to other suspend and resume operations in ManagedServer.

Jira issue is: https://issues.jboss.org/browse/WFCORE-1535


Implementation note:
It looks like that ServerInventory#suspendServer(String serverName) does 99% the same as ServerInventory#awaitServerSuspend(Set<String> waitForServers, int timeoutInSeconds, BlockingTimeout blockingTimeout) using a timeoutInSeconds = 0. So in this issue there is a proposal to simplifying them.

The small difference is the following. Internally ServerInventory#suspendServer(String serverName) is executing this operation using the ManagedServer#suspend():

```
final ModelNode operation = new ModelNode();
operation.get(OP).set(SUSPEND);
operation.get(OP_ADDR).setEmptyList();
```

and ServerInventory#awaitServerSuspend(Set<String> waitForServers, int timeoutInSeconds, BlockingTimeout blockingTimeout) is executing this operation using the ManagedServer#suspend(timeoutInSeconds):

```
final ModelNode operation = new ModelNode();
operation.get(OP).set(SUSPEND);
operation.get(OP_ADDR).setEmptyList();
operation.get(TIMEOUT).set(timeoutInSeconds);
```

If there is no TIMEOUT attribute in the operation sent to ServerSuspendHandler, it will use 0 for the suspend timeout. 
With the changes in this issue when :suspend-servers (without any explicity timeout) is executed, now the TIMEOUT attribute is sent with the operation with 0 as value simplifying the code (I think) in ServerInventoryImpl. I cannot see any problems with this difference behaviour. Is it correct for you too?