### PR TITLE
Systemd example

### DIFF
--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/init.d/wildfly-init-debian.sh
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/init.d/wildfly-init-debian.sh
@@ -59,7 +59,7 @@ fi
 
 # Location of wildfly
 if [ -z "$JBOSS_HOME" ]; then
-	JBOSS_HOME="/opt/wildfly"
+	JBOSS_HOME="/usr/share/wildfly"
 fi
 export JBOSS_HOME
 

--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/init.d/wildfly.conf
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/init.d/wildfly.conf
@@ -6,7 +6,7 @@
 # JAVA_HOME="/usr/lib/jvm/default-java"
 
 ## Location of WildFly
-# JBOSS_HOME="/opt/wildfly"
+# JBOSS_HOME="/usr/share/wildfly"
 
 ## The username who should own the process.
 # JBOSS_USER=wildfly

--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/systemd/README
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/systemd/README
@@ -3,21 +3,21 @@
 == Create a wildfly user
 
     # groupadd -r wildfly
-    # useradd -r -g wildfly -d /opt/wildfly -s /sbin/nologin wildfly
+    # useradd -r -g wildfly -d /usr/share/wildfly -s /sbin/nologin wildfly
 
 == Install WildFly
 
-    # tar xvzf wildfly-10.0.0.Final.tar.gz -C /opt
-    # ln -s /opt/wildfly-10.0.0.Final /opt/wildfly
-    # chown -R wildfly:wildfly /opt/wildfly
+    # tar xvzf wildfly-10.0.0.Final.tar.gz -C /var/tmp
+    # ln -s /var/tmp/wildfly-10.0.0.Final /usr/share/wildfly
+    # chown -R wildfly:wildfly /usr/share/wildfly
 
 == Configure systemd
 
     # mkdir /etc/wildfly
     # cp wildfly.conf /etc/wildfly/
     # cp wildfly.service /etc/systemd/system/
-    # cp launch.sh /opt/wildfly/bin/
-    # chmod +x /opt/wildfly/bin/launch.sh
+    # cp launch.sh /usr/share/wildfly/bin/
+    # chmod +x /usr/share/wildfly/bin/launch.sh
 
 == Start and enable
 

--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/systemd/launch.sh
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/systemd/launch.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "x$WILDFLY_HOME" = "x" ]; then
-    WILDFLY_HOME="/opt/wildfly"
+    WILDFLY_HOME="/usr/share/wildfly"
 fi
 
 if [[ "$1" == "domain" ]]; then

--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/systemd/wildfly.service
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/systemd/wildfly.service
@@ -5,12 +5,14 @@ Before=httpd.service
 
 [Service]
 Environment=LAUNCH_JBOSS_IN_BACKGROUND=1
+EnvironmentFile=-/etc/wildfly/wildfly.d/*
 EnvironmentFile=-/etc/wildfly/wildfly.conf
 User=wildfly
 LimitNOFILE=102642
 PIDFile=/var/run/wildfly/wildfly.pid
-ExecStart=/opt/wildfly/bin/launch.sh $WILDFLY_MODE $WILDFLY_CONFIG $WILDFLY_BIND
+ExecStart=/usr/share/wildfly/bin/launch.sh $WILDFLY_MODE $WILDFLY_CONFIG $WILDFLY_BIND
 StandardOutput=null
 
 [Install]
 WantedBy=multi-user.target
+

--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/systemd/wildfly.service
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/systemd/wildfly.service
@@ -7,6 +7,7 @@ Before=httpd.service
 Environment=LAUNCH_JBOSS_IN_BACKGROUND=1
 EnvironmentFile=-/etc/wildfly/wildfly.d/*
 EnvironmentFile=-/etc/wildfly/wildfly.conf
+Sockets=httpd.socket
 User=wildfly
 LimitNOFILE=102642
 PIDFile=/var/run/wildfly/wildfly.pid


### PR DESCRIPTION
Original examples were better WFLY-4570 and /usr/share is actually packaged on fedora (wildfly 8: https://apps.fedoraproject.org/packages/wildfly/contents/ ) and used in wildfly 10 in COPR: https://github.com/goldmann/wildfly-copr

Regardless, these are just examples.

Additionally, it can be useful to activate the httpd.socket if it exists.
