### PR TITLE
[WFCORE-1474] CLI version command should not use JBoss AS in its outp…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/VersionHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/VersionHandler.java
@@ -67,7 +67,7 @@ public class VersionHandler implements CommandHandler {
         final StringBuilder buf = new StringBuilder();
         buf.append("JBoss Admin Command-line Interface\n");
         buf.append("JBOSS_HOME: ").append(WildFlySecurityManager.getEnvPropertyPrivileged("JBOSS_HOME", null)).append('\n');
-        buf.append("JBoss AS release: ");
+        buf.append("Release: ");
         final ModelControllerClient client = ctx.getModelControllerClient();
         if(client == null) {
             buf.append("<connect to the controller and re-run the version command to see the release info>\n");
@@ -97,7 +97,7 @@ public class VersionHandler implements CommandHandler {
                         }
 
                         if(result.hasDefined(Util.PRODUCT_NAME)) {
-                            buf.append("\nJBoss AS product: ").append(result.get(Util.PRODUCT_NAME).asString());
+                            buf.append("\nProduct: ").append(result.get(Util.PRODUCT_NAME).asString());
                             if(result.hasDefined(Util.PRODUCT_VERSION)) {
                                 buf.append(' ').append(result.get(Util.PRODUCT_VERSION).asString());
                             }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliArgumentsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliArgumentsTestCase.java
@@ -50,7 +50,7 @@ public class CliArgumentsTestCase {
         final String result = cli.executeNonInteractive();
         assertNotNull(result);
         assertTrue(result, result.contains("JBOSS_HOME"));
-        assertTrue(result, result.contains("JBoss AS release"));
+        assertTrue(result, result.contains("Release"));
         assertTrue(result, result.contains("JAVA_HOME"));
         assertTrue(result, result.contains("java.version"));
         assertTrue(result, result.contains("java.vm.vendor"));
@@ -66,7 +66,7 @@ public class CliArgumentsTestCase {
         final String result = cli.executeNonInteractive();
         assertNotNull(result);
         assertTrue(result, result.contains("JBOSS_HOME"));
-        assertTrue(result, result.contains("JBoss AS release"));
+        assertTrue(result, result.contains("Release"));
         assertTrue(result, result.contains("JAVA_HOME"));
         assertTrue(result, result.contains("java.version"));
         assertTrue(result, result.contains("java.vm.vendor"));
@@ -89,7 +89,7 @@ public class CliArgumentsTestCase {
         final String result = cli.executeNonInteractive();
         assertNotNull(result);
         assertTrue(result, result.contains("JBOSS_HOME"));
-        assertTrue(result, result.contains("JBoss AS release"));
+        assertTrue(result, result.contains("Release"));
         assertTrue(result, result.contains("JAVA_HOME"));
         assertTrue(result, result.contains("java.version"));
         assertTrue(result, result.contains("java.vm.vendor"));
@@ -110,7 +110,7 @@ public class CliArgumentsTestCase {
 
         assertNotNull(result);
         assertTrue(result, result.contains("JBOSS_HOME"));
-        assertTrue(result, result.contains("JBoss AS release"));
+        assertTrue(result, result.contains("Release"));
         assertTrue(result, result.contains("JAVA_HOME"));
         assertTrue(result, result.contains("java.version"));
         assertTrue(result, result.contains("java.vm.vendor"));


### PR DESCRIPTION
…ut field names

This commit removes "JBoss AS" from the headers of the displayed info table.

This may potentially break scripts or applications analyzing the output and looking for specific fields.

Alexey