### PR TITLE
[2.x] [WFCORE-1624] Upgrade jboss-logmanager from 1.0.3.Final to 1.0.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <version.org.jboss.jboss-vfs>3.2.12.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.logmanager.jboss-logmanager>2.0.3.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.0.4.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>1.4.11.Final</version.org.jboss.marshalling.jboss-marshalling>
         <!-- this is test only dependancy -->


### PR DESCRIPTION
This is opened against 2.x as well because https://github.com/wildfly/wildfly-core/pull/1517 was also in 2.x. The log manager will fail to boot a custom handler without the fix for https://issues.jboss.org/browse/LOGMGR-127.