### PR TITLE
[WFCORE-1617] fix tab completion for cli variables and properties.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultCallbackHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultCallbackHandler.java
@@ -625,7 +625,7 @@ public class DefaultCallbackHandler extends ValidatingCallbackHandler implements
 
     @Override
     public int getLastChunkIndex() {
-        return lastChunkIndex;
+        return lastChunkIndex - substitutedLine.length() + originalLine.length();
     }
 
     @Override

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/VariablesTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/VariablesTestCase.java
@@ -67,6 +67,7 @@ public class VariablesTestCase {
         ctx.setVariable(NODE_NAME_VAR_NAME, NODE_NAME_VAR_VALUE);
         ctx.setVariable(OP_VAR_NAME, OP_VAR_VALUE);
         ctx.setVariable(OP_PROP_VAR_NAME, OP_PROP_VAR_VALUE);
+        ctx.setVariable("myvar", "/subsystem=logging");
     }
 
     @After
@@ -75,6 +76,7 @@ public class VariablesTestCase {
         ctx.setVariable(NODE_NAME_VAR_NAME, null);
         ctx.setVariable(OP_VAR_NAME, null);
         ctx.setVariable(OP_PROP_VAR_NAME, null);
+        ctx.setVariable("myVar", null);
     }
 
     @Test
@@ -218,6 +220,13 @@ public class VariablesTestCase {
         final List<String> props = parsed.getOtherProperties();
         assertEquals(1, props.size());
         assertEquals("v=\\$" + OP_VAR_NAME, props.get(0));
+    }
+
+    @Test
+    public void testLastChunkIndex() throws Exception {
+        final ParsedCommandLine parsed = parse("$myvar:re");
+        assertEquals("re", parsed.getOperationName());
+        assertEquals(7, parsed.getLastChunkIndex());
     }
 
     private void assertFailedToParse(String line) {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1617

DefaultCallbackHandler sets "lastChunkIndex" during every necessary validation (validatedNodeType, validatedNodeName, validatedOperationName, etc) which is based on resolved value. This gives an incorrect offset value in case of variable or property substitution is applied.