### PR TITLE
[WFCORE-1645] Missing whitespace indent in module command help message

### DIFF
--- a/cli/src/main/resources/help/module.txt
+++ b/cli/src/main/resources/help/module.txt
@@ -39,11 +39,11 @@ DESCRIPTION
 
 ARGUMENTS
 
---module-root-dir - (optional) The absolute file path to the server's modules 
+ --module-root-dir - (optional) The absolute file path to the server's modules 
                     directory. By default the module is added to (or removed from)
                     JBOSS_HOME/modules
  
---name          - (required) the name of the module to be added or removed.
+ --name          - (required) the name of the module to be added or removed.
                    NOTE: slot is not a part of the module name.
 
  --slot          - (optional) specifies a slot which should be created or


### PR DESCRIPTION
Upstream issue:
https://issues.jboss.org/browse/WFCORE-1645