### PR TITLE
[2.x branch] Enhancement WFCORE-1597 

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/parsing/ManagementXml_4.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/parsing/ManagementXml_4.java
@@ -1984,8 +1984,7 @@ class ManagementXml_4 extends ManagementXml {
                 SSLServerIdentityResourceDefinition.ENABLED_PROTOCOLS.marshallAsElement(ssl, writer);
             }
 
-            boolean hasProvider = ssl.hasDefined(KEYSTORE_PROVIDER)
-                    && (JKS.equals(ssl.require(KEYSTORE_PROVIDER).asString()) == false);
+            boolean hasProvider = ssl.hasDefined(KEYSTORE_PROVIDER) && !JKS.equalsIgnoreCase(ssl.require(KEYSTORE_PROVIDER).asString());
             if (hasProvider || ssl.hasDefined(KeystoreAttributes.KEYSTORE_PATH.getName())) {
                 writer.writeEmptyElement(Element.KEYSTORE.getLocalName());
                 KeystoreAttributes.KEYSTORE_PROVIDER.marshallAsAttribute(ssl, writer);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -557,8 +557,8 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
 
         ServiceName keyManagerServiceName = null;
 
-        String provider = KeystoreAttributes.KEYSTORE_PROVIDER.resolveModelAttribute(context, ssl).asString();
-        if (ssl.hasDefined(KEYSTORE_PATH) || (JKS.equals(provider) == false)) {
+        final String provider = KeystoreAttributes.KEYSTORE_PROVIDER.resolveModelAttribute(context, ssl).asString();
+        if (ssl.hasDefined(KEYSTORE_PATH) || !JKS.equalsIgnoreCase(provider)) {
             keyManagerServiceName = AbstractKeyManagerService.ServiceUtil.createServiceName(SecurityRealm.ServiceUtil.createServiceName(realmName));
             addKeyManagerService(context, ssl, keyManagerServiceName, serviceTarget);
         }
@@ -674,11 +674,10 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
         final ServiceBuilder<TrustManager[]> serviceBuilder;
         char[] keystorePassword = KeystoreAttributes.KEYSTORE_PASSWORD.resolveModelAttribute(context, ssl).asString()
                 .toCharArray();
-        String provider = KeystoreAttributes.KEYSTORE_PROVIDER.resolveModelAttribute(context, ssl).asString();
+        final String provider = KeystoreAttributes.KEYSTORE_PROVIDER.resolveModelAttribute(context, ssl).asString();
 
-        if (JKS.equals(provider) == false) {
-            ProviderTrustManagerService trustManagerService = new ProviderTrustManagerService(provider, keystorePassword);
-
+        if (!JKS.equalsIgnoreCase(provider)) {
+            final ProviderTrustManagerService trustManagerService = new ProviderTrustManagerService(provider, keystorePassword);
             serviceBuilder = serviceTarget.addService(serviceName, trustManagerService);
         } else {
             String path = KeystoreAttributes.KEYSTORE_PATH.resolveModelAttribute(context, ssl).asString();


### PR DESCRIPTION
The commit here implements the enhancement noted in https://issues.jboss.org/browse/WFCORE-1597 to be a bit lenient while checking if the configured truststore's keystore provider type is JKS, to avoid running into hard to debug SSL issues as noted in the forum thread here https://developer.jboss.org/message/958142#958142