### PR TITLE
[WFCORE-1588] Register runtime attribtes depends on the server type

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -415,13 +415,14 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
     }
 
     /**
-     * Adds the {@link AttributeAccess.Flag#FORCE_REGISTRATION} flag.
+     * Adds the {@link AttributeAccess.Flag#RUNTIME_SERVICE_NOT_REQUIRED} flag.
      *
      * @return a builder that can be used to continue building the attribute definition
      */
-    public BUILDER forceRegistration() {
-        return addFlag(AttributeAccess.Flag.FORCE_REGISTRATION);
+    public BUILDER setRuntimeServiceNotRequired() {
+        return addFlag(AttributeAccess.Flag.RUNTIME_SERVICE_NOT_REQUIRED);
     }
+
     /**
      * Adds the {@link AttributeAccess.Flag#RESTART_ALL_SERVICES} flag and removes any conflicting flag.
      *

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionSubsystemResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionSubsystemResourceDefinition.java
@@ -38,7 +38,6 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelType;
 
@@ -51,19 +50,26 @@ public class ExtensionSubsystemResourceDefinition extends SimpleResourceDefiniti
     public static final ListAttributeDefinition XML_NAMESPACES = new StringListAttributeDefinition.Builder(ModelDescriptionConstants.XML_NAMESPACES)
             .setAllowNull(false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setElementValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, false))
             .build();
 
     public static final SimpleAttributeDefinition MAJOR_VERSION = new SimpleAttributeDefinitionBuilder(MANAGEMENT_MAJOR_VERSION, ModelType.INT, true)
-            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
+            .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
+            .build();
 
     public static final SimpleAttributeDefinition MINOR_VERSION = new SimpleAttributeDefinitionBuilder(MANAGEMENT_MINOR_VERSION, ModelType.INT, true)
             .setValidator(new IntRangeValidator(0, Integer.MAX_VALUE, true, false))
-            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
+            .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
+            .build();
 
     public static final SimpleAttributeDefinition MICRO_VERSION = new SimpleAttributeDefinitionBuilder(MANAGEMENT_MICRO_VERSION, ModelType.INT, true)
             .setValidator(new IntRangeValidator(0, Integer.MAX_VALUE, true, false))
-            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
+            .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
+            .build();
 
     ExtensionSubsystemResourceDefinition() {
         super(new Parameters(PathElement.pathElement(SUBSYSTEM), ControllerResolver.getResolver(EXTENSION, SUBSYSTEM)).setRuntime());

--- a/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
@@ -140,9 +140,11 @@ public final class AttributeAccess {
          */
         ALIAS,
         /**
-         * Force the registration of the attribute regardless of the actual process type.
+         * An attribute which does not require runtime MSC services to be read or written.
+         * This flag can be used in conjunction with STORAGE_RUNTIME to specify that a runtime
+         * attribute can work in the absence of runtime services.
          */
-        FORCE_REGISTRATION
+         RUNTIME_SERVICE_NOT_REQUIRED
     }
 
     private final AccessType access;

--- a/controller/src/main/java/org/jboss/as/controller/services/path/PathResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/PathResourceDefinition.java
@@ -71,6 +71,7 @@ public abstract class PathResourceDefinition extends SimpleResourceDefinition {
             SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.READ_ONLY, ModelType.BOOLEAN, true)
                 .setDefaultValue(new ModelNode(false))
                 .setStorageRuntime()
