### PR TITLE
Add legacy controllers 2.0.0.Final - support for EAP7 target

### DIFF
--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractCoreModelTest.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractCoreModelTest.java
@@ -52,6 +52,7 @@ public abstract class AbstractCoreModelTest {
     @After
     public void cleanup() throws Exception {
         delegate.cleanup();
+        delegate.setCurrentTransformerClassloaderParameter(null);
     }
 
     CoreModelTestDelegate getDelegate() {

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractKernelServicesImpl.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractKernelServicesImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.jboss.as.controller.CapabilityRegistry;
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationFailedException;
@@ -69,7 +70,7 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
         //TODO initialize the path manager service like we do for subsystems?
 
         //Create the controller
-        ServiceContainer container = ServiceContainer.Factory.create("test" + counter.incrementAndGet());
+        ServiceContainer container = ServiceContainer.Factory.create("core-test" + counter.incrementAndGet());
         ServiceTarget target = container.subTarget();
 
         //Initialize the content repository
@@ -102,6 +103,7 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
         }
 
         ModelTestModelControllerService svc = testModelControllerFactory.create(processType, runningModeControl, persister, validateOpsFilter, type, modelInitializer, extensionRegistry);
+
         ServiceBuilder<ModelController> builder = target.addService(Services.JBOSS_SERVER_CONTROLLER, svc);
         builder.addDependency(ContentRepository.SERVICE_NAME, ContentRepository.class, testModelControllerFactory.getContentRepositoryInjector(svc));
         builder.install();
@@ -146,7 +148,8 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
         @Override
         public ModelTestModelControllerService create(ProcessType processType, RunningModeControl runningModeControl,
                 StringConfigurationPersister persister, ModelTestOperationValidatorFilter validateOpsFilter, TestModelType type, ModelInitializer modelInitializer, ExtensionRegistry extensionRegistry) {
-            return TestModelControllerService.create(processType, runningModeControl, persister, validateOpsFilter, type, modelInitializer, extensionRegistry);
+            CapabilityRegistry cr = new CapabilityRegistry(processType.isServer());
+            return TestModelControllerService.create(processType, runningModeControl, persister, validateOpsFilter, type, modelInitializer, extensionRegistry, cr);
         }
 
         @Override

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
@@ -728,10 +728,10 @@ public class CoreModelTestDelegate {
                 classLoaderBuilder.addMavenResourceURL("org.wildfly.legacy.test:wildfly-legacy-spi:" + Version.LEGACY_TEST_CONTROLLER_VERSION);
 
                 if (testControllerVersion != ModelTestControllerVersion.MASTER) {
-                    String groupId = testControllerVersion.getMavenGavVersion().startsWith("7.") ? "org.jboss.as" : "org.wildfly";
-                    String hostControllerArtifactId = testControllerVersion.getMavenGavVersion().startsWith("7.") ? "jboss-as-host-controller" : "wildfly-host-controller";
+                    String groupId = testControllerVersion.getCoreMavenGroupId();
+                    String hostControllerArtifactId = testControllerVersion.getHostControllerMavenArtifactId();
 
-                    classLoaderBuilder.addRecursiveMavenResourceURL(groupId + ":" + hostControllerArtifactId + ":" + testControllerVersion.getMavenGavVersion());
+                    classLoaderBuilder.addRecursiveMavenResourceURL(groupId + ":" + hostControllerArtifactId + ":" + testControllerVersion.getCoreVersion());
                     classLoaderBuilder.addMavenResourceURL("org.wildfly.legacy.test:wildfly-legacy-core-" + testControllerVersion.getTestControllerVersion() + ":" + Version.LEGACY_TEST_CONTROLLER_VERSION);
 
                 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/AccessAuthorizationTransformationTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/AccessAuthorizationTransformationTestCase.java
@@ -25,7 +25,6 @@ package org.jboss.as.core.model.test.access;
 import java.util.List;
 
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
@@ -34,8 +33,6 @@ import org.jboss.as.core.model.test.TestModelType;
 import org.jboss.as.core.model.test.TransformersTestParameterized;
 import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
 import org.jboss.as.core.model.test.util.TransformersTestParameter;
-import org.jboss.as.domain.management.CoreManagementResourceDefinition;
-import org.jboss.as.domain.management.access.AccessAuthorizationResourceDefinition;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
@@ -65,15 +62,11 @@ public class AccessAuthorizationTransformationTestCase extends AbstractCoreModel
 
     @Test
     public void testAllowNonRBAC() throws Exception {
-
         KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
                 .setXmlResource("domain-transform-no-rbac-provider.xml");
 
         LegacyKernelServicesInitializer initializer = builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion)
                 .skipReverseControllerCheck();
-        if (ModelVersion.compare(ModelVersion.create(1, 4, 0), modelVersion) > 0) {
-
-        }
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());
@@ -82,29 +75,6 @@ public class AccessAuthorizationTransformationTestCase extends AbstractCoreModel
         Assert.assertTrue(legacyServices.isSuccessfulBoot());
 
         ModelNode legacyModel = checkCoreModelTransformation(mainServices, modelVersion);
-
+        mainServices.shutdown();
     }
-
-    @Test
-    public void testRejectRBAC() throws Exception {
-        if (ModelVersion.compare(ModelVersion.create(1, 4, 0), modelVersion) > 0) {
-            return;
-        }
-
-        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN)
-                .setXmlResource("domain-transform-rbac-provider.xml");
-
-        builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion)
-                .addOperationValidationExclude("write-attribute",
-                        PathAddress.pathAddress(CoreManagementResourceDefinition.PATH_ELEMENT, AccessAuthorizationResourceDefinition.PATH_ELEMENT))
-                .skipReverseControllerCheck();
-
-        KernelServices mainServices = builder.build();
-        Assert.assertTrue(mainServices.isSuccessfulBoot());
-
-        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
-        Assert.assertFalse(legacyServices.isSuccessfulBoot());
-
-    }
-
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/ServerGroupScopedRolesTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/ServerGroupScopedRolesTestCase.java
@@ -55,6 +55,7 @@ import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.TestModelType;
 import org.jboss.dmr.ModelNode;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -83,6 +84,12 @@ public class ServerGroupScopedRolesTestCase extends AbstractCoreModelTest {
                 .validateDescription()
                 .build();
     }
