### PR TITLE
Client old server

### DIFF
--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/OldVersionTestRunner.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/OldVersionTestRunner.java
@@ -21,6 +21,8 @@
  */
 package org.wildfly.client.old.server.util;
 
+import static org.wildfly.core.testrunner.Server.LEGACY_JAVA_HOME;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -63,6 +65,8 @@ public class OldVersionTestRunner extends Suite {
     private static final String LARGE_DEPLOYMENT_NAME = "large-deployment.xml";
 
     static final String DEPLOYMENT_SIZE = "jboss.test.client.old.server.size";
+
+
 
     static String OLD_VERSIONS_DIR = OldVersionCopier.OLD_VERSIONS_DIR;
 
@@ -249,16 +253,15 @@ public class OldVersionTestRunner extends Suite {
                     throw new IllegalStateException("Could not determine " + version.getJdk() +
                             " home from either -D" + prop);
                 }
-                System.setProperty("legacy.java.home", jdkHome);
+                System.setProperty(LEGACY_JAVA_HOME, jdkHome);
 
                 //Server has this
                 //    private final String jvmArgs = System.getProperty("jvm.args", "-Xmx512m -XX:MaxMetaspaceSize=256m");
                 //-XX:MaxMetaspaceSize is not available < JDK 8, so remove it:
                 System.setProperty("jvm.args", "-Xmx512m");
+            } else {
+                System.clearProperty(LEGACY_JAVA_HOME);
             }
-        }
-
-        private void setJdk(Version.JDK version, String propName, String defaultName) {
         }
     }
 

--- a/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/Version.java
+++ b/testsuite/client-old-server/src/test/java/org/wildfly/client/old/server/util/Version.java
@@ -28,21 +28,28 @@ public class Version {
 
     static final String AS = "jboss-as-";
     static final String WILDFLY = "wildfly-";
+    static final String WILDFLY_CORE = "wildfly-core-";
     static final String EAP = "jboss-eap-";
 
     public enum AsVersion {
+        //For these we only had a full distribution
         AS_7_1_2_FINAL(AS, "7.1.2.Final", false, JDK.JDK6, "remote", "9999"),
         AS_7_1_3_FINAL(AS, "7.1.3.Final", false, JDK.JDK6, "remote", "9999"),
         AS_7_2_0_FINAL(AS, "7.2.0.Final", false, JDK.JDK6, "remote", "9999"),
         WF_8_0_0_FINAL(WILDFLY, "8.0.0.Final", false, JDK.JDK8, "http-remoting", "9990"),
         WF_8_1_0_FINAL(WILDFLY, "8.1.0.Final", false, JDK.JDK8, "http-remoting", "9990"),
         WF_8_2_0_FINAL(WILDFLY, "8.2.0.Final", false, JDK.JDK8, "http-remoting", "9990"),
-        WF_9_0_0_FINAL(WILDFLY, "9.0.0.Final", false, JDK.JDK8, "http-remoting", "9990"),
-        WF_10_0_0_FINAL(WILDFLY, "10.0.0.Final", false, JDK.JDK8, "http-remoting", "9990"),
 
+        //For these we have a core distribution, and these versions are not tested in mixed domain. So to save space on
+        //the CI we just use the core versions used in the WildFly versions
+        WF_9_0_0_FINAL(WILDFLY_CORE, "1.0.0.Final", false, JDK.JDK8, "http-remoting", "9990"),
+        WF_10_0_0_FINAL(WILDFLY_CORE, "2.0.10.Final", false, JDK.JDK8, "http-remoting", "9990"),
+
+        //For these we only had a full distribution
         EAP_6_2_0(EAP, "6.2.0", true, JDK.JDK6, "remote", "9999"),
         EAP_6_3_0(EAP, "6.3.0", true, JDK.JDK7, "remote", "9999"),
         EAP_6_4_0(EAP, "6.4.0", true, JDK.JDK8, "remote", "9999"),
+        //Although EAP >= 7 is split, the full distribution is needed in the mixed domain tests
         EAP_7_0_0(EAP, "7.0.0", true, JDK.JDK8, "http-remoting", "9990");
 
 

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -41,13 +41,15 @@ import org.wildfly.core.launcher.StandaloneCommandBuilder;
  */
 public class Server {
 
+    public static final String LEGACY_JAVA_HOME = "legacy.java.home";
+
     private final String jbossHome = System.getProperty("jboss.home", System.getenv("JBOSS_HOME"));
     private final String modulePath = System.getProperty("module.path");
     private final String jvmArgs = System.getProperty("jvm.args", "-Xmx512m -XX:MaxMetaspaceSize=256m");
     private final String jbossArgs = System.getProperty("jboss.args");
     private final String javaHome = System.getProperty("java.home", System.getenv("JAVA_HOME"));
     //Use this when specifying an older java to be used for running the server
-    private final String legacyJavaHome = System.getProperty("legacy.java.home");
+    private final String legacyJavaHome = System.getProperty(LEGACY_JAVA_HOME);
     private String serverConfig = System.getProperty("server.config", "standalone.xml");
     private final int managementPort = Integer.getInteger("management.port", 9990);
     private final String managementAddress = System.getProperty("management.address", "localhost");


### PR DESCRIPTION
Use core dist where appropriate to save space
Clear the legacy jdk version property if we are using the current jdk