### PR TITLE
[WFCORE-1106] Don't execute Stage.RUNTIME steps when capabilities associated with the address are reload-required

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -161,12 +161,15 @@ public abstract class AbstractControllerService implements Service<ModelControll
      * @param prepareStep             the prepare step to prepend to operation execution
      * @param expressionResolver      the expression resolver
      * @param auditLogger             the audit logger
+     * @param authorizer              handles authorization
+     * @param capabilityRegistry      the capability registry
      */
     protected AbstractControllerService(final ProcessType processType, final RunningModeControl runningModeControl,
                                         final ConfigurationPersister configurationPersister,
                                         final ControlledProcessState processState, final ResourceDefinition rootResourceDefinition,
                                         final OperationStepHandler prepareStep, final ExpressionResolver expressionResolver,
-                                        final ManagedAuditLogger auditLogger, final DelegatingConfigurableAuthorizer authorizer, CapabilityRegistry capabilityRegistry) {
+                                        final ManagedAuditLogger auditLogger, final DelegatingConfigurableAuthorizer authorizer,
+                                        final CapabilityRegistry capabilityRegistry) {
         this(processType, runningModeControl, configurationPersister, processState, rootResourceDefinition, null,
                 prepareStep, expressionResolver, auditLogger, authorizer, capabilityRegistry);
     }

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -1090,7 +1090,8 @@ abstract class AbstractOperationContext implements OperationContext {
         if (processState.isReloadSupported()) {
             activeStep.restartStamp = processState.setReloadRequired();
             activeStep.response.get(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD).set(true);
-            getManagementModel().getCapabilityRegistry().capabilityReloadRequired(activeStep.address);
+            getManagementModel().getCapabilityRegistry().capabilityReloadRequired(activeStep.address,
+                    activeStep.getManagementResourceRegistration(getManagementModel()));
         } else {
             restartRequired();
         }
@@ -1100,7 +1101,8 @@ abstract class AbstractOperationContext implements OperationContext {
     public final void restartRequired() {
         activeStep.restartStamp = processState.setRestartRequired();
         activeStep.response.get(RESPONSE_HEADERS, OPERATION_REQUIRES_RESTART).set(true);
-        getManagementModel().getCapabilityRegistry().capabilityRestartRequired(activeStep.address);
+        getManagementModel().getCapabilityRegistry().capabilityRestartRequired(activeStep.address,
+                activeStep.getManagementResourceRegistration(getManagementModel()));
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.controller;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -57,6 +60,7 @@ import org.jboss.msc.service.ServiceName;
  * @author Tomaz Cerar (c) 2015 Red Hat Inc.
  */
 public final class CapabilityRegistry implements ImmutableCapabilityRegistry, PossibleCapabilityRegistry, RuntimeCapabilityRegistry {
+
     private final Map<CapabilityId, RuntimeCapabilityRegistration> capabilities = new HashMap<>();
     private final Map<CapabilityId, Map<String, RuntimeRequirementRegistration>> requirements = new HashMap<>();
     private final Map<CapabilityId, Map<String, RuntimeRequirementRegistration>> runtimeOnlyRequirements = new HashMap<>();
@@ -64,6 +68,8 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
     private final Set<CapabilityScope> knownContexts;
     private final ResolutionContextImpl resolutionContext = new ResolutionContextImpl();
     private final Map<CapabilityId, CapabilityRegistration> possibleCapabilities = new ConcurrentHashMap<>();
+    private final Set<CapabilityId> reloadCapabilities = new HashSet<>();
+    private final Set<CapabilityId> restartCapabilities = new HashSet<>();
 
     private final ReentrantReadWriteLock reentrantReadWriteLock = new ReentrantReadWriteLock();
     private final ReentrantReadWriteLock.ReadLock readLock = reentrantReadWriteLock.readLock();
@@ -189,8 +195,8 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
     }
 
     /**
-     * This memust be called with the write lock held.
-     * @param requirement
+     * This must be called with the write lock held.
+     * @param requirement the requirement
      */
     private void registerRequirement(RuntimeRequirementRegistration requirement) {
         assert writeLock.isHeldByCurrentThread();
@@ -306,6 +312,136 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
                 modified = true;
             }
         }
+    }
+
+    @Override
+    public Map<CapabilityId, RuntimeStatus> getRuntimeStatus(PathAddress address) {
+        readLock.lock();
+        try {
+            Map<CapabilityId, RuntimeStatus> result;
+            Set<CapabilityId> ids = getCapabilitiesForAddress(address);
+            int size = ids.size();
+            if (size == 0) {
+                result = Collections.emptyMap();
+            } else {
+                Set<CapabilityId> examined = new HashSet<>();
+                if (size == 1) {
+                    CapabilityId id = ids.iterator().next();
+                    result = Collections.singletonMap(id, getCapabilityStatus(id, examined));
+                } else {
+                    result = new HashMap<>(size);
+                    for (CapabilityId id : ids) {
+                        result.put(id, getCapabilityStatus(id, examined));
+                    }
+                }
+            }
+            return result;
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    private RuntimeStatus getCapabilityStatus(CapabilityId id, Set<CapabilityId> examined) {
+        // This is meant for checking runtime stuff, which should only be for servers or
+        // HC runtime stuff, both of which use CapabilityScope.GLOBAL. So this assert
+        // is to check that assumption is valid, as further thought is needed if not.
+        assert id.getScope().equals(CapabilityScope.GLOBAL);
+
+        if (restartCapabilities.contains(id)) {
+            return RuntimeStatus.RESTART_REQUIRED;
+        }
+        if (reloadCapabilities.contains(id)) {
+            return RuntimeStatus.RELOAD_REQUIRED;
+        }
+        examined.add(id);
+
+        Map<String, RuntimeRequirementRegistration> dependents = requirements.get(id);
+        RuntimeStatus status = getDependentCapabilityStatus(dependents, examined);
+        if (status == RuntimeStatus.NORMAL) {
+            dependents = requirements.get(id);
+            status = getDependentCapabilityStatus(dependents, examined);
+        }
+        return status;
+    }
+
+    private RuntimeStatus getDependentCapabilityStatus(Map<String, RuntimeRequirementRegistration> dependents, Set<CapabilityId> examined) {
+        RuntimeStatus result = RuntimeStatus.NORMAL;
+        if (dependents != null) {
+            for (String dependent : dependents.keySet()) {
+                CapabilityId dependentId = new CapabilityId(dependent, CapabilityScope.GLOBAL);
+                if (!examined.contains(dependentId)) {
+                    RuntimeStatus status = getCapabilityStatus(dependentId, examined);
+                    if (status == RuntimeStatus.RESTART_REQUIRED) {
+                        result = status;
+                        break; // no need to check anything else
+                    } else if (status == RuntimeStatus.RELOAD_REQUIRED) {
+                        result = status;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void capabilityReloadRequired(PathAddress address) {
+        writeLock.lock();
+        try {
+            reloadCapabilities.addAll(getCapabilitiesForAddress(address));
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void capabilityRestartRequired(PathAddress address) {
+        writeLock.lock();
+        try {
+            restartCapabilities.addAll(getCapabilitiesForAddress(address));
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    private Set<CapabilityId> getCapabilitiesForAddress(PathAddress address) {
+        Set<CapabilityId> result = null;
+        PathAddress curAddress = address;
+        while (result == null) {
+            // TODO this is inefficient. But it's only called post-boot when the process is already reload-required
+            for (Map.Entry<CapabilityId, RuntimeCapabilityRegistration> entry : capabilities.entrySet()) {
+                for (RegistrationPoint point : entry.getValue().getRegistrationPoints()) {
+                    if (curAddress.equals(point.getAddress())) {
+                        if (result == null) {
+                            result = new HashSet<>();
+                        }
+                        result.add(entry.getKey());
+                        break;
+                    }
+                }
+            }
+            if (result == null) {
+                // This address exposed no capability, but it may represent a config chunk for
+                // a capability exposed by a parent resource, so we need to check parents.
+                //
+                // Here we check up to the first child level. The root resource for a process
+                // will not expose a capability that is configured by children, so it is incorrect
+                // to check beyond the first level. In the domain mode /host=* tree, we
+                // only check up to the 2nd child level, because the /host=x level is the root node
+                // for the HC process.
+                // We stop navigating up when the current address' final path element is subsystem=X,
+                // because above that level are kernel resources, and kernel resources do not expose
+                // capabilities that are configured by subsystem children.
+                int addrSize = curAddress.size();
+                if (addrSize > 1 && !SUBSYSTEM.equals(curAddress.getLastElement().getKey())
+                        && !(addrSize == 2 && HOST.equals(curAddress.getElement(0).getKey()))) {
+                    curAddress = curAddress.getParent();
+                    // loop continues
+                } else {
+                    result = Collections.emptySet();
+                }
+            }
+        }
+        return result;
     }
 
 
@@ -441,13 +577,14 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
         }
     }
 
-    public Set<PathAddress> getPossibleProviderPoints(CapabilityId capabilityId){
+    @Override
+    public Set<PathAddress> getPossibleProviderPoints(CapabilityId capabilityId) {
         Set<PathAddress> result = new LinkedHashSet<>();
         readLock.lock();
         try {
-            capabilityId = capabilityId.getScope() == CapabilityScope.GLOBAL?capabilityId: new CapabilityId(capabilityId.getName(), CapabilityScope.GLOBAL);
-            CapabilityRegistration<RuntimeCapability> reg =  possibleCapabilities.get(capabilityId);
-            if (reg!=null){
+            capabilityId = capabilityId.getScope() == CapabilityScope.GLOBAL ? capabilityId : new CapabilityId(capabilityId.getName(), CapabilityScope.GLOBAL);
+            CapabilityRegistration<RuntimeCapability> reg = possibleCapabilities.get(capabilityId);
+            if (reg != null) {
                 result.addAll(reg.getRegistrationPoints().stream().map(RegistrationPoint::getAddress).collect(Collectors.toList()));
             }
 
@@ -472,7 +609,7 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
             }
             publishedFullRegistry.writeLock.lock();
             try {
-                publishedFullRegistry.clear();
+                publishedFullRegistry.clear(true);
                 copy(this, publishedFullRegistry);
                 modified = false;
             } finally {
@@ -494,7 +631,7 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
         try {
             publishedFullRegistry.readLock.lock();
             try {
-                clear();
+                clear(true);
                 copy(publishedFullRegistry, this);
                 modified = false;
             } finally {
@@ -522,6 +659,8 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
         });
         copyRequirements(source.requirements, target.requirements);
         copyRequirements(source.runtimeOnlyRequirements, target.runtimeOnlyRequirements);
+        target.reloadCapabilities.addAll(source.reloadCapabilities);
+        target.restartCapabilities.addAll(source.restartCapabilities);
         if (!forServer) {
             target.knownContexts.addAll(source.knownContexts);
         }
@@ -531,12 +670,20 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
      * Clears capability registry
      */
     void clear() {
+        clear(false);
+    }
+
+    private void clear(boolean restartRequired) {
         writeLock.lock();
         try {
             capabilities.clear();
             possibleCapabilities.clear();
             requirements.clear();
             runtimeOnlyRequirements.clear();
+            reloadCapabilities.clear();
+            if (restartRequired) {
+                restartCapabilities.clear();
+            }
             modified = true;
         } finally {
             writeLock.unlock();

--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -128,6 +128,36 @@ public interface OperationContext extends ExpressionResolver {
     void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException;
 
     /**
+     * Add a {@link org.jboss.as.controller.OperationContext.Stage#MODEL} execution step to this operation process,
+     * including descriptive information for the operation.
+     * <p>
+     * This method is primarily intended for internal use.
+     * </p>
+     *
+     * @param stepDefinition the definition of the step to add
+     * @param stepHandler the handler for the step
+     * @param addFirst add the handler before the others  @throws IllegalArgumentException if the step handler is not valid for this controller type
+     * @throws java.lang.IllegalStateException if {@link #getCurrentStage() the current stage} is not {@link Stage#MODEL}
+     */
+    void addModelStep(OperationDefinition stepDefinition, OperationStepHandler stepHandler, boolean addFirst) throws IllegalArgumentException;
+
+    /**
+     * Add a {@link org.jboss.as.controller.OperationContext.Stage#MODEL} execution step to this operation process,
+     * including descriptive information for the operation.
+     * <p>
+     * This method is primarily intended for use by a handler for the {@code composite} operation.
+     * </p>
+     *
+     * @param response the response which the nested step should populate
+     * @param operation the operation body to pass into the added step
+     * @param stepDefinition the definition of the step to add
+     * @param stepHandler the handler for the step
+     * @param addFirst add the handler before the others  @throws IllegalArgumentException if the step handler is not valid for this controller type
+     * @throws java.lang.IllegalStateException if {@link #getCurrentStage() the current stage} is not {@link Stage#MODEL}
+     */
+    void addModelStep(ModelNode response, ModelNode operation, OperationDefinition stepDefinition, OperationStepHandler stepHandler, boolean addFirst) throws IllegalArgumentException;
+
+    /**
      * Get a stream which is attached to the request.
      *
      * @param index the index
@@ -798,7 +828,7 @@ public interface OperationContext extends ExpressionResolver {
      * where a capability optionally depends on another capability, and whether or not that requirement is needed is
      * not known when the capability is first registered.
      * <p>
-     * This method should be used in preference to {@link #requestOptionalCapability(String, String, String)}
+     * This method should be used in preference to {@link #requireOptionalCapability(String, String, String)}
      * when, based on its own configuration, the caller knows in {@link org.jboss.as.controller.OperationContext.Stage#MODEL}
      * that the optional capability is actually required in the current process.
      * </p>

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -1629,7 +1629,8 @@ final class OperationContextImpl extends AbstractOperationContext {
     CapabilityRegistry.RuntimeStatus getStepCapabilityStatus(Step step){
 
         RuntimeCapabilityRegistry.RuntimeStatus result = RuntimeCapabilityRegistry.RuntimeStatus.NORMAL;
-        Map<CapabilityId, RuntimeCapabilityRegistry.RuntimeStatus> statuses = managementModel.getCapabilityRegistry().getRuntimeStatus(step.address);
+        Map<CapabilityId, RuntimeCapabilityRegistry.RuntimeStatus> statuses =
+                managementModel.getCapabilityRegistry().getRuntimeStatus(step.address, step.getManagementResourceRegistration(managementModel));
         if (statuses.isEmpty()) {
             // TODO. If there are no capabilities but the process is reload/restart required, then what?
             // Should we interpret this as meaning the step depends on all capabilities and something must be

--- a/controller/src/main/java/org/jboss/as/controller/ResourceBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/ResourceBuilder.java
@@ -24,7 +24,10 @@
 
 package org.jboss.as.controller;
 
+import java.util.Set;
+
 import org.jboss.as.controller.capability.Capability;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
@@ -76,6 +79,14 @@ public interface ResourceBuilder {
     ResourceBuilder addCapability(Capability capability);
 
     ResourceBuilder addCapabilities(Capability... capability);
+
+    default ResourceBuilder setIncorporatingCapabilities(Set<RuntimeCapability> incorporating) {
+        // We have a default implementation so unknown impls can compile, but if anyone calls
+        // this against those unknown impls, that will fail. The expectation is there are no
+        // such impls.
+        // TODO remove this default impl at some point
+        throw new UnsupportedOperationException();
+    }
 
     ResourceDefinition build();
 

--- a/controller/src/main/java/org/jboss/as/controller/ResourceBuilderRoot.java
+++ b/controller/src/main/java/org/jboss/as/controller/ResourceBuilderRoot.java
@@ -25,8 +25,10 @@
 package org.jboss.as.controller;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.as.controller.capability.Capability;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -51,6 +53,7 @@ class ResourceBuilderRoot implements ResourceBuilder {
     private final List<ResourceBuilderRoot> children = new LinkedList<ResourceBuilderRoot>();
     private final ResourceBuilderRoot parent;
     private boolean isRuntime = false;
+    private Set<RuntimeCapability> incorporatingCapabilities;
 
 
     /** Normal constructor */
@@ -74,6 +77,9 @@ class ResourceBuilderRoot implements ResourceBuilder {
         this.operations.addAll(toCopy.operations);
         this.capabilities.addAll(toCopy.capabilities);
         this.children.addAll(toCopy.children);
+        if (toCopy.incorporatingCapabilities != null) {
+            this.incorporatingCapabilities = new HashSet<>(toCopy.incorporatingCapabilities);
+        }
         this.addHandler = toCopy.addHandler;
         this.removeHandler = toCopy.removeHandler;
         this.deprecationData = toCopy.deprecationData;
@@ -193,6 +199,12 @@ class ResourceBuilderRoot implements ResourceBuilder {
         return this;
     }
 
+    @Override
+    public ResourceBuilder setIncorporatingCapabilities(Set<RuntimeCapability> incorporating) {
+        this.incorporatingCapabilities = incorporating;
+        return this;
+    }
+
     public ResourceBuilder pushChild(final PathElement pathElement) {
         return pushChild(pathElement, resourceResolver.getChildResolver(pathElement.getKey()));
     }
@@ -260,7 +272,7 @@ class ResourceBuilderRoot implements ResourceBuilder {
                     .setDeprecationData(builder.deprecationData)
                     .setRuntime(builder.isRuntime)
                     .setCapabilities(builder.capabilities.toArray(new RuntimeCapability[builder.capabilities.size()]))
-
+                    .setIncorporatingCapabilities(builder.incorporatingCapabilities)
             );
             this.builder = builder;
         }

--- a/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleResourceDefinition.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -60,6 +61,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
     private volatile DeprecationData deprecationData;
     private final boolean orderedChild;
     private final RuntimeCapability[] capabilities;
+    private final Set<RuntimeCapability> incorporatingCapabilities;
     private final List<AccessConstraintDefinition> accessConstraints;
     private final int minOccurs;
     private final int maxOccurs;
@@ -89,6 +91,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
         this.runtime = false;
         this.orderedChild = false;
         this.capabilities = new RuntimeCapability[0];
+        this.incorporatingCapabilities = null;
         this.accessConstraints = Collections.emptyList();
         this.minOccurs = 0;
         this.maxOccurs = Integer.MAX_VALUE;
@@ -281,6 +284,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
         this.runtime = runtime;
         this.orderedChild = false;
         this.capabilities = new RuntimeCapability[0];
+        this.incorporatingCapabilities = null;
         this.accessConstraints = Collections.emptyList();
         this.minOccurs = 0;
         this.maxOccurs = Integer.MAX_VALUE;
@@ -304,6 +308,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
         this.orderedChild = parameters.orderedChildResource;
         this.descriptionProvider = null;
         this.capabilities = parameters.capabilities;
+        this.incorporatingCapabilities = parameters.incorporatingCapabilities;
         if (parameters.accessConstraints != null) {
             this.accessConstraints = Arrays.asList(parameters.accessConstraints);
         } else {
@@ -362,6 +367,9 @@ public class SimpleResourceDefinition implements ResourceDefinition {
             for (RuntimeCapability c : capabilities) {
                 resourceRegistration.registerCapability(c);
             }
+        }
+        if (incorporatingCapabilities != null) {
+            resourceRegistration.registerIncorporatingCapabilities(incorporatingCapabilities);
         }
     }
 
@@ -529,6 +537,7 @@ public class SimpleResourceDefinition implements ResourceDefinition {
         private DeprecationData deprecationData;
         private boolean orderedChildResource;
         private RuntimeCapability[] capabilities;
+        private Set<RuntimeCapability> incorporatingCapabilities;
         private AccessConstraintDefinition[] accessConstraints;
         private int minOccurs = 0;
         private int maxOccurs = Integer.MAX_VALUE;
@@ -710,6 +719,9 @@ public class SimpleResourceDefinition implements ResourceDefinition {
             return this;
         }
 
-
+        public Parameters setIncorporatingCapabilities(Set<RuntimeCapability> incorporatingCapabilities) {
+            this.incorporatingCapabilities = incorporatingCapabilities;
+            return this;
+        }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistry.java
@@ -25,6 +25,7 @@ package org.jboss.as.controller.capability.registry;
 import java.util.Map;
 
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 
 /**
  * Registry of {@link org.jboss.as.controller.capability.RuntimeCapability capabilities} available in the runtime.
@@ -99,25 +100,28 @@ public interface RuntimeCapabilityRegistry extends ImmutableCapabilityRegistry {
     /**
      * Gets the status of any capabilities associated with the given resource address.
      *
-     * @param  address the address. Cannot be {@code null}
+     * @param address the address. Cannot be {@code null}
+     * @param resourceRegistration the registration for the resource at {@code address}. Cannot be {@code null}
      * @return a map of capability ids to their runtime status. Will not return {@code null} but may return
      *         an empty map if no capabilities are associated with the address.
      */
-    Map<CapabilityId, RuntimeStatus> getRuntimeStatus(PathAddress address);
+    Map<CapabilityId, RuntimeStatus> getRuntimeStatus(PathAddress address, ImmutableManagementResourceRegistration resourceRegistration);
 
     /**
      * Notification that any capabilities associated with the given address require reload in order to bring their
      * runtime services into sync with their persistent configuration.
      *
      * @param address the address. Cannot be {@code null}
+     * @param resourceRegistration the registration for the resource at {@code address}. Cannot be {@code null}
      */
-    void capabilityReloadRequired(PathAddress address);
+    void capabilityReloadRequired(PathAddress address, ImmutableManagementResourceRegistration resourceRegistration);
 
     /**
      * Notification that any capabilities associated with the given address require restart in order to bring their
      * runtime services into sync with their persistent configuration.
      *
      * @param address the address. Cannot be {@code null}
+     * @param resourceRegistration the registration for the resource at {@code address}. Cannot be {@code null}
      */
-    void capabilityRestartRequired(PathAddress address);
+    void capabilityRestartRequired(PathAddress address, ImmutableManagementResourceRegistration resourceRegistration);
 }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/RuntimeCapabilityRegistry.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.controller.capability.registry;
 
+import java.util.Map;
+
 import org.jboss.as.controller.PathAddress;
 
 /**
@@ -31,6 +33,26 @@ import org.jboss.as.controller.PathAddress;
  * @author Tomaz Cerar (c) 2015 Red Hat Inc.
  */
 public interface RuntimeCapabilityRegistry extends ImmutableCapabilityRegistry {
+
+    enum RuntimeStatus {
+        /**
+         * Runtime services are functioning normally as per their persistent configuration
+         * and the process' current {@linkplain org.jboss.as.controller.RunningMode running mode}.
+         * Note that this may mean no runtime services if that is normal for the process type and running
+         * mode. */
+        NORMAL,
+        /**
+         * The process needs to be reloaded to bring runtime services for a capability in sync with
+         * their persistent configuration.
+         */
+        RELOAD_REQUIRED,
+        /**
+         * The process needs to be restarted to bring runtime services for a capability in sync with
+         * their persistent configuration.
+         */
+        RESTART_REQUIRED;
+    }
+
     /**
      * Registers a capability with the system. Any
      * {@link org.jboss.as.controller.capability.AbstractCapability#getRequirements() requirements}
@@ -73,4 +95,29 @@ public interface RuntimeCapabilityRegistry extends ImmutableCapabilityRegistry {
      * registration points for the capability still exist
      */
     RuntimeCapabilityRegistration removeCapability(String capabilityName, CapabilityScope scope, PathAddress registrationPoint);
+
+    /**
+     * Gets the status of any capabilities associated with the given resource address.
+     *
+     * @param  address the address. Cannot be {@code null}
+     * @return a map of capability ids to their runtime status. Will not return {@code null} but may return
+     *         an empty map if no capabilities are associated with the address.
+     */
+    Map<CapabilityId, RuntimeStatus> getRuntimeStatus(PathAddress address);
+
+    /**
+     * Notification that any capabilities associated with the given address require reload in order to bring their
+     * runtime services into sync with their persistent configuration.
+     *
+     * @param address the address. Cannot be {@code null}
+     */
+    void capabilityReloadRequired(PathAddress address);
+
+    /**
+     * Notification that any capabilities associated with the given address require restart in order to bring their
+     * runtime services into sync with their persistent configuration.
+     *
+     * @param address the address. Cannot be {@code null}
+     */
+    void capabilityRestartRequired(PathAddress address);
 }

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -78,6 +78,7 @@ import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.controller.persistence.SubsystemXmlWriterRegistry;
 import org.jboss.as.controller.registry.AliasEntry;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.NotificationEntry;
 import org.jboss.as.controller.registry.OperationEntry;
@@ -808,6 +809,16 @@ public class ExtensionRegistry {
         }
 
         @Override
+        public ImmutableManagementResourceRegistration getParent() {
+            ManagementResourceRegistration deplParent = (ManagementResourceRegistration) deployments.getParent();
+            ManagementResourceRegistration subParent = (ManagementResourceRegistration) subdeployments.getParent();
+            if (deployments == subParent) {
+                return deplParent;
+            }
+            return new DeploymentManagementResourceRegistration(deplParent, subParent);
+        }
+
+        @Override
         public int getMaxOccurs() {
             return deployments.getMaxOccurs();
         }
@@ -1036,6 +1047,12 @@ public class ExtensionRegistry {
         }
 
         @Override
+        public void registerIncorporatingCapabilities(Set<RuntimeCapability> capabilities) {
+            deployments.registerIncorporatingCapabilities(capabilities);
+            subdeployments.registerIncorporatingCapabilities(capabilities);
+        }
+
+        @Override
         public AliasEntry getAliasEntry() {
             return deployments.getAliasEntry();
         }
@@ -1048,6 +1065,11 @@ public class ExtensionRegistry {
         @Override
         public Set<RuntimeCapability> getCapabilities() {
             return deployments.getCapabilities();
+        }
+
+        @Override
+        public Set<RuntimeCapability> getIncorporatingCapabilities() {
+            return deployments.getIncorporatingCapabilities();
         }
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/AbstractResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AbstractResourceRegistration.java
@@ -73,7 +73,7 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
         }
     }
 
-    NodeSubregistry getParent() {
+    NodeSubregistry getParentSubRegistry() {
         return parent;
     }
 
@@ -421,6 +421,19 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
 
     abstract Set<RuntimeCapability> getCapabilities(ListIterator<PathElement> iterator);
 
+    @Override
+    public final Set<RuntimeCapability> getIncorporatingCapabilities() {
+
+        if (parent != null) {
+            RootInvocation ri = getRootInvocation();
+            return ri.root.getIncorporatingCapabilities(ri.pathAddress.iterator());
+        }
+        // else we are the root
+        return getIncorporatingCapabilities(pathAddress.iterator());
+    }
+
+    abstract Set<RuntimeCapability> getIncorporatingCapabilities(ListIterator<PathElement> iterator);
+
     private RootInvocation getRootInvocation() {
         RootInvocation result = null;
         if (parent != null) {
@@ -486,6 +499,11 @@ abstract class AbstractResourceRegistration implements ManagementResourceRegistr
     @Override
     public PathAddress getPathAddress() {
         return pathAddress;
+    }
+
+    @Override
+    public ImmutableManagementResourceRegistration getParent() {
+        return parent == null ? null : parent.getParent();
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/registry/AliasResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AliasResourceRegistration.java
@@ -79,8 +79,7 @@ final class AliasResourceRegistration extends AbstractResourceRegistration imple
         if (targetOp == null) {
             return null;
         }
-        return new OperationEntry(handler, targetOp.getDescriptionProvider(), targetOp.isInherited(), targetOp.getType(),
-                                    targetOp.getFlags(), null);
+        return new OperationEntry(targetOp.getOperationDefinition(), handler, targetOp.isInherited());
     }
 
     @Override
@@ -211,8 +210,7 @@ final class AliasResourceRegistration extends AbstractResourceRegistration imple
         for (Map.Entry<String, OperationEntry> entry : providers.entrySet()) {
             OperationEntry value = entry.getValue();
             providers.put(entry.getKey(),
-                    new OperationEntry(handler, value.getDescriptionProvider(), value.isInherited(),
-                            value.getType(), value.getFlags(), value.getAccessConstraints()));
+                    new OperationEntry(value.getOperationDefinition(), handler, value.isInherited()));
         }
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/AliasResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AliasResourceRegistration.java
@@ -204,6 +204,11 @@ final class AliasResourceRegistration extends AbstractResourceRegistration imple
     }
 
     @Override
+    public void registerIncorporatingCapabilities(Set<RuntimeCapability> capabilities) {
+        throw alreadyRegistered();
+    }
+
+    @Override
     void getOperationDescriptions(final ListIterator<PathElement> iterator, final Map<String, OperationEntry> providers, final boolean inherited) {
         Map<String, OperationEntry> temp = new HashMap<String, OperationEntry>();
         target.getOperationDescriptions(iterator, temp, inherited);
@@ -314,5 +319,10 @@ final class AliasResourceRegistration extends AbstractResourceRegistration imple
     @Override
     Set<RuntimeCapability> getCapabilities(ListIterator<PathElement> iterator) {
         return target.getCapabilities(iterator);
+    }
+
+    @Override
+    Set<RuntimeCapability> getIncorporatingCapabilities(ListIterator<PathElement> iterator) {
+        return target.getIncorporatingCapabilities(iterator);
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -228,8 +228,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
     public void registerOperationHandler(OperationDefinition definition, OperationStepHandler handler, boolean inherited) {
         checkPermission();
         String opName = definition.getName();
-        OperationEntry entry = new OperationEntry(handler, definition.getDescriptionProvider(), inherited, definition.getEntryType(),
-                definition.getFlags(), definition.getAccessConstraints());
+        OperationEntry entry = new OperationEntry(definition, handler, inherited);
         writeLock.lock();
         try {
             if (operations == null) {

--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -78,6 +78,8 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
     private Set<RuntimeCapability> capabilities;
 
+    private Set<RuntimeCapability> incorporatingCapabilities;
+
     private final Lock readLock;
     private final Lock writeLock;
     /**
@@ -193,7 +195,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         List<AccessConstraintDefinition> list = new ArrayList<AccessConstraintDefinition>();
         while (reg != null) {
             reg.addAccessConstraints(list);
-            NodeSubregistry parent = reg.getParent();
+            NodeSubregistry parent = reg.getParentSubRegistry();
             reg = parent == null ? null : parent.getParent();
         }
         return Collections.unmodifiableList(list);
@@ -584,6 +586,34 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         }
     }
 
+    @Override
+    Set<RuntimeCapability> getIncorporatingCapabilities(ListIterator<PathElement> iterator) {
+        if (iterator.hasNext()) {
+            final PathElement next = iterator.next();
+            final NodeSubregistry subregistry = getSubregistry(next.getKey());
+            if (subregistry == null) {
+                return Collections.emptySet();
+            }
+            return subregistry.getIncorporatingCapabilities(iterator, next.getValue());
+        } else {
+            checkPermission();
+            readLock.lock();
+            try {
+                Set<RuntimeCapability> result;
+                if (incorporatingCapabilities != null) {
+                    result = incorporatingCapabilities;
+                } else if (capabilities != null && !capabilities.isEmpty()) {
+                    result = Collections.emptySet();
+                } else {
+                    result = null;
+                }
+                return result;
+            } finally {
+                readLock.unlock();
+            }
+        }
+    }
+
 
     @Override
     public void registerProxyController(final PathElement address, final ProxyController controller) throws IllegalArgumentException {
@@ -625,6 +655,22 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             capabilities.add(capability);
             if (capabilityRegistry != null) {
                 capabilityRegistry.registerPossibleCapability(capability, getPathAddress());
+            }
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public void registerIncorporatingCapabilities(Set<RuntimeCapability> capabilities) {
+        writeLock.lock();
+        try {
+            if (capabilities == null) {
+                incorporatingCapabilities = null;
+            } else if (capabilities.isEmpty()) {
+                incorporatingCapabilities = Collections.emptySet();
+            } else {
+                incorporatingCapabilities = Collections.unmodifiableSet(new HashSet<>(capabilities));
             }
         } finally {
             writeLock.unlock();

--- a/controller/src/main/java/org/jboss/as/controller/registry/DelegatingImmutableManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/DelegatingImmutableManagementResourceRegistration.java
@@ -60,6 +60,11 @@ public class DelegatingImmutableManagementResourceRegistration implements Immuta
     }
 
     @Override
+    public ImmutableManagementResourceRegistration getParent() {
+        return delegate.getParent();
+    }
+
+    @Override
     public int getMaxOccurs() {
         return delegate.getMaxOccurs();
     }
@@ -178,5 +183,10 @@ public class DelegatingImmutableManagementResourceRegistration implements Immuta
     @Override
     public Set<RuntimeCapability> getCapabilities() {
         return delegate.getCapabilities();
+    }
+
+    @Override
+    public Set<RuntimeCapability> getIncorporatingCapabilities() {
+        return delegate.getIncorporatingCapabilities();
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/DelegatingManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/DelegatingManagementResourceRegistration.java
@@ -95,6 +95,11 @@ public class DelegatingManagementResourceRegistration implements ManagementResou
     }
 
     @Override
+    public ImmutableManagementResourceRegistration getParent() {
+        return getDelegate().getParent();
+    }
+
+    @Override
     public int getMaxOccurs() {
         return getDelegate().getMaxOccurs();
     }
@@ -321,8 +326,18 @@ public class DelegatingManagementResourceRegistration implements ManagementResou
     }
 
     @Override
+    public void registerIncorporatingCapabilities(Set<RuntimeCapability> capabilities) {
+        getDelegate().registerIncorporatingCapabilities(capabilities);
+    }
+
+    @Override
     public Set<RuntimeCapability> getCapabilities() {
         return getDelegate().getCapabilities();
+    }
+
+    @Override
+    public Set<RuntimeCapability> getIncorporatingCapabilities() {
+        return getDelegate().getIncorporatingCapabilities();
     }
 
     private ManagementResourceRegistration getDelegate() {

--- a/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
@@ -24,6 +24,7 @@ package org.jboss.as.controller.registry;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.NotificationDefinition;
@@ -305,6 +306,26 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
      * @param capability a capability to register
      */
     void registerCapability(RuntimeCapability capability);
+
+    /**
+     * Registers a set of capabilities that this resource does not directly provide but to which it contributes. This
+     * will only include capabilities for which this resource <strong>does not</strong> control the
+     * {@link #registerCapability(RuntimeCapability) registration of the capability}. Any capabilities registered by
+     * this resource will instead be included in the return value for {@link #getCapabilities()}.
+     * <p>
+     * Use of this method is only necessary if the caller wishes to specifically record capability incorporation,
+     * instead of relying on the default resolution mechanism detailed in {@link #getIncorporatingCapabilities()}, or
+     * if it wishes disable the default resolution mechanism and specifically declare that this resource does not
+     * contribute to parent capabilities. It does the latter by passing an empty set as the {@code capabilities}
+     * parameter. Passing an empty set is not necessary if this resource itself directly
+     * {@link #registerCapability(RuntimeCapability) provides a capability}, as it is the contract of
+     * {@link #getIncorporatingCapabilities()} that in that case it must return an empty set.
+     *
+     * @param  capabilities set of capabilities, or {@code null} if default resolution of capabilities to which this
+     *                      resource contributes should be used; an empty set can be used to indicate this resource
+     *                      does not contribute to capabilities provided by its parent
+     */
+    void registerIncorporatingCapabilities(Set<RuntimeCapability> capabilities);
 
     /**
      * A factory for creating a new, root model node registration.

--- a/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/NodeSubregistry.java
@@ -416,6 +416,28 @@ final class NodeSubregistry {
         return result;
     }
 
+    Set<RuntimeCapability> getIncorporatingCapabilities(ListIterator<PathElement> iterator, String child) {
+
+        final RegistrySearchControl searchControl = new RegistrySearchControl(iterator, child);
+
+        Set<RuntimeCapability> result = null;
+        if (searchControl.getSpecifiedRegistry() != null) {
+            result = searchControl.getSpecifiedRegistry().getIncorporatingCapabilities(searchControl.getIterator());
+        }
+
+        if (searchControl.getWildCardRegistry() != null) {
+            final Set<RuntimeCapability> wildCardChildren = searchControl.getWildCardRegistry().getIncorporatingCapabilities(searchControl.getIterator());
+            if (result == null) {
+                result = wildCardChildren;
+            } else if (wildCardChildren != null) {
+                // Merge
+                result = new HashSet<RuntimeCapability>(result);
+                result.addAll(wildCardChildren);
+            }
+        }
+        return result;
+    }
+
     Set<String> getOrderedChildTypes(ListIterator<PathElement> iterator, String child) {
 
         final RegistrySearchControl searchControl = new RegistrySearchControl(iterator, child);

--- a/controller/src/main/java/org/jboss/as/controller/registry/OperationEntry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/OperationEntry.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
+import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
@@ -68,25 +69,18 @@ public final class OperationEntry {
         RUNTIME_ONLY
     }
 
+    private final OperationDefinition operationDefinition;
     private final OperationStepHandler operationHandler;
-    private final DescriptionProvider descriptionProvider;
-    private final EntryType type;
-    private final EnumSet<Flag> flags;
     private final boolean inherited;
-    private final List<AccessConstraintDefinition> accessConstraints;
 
-    OperationEntry(final OperationStepHandler operationHandler, final DescriptionProvider descriptionProvider,
-                   final boolean inherited, final EntryType type, final EnumSet<Flag> flags, final List<AccessConstraintDefinition> accessConstraints) {
+    OperationEntry(final OperationDefinition definition, final OperationStepHandler operationHandler, final boolean inherited) {
+        this.operationDefinition = definition;
         this.operationHandler = operationHandler;
-        this.descriptionProvider = descriptionProvider;
         this.inherited = inherited;
-        this.type = type;
-        this.flags = flags == null ? EnumSet.noneOf(Flag.class) : flags;
-        this.accessConstraints = accessConstraints == null ? Collections.<AccessConstraintDefinition>emptyList() : accessConstraints;
     }
 
-    OperationEntry(final OperationStepHandler operationHandler, final DescriptionProvider descriptionProvider, final boolean inherited, final EntryType type) {
-       this(operationHandler, descriptionProvider, inherited, type, EnumSet.noneOf(Flag.class), null);
+    public OperationDefinition getOperationDefinition() {
+        return operationDefinition;
     }
 
     public OperationStepHandler getOperationHandler() {
@@ -94,7 +88,7 @@ public final class OperationEntry {
     }
 
     public DescriptionProvider getDescriptionProvider() {
-        return descriptionProvider;
+        return operationDefinition.getDescriptionProvider();
     }
 
     public boolean isInherited() {
@@ -102,15 +96,17 @@ public final class OperationEntry {
     }
 
     public EntryType getType() {
-        return type;
+        return operationDefinition.getEntryType();
     }
 
     public EnumSet<Flag> getFlags() {
+        EnumSet<Flag> flags = operationDefinition.getFlags();
         return flags == null ? EnumSet.noneOf(Flag.class) : flags.clone();
     }
 
     public List<AccessConstraintDefinition> getAccessConstraints() {
-        return accessConstraints;
+        List<AccessConstraintDefinition> accessConstraints = operationDefinition.getAccessConstraints();
+        return accessConstraints == null ? Collections.emptyList() : accessConstraints;
     }
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
@@ -391,6 +391,11 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
         }
 
         @Override
+        public PathAddress getPathAddress() {
+            return pathAddress;
+        }
+
+        @Override
         public OperationEntry getOperationEntry(PathAddress address, String operationName) {
             checkPermission();
             return ProxyControllerRegistration.this.operationEntry;

--- a/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
@@ -143,6 +143,11 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
     }
 
     @Override
+    public void registerIncorporatingCapabilities(Set<RuntimeCapability> capabilities) {
+        throw alreadyRegistered();
+    }
+
+    @Override
     public void unregisterSubModel(final PathElement address) throws IllegalArgumentException {
         throw alreadyRegistered();
     }
@@ -265,6 +270,11 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
 
     @Override
     Set<RuntimeCapability> getCapabilities(ListIterator<PathElement> iterator) {
+        return Collections.emptySet();
+    }
+
+    @Override
+    Set<RuntimeCapability> getIncorporatingCapabilities(ListIterator<PathElement> iterator) {
         return Collections.emptySet();
     }
 
@@ -407,6 +417,16 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
         public OperationEntry getOperationEntry(PathAddress address, String operationName) {
             checkPermission();
             return ProxyControllerRegistration.this.operationEntry;
+        }
+
+        @Override
+        public ImmutableManagementResourceRegistration getParent() {
+            PathAddress parentAddress = ProxyControllerRegistration.this.getPathAddress();
+            if (pathAddress.size() == parentAddress.size() + 1) {
+                return ProxyControllerRegistration.this;
+            } else {
+                return new ChildRegistration(pathAddress.getParent());
+            }
         }
 
         @Override

--- a/controller/src/main/java/org/jboss/as/controller/services/path/PathEntry.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/PathEntry.java
@@ -84,14 +84,19 @@ public class PathEntry {
     }
 
     /**
-     * Gets the relative to
+     * Gets the name of the logical path this path is relative to, if any.
      *
-     * @return the name of the path this path is relative to. If {@code null} this is an absolute path
+     * @return the name of the logical path. If {@code null} this is an absolute path
      */
     String getRelativeTo() {
         return relativeTo;
     }
 
+    /**
+     * Gets whether the path is immutable, and cannot be removed or modified via a management operation.
+     *
+     * @return {@code true} if the path is immutable
+     */
     boolean isReadOnly() {
         return readOnly;
     }

--- a/controller/src/main/java/org/jboss/as/controller/services/path/PathManager.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/PathManager.java
@@ -141,7 +141,11 @@ public interface PathManager {
         Event getEvent();
     }
 
-    static class ReloadServerCallback {
+    /**
+     * Factory for a {@link Callback} that always calls {@link PathEventContext#reloadRequired()} from its
+     * {@link Callback#pathModelEvent(PathEventContext, String)} method.
+     */
+    class ReloadServerCallback {
         public static Callback create() {
             return  new Callback() {
                 @Override

--- a/controller/src/main/java/org/jboss/as/controller/services/path/PathWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/PathWriteAttributeHandler.java
@@ -44,13 +44,10 @@ import org.jboss.dmr.ModelNode;
 class PathWriteAttributeHandler extends AbstractWriteAttributeHandler<PathWriteAttributeHandler.PathUpdate> {
 
     private final PathManagerService pathManager;
-    private final boolean services;
 
-
-    PathWriteAttributeHandler(final PathManagerService pathManager, final SimpleAttributeDefinition definition, final boolean services) {
+    PathWriteAttributeHandler(final PathManagerService pathManager, final SimpleAttributeDefinition definition) {
         super(definition);
         this.pathManager = pathManager;
-        this.services = services;
     }
 
     @Override
@@ -61,7 +58,7 @@ class PathWriteAttributeHandler extends AbstractWriteAttributeHandler<PathWriteA
         if (model.getModel().get(READ_ONLY.getName()).asBoolean(false)) {
             throw ControllerLogger.ROOT_LOGGER.cannotModifyReadOnlyPath(pathName);
         }
-        if (services) {
+        if (pathManager != null) {
             final PathEntry pathEntry = pathManager.getPathEntry(pathName);
             if (pathEntry.isReadOnly()) {
                 throw ControllerLogger.ROOT_LOGGER.pathEntryIsReadOnly(operation.require(OP_ADDR).asString());
@@ -71,7 +68,7 @@ class PathWriteAttributeHandler extends AbstractWriteAttributeHandler<PathWriteA
 
     @Override
     protected boolean requiresRuntime(OperationContext context) {
-        return services;
+        return pathManager != null;
     }
 
     @Override

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
@@ -22,9 +22,17 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.capability.Capability;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.operations.validation.AbstractParameterValidator;
@@ -32,16 +40,15 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.test.AbstractControllerTestBase;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.AbstractServiceListener;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.xnio.Pool;
 import org.xnio.XnioWorker;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 
 /**
  * @author Tomaz Cerar (c) 2015 Red Hat Inc.
@@ -68,14 +75,36 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
     private static final RuntimeCapability<Void> TEST_CAPABILITY1 = RuntimeCapability.Builder.of("org.wildfly.test.capability1", true, Void.class).build();
     private static final RuntimeCapability<Void> TEST_CAPABILITY2 = RuntimeCapability.Builder.of("org.wildfly.test.capability2", true, Void.class).build();
     private static final RuntimeCapability<Void> TEST_CAPABILITY3 = RuntimeCapability.Builder.of("org.wildfly.test.capability3", true, Void.class).build();
+    private static final RuntimeCapability<Void> PROFILE_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.profile-capability", true, Void.class).build();
+    private static final RuntimeCapability<Void> HOST_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.host-capability", true, Void.class).build();
+    private static final RuntimeCapability<Void> RELOADED_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.reloaded-capability", true, Void.class).build();
+    private static final RuntimeCapability<Void> INDEPENDENT_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.independent-capability", true, Void.class).build();
+    private static final RuntimeCapability<Void> ROOT_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.root-capability", false, Void.class).build();
+    private static final RuntimeCapability<Void> DEPENDENT_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.dep-capability", false, Void.class)
+            .addRequirements(ROOT_CAPABILITY.getName()).build();
+    private static final RuntimeCapability<Void> TRANS_DEP_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.test.trans-dep-capability", false, Void.class)
+            .addRequirements(DEPENDENT_CAPABILITY.getName()).build();
 
     private static PathAddress TEST_ADDRESS1 = PathAddress.pathAddress("subsystem", "test1");
     private static PathAddress TEST_ADDRESS2 = PathAddress.pathAddress("subsystem", "test2");
     private static PathAddress TEST_ADDRESS3 = PathAddress.pathAddress("sub", "resource");
     private static PathAddress TEST_ADDRESS4 = PathAddress.pathAddress("subsystem", "test4");
 
+    private static PathElement RELOAD_ELEMENT = PathElement.pathElement("subsystem", "reload");
+    private static PathElement CHILD_ELEMENT = PathElement.pathElement("child", "test");
+    private static PathElement GRANDCHILD_ELEMENT = PathElement.pathElement("grandchild", "test");
+    private static PathElement INFANT_ELEMENT = PathElement.pathElement("infant", "test");
+    private static PathElement INDEPENDENT_ELEMENT = PathElement.pathElement("independent", "test");
+    private static PathElement UNINCORPORATED_ELEMENT = PathElement.pathElement("unincorporated", "test");
+    private static PathElement HOST_ELEMENT = PathElement.pathElement("host", "test");
+
+
+    private static PathElement PROFILE_ELEMENT = PathElement.pathElement("profile", "test");
+    private static PathElement NO_CAP_ELEMENT = PathElement.pathElement("subsystem", "no-cap");
+    private static PathElement DEP_CAP_ELEMENT = PathElement.pathElement("subsystem", "dep-cap");
+
     private static ResourceDefinition TEST_RESOURCE1 = ResourceBuilder.Factory.create(TEST_ADDRESS1.getElement(0),
-            new NonResolvingResourceDescriptionResolver())
+            NonResolvingResourceDescriptionResolver.INSTANCE)
             .setAddOperation(new AbstractAddStepHandler(new HashSet<>(Arrays.asList(IO_POOL_RUNTIME_CAPABILITY, IO_WORKER_RUNTIME_CAPABILITY)), ad, other))
             .setRemoveOperation(new ReloadRequiredRemoveStepHandler(IO_POOL_RUNTIME_CAPABILITY, IO_WORKER_RUNTIME_CAPABILITY))
             .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
@@ -92,7 +121,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             .build();
 
     private static final ResourceDefinition SUB_RESOURCE = ResourceBuilder.Factory.create(TEST_ADDRESS3.getElement(0),
-                new NonResolvingResourceDescriptionResolver())
+            NonResolvingResourceDescriptionResolver.INSTANCE)
                 .setAddOperation(new AbstractAddStepHandler(Collections.singleton(TEST_CAPABILITY3)))
                 .setRemoveOperation(new ReloadRequiredRemoveStepHandler(TEST_CAPABILITY3))
                 .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
@@ -101,7 +130,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
 
 
     private static ResourceDefinition TEST_RESOURCE2 = ResourceBuilder.Factory.create(TEST_ADDRESS2.getElement(0),
-            new NonResolvingResourceDescriptionResolver())
+            NonResolvingResourceDescriptionResolver.INSTANCE)
             .setAddOperation(new AbstractAddStepHandler(Collections.singleton(TEST_CAPABILITY2), ad, other))
             .setRemoveOperation(new ReloadRequiredRemoveStepHandler(TEST_CAPABILITY2))
             .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
@@ -123,7 +152,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             .build();
 
     private static ResourceDefinition TEST_RESOURCE4 = ResourceBuilder.Factory.create(TEST_ADDRESS4.getElement(0),
-            new NonResolvingResourceDescriptionResolver())
+            NonResolvingResourceDescriptionResolver.INSTANCE)
             .setAddOperation(new AbstractAddStepHandler(new HashSet<>(Arrays.asList(IO_POOL_RUNTIME_CAPABILITY, IO_WORKER_RUNTIME_CAPABILITY)), ad, other) {
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
@@ -144,31 +173,144 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             .addCapability(IO_WORKER_RUNTIME_CAPABILITY)
             .build();
 
-    private ManagementResourceRegistration rootRegistration;
+    private static final OperationStepHandler RELOAD_HANDLER = new OperationStepHandler() {
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            context.reloadRequired();
+            context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
+        }
+    };
+    private static final OperationDefinition RELOAD_DEFINITION = new SimpleOperationDefinition("reload", NonResolvingResourceDescriptionResolver.INSTANCE);
+
+    private static final OperationStepHandler RUNTIME_MOD_HANDLER = new OperationStepHandler() {
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            context.addStep(new OperationStepHandler() {
+                @Override
+                public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                    // If we execute, the result is now defined
+                    context.getResult().set(true);
+                }
+            }, OperationContext.Stage.RUNTIME);
+        }
+    };
+
+    private static final OperationDefinition RUNTIME_MOD_DEFINITION = new SimpleOperationDefinition("runtime-mod", NonResolvingResourceDescriptionResolver.INSTANCE);
+    private static final OperationDefinition RUNTIME_ONLY_DEFINITION = new SimpleOperationDefinitionBuilder("runtime-only", NonResolvingResourceDescriptionResolver.INSTANCE)
+            .setRuntimeOnly()
+            .build();
+
+    private static ResourceBuilder createReloadTestResourceBuilder(PathElement address, RuntimeCapability... caps) {
+        return addReloadTestOps(ResourceBuilder.Factory.create(address, NonResolvingResourceDescriptionResolver.INSTANCE), caps);
+    }
+
+    private static ResourceBuilder addReloadTestOps(ResourceBuilder builder, RuntimeCapability... caps) {
+        ResourceBuilder result = builder
+                .addOperation(RELOAD_DEFINITION, RELOAD_HANDLER)
+                .addOperation(RUNTIME_MOD_DEFINITION, RUNTIME_MOD_HANDLER)
+                .addOperation(RUNTIME_ONLY_DEFINITION, RUNTIME_MOD_HANDLER);
+        if (caps != null && caps.length > 0) {
+            result = result.addCapabilities((Capability[]) caps)
+                    .setAddOperation(new AbstractAddStepHandler())
+                    .setRemoveOperation(new ModelOnlyRemoveStepHandler());
+        }
+        return result;
+    }
+
+    private static ResourceDefinition RELOAD_PARENT = createReloadTestResourceBuilder(RELOAD_ELEMENT, RELOADED_CAPABILITY)
+            .pushChild(createReloadTestResourceBuilder(INDEPENDENT_ELEMENT, INDEPENDENT_CAPABILITY))
+                .pushChild(createReloadTestResourceBuilder(CHILD_ELEMENT)).pop()
+            .pop()
+            .pushChild(createReloadTestResourceBuilder(UNINCORPORATED_ELEMENT))
+                .setIncorporatingCapabilities(Collections.emptySet())
+                .pushChild(createReloadTestResourceBuilder(CHILD_ELEMENT)).pop()
+            .pop()
+            .pushChild(createReloadTestResourceBuilder(CHILD_ELEMENT))
+                .pushChild(createReloadTestResourceBuilder(GRANDCHILD_ELEMENT))
+                    .pushChild(createReloadTestResourceBuilder(INFANT_ELEMENT))
+                    .pop()
+                .pop()
+                .pushChild(createReloadTestResourceBuilder(UNINCORPORATED_ELEMENT))
+                    .setIncorporatingCapabilities(Collections.emptySet())
+                    .pushChild(createReloadTestResourceBuilder(INFANT_ELEMENT)).pop()
+                .pop()
+            .pop()
+            .build();
+
+    private static ResourceDefinition HOST_RESOURCE = createReloadTestResourceBuilder(HOST_ELEMENT, HOST_CAPABILITY)
+            .pushChild(createReloadTestResourceBuilder(CHILD_ELEMENT)).pop()
+            .build();
+
+    private static ResourceDefinition PROFILE_RESOURCE = createReloadTestResourceBuilder(PROFILE_ELEMENT, PROFILE_CAPABILITY)
+            .pushChild(createReloadTestResourceBuilder(NO_CAP_ELEMENT))
+                .pushChild(createReloadTestResourceBuilder(CHILD_ELEMENT)).pop()
+            .pop()
+            .build();
+
+    private static ResourceDefinition NO_CAP_RESOURCE = createReloadTestResourceBuilder(CHILD_ELEMENT)
+            .build();
+
+    private static ResourceDefinition DEP_CAP_RESOURCE = createReloadTestResourceBuilder(DEP_CAP_ELEMENT, DEPENDENT_CAPABILITY)
+            .pushChild(createReloadTestResourceBuilder(CHILD_ELEMENT, TRANS_DEP_CAPABILITY)).pop()
+            .build();
+
+    private static final int RELOAD_CAP_COUNT = 6;
+
+    private ManagementModel managementModel;
 
     @Override
     protected void initModel(ManagementModel managementModel) {
-        rootRegistration = managementModel.getRootResourceRegistration();
+        this.managementModel = managementModel;
+        ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
         // register the global operations to be able to call :read-attribute and :write-attribute
         GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
         // register the global notifications so there is no warning that emitted notifications are not described by the resource.
         GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
         rootRegistration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
-        rootRegistration.registerOperationHandler(new SimpleOperationDefinition("clean", new NonResolvingResourceDescriptionResolver()), (context, operation) -> {
+        rootRegistration.registerOperationHandler(new SimpleOperationDefinition("clean", NonResolvingResourceDescriptionResolver.INSTANCE), (context, operation) -> {
             ManagementResourceRegistration mrr = context.getResourceRegistrationForUpdate();
             mrr.unregisterSubModel(TEST_ADDRESS1.getElement(0));
             mrr.unregisterSubModel(TEST_ADDRESS2.getElement(0));
             mrr.unregisterSubModel(TEST_ADDRESS4.getElement(0));
+            mrr.getSubModel(PathAddress.pathAddress(RELOAD_ELEMENT)).unregisterSubModel(INDEPENDENT_ELEMENT);
+            mrr.unregisterSubModel(RELOAD_ELEMENT);
+            mrr.unregisterSubModel(HOST_ELEMENT);
+            mrr.unregisterSubModel(PROFILE_ELEMENT);
+            mrr.unregisterSubModel(CHILD_ELEMENT);
+            mrr.getSubModel(PathAddress.pathAddress(DEP_CAP_ELEMENT)).unregisterSubModel(CHILD_ELEMENT);
+            mrr.unregisterSubModel(DEP_CAP_ELEMENT);
         });
 
-        rootRegistration.registerOperationHandler(new SimpleOperationDefinition("create", new NonResolvingResourceDescriptionResolver()), (context, operation) -> {
+        rootRegistration.registerOperationHandler(new SimpleOperationDefinition("create", NonResolvingResourceDescriptionResolver.INSTANCE), (context, operation) -> {
             ManagementResourceRegistration mrr = context.getResourceRegistrationForUpdate();
             mrr.registerSubModel(TEST_RESOURCE1);
             mrr.registerSubModel(TEST_RESOURCE2);
             mrr.registerSubModel(TEST_RESOURCE4);
+            mrr.registerSubModel(RELOAD_PARENT);
+            mrr.registerSubModel(HOST_RESOURCE);
+            mrr.registerSubModel(PROFILE_RESOURCE);
+            mrr.registerSubModel(NO_CAP_RESOURCE);
+            mrr.registerSubModel(DEP_CAP_RESOURCE);
         });
-
+        rootRegistration.registerOperationHandler(new SimpleOperationDefinition("root-cap", NonResolvingResourceDescriptionResolver.INSTANCE),
+                new OperationStepHandler() {
+                    @Override
+                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                        context.registerCapability(ROOT_CAPABILITY);
+                    }
+                });
+        rootRegistration.registerOperationHandler(new SimpleOperationDefinition("no-root-cap", NonResolvingResourceDescriptionResolver.INSTANCE),
+                new OperationStepHandler() {
+                    @Override
+                    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                        context.deregisterCapability(ROOT_CAPABILITY.getName());
+                    }
+                });
+        rootRegistration.registerOperationHandler(RELOAD_DEFINITION, RELOAD_HANDLER);
+        rootRegistration.registerOperationHandler(RUNTIME_MOD_DEFINITION, RUNTIME_MOD_HANDLER);
+        rootRegistration.registerOperationHandler(RUNTIME_ONLY_DEFINITION, RUNTIME_MOD_HANDLER);
     }
+
     @Before
     public void createModel() throws OperationFailedException {
         Assert.assertEquals(0, capabilityRegistry.getCapabilities().size());
@@ -188,9 +330,9 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
 
     @Test
     public void testCapabilityRegistration() throws OperationFailedException {
-        ManagementResourceRegistration registration = rootRegistration.getSubModel(TEST_ADDRESS1);
+        ManagementResourceRegistration registration = managementModel.getRootResourceRegistration().getSubModel(TEST_ADDRESS1);
         Assert.assertEquals(2, registration.getCapabilities().size());
-        Assert.assertEquals(3, capabilityRegistry.getPossibleCapabilities().size());  //resource1 has 2 + 1 from resource 2
+        Assert.assertEquals(RELOAD_CAP_COUNT + 3, capabilityRegistry.getPossibleCapabilities().size());  //resource1 has 2 + 1 from resource 2
         Assert.assertEquals(0, capabilityRegistry.getCapabilities().size());
 
         ModelNode addOp = createOperation(ADD, TEST_ADDRESS1);
@@ -202,7 +344,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
         //post boot registration
         executeCheckNoFailure(createOperation("add-cap", TEST_ADDRESS1));
         Assert.assertEquals(3, registration.getCapabilities().size());
-        Assert.assertEquals(4, capabilityRegistry.getPossibleCapabilities().size());
+        Assert.assertEquals(RELOAD_CAP_COUNT + 4, capabilityRegistry.getPossibleCapabilities().size());
 
 
         executeCheckNoFailure(createOperation(REMOVE, TEST_ADDRESS1));
@@ -213,17 +355,17 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
         executeCheckNoFailure(add2Op);
 
         Assert.assertEquals(1, capabilityRegistry.getCapabilities().size());
-        Assert.assertEquals(4, capabilityRegistry.getPossibleCapabilities().size());
+        Assert.assertEquals(RELOAD_CAP_COUNT + 4, capabilityRegistry.getPossibleCapabilities().size());
 
         executeCheckNoFailure(createOperation("add-sub-resource", TEST_ADDRESS2));
 
         Assert.assertEquals(1, capabilityRegistry.getCapabilities().size());
-        Assert.assertEquals(5, capabilityRegistry.getPossibleCapabilities().size());
+        Assert.assertEquals(RELOAD_CAP_COUNT + 5, capabilityRegistry.getPossibleCapabilities().size());
 
         executeCheckNoFailure(createOperation("remove-sub-resource", TEST_ADDRESS2));
 
         Assert.assertEquals(1, capabilityRegistry.getCapabilities().size());
-        Assert.assertEquals(4, capabilityRegistry.getPossibleCapabilities().size());
+        Assert.assertEquals(RELOAD_CAP_COUNT + 4, capabilityRegistry.getPossibleCapabilities().size());
 
         //remove test2 resource so capabilites are moved
         executeCheckNoFailure(createOperation(REMOVE, TEST_ADDRESS2));
@@ -274,5 +416,312 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
         Assert.assertEquals(2, capabilityRegistry.getCapabilities().size());
         executeCheckNoFailure(createOperation(REMOVE, TEST_ADDRESS1));
         Assert.assertEquals(0, capabilityRegistry.getCapabilities().size());
+    }
+
+    // Check that subsystem=reload requiring reload prevents runtime execution of
+    // subsystem=reload/child=test, since it is incorporated by the parent resource cap
+    @Test
+    public void testChildReload() throws OperationFailedException {
+        add(RELOAD_ELEMENT);
+        try {
+            requireReload(RELOAD_ELEMENT);
+            runtimeCheck(false, RELOAD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT);
+            runtimeCheck(false, RELOAD_ELEMENT, CHILD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT, CHILD_ELEMENT);
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            remove(RELOAD_ELEMENT);
+        }
+    }
+
+    // Check that subsystem=reload requiring reload prevents runtime execution of
+    // subsystem=reload/child=test/grandchild=test, since it is incorporated by the parent resource cap
+    @Test
+    public void testGrandChildReload() throws OperationFailedException {
+        add(RELOAD_ELEMENT);
+        try {
+            requireReload(RELOAD_ELEMENT);
+            runtimeCheck(false, RELOAD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT);
+            runtimeCheck(false, RELOAD_ELEMENT, CHILD_ELEMENT, GRANDCHILD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT, CHILD_ELEMENT, GRANDCHILD_ELEMENT);
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            remove(RELOAD_ELEMENT);
+        }
+    }
+
+    // Check that subsystem=reload requiring reload prevents runtime execution of
+    // subsystem=reload/child=test/grandchild=test/infant=test, since it is incorporated by the parent resource cap
+    // This one is getting a bit extreme. :)
+    @Test
+    public void testInfantReload() throws OperationFailedException {
+        add(RELOAD_ELEMENT);
+        try {
+            requireReload(RELOAD_ELEMENT);
+            runtimeCheck(false, RELOAD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT);
+            runtimeCheck(false, RELOAD_ELEMENT, CHILD_ELEMENT, GRANDCHILD_ELEMENT, INFANT_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT, CHILD_ELEMENT, GRANDCHILD_ELEMENT, INFANT_ELEMENT);
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            remove(RELOAD_ELEMENT);
+        }
+    }
+
+    // Check that subsystem=reload requiring reload doesn't prevent runtime execution of
+    // subsystem=reload/independent=test, since it has its own capability
+    @Test
+    public void testIndependentCapabilityReload() throws OperationFailedException {
+        add(RELOAD_ELEMENT);
+        try {
+            requireReload(RELOAD_ELEMENT);
+            runtimeCheck(false, RELOAD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT);
+            // First, check what happens when the independent-capability isn't even registered yet
+            // This is kind of an odd case, but good to verify
+            runtimeCheck(true, RELOAD_ELEMENT, INDEPENDENT_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT, INDEPENDENT_ELEMENT);
+            runtimeCheck(true, RELOAD_ELEMENT, INDEPENDENT_ELEMENT, CHILD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT, INDEPENDENT_ELEMENT, CHILD_ELEMENT);
+            // Add the independent element child so its independent-capability is registered
+            add(RELOAD_ELEMENT, INDEPENDENT_ELEMENT);
+            try {
+                runtimeCheck(true, RELOAD_ELEMENT, INDEPENDENT_ELEMENT);
+                runtimeOnlyCheck(true, RELOAD_ELEMENT, INDEPENDENT_ELEMENT);
+                runtimeCheck(true, RELOAD_ELEMENT, INDEPENDENT_ELEMENT, CHILD_ELEMENT);
+                runtimeOnlyCheck(true, RELOAD_ELEMENT, INDEPENDENT_ELEMENT, CHILD_ELEMENT);
+                // Make sure triggering reload of independent element child affects things
+                requireReload(RELOAD_ELEMENT, INDEPENDENT_ELEMENT);
+                runtimeCheck(false, RELOAD_ELEMENT, INDEPENDENT_ELEMENT);
+                runtimeOnlyCheck(true, RELOAD_ELEMENT, INDEPENDENT_ELEMENT);
+                runtimeCheck(false, RELOAD_ELEMENT, INDEPENDENT_ELEMENT, CHILD_ELEMENT);
+                runtimeOnlyCheck(true, RELOAD_ELEMENT, INDEPENDENT_ELEMENT, CHILD_ELEMENT);
+            }  finally {
+                //noinspection ThrowFromFinallyBlock
+                remove(RELOAD_ELEMENT, INDEPENDENT_ELEMENT);
+            }
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            remove(RELOAD_ELEMENT);
+        }
+    }
+
+    // Check that subsystem=reload requiring reload doesn't prevent runtime execution of
+    // subsystem=reload/unincorporated=test, since it is not incorporated by the parent resource cap
+    @Test
+    public void testUnincorporatedChildResourceReload() throws OperationFailedException {
+        add(RELOAD_ELEMENT);
+        try {
+            requireReload(RELOAD_ELEMENT);
+            runtimeCheck(false, RELOAD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT);
+            runtimeCheck(true, RELOAD_ELEMENT, UNINCORPORATED_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT, UNINCORPORATED_ELEMENT);
+            runtimeCheck(true, RELOAD_ELEMENT, UNINCORPORATED_ELEMENT, CHILD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT, UNINCORPORATED_ELEMENT, CHILD_ELEMENT);
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            remove(RELOAD_ELEMENT);
+        }
+    }
+
+    // Check that subsystem=reload requiring reload doesn't prevent runtime execution of
+    // subsystem=reload/child=test/unincorporated=test, since it is not incorporated by
+    // the grandparent resource cap. Also test subsystem=reload/child=test/unincorporated=test/infant=test
+    // to verify that its unincorporated parent stops checks further up the chain
+    @Test
+    public void testUnincorporatedGranchildResourceReload() throws OperationFailedException {
+        add(RELOAD_ELEMENT);
+        try {
+            requireReload(RELOAD_ELEMENT);
+            runtimeCheck(false, RELOAD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT);
+            runtimeCheck(true, RELOAD_ELEMENT, CHILD_ELEMENT, UNINCORPORATED_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT, CHILD_ELEMENT, UNINCORPORATED_ELEMENT);
+            runtimeCheck(true, RELOAD_ELEMENT, CHILD_ELEMENT, UNINCORPORATED_ELEMENT, INFANT_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT, CHILD_ELEMENT, UNINCORPORATED_ELEMENT, INFANT_ELEMENT);
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            remove(RELOAD_ELEMENT);
+        }
+
+    }
+
+    // Check that root resource requiring reload doesn't prevent runtime execution of
+    // /child=test, since root resource capabilities don't block children
+    @Test
+    public void testRootExclusion() throws OperationFailedException {
+        executeCheckNoFailure(Util.createEmptyOperation("root-cap", PathAddress.EMPTY_ADDRESS));
+        try {
+            requireReload();
+            runtimeCheck(false);
+            runtimeOnlyCheck(true);
+            runtimeCheck(true, CHILD_ELEMENT);
+            runtimeOnlyCheck(true, CHILD_ELEMENT);
+            runtimeCheck(true, RELOAD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT);
+            // Now add the reload subsystem so its capability is registered
+            add(RELOAD_ELEMENT);
+            try {
+                runtimeCheck(true, RELOAD_ELEMENT);
+                runtimeOnlyCheck(true, RELOAD_ELEMENT);
+                // Now trigger reload-required from the reload subsystem
+                requireReload(RELOAD_ELEMENT);
+                runtimeCheck(false, RELOAD_ELEMENT);
+                runtimeOnlyCheck(true, RELOAD_ELEMENT);
+            } finally {
+                //noinspection ThrowFromFinallyBlock
+                remove(RELOAD_ELEMENT);
+            }
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            executeCheckNoFailure(Util.createEmptyOperation("no-root-cap", PathAddress.EMPTY_ADDRESS));
+        }
+    }
+
+    // Check that /host=test resource requiring reload doesn't prevent runtime execution of
+    // /host=test/child=test, since host root resource capabilities don't block children
+    @Test
+    public void testHostRootExclusion() throws OperationFailedException {
+        add(HOST_ELEMENT);
+        try {
+            requireReload(HOST_ELEMENT);
+            runtimeCheck(false, HOST_ELEMENT);
+            runtimeOnlyCheck(true, HOST_ELEMENT);
+            runtimeCheck(true, HOST_ELEMENT, CHILD_ELEMENT);
+            runtimeOnlyCheck(true, HOST_ELEMENT, CHILD_ELEMENT);
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            remove(HOST_ELEMENT);
+        }
+    }
+
+    // Check that /profile=test resource requiring reload doesn't prevent runtime execution of
+    // /profile=test/subsystem=no-cap, since kernel resource capabilities don't block subsystems
+    @Test
+    public void testProfileExclusion() throws OperationFailedException {
+        add(PROFILE_ELEMENT);
+        try {
+            requireReload(PROFILE_ELEMENT);
+            runtimeCheck(false, PROFILE_ELEMENT);
+            runtimeOnlyCheck(true, PROFILE_ELEMENT);
+            runtimeCheck(true, PROFILE_ELEMENT, NO_CAP_ELEMENT);
+            runtimeOnlyCheck(true, PROFILE_ELEMENT, NO_CAP_ELEMENT);
+            runtimeCheck(true, PROFILE_ELEMENT, NO_CAP_ELEMENT, CHILD_ELEMENT);
+            runtimeOnlyCheck(true, PROFILE_ELEMENT, NO_CAP_ELEMENT, CHILD_ELEMENT);
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            remove(PROFILE_ELEMENT);
+        }
+    }
+
+    // Transitive dependency check
+    // Check that subsystem=dep-cap requires reload once the root resource "root-cap"
+    // does, because the subsystem=dep-cap's capability requires root-cap.
+    @Test
+    public void testDependentCapabilities() throws OperationFailedException {
+
+        executeCheckNoFailure(Util.createEmptyOperation("root-cap", PathAddress.EMPTY_ADDRESS));
+        try {
+            add(DEP_CAP_ELEMENT);
+            try {
+                add(DEP_CAP_ELEMENT, CHILD_ELEMENT);
+                try {
+                    runtimeCheck(true, DEP_CAP_ELEMENT);
+                    runtimeOnlyCheck(true, DEP_CAP_ELEMENT);
+                    runtimeCheck(true, DEP_CAP_ELEMENT, CHILD_ELEMENT);
+                    runtimeOnlyCheck(true, DEP_CAP_ELEMENT, CHILD_ELEMENT);
+                    requireReload();
+                    runtimeCheck(false, DEP_CAP_ELEMENT);
+                    runtimeOnlyCheck(true, DEP_CAP_ELEMENT);
+                    runtimeCheck(false, DEP_CAP_ELEMENT, CHILD_ELEMENT);
+                    runtimeOnlyCheck(true, DEP_CAP_ELEMENT, CHILD_ELEMENT);
+                } finally {
+                    //noinspection ThrowFromFinallyBlock
+                    remove(DEP_CAP_ELEMENT, CHILD_ELEMENT);
+                }
+            } finally {
+                //noinspection ThrowFromFinallyBlock
+                remove(DEP_CAP_ELEMENT);
+            }
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            executeCheckNoFailure(Util.createEmptyOperation("no-root-cap", PathAddress.EMPTY_ADDRESS));
+        }
+    }
+
+    @Test
+    public void testClear() throws OperationFailedException, InterruptedException {
+        add(RELOAD_ELEMENT);
+        try {
+            requireReload(RELOAD_ELEMENT);
+            runtimeCheck(false, RELOAD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT);
+
+            // Do a mock reload
+            CountDownLatch latch = new CountDownLatch(1);
+            ServiceController<?> svc = container.getRequiredService(ServiceName.of("ModelController"));
+            svc.addListener(new AbstractServiceListener<Object>(){
+
+                @Override
+                public void listenerAdded(ServiceController<?> controller) {
+                    controller.setMode(ServiceController.Mode.NEVER);
+                }
+
+                @Override
+                public void transition(ServiceController<?> controller, ServiceController.Transition transition) {
+                    if (transition == ServiceController.Transition.STOPPING_to_DOWN) {
+                        controller.setMode(ServiceController.Mode.ACTIVE);
+                    } else if (transition == ServiceController.Transition.STARTING_to_UP) {
+                        controller.removeListener(this);
+                        latch.countDown();
+                    }
+                }
+            });
+            Assert.assertTrue("Failed to reload", latch.await(30, TimeUnit.SECONDS));
+
+            Assert.assertEquals(0, capabilityRegistry.getCapabilities().size());
+            Assert.assertEquals(0, capabilityRegistry.getPossibleCapabilities().size());
+            runtimeCheck(true, RELOAD_ELEMENT);
+            runtimeOnlyCheck(true, RELOAD_ELEMENT);
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            remove(RELOAD_ELEMENT);
+        }
+    }
+
+    private void add(PathElement... address) throws OperationFailedException {
+        executeCheckNoFailure(Util.createEmptyOperation("add", PathAddress.pathAddress(address)));
+    }
+    private void remove(PathElement... address) throws OperationFailedException {
+        executeCheckNoFailure(Util.createEmptyOperation("remove", PathAddress.pathAddress(address)));
+    }
+
+    private void requireReload(PathElement... elements) throws OperationFailedException {
+        PathAddress address = PathAddress.pathAddress(elements);
+        executeCheckNoFailure(Util.createEmptyOperation(RELOAD_DEFINITION.getName(), address));
+    }
+
+    private void runtimeCheck(boolean expectResult, PathElement... elements) throws OperationFailedException {
+        runtimeCheck(false, expectResult, elements);
+    }
+
+    private void runtimeOnlyCheck(boolean expectResult, PathElement... elements) throws OperationFailedException {
+        runtimeCheck(true, expectResult, elements);
+    }
+
+    private void runtimeCheck(boolean runtimeOnly, boolean expectResult, PathElement... elements) throws OperationFailedException {
+        OperationDefinition opDef = runtimeOnly ? RUNTIME_ONLY_DEFINITION : RUNTIME_MOD_DEFINITION;
+        PathAddress address = PathAddress.pathAddress(elements);
+        ModelNode op = Util.createEmptyOperation(opDef.getName(), address);
+        ModelNode result = executeForResult(op);
+        if (expectResult) {
+            Assert.assertTrue(result.toString(), result.isDefined());
+            Assert.assertTrue(result.toString(), result.asBoolean());
+        } else {
+            Assert.assertFalse(result.toString(), result.isDefined());
+        }
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
@@ -244,7 +244,15 @@ public class OperationTimeoutUnitTestCase {
     }
 
     public static class BlockingServiceHandler implements OperationStepHandler {
-        static final SimpleOperationDefinition DEFINITION = new SimpleOperationDefinition("block", new NonResolvingResourceDescriptionResolver());
+        static final SimpleOperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("block", new NonResolvingResourceDescriptionResolver())
+                // this isn't really runtime-only but we lie and say it is to let
+                // testBlockAwaitingRuntimeLock() work. That test relies on first
+                // messing up MSC in order to how the next op that blocks waiting
+                // for MSC stability reacts, but messing up MSC also puts the process
+                // in restart-required. If this op isn't "runtime-only" the controller
+                // won't let it run then.
+                .setRuntimeOnly()
+                .build();
         @Override
         public void execute(OperationContext context, ModelNode operation) {
 

--- a/controller/src/test/java/org/jboss/as/controller/access/management/AuthorizedAddressTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/management/AuthorizedAddressTest.java
@@ -32,6 +32,7 @@ import java.io.InputStream;
 import java.util.Set;
 
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -146,6 +147,16 @@ public class AuthorizedAddressTest {
 
         @Override
         public void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, Stage stage, boolean addFirst) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void addModelStep(OperationDefinition stepDefinition, OperationStepHandler stepHandler, boolean addFirst) throws IllegalArgumentException {
+            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        }
+
+        @Override
+        public void addModelStep(ModelNode response, ModelNode operation, OperationDefinition stepDefinition, OperationStepHandler stepHandler, boolean addFirst) throws IllegalArgumentException {
             throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         }
 

--- a/controller/src/test/java/org/jboss/as/controller/registry/ProxyControllerRegistrationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/registry/ProxyControllerRegistrationUnitTestCase.java
@@ -1,0 +1,82 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.controller.registry;
+
+import org.jboss.as.controller.BlockingTimeout;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProxyController;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.client.OperationAttachments;
+import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests of behavior of a ManagementResourceRegistration for a proxied resource.
+ *
+ * @author Brian Stansberry
+ */
+public class ProxyControllerRegistrationUnitTestCase {
+
+    private static final PathElement PROXY_ELEMENT = PathElement.pathElement("proxy", "a");
+    private static final PathAddress LAST_ADDRESS = PathAddress.EMPTY_ADDRESS.append(PROXY_ELEMENT).append("child", "one").append("grandchild", "z");
+
+    private ManagementResourceRegistration root;
+    private ProxyController proxyController;
+
+    @Before
+    public void setup() {
+        root = ManagementResourceRegistration.Factory.create(new SimpleResourceDefinition(null, new NonResolvingResourceDescriptionResolver()));
+        proxyController = new ProxyController() {
+            @Override
+            public PathAddress getProxyNodeAddress() {
+                return PathAddress.pathAddress(PROXY_ELEMENT);
+            }
+
+            @Override
+            public void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control, OperationAttachments attachments, BlockingTimeout blockingTimeout) {
+                throw new UnsupportedOperationException();
+            }
+        };
+        root.registerProxyController(PROXY_ELEMENT, proxyController);
+    }
+
+    @Test
+    public void testAddressesAndParents() {
+        PathAddress address = LAST_ADDRESS;
+        ImmutableManagementResourceRegistration mrr = root.getSubModel(address);
+        while (address != null) {
+            if (address.size() > 0) {
+                Assert.assertEquals(LAST_ADDRESS.subAddress(0, address.size()), mrr.getPathAddress());
+                Assert.assertTrue(mrr.isRemote());
+                Assert.assertEquals(proxyController, mrr.getProxyController(PathAddress.EMPTY_ADDRESS));
+                Assert.assertEquals(proxyController, root.getProxyController(address));
+                address = address.getParent();
+                mrr = mrr.getParent();
+            } else {
+                Assert.assertEquals(PathAddress.EMPTY_ADDRESS, mrr.getPathAddress());
+                Assert.assertEquals(root, mrr);
+                // break the loop
+                address = null;
+            }
+        }
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
@@ -73,7 +73,7 @@ public abstract class AbstractControllerTestBase {
 
     protected abstract void initModel(ManagementModel managementModel);
 
-    private ServiceContainer container;
+    protected ServiceContainer container;
     protected ModelController controller;
     protected final ProcessType processType;
     protected CapabilityRegistry capabilityRegistry;

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelActiveOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelActiveOperationHandler.java
@@ -59,6 +59,7 @@ public class CancelActiveOperationHandler implements OperationStepHandler {
             DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS, ACTIVE_OPERATION))
             .setReplyType(ModelType.BOOLEAN)
             .withFlag(OperationEntry.Flag.HOST_CONTROLLER_ONLY)
+            .setRuntimeOnly()
             .build();
 
     static final OperationStepHandler INSTANCE = new CancelActiveOperationHandler();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelNonProgressingOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelNonProgressingOperationHandler.java
@@ -67,6 +67,7 @@ public class CancelNonProgressingOperationHandler implements OperationStepHandle
             DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS))
             .setReplyType(ModelType.STRING)
             .withFlag(OperationEntry.Flag.HOST_CONTROLLER_ONLY)
+            .setRuntimeOnly()
             .build();
 
     static final OperationStepHandler INSTANCE = new CancelNonProgressingOperationHandler();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationSlaveStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationSlaveStepHandler.java
@@ -158,7 +158,7 @@ class OperationSlaveStepHandler {
         final OperationEntry entry = context.getRootResourceRegistration().getOperationEntry(PathAddress.pathAddress(operation.get(OP_ADDR)), operationName);
         if(entry != null) {
             if (context.isBooting() || localHostControllerInfo.isMasterDomainController()) {
-                context.addStep(localReponse, operation, entry.getOperationHandler(), OperationContext.Stage.MODEL);
+                context.addModelStep(localReponse, operation, entry.getOperationDefinition(), entry.getOperationHandler(), false);
             } else {
                 final OperationStepHandler wrapper;
                 // For slave host controllers wrap the operation handler to synchronize missing configuration
@@ -169,7 +169,7 @@ class OperationSlaveStepHandler {
                 } else {
                     wrapper = entry.getOperationHandler();
                 }
-                context.addStep(localReponse, operation, wrapper, OperationContext.Stage.MODEL);
+                context.addModelStep(localReponse, operation, entry.getOperationDefinition(), wrapper, false);
             }
         } else {
             throw new OperationFailedException(ControllerLogger.ROOT_LOGGER.noHandlerForOperation(operationName, PathAddress.pathAddress(operation.get(OP_ADDR))));

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/PrepareStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/PrepareStepHandler.java
@@ -42,6 +42,7 @@ import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.host.controller.ignored.IgnoredDomainResourceRegistry;
 import org.jboss.dmr.ModelNode;
@@ -121,9 +122,9 @@ public class PrepareStepHandler  implements OperationStepHandler {
         final String operationName =  operation.require(OP).asString();
 
         final ImmutableManagementResourceRegistration registration = context.getResourceRegistration();
-        final OperationStepHandler stepHandler = context.getRootResourceRegistration().getOperationHandler(PathAddress.pathAddress(operation.get(OP_ADDR)), operationName);
-        if (stepHandler != null) {
-            context.addStep(stepHandler, OperationContext.Stage.MODEL);
+        final OperationEntry stepEntry = context.getRootResourceRegistration().getOperationEntry(PathAddress.pathAddress(operation.get(OP_ADDR)), operationName);
+        if (stepEntry != null) {
+            context.addModelStep(stepEntry.getOperationDefinition(), stepEntry.getOperationHandler(), false);
         } else {
             PathAddress pathAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
             if (! context.isBooting()) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -322,7 +322,7 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
         coreMgmt.registerSubModel(new HostConnectionResourceDefinition(hostRegistrations));
 
         resourceRegistration.registerSubModel(new ProfileResourceDefinition(hostControllerInfo, ignoredDomainResourceRegistry));
-        resourceRegistration.registerSubModel(PathResourceDefinition.createNamed(pathManager));
+        resourceRegistration.registerSubModel(PathResourceDefinition.createNamed());
         ResourceDefinition domainDeploymentDefinition = isMaster
                 ? DomainDeploymentResourceDefinition.createForDomainMaster(contentRepo)
                 : DomainDeploymentResourceDefinition.createForDomainSlave(environment.isBackupDomainFiles(), fileRepository, contentRepo);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -238,7 +238,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
                                                             final HostRunningModeControl runningModeControl,
                                                             final ControlledProcessState processState,
                                                             final BootstrapListener bootstrapListener,
-                                                            final PathManagerService pathManager){
+                                                            final PathManagerService pathManager,
+                                                            final CapabilityRegistry capabilityRegistry) {
         final ConcurrentMap<String, ProxyController> hostProxies = new ConcurrentHashMap<String, ProxyController>();
         final Map<String, ProxyController> serverProxies = new ConcurrentHashMap<String, ProxyController>();
         final LocalHostControllerInfoImpl hostControllerInfo = new LocalHostControllerInfoImpl(processState, environment);
@@ -252,7 +253,6 @@ public class DomainModelControllerService extends AbstractControllerService impl
         final ProcessType processType = environment.getProcessType();
         final ExtensionRegistry hostExtensionRegistry = new ExtensionRegistry(processType, runningModeControl, auditLogger, authorizer, hostControllerInfoAccessor);
         final ExtensionRegistry extensionRegistry = new ExtensionRegistry(processType, runningModeControl, auditLogger, authorizer, hostControllerInfoAccessor);
-        final CapabilityRegistry capabilityRegistry = new CapabilityRegistry(processType.isServer());
         final PrepareStepHandler prepareStepHandler = new PrepareStepHandler(hostControllerInfo,
                 hostProxies, serverProxies, ignoredRegistry, extensionRegistry);
         final ExpressionResolver expressionResolver = new RuntimeExpressionResolver(vaultReader);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import org.jboss.as.controller.CapabilityRegistry;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.remoting.HttpListenerRegistryService;
@@ -88,6 +89,7 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
     private final HostRunningModeControl runningModeControl;
     private final ControlledProcessState processState;
     private final String authCode;
+    private final CapabilityRegistry capabilityRegistry;
     private volatile FutureServiceContainer futureContainer;
     private volatile long startTime;
 
@@ -99,6 +101,7 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
         this.processState = processState;
         this.startTime = environment.getStartTime();
         this.futureContainer = futureContainer;
+        this.capabilityRegistry = new CapabilityRegistry(false);
     }
 
     public HostControllerService(final HostControllerEnvironment environment, final HostRunningModeControl runningModeControl,
@@ -188,7 +191,8 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
         serviceTarget.addService(Services.JBOSS_PRODUCT_CONFIG_SERVICE, new ValueService<ProductConfig>(productConfigValue))
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
-        DomainModelControllerService.addService(serviceTarget, environment, runningModeControl, processState, bootstrapListener, hostPathManagerService);
+        DomainModelControllerService.addService(serviceTarget, environment, runningModeControl, processState,
+                bootstrapListener, hostPathManagerService, capabilityRegistry);
         ContentCleanerService.addServiceOnHostController(serviceTarget, DomainModelControllerService.SERVICE_NAME, HC_EXECUTOR_SERVICE_NAME, HC_SCHEDULED_EXECUTOR_SERVICE_NAME);
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -435,6 +435,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
         final ManagementResourceRegistration jvms = hostRegistration.registerSubModel(JvmResourceDefinition.GLOBAL);
 
         //Paths
+        // TODO why resolvable?
         hostRegistration.registerSubModel(PathResourceDefinition.createResolvableSpecified(pathManager));
 
         //interface

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
@@ -196,7 +196,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
 
         //server paths
-        resourceRegistration.registerSubModel(PathResourceDefinition.createSpecifiedNoServices(pathManager));
+        resourceRegistration.registerSubModel(PathResourceDefinition.createSpecifiedNoServices());
 
         resourceRegistration.registerSubModel(new InterfaceResourceDefinition(
                 SpecifiedInterfaceAddHandler.INSTANCE,

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -287,6 +287,16 @@ public abstract class AbstractOperationTestCase {
         }
 
         @Override
+        public void addModelStep(OperationDefinition stepDefinition, OperationStepHandler stepHandler, boolean addFirst) throws IllegalArgumentException {
+            addStep(stepHandler, Stage.MODEL);
+        }
+
+        @Override
+        public void addModelStep(ModelNode response, ModelNode operation, OperationDefinition stepDefinition, OperationStepHandler stepHandler, boolean addFirst) throws IllegalArgumentException {
+            addStep(operation, stepHandler, Stage.MODEL);
+        }
+
+        @Override
         public PathAddress getCurrentAddress() {
             return operationAddress;
         }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -889,6 +889,11 @@ public abstract class AbstractOperationTestCase {
         }
 
         @Override
+        public void registerIncorporatingCapabilities(Set<RuntimeCapability> capabilities) {
+
+        }
+
+        @Override
         public void registerOperationHandler(OperationDefinition definition, OperationStepHandler handler) {
 
         }
@@ -968,6 +973,11 @@ public abstract class AbstractOperationTestCase {
         }
 
         @Override
+        public ImmutableManagementResourceRegistration getParent() {
+            return null;
+        }
+
+        @Override
         public boolean isRuntimeOnly() {
             return false;
         }
@@ -980,6 +990,11 @@ public abstract class AbstractOperationTestCase {
         @Override
         public Set<RuntimeCapability> getCapabilities() {
             return Collections.emptySet();
+        }
+
+        @Override
+        public Set<RuntimeCapability> getIncorporatingCapabilities() {
+            return null;
         }
 
         @Override

--- a/logging/src/test/java/org/jboss/as/logging/HandlerLegacyOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/HandlerLegacyOperationsTestCase.java
@@ -53,9 +53,6 @@ public class HandlerLegacyOperationsTestCase extends AbstractOperationsTestCase 
     public void testOperations() throws Exception {
         final KernelServices kernelServices = boot();
 
-        testAsyncHandler(kernelServices, null);
-        testAsyncHandler(kernelServices, PROFILE);
-
         testConsoleHandler(kernelServices, null);
         testConsoleHandler(kernelServices, PROFILE);
 
@@ -67,6 +64,11 @@ public class HandlerLegacyOperationsTestCase extends AbstractOperationsTestCase 
 
         testSizeRotatingFileHandler(kernelServices, null);
         testPeriodicRotatingFileHandler(kernelServices, PROFILE);
+
+        // Run these last as they put the server in reload-required, and the later
+        // ones will not update runtime once that is done
+        testAsyncHandler(kernelServices, null);
+        testAsyncHandler(kernelServices, PROFILE);
     }
 
     private void testAsyncHandler(final KernelServices kernelServices, final String profileName) throws Exception {

--- a/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
@@ -68,9 +68,6 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
     public void testOperations() throws Exception {
         final KernelServices kernelServices = boot();
 
-        testAsyncHandler(kernelServices, null);
-        testAsyncHandler(kernelServices, PROFILE);
-
         testConsoleHandler(kernelServices, null);
         testConsoleHandler(kernelServices, PROFILE);
 
@@ -85,6 +82,11 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
 
         testSizeRotatingFileHandler(kernelServices, null);
         testSizeRotatingFileHandler(kernelServices, PROFILE);
+
+        // Run these last as they put the server in reload-required, and the later
+        // ones will not update runtime once that is done
+        testAsyncHandler(kernelServices, null);
+        testAsyncHandler(kernelServices, PROFILE);
     }
 
     @Test

--- a/server/src/main/java/org/jboss/as/server/BootstrapImpl.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapImpl.java
@@ -259,6 +259,7 @@ final class BootstrapImpl implements Bootstrap {
                             latch.await();
                             break;
                         } catch (InterruptedException e) {
+                            // ignored
                         }
                     }
                 }

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -455,6 +455,7 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
         PlatformMBeanResourceRegistrar.registerPlatformMBeanResources(resourceRegistration);
 
         // Paths
+        // TODO why not resolvable?
         resourceRegistration.registerSubModel(PathResourceDefinition.createSpecified(pathManager));
 
         //capability registry

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -942,6 +942,11 @@ final class SubsystemTestDelegate {
         }
 
         @Override
+        public ImmutableManagementResourceRegistration getParent() {
+            return null;
+        }
+
+        @Override
         public boolean isRuntimeOnly() {
             return false;
         }
@@ -1084,8 +1089,18 @@ final class SubsystemTestDelegate {
         }
 
         @Override
+        public void registerIncorporatingCapabilities(Set<RuntimeCapability> capabilities) {
+
+        }
+
+        @Override
         public Set<RuntimeCapability> getCapabilities() {
             return Collections.emptySet();
+        }
+
+        @Override
+        public Set<RuntimeCapability> getIncorporatingCapabilities() {
+            return null;
         }
 
         @Override

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CapabilityReloadRequiredUnitTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CapabilityReloadRequiredUnitTestCase.java
@@ -1,0 +1,297 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INET_ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOOPBACK;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_REQUIRES_RELOAD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_REF;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOURCE_PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.management.extension.ExtensionUtils;
+import org.jboss.as.test.integration.management.extension.dependent.DependentExtension;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test of WFCORE-1106 behavior.
+ *
+ * @author Brian Stansberry
+ */
+public class CapabilityReloadRequiredUnitTestCase {
+
+    private static final String WFCORE1106 = "WFCORE-1106";
+
+    private static final String WFCORE1106_OSB = WFCORE1106 + "-osb";
+
+    private static final String WFCORE1106_OSB2 = WFCORE1106_OSB + "-2";
+    private static final PathAddress EXT = PathAddress.pathAddress(EXTENSION, WFCORE1106);
+    private static final PathAddress IFACE = PathAddress.pathAddress(INTERFACE, WFCORE1106);
+    private static final PathAddress SB = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "other-sockets").append(SOCKET_BINDING, WFCORE1106);
+    private static final PathAddress OSB = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "other-sockets").append(LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING, WFCORE1106_OSB);
+    private static final PathAddress OSB_2 = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "other-sockets").append(LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING, WFCORE1106_OSB2);
+    private static final PathAddress SUB = PathAddress.pathAddress(PROFILE, "other").append(SUBSYSTEM, DependentExtension.SUBSYSTEM_NAME);
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainMasterLifecycleUtil;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        ExtensionUtils.createExtensionModule(WFCORE1106, DependentExtension.class);
+        testSupport = DomainTestSuite.createSupport(CapabilityReloadRequiredUnitTestCase.class.getSimpleName());
+        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        try {
+            testSupport = null;
+            domainMasterLifecycleUtil = null;
+            DomainTestSuite.stopSupport();
+        } finally {
+            ExtensionUtils.deleteExtensionModule(WFCORE1106);
+        }
+    }
+
+    @Before
+    public void setup() throws IOException {
+
+        ModelNode addOp = Util.createAddOperation(IFACE);
+        addOp.get(LOOPBACK).set(true);
+        executeOp(addOp);
+
+        addOp = Util.createAddOperation(SB);
+        addOp.get(INTERFACE).set(WFCORE1106);
+        addOp.get(PORT).set(12345);
+        executeOp(addOp);
+
+        addOp = Util.createAddOperation(OSB);
+        addOp.get(SOCKET_BINDING_REF).set(WFCORE1106);
+        executeOp(addOp);
+
+        addOp = Util.createAddOperation(OSB_2);
+        addOp.get(SOCKET_BINDING_REF).set(WFCORE1106);
+        executeOp(addOp);
+
+        addOp = Util.createAddOperation(EXT);
+        executeOp(addOp);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+
+        IOException ioe = null;
+        AssertionError ae = null;
+        RuntimeException re = null;
+
+        PathAddress[] cleanUp = {SUB, EXT, OSB, OSB_2, SB};
+        for (int i = 0; i < cleanUp.length; i++) {
+            try {
+                executeOp(Util.createRemoveOperation(cleanUp[i]));
+            } catch (IOException e) {
+                if (ioe == null) {
+                    ioe = e;
+                }
+            } catch (AssertionError e) {
+                if (i > 0 && i < cleanUp.length - 1 && ae == null) {
+                    ae = e;
+                } // else ignore because in a failed test SUB may not exist, causing remove to fail
+                  // and because removing the interface will definitely fail
+            } catch (RuntimeException e) {
+                if (re == null) {
+                    re = e;
+                }
+            }
+        }
+
+        try {
+            ModelNode op = Util.createEmptyOperation(RELOAD_SERVERS, PathAddress.pathAddress(SERVER_GROUP, "other-server-group"));
+            op.get(BLOCKING).set(true);
+            executeOp(op);
+        } catch (IOException e) {
+            if (ioe == null) {
+                ioe = e;
+            }
+        } catch (AssertionError e) {
+            if (ae == null) {
+                ae = e;
+            }
+        } catch (RuntimeException e) {
+            if (re == null) {
+                re = e;
+            }
+        }
+
+        try {
+            executeOp(Util.createRemoveOperation(IFACE));
+        } catch (IOException e) {
+            if (ioe == null) {
+                ioe = e;
+            }
+        } catch (AssertionError e) {
+            if (ae == null) {
+                ae = e;
+            }
+        } catch (RuntimeException e) {
+            if (re == null) {
+                re = e;
+            }
+        }
+
+        if (ioe != null) {
+            throw ioe;
+        }
+
+        if (ae != null) {
+            throw ae;
+        }
+
+        if (re != null) {
+            throw re;
+        }
+    }
+
+    @Test
+    public void testCapabilityReloadEffects() throws IOException {
+        // Change the interface to put its capability into r-r
+        ModelNode op = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+        ModelNode steps = op.get(STEPS);
+        steps.add(Util.getUndefineAttributeOperation(IFACE, LOOPBACK));
+        steps.add(Util.getWriteAttributeOperation(IFACE, INET_ADDRESS, "${jboss.bind.address:127.0.0.1}"));
+        assertStepRequiresReload(op, "main-server-group", "other-server-group");
+
+        // Add the loc -- should get a restart-required header
+        op = Util.createAddOperation(SUB);
+        op.get("osb").set(WFCORE1106_OSB);
+        assertStepRequiresReload(op);
+
+        // reload
+        op = Util.createEmptyOperation(RELOAD_SERVERS, PathAddress.pathAddress(SERVER_GROUP, "other-server-group"));
+        op.get(BLOCKING).set(true);
+        executeOp(op);
+
+        // Change the l-o-c -- should *not* get a restart-required header
+        op = Util.getWriteAttributeOperation(SUB, "osb", WFCORE1106_OSB2);
+
+        assertStepDoesNotRequireReload(op);
+
+        // Change the o-s-b to put its capability into r-r
+
+        op = Util.getWriteAttributeOperation(OSB, SOURCE_PORT, 54321);
+        assertStepRequiresReload(op);
+
+        // Change the l-o-c -- should get a restart-required header
+        op = Util.getWriteAttributeOperation(SUB, "osb", WFCORE1106_OSB);
+        assertStepRequiresReload(op);
+
+        // Remove the subsystem and osb
+        op = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+        steps = op.get(STEPS);
+        steps.add(Util.createRemoveOperation(SUB));
+        steps.add(Util.createRemoveOperation(OSB));
+        assertStepRequiresReload(op);
+
+        // Re-add  -- should still get a restart-required header on SUB
+        // because removing the o-s-b capability doesn't flush the need to reload
+        // We also get a r-r header on the o-s-b add
+        op = Util.createAddOperation(OSB);
+        op.get(SOCKET_BINDING_REF).set(WFCORE1106);
+        assertStepRequiresReload(op);
+        op = Util.createAddOperation(SUB);
+        op.get("osb").set(WFCORE1106_OSB);
+        assertStepRequiresReload(op);
+
+    }
+
+    private void assertStepRequiresReload(ModelNode op) throws IOException {
+        assertRequiresReload(op, true, "other-server-group");
+    }
+
+    private void assertStepRequiresReload(ModelNode op, String... serverGroups) throws IOException {
+        assertRequiresReload(op, true, serverGroups);
+    }
+
+    private void assertStepDoesNotRequireReload(ModelNode op) throws IOException {
+        assertRequiresReload(op, false, "other-server-group");
+    }
+
+    private void assertRequiresReload(ModelNode op, boolean expectRequires, String... serverGroups) throws IOException {
+        ModelNode origResp = executeOp(op);
+        for (String sg : serverGroups) {
+            for (Property prop : origResp.get(SERVER_GROUPS, sg, HOST).asPropertyList()) {
+                String host = prop.getName();
+                for (Property prop2 : prop.getValue().asPropertyList()) {
+                    String server = prop2.getName();
+                    ModelNode response = prop2.getValue().get(RESPONSE);
+                    // Hack for composites
+                    if (COMPOSITE.equals(op.get(OP).asString())) {
+                        response = response.get(RESULT, "step-1");
+                    }
+                    String target = " " + sg + "/" + host + "/" + server;
+                    if (expectRequires) {
+                        assertTrue(origResp.toString() + target, response.hasDefined(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD));
+                        assertTrue(origResp.toString() + target, response.get(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD).asBoolean());
+                    } else {
+                        assertFalse(origResp.toString() + target, response.hasDefined(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD));
+                    }
+                }
+            }
+        }
+    }
+
+    private ModelNode executeOp(ModelNode op) throws IOException {
+        ModelNode response = domainMasterLifecycleUtil.getDomainClient().execute(op);
+        assertTrue(response.toString(), response.hasDefined(OUTCOME));
+        assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        return response;
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -38,6 +38,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses ({
         AuditLogTestCase.class,
         IgnoredResourcesProfileCloneTestCase.class,
+        CapabilityReloadRequiredUnitTestCase.class,
         CompositeOperationTestCase.class,
         CoreResourceManagementTestCase.class,
         DeploymentRolloutFailureTestCase.class,

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/DependentExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/DependentExtension.java
@@ -1,0 +1,55 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2011, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.test.integration.management.extension.dependent;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
+/**
+ * @author Brian Stansberry
+ */
+public class DependentExtension implements Extension {
+
+    public static final String SUBSYSTEM_NAME = "dependent-extension";
+
+    static final String NAMESPACE = "urn:jboss:domain:dependent-extension:1.0";
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        System.out.println("Initializing DependentExtension");
+        SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
+        ManagementResourceRegistration subsystem = registration.registerSubsystemModel(RootResourceDefinition.INSTANCE);
+        subsystem.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE, false);
+        registration.registerXMLElementWriter(SubsystemParser.INSTANCE);
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE, SubsystemParser.INSTANCE);
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/RootResourceDefinition.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/RootResourceDefinition.java
@@ -1,0 +1,117 @@
+/*
+ *
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2014, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * /
+ */
+
+package org.jboss.as.test.integration.management.extension.dependent;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractWriteAttributeHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.ServiceRemoveStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.network.OutboundSocketBinding;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.AbstractService;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+
+/**
+ * @author Brian Stansberry (c) 2016 Red Hat Inc.
+ */
+public class RootResourceDefinition extends PersistentResourceDefinition {
+    private static final String RUNTIME_CAPABILITY_NAME = "org.wildfly.test.dependent";
+
+    private static final RuntimeCapability<Void> RUNTIME_CAPABILITY =
+            RuntimeCapability.Builder.of(RUNTIME_CAPABILITY_NAME, false, Integer.class).build();
+
+    static final SimpleAttributeDefinition ATTRIBUTE = new SimpleAttributeDefinitionBuilder("osb", ModelType.STRING)
+            .setCapabilityReference("org.wildfly.network.outbound-socket-binding", RUNTIME_CAPABILITY)
+            .build();
+
+    static final PersistentResourceDefinition INSTANCE = new RootResourceDefinition();
+
+    private RootResourceDefinition() {
+        super(new Parameters(PathElement.pathElement(SUBSYSTEM, DependentExtension.SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver())
+                .setAddHandler(AddSubsystemHandler.INSTANCE)
+                .setRemoveHandler(new ServiceRemoveStepHandler(AddSubsystemHandler.INSTANCE, RUNTIME_CAPABILITY))
+                .setCapabilities(RUNTIME_CAPABILITY));
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        OperationStepHandler write = new AbstractWriteAttributeHandler<Void>(ATTRIBUTE) {
+
+            @Override
+            protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder<Void> handbackHolder) throws OperationFailedException {
+                // no-op
+                return false;
+            }
+
+            @Override
+            protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode valueToRestore, ModelNode valueToRevert, Void handback) throws OperationFailedException {
+                // no-op
+            }
+        };
+        resourceRegistration.registerReadWriteAttribute(ATTRIBUTE, null, write);
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return Collections.singleton(ATTRIBUTE);
+    }
+
+    private static class AddSubsystemHandler extends AbstractAddStepHandler {
+
+        private static final AbstractAddStepHandler INSTANCE = new AddSubsystemHandler();
+
+        private AddSubsystemHandler()  {
+            super(ATTRIBUTE);
+        }
+
+        @Override
+        protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+            String osb = ATTRIBUTE.resolveModelAttribute(context, resource.getModel()).asString();
+            Service<Void> service = new AbstractService<Void>() {};
+            context.getServiceTarget().addService(ServiceName.of("wfcore-1106"), service)
+                    .addDependency(context.getCapabilityServiceName("org.wildfly.network.outbound-socket-binding", osb, OutboundSocketBinding.class))
+                    .install();
+
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/SubsystemParser.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/SubsystemParser.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.management.extension.dependent;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.PersistentResourceXMLParser;
+
+/**
+ * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
+ */
+class SubsystemParser extends PersistentResourceXMLParser {
+
+    static final SubsystemParser INSTANCE = new SubsystemParser();
+
+    private final PersistentResourceXMLDescription xmlDescription;
+
+    private SubsystemParser() {
+        xmlDescription = builder(RootResourceDefinition.INSTANCE, DependentExtension.NAMESPACE)
+                .addAttributes(RootResourceDefinition.ATTRIBUTE)
+                .build();
+    }
+
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+        return xmlDescription;
+    }
+}
+

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/dependent/module.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/dependent/module.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="WFCORE-1106">
+
+    <resources>
+        <resource-root path="test-extension.jar"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.as.network"/>
+        <module name="org.jboss.as.server" />
+        <module name="org.jboss.msc"/>
+        <module name="org.jboss.logging"/>
+    </dependencies>
+</module>

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/dependent/org.jboss.as.controller.Extension
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/dependent/org.jboss.as.controller.Extension
@@ -1,0 +1,1 @@
+org.jboss.as.test.integration.management.extension.dependent.DependentExtension

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
@@ -29,7 +29,9 @@ import org.jboss.logmanager.handlers.ConsoleHandler;
 import org.jboss.logmanager.handlers.QueueHandler;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
 import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.ServerSetupTask;
 import org.wildfly.core.testrunner.WildflyTestRunner;
 
 /**
@@ -98,5 +100,19 @@ public class CustomHandlerOperationsTestCase extends AbstractLoggingOperationsTe
             return createAddress("custom-handler", name);
         }
         return createAddress("logging-profile", profileName, "custom-handler", name);
+    }
+
+    static class CustomHandlerSetUp implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient) throws Exception {
+            //no-op
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient) throws Exception {
+            //TODO implement tearDown
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/CapabilityReloadRequiredUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/CapabilityReloadRequiredUnitTestCase.java
@@ -1,0 +1,235 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.wildfly.core.test.standalone.mgmt;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INET_ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOOPBACK;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_REQUIRES_RELOAD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_REF;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOURCE_PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.extension.ExtensionUtils;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jboss.as.test.integration.management.extension.dependent.DependentExtension;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Test of WFCORE-1106 behavior.
+ *
+ * @author Brian Stansberry
+ */
+@ServerSetup(ServerReload.SetupTask.class)
+@RunWith(WildflyTestRunner.class)
+public class CapabilityReloadRequiredUnitTestCase {
+
+    private static final String WFCORE1106 = "WFCORE-1106";
+
+    private static final String WFCORE1106_OSB = WFCORE1106 + "-osb";
+
+    private static final String WFCORE1106_OSB2 = WFCORE1106_OSB + "-2";
+    private static final PathAddress EXT = PathAddress.pathAddress(EXTENSION, WFCORE1106);
+    private static final PathAddress IFACE = PathAddress.pathAddress(INTERFACE, WFCORE1106);
+    private static final PathAddress SB = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "standard-sockets").append(SOCKET_BINDING, WFCORE1106);
+    private static final PathAddress OSB = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "standard-sockets").append(LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING, WFCORE1106_OSB);
+    private static final PathAddress OSB_2 = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "standard-sockets").append(LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING, WFCORE1106_OSB2);
+    private static final PathAddress SUB = PathAddress.pathAddress(SUBSYSTEM, DependentExtension.SUBSYSTEM_NAME);
+
+    @Inject
+    private static ManagementClient managementClient;
+
+    @Before
+    public void setup() throws IOException {
+        ExtensionUtils.createExtensionModule(WFCORE1106, DependentExtension.class);
+
+        ModelNode addOp = Util.createAddOperation(IFACE);
+        addOp.get(LOOPBACK).set(true);
+        executeOp(addOp);
+
+        addOp = Util.createAddOperation(SB);
+        addOp.get(INTERFACE).set(WFCORE1106);
+        addOp.get(PORT).set(12345);
+        executeOp(addOp);
+
+        addOp = Util.createAddOperation(OSB);
+        addOp.get(SOCKET_BINDING_REF).set(WFCORE1106);
+        executeOp(addOp);
+
+        addOp = Util.createAddOperation(OSB_2);
+        addOp.get(SOCKET_BINDING_REF).set(WFCORE1106);
+        executeOp(addOp);
+
+        addOp = Util.createAddOperation(EXT);
+        executeOp(addOp);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        try {
+            IOException ioe = null;
+            AssertionError ae = null;
+            RuntimeException re = null;
+
+            PathAddress[] cleanUp = {SUB, EXT, OSB, OSB_2, SB, IFACE};
+            for (int i = 0; i < cleanUp.length; i++) {
+                try {
+                    ModelNode op = Util.createRemoveOperation(cleanUp[i]);
+                    op.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+                    executeOp(op);
+                } catch (IOException e) {
+                    if (ioe == null) {
+                        ioe = e;
+                    }
+                } catch (AssertionError e) {
+                    if (i > 0 && i < cleanUp.length - 1 && ae == null) {
+                        ae = e;
+                    } // else ignore because in a failed test SUB may not exist, causing remove to fail
+                      // and because removing the interface will definitely fail
+                } catch (RuntimeException e) {
+                    if (re == null) {
+                        re = e;
+                    }
+                }
+            }
+
+            if (ioe != null) {
+                throw ioe;
+            }
+
+            if (ae != null) {
+                throw ae;
+            }
+
+            if (re != null) {
+                throw re;
+            }
+        } finally {
+            ExtensionUtils.deleteExtensionModule(WFCORE1106);
+        }
+    }
+
+    @Test
+    public void testCapabilityReloadEffects() throws IOException {
+        // Change the interface to put its capability into r-r
+        ModelNode op = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+        ModelNode steps = op.get(STEPS);
+        steps.add(Util.getUndefineAttributeOperation(IFACE, LOOPBACK));
+        steps.add(Util.getWriteAttributeOperation(IFACE, INET_ADDRESS, "${jboss.bind.address:127.0.0.1}"));
+        assertStepRequiresReload(op);
+
+        // Add the loc -- should get a restart-required header
+        op = Util.createAddOperation(SUB);
+        op.get("osb").set(WFCORE1106_OSB);
+        assertStepRequiresReload(op);
+
+        // reload
+        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+
+        // Change the l-o-c -- should *not* get a restart-required header
+        op = Util.getWriteAttributeOperation(SUB, "osb", WFCORE1106_OSB2);
+
+        assertStepDoesNotRequireReload(op);
+
+        // Change the o-s-b to put its capability into r-r
+
+        op = Util.getWriteAttributeOperation(OSB, SOURCE_PORT, 54321);
+        assertStepRequiresReload(op);
+
+        // Change the l-o-c -- should get a restart-required header
+        op = Util.getWriteAttributeOperation(SUB, "osb", WFCORE1106_OSB);
+        assertStepRequiresReload(op);
+
+        // Remove the subsystem and osb
+        op = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+        steps = op.get(STEPS);
+        steps.add(Util.createRemoveOperation(SUB));
+        steps.add(Util.createRemoveOperation(OSB));
+        assertStepRequiresReload(op);
+
+        // Re-add  -- should still get a restart-required header on SUB
+        // because removing the o-s-b capability doesn't flush the need to reload
+        // We also get a r-r header on the o-s-b add
+        op = Util.createAddOperation(OSB);
+        op.get(SOCKET_BINDING_REF).set(WFCORE1106);
+        assertStepRequiresReload(op);
+        op = Util.createAddOperation(SUB);
+        op.get("osb").set(WFCORE1106_OSB);
+        assertStepRequiresReload(op);
+
+    }
+
+    private void assertStepRequiresReload(ModelNode op) throws IOException {
+        assertRequiresReload(op, true);
+    }
+
+    private void assertStepDoesNotRequireReload(ModelNode op) throws IOException {
+        assertRequiresReload(op, false);
+    }
+
+    private void assertRequiresReload(ModelNode op, boolean expectReload) throws IOException {
+        ModelNode response = executeOp(op);
+        ModelNode origRsp = response;
+        // Hack for composites
+        if (COMPOSITE.equals(op.get(OP).asString())) {
+            response = response.get(RESULT, "step-1");
+        }
+        if (expectReload) {
+            assertTrue(origRsp.toString(), response.hasDefined(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD));
+            assertTrue(origRsp.toString(), response.get(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD).asBoolean());
+        } else {
+            assertFalse(origRsp.toString(), response.hasDefined(RESPONSE_HEADERS, OPERATION_REQUIRES_RELOAD));
+        }
+    }
+
+    private ModelNode executeOp(ModelNode op) throws IOException {
+        ModelNode response = managementClient.getControllerClient().execute(op);
+        assertTrue(response.toString(), response.hasDefined(OUTCOME));
+        assertEquals(response.toString(), SUCCESS, response.get(OUTCOME).asString());
+        return response;
+    }
+}

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ConfigurationChangesHistoryTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ConfigurationChangesHistoryTestCase.java
@@ -128,7 +128,7 @@ public class ConfigurationChangesHistoryTestCase extends ContainerResourceMgmtTe
     public void testConfigurationChanges() throws Exception {
         final ModelNode listConfigurationChanges = Util.createOperation(ConfigurationChangeResourceDefinition.OPERATION_NAME, ADDRESS);
         List<ModelNode> changes = getManagementClient().executeForResult(listConfigurationChanges).asList();
-        assertThat(changes.size(), is(MAX_HISTORY_SIZE));
+        assertThat(changes.toString(), changes.size(), is(MAX_HISTORY_SIZE));
         for(ModelNode change : changes) {
             assertThat(change.hasDefined(OPERATION_DATE), is(true));
             assertThat(change.hasDefined(USER_ID), is(false));
@@ -167,7 +167,7 @@ public class ConfigurationChangesHistoryTestCase extends ContainerResourceMgmtTe
         getModelControllerClient().execute(update);
         final ModelNode listConfigurationChanges = Util.createOperation(ConfigurationChangeResourceDefinition.OPERATION_NAME, ADDRESS);
         List<ModelNode> changes = getManagementClient().executeForResult(listConfigurationChanges).asList();
-        assertThat(changes.size(), is(ALL_MAX_HISTORY_SIZE));
+        assertThat(changes.toString(), changes.size(), is(ALL_MAX_HISTORY_SIZE));
         for(ModelNode change : changes) {
             assertThat(change.hasDefined(OPERATION_DATE), is(true));
             assertThat(change.hasDefined(USER_ID), is(false));


### PR DESCRIPTION
Replaces #1475 which had too much CI noise from test runs before a required downstream update was merged. Same code though.

See https://issues.jboss.org/browse/WFCORE-1106 description for the conceptual details.

I can squash the seven commits before merging; right now they are separate commits to perhaps help reviewers understand the change.

On WFCORE-1106 I commented about how perhaps we should reject "reload" ops when the server is in restart-required. I haven't done anything about that here.