+
+    @After
+    public void cleanMeUp(){
+        kernelServices.shutdown();
+    }
+
 
     @Test
     public void testReadServerGroupScopedRole() {

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/StandaloneAccessControlTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/StandaloneAccessControlTestCase.java
@@ -142,6 +142,7 @@ public class StandaloneAccessControlTestCase extends AbstractCoreModelTest {
                 kernelServices.executeOperation(
                         Util.getReadAttributeOperation(applicationAddress, ApplicationClassificationConfigResourceDefinition.CONFIGURED_APPLICATION.getName())));
         checkResultExists(result, new ModelNode());
+        kernelServices.shutdown();
 
     }
 

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/auditlog/AbstractAuditLogTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/auditlog/AbstractAuditLogTestCase.java
@@ -57,6 +57,7 @@ public abstract class AbstractAuditLogTestCase extends AbstractCoreModelTest {
                 .setXml(marshalled)
                 .build();
             Assert.assertTrue(kernelServices.isSuccessfulBoot());
+        kernelServices.shutdown();
     }
 
     KernelServicesBuilder createKernelServicesBuilder() {

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/StandaloneBootErrorsTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/boot/StandaloneBootErrorsTestCase.java
@@ -98,5 +98,6 @@ public class StandaloneBootErrorsTestCase extends AbstractBootErrorTestCase {
         Assert.assertThat(error.asString(), error.hasDefined(FAILURE_DESCRIPTION), is(true));
         Assert.assertThat(error.asString(), error.get(FAILURE_DESCRIPTION).asString(), containsString("testhost"));
         Assert.assertThat(error.asString(), error.hasDefined(FAILED_SERVICES), is(false));
+        kernelServices.shutdown();
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/JvmTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/JvmTransformersTestCase.java
@@ -139,6 +139,7 @@ public class JvmTransformersTestCase extends AbstractCoreModelTest {
                     FIXER,
                     FIXER);
         }
+        mainServices.shutdown();
     }
 
     private FailedOperationTransformationConfig getConfig() {

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/PathsTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/PathsTransformersTestCase.java
@@ -21,33 +21,22 @@
 */
 package org.jboss.as.core.model.test.paths;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
-
 import java.util.List;
 
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
-import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.TestModelType;
 import org.jboss.as.core.model.test.TransformersTestParameterized;
 import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
-import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
 import org.jboss.as.core.model.test.util.TransformersTestParameter;
-import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelTestControllerVersion;
-import org.jboss.as.model.test.ModelTestUtils;
-import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 @RunWith(TransformersTestParameterized.class)
@@ -61,7 +50,7 @@ public class PathsTransformersTestCase extends AbstractCoreModelTest {
     }
 
     @TransformersParameter
-    public static List<TransformersTestParameter> parameters(){
+    public static List<TransformersTestParameter> parameters() {
         return TransformersTestParameter.setupVersions();
     }
 
@@ -80,24 +69,4 @@ public class PathsTransformersTestCase extends AbstractCoreModelTest {
         checkCoreModelTransformation(mainServices, modelVersion);
     }
 
-    @Test
-    public void testRejectTransformers71x() throws Exception {
-
-        if (modelVersion.getMajor() > 1 || modelVersion.getMinor() > 3) {
-            return;
-        }
-
-        KernelServicesBuilder builder = createKernelServicesBuilder(TestModelType.DOMAIN);
-
-        // Add legacy subsystems
-        LegacyKernelServicesInitializer legacyInitializer =
-                StandardServerGroupInitializers.addServerGroupInitializers(builder.createLegacyKernelServicesBuilder(modelVersion, testControllerVersion));
-
-        KernelServices mainServices = builder.build();
-
-        List<ModelNode> ops = builder.parseXmlResource("domain-expressions.xml");
-        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops, new FailedOperationTransformationConfig()
-                .addFailedAttribute(PathAddress.pathAddress(PathElement.pathElement(PATH)),
-                        new FailedOperationTransformationConfig.RejectExpressionsConfig(PathResourceDefinition.PATH)));
-    }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/shipped/ShippedConfigurationsModelTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/shipped/ShippedConfigurationsModelTestCase.java
@@ -45,7 +45,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class ShippedConfigurationsModelTestCase extends AbstractCoreModelTest {

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -27,14 +27,13 @@ import java.util.List;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.core.model.test.ClassloaderParameter;
 import org.jboss.as.model.test.ModelTestControllerVersion;
+import org.jboss.as.version.Version;
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class TransformersTestParameter extends ClassloaderParameter {
-
-    private static final String TEST_OLD_LEGACY = "jboss.test.transformers.core.old";
 
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
@@ -58,13 +57,15 @@ public class TransformersTestParameter extends ClassloaderParameter {
 
     public static List<TransformersTestParameter> setupVersions(){
         List<TransformersTestParameter> data = new ArrayList<TransformersTestParameter>();
-        data.add(new TransformersTestParameter(ModelVersion.create(4, 0, 0), ModelTestControllerVersion.MASTER));
+        data.add(new TransformersTestParameter(ModelVersion.create(Version.MANAGEMENT_MAJOR_VERSION, Version.MANAGEMENT_MINOR_VERSION, Version.MANAGEMENT_MICRO_VERSION)
+                , ModelTestControllerVersion.MASTER));
 
-        //EAP releases - these will only get tested if the EAPRepositoryReachableUtil.TEST_TRANSFORMERS_EAP system property is set AND the EAP repostitory is available
         //we only test EAP 6.2/AS7.3 and newer
         data.add(new TransformersTestParameter(ModelVersion.create(1, 5, 0), ModelTestControllerVersion.EAP_6_2_0));
         data.add(new TransformersTestParameter(ModelVersion.create(1, 6, 0), ModelTestControllerVersion.EAP_6_3_0));
         data.add(new TransformersTestParameter(ModelVersion.create(1, 7, 0), ModelTestControllerVersion.EAP_6_4_0));
+        //code legacy controller has some issues atm
+        data.add(new TransformersTestParameter(ModelVersion.create(4, 1, 0), ModelTestControllerVersion.EAP_7_0_0));
 
         return data;
     }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -63,7 +63,7 @@ public class DomainTransformers {
     static final ModelVersion VERSION_1_6 = ModelVersion.create(1, 6, 0);
     // EAP 6.4.0
     static final ModelVersion VERSION_1_7 = ModelVersion.create(1, 7, 0);
- // EAP 6.4.0 CP07
+    // EAP 6.4.0 CP07
     static final ModelVersion VERSION_1_8 = ModelVersion.create(1, 8, 0);
     //WF 8.0.0.Final
     static final ModelVersion VERSION_2_0 = ModelVersion.create(2, 0, 0);
@@ -73,6 +73,9 @@ public class DomainTransformers {
     static final ModelVersion VERSION_3_0 = ModelVersion.create(3, 0, 0);
     //WF 10.0.0
     static final ModelVersion VERSION_4_0 = ModelVersion.create(4, 0, 0);
+
+    //EAP7.0.0
+    static final ModelVersion VERSION_4_1 = ModelVersion.create(4, 1, 0);
 
     //All versions before WildFly 10/EAP 7, which do not understand /profile=xxx:clone
     private static final ModelVersion[] PRE_PROFILE_CLONE_VERSIONS = new ModelVersion[]{VERSION_3_0, VERSION_2_1, VERSION_2_0, VERSION_1_8, VERSION_1_7, VERSION_1_6, VERSION_1_5};
@@ -125,7 +128,7 @@ public class DomainTransformers {
 
     private static void registerChainedManagementTransformers(TransformerRegistry registry, ModelVersion currentVersion) {
         ChainedTransformationDescriptionBuilder builder = ManagementTransformers.buildTransformerChain(currentVersion);
-        registerChainedTransformer(registry, builder, VERSION_1_5, VERSION_1_6, VERSION_1_7, VERSION_1_8);
+        registerChainedTransformer(registry, builder, VERSION_1_5, VERSION_1_6, VERSION_1_7, VERSION_1_8, VERSION_4_1);
     }
 
     private static void registerChainedServerGroupTransformers(TransformerRegistry registry, ModelVersion currentVersion) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ManagementTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ManagementTransformers.java
@@ -26,13 +26,11 @@ import java.util.Locale;
 
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.transform.ResourceTransformationContext;
-import org.jboss.as.controller.transform.ResourceTransformer;
 import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
@@ -58,26 +56,34 @@ class ManagementTransformers {
         // Discard the domain level core-service=management resource and its children unless RBAC is enabled
         // Configuring rbac details is OK (i.e. discarable), so long as the provider is not enabled
         ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedInstance(CoreManagementResourceDefinition.PATH_ELEMENT, currentVersion);
-        ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(currentVersion, DomainTransformers.VERSION_1_8);
-        builder.setCustomResourceTransformer(new ResourceTransformer() {
-            @Override
-            public void transformResource(ResourceTransformationContext context, PathAddress address, Resource resource) throws OperationFailedException {
-                Resource accessAuth = resource.getChild(AccessAuthorizationResourceDefinition.PATH_ELEMENT);
-                if (accessAuth != null) {
-                    ModelNode model = accessAuth.getModel();
-                    String providerName = AccessAuthorizationResourceDefinition.PROVIDER.resolveModelAttribute(ExpressionResolver.REJECTING, model).asString();
-                    AccessAuthorizationResourceDefinition.Provider provider = AccessAuthorizationResourceDefinition.Provider.valueOf(providerName.toUpperCase(Locale.ENGLISH));
-                    if (provider != AccessAuthorizationResourceDefinition.Provider.SIMPLE) {
-                        // Continue to lower levels where this will be rejected
-                        final ResourceTransformationContext childContext = context.addTransformedResource(PathAddress.EMPTY_ADDRESS, resource);
-                        childContext.processChildren(resource);
-                    }
-                }
 
-                // else do nothing, i.e. acts as a discard
+        //we need special case for current to 1.7 aka EAP6.4.0, this should be uncommented and tested bit more carefully
+        /*ResourceTransformationDescriptionBuilder builderCurrentTo17 = chainedBuilder.createBuilder(currentVersion, DomainTransformers.VERSION_1_7);
+        builderCurrentTo17.addChildResource(AccessAuthorizationResourceDefinition.PATH_ELEMENT)
+                .addChildResource(AccessConstraintResources.SENSITIVITY_PATH_ELEMENT)
+                .addChildResource(SensitivityClassificationTypeResourceDefinition.PATH_ELEMENT)
+                .discardChildResource(PathElement.pathElement(SensitivityResourceDefinition.PATH_ELEMENT.getKey(), SensitivityClassification.SERVER_SSL.getName()))
+                .build();*/
+
+
+        //eap7.0.0 --> EAP 6.4.0 CP7, be careful. 1.8.0 model is part of CP7 only.
+        ResourceTransformationDescriptionBuilder builder41to18 = chainedBuilder.createBuilder(DomainTransformers.VERSION_4_1, DomainTransformers.VERSION_1_8);
+        builder41to18.setCustomResourceTransformer((context, address, resource) -> {
+            Resource accessAuth = resource.getChild(AccessAuthorizationResourceDefinition.PATH_ELEMENT);
+            if (accessAuth != null) {
+                ModelNode model = accessAuth.getModel();
+                String providerName = AccessAuthorizationResourceDefinition.PROVIDER.resolveModelAttribute(ExpressionResolver.REJECTING, model).asString();
+                AccessAuthorizationResourceDefinition.Provider provider = AccessAuthorizationResourceDefinition.Provider.valueOf(providerName.toUpperCase(Locale.ENGLISH));
+                if (provider != AccessAuthorizationResourceDefinition.Provider.SIMPLE) {
+                    // Continue to lower levels where this will be rejected
+                    final ResourceTransformationContext childContext = context.addTransformedResource(PathAddress.EMPTY_ADDRESS, resource);
+                    childContext.processChildren(resource);
+                }
             }
+
+            // else do nothing, i.e. acts as a discard
         });
-        ResourceTransformationDescriptionBuilder accessBuilder = builder.addChildResource(AccessAuthorizationResourceDefinition.PATH_ELEMENT)
+        ResourceTransformationDescriptionBuilder accessBuilder = builder41to18.addChildResource(AccessAuthorizationResourceDefinition.PATH_ELEMENT)
             .getAttributeBuilder()
                 .addRejectCheck(RejectAttributeChecker.DEFINED, AccessAuthorizationResourceDefinition.PROVIDER)
                 .setDiscard(new DiscardAttributeChecker.DefaultDiscardAttributeChecker() {

--- a/logging/src/test/resources/logging_3_0.xml
+++ b/logging/src/test/resources/logging_3_0.xml
@@ -1,0 +1,230 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2016, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:logging:3.0">
+    <add-logging-api-dependencies value="false"/>
+    <use-deployment-logging-config value="false"/>
+
+    <async-handler name="async">
+        <queue-length value="10"/>
+        <overflow-action value="block"/>
+        <subhandlers>
+            <handler name="sizeLogger"/>
+            <handler name="simpleFile"/>
+        </subhandlers>
+    </async-handler>
+
+    <console-handler name="CONSOLE">
+        <level name="INFO"/>
+        <filter-spec value="levelRange(TRACE,WARN)" />
+        <formatter>
+            <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+        </formatter>
+        <target name="console"/>
+    </console-handler>
+
+    <file-handler name="anotherFile" enabled="false">
+        <filter-spec value="levelRange(TRACE,WARN]" />
+        <formatter>
+            <named-formatter name="PATTERN"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="another.log"/>
+        <append value="true"/>
+    </file-handler>
+
+    <file-handler name="simpleFile">
+        <level name="INFO"/>
+        <filter-spec value="deny"/>
+        <formatter>
+            <named-formatter name="PATTERN"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="fileHandler.log"/>
+        <append value="true"/>
+    </file-handler>
+
+    <!-- Can't use custom handlers as they require JBoss Modules
+    <custom-handler name="customHandler" module="org.jboss.logmanager" class="org.jboss.logmanager.handler.ConsoleHandler">
+        <filter>
+            <replace pattern="\b(Name)|\b(name)" replacement="user" replace-all="true"/>
+        </filter>
+        <properties>
+            <property name="autoFlush" value="true" />
+            <property name="target" value="SYSTEM_OUT" />
+        </properties>
+    </custom-handler>
+
+    <custom-handler name="log4jAppender" module="org.apache.log4j" class="org.apache.log4j.ConsoleAppender">
+        <properties>
+            <property name="target" value="System.out"/>
+        </properties>
+    </custom-handler> -->
+
+    <periodic-rotating-file-handler name="FILE">
+        <encoding value="UTF-8"/>
+        <filter-spec value="any(levels(INFO),not(levels(TRACE)))"/>
+        <formatter>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="server.log"/>
+        <suffix value=".yyyy-MM-dd"/>
+    </periodic-rotating-file-handler>
+
+    <periodic-size-rotating-file-handler name="psHandler">
+        <level name="DEBUG"/>
+        <encoding value="UTF-8"/>
+        <filter-spec value="all(levelChange(DEBUG),match(&quot;JBAS+\\d&quot;))"/>
+        <formatter>
+            <named-formatter name="PATTERN"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="ps.log"/>
+        <rotate-size value="64m"/>
+        <max-backup-index value="1024"/>
+        <suffix value=".yyyy-MM-dd"/>
+        <append value="false"/>
+    </periodic-size-rotating-file-handler>
+
+    <size-rotating-file-handler name="sizeLogger" rotate-on-boot="true">
+        <level name="DEBUG"/>
+        <encoding value="UTF-8"/>
+        <filter-spec value="all(levelChange(DEBUG),match(&quot;JBAS+\\d&quot;))"/>
+        <file relative-to="jboss.server.log.dir" path="sizeLogger.log"/>
+        <rotate-size value="64m"/>
+        <max-backup-index value="1024"/>
+        <append value="false"/>
+        <suffix value=".yyyy-MM-dd'T'HH:mm:ssZ"/>
+    </size-rotating-file-handler>
+
+    <syslog-handler name="syslog" enabled="false">
+        <level name="INFO"/>
+        <server-address value="127.0.0.1"/>
+        <hostname value="jboss.org"/>
+        <port value="514"/>
+        <app-name value="my-app"/>
+        <formatter>
+            <syslog-format syslog-type="RFC5424"/>
+        </formatter>
+        <facility value="user-level"/>
+    </syslog-handler>
+
+    <logger category="com.example" use-parent-handlers="false">
+        <level name="TRACE"/>
+        <filter-spec value="levelRange[TRACE,WARN)"/>
+        <handlers>
+            <handler name="sizeLogger"/>
+            <handler name="CONSOLE"/>
+        </handlers>
+    </logger>
+
+    <logger category="com.arjuna">
+        <level name="WARN"/>
+        <filter-spec value="levelRange[TRACE,WARN]"/>
+    </logger>
+
+    <root-logger>
+        <level name="INFO"/>
+        <handlers>
+            <handler name="CONSOLE"/>
+            <handler name="FILE"/>
+        </handlers>
+    </root-logger>
+
+    <formatter name="PATTERN">
+        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n" color-map="info:cyan,warn:yellow,error:red"/>
+    </formatter>
+
+    <logging-profiles>
+        <logging-profile name="test-profile">
+
+            <console-handler name="CONSOLE">
+                <level name="ALL"/>
+                <filter-spec value="levelRange(TRACE,WARN)"/>
+                <formatter>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+                </formatter>
+                <target name="console"/>
+            </console-handler>
+
+            <file-handler name="simpleFile">
+                <level name="INFO"/>
+                <filter-spec value="deny"/>
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="profileFileHandler.log"/>
+                <append value="true"/>
+            </file-handler>
+
+            <periodic-size-rotating-file-handler name="psHandler">
+                <level name="DEBUG"/>
+                <encoding value="UTF-8"/>
+                <filter-spec value="all(levelChange(DEBUG),match(&quot;JBAS+\\d&quot;))"/>
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="ps.log"/>
+                <rotate-size value="64m"/>
+                <max-backup-index value="1024"/>
+                <suffix value=".yyyy-MM-dd"/>
+                <append value="false"/>
+            </periodic-size-rotating-file-handler>
+
+            <size-rotating-file-handler name="sizeLogger" rotate-on-boot="true">
+                <level name="DEBUG"/>
+                <encoding value="UTF-8"/>
+                <filter-spec value="all(levelChange(DEBUG),match(&quot;JBAS+\\d&quot;))"/>
+                <formatter>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="sizeLogger.log"/>
+                <rotate-size value="64m"/>
+                <max-backup-index value="1024"/>
+                <append value="false"/>
+                <suffix value=".yyyy-MM-dd'T'HH:mm:ssZ"/>
+            </size-rotating-file-handler>
+
+            <syslog-handler name="syslog">
+                <level name="WARN"/>
+                <server-address value="localhost"/>
+                <hostname value="community.jboss.org"/>
+                <port value="514"/>
+                <app-name value="my-app"/>
+                <formatter>
+                    <syslog-format syslog-type="RFC3164"/>
+                </formatter>
+                <facility value="user-level"/>
+            </syslog-handler>
+
+            <logger category="org.jboss.as.logging">
+                <level name="TRACE"/>
+                <filter-spec value="levelRange[TRACE,WARN)"/>
+            </logger>
+
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="syslog"/>
+                </handlers>
+            </root-logger>
+
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n" color-map="info:cyan"/>
+            </formatter>
+        </logging-profile>
+    </logging-profiles>
+</subsystem>

--- a/model-test/src/main/java/org/jboss/as/model/test/MavenSettings.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/MavenSettings.java
@@ -1,0 +1,354 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.model.test;
+
+import static javax.xml.stream.XMLStreamConstants.END_DOCUMENT;
+import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.security.AccessController;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+
+/**
+ * @author Tomaz Cerar (c) 2014 Red Hat Inc.
+ */
+final class MavenSettings {
+    private static final Object settingLoaderMutex = new Object();
+
+    private static volatile MavenSettings mavenSettings;
+
+    private Path localRepository = null;
+    private final List<String> remoteRepositories = new LinkedList<>();
+    private final Map<String, Profile> profiles = new HashMap<>();
+    private final List<String> activeProfileNames = new LinkedList<>();
+
+    MavenSettings() {
+        configureDefaults();
+    }
+
+    static MavenSettings getSettings() {
+        if (mavenSettings != null) {
+            return mavenSettings;
+        }
+        synchronized (settingLoaderMutex) {
+            if (mavenSettings != null) {
+                return mavenSettings;
+            }
+
+            return mavenSettings = doIo(() -> {
+                MavenSettings settings = new MavenSettings();
+
+                Path m2 = Paths.get(System.getProperty("user.home"), ".m2");
+                Path settingsPath = m2.resolve("settings.xml");
+
+                if (Files.notExists(settingsPath)) {
+                    String mavenHome = System.getenv("M2_HOME");
+                    if (mavenHome != null) {
+                        settingsPath = Paths.get(mavenHome, "conf", "settings.xml");
+                    }
+                }
+                if (Files.exists(settingsPath)) {
+                    parseSettingsXml(settingsPath, settings);
+                }
+                if (settings.getLocalRepository() == null) {
+                    Path repository = m2.resolve("repository");
+                    settings.setLocalRepository(repository);
+                }
+                settings.resolveActiveSettings();
+                return settings;
+            });
+        }
+    }
+
+    private static <T> T doIo(PrivilegedExceptionAction<T> action) throws RuntimeException {
+        try {
+            return AccessController.doPrivileged(action);
+        } catch (PrivilegedActionException e) {
+            try {
+                throw e.getCause();
+            } catch (IOException | RuntimeException | Error e1) {
+                throw new RuntimeException(e1);
+            } catch (Throwable t) {
+                throw new UndeclaredThrowableException(t);
+            }
+        }
+    }
+
+    static MavenSettings parseSettingsXml(Path settings, MavenSettings mavenSettings) throws IOException {
+        try {
+
+
+            //reader.setFeature(FEATURE_PROCESS_NAMESPACES, false);
+            InputStream source = Files.newInputStream(settings, StandardOpenOption.READ);
+            XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(source);
+
+            int eventType;
+            while ((eventType = reader.next()) != END_DOCUMENT) {
+                switch (eventType) {
+                    case START_ELEMENT: {
+                        switch (reader.getLocalName()) {
+                            case "settings": {
+                                parseSettings(reader, mavenSettings);
+                                break;
+                            }
+                        }
+                    }
+                    default: {
+                        break;
+                    }
+                }
+            }
+            return mavenSettings;
+        } catch (XMLStreamException e) {
+            throw new IOException("Could not parse maven settings.xml", e);
+        }
+
+    }
+
+    private static void parseSettings(final XMLStreamReader reader, MavenSettings mavenSettings) throws XMLStreamException, IOException {
+        int eventType;
+        while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+            switch (eventType) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    switch (reader.getLocalName()) {
+                        case "localRepository": {
+                            String localRepository = reader.getElementText();
+                            if (localRepository != null && !localRepository.trim().isEmpty()) {
+                                mavenSettings.setLocalRepository(Paths.get(localRepository));
+                            }
+                            break;
+                        }
+                        case "profiles": {
+                            while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+                                if (eventType == START_ELEMENT) {
+                                    switch (reader.getLocalName()) {
+                                        case "profile": {
+                                            parseProfile(reader, mavenSettings);
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    break;
+                                }
+                            }
+                            break;
+                        }
+                        case "activeProfiles": {
+                            while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+                                if (eventType == START_ELEMENT) {
+                                    switch (reader.getLocalName()) {
+                                        case "activeProfile": {
+                                            mavenSettings.addActiveProfile(reader.getElementText());
+                                            break;
+                                        }
+                                    }
+                                } else {
+                                    break;
+                                }
+
+                            }
+                            break;
+                        }
+                        default: {
+                            skip(reader);
+                        }
+                    }
+                    break;
+                }
+                default: {
+                    throw new XMLStreamException("Unexpected content", reader.getLocation());
+                }
+            }
+        }
+        throw new XMLStreamException("Unexpected end of document", reader.getLocation());
+    }
+
+    private static void parseProfile(final XMLStreamReader reader, MavenSettings mavenSettings) throws XMLStreamException, IOException {
+        int eventType;
+        Profile profile = new Profile();
+        while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+            if (eventType == START_ELEMENT) {
+                switch (reader.getLocalName()) {
+                    case "id": {
+                        profile.setId(reader.getElementText());
+                        break;
+                    }
+                    case "repositories": {
+                        while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+                            if (eventType == START_ELEMENT) {
+                                switch (reader.getLocalName()) {
+                                    case "repository": {
+                                        parseRepository(reader, profile);
+                                        break;
+                                    }
+                                }
+                            } else {
+                                break;
+                            }
+
+                        }
+                        break;
+                    }
+                    default: {
+                        skip(reader);
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        mavenSettings.addProfile(profile);
+    }
+
+    private static void parseRepository(final XMLStreamReader reader, Profile profile) throws XMLStreamException, IOException {
+        int eventType;
+        while ((eventType = reader.nextTag()) != END_DOCUMENT) {
+            if (eventType == START_ELEMENT) {
+                switch (reader.getLocalName()) {
+                    case "url": {
+                        profile.addRepository(reader.getElementText());
+                        break;
+                    }
+                    default: {
+                        skip(reader);
+                    }
+                }
+            } else {
+                break;
+            }
+
+        }
+    }
+
+    private static void skip(XMLStreamReader parser) throws XMLStreamException, IOException {
+        if (parser.getEventType() != XMLStreamReader.START_ELEMENT) {
+            throw new IllegalStateException();
+        }
+        int depth = 1;
+        while (depth != 0) {
+            switch (parser.next()) {
+                case XMLStreamReader.END_ELEMENT:
+                    depth--;
+                    break;
+                case XMLStreamReader.START_ELEMENT:
+                    depth++;
+                    break;
+            }
+        }
+    }
+
+    private void configureDefaults() {
+        //always add maven central
+        remoteRepositories.add("https://repo1.maven.org/maven2/");
+        String localRepositoryPath = System.getProperty("localRepository");
+        if (localRepositoryPath != null && !localRepositoryPath.trim().isEmpty()) {
+            localRepository = Paths.get(localRepositoryPath);
+        }
+        localRepositoryPath = System.getProperty("maven.repo.local");
+        if (localRepositoryPath != null && !localRepositoryPath.trim().isEmpty()) {
+            localRepository = Paths.get(localRepositoryPath);
+        }
+        String remoteRepository = System.getProperty("remote.maven.repo");
+        if (remoteRepository != null) {
+            for (String repo : remoteRepository.split(",")) {
+                if (!repo.endsWith("/")) {
+                    repo += "/";
+                }
+                remoteRepositories.add(repo);
+            }
+        }
+    }
+
+    private void setLocalRepository(Path localRepository) {
+        this.localRepository = localRepository;
+    }
+
+    Path getLocalRepository() {
+        return localRepository;
+    }
+
+    List<String> getRemoteRepositories() {
+        return remoteRepositories;
+    }
+
+    private void addProfile(Profile profile) {
+        this.profiles.put(profile.getId(), profile);
+    }
+
+    private void addActiveProfile(String profileName) {
+        activeProfileNames.add(profileName);
+    }
+
+    private void resolveActiveSettings() {
+        for (String name : activeProfileNames) {
+            Profile p = profiles.get(name);
+            if (p != null) {
+                remoteRepositories.addAll(p.getRepositories());
+            }
+        }
+    }
+
+
+    static final class Profile {
+        private String id;
+        final List<String> repositories = new LinkedList<>();
+
+        Profile() {
+
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        void addRepository(String url) {
+            if (!url.endsWith("/")) {
+                url += "/";
+            }
+            repositories.add(url);
+        }
+
+        List<String> getRepositories() {
+            return repositories;
+        }
+    }
+}

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -27,49 +27,64 @@ import java.util.Properties;
 public enum ModelTestControllerVersion {
     //AS releases
     MASTER (CurrentVersion.VERSION, false, null),
-    @Deprecated
-    V7_1_2_FINAL ("7.1.2.Final", false, "7.1.2", false),
-    @Deprecated
-    V7_1_3_FINAL ("7.1.3.Final", false, "7.1.2", false),
-    @Deprecated
-    V7_2_0_FINAL ("7.2.0.Final", false, "7.2.0" ,false),
 
     //WILDFLY RELEASES
+    @Deprecated
     WILDFLY_8_0_0_FINAL ("8.0.0.Final", false, "8.0.0", false),
+    @Deprecated
     WILDFLY_8_1_0_FINAL ("8.1.0.Final", false, "8.0.0", false),
+    @Deprecated
     WILDFLY_8_2_0_FINAL ("8.2.0.Final", false, "8.0.0", false),
-
     //EAP releases
-    @Deprecated
-    EAP_6_0_0 ("7.1.2.Final-redhat-1", true, "7.1.2", false),
-    @Deprecated
-    EAP_6_0_1 ("7.1.3.Final-redhat-4", true, "7.1.2", false),
-    @Deprecated
-    EAP_6_1_0 ("7.2.0.Final-redhat-8", true, "7.2.0", false),
-    @Deprecated
-    EAP_6_1_1 ("7.2.1.Final-redhat-10", true, "7.2.0" ,false),
 
     EAP_6_2_0 ("7.3.0.Final-redhat-14", true, "7.3.0"), //EAP 6.2 is the earliest version we support for transformers
     EAP_6_3_0 ("7.4.0.Final-redhat-19", true, "7.4.0"),
-    EAP_6_4_0 ("7.5.0.Final-redhat-21", true, "7.5.0")
+    EAP_6_4_0 ("7.5.0.Final-redhat-21", true, "7.5.0"),
+    EAP_7_0_0 ("7.0.0.GA-redhat-2", true, "10.0.0", true, "2.1.0.Final")
     ;
 
     private final String mavenGavVersion;
     private final String testControllerVersion;
     private final boolean eap;
     private final boolean validLegacyController;
+    private final String coreVersion;
+    private final String mavenGroupId;
+    private final String coreMavenGroupId;
+    private final String serverMavenArtifactId;
+    private final String hostControllerMavenArtifactId;
+
     private ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion) {
-        this.mavenGavVersion = mavenGavVersion;
-        this.testControllerVersion = testControllerVersion;
-        this.eap = eap;
-        this.validLegacyController = true;
+        this(mavenGavVersion, eap, testControllerVersion, true, null);
     }
 
     private ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion, boolean validLegacyController) {
+        this(mavenGavVersion, eap, testControllerVersion, validLegacyController, null);
+    }
+    private ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion, boolean validLegacyController, String coreVersion) {
         this.mavenGavVersion = mavenGavVersion;
         this.testControllerVersion = testControllerVersion;
         this.eap = eap;
         this.validLegacyController = validLegacyController;
+        this.coreVersion = coreVersion == null? mavenGavVersion : coreVersion; //full == core
+        if (eap) {
+            if (coreVersion != null) { //eap 7+ has core version defined
+                this.coreMavenGroupId = "org.wildfly.core";
+                this.mavenGroupId = "org.jboss.eap";
+                this.serverMavenArtifactId = "wildfly-server";
+                this.hostControllerMavenArtifactId = "wildfly-host-controller";
+            } else { //we have EAP6
+                this.mavenGroupId = "org.jboss.as";
+                this.coreMavenGroupId = "org.jboss.as"; //full == core
+                this.serverMavenArtifactId = "jboss-as-server";
+                this.hostControllerMavenArtifactId = "jboss-as-host-controller";
+            }
+
+        } else { //we only handle WildFly 9+ as legacy version, we don't care about AS7.x.x community releases.
+            this.coreMavenGroupId = "org.wildfly.core";
+            this.mavenGroupId = "org.wildfly";
+            this.serverMavenArtifactId = "wildfly-server";
+            this.hostControllerMavenArtifactId = "wildfly-host-controller";
+        }
     }
 
     public String getMavenGavVersion() {
@@ -86,6 +101,26 @@ public enum ModelTestControllerVersion {
 
     public boolean hasValidLegacyController() {
         return validLegacyController;
+    }
+
+    public String getCoreVersion() {
+        return coreVersion;
+    }
+
+    public String getMavenGroupId() {
+        return mavenGroupId;
+    }
+
+    public String getCoreMavenGroupId() {
+        return coreMavenGroupId;
+    }
+
+    public String getServerMavenArtifactId() {
+        return serverMavenArtifactId;
+    }
+
+    public String getHostControllerMavenArtifactId() {
+        return hostControllerMavenArtifactId;
     }
 
     public interface CurrentVersion {

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestLegacyControllerKernelServicesProxy.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestLegacyControllerKernelServicesProxy.java
@@ -26,9 +26,11 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAI
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -253,6 +255,13 @@ public abstract class ModelTestLegacyControllerKernelServicesProxy {
         } catch (Exception e) {
             unwrapInvocationTargetRuntimeException(e);
             throw new RuntimeException(e);
+        }
+        if (childFirstClassLoader instanceof URLClassLoader){
+            try {
+                ((URLClassLoader)childFirstClassLoader).close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/model-test/src/test/java/org/jboss/as/model/test/MavenSettingsTest.java
+++ b/model-test/src/test/java/org/jboss/as/model/test/MavenSettingsTest.java
@@ -1,0 +1,115 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.model.test;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.jboss.modules.maven.ArtifactCoordinates;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author Tomaz Cerar (c) 2015 Red Hat Inc.
+ */
+public class MavenSettingsTest {
+
+    void clearCachedSettings() throws Exception {
+        Field mavenSettings = MavenSettings.class.getDeclaredField("mavenSettings");
+        mavenSettings.setAccessible(true);
+        mavenSettings.set(null, null);
+    }
+    private static String passedLocalRepository;
+
+    @BeforeClass
+    public static void before(){
+        passedLocalRepository = System.getProperty("localRepository");
+        System.clearProperty("localRepository");
+    }
+    @AfterClass
+    public static void after(){
+        System.setProperty("localRepository", passedLocalRepository);
+    }
+
+    @Rule
+    public TemporaryFolder tmpdir = new TemporaryFolder();
+
+    @Test
+    public void testWithPassedRepository() throws Exception {
+        System.setProperty("maven.repo.local", tmpdir.newFolder("repository").getAbsolutePath());
+        System.setProperty("remote.maven.repo", "http://repository.jboss.org/nexus/content/groups/public/,https://maven-central.storage.googleapis.com/");
+
+        try {
+            clearCachedSettings();
+            MavenSettings settings = MavenSettings.getSettings();
+            List<String> remoteRepos = settings.getRemoteRepositories();
+            Assert.assertTrue(remoteRepos.size() >= 3); //at least 3 must be present, other can come from settings.xml
+            Assert.assertTrue(remoteRepos.contains("https://repo1.maven.org/maven2/"));
+            Assert.assertTrue(remoteRepos.contains("http://repository.jboss.org/nexus/content/groups/public/"));
+            Assert.assertTrue(remoteRepos.contains("https://maven-central.storage.googleapis.com/"));
+
+        } finally {
+            System.clearProperty("maven.repo.local");
+            System.clearProperty("remote.repository");
+        }
+    }
+
+    @Test
+    public void testWithEmptyPassedRepository() throws Exception {
+        Path userRepo = tmpdir.newFolder(".m2", "repository").toPath();
+        String userHome = System.getProperty("user.home");
+        System.setProperty("user.home", tmpdir.getRoot().getAbsolutePath());
+        System.setProperty("maven.repo.local", "");
+
+        try {
+            clearCachedSettings();
+            MavenSettings settings = MavenSettings.getSettings();
+            Assert.assertEquals(userRepo, settings.getLocalRepository());
+        } finally {
+            System.setProperty("user.home", userHome);
+            System.clearProperty("maven.repo.local");
+        }
+    }
+
+    @Test
+    public void testEmptyLocalRepo() throws Exception {
+        MavenSettings settings = new MavenSettings();
+
+        MavenSettings.parseSettingsXml(Paths.get(MavenSettingsTest.class.getResource("settings-empty-local-repo.xml").toURI()), settings);
+        Assert.assertNull(settings.getLocalRepository());//local repo shouldn't be set
+
+    }
+
+    /**
+     * testing is snapshot resolving works properly, as in case of snapshot version, we need to use different path than exact version.
+     * @throws Exception
+     */
+    @Test
+    public void testSnapshotResolving()throws Exception{
+        ArtifactCoordinates coordinates = ArtifactCoordinates.fromString("org.wildfly.core:wildfly-version:2.0.5.Final-20151222.144931-1");
+        String path = coordinates.relativeArtifactPath('/');
+        Assert.assertEquals("org/wildfly/core/wildfly-version/2.0.5.Final-SNAPSHOT/wildfly-version-2.0.5.Final-20151222.144931-1", path);
+    }
+}

--- a/model-test/src/test/resources/org/jboss/as/model/test/settings-empty-local-repo.xml
+++ b/model-test/src/test/resources/org/jboss/as/model/test/settings-empty-local-repo.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/settings/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+>
+
+    <localRepository/>
+    <profiles>
+        <profile>
+            <id>jboss-public-repository</id>
+            <repositories>
+
+
+                <repository>
+                    <id>jboss-public-repository-group</id>
+                    <name>JBoss Public Maven Repository Group</name>
+                    <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </repository>
+
+                <repository>
+                    <id>jboss-developer-repository-group</id>
+                    <name>JBoss Developer Maven Repository Group</name>
+                    <url>https://repository.jboss.org/nexus/content/groups/developer/</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+
+
+        </profile>
+        <profile>
+            <id>eap-repo</id>
+            <repositories>
+                <repository>
+                    <id>brew-maven-repo</id>
+                    <name>Red Hat Brew repo</name>
+                    <url>http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6-rhel-6-build/latest/maven/</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>brew-maven-repo</id>
+                    <name>Red Hat Brew repo</name>
+                    <url>http://download.lab.bos.redhat.com/brewroot/repos/jb-eap-6-rhel-6-build/latest/maven/</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+
+
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>jboss-public-repository</activeProfile>
+    </activeProfiles>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpclient>4.5</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.1</version.org.apache.httpcomponents.httpcore>
-        <version.org.apache.maven>3.2.1</version.org.apache.maven>
+        <version.org.apache.maven>3.3.9</version.org.apache.maven>
         <version.org.apache.xerces>2.11.0.SP4</version.org.apache.xerces>
         <version.org.codehaus.plexus.plexus-utils>3.0.21</version.org.codehaus.plexus.plexus-utils>
         <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
@@ -127,10 +127,10 @@
         <version.org.picketbox>4.9.6.Final</version.org.picketbox>
         <version.org.slf4j>1.7.7.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
-        <version.org.eclipse.aether>1.0.0.v20140518</version.org.eclipse.aether>
-        <version.org.wildfly.build-tools>1.1.3.Final</version.org.wildfly.build-tools>
+        <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
+        <version.org.wildfly.build-tools>1.1.6.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.common>1.2.0.Beta1</version.org.wildfly.common>
-        <version.org.wildfly.legacy.test>1.0.0.Final</version.org.wildfly.legacy.test>
+        <version.org.wildfly.legacy.test>2.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.security.elytron>1.0.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
@@ -160,7 +160,7 @@
         <!-- The name of the root checkout folder to create org.jboss.model.test.classpath.cache under for subsystem-test and core-model-test -->
         <org.jboss.model.test.cache.root>[pom.xml,testsuite]</org.jboss.model.test.cache.root>
         <!-- Location relative to root that will be used for the cached legacy classpaths used by subsystem-test and core-model-test-->
-        <org.jboss.model.test.classpath.cache>target/model-test-classpath-cache</org.jboss.model.test.classpath.cache>
+        <org.jboss.model.test.classpath.cache>target/model-test-cache</org.jboss.model.test.classpath.cache>
     </properties>
 
     <modules>

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -266,11 +266,7 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         GlobalOperationHandlers.registerGlobalOperations(resourceRegistration, ProcessType.STANDALONE_SERVER);
 
-        if (serverEnvironment != null) {
-            resourceRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION, ValidateOperationHandler.INSTANCE);
-        } else {
-            resourceRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION, ValidateOperationHandler.INSTANCE);
-        }
+        resourceRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION, ValidateOperationHandler.INSTANCE);
 
         // Other root resource operations
         resourceRegistration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE, false);

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/bridge/impl/LegacyControllerKernelServicesProxy.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/bridge/impl/LegacyControllerKernelServicesProxy.java
@@ -85,7 +85,7 @@ public class LegacyControllerKernelServicesProxy extends ModelTestLegacyControll
             if (readFullModelDescription == null) {
                 readFullModelDescription = childFirstClassLoaderServices.getClass().getMethod("readFullModelDescription",
                         childFirstClassLoader.loadClass(ModelNode.class.getName()));
-                System.out.println(readFullModelDescription);
+                //System.out.println(readFullModelDescription);
             }
             return convertModelNodeFromChildCl(
                     readFullModelDescription.invoke(childFirstClassLoaderServices,

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractKernelServicesImpl.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractKernelServicesImpl.java
@@ -1,6 +1,5 @@
 package org.jboss.as.subsystem.test;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -67,7 +66,7 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
         additionalInit.setupController(controllerInitializer);
 
         //Initialize the controller
-        ServiceContainer container = ServiceContainer.Factory.create("test" + counter.incrementAndGet());
+        ServiceContainer container = ServiceContainer.Factory.create("subsystem-test" + (legacyModelVersion != null ? "-legacy-" : "-") + counter.incrementAndGet());
         ServiceTarget target = container.subTarget();
         List<ModelNode> extraOps = controllerInitializer.initializeBootOperations();
         List<ModelNode> allOps = new ArrayList<ModelNode>();
@@ -132,16 +131,6 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
             //This is compiled against the current version of WildFly
             return SubsystemDescriptionDump.readFullModelDescription(addr, reg);
         } catch (NoSuchMethodError e) {
-            if (getControllerClassSimpleName().equals("TestModelControllerService7_1_2")) {
-                try {
-                    //Older versions use ManagementResourceRegistration in the method signature, while the newer ones above use ImmutableResourceRegistration
-                    //Call via reflection instead
-                    Method m = SubsystemDescriptionDump.class.getMethod("readFullModelDescription", PathAddress.class, ManagementResourceRegistration.class);
-                    return (ModelNode)m.invoke(null, addr, reg);
-                } catch (Exception e1) {
-                    throw new RuntimeException(e1);
-                }
-            }
             throw e;
         }
     }

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -34,6 +34,7 @@ import java.io.PrintWriter;
 import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -841,9 +842,9 @@ final class SubsystemTestDelegate {
             classLoaderBuilder.addMavenResourceURL("org.wildfly.legacy.test:wildfly-legacy-spi:" + Version.LEGACY_TEST_CONTROLLER_VERSION);
 
             if (testControllerVersion != ModelTestControllerVersion.MASTER && testControllerVersion.getTestControllerVersion() != null) {
-                String groupId = testControllerVersion.getMavenGavVersion().startsWith("7.") ? "org.jboss.as" : "org.wildfly";
-                String serverArtifactId = testControllerVersion.getMavenGavVersion().startsWith("7.") ? "jboss-as-server" : "wildfly-server";
-                classLoaderBuilder.addRecursiveMavenResourceURL(groupId + ":" + serverArtifactId + ":" + testControllerVersion.getMavenGavVersion());
+                String groupId = testControllerVersion.getCoreMavenGroupId();
+                String serverArtifactId = testControllerVersion.getServerMavenArtifactId();
+                classLoaderBuilder.addRecursiveMavenResourceURL(groupId + ":" + serverArtifactId + ":" + testControllerVersion.getCoreVersion());
 
                 //TODO Even with this there are some workarounds needed in JGroupsSubsystemTransformerTestCase, InfinispanSubsystemTransformersTestCase and LoggingSubsystemTestCase
                 //Don't load modules from the scoped classloader to avoid some funky stuff going on when initializing the JAXP redirect
@@ -853,7 +854,7 @@ final class SubsystemTestDelegate {
 
                 classLoaderBuilder.addMavenResourceURL("org.wildfly.legacy.test:wildfly-legacy-subsystem-" + testControllerVersion.getTestControllerVersion() + ":" + Version.LEGACY_TEST_CONTROLLER_VERSION);
             }
-            ClassLoader legacyCl = classLoaderBuilder.build();
+            URLClassLoader legacyCl = classLoaderBuilder.build();
 
             ScopedKernelServicesBootstrap scopedBootstrap = new ScopedKernelServicesBootstrap(legacyCl);
             return scopedBootstrap.createKernelServices(mainSubsystemName, extensionClassName != null ? extensionClassName : mainExtension.getClass().getName(), additionalInit,

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/TestModelControllerService.java
@@ -82,6 +82,7 @@ class TestModelControllerService extends ModelTestModelControllerService impleme
         this.extensionRegistry = extensionRegistry;
         this.runningModeControl = runningModeControl;
         this.registerTransformers = registerTransformers;
+
     }
 
     static TestModelControllerService create(final Extension mainExtension, final ControllerInitializer controllerInitializer,
@@ -115,6 +116,8 @@ class TestModelControllerService extends ModelTestModelControllerService impleme
         additionalInit.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration,
                 managementModel.getCapabilityRegistry());
         rootRegistration.registerOperationHandler(TransformerAttachmentGrabber.DESC, new TransformerAttachmentGrabber());
+        // register the global notifications so there is no warning that emitted notifications are not described by the resource.
+        GlobalNotifications.registerGlobalNotifications(managementModel.getRootResourceRegistration(), processType);
     }
 
     /** @deprecated only for legacy version support */
@@ -129,7 +132,6 @@ class TestModelControllerService extends ModelTestModelControllerService impleme
 
         rootRegistration.registerSubModel(ServerDeploymentResourceDefinition.create(contentRepository, null));
 
-        GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
         controllerInitializer.setTestModelControllerAccessor(this);
         controllerInitializer.initializeModel(rootResource, rootRegistration);
     }

--- a/subsystem-test/tests/pom.xml
+++ b/subsystem-test/tests/pom.xml
@@ -35,18 +35,6 @@
     <artifactId>wildfly-subsystem-test-tests</artifactId>
     <name>WildFly: Subsystem Test Framework Tests</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <forkMode>always</forkMode>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
            <groupId>org.wildfly.core</groupId>

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/extrasubsystem/subsystem/ExtraSubsystemTestCase.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/extrasubsystem/subsystem/ExtraSubsystemTestCase.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistryType;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -173,7 +174,7 @@ public class ExtraSubsystemTestCase extends AbstractSubsystemTest {
         describeOp.get(OP_ADDR).set(
                 PathAddress.pathAddress(
                         PathElement.pathElement(SUBSYSTEM, DependencySubsystemExtension.SUBSYSTEM_NAME)).toModelNode());
-        ArrayList<ModelNode> allOps = new ArrayList<ModelNode>();
+        ArrayList<ModelNode> allOps = new ArrayList<>();
         allOps.addAll(checkResultAndGetContents(servicesA.executeOperation(describeOp)).asList());
         describeOp.get(OP_ADDR).set(
                 PathAddress.pathAddress(
@@ -201,10 +202,8 @@ public class ExtraSubsystemTestCase extends AbstractSubsystemTest {
         }
 
         @Override
-        public void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource,
-                ManagementResourceRegistration rootRegistration) {
+        protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration, RuntimeCapabilityRegistry capabilityRegistry) {
             dependency.initialize(extensionRegistry.getExtensionContext(DependencySubsystemExtension.EXTENSION_NAME, rootRegistration, ExtensionRegistryType.SLAVE));
         }
-
     }
 }

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/simple/TransformerSubsystemTestCase.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/subsystem/simple/TransformerSubsystemTestCase.java
@@ -26,9 +26,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
@@ -43,6 +44,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.exporter.StreamExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -52,21 +54,25 @@ import org.junit.Test;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class TransformerSubsystemTestCase extends AbstractSubsystemBaseTest {
+    private static final Path LEGACY_ARCHIVE = Paths.get("target/legacy-archive-transformers.jar");
 
     public TransformerSubsystemTestCase() {
         super(VersionedExtensionCommon.SUBSYSTEM_NAME, new VersionedExtension2());
     }
 
     @BeforeClass
-    public static void createLegacyJars() throws MalformedURLException {
-        JavaArchive legacySubsystemArchive = ShrinkWrap.create(JavaArchive.class, "legacy-archive.jar");
+    public static void createLegacyJars() throws IOException {
+        JavaArchive legacySubsystemArchive = ShrinkWrap.create(JavaArchive.class, "legacy-archive-transformers.jar");
         legacySubsystemArchive.addPackage(VersionedExtension2.class.getPackage());
         StreamExporter exporter = legacySubsystemArchive.as(ZipExporter.class);
-        File file = new File("target/legacy-archive.jar");
-        if (file.exists()) {
-            file.delete();
-        }
-        exporter.exportTo(file);
+
+        Files.deleteIfExists(LEGACY_ARCHIVE);
+        exporter.exportTo(LEGACY_ARCHIVE.toFile());
+    }
+
+    @AfterClass
+    public static void clean() throws IOException {
+        Files.deleteIfExists(LEGACY_ARCHIVE);
     }
 
     @Override
@@ -94,13 +100,18 @@ public class TransformerSubsystemTestCase extends AbstractSubsystemBaseTest {
         testTransformers(ModelTestControllerVersion.EAP_6_4_0);
     }
 
+    @Test
+    public void testTransformersEAP700() throws Exception {
+        testTransformers(ModelTestControllerVersion.EAP_7_0_0);
+    }
+
     private void testTransformers(ModelTestControllerVersion controllerVersion) throws Exception {
         ModelVersion oldVersion = ModelVersion.create(1, 0, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(null)
                 .setSubsystemXml(getSubsystemXml());
         builder.createLegacyKernelServicesBuilder(null, controllerVersion, oldVersion)
                 .setExtensionClassName(VersionedExtension1.class.getName())
-                .addSimpleResourceURL("target/legacy-archive.jar")
+                .addSimpleResourceURL(LEGACY_ARCHIVE.toString())
                 .skipReverseControllerCheck();
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(oldVersion);
@@ -136,6 +147,8 @@ public class TransformerSubsystemTestCase extends AbstractSubsystemBaseTest {
         writeAttribute = Util.getWriteAttributeOperation(subsystemAddress, "test-attribute", "something else");
         op = mainServices.executeInMainAndGetTheTransformedOperation(writeAttribute, oldVersion);
         Assert.assertTrue(op.rejectOperation(success()));
+        legacyServices.shutdown();
+        mainServices.shutdown();
     }
 
     private static ModelNode success() {


### PR DESCRIPTION
- improve maven downloader, now pareses settings.xml and uses that for configuration
- remove all deprecated versions from ModelTestControllerVersion
- ModelTestControllerVersion now also has core version available and its maven coordinates
- some cleanup of old and no longer used methods / constructors in legacy controllers
- add core model testing against eap7
- add core transformers to pass against EAP7
