### PR TITLE
[2.x] WFCORE-1554 Building an attribute based on another attribute does not copy CapabilityReferenceRecorder

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -145,6 +145,7 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
             this.arbitraryDescriptors = new HashMap<>(basis.getArbitraryDescriptors().size());
             this.arbitraryDescriptors.putAll(basis.getArbitraryDescriptors());
         }
+        this.referenceRecorder = basis.getReferenceRecorder();
     }
 
     /**


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1554