### PR TITLE
[WFCORE-1611] fix CLI stuck if SIGINT is send during authentication dialogue.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CliShutdownHook.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliShutdownHook.java
@@ -58,16 +58,16 @@ public class CliShutdownHook {
     }
 
     public static void add(Handler handler) {
-        synchronized(handlers) {
-            if (!shuttingDown) {
+        if (!shuttingDown) {
+            synchronized (handlers) {
                 handlers.add(handler);
             }
         }
     }
 
     public static void remove(Handler handler) {
-        synchronized(handlers) {
-            if (!shuttingDown) {
+        if (!shuttingDown) {
+            synchronized (handlers) {
                 handlers.remove(handler);
             }
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1611
Fix a potential deadlock on _handlers_ in issue reported scenario.