### PR TITLE
[WFCORE-1579] Perform check when changing 'path' attribute of deploym…

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/WritePathAttributeHandler.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/WritePathAttributeHandler.java
@@ -77,8 +77,9 @@ public class WritePathAttributeHandler extends ReloadRequiredWriteAttributeHandl
                     } else if (!Files.isDirectory(fullPath)) {
                         ROOT_LOGGER.isNotADirectory(fullPath.toString());
                     } else if (!Files.isReadable(fullPath)) {
+                        ROOT_LOGGER.directoryIsNotReadable(fullPath.toString());
+                    } else if (!Files.isWritable(fullPath)) {
                         ROOT_LOGGER.directoryIsNotWritable(fullPath.toString());
-
                     }
                 }
             }, Stage.RUNTIME);

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/logging/DeploymentScannerLogger.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/logging/DeploymentScannerLogger.java
@@ -424,4 +424,16 @@ public interface DeploymentScannerLogger extends BasicLogger {
 
     @Message(id = 40, value = "Could not find relative-to path entry for %s")
     OperationFailedException pathEntryNotFound(String pathName);
+
+    @LogMessage(level = WARN)
+    @Message(id = 41, value = "%s is not readable")
+    void directoryIsNotReadable(String path);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 42, value = "Boot-time scan failed due to inaccessible deployment directory: %s")
+    void bootTimeScanFailed(String dir);
+
+    @LogMessage(level = WARN)
+    @Message(id = 43, value = "Deployment directory scan failed due to inaccessible deployment directory: %s")
+    void scanFailed(String dir);
 }

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentScannerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentScannerTestCase.java
@@ -135,10 +135,8 @@ public class DeploymentScannerTestCase extends ContainerResourceMgmtTestBase {
 
         final ModelNode result = executeOperation(addScannerForNonExistentPath, false);
         // check that it failed
-        assertEquals("Adding a deployment scanner for a non-existent path was expected to fail but it passed", "failed", result.get("outcome").asString());
+        assertEquals("Adding a deployment scanner for a non-existent path was expected to succeed but it failed", "success", result.get("outcome").asString());
 
-        // check that rollback was success and we can create proper deployment scanner with the same name that failed
-        addDeploymentScanner();
         try {
             assertTestDeploymentScannerResourceExists();
         } finally {


### PR DESCRIPTION
…ent-scanner instance

https://issues.jboss.org/browse/WFCORE-1579
https://issues.jboss.org/browse/JBEAP-4874

Changes to the deployment scanner so that if deployment dir is not accessible:
* bootTimeScan() is skipped and error is logged (before the server failed to start)
* establishDeployedContentList() is not performed during startScanner(), instead it will be performed during first scan when deployment dir is accessible