### PR TITLE
Fix for WFCORE-1614

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CliConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/CliConfig.java
@@ -177,4 +177,12 @@ public interface CliConfig {
      *          otherwise - false
      */
     boolean isAccessControl();
+
+    /**
+     * When enabled, in non interactive mode, the command name and arguments are displayed prior to any
+     * command output.
+     *
+     * @return true, the commands are echoed, false, commands are not echoed.
+     */
+    boolean isEchoCommand();
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -154,6 +154,8 @@ public class CliLauncher {
                     }
                 } else if (arg.equals("--no-local-auth")) {
                     ctxBuilder.setDisableLocalAuth(true);
+                } else if (arg.equals("--echo-command")) {
+                    ctxBuilder.setEchoCommand(true);
                 } else if (arg.equals("--error-on-interact")) {
                     ctxBuilder.setErrorOnInteract(true);
                     errorOnInteract = true;

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextConfiguration.java
@@ -39,8 +39,13 @@ public class CommandContextConfiguration {
     private final int connectionTimeout;
     private boolean silent;
     private Boolean errorOnInteract;
+    private final boolean echoCommand;
 
-    private CommandContextConfiguration(String controller, String username, char[] password, String clientBindAddress, boolean disableLocalAuth, boolean initConsole, int connectionTimeout, InputStream consoleInput, OutputStream consoleOutput) {
+    private CommandContextConfiguration(String controller, String username,
+            char[] password, String clientBindAddress,
+            boolean disableLocalAuth, boolean initConsole, int connectionTimeout,
+            InputStream consoleInput, OutputStream consoleOutput,
+            boolean echoCommand) {
         this.controller = controller;
         this.username = username;
         this.password = password;
@@ -50,6 +55,7 @@ public class CommandContextConfiguration {
         this.initConsole = initConsole;
         this.disableLocalAuth = disableLocalAuth || username != null;
         this.connectionTimeout = connectionTimeout;
+        this.echoCommand = echoCommand;
     }
 
     public String getController() {
@@ -96,6 +102,10 @@ public class CommandContextConfiguration {
         return errorOnInteract;
     }
 
+    public boolean isEchoCommand() {
+        return echoCommand;
+    }
+
     public static class Builder {
         private String controller;
         private String username;
@@ -109,7 +119,7 @@ public class CommandContextConfiguration {
         private boolean disableLocalAuthUnset = true;
         private boolean silent;
         private Boolean errorOnInteract;
-
+        private boolean echoCommand;
         public Builder() {
         }
 
@@ -118,13 +128,18 @@ public class CommandContextConfiguration {
                 this.disableLocalAuth = username != null;
             }
             final CommandContextConfiguration config = new CommandContextConfiguration(controller, username, password, clientBindAddress, disableLocalAuth,
-                    initConsole, connectionTimeout, consoleInput, consoleOutput);
+                    initConsole, connectionTimeout, consoleInput, consoleOutput, echoCommand);
             config.silent = silent;
             config.errorOnInteract = errorOnInteract;
             return config;
         }
         public Builder setController(String controller) {
             this.controller = controller;
+            return this;
+        }
+
+        public Builder setEchoCommand(boolean echoCommand) {
+            this.echoCommand = echoCommand;
             return this;
         }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/Namespace.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Namespace.java
@@ -50,7 +50,9 @@ public enum Namespace {
 
     CLI_2_0("urn:jboss:cli:2.0"),
 
-    CLI_3_0("urn:jboss:cli:3.0");
+    CLI_3_0("urn:jboss:cli:3.0"),
+
+    CLI_3_1("urn:jboss:cli:3.1");
 
     /**
      * The current namespace version.

--- a/cli/src/main/resources/help/help.txt
+++ b/cli/src/main/resources/help/help.txt
@@ -11,6 +11,7 @@ Usage:
                      [--no-local-auth]
                      [--error-on-interact]
                      [--timeout=timeout]
+                     [--echo-command]
 
  --help (-h)     - prints (this) basic description of the command line utility.
 
@@ -89,6 +90,8 @@ Usage:
  --bind          - specifies to which address the CLI is going to be bound.
                    If none is provided then the CLI will choose one automatically as needed.
 
+ --echo-command  - include the prompt with the command into the output 
+                   for each command executed in non-interactive mode.
 
 For a list of available commands execute
 

--- a/cli/src/main/resources/schema/wildfly-cli_3_1.xsd
+++ b/cli/src/main/resources/schema/wildfly-cli_3_1.xsd
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2016, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:jboss:cli:3.1" targetNamespace="urn:jboss:cli:3.1"
+    elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+    <xs:element name="jboss-cli">
+        <xs:annotation>
+            <xs:documentation>
+                Root element for the WildFly Command Line Interface configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="default-protocol" minOccurs="0" default="http-remoting">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The default protocol to use when controller addresses are supplied without one.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:simpleContent>
+                            <xs:extension base="xs:string">
+                                <xs:attribute name="use-legacy-override" type="xs:boolean" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The default protocol is used where a connection address is specified and no
+                                            protocol is specified, in previous versions the port 9999 would have been used with the remoting
+                                            protocol - this attribute set to true causes the protocol to default to remoting if the port
+                                            number is 9999.
+
+                                            If this attribute is set to false then the specified default is used regardless
+                                            of the port number for addresses with no protocol.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:extension>
+                        </xs:simpleContent>
+                    </xs:complexType>
+                </xs:element>
+
+                <xs:element name="default-controller" type="controllerAddress" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If no default controller is specifed then the default will be assumed to be using host 'localhost'
+                            along with the default-protocol (Which will be http-remoting if not defined) and the port will be whatever
+                            default corresponds to the selected protocol.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element name="controllers" type="controllersType" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The names controller alias mappings.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element name="validate-operation-requests" type="xs:boolean" default="true" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Indicates whether the parameter list of the operation reuqests should be validated before the
+                            requests are sent to the controller for the execution.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element name="history" type="historyType" minOccurs="0" />
+
+                <xs:element name="resolve-parameter-values" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether to resolve system properties specified as command argument (or operation parameter) values
+                            before sending the operation request to the controller or let the resolution happen on the server side.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element name="connection-timeout" type="xs:int" default="5000" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The time allowed to establish a connection with the controller.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element name="ssl" type="sslType" minOccurs="0" />
+
+                <xs:element name="silent" type="xs:boolean" default="false" minOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether to write info and error messages to the terminal output.
+                            
+                            Even if the value is false, the messages will still be logged using 
+                            the logger if its configuration allows and/or if the output target was
+                            specified as part of the command line using '>'.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element name="access-control" type="xs:boolean" default="true" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the management-related commands and attributes should be filtered for the current user
+                            based on the permissions the user has been granted. In other words, if access-control is true, the
+                            tab-completion will hide commands and attributes the user is not allowed to access. In case the user attempts to
+                            execute a command or an operation without having sufficient permissions to do so, regardless of the value this
+                            element has, the attempt will fail with an access control error.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                
+                <xs:element name="echo-command" type="xs:boolean" default="false" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Commands executed in non interactive modes (scripts, list of commands, CLI API), have their name and list of options
+                            printed prior to the command actual output. This does help match command with printed result.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="controllerAddress">
+        <xs:annotation>
+            <xs:documentation>
+                The address of a controller.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="protocol" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        If no protocol is specified then the value for 'default-protocol' will be used.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="host" type="xs:string" minOccurs="0" default="localhost" />
+            <xs:element name="port" type="xs:int" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        If a port is not specified then the default port will be identified based on the protocol selected.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="namedController">
+        <xs:complexContent>
+            <xs:extension base="controllerAddress">
+                <xs:attribute name="name" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of this controller alias.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="controllersType">
+        <xs:sequence>
+            <xs:element name="controller" type="namedController" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="historyType">
+        <xs:annotation>
+            <xs:documentation>
+                This element contains the configuration for the commands and operations history log.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="enabled" type="xs:boolean" minOccurs="0" default="true" />
+            <xs:element name="file-name" type="xs:string" minOccurs="0" default=".jboss-cli-history" />
+            <xs:element name="file-dir" type="xs:string" minOccurs="0" default="${user.home}" />
+            <xs:element name="max-size" type="xs:int" minOccurs="0" default="500" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="sslType">
+        <xs:annotation>
+            <xs:documentation>
+                This element contains the configuration for the Key and Trust stores
+                used for SSL.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="vault" type="vaultType" minOccurs="0" />
+            <xs:element name="key-store" type="xs:string" minOccurs="0" />
+            <xs:element name="key-store-password" type="xs:string" minOccurs="0" />
+            <xs:element name="alias" type="xs:string" minOccurs="0" />
+            <xs:element name="key-password" type="xs:string" minOccurs="0" />
+            <xs:element name="trust-store" type="xs:string" minOccurs="0" />
+            <xs:element name="trust-store-password" type="xs:string" minOccurs="0" />
+            <xs:element name="modify-trust-store" type="xs:boolean" default="true" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Setting to true will cause the CLI to prompt when unrecognised certificates are received and allow
+                        them to be stored in the truststore.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="vaultType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    Vault Configuration. If no 'code' and 'module' are supplied the default implementation will be used.
+                    If 'code' is specified but no 'module', it will look for the class named by 'specified' in the picketbox module.
+                    If 'module' is specified, it will look for the class specified by 'code' in the module specified by 'module'.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="vault-option" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="code" type="xs:string" use="optional"/>
+        <xs:attribute name="module" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="propertyType">
+        <xs:attribute name="name" use="required"/>
+        <xs:attribute name="value" use="optional"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
@@ -118,4 +118,9 @@ public class MockCliConfig implements CliConfig {
     public boolean isAccessControl() {
         return false;
     }
+
+    @Override
+    public boolean isEchoCommand() {
+        return false;
+    }
 }

--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.xml
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.xml
@@ -3,7 +3,7 @@
 <!--
    WildFly Command-line Interface configuration.
 -->
-<jboss-cli xmlns="urn:jboss:cli:2.0">
+<jboss-cli xmlns="urn:jboss:cli:3.1">
 
     <default-protocol use-legacy-override="true">http-remoting</default-protocol>
 
@@ -44,4 +44,7 @@
 
     <!-- Whether to filter out commands and attributes based on user's permissions -->
     <access-control>false</access-control>
+
+    <!-- Include the prompt with the command into the output for each command executed in non-interactive mode -->
+    <echo-command>false</echo-command>
 </jboss-cli>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliConfigTestCase.java
@@ -1,0 +1,162 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+public class CliConfigTestCase {
+    @Test
+    public void testEchoCommand() throws Exception {
+        File f = createConfigFile(true);
+        CliProcessWrapper cli = new CliProcessWrapper()
+                .setCliConfig(f.getAbsolutePath())
+                .addCliArgument("--command=version");
+        final String result = cli.executeNonInteractive();
+        assertNotNull(result);
+        assertTrue(result, result.contains("[disconnected /] version"));
+    }
+
+    @Test
+    public void testNoEchoCommand() throws Exception {
+        File f = createConfigFile(false);
+        CliProcessWrapper cli = new CliProcessWrapper()
+                .setCliConfig(f.getAbsolutePath())
+                .addCliArgument("--command=version");
+        final String result = cli.executeNonInteractive();
+        assertNotNull(result);
+        assertFalse(result, result.contains("[disconnected /] version"));
+    }
+
+    @Test
+    public void testWorkFlowEchoCommand() throws Exception {
+        File f = createConfigFile(true);
+        File script = createScript();
+        CliProcessWrapper cli = new CliProcessWrapper()
+                .setCliConfig(f.getAbsolutePath())
+                .addCliArgument("--file=" + script.getAbsolutePath())
+                .addCliArgument("--controller=" +
+                        TestSuiteEnvironment.getServerAddress() + ":" +
+                        TestSuiteEnvironment.getServerPort())
+                .addCliArgument("--connect");
+        final String result = cli.executeNonInteractive();
+        assertNotNull(result);
+        assertTrue(result, result.contains(":read-attribute(name=foo)"));
+        assertTrue(result, result.contains("/system-property=catch:add(value=bar)"));
+        assertTrue(result, result.contains("/system-property=finally:add(value=bar)"));
+        assertTrue(result, result.contains("/system-property=finally2:add(value=bar)"));
+        assertTrue(result, result.contains("if (outcome == success) of /system-property=catch:read-attribute(name=value)"));
+        assertTrue(result, result.contains("set prop=Catch\\ block\\ was\\ executed"));
+        assertTrue(result, result.contains("/system-property=finally:write-attribute(name=value, value=if)"));
+
+        assertFalse(result, result.contains("/system-property=catch2:add(value=bar)"));
+        assertFalse(result, result.contains("set prop=Catch\\ block\\ wasn\\'t\\ executed"));
+        assertFalse(result, result.contains("/system-property=finally:write-attribute(name=value, value=else)"));
+
+        assertTrue(result, result.contains("/system-property=catch:remove()"));
+        assertTrue(result, result.contains("/system-property=finally:remove()"));
+        assertTrue(result, result.contains("/system-property=finally2:remove()"));
+    }
+
+    private static File createScript() {
+         File f = new File(TestSuiteEnvironment.getTmpDir(), "test-script" +
+                System.currentTimeMillis() + ".cli");
+        f.deleteOnExit();
+        try (Writer stream = Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8)) {
+            stream.write("try\n");
+            stream.write("    :read-attribute(name=foo)\n");
+            stream.write("catch\n");
+            stream.write("    /system-property=catch:add(value=bar)\n");
+            stream.write("finally\n");
+            stream.write("    /system-property=finally:add(value=bar)\n");
+            stream.write("end-try\n");
+
+            stream.write("try\n");
+            stream.write("    /system-property=catch:read-attribute(name=value)\n");
+            stream.write("catch\n");
+            stream.write("    /system-property=catch2:add(value=bar)\n");
+            stream.write("finally\n");
+            stream.write("    /system-property=finally2:add(value=bar)\n");
+            stream.write(" end-try\n");
+
+            stream.write("/system-property=*:read-resource\n");
+            stream.write("if (outcome == success) of /system-property=catch:read-attribute(name=value)\n");
+            stream.write("    set prop=Catch\\ block\\ was\\ executed\n");
+            stream.write("    /system-property=finally:write-attribute(name=value, value=if)\n");
+            stream.write("else\n");
+            stream.write("    set prop=Catch\\ block\\ wasn\\'t\\ executed\n");
+            stream.write("    /system-property=finally:write-attribute(name=value, value=else)\n");
+            stream.write("end-if\n");
+            stream.write("/system-property=catch:remove()\n");
+            stream.write("/system-property=finally:remove()\n");
+            stream.write("/system-property=finally2:remove()\n");
+        } catch (IOException ex) {
+           fail("Failure creating script file " + ex);
+        }
+        return f;
+    }
+
+    private static File createConfigFile(Boolean enable) {
+        File f = new File(TestSuiteEnvironment.getTmpDir(), "test-jboss-cli" +
+                System.currentTimeMillis() + ".xml");
+        f.deleteOnExit();
+        String namespace = "urn:jboss:cli:3.1";
+        XMLOutputFactory output = XMLOutputFactory.newInstance();
+        try (Writer stream = Files.newBufferedWriter(f.toPath(), StandardCharsets.UTF_8)) {
+            XMLStreamWriter writer = output.createXMLStreamWriter(stream);
+            writer.writeStartDocument();
+            writer.writeStartElement("jboss-cli");
+            writer.writeDefaultNamespace(namespace);
+            writer.writeStartElement("echo-command");
+            writer.writeCharacters(enable.toString());
+            writer.writeEndElement(); //echo-command
+            writer.writeEndElement(); //jboss-cli
+            writer.writeEndDocument();
+            writer.flush();
+            writer.close();
+        } catch (XMLStreamException | IOException ex) {
+            fail("Failure creating config file " + ex);
+        }
+        return f;
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlConfigTestCase.java
@@ -48,6 +48,7 @@ public class JBossCliXmlConfigTestCase {
     public void testSSLElement() {
         testConfig("2.0");
         testConfig("3.0");
+        testConfig("3.1");
     }
 
     private static void testConfig(String version) {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlValidationTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/JBossCliXmlValidationTestCase.java
@@ -57,7 +57,7 @@ public class JBossCliXmlValidationTestCase {
         schemaFactory.setErrorHandler(new ErrorHandlerImpl());
         //schemaFactory.setResourceResolver(new XMLResourceResolver());
 
-        Schema schema = schemaFactory.newSchema(resourceToURL("schema/jboss-as-cli_2_0.xsd"));
+        Schema schema = schemaFactory.newSchema(resourceToURL("schema/wildfly-cli_3_1.xsd"));
         Validator validator = schema.newValidator();
         validator.validate(new DOMSource(document));
 


### PR DESCRIPTION
In addition to allow for echoing the command in non interactive mode, the CLI XSD config file has been upgraded to release 3.1. Although the latest XSD was 3.0, the shipped xml config file was still 2.0. I have upgraded the shipped XML file to release 3.1.
The test that was conflicting with WFCORE-1590 has been fixed.