+                .setRuntimeServiceNotRequired()
                 .build();
 
     /**

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessAuthorizationResourceDefinition.java
@@ -87,10 +87,12 @@ public class AccessAuthorizationResourceDefinition extends SimpleResourceDefinit
 
     static final ListAttributeDefinition STANDARD_ROLE_NAMES = new StringListAttributeDefinition.Builder(ModelDescriptionConstants.STANDARD_ROLE_NAMES)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     static final ListAttributeDefinition ALL_ROLE_NAMES = new StringListAttributeDefinition.Builder(ModelDescriptionConstants.ALL_ROLE_NAMES)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     public static final List<AttributeDefinition> CONFIG_ATTRIBUTES = Arrays.<AttributeDefinition>asList(PROVIDER, PERMISSION_COMBINATION_POLICY);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/ApplicationClassificationConfigResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/ApplicationClassificationConfigResourceDefinition.java
@@ -61,6 +61,7 @@ public class ApplicationClassificationConfigResourceDefinition extends SimpleRes
 
     public static SimpleAttributeDefinition DEFAULT_APPLICATION = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DEFAULT_APPLICATION, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     public static SimpleAttributeDefinition CONFIGURED_APPLICATION = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.CONFIGURED_APPLICATION, ModelType.BOOLEAN, true)

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/SensitivityResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/SensitivityResourceDefinition.java
@@ -71,15 +71,18 @@ public class SensitivityResourceDefinition extends SimpleResourceDefinition {
 
     public static SimpleAttributeDefinition DEFAULT_REQUIRES_ADDRESSABLE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DEFAULT_REQUIRES_ADDRESSABLE, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
 
     public static SimpleAttributeDefinition DEFAULT_REQUIRES_READ = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DEFAULT_REQUIRES_READ, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     public static SimpleAttributeDefinition DEFAULT_REQUIRES_WRITE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DEFAULT_REQUIRES_WRITE, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     public static SimpleAttributeDefinition CONFIGURED_REQUIRES_ADDRESSABLE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.CONFIGURED_REQUIRES_ADDRESSABLE, ModelType.BOOLEAN, true)

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/AuditLogHandlerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/AuditLogHandlerResourceDefinition.java
@@ -74,11 +74,13 @@ public class AuditLogHandlerResourceDefinition extends SimpleResourceDefinition 
     public static final SimpleAttributeDefinition FAILURE_COUNT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.FAILURE_COUNT, ModelType.INT)
         .setAllowNull(false)
         .setStorageRuntime()
+        .setRuntimeServiceNotRequired()
         .build();
 
     public static final SimpleAttributeDefinition DISABLED_DUE_TO_FAILURE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.DISABLED_DUE_TO_FAILURE, ModelType.BOOLEAN)
         .setAllowNull(false)
         .setStorageRuntime()
+        .setRuntimeServiceNotRequired()
         .build();
 
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapCacheResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapCacheResourceDefinition.java
@@ -104,7 +104,8 @@ public class LdapCacheResourceDefinition extends SimpleResourceDefinition {
 
     // Current Size - int
     public static final SimpleAttributeDefinition CACHE_SIZE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.CACHE_SIZE, ModelType.INT)
-            .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
+            .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.SECONDS)
             .build();
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -157,15 +157,18 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
         .build();
     public static final SimpleAttributeDefinition PROCESS_TYPE = SimpleAttributeDefinitionBuilder.create(ServerDescriptionConstants.PROCESS_TYPE, ModelType.STRING)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setValidator(NOT_NULL_STRING_LENGTH_ONE_VALIDATOR)
             .build();
     public static final SimpleAttributeDefinition LAUNCH_TYPE = SimpleAttributeDefinitionBuilder.create(ServerDescriptionConstants.LAUNCH_TYPE, ModelType.STRING)
             .setValidator(new EnumValidator<LaunchType>(LaunchType.class, false, false))
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     public static final SimpleAttributeDefinition LOCAL_HOST_NAME = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.LOCAL_HOST_NAME, ModelType.STRING, true)
             .setValidator(NOT_NULL_STRING_LENGTH_ONE_VALIDATOR)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     public static final SimpleAttributeDefinition ORGANIZATION_IDENTIFIER = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DOMAIN_ORGANIZATION, ModelType.STRING, true)

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostConnectionResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostConnectionResourceDefinition.java
@@ -57,26 +57,32 @@ public class HostConnectionResourceDefinition extends SimpleResourceDefinition {
 
     private static final AttributeDefinition CONNECTION_DEF = SimpleAttributeDefinitionBuilder.create(HostConnectionInfo.CONNECTED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static final AttributeDefinition TIMESTAMP_DEF = SimpleAttributeDefinitionBuilder.create(HostConnectionInfo.TIMESTAMP, ModelType.LONG, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static final AttributeDefinition EVENT_TYPE_DEF = SimpleAttributeDefinitionBuilder.create(HostConnectionInfo.TYPE, ModelType.STRING, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static final AttributeDefinition ADDRESS_DEF = SimpleAttributeDefinitionBuilder.create(HostConnectionInfo.ADDRESS, ModelType.STRING, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static final ObjectTypeAttributeDefinition EVENT = ObjectTypeAttributeDefinition.Builder.of("event", EVENT_TYPE_DEF, ADDRESS_DEF, TIMESTAMP_DEF)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static final ObjectListAttributeDefinition EVENT_LIST = ObjectListAttributeDefinition.Builder.of(HostConnectionInfo.EVENTS, EVENT)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static final OperationDefinition PRUNE_EXPIRED_DEF = new SimpleOperationDefinitionBuilder("prune-expired", RESOLVER)

--- a/host-controller/src/main/java/org/jboss/as/host/controller/descriptions/HostEnvironmentResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/descriptions/HostEnvironmentResourceDefinition.java
@@ -39,7 +39,6 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.persistence.ConfigurationFile;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.host.controller.HostControllerEnvironment;
 import org.jboss.dmr.ModelNode;
@@ -135,11 +134,16 @@ public class HostEnvironmentResourceDefinition extends SimpleResourceDefinition 
     }
 
     private static AttributeDefinition createAttributeDefinition(String name, ModelType type) {
-        return SimpleAttributeDefinitionBuilder.create(name, type).setFlags(AttributeAccess.Flag.STORAGE_RUNTIME).build();
+        return SimpleAttributeDefinitionBuilder.create(name, type)
+                .setStorageRuntime()
+                .setRuntimeServiceNotRequired()
+                .build();
     }
 
     private static AttributeDefinition createAttributeDefinition(String name, ModelType type, AccessConstraintDefinition... accessConstraints) {
-        SimpleAttributeDefinitionBuilder builder = SimpleAttributeDefinitionBuilder.create(name, type).setFlags(AttributeAccess.Flag.STORAGE_RUNTIME);
+        SimpleAttributeDefinitionBuilder builder = SimpleAttributeDefinitionBuilder.create(name, type)
+                .setStorageRuntime()
+                .setRuntimeServiceNotRequired();
         if (accessConstraints != null) {
             for (AccessConstraintDefinition acd : accessConstraints) {
                 builder = builder.addAccessConstraint(acd);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/discovery/DiscoveryOptionResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/discovery/DiscoveryOptionResourceDefinition.java
@@ -55,12 +55,14 @@ public class DiscoveryOptionResourceDefinition extends SimpleResourceDefinition 
     public static final SimpleAttributeDefinition CODE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.CODE, ModelType.STRING)
         .setValidator(new StringLengthValidator(1))
         .setStorageRuntime()
+        .setRuntimeServiceNotRequired()
         .build();
 
     public static final SimpleAttributeDefinition MODULE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.MODULE, ModelType.STRING, true)
         .setDefaultValue(new ModelNode(DEFAULT_MODULE))
         .setValidator(new StringLengthValidator(1))
         .setStorageRuntime()
+        .setRuntimeServiceNotRequired()
         .build();
 
     public static final PropertiesAttributeDefinition PROPERTIES = new PropertiesAttributeDefinition.Builder(ModelDescriptionConstants.PROPERTIES, true)
@@ -68,6 +70,7 @@ public class DiscoveryOptionResourceDefinition extends SimpleResourceDefinition 
         .setCorrector(MapAttributeDefinition.LIST_TO_MAP_CORRECTOR)
         .setAllowExpression(true)
         .setStorageRuntime()
+        .setRuntimeServiceNotRequired()
         .build();
 
     public static final AttributeDefinition[] DISCOVERY_ATTRIBUTES = new AttributeDefinition[] {CODE, MODULE, PROPERTIES};

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -161,11 +161,13 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
             .setAllowNull(true)
             .setMinSize(1)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     public static final SimpleAttributeDefinition UUID = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.UUID, ModelType.STRING, false)
             .setValidator(new StringLengthValidator(1, true))
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     public static final SimpleAttributeDefinition ORGANIZATION_IDENTIFIER = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ORGANIZATION, ModelType.STRING, true)
@@ -175,15 +177,18 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition DOMAIN_ORGANIZATION_IDENTIFIER = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DOMAIN_ORGANIZATION, ModelType.STRING, true)
             .setValidator(new StringLengthValidator(1, true))
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     // the current runtime configuration state, replaces HOST_STATE
     public static final SimpleAttributeDefinition RUNTIME_CONFIGURATION_STATE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.RUNTIME_CONFIGURATION_STATE, ModelType.STRING)
             .setMinSize(1)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     public static final SimpleAttributeDefinition HOST_STATE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.HOST_STATE, ModelType.STRING)
             .setMinSize(1)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     public static final SimpleAttributeDefinition DIRECTORY_GROUPING = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.DIRECTORY_GROUPING, ModelType.STRING, true).
             addFlag(AttributeAccess.Flag.RESTART_ALL_SERVICES).
@@ -194,6 +199,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition MASTER = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.MASTER, ModelType.BOOLEAN, true)
             .setDefaultValue(new ModelNode(false))
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setResourceOnly()
             .build();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
@@ -118,7 +118,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
 
     public static final SimpleAttributeDefinition STATUS = SimpleAttributeDefinitionBuilder.create(ServerStatusHandler.ATTRIBUTE_NAME, ModelType.STRING)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setValidator(new EnumValidator<ServerStatus>(ServerStatus.class, false, false))
             .build();
 

--- a/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentResourceDefinition.java
+++ b/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentResourceDefinition.java
@@ -87,6 +87,7 @@ public class ManagedDMRContentResourceDefinition extends SimpleResourceDefinitio
     private static AttributeDefinition getContentAttributeDefinition(final ParameterValidator contentValidator) {
         return SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.CONTENT, ModelType.OBJECT)
                 .setStorageRuntime()
+                .setRuntimeServiceNotRequired()
                 .setValidator(contentValidator)
                 .build();
     }

--- a/patching/src/main/java/org/jboss/as/patching/management/PatchResourceDefinition.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/PatchResourceDefinition.java
@@ -62,12 +62,15 @@ class PatchResourceDefinition extends SimpleResourceDefinition {
 
     static final AttributeDefinition VERSION = SimpleAttributeDefinitionBuilder.create("version", ModelType.STRING)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     static final AttributeDefinition CUMULATIVE_PATCH_ID = SimpleAttributeDefinitionBuilder.create(Constants.CUMULATIVE, ModelType.STRING)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     static final AttributeDefinition PATCHES = PrimitiveListAttributeDefinition.Builder.of(Constants.PATCHES, ModelType.STRING)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     // Patch operation

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/BufferPoolResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/BufferPoolResourceDefinition.java
@@ -47,18 +47,18 @@ class BufferPoolResourceDefinition extends SimpleResourceDefinition {
 
     private static AttributeDefinition MEMORY_USED_NAME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.MEMORY_USED_NAME, ModelType.LONG, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .build();
     private static AttributeDefinition TOTAL_CAPACITY = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.TOTAL_CAPACITY, ModelType.LONG, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .build();
 
     private static AttributeDefinition COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COUNT, ModelType.LONG, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static final List<AttributeDefinition> METRICS = Arrays.asList(

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ClassLoadingResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ClassLoadingResourceDefinition.java
@@ -17,22 +17,23 @@ class ClassLoadingResourceDefinition extends SimpleResourceDefinition {
     //metrics
     private static SimpleAttributeDefinition TOTAL_LOADED_CLASS_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.TOTAL_LOADED_CLASS_COUNT, ModelType.LONG, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
     private static SimpleAttributeDefinition LOADED_CLASS_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.LOADED_CLASS_COUNT, ModelType.INT, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
     private static SimpleAttributeDefinition UNLOADED_CLASS_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.UNLOADED_CLASS_COUNT, ModelType.LONG, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
     //r+w attributes
     private static SimpleAttributeDefinition VERBOSE = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.VERBOSE, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     static final List<String> CLASSLOADING_METRICS = Arrays.asList(

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CompilationResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CompilationResourceDefinition.java
@@ -19,14 +19,16 @@ class CompilationResourceDefinition extends SimpleResourceDefinition {
     //metrics
     static SimpleAttributeDefinition NAME = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.NAME, ModelType.STRING, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     static SimpleAttributeDefinition COMPILATION_TIME_MONITORING_SUPPORTED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COMPILATION_TIME_MONITORING_SUPPORTED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     static SimpleAttributeDefinition TOTAL_COMPILATION_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.TOTAL_COMPILATION_TIME, ModelType.LONG, true)
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
     protected static final List<String> COMPILATION_READ_ATTRIBUTES = Arrays.asList(
             NAME.getName(),

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/GarbageCollectorResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/GarbageCollectorResourceDefinition.java
@@ -46,16 +46,17 @@ class GarbageCollectorResourceDefinition extends SimpleResourceDefinition {
     //metrics
     private static SimpleAttributeDefinition COLLECTION_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_COUNT, ModelType.LONG, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
     private static SimpleAttributeDefinition COLLECTION_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_TIME, ModelType.LONG, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .build();
     private static AttributeDefinition MEMORY_POOL_NAMES = new StringListAttributeDefinition.Builder(PlatformMBeanConstants.MEMORY_POOL_NAMES)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static final List<SimpleAttributeDefinition> METRICS = Arrays.asList(

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryManagerResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryManagerResourceDefinition.java
@@ -45,11 +45,11 @@ import org.jboss.dmr.ModelType;
 class MemoryManagerResourceDefinition extends SimpleResourceDefinition {
     private static SimpleAttributeDefinition VALID = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.VALID, ModelType.BOOLEAN, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
     private static AttributeDefinition MEMORY_POOL_NAMES = new StringListAttributeDefinition.Builder(PlatformMBeanConstants.MEMORY_POOL_NAMES)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
 
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryPoolResourceDefinition.java
@@ -53,53 +53,58 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
 
     private static AttributeDefinition MEMORY_MANAGER_NAMES = new StringListAttributeDefinition.Builder(PlatformMBeanConstants.MEMORY_MANAGER_NAMES)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static AttributeDefinition TYPE = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.TYPE, ModelType.STRING, false)
             .setValidator(new EnumValidator<MemoryType>(MemoryType.class, false))
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static AttributeDefinition USAGE_THRESHOLD = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.USAGE_THRESHOLD, ModelType.LONG, true)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .setValidator(new IntRangeValidator(0))
             .build();
 
     private static AttributeDefinition USAGE_THRESHOLD_EXCEEDED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.USAGE_THRESHOLD_EXCEEDED, ModelType.BOOLEAN, true)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static AttributeDefinition USAGE_THRESHOLD_SUPPORTED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.USAGE_THRESHOLD_SUPPORTED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static AttributeDefinition USAGE_THRESHOLD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.USAGE_THRESHOLD_COUNT, ModelType.LONG, true)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     private static AttributeDefinition COLLECTION_USAGE_THRESHOLD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_USAGE_THRESHOLD_COUNT, ModelType.LONG, true)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     private static AttributeDefinition COLLECTION_USAGE_THRESHOLD = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_USAGE_THRESHOLD, ModelType.LONG, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .setValidator(new IntRangeValidator(0))
             .build();
 
     private static AttributeDefinition COLLECTION_USAGE_THRESHOLD_SUPPORTED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_USAGE_THRESHOLD_SUPPORTED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     private static AttributeDefinition COLLECTION_USAGE_THRESHOLD_EXCEEDED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.COLLECTION_USAGE_THRESHOLD_EXCEEDED, ModelType.BOOLEAN, true)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
 
 
@@ -121,7 +126,7 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
             PlatformMBeanConstants.MEMORY_COMMITTED,
             PlatformMBeanConstants.MEMORY_MAX)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setAllowNull(false)
             .build();
 
@@ -132,7 +137,7 @@ class MemoryPoolResourceDefinition extends SimpleResourceDefinition {
             PlatformMBeanConstants.MEMORY_COMMITTED,
             PlatformMBeanConstants.MEMORY_MAX)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
 
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/MemoryResourceDefinition.java
@@ -47,7 +47,7 @@ class MemoryResourceDefinition extends SimpleResourceDefinition {
     //metrics
     private static SimpleAttributeDefinition OBJECT_PENDING_FINALIZATION_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.OBJECT_PENDING_FINALIZATION_COUNT, ModelType.INT, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
@@ -60,7 +60,7 @@ class MemoryResourceDefinition extends SimpleResourceDefinition {
             PlatformMBeanConstants.MEMORY_MAX
     )
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setAllowNull(false)
             .build();
 
@@ -71,12 +71,13 @@ class MemoryResourceDefinition extends SimpleResourceDefinition {
             PlatformMBeanConstants.MEMORY_COMMITTED,
             PlatformMBeanConstants.MEMORY_MAX)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setAllowNull(false)
             .build();
 
     private static AttributeDefinition VERBOSE = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.VERBOSE, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static final List<SimpleAttributeDefinition> METRICS = Arrays.asList(

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/OperatingSystemResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/OperatingSystemResourceDefinition.java
@@ -46,22 +46,24 @@ class OperatingSystemResourceDefinition extends SimpleResourceDefinition {
 
     private static SimpleAttributeDefinition AVAILABLE_PROCESSORS = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.AVAILABLE_PROCESSORS, ModelType.INT, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     private static SimpleAttributeDefinition SYSTEM_LOAD_AVERAGE = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.SYSTEM_LOAD_AVERAGE, ModelType.DOUBLE, false)
             .setMeasurementUnit(MeasurementUnit.PERCENTAGE)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
 
 
     private static AttributeDefinition ARCH = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.ARCH, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     private static AttributeDefinition VERSION = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.VERSION, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static final List<SimpleAttributeDefinition> METRICS = Arrays.asList(

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/PlatformMBeanConstants.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/PlatformMBeanConstants.java
@@ -77,6 +77,7 @@ public class PlatformMBeanConstants {
 
     static SimpleAttributeDefinition OBJECT_NAME = SimpleAttributeDefinitionBuilder.create("object-name", ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
 
@@ -105,21 +106,25 @@ public class PlatformMBeanConstants {
     public static final String INIT = "init";
     static SimpleAttributeDefinition MEMORY_INIT = SimpleAttributeDefinitionBuilder.create(INIT, ModelType.LONG, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .build();
     public static final String USED = "used";
     static SimpleAttributeDefinition MEMORY_USED = SimpleAttributeDefinitionBuilder.create(USED, ModelType.LONG, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .build();
     public static final String COMMITTED = "committed";
     static SimpleAttributeDefinition MEMORY_COMMITTED = SimpleAttributeDefinitionBuilder.create(COMMITTED, ModelType.LONG, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .build();
     public static final String MAX = "max";
     static SimpleAttributeDefinition MEMORY_MAX = SimpleAttributeDefinitionBuilder.create(MAX, ModelType.LONG, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.BYTES)
             .build();
 
@@ -278,9 +283,11 @@ public class PlatformMBeanConstants {
     //read attributes
     static AttributeDefinition NAME = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.NAME, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     static AttributeDefinition VALID = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.VALID, ModelType.BOOLEAN, false)
                     .setStorageRuntime()
+                    .setRuntimeServiceNotRequired()
                     .build();
 
     private PlatformMBeanConstants() {

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/RuntimeResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/RuntimeResourceDefinition.java
@@ -49,61 +49,75 @@ class RuntimeResourceDefinition extends SimpleResourceDefinition {
     private static AttributeDefinition UPTIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.UPTIME, ModelType.LONG, false)
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
 
     private static AttributeDefinition START_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.START_TIME, ModelType.LONG, false)
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     //todo convert to proper list! new StringListAttributeDefinition.Builder(PlatformMBeanConstants.SYSTEM_PROPERTIES)
      private static AttributeDefinition SYSTEM_PROPERTIES = new SimpleMapAttributeDefinition.Builder(PlatformMBeanConstants.SYSTEM_PROPERTIES,true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SYSTEM_PROPERTY)
             .build();
 
     private static AttributeDefinition INPUT_ARGUMENTS = new StringListAttributeDefinition.Builder(PlatformMBeanConstants.INPUT_ARGUMENTS)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.JVM)
             .setAllowNull(true)
             .build();
 
     private static AttributeDefinition VM_NAME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.VM_NAME, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     private static AttributeDefinition VM_VENDOR = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.VM_VENDOR, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     private static AttributeDefinition VM_VERSION = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.VM_VERSION, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     private static AttributeDefinition SPEC_NAME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.SPEC_NAME, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     private static AttributeDefinition SPEC_VENDOR = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.SPEC_VENDOR, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     private static AttributeDefinition SPEC_VERSION = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.SPEC_VERSION, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     private static AttributeDefinition MANAGEMENT_SPEC_VERSION = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.MANAGEMENT_SPEC_VERSION, ModelType.STRING, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     private static AttributeDefinition CLASS_PATH = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.CLASS_PATH, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.JVM)
             .build();
     private static AttributeDefinition LIBRARY_PATH = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.LIBRARY_PATH, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.JVM)
             .build();
     private static AttributeDefinition BOOT_CLASS_PATH_SUPPORTED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.BOOT_CLASS_PATH_SUPPORTED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.JVM)
             .build();
     private static AttributeDefinition BOOT_CLASS_PATH = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.BOOT_CLASS_PATH, ModelType.STRING, true)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.JVM)
             .build();
 

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadResourceDefinition.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/ThreadResourceDefinition.java
@@ -49,68 +49,76 @@ class ThreadResourceDefinition extends SimpleResourceDefinition {
     static AttributeDefinition CURRENT_THREAD_CPU_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.CURRENT_THREAD_CPU_TIME, ModelType.LONG, false)
             .setMeasurementUnit(MeasurementUnit.NANOSECONDS)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
 
     static AttributeDefinition CURRENT_THREAD_USER_TIME = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.CURRENT_THREAD_USER_TIME, ModelType.LONG, false)
             .setMeasurementUnit(MeasurementUnit.NANOSECONDS)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .build();
 
 
     static AttributeDefinition ALL_THREAD_IDS = new PrimitiveListAttributeDefinition.Builder(PlatformMBeanConstants.ALL_THREAD_IDS, ModelType.LONG)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     static AttributeDefinition THREAD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.THREAD_COUNT, ModelType.INT, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     static AttributeDefinition PEAK_THREAD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.PEAK_THREAD_COUNT, ModelType.INT, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     static AttributeDefinition TOTAL_STARTED_THREAD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.TOTAL_STARTED_THREAD_COUNT, ModelType.LONG, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     static AttributeDefinition DAEMON_THREAD_COUNT = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.DAEMON_THREAD_COUNT, ModelType.INT, false)
             .setStorageRuntime()
-            .forceRegistration()
+            .setRuntimeServiceNotRequired()
             .setMeasurementUnit(MeasurementUnit.NONE)
             .build();
 
     static AttributeDefinition THREAD_CONTENTION_MONITORING_SUPPORTED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.THREAD_CONTENTION_MONITORING_SUPPORTED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     static AttributeDefinition THREAD_CONTENTION_MONITORING_ENABLED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.THREAD_CONTENTION_MONITORING_ENABLED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     static AttributeDefinition THREAD_CPU_TIME_SUPPORTED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.THREAD_CPU_TIME_SUPPORTED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     static AttributeDefinition CURRENT_THREAD_CPU_TIME_SUPPORTED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.CURRENT_THREAD_CPU_TIME_SUPPORTED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     static AttributeDefinition THREAD_CPU_TIME_ENABLED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.THREAD_CPU_TIME_ENABLED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     static AttributeDefinition OBJECT_MONITOR_USAGE_SUPPORTED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.OBJECT_MONITOR_USAGE_SUPPORTED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
     static AttributeDefinition SYNCHRONIZER_USAGE_SUPPORTED = SimpleAttributeDefinitionBuilder.create(PlatformMBeanConstants.SYNCHRONIZER_USAGE_SUPPORTED, ModelType.BOOLEAN, false)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
 

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ModuleLoadingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ModuleLoadingResourceDefinition.java
@@ -87,6 +87,7 @@ public class ModuleLoadingResourceDefinition extends SimpleResourceDefinition {
         AttributeDefinition ad = SimpleListAttributeDefinition.Builder.of("module-roots",
                 new SimpleAttributeDefinitionBuilder("module-root", ModelType.STRING).build())
                 .setStorageRuntime()
+                .setRuntimeServiceNotRequired()
                 .setDeprecated(ModelVersion.create(1, 4, 0))
                 .build();
         resourceRegistration.registerReadOnlyAttribute(ad, new ListModuleRootsHandler());

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -177,29 +177,35 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
     // replaces SERVER_STATE below, aliased in #ProcessStateAttributeHandler
     public static final SimpleAttributeDefinition RUNTIME_CONFIGURATION_STATE = SimpleAttributeDefinitionBuilder.create(ServerDescriptionConstants.RUNTIME_CONFIGURATION_STATE, ModelType.STRING)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setValidator(NOT_NULL_STRING_LENGTH_ONE_VALIDATOR)
             .build();
     public static final SimpleAttributeDefinition SERVER_STATE = SimpleAttributeDefinitionBuilder.create(ServerDescriptionConstants.PROCESS_STATE, ModelType.STRING)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setValidator(NOT_NULL_STRING_LENGTH_ONE_VALIDATOR)
             .build();
     public static final SimpleAttributeDefinition PROCESS_TYPE = SimpleAttributeDefinitionBuilder.create(ServerDescriptionConstants.PROCESS_TYPE, ModelType.STRING)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setValidator(NOT_NULL_STRING_LENGTH_ONE_VALIDATOR)
             .build();
     public static final SimpleAttributeDefinition LAUNCH_TYPE = SimpleAttributeDefinitionBuilder.create(ServerDescriptionConstants.LAUNCH_TYPE, ModelType.STRING)
             .setValidator(new EnumValidator<LaunchType>(LaunchType.class, false, false))
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     public static final AttributeDefinition RUNNING_MODE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.RUNNING_MODE, ModelType.STRING)
             .setValidator(new EnumValidator<RunningMode>(RunningMode.class, false, false))
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
     public static final AttributeDefinition SUSPEND_STATE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SUSPEND_STATE, ModelType.STRING)
             .setValidator(new EnumValidator<SuspendController.State>(SuspendController.State.class, false, false))
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .build();
 
 

--- a/server/src/main/java/org/jboss/as/server/services/net/BindingMetricHandlers.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingMetricHandlers.java
@@ -81,7 +81,7 @@ public final class BindingMetricHandlers {
         public static final AttributeDefinition ATTRIBUTE_DEFINITION = SimpleAttributeDefinitionBuilder.create(ATTRIBUTE_NAME, ModelType.BOOLEAN)
                 .setAllowNull(true)
                 .setStorageRuntime()
-                .forceRegistration()
+                .setRuntimeServiceNotRequired()
                 .build();
         public static final OperationStepHandler INSTANCE = new BoundHandler();
 
@@ -107,7 +107,7 @@ public final class BindingMetricHandlers {
         public static final AttributeDefinition ATTRIBUTE_DEFINITION = SimpleAttributeDefinitionBuilder.create(ATTRIBUTE_NAME, ModelType.STRING)
                 .setAllowNull(true)
                 .setStorageRuntime()
-                .forceRegistration()
+                .setRuntimeServiceNotRequired()
                 .build();
         public static final OperationStepHandler INSTANCE = new BoundAddressHandler();
 
@@ -136,7 +136,7 @@ public final class BindingMetricHandlers {
                 .setAllowNull(true)
                 .setValidator(new IntRangeValidator(1, Integer.MAX_VALUE, true, false))
                 .setStorageRuntime()
-                .forceRegistration()
+                .setRuntimeServiceNotRequired()
                 .build();
 
         public static final OperationStepHandler INSTANCE = new BoundPortHandler();

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/streams/LogStreamExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/streams/LogStreamExtension.java
@@ -73,6 +73,7 @@ public class LogStreamExtension implements Extension {
 
     public static final AttributeDefinition LOG_FILE = SimpleAttributeDefinitionBuilder.create("log-file", ModelType.INT)
             .setStorageRuntime()
+            .setRuntimeServiceNotRequired()
             .setAllowNull(true)
             .build();
 


### PR DESCRIPTION
* register runtime attribute in the ConcreteResourceRegistration only when they are
  meaningful (for the given ProcessType/RunningMode).
* rename attribute's flag to FORCE_REGISTRATION to
  RUNTIME_SERVICE_NOT_REQUIRED and update the API in
  AttributeDefinitionBuilder
* add call to setRuntimeServiceNotRequired() for every attribute definition that
  was flagged as storage-runtime *but* was not depending on runtime
  services to handle the attribute.

JIRA: https://issues.jboss.org/browse/WFCORE-1588