### PR TITLE
[WFCORE-1627] CLI tab comple should reflect current position of prompt. Enable DeployCompletionTestCase.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandCompleter.java
@@ -83,7 +83,15 @@ public class CommandCompleter implements CommandLineCompleter {
 
         final DefaultCallbackHandler parsedCmd = (DefaultCallbackHandler) ctx.getParsedCommandLine();
         try {
-            parsedCmd.parse(ctx.getCurrentNodePath(), buffer, false, ctx);
+            // WFCORE-1627 parse current position if cursor moves
+            if (ctx.getArgumentsString() == null && buffer.length() > cursor) {
+                parsedCmd.parse(ctx.getCurrentNodePath(), buffer.substring(0, cursor), false, ctx);
+            } else if (ctx.getArgumentsString() != null && buffer.length() - ctx.getArgumentsString().length() > cursor) {
+                // multiple lines
+                parsedCmd.parse(ctx.getCurrentNodePath(), buffer.substring(0, ctx.getArgumentsString().length() + cursor), false, ctx);
+            } else {
+                parsedCmd.parse(ctx.getCurrentNodePath(), buffer, false, ctx);
+            }
         } catch(UnresolvedVariableException e) {
             final String variable = e.getExpression();
             if(buffer.endsWith(variable)) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/Console.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Console.java
@@ -144,8 +144,9 @@ public interface Console {
                                     co.getBuffer(), co.getCursor(), candidates);
                             co.setOffset(offset);
                             co.setCompletionCandidates(candidates);
-                            if (co.getCompletionCandidates().size() == 1 &&
-                                    co.getCompletionCandidates().get(0).getCharacters().startsWith(co.getBuffer()))
+                            String buffer = cmdCtx.getArgumentsString() == null ? co.getBuffer() : ctx.getArgumentsString() + co.getBuffer();
+                            if (co.getCompletionCandidates().size() == 1
+                                    && co.getCompletionCandidates().get(0).getCharacters().startsWith(buffer))
                                 co.doAppendSeparator(true);
                             else
                                 co.doAppendSeparator(false);

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -77,6 +77,8 @@ public class MockCommandContext implements CommandContext {
     private boolean silent;
     private ConnectionInfoBeanMock connInfo =  new ConnectionInfoBeanMock();
 
+    private String buffer;
+
     public MockCommandContext() {
         connInfo.setUsername("test");
         set(Scope.CONTEXT, "connection_info", connInfo);
@@ -84,6 +86,7 @@ public class MockCommandContext implements CommandContext {
 
     public void parseCommandLine(String buffer, boolean validate) throws CommandFormatException {
         try {
+            this.buffer = buffer;
             parsedCmd.parse(prefix, buffer, validate);
         } catch (CommandFormatException e) {
             if(!parsedCmd.endsOnAddressOperationNameSeparator() || !parsedCmd.endsOnSeparator()) {
@@ -92,13 +95,16 @@ public class MockCommandContext implements CommandContext {
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.jboss.as.cli.CommandContext#getCommandArguments()
-     */
     @Override
     public String getArgumentsString() {
-        // TODO Auto-generated method stub
-        return null;
+        // just for test like CommandCompletionTestCase
+        // mock method to support completion of commands and ops spread across multiple lines like in CommandContextImpl
+        if (buffer == null) {
+            return null;
+        } else {
+            int index = buffer.indexOf("\\n");
+            return index == -1 ? null : buffer.substring(0, index);
+        }
     }
 
     /* (non-Javadoc)

--- a/cli/src/test/java/org/jboss/as/cli/completion/operation/test/CommandCompletionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/operation/test/CommandCompletionTestCase.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.completion.operation.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.cli.CommandCompleter;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.CommandRegistry;
+import org.jboss.as.cli.completion.mock.MockCommandContext;
+import org.jboss.as.cli.completion.mock.MockNode;
+import org.jboss.as.cli.completion.mock.MockOperation;
+import org.jboss.as.cli.completion.mock.MockOperationCandidatesProvider;
+import org.junit.Test;
+
+/**
+ * @author wangc
+ *
+ */
+public class CommandCompletionTestCase {
+
+    private CommandRegistry cmdRegistry;
+    private CommandCompleter cmdCompleter;
+    private MockCommandContext ctx;
+
+    private static final String OPERATION1 = "operation-no-properties";
+    private static final String OPERATION2 = "operation-property-a";
+    private static final String OPERATION3 = "operation-properties-a-b";
+
+    private static final String OPERATION = ":operation-p";
+    private static final String OPERATION_MULTILINES_FULL = ":opera\\ntion-p";
+    private static final String OPERATION_MULTILINES_NEWLINE = "tion-p";
+
+    public CommandCompletionTestCase() {
+
+        MockNode root = new MockNode("root");
+
+        MockOperation op = new MockOperation(OPERATION1);
+        root.addOperation(op);
+
+        op = new MockOperation(OPERATION2);
+        root.addOperation(op);
+
+        op = new MockOperation(OPERATION3);
+        root.addOperation(op);
+
+        ctx = new MockCommandContext();
+        ctx.setOperationCandidatesProvider(new MockOperationCandidatesProvider(root));
+
+        cmdRegistry = new CommandRegistry();
+        cmdCompleter = new CommandCompleter(cmdRegistry);
+    }
+
+    @Test
+    public void testSelectedCandidates() {
+        // usual case, test cursor is next to "operation-p", it should find 2 candidates
+        List<String> candidates = fetchCandidates(OPERATION, OPERATION.length(), false);
+        assertNotNull(candidates);
+        assertEquals(Arrays.asList(OPERATION3, OPERATION2), candidates);
+    }
+
+    @Test
+    public void testSelectedCandidatesCursorMoveLeft() {
+        // test cursor moves to left next to "operation", it should find 3 candidates
+        List<String> candidates = fetchCandidates(OPERATION, 9, false);
+        assertNotNull(candidates);
+        assertEquals(Arrays.asList(OPERATION1, OPERATION3, OPERATION2), candidates);
+    }
+
+    @Test
+    public void testSelectedCandidatesCursorMoveRight() {
+        // test cursor moves to way right to "operation-p", it should find 2 candidates
+        List<String> candidates = fetchCandidates(OPERATION, OPERATION.length() + 10, false);
+        assertNotNull(candidates);
+        assertEquals(Arrays.asList(OPERATION3, OPERATION2), candidates);
+    }
+
+    @Test
+    public void testSelectedCandidatesWithMultipleLines() {
+        // test cursor moves to new line in multiples lines context, it should find 2 candidates
+        List<String> candidates = fetchCandidates(OPERATION_MULTILINES_FULL, 6, true);
+        assertNotNull(candidates);
+        assertEquals(Arrays.asList(OPERATION3, OPERATION2), candidates);
+    }
+
+    @Test
+    public void testSelectedCandidatesWithMultipleLinesCursorMoveLeft() {
+        // test cursor moves to left in multiples lines context, it should find 3 candidates
+        List<String> candidates = fetchCandidates(OPERATION_MULTILINES_FULL, 1, true);
+        assertNotNull(candidates);
+        assertEquals(Arrays.asList(OPERATION1, OPERATION3, OPERATION2), candidates);
+    }
+
+    @Test
+    public void testSelectedCandidatesWithMultipleLinesCursorMoveRight() {
+        // test cursor moves to left in multiples lines context, it should find 2 candidates
+        List<String> candidates = fetchCandidates(OPERATION_MULTILINES_FULL, OPERATION_MULTILINES_FULL.length() + 10, true);
+        assertNotNull(candidates);
+        assertEquals(Arrays.asList(OPERATION3, OPERATION2), candidates);
+    }
+
+    protected List<String> fetchCandidates(String buffer, int cursor, boolean multiLines) {
+        ArrayList<String> candidates = new ArrayList<String>();
+        try {
+            ctx.parseCommandLine(buffer, false);
+        } catch (CommandFormatException e) {
+            return Collections.emptyList();
+        }
+        if (multiLines) {
+            cmdCompleter.complete(ctx, OPERATION_MULTILINES_NEWLINE, cursor, candidates);
+        } else {
+            cmdCompleter.complete(ctx, buffer, cursor, candidates);
+        }
+
+        return candidates;
+    }
+
+}

--- a/cli/src/test/java/org/jboss/as/cli/completion/operation/test/DeployCompletionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/operation/test/DeployCompletionTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.as.cli.parsing.DefaultParsingState;
 import org.jboss.as.cli.parsing.ParserUtil;
 import org.jboss.as.cli.parsing.operation.HeaderListState;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -47,14 +46,14 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Bartosz Spyrko-Smietanko
  */
-public class DeployCompletionTest {
+public class DeployCompletionTestCase {
     private DefaultParsingState headerParsingInitialState;
     final DefaultCallbackHandler headerParsingCallback;
 
     private MockCommandContext ctx;
     private CommandCompleter cmdCompleter;
 
-    public DeployCompletionTest() throws Exception {
+    public DeployCompletionTestCase() throws Exception {
         ctx = new MockCommandContext() {
             @Override
             public boolean isDomainMode() {
@@ -100,7 +99,6 @@ public class DeployCompletionTest {
     }
 
     @Test
-    @Ignore("Will not work until WFCORE-1572 is resolved")
     public void testDontListDeprecatedIdArgumentWhenNoArgumentsAreStarted() throws Exception {
         ArrayList<String> candidates = complete("deploy --headers={rollout ");
 
@@ -124,7 +122,7 @@ public class DeployCompletionTest {
     private ArrayList<String> complete(String buffer) {
         ArrayList<String> candidates = new ArrayList<>();
 
-        cmdCompleter.complete(ctx, buffer, 0, candidates);
+        cmdCompleter.complete(ctx, buffer, buffer.length(), candidates);
         return candidates;
     }
 


### PR DESCRIPTION
…rompt. Enable DeployCompletionTestCase.

https://issues.jboss.org/browse/WFCORE-1627 
1. fix a tab completion issue when cursor moves.
2. DeployCompletionTest is never running, rename it to match *TestCase pattern. Also enable an ignored test. 