### PR TITLE
[WFCORE-1625] Fix operations output in :read-resource-description

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -52,6 +52,7 @@ public class ModelDescriptionConstants {
     public static final String ALLOW_RESOURCE_SERVICE_RESTART = "allow-resource-service-restart";
     public static final String ALLOWED_ORIGINS = "allowed-origins";
     public static final String ALL_ROLE_NAMES = "all-role-names";
+    public static final String ALL_SERVICES = "all-services";
     public static final String ALTERNATIVES = "alternatives";
     public static final String ANY = "any";
     public static final String ANY_ADDRESS = "any-address";
@@ -298,6 +299,7 @@ public class ModelDescriptionConstants {
     public static final String NETWORK = "network";
     public static final String NILLABLE = "nillable";
     public static final String NIL_SIGNIFICANT = "nil-significant";
+    public static final String NO_SERVICES = "no-services";
     public static final String NOT = "not";
     public static final String NOTIFICATION = "notification";
     public static final String NOTIFICATION_DATA_TYPE = "data-type";
@@ -385,6 +387,7 @@ public class ModelDescriptionConstants {
     public static final String RESOLVE_EXPRESSIONS = "resolve-expressions";
     public static final String RESOURCE_ADDED_NOTIFICATION = "resource-added";
     public static final String RESOURCE_REMOVED_NOTIFICATION = "resource-removed";
+    public static final String RESOURCE_SERVICES = "resource-services";
     public static final String RESPONSE = "response";
     public static final String RESPONSE_HEADERS = "response-headers";
     public static final String RESTART = "restart";

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -24,17 +24,21 @@ package org.jboss.as.controller.operations.global;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALL_SERVICES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXCEPTIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXECUTE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.JVM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NO_SERVICES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESOURCE_SERVICES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART_REQUIRED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STORAGE;
@@ -216,8 +220,8 @@ public class ReadResourceDescriptionHandler extends GlobalOperationHandlers.Abst
             for (final Map.Entry<String, OperationEntry> entry : registry.getOperationDescriptions(PathAddress.EMPTY_ADDRESS, inherited).entrySet()) {
                 if (entry.getValue().getType() == OperationEntry.EntryType.PUBLIC) {
                     if (context.getProcessType() != ProcessType.DOMAIN_SERVER || entry.getValue().getFlags().contains(OperationEntry.Flag.RUNTIME_ONLY)) {
-                        final DescriptionProvider provider = entry.getValue().getDescriptionProvider();
-                        operations.put(entry.getKey(), provider.getModelDescription(locale));
+                        ReadOperationDescriptionHandler.DescribedOp describedOp = new ReadOperationDescriptionHandler.DescribedOp(entry.getValue(), locale);
+                        operations.put(entry.getKey(), describedOp.getDescription());
                     }
                 }
             }
@@ -251,13 +255,13 @@ public class ReadResourceDescriptionHandler extends GlobalOperationHandlers.Abst
                 if (accessType == AttributeAccess.AccessType.READ_WRITE) {
                     Set<AttributeAccess.Flag> flags = access.getFlags();
                     if (flags.contains(AttributeAccess.Flag.RESTART_ALL_SERVICES)) {
-                        attrNode.get(RESTART_REQUIRED).set("all-services");
+                        attrNode.get(RESTART_REQUIRED).set(ALL_SERVICES);
                     } else if (flags.contains(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)) {
-                        attrNode.get(RESTART_REQUIRED).set("resource-services");
+                        attrNode.get(RESTART_REQUIRED).set(RESOURCE_SERVICES);
                     } else if (flags.contains(AttributeAccess.Flag.RESTART_JVM)) {
-                        attrNode.get(RESTART_REQUIRED).set("jvm");
+                        attrNode.get(RESTART_REQUIRED).set(JVM);
                     } else {
-                        attrNode.get(RESTART_REQUIRED).set("no-services");
+                        attrNode.get(RESTART_REQUIRED).set(NO_SERVICES);
                     }
                 }
             }


### PR DESCRIPTION
* in ReadResourceDescriptionHandler, delegate to
  ReadOperationDescriptionHandler's DescribedOp to ensure a consistent
  operation description in both :read-resource-description and
  :read-operation-descripion

JIRA: https://issues.jboss.org/browse/WFCORE-1625