### PR TITLE
EAP7 remoting transformers test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
         <version.org.wildfly.build-tools>1.1.6.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.common>1.2.0.Beta1</version.org.wildfly.common>
-        <version.org.wildfly.legacy.test>2.0.0.Final</version.org.wildfly.legacy.test>
+        <version.org.wildfly.legacy.test>2.0.1.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.security.elytron>1.0.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestUtil.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestUtil.java
@@ -50,10 +50,16 @@ import org.wildfly.extension.io.IOExtension;
 class RemotingSubsystemTestUtil {
 
     static final AdditionalInitialization DEFAULT_ADDITIONAL_INITIALIZATION =
-            AdditionalInitialization.withCapabilities(buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
+            AdditionalInitialization.withCapabilities(
+                    buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
                     RemotingEndpointResource.WORKER.getDefaultValue().asString()),
                     // This one is specified in one of the test configs
-                    buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY, "default-remoting"));
+                    buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY, "default-remoting"),
+                    buildDynamicCapabilityName("org.wildfly.network.outbound-socket-binding", "dummy-outbound-socket"),
+                    buildDynamicCapabilityName("org.wildfly.network.outbound-socket-binding", "other-outbound-socket")
+
+
+                    );
 
     static final AdditionalInitialization HC_ADDITIONAL_INITIALIZATION =
             new AdditionalInitialization.ManagementAdditionalInitialization() {

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
@@ -119,6 +119,29 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemTest
         checkRejectEndpointConfiguration(mainServices, oldVersion);
     }
 
+
+    @Test
+    public void testTransformersEAP700() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(DEFAULT_ADDITIONAL_INITIALIZATION)
+                .setSubsystemXmlResource("remoting-with-expressions-and-good-legacy-protocol.xml");
+        ModelVersion oldVersion = ModelVersion.create(3, 0, 0);
+
+
+        ModelTestControllerVersion controllerVersion = ModelTestControllerVersion.EAP_7_0_0;
+        // Add legacy subsystems
+        builder.createLegacyKernelServicesBuilder(DEFAULT_ADDITIONAL_INITIALIZATION, controllerVersion, oldVersion)
+                .addMavenResourceURL("org.wildfly.core:wildfly-remoting:" + controllerVersion.getCoreVersion())
+                .skipReverseControllerCheck();
+        //.configureReverseControllerCheck(createAdditionalInitialization(), null);
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(oldVersion);
+        assertNotNull(legacyServices);
+        assertTrue(legacyServices.isSuccessfulBoot());
+
+        checkSubsystemModelTransformation(mainServices, oldVersion, null, false);
+    }
+
     private void checkRejectOutboundConnectionProtocolNotRemote(KernelServices mainServices, ModelVersion version, String type, String name) throws OperationFailedException {
         ModelNode operation = new ModelNode();
         operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);


### PR DESCRIPTION
- upgrade wildfly-legacy-test 2.0.1.Final to address additional capability registration in subsystem tests