### PR TITLE
[2.x] WFCORE-1374 - backport jdk9 related changes from master

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -201,6 +201,16 @@
 
         <!-- Test Dependencies -->
         <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -35,6 +35,20 @@
     </resources>
 
     <dependencies>
+        <!-- JAXP default dependencies. DO NOT REMOVE!!!
+             These are loaded by the JAXP redirect facility in jboss-modules when this module is used
+             as a boot module. The purpose is to provide a common default JAXP implementation on all JDKs.
+             This is necessary since we have to override the JAXP APIs to fix incompatibilities
+             with modular class-loading. In the future we may be able to replace this construct
+             if JAXP APIs are fixed on all known JVMs *and* we implement a subsystem to provide a similar
+             default/fallback common parser behavior. Please discuss any design changes in this area
+             on the WildFly development mailing list before enacting.
+        -->
+        <module name="org.apache.xalan" services="import" optional="true"/>
+        <module name="org.apache.xerces" services="import"/>
+        <module name="org.codehaus.woodstox" services="import"/>
+        <!-- END JAXP default dependencies -->
+
         <module name="org.jboss.aesh"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.as.controller-client"/>

--- a/core-model-test/pom.xml
+++ b/core-model-test/pom.xml
@@ -52,6 +52,17 @@
            <groupId>org.wildfly.core</groupId>
            <artifactId>wildfly-model-test</artifactId>
         </dependency>
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -561,27 +561,22 @@ public final class Main {
         final Map<String, String> hostSystemProperties = new HashMap<String, String>();
         try {
             RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
+            String propertyName, propertyValue;
             for (String arg : runtime.getInputArguments()) {
                 if (arg != null && arg.length() > 2 && arg.startsWith("-D")) {
                     arg = arg.substring(2);
-                    String[] split = arg.split("=");
-                    if (!hostSystemProperties.containsKey(split[0])) {
-                        String val;
-                        if (split.length == 1) {
-                            val = null;
-                        } else if (split.length == 2) {
-                            val = split[1];
-                        } else {
-                            //Things like -Djava.security.policy==/Users/kabir/tmp/permit.policy will end up here, and the extra '=' needs to be part of the value,
-                            //see http://docs.oracle.com/javase/6/docs/technotes/guides/security/PolicyFiles.html
-                            StringBuilder sb = new StringBuilder();
-                            for (int i = 2 ; i < split.length ; i++) {
-                                sb.append("=");
-                            }
-                            sb.append(split[split.length - 1]);
-                            val = sb.toString();
-                        }
-                        hostSystemProperties.put(split[0], val);
+                    int equalIndex = arg.indexOf("=");
+                    if (equalIndex >= 0) {
+                        //Things like -Djava.security.policy==/Users/kabir/tmp/permit.policy will end up here, and the extra '=' needs to be part of the value,
+                        //see http://docs.oracle.com/javase/6/docs/technotes/guides/security/PolicyFiles.html
+                        propertyName = arg.substring(0, equalIndex);
+                        propertyValue = arg.substring(equalIndex + 1);
+                    } else {
+                        propertyName = arg;
+                        propertyValue = null;
+                    }
+                    if (!hostSystemProperties.containsKey(propertyName)) {
+                        hostSystemProperties.put(propertyName, propertyValue);
                     }
                 }
             }

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -171,6 +171,18 @@
 
         <!-- Test dependencies -->
         <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman</artifactId>
             <scope>test</scope>

--- a/patching/pom.xml
+++ b/patching/pom.xml
@@ -162,7 +162,11 @@
             <artifactId>byteman-bmunit</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/patching/src/main/java/org/jboss/as/patching/metadata/PatchMerger.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/PatchMerger.java
@@ -23,9 +23,11 @@
 package org.jboss.as.patching.metadata;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -84,7 +86,7 @@ public class PatchMerger {
 
             patch = merge(patch, patch2Metadata);
 
-            try (FileWriter writer = new FileWriter(new File(mergedDir, f.getName()))){
+            try (Writer writer = Files.newBufferedWriter(new File(mergedDir, f.getName()).toPath(), StandardCharsets.UTF_8)){
                 PatchXml.marshal(writer, patch);
             } catch (Exception e) {
                 throw new PatchingException("Failed to marshal merged metadata into " + f.getName(), e);
@@ -94,9 +96,8 @@ public class PatchMerger {
 
         // the latest patch.xml
         copyFile(new File(patch2Dir, PatchXml.PATCH_XML), new File(mergedDir, patch2Metadata.getIdentity().getVersion() +  PATCH_XML_SUFFIX));
-
         // merged patch.xml is the metadata from the earliest version to the latest
-        try (FileWriter writer = new FileWriter(new File(mergedDir, PatchXml.PATCH_XML))){
+        try (Writer writer = Files.newBufferedWriter(new File(mergedDir, PatchXml.PATCH_XML).toPath(), StandardCharsets.UTF_8)){
             PatchXml.marshal(writer, mergedMetadata);
         } catch (Exception e) {
             throw new PatchingException("Failed to marshal merged metadata into " + PatchXml.PATCH_XML, e);
@@ -124,7 +125,7 @@ public class PatchMerger {
 
     private static void copyFile(File source, File target) throws PatchingException {
         try {
-            IoUtils.copy(source, target);
+            Files.copy(source.toPath(), target.toPath());
         } catch (IOException e1) {
             throw new PatchingException("Failed to copy " + source.getAbsolutePath() + " to " + target.getAbsolutePath());
         }

--- a/patching/src/main/java/org/jboss/as/patching/metadata/PatchXml.java
+++ b/patching/src/main/java/org/jboss/as/patching/metadata/PatchXml.java
@@ -22,8 +22,6 @@
 
 package org.jboss.as.patching.metadata;
 
-import static org.jboss.as.patching.IoUtils.safeClose;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -170,12 +168,8 @@ public class PatchXml {
     }
 
     public static PatchMetadataResolver parse(final File patchXml, InstalledIdentity original) throws IOException, XMLStreamException {
-
-        final InputStream is = new FileInputStream(patchXml);
-        try {
+        try (final InputStream is = new FileInputStream(patchXml)){
             return parse(is, original);
-        } finally {
-            safeClose(is);
         }
     }
 

--- a/patching/src/test/java/org/jboss/as/patching/metadata/PatchXmlUnitTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/metadata/PatchXmlUnitTestCase.java
@@ -22,11 +22,6 @@
 
 package org.jboss.as.patching.metadata;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,11 +30,15 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URL;
 import java.util.Scanner;
-
 import javax.xml.stream.XMLStreamException;
 
 import org.junit.Test;
 import org.xnio.IoUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Emanuel Muckenhuber
@@ -126,14 +125,13 @@ public class PatchXmlUnitTestCase {
     private void doMarshall(String fileName) throws Exception {
         final String original = toString(fileName);
 
-        final InputStream is = getResource(fileName);
-        final Patch patch = PatchXml.parse(is).resolvePatch(null, null);
-
-        final StringWriter writer = new StringWriter();
-        PatchXml.marshal(writer, patch);
-        final String marshalled = writer.toString();
-
-        XMLUtils.compareXml(original, marshalled, false);
+        try (final InputStream is = getResource(fileName)) {
+            final Patch patch = PatchXml.parse(is).resolvePatch(null, null);
+            final StringWriter writer = new StringWriter();
+            PatchXml.marshal(writer, patch);
+            final String marshalled = writer.toString();
+            XMLUtils.compareXml(original, marshalled, false);
+        }
     }
 
     static InputStream getResource(String name) throws IOException {

--- a/patching/src/test/java/org/jboss/as/patching/tests/PatchModuleInvalidationWithRenamingFailureTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/PatchModuleInvalidationWithRenamingFailureTestCase.java
@@ -131,6 +131,7 @@ public class PatchModuleInvalidationWithRenamingFailureTestCase extends Abstract
         final Constructor<?> constructor = clazz.getConstructor(String.class);
         final Object instance = constructor.newInstance("test");
         Assert.assertNotNull(instance);
+        cl.close();
     }
 
     static void assertNotLoadable(final File jar) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -105,10 +105,10 @@
         <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logmanager.jboss-logmanager>2.0.3.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
-        <version.org.jboss.marshalling.jboss-marshalling>1.4.10.Final</version.org.jboss.marshalling.jboss-marshalling>
+        <version.org.jboss.marshalling.jboss-marshalling>1.4.11.Final</version.org.jboss.marshalling.jboss-marshalling>
         <!-- this is test only dependancy -->
         <version.org.jboss.metadata.jboss-metadata-common>10.0.0.Final</version.org.jboss.metadata.jboss-metadata-common>
-        <version.org.jboss.modules.jboss-modules>1.5.1.Final</version.org.jboss.modules.jboss-modules>
+        <version.org.jboss.modules.jboss-modules>1.5.2.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.6.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>4.0.21.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>2.0.1.Final</version.org.jboss.remotingjmx.remoting-jmx>
@@ -138,9 +138,13 @@
         <version.org.zanata.plugin>3.1.1</version.org.zanata.plugin>
         <version.xml.plugin>1.0</version.xml.plugin>
 
+        <!-- Modularized JDK support (various workarounds) - activated via profile -->
+        <modular.jdk.args/>
+        <modular.jdk.props/>
+
         <!-- Surefire args -->
         <surefire.jpda.args/>
-        <surefire.system.args>-ea ${surefire.jpda.args}</surefire.system.args>
+        <surefire.system.args>${modular.jdk.args} ${modular.jdk.props} -ea -Duser.region=US -Duser.language=en -XX:MaxMetaspaceSize=256m ${surefire.jpda.args}</surefire.system.args>
 
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
@@ -278,7 +282,7 @@
                                   <value>${test.level}</value>
                               </property>
                           </systemProperties>
-                          <argLine>-Duser.region=US -Duser.language=en -XX:MaxMetaspaceSize=256m</argLine>
+                          <argLine>${surefire.system.args}</argLine>
                     </configuration>
 
                 </plugin>
@@ -1464,6 +1468,40 @@
 
     <!-- Profiles -->
     <profiles>
+        <!--
+          Name: modularizedJdk
+          Descr: various workarounds activation for modularized JDK
+        -->
+        <profile>
+            <id>modularizedJdk</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <properties>
+                <!-- [WFCORE-1431] remove SASL workaround -->
+                <modular.jdk.args>-XaddExports:java.security.sasl/com.sun.security.sasl.digest=ALL-UNNAMED -XaddExports:java.security.sasl/com.sun.security.sasl=ALL-UNNAMED -XaddExports:jdk.unsupported/sun.reflect=ALL-UNNAMED -XaddExports:jdk.unsupported/sun.misc=ALL-UNNAMED</modular.jdk.args>
+                <!-- [WFCORE-1494] remove JUL workaround -->
+                <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true</modular.jdk.props>
+            </properties>
+            <build>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <version>${version.compiler.plugin}</version>
+                            <configuration>
+                                <!-- fork is needed so compiler args can be used -->
+                                <fork>true</fork>
+                                <compilerArgs>
+                                    <arg>-J-addmods</arg>
+                                    <arg>-Jjava.annotations.common</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+
+                    </plugins>
+            </build>
+        </profile>
         <!--
           Name: jpda
           Descr: Enable JPDA remote debuging

--- a/remoting/tests/pom.xml
+++ b/remoting/tests/pom.xml
@@ -51,6 +51,22 @@
         <!-- Test deps -->
 
         <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.1.jbossorg-2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
@@ -66,6 +82,5 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -159,8 +159,17 @@
             <artifactId>picketbox</artifactId>
         </dependency>
         -->
-
         <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -51,7 +51,6 @@
         <xslt.scripts.dir>${basedir}/../src/test/xslt</xslt.scripts.dir>
         <enforcer.skip>true</enforcer.skip>
         <jbossas.ts.dir>${basedir}/..</jbossas.ts.dir>
-
     </properties>
 
     <!--
@@ -178,7 +177,7 @@
                     <argLine>${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
 
                     <systemPropertyVariables>
-                        <jboss.options>-ea ${surefire.system.args}</jboss.options>
+                        <jboss.options>${surefire.system.args}</jboss.options>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                         <jboss.home>${project.basedir}/target/wildfly-core</jboss.home>
                         <module.path>${jboss.dist}/modules</module.path>
@@ -187,7 +186,7 @@
                         <management.address>${management.address}</management.address>
                         <settings.localRepository>${settings.localRepository}</settings.localRepository>
                         <cli.args>-Dmaven.repo.local=${settings.localRepository}</cli.args>
-                        <server.jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
+                        <server.jvm.args>${modular.jdk.args} -Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
                     </systemPropertyVariables>
                     <includes>
                          <include>org/jboss/as/test/integration/domain/autoignore/*TestCase.java</include>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -136,7 +136,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-
                             <!-- Workaround for nasty and hacky tests not cleaning up completely after themselves. -->
                             <runOrder>alphabetical</runOrder>
                             <!-- This project includes tests of server embedding, so we cannot reuse forks
@@ -151,6 +150,7 @@
                                 <jboss.home>${wildfly.home}</jboss.home>
                                 <module.path>${wildfly.home}/modules/</module.path>
                                 <jvm.args>-javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar},sys:${org.wildfly.core:wildfly-core-testsuite-shared:jar} -Dorg.jboss.byteman.transform.all -Dorg.jboss.byteman.verbose=true -Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
+                                <cli.jvm.args>${modular.jdk.args}</cli.jvm.args>
                                 <cli.args>-Dmaven.repo.local=${settings.localRepository}</cli.args>
                                 <javax.net.ssl.trustStore>${basedir}/src/test/resources/ssl/jbossClient.truststore</javax.net.ssl.trustStore>
                                 <javax.net.ssl.keyStore>${basedir}/src/test/resources/ssl/jbossClient.keystore</javax.net.ssl.keyStore>

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/CumulativePatchingScenariosTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/CumulativePatchingScenariosTestCase.java
@@ -527,7 +527,7 @@ public class CumulativePatchingScenariosTestCase extends AbstractPatchingTestCas
             controller.stop();
         }
     }
-
+    //todo this should be done via CLI commands not by manipulating xml DOM
     private void addSystemProperties(String filePath) throws Exception {
         // modify xml
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -135,7 +135,7 @@
         <surefire.memory.args>-Xmx512m -XX:MaxMetaspaceSize=256m</surefire.memory.args>
         <surefire.jpda.args></surefire.jpda.args>
         <as.debug.port>8787</as.debug.port>
-        <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist}</surefire.system.args>
+        <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args} ${modular.jdk.args} ${modular.jdk.props} -Djboss.dist=${jboss.dist}</surefire.system.args>
         <surefire.forked.process.timeout>1500</surefire.forked.process.timeout>
 
         <!-- If servers should be killed before the test suite is run-->
@@ -180,6 +180,23 @@
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>compile</scope>
             <optional>true</optional>
+        </dependency>
+        <!-- needed to make JAXP work properly -->
+        <dependency>
+            <groupId>org.codehaus.woodstox</groupId>
+            <artifactId>woodstox-core-asl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xerces</groupId>
+            <artifactId>xercesImpl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.1.jbossorg-2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/interfaces/JmxManagementInterface.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/interfaces/JmxManagementInterface.java
@@ -191,13 +191,17 @@ public class JmxManagementInterface implements ManagementInterface {
         for (MBeanAttributeInfo attribute : attributeInfos) {
             String attributeName = attribute.getName();
             try {
-                Object attributeValue = connection.getAttribute(objectName, attributeName);
                 try {
+                    Object attributeValue = connection.getAttribute(objectName, attributeName);
                     attributes.get(JmxInterfaceStringUtils.toDashCase(attributeName)).set(modelNode(attributeValue));
                 } catch (UnsupportedOperationException e) {
                     // happens for some attributes that are represented as a Tabular***; let's just ignore them
                 }
             } catch (Exception e) {
+                if (e.getMessage().contains("UnsupportedOperationException")){
+                    //in some rare cases it throws RuntimeException with UOE in message.
+                    continue;
+                }
                 // see RbacUtil.checkOperationResult for error codes
                 // TODO could possibly use MBeanAttributeInfo#isReadable instead of error codes, but it's currently broken
                 String message = e.getMessage();

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlConfigTestCase.java
@@ -22,9 +22,11 @@
 package org.jboss.as.test.integration.management.cli;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -100,7 +102,7 @@ public class JBossCliXmlConfigTestCase {
         File f = new File(TestSuiteEnvironment.getTmpDir(), "test-jboss-cli.xml");
         String namespace = "urn:jboss:cli:" + version;
         XMLOutputFactory output = XMLOutputFactory.newInstance();
-        try (FileWriter stream = new FileWriter(f)) {
+        try (Writer stream = Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8)) {
             XMLStreamWriter writer = output.createXMLStreamWriter(stream);
             writer.writeStartDocument();
             writer.writeStartElement("jboss-cli");


### PR DESCRIPTION
- Update compiler config for JDK9 b118+
- WFCORE-1374 - make code work with jdk9b115 and newer
- upgrade jboss-modules to 1.5.2.Final
- upgrade jboss-marshalling to 1.4.11.Final
- [WFCORE-1490] JDK9 doesn't provide sun.boot.class.path attribute
- [WFCORE-1491] Don't rely on default (JDK) JAXP providers - specify explicit ones
- [WFCORE-1493] Fix proper -Djdk.launcher.addexports.%d JVM property values propagation
- [WFCORE-1431] Define and propagate ${modular.jdk.args} property where necessary
- Properly create writers with charset and cleanup resources