### PR TITLE
[WFCORE-1632] Server processing request isn't stopped immediately but…

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerService.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerService.java
@@ -61,7 +61,7 @@ public class WorkerService implements Service<XnioWorker> {
     public void stop(StopContext context) {
         this.stopContext = context;
         context.asynchronous();
-        worker.shutdown();
+        worker.shutdownNow();
         worker = null;
     }
 


### PR DESCRIPTION
… waits for request processing to finish

Jira: https://issues.jboss.org/browse/WFCORE-1632

If we should not be waiting for threads to complete before shutting down, I think we should call the `XnioWorker.shutdownNow()` instead of `XnioWorker.shutdown()`, the `XnioWorker.shutdownNow()` will interrupt the execution of the running threads.
