### PR TITLE
[WFCORE-1581] Convert LIST of PROPERTY to OBJECT for attributes of type OBJECT

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/AbstractJvmModelTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/AbstractJvmModelTest.java
@@ -179,7 +179,9 @@ public abstract class AbstractJvmModelTest extends AbstractCoreModelTest {
     @Test
     public void testWriteEnvironmentVariables() throws Exception {
         KernelServices kernelServices = doEmptyJvmAdd();
-        ModelNode value = new ModelNode().add("ENV1", "one").add("ENV2", "two");
+        ModelNode value = new ModelNode();
+        value.get("ENV1").set("one");
+        value.get("ENV2").set("two");
         Assert.assertEquals(value, writeTest(kernelServices, "environment-variables", value));
     }
 
@@ -196,7 +198,9 @@ public abstract class AbstractJvmModelTest extends AbstractCoreModelTest {
         ModelNode permgenSizeValue = new ModelNode("permGenSize");
         ModelNode maxPermSizeValue = new ModelNode("maxPermSize");
         ModelNode jvmOptionsValue = new ModelNode().add("-Xmx100m").add("-Xms30m");
-        ModelNode environmentVariablesValue = new ModelNode().add("ENV1", "one").add("ENV2", "two");
+        ModelNode environmentVariablesValue = new ModelNode();
+        environmentVariablesValue.get("ENV1").set("one");
+        environmentVariablesValue.get("ENV2").set("two");
 
         ModelNode debugEnabledValue = new ModelNode(true);
         ModelNode debugOptionsValue = new ModelNode("debugOptions");

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/JvmXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/JvmXml.java
@@ -289,7 +289,7 @@ public class JvmXml {
             }
             final String[] array = requireAttributes(reader, Attribute.NAME.getLocalName(), Attribute.VALUE.getLocalName());
             requireNoContent(reader);
-            properties.add(array[0], ParseUtils.parsePossibleExpression(array[1]));
+            properties.get(array[0]).set(ParseUtils.parsePossibleExpression(array[1]));
         }
 
         if (!properties.isDefined()) {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomFormattersTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomFormattersTestCase.java
@@ -71,8 +71,8 @@ public class CustomFormattersTestCase extends AbstractLoggingOperationsTestCase 
         executeOperation(op);
 
         // Write some properties
-        final ModelNode properties = new ModelNode().setEmptyList();
-        properties.add("pattern", "%s%E%n");
+        final ModelNode properties = new ModelNode().setEmptyObject();
+        properties.get("pattern").set("%s%E%n");
         testWrite(CUSTOM_FORMATTER_ADDRESS, "properties", properties);
 
         // Undefine the properties


### PR DESCRIPTION
It wouldn't surprise me if this requires changes in full, as I had to fix some stuff in core to avoid failures due to incorrectly formatted params being compared to the resulting model. That's what the last 3 commits are.

Update: I was right. PR to fix test failures is https://github.com/wildfly/wildfly/pull/8957 . CI job to test this in combo with that PR is https://ci.wildfly.org/viewLog.html?buildId=18356&tab=buildResultsDiv&buildTypeId=WF_WildFlyCoreIntegrationExperiments