### PR TITLE
[WFCORE-1642]: Fix domain mode for configuration changes.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/CoreManagementResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/CoreManagementResourceDefinition.java
@@ -94,9 +94,9 @@ public class CoreManagementResourceDefinition extends SimpleResourceDefinition {
             resourceRegistration.registerSubModel(ManagementControllerResourceDefinition.INSTANCE);
             resourceRegistration.registerSubModel(SecurityRealmResourceDefinition.INSTANCE);
             resourceRegistration.registerSubModel(LdapConnectionResourceDefinition.newInstance());
+            // Configuration Changes
+            resourceRegistration.registerSubModel(ConfigurationChangeResourceDefinition.INSTANCE);
         }
-        // Configuration Changes
-        resourceRegistration.registerSubModel(ConfigurationChangeResourceDefinition.INSTANCE);
 
         for (ResourceDefinition current : interfaces) {
             resourceRegistration.registerSubModel(current);
@@ -105,6 +105,7 @@ public class CoreManagementResourceDefinition extends SimpleResourceDefinition {
         switch (environment) {
             case DOMAIN:
                 resourceRegistration.registerSubModel(AccessAuthorizationResourceDefinition.forDomain(authorizer));
+                resourceRegistration.registerSubModel(ConfigurationChangeResourceDefinition.forDomain());
                 break;
             case DOMAIN_SERVER:
                 resourceRegistration.registerSubModel(AccessAuthorizationResourceDefinition.forDomainServer(authorizer));

--- a/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
@@ -1237,6 +1237,9 @@ public interface DomainManagementLogger extends BasicLogger {
     IllegalArgumentException asnInvalidLength();
 
     /* End X.500 exceptions */
+    @Message(id = 135, value = "The resource %s wasn't working properly and has been removed.")
+    String removedOutOfOrderResource(final String address);
+
     /**
      * Information message saying the username and password must be different.
      *

--- a/domain-management/src/main/resources/org/jboss/as/domain/management/_private/LocalDescriptions.properties
+++ b/domain-management/src/main/resources/org/jboss/as/domain/management/_private/LocalDescriptions.properties
@@ -245,6 +245,7 @@ core.management.host-connection=Information about the connection state of a slav
 
 core.management.service.configuration-changes=Service to store and list configuration changes.
 core.management.service.configuration-changes.add=Add the history for configuration changes.
+core.management.service.configuration-changes.deprecated=The configuration changes service at the root of a Domain Controller is deprecated and may be removed or moved in future versions.
 core.management.service.configuration-changes.remove=Remove the configuration changes and clear the history.
 core.management.service.configuration-changes.max-history=The maximum number of configuration changes stored in history.
 core.management.service.configuration-changes.list-changes=List the last configuration changes.

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerOperationsFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerOperationsFactory.java
@@ -30,6 +30,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUDIT_LOG;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTHENTICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTHORIZATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONFIGURATION_CHANGES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONNECTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONSTRAINT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
@@ -59,6 +60,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LDA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOGGER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX_HISTORY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAMESPACES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -82,6 +84,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP_SCOPED_ROLE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_IDENTITY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_LOGGER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SIZE_ROTATING_FILE_HANDLER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE;
@@ -241,6 +244,7 @@ public final class ManagedServerOperationsFactory {
         addAuditLog(updates);
         addManagementConnections(updates);
         addManagementAuthorization(updates);
+        addConfigurationChanges(updates);
         addInterfaces(updates);
         addSocketBindings(updates, portOffSet, socketBindingRef, defaultInterface);
         addSubsystems(updates);
@@ -539,6 +543,15 @@ public final class ManagedServerOperationsFactory {
                 final PathAddress loggerAddress = auditLogAddr.append(LOGGER, AUDIT_LOG);
                 AuditLogLoggerResourceDefinition.createServerAddOperations(updates, loggerAddress, auditLogModel.get(SERVER_LOGGER, AUDIT_LOG));
             }
+        }
+    }
+
+    private void addConfigurationChanges(ModelNodeList updates) {
+        final ModelNode configurationChangesModel = hostModel.get(CORE_SERVICE, MANAGEMENT, SERVICE, CONFIGURATION_CHANGES);
+        if (configurationChangesModel.isDefined()) {
+            ModelNode addConfigurationChanges = Util.createAddOperation(PathAddress.pathAddress().append(CORE_SERVICE, MANAGEMENT).append(SERVICE, CONFIGURATION_CHANGES));
+            addConfigurationChanges.get(MAX_HISTORY).set(configurationChangesModel.get(MAX_HISTORY));
+            updates.add(addConfigurationChanges);
         }
     }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ConfigurationChangesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ConfigurationChangesTestCase.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright (C) 2016 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.test.integration.domain;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.jboss.as.controller.audit.JsonAuditLogItemFormatter.REMOTE_ADDRESS;
+import static org.jboss.as.controller.client.helpers.ClientConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
+import static org.jboss.as.controller.client.helpers.ClientConstants.RESULT;
+import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_MECHANISM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOWED_ORIGINS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUDIT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUDIT_LOG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_UUID;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HTTP_INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IN_MEMORY_HANDLER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOGGER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOG_BOOT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX_HISTORY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_DATE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.junit.Assert.assertThat;
+import static org.productivity.java.syslog4j.impl.message.pci.PCISyslogMessage.USER_ID;
+
+import java.io.IOException;
+import java.util.List;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.domain.management.ConfigurationChangeResourceDefinition;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class ConfigurationChangesTestCase {
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainMasterLifecycleUtil;
+    private static DomainLifecycleUtil domainSlaveLifecycleUtil;
+    private static final Logger logger = Logger.getLogger(ConfigurationChangesTestCase.class);
+
+    private static final int MAX_HISTORY_SIZE = 100;
+
+    private static final PathElement HOST_MASTER = PathElement.pathElement(HOST, "master");
+    private static final PathElement HOST_SLAVE = PathElement.pathElement(HOST, "slave");
+    private static final PathAddress ALLOWED_ORIGINS_ADDRESS = PathAddress.pathAddress()
+            .append(CORE_SERVICE, MANAGEMENT)
+            .append(MANAGEMENT_INTERFACE, HTTP_INTERFACE);
+    private static final PathAddress AUDIT_LOG_ADDRESS = PathAddress.pathAddress()
+            .append(CORE_SERVICE, MANAGEMENT)
+            .append(ACCESS, AUDIT)
+            .append(LOGGER, AUDIT_LOG);
+    private static final PathAddress SYSTEM_PROPERTY_ADDRESS = PathAddress.pathAddress()
+            .append(SYSTEM_PROPERTY, "test");
+    private static final PathAddress ADDRESS = PathAddress.pathAddress()
+            .append(PathElement.pathElement(CORE_SERVICE, MANAGEMENT))
+            .append(ConfigurationChangeResourceDefinition.PATH);
+    private static final PathAddress IN_MEMORY_HANDLER_ADDRESS = PathAddress.pathAddress()
+            .append(CORE_SERVICE, MANAGEMENT)
+            .append(ACCESS, AUDIT)
+            .append(IN_MEMORY_HANDLER, "test");
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+         DomainTestSupport.Configuration configuration = DomainTestSupport.Configuration.create(ConfigurationChangesTestCase.class.getSimpleName(),
+                    "domain-configs/domain-config-changes.xml", "host-configs/host-master-config-changes.xml", "host-configs/host-slave-config-changes.xml",
+                    false, false, false, false, false);
+        testSupport = DomainTestSupport.createAndStartSupport(configuration);
+        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+        domainSlaveLifecycleUtil = testSupport.getDomainSlaveLifecycleUtil();
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        testSupport.stop();
+        domainMasterLifecycleUtil = null;
+        domainSlaveLifecycleUtil = null;
+        testSupport = null;
+    }
+
+    public void createConfigurationChanges(PathElement host) throws Exception {
+        DomainClient client = domainMasterLifecycleUtil.getDomainClient();
+        final ModelNode add = Util.createAddOperation(PathAddress.pathAddress().append(host).append(ADDRESS));
+        add.get(ConfigurationChangeResourceDefinition.MAX_HISTORY.getName()).set(MAX_HISTORY_SIZE);
+        client.execute(add);
+        PathAddress allowedOrigins = PathAddress.pathAddress().append(host).append(ALLOWED_ORIGINS_ADDRESS);
+        ModelNode setAllowedOrigins = Util.createEmptyOperation("list-add", allowedOrigins);
+        setAllowedOrigins.get(NAME).set(ALLOWED_ORIGINS);
+        setAllowedOrigins.get(VALUE).set( "http://www.wildfly.org");
+        client.execute(setAllowedOrigins);
+        PathAddress auditLogAddress = PathAddress.pathAddress().append(host).append(AUDIT_LOG_ADDRESS);
+        ModelNode disableLogBoot = Util.getWriteAttributeOperation(auditLogAddress, LOG_BOOT, false);
+        client.execute(disableLogBoot);
+        //read
+        client.execute(Util.getReadAttributeOperation(allowedOrigins, ALLOWED_ORIGINS));
+        //invalid operation
+        client.execute(Util.getUndefineAttributeOperation(allowedOrigins, "not-exists-attribute"));
+        //invalid operation
+        client.execute(Util.getWriteAttributeOperation(allowedOrigins, "not-exists-attribute", "123456"));
+        //write operation, failed
+        ModelNode setAllowedOriginsFails = Util.getWriteAttributeOperation(allowedOrigins, ALLOWED_ORIGINS, "123456");//wrong type, expected is LIST, op list-add
+        client.execute(setAllowedOriginsFails);
+        PathAddress systemPropertyAddress = PathAddress.pathAddress().append(host).append(SYSTEM_PROPERTY_ADDRESS);
+        ModelNode setSystemProperty = Util.createAddOperation(systemPropertyAddress);
+        setSystemProperty.get(VALUE).set("changeConfig");
+        client.execute(setSystemProperty);
+        ModelNode unsetAllowedOrigins = Util.getUndefineAttributeOperation(allowedOrigins, ALLOWED_ORIGINS);
+        client.execute(unsetAllowedOrigins);
+        ModelNode enableLogBoot = Util.getWriteAttributeOperation(auditLogAddress, LOG_BOOT, true);
+        client.execute(enableLogBoot);
+        ModelNode unsetSystemProperty = Util.createRemoveOperation(systemPropertyAddress);
+        client.execute(unsetSystemProperty);
+        PathAddress inMemoryAddress = PathAddress.pathAddress().append(host).append(IN_MEMORY_HANDLER_ADDRESS);
+        ModelNode addInMemoryHandler = Util.createAddOperation(inMemoryAddress);
+        client.execute(addInMemoryHandler);
+        ModelNode editInMemoryHandler = Util.getWriteAttributeOperation(inMemoryAddress, MAX_HISTORY, 50);
+        client.execute(editInMemoryHandler);
+        ModelNode removeInMemoryHandler = Util.createRemoveOperation(inMemoryAddress);
+        client.execute(removeInMemoryHandler);
+    }
+
+    @Test
+    public void testConfigurationChanges() throws Exception {
+        createConfigurationChanges(HOST_MASTER);
+        createConfigurationChanges(HOST_SLAVE);
+        try {
+            checkConfigurationChanges(readConfigurationChanges(domainMasterLifecycleUtil.getDomainClient(), HOST_MASTER), 11);
+            checkConfigurationChanges(readConfigurationChanges(domainMasterLifecycleUtil.getDomainClient(), HOST_SLAVE), 11);
+            checkConfigurationChanges(readConfigurationChanges(domainSlaveLifecycleUtil.getDomainClient(), HOST_SLAVE), 11);
+            checkRootConfigurationChangeWarning(domainMasterLifecycleUtil.getDomainClient());
+            setConfigurationChangeMaxHistory(domainMasterLifecycleUtil.getDomainClient(), HOST_MASTER, 20);
+            checkMaxHistorySize(domainMasterLifecycleUtil.getDomainClient(), 20, HOST_MASTER, PathElement.pathElement(SERVER, "main-one"));
+            checkMaxHistorySize(domainMasterLifecycleUtil.getDomainClient(), MAX_HISTORY_SIZE, HOST_SLAVE, PathElement.pathElement(SERVER, "other-three"));
+        } finally {
+            clearConfigurationChanges(HOST_MASTER);
+            clearConfigurationChanges(HOST_SLAVE);
+        }
+    }
+
+    @Test
+    public void testConfigurationChangesOnSlave() throws Exception {
+        createConfigurationChanges(HOST_SLAVE);
+        try {
+            PathAddress systemPropertyAddress = PathAddress.pathAddress().append(HOST_SLAVE).append(SYSTEM_PROPERTY, "slave");
+            ModelNode setSystemProperty = Util.createAddOperation(systemPropertyAddress);
+            setSystemProperty.get(VALUE).set("slave-config");
+            domainSlaveLifecycleUtil.getDomainClient().execute(setSystemProperty);
+            systemPropertyAddress = PathAddress.pathAddress().append(SERVER_GROUP, "main-server-group").append(SYSTEM_PROPERTY, "main");
+            setSystemProperty = Util.createAddOperation(systemPropertyAddress);
+            setSystemProperty.get(VALUE).set("main-config");
+            domainMasterLifecycleUtil.getDomainClient().execute(setSystemProperty);
+            List<ModelNode> changesOnSlaveHC = readConfigurationChanges(domainSlaveLifecycleUtil.getDomainClient(), HOST_SLAVE);
+            List<ModelNode> changesOnSlaveDC = readConfigurationChanges(domainMasterLifecycleUtil.getDomainClient(), HOST_SLAVE);
+            checkSlaveConfigurationChanges(changesOnSlaveHC, 12);
+            setConfigurationChangeMaxHistory(domainMasterLifecycleUtil.getDomainClient(), HOST_SLAVE, 20);
+            checkMaxHistorySize(domainMasterLifecycleUtil.getDomainClient(), 20, HOST_SLAVE, PathElement.pathElement(SERVER, "other-three"));
+            checkMaxHistorySize(domainSlaveLifecycleUtil.getDomainClient(), 20, HOST_SLAVE, PathElement.pathElement(SERVER, "other-three"));
+            assertThat(changesOnSlaveHC.size(), is(changesOnSlaveDC.size()));
+        } finally {
+            clearConfigurationChanges(HOST_SLAVE);
+        }
+    }
+
+    private void checkRootConfigurationChangeWarning(DomainClient client) throws IOException {
+        PathAddress address = ADDRESS;
+        ModelNode addConfigurationChanges = Util.createAddOperation(address);
+        addConfigurationChanges.get(ConfigurationChangeResourceDefinition.MAX_HISTORY.getName()).set(MAX_HISTORY_SIZE);
+        ModelNode response = client.execute(addConfigurationChanges);
+        assertThat(response.asString(), response.get(OUTCOME).asString(), is(SUCCESS));
+        assertThat(response.get(RESULT).asString(), containsString("WFLYDM0135"));
+    }
+
+    private void checkConfigurationChanges(List<ModelNode> changes, int size) throws IOException {
+        assertThat(changes.size(), is(size));
+        for (ModelNode change : changes) {
+            assertThat(change.hasDefined(OPERATION_DATE), is(true));
+            assertThat(change.hasDefined(USER_ID), is(false));
+            assertThat(change.hasDefined(DOMAIN_UUID), is(true));
+            assertThat(change.hasDefined(ACCESS_MECHANISM), is(true));
+            assertThat(change.get(ACCESS_MECHANISM).asString(), is("NATIVE"));
+            assertThat(change.hasDefined(REMOTE_ADDRESS), is(true));
+            assertThat(change.get(OPERATIONS).asList().size(), is(1));
+        }
+        validateChanges(changes);
+    }
+
+    private void checkSlaveConfigurationChanges( List<ModelNode> changes, int size) throws IOException {
+        assertThat(changes.size(), is(size));
+        for (ModelNode change : changes) {
+            assertThat(change.hasDefined(OPERATION_DATE), is(true));
+            assertThat(change.hasDefined(USER_ID), is(false));
+            assertThat(change.hasDefined(DOMAIN_UUID), is(true));
+            assertThat(change.hasDefined(ACCESS_MECHANISM), is(true));
+            assertThat(change.get(ACCESS_MECHANISM).asString(), is("NATIVE"));
+            assertThat(change.hasDefined(REMOTE_ADDRESS), is(true));
+            assertThat(change.get(OPERATIONS).asList().size(), is(1));
+        }
+        ModelNode currentChange = changes.get(0);
+        assertThat(currentChange.get(OUTCOME).asString(), is(SUCCESS));
+        ModelNode currentChangeOp = currentChange.get(OPERATIONS).asList().get(0);
+        assertThat(currentChangeOp.get(OP).asString(), is(ADD));
+        assertThat(removePrefix(currentChangeOp).toString(), is(PathAddress.pathAddress(SYSTEM_PROPERTY, "slave").toString()));
+        assertThat(currentChangeOp.get(VALUE).asString(), is("slave-config"));
+        validateChanges(changes.subList(1, changes.size() - 1));
+    }
+
+    private void validateChanges(List<ModelNode> changes) throws IOException {
+        for (ModelNode change : changes) {
+            assertThat(change.hasDefined(OPERATION_DATE), is(true));
+            assertThat(change.hasDefined(USER_ID), is(false));
+            assertThat(change.hasDefined(DOMAIN_UUID), is(true));
+            assertThat(change.hasDefined(ACCESS_MECHANISM), is(true));
+            assertThat(change.get(ACCESS_MECHANISM).asString(), is("NATIVE"));
+            assertThat(change.hasDefined(REMOTE_ADDRESS), is(true));
+            assertThat(change.get(OPERATIONS).asList().size(), is(1));
+        }
+        ModelNode currentChange = changes.get(0);
+        assertThat(currentChange.get(OUTCOME).asString(), is(SUCCESS));
+        ModelNode currentChangeOp = currentChange.get(OPERATIONS).asList().get(0);
+        assertThat(currentChangeOp.get(OP).asString(), is(REMOVE));
+        assertThat(removePrefix(currentChangeOp).toString(), is(IN_MEMORY_HANDLER_ADDRESS.toString()));
+
+        currentChange = changes.get(1);
+        assertThat(currentChange.get(OUTCOME).asString(), is(SUCCESS));
+        currentChangeOp = currentChange.get(OPERATIONS).asList().get(0);
+        assertThat(currentChangeOp.get(OP).asString(), is(WRITE_ATTRIBUTE_OPERATION));
+        assertThat(removePrefix(currentChangeOp).toString(), is(IN_MEMORY_HANDLER_ADDRESS.toString()));
+        assertThat(currentChangeOp.get(VALUE).asInt(), is(50));
+
+        currentChange = changes.get(2);
+        assertThat(currentChange.get(OUTCOME).asString(), is(SUCCESS));
+        currentChangeOp = currentChange.get(OPERATIONS).asList().get(0);
+        assertThat(currentChangeOp.get(OP).asString(), is(ADD));
+        assertThat(removePrefix(currentChangeOp).toString(), is(IN_MEMORY_HANDLER_ADDRESS.toString()));
+
+        currentChange = changes.get(3);
+        assertThat(currentChange.get(OUTCOME).asString(), is(SUCCESS));
+        currentChangeOp = currentChange.get(OPERATIONS).asList().get(0);
+        assertThat(currentChangeOp.get(OP).asString(), is(REMOVE));
+       assertThat(removePrefix(currentChangeOp).toString(), is(SYSTEM_PROPERTY_ADDRESS.toString()));
+
+        currentChange = changes.get(4);
+        assertThat(currentChange.get(OUTCOME).asString(), is(SUCCESS));
+        currentChangeOp = currentChange.get(OPERATIONS).asList().get(0);
+        assertThat(currentChangeOp.get(OP).asString(), is(WRITE_ATTRIBUTE_OPERATION));
+        assertThat(removePrefix(currentChangeOp).toString(), is(AUDIT_LOG_ADDRESS.toString()));
+        assertThat(currentChangeOp.get(VALUE).asBoolean(), is(true));
+
+        currentChange = changes.get(5);
+        assertThat(currentChange.get(OUTCOME).asString(), is(SUCCESS));
+        currentChangeOp = currentChange.get(OPERATIONS).asList().get(0);
+        assertThat(currentChangeOp.get(OP).asString(), is(UNDEFINE_ATTRIBUTE_OPERATION));
+        assertThat(removePrefix(currentChangeOp).toString(), is(ALLOWED_ORIGINS_ADDRESS.toString()));
+
+        assertThat(currentChangeOp.get(NAME).asString(), is(ALLOWED_ORIGINS));
+
+        currentChange = changes.get(6);
+        assertThat(currentChange.get(OUTCOME).asString(), is(SUCCESS));
+        currentChangeOp = currentChange.get(OPERATIONS).asList().get(0);
+        assertThat(currentChangeOp.get(OP).asString(), is(ADD));
+        assertThat(removePrefix(currentChangeOp).toString(), is(SYSTEM_PROPERTY_ADDRESS.toString()));
+        assertThat(currentChangeOp.get(VALUE).asString(), is("changeConfig"));
+
+        currentChange = changes.get(7);
+        assertThat(currentChange.get(OUTCOME).asString(), is(FAILED));
+        currentChangeOp = currentChange.get(OPERATIONS).asList().get(0);
+        assertThat(currentChangeOp.get(NAME).asString(), is(ALLOWED_ORIGINS));
+    }
+
+    private PathAddress removePrefix(ModelNode operation) {
+        return PathAddress.pathAddress(operation.get(OP_ADDR)).subAddress(1);
+    }
+
+    public List<ModelNode> readConfigurationChanges(DomainClient client, PathElement prefix) throws IOException {
+        PathAddress address = ADDRESS;
+        if(prefix != null) {
+            address = PathAddress.pathAddress().append(prefix).append(ADDRESS);
+        }
+        ModelNode readConfigChanges = Util.createOperation(ConfigurationChangeResourceDefinition.OPERATION_NAME, address);
+        ModelNode response = client.execute(readConfigChanges);
+        assertThat(response.asString(), response.get(OUTCOME).asString(), is(SUCCESS));
+        logger.info("For " + prefix + " we have " + response.get(RESULT));
+        return response.get(RESULT).asList();
+    }
+
+    private void setConfigurationChangeMaxHistory(DomainClient client, PathElement prefix, int size) throws IOException, UnsuccessfulOperationException {
+        PathAddress address = PathAddress.pathAddress().append(prefix).append(ADDRESS);
+        ModelNode writeMaxHistorySize = Util.getWriteAttributeOperation(address, MAX_HISTORY, size);
+        ModelNode response = client.execute(writeMaxHistorySize);
+        assertThat(response.asString(), response.get(OUTCOME).asString(), is(SUCCESS));
+        checkMaxHistorySize(client, size, prefix);
+    }
+
+    private void checkMaxHistorySize(DomainClient client,  int expectedSize, PathElement ... prefix) throws UnsuccessfulOperationException {
+        PathAddress address = PathAddress.pathAddress().append(prefix).append(ADDRESS);
+        ModelNode readMaxHistorySize = Util.getReadAttributeOperation(address, MAX_HISTORY);
+        ModelNode result = executeForResult(client, readMaxHistorySize);
+        assertThat(result.asInt(), is(expectedSize));
+    }
+
+    public void clearConfigurationChanges(PathElement host) throws UnsuccessfulOperationException {
+        DomainClient client = domainMasterLifecycleUtil.getDomainClient();
+        final ModelNode remove = Util.createRemoveOperation(PathAddress.pathAddress().append(host).append(ADDRESS));
+        executeForResult(client, remove);
+    }
+
+    public ModelNode executeForResult(final DomainClient client, final ModelNode operation) throws UnsuccessfulOperationException {
+        try {
+            final ModelNode result = client.execute(operation);
+            checkSuccessful(result, operation);
+            return result.get(RESULT);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void checkSuccessful(final ModelNode result,
+                                 final ModelNode operation) throws UnsuccessfulOperationException {
+        if (!SUCCESS.equals(result.get(OUTCOME).asString())) {
+            logger.error("Operation " + operation + " did not succeed. Result was " + result);
+            throw new UnsuccessfulOperationException(result.get(FAILURE_DESCRIPTION).toString());
+        }
+    }
+}

--- a/testsuite/domain/src/test/resources/domain-configs/domain-config-changes.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-config-changes.xml
@@ -1,0 +1,290 @@
+<!--
+  ~ /*
+  ~ * JBoss, Home of Professional Open Source.
+  ~ * Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ * as indicated by the @author tags. See the copyright.txt file in the
+  ~ * distribution for a full listing of individual contributors.
+  ~ *
+  ~ * This is free software; you can redistribute it and/or modify it
+  ~ * under the terms of the GNU Lesser General Public License as
+  ~ * published by the Free Software Foundation; either version 2.1 of
+  ~ * the License, or (at your option) any later version.
+  ~ *
+  ~ * This software is distributed in the hope that it will be useful,
+  ~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ * Lesser General Public License for more details.
+  ~ *
+  ~ * You should have received a copy of the GNU Lesser General Public
+  ~ * License along with this software; if not, write to the Free
+  ~ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~ */
+  -->
+
+<domain xmlns="urn:jboss:domain:5.0">
+
+    <extensions>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.jboss.as.remoting"/>
+        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.request-controller"/>
+    </extensions>
+
+    <system-properties>
+        <property name="jboss.domain.test.property.one" value="ONE"/>
+        <property name="jboss.domain.test.property.two" value="${jboss.domain.test.property.one}"/>
+    </system-properties>
+
+    <paths>
+        <path name="domainTestPath"/>
+    </paths>
+
+    <management>
+        <!--<configuration-changes max-history="100"/>-->
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+
+    <profiles>
+
+        <profile name="web-only">
+            <subsystem xmlns="urn:jboss:domain:io:1.1">
+                <worker name="default" />
+                <buffer-pool name="default" />
+            </subsystem>
+        </profile>
+        <profile name="default">
+            <!-- include profile="web-only"/ -->
+            <subsystem xmlns="urn:jboss:domain:io:1.1">
+                <worker name="default" />
+                <buffer-pool name="default" />
+            </subsystem>
+
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                </console-handler>
+
+                <periodic-rotating-file-handler name="FILE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                </periodic-rotating-file-handler>
+                <logger category="org.jboss.as.controller">
+                    <level name="TRACE"/>
+                </logger>
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:remoting:3.0">
+                <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+                <expose-resolved-model/>
+                <expose-expression-model/>
+                <remoting-connector/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:request-controller:1.0">
+            </subsystem>
+        </profile>
+        <profile name="other">
+            <!-- include profile="default"/ -->
+            <subsystem xmlns="urn:jboss:domain:io:1.1">
+                <worker name="default"/>
+                <buffer-pool name="default"/>
+            </subsystem>
+
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                </console-handler>
+
+                <periodic-rotating-file-handler name="FILE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                </periodic-rotating-file-handler>
+                <logger category="org.jboss.as.controller">
+                    <level name="TRACE"/>
+                </logger>
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+            </subsystem>
+
+            <subsystem xmlns="urn:jboss:domain:remoting:3.0">
+                <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+            </subsystem>
+
+            <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+                <expose-resolved-model/>
+                <expose-expression-model/>
+                <remoting-connector/>
+            </subsystem>
+
+            <subsystem xmlns="urn:jboss:domain:request-controller:1.0">
+            </subsystem>
+        </profile>
+        <profile name="ignored">
+            <subsystem xmlns="urn:jboss:domain:jmx:1.3"/>
+        </profile>
+        <profile name="minimal">
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                </console-handler>
+                <periodic-rotating-file-handler name="FILE">
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                    <append value="true"/>
+                </periodic-rotating-file-handler>
+                <logger category="org.jboss.as.controller">
+                    <level name="TRACE"/>
+                </logger>
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+            </subsystem>
+        </profile>
+    </profiles>
+
+    <!--
+         Named interfaces that can be referenced elsewhere. Different
+         mechanisms for associating an IP address with the interface
+         are shown.
+    -->
+    <interfaces>
+        <interface name="management"/>
+        <interface name="public"/>
+    </interfaces>
+
+    <socket-binding-groups>
+        <socket-binding-group name="web-sockets" default-interface="public">
+            <socket-binding name="http" port="8080"/>
+            <socket-binding name="https" port="8443"/>
+        </socket-binding-group>
+        <socket-binding-group name="standard-sockets" default-interface="public">
+            <socket-binding name="ajp" port="8009"/>
+            <socket-binding name="http" port="8080"/>
+            <socket-binding name="https" port="8443"/>
+            <!-- include socket-binding-group="web-sockets"/-->
+            <socket-binding name="jmx-connector-registry" interface="management" port="1090"/>
+            <socket-binding name="jmx-connector-server" interface="management" port="1091"/>
+            <socket-binding name="remoting" port="4447"/>
+            <socket-binding name="txn-recovery-environment" port="4712"/>
+            <socket-binding name="txn-status-manager" port="4713"/>
+            <socket-binding name="messaging" port="5445"/>
+            <socket-binding name="messaging-throughput" port="5455"/>
+            <outbound-socket-binding name="mail-smtp">
+                <remote-destination host="localhost" port="25"/>
+            </outbound-socket-binding>
+        </socket-binding-group>
+        <socket-binding-group name="other-sockets" default-interface="public">
+            <socket-binding name="ajp" port="8009"/>
+            <socket-binding name="http" port="8080"/>
+            <socket-binding name="https" port="8443"/>
+            <socket-binding name="jmx-connector-registry" interface="management" port="1090"/>
+            <socket-binding name="jmx-connector-server" interface="management" port="1091"/>
+            <socket-binding name="remoting" port="4447"/>
+            <socket-binding name="txn-recovery-environment" port="4712"/>
+            <socket-binding name="txn-status-manager" port="4713"/>
+            <socket-binding name="messaging" port="5445"/>
+            <socket-binding name="messaging-throughput" port="5455"/>
+            <outbound-socket-binding name="mail-smtp">
+                <remote-destination host="localhost" port="25"/>
+            </outbound-socket-binding>
+            <!-- include socket-binding-group="standard-sockets"/-->
+        </socket-binding-group>
+        <socket-binding-group name="ignored" default-interface="public">
+            <socket-binding name="http" port="8080"/>
+        </socket-binding-group>
+        <socket-binding-group name="reload-sockets" default-interface="public"/>
+    </socket-binding-groups>
+
+    <server-groups>
+        <server-group name="main-server-group" profile="default">
+            <jvm name="default">
+                <heap size="64m" max-size="512m"/>
+                <environment-variables>
+                    <variable name="DOMAIN_TEST_MAIN_GROUP" value="main_group"/>
+                </environment-variables>
+            </jvm>
+            <socket-binding-group ref="standard-sockets"/>
+        </server-group>
+
+        <server-group name="other-server-group" profile="other">
+            <jvm name="default">
+                <heap size="64m" max-size="512m"/>
+            </jvm>
+            <socket-binding-group ref="other-sockets"/>
+        </server-group>
+
+        <server-group name="ignored-profile" profile="ignored">
+            <socket-binding-group ref="standard-sockets"/>
+        </server-group>
+
+        <server-group name="ignored-sockets" profile="default">
+            <socket-binding-group ref="ignored"/>
+        </server-group>
+
+        <server-group name="minimal" profile="minimal">
+            <socket-binding-group ref="standard-sockets"/>
+        </server-group>
+
+        <server-group name="reload-test-group" profile="minimal">
+            <socket-binding-group ref="reload-sockets"/>
+            <jvm name="default">
+                <heap size="64m" max-size="64m"/>
+            </jvm>
+        </server-group>
+
+        <server-group name="failure-test-group" profile="default">
+            <socket-binding-group ref="standard-sockets"/>
+            <jvm name="default" java-home="/usr/java/wrongPath">
+                <heap size="64m" max-size="64m"/>
+            </jvm>
+        </server-group>
+    </server-groups>
+
+
+</domain>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-config-changes.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-config-changes.xml
@@ -1,0 +1,161 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<host xmlns="urn:jboss:domain:5.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:5.0 wildfly-config_5_0.xsd"
+      name="master" organization="core-master">
+
+    <extensions>
+        <extension module="org.jboss.as.jmx"/>
+    </extensions>
+
+    <paths>
+        <path name="domainTestPath" path="/tmp" />
+    </paths>
+
+    <management>
+        <!--<configuration-changes max-history="100"/>-->
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                     <local default-user="$local" skip-group-loading="true"/>
+                     <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                     <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="host-file" formatter="json-formatter" relative-to="jboss.domain.data.dir" path="audit-log.log"/>
+                <file-handler name="server-file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="host-file"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="server-file"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="9999"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm">
+                <http-upgrade enabled="true" />
+                <socket interface="management" port="9990"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+       <local/>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.master.address}"/>
+        </interface>
+        <!-- AS7-4177 specify the "public" interface in each server to test that handling -->
+    </interfaces>
+
+	<jvms>
+	   <jvm name="default">
+          <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
+          <environment-variables>
+              <variable name="DOMAIN_TEST_JVM" value="jvm"/>
+          </environment-variables>
+            <!--
+            <jvm-options>
+                <option value="-Xdebug"/>
+                <option value="-Xnoagent"/>
+                <option value="-Djava.compiler=NONE"/>
+                <option value="-agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=y"/>
+
+            </jvm-options>
+            -->
+       </jvm>
+	</jvms>
+
+    <servers>
+        <server name="main-one" group="main-server-group">
+            <paths>
+                <path name="domainTestPath" path="main-one" relative-to="jboss.server.temp.dir" />
+            </paths>
+            <interfaces>
+                <interface name="public">
+                    <inet-address value="${jboss.test.host.master.address}"/>
+                </interface>
+            </interfaces>
+            <!-- server-one inherits the default socket-group declared in the server-group -->
+            <jvm name="default">
+	             <environment-variables>
+	                 <variable name="DOMAIN_TEST_SERVER" value="server"/>
+	             </environment-variables>
+            </jvm>
+        </server>
+        <server name="main-two" group="main-server-group" auto-start="false">
+            <interfaces>
+                <interface name="public">
+                    <inet-address value="${jboss.test.host.master.address}"/>
+                </interface>
+            </interfaces>
+            <!-- server-two avoids port conflicts by incrementing the ports in
+                 the default socket-group declared in the server-group -->
+            <socket-bindings socket-binding-group="standard-sockets" port-offset="150"/>
+            <jvm name="default">
+                <heap size="64m" max-size="256m"/>
+            </jvm>
+        </server>
+        <server name="other-one" group="other-server-group" auto-start="false">
+            <interfaces>
+                <interface name="public">
+                    <inet-address value="${jboss.test.host.master.address}"/>
+                </interface>
+            </interfaces>
+            <!-- server-three avoids port conflicts by incrementing the ports in
+                 the default socket-group declared in the server-group -->
+            <socket-bindings port-offset="250"/>
+        </server>
+    </servers>
+
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+    </profile>
+</host>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-config-changes.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-config-changes.xml
@@ -1,0 +1,145 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<host xmlns="urn:jboss:domain:5.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:5.0 wildfly-config_5_0.xsd"
+      name="slave">
+
+    <extensions>
+        <extension module="org.jboss.as.jmx"/>
+    </extensions>
+
+    <paths>
+        <path name="domainTestPath" path="/tmp" />
+    </paths>
+
+    <management>
+        <!--<configuration-changes max-history="100"/>-->
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                     <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA==" />
+                </server-identities>
+                <authentication>
+                     <local default-user="$local" skip-group-loading="true" />
+                     <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true" />
+                    <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="host-file" formatter="json-formatter" relative-to="jboss.domain.data.dir" path="audit-log.log"/>
+                <file-handler name="server-file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="host-file"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="server-file"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="19999"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm" console-enabled="false">
+                <http-upgrade enabled="true" />
+                <socket interface="management" port="19990"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+        <!-- Remote domain controller configuration with a host and port -->
+        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+            <ignored-resources type="extension">
+                <instance name="org.jboss.as.threads"/>
+            </ignored-resources>
+            <ignored-resources type="profile">
+                <instance name="ignored"/>
+            </ignored-resources>
+            <ignored-resources type="socket-binding-group">
+                <instance name="ignored"/>
+            </ignored-resources>
+            <ignored-resources type="foo" wildcard="true">
+                <instance name="ignored"/>
+            </ignored-resources>
+            <ignored-resources type="server-group">
+                <instance name="ignored-sockets"/>
+                <instance name="ignored-profile"/>
+                <instance name="minimal" />
+            </ignored-resources>
+        </remote>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+
+	<jvms>
+	   <jvm name="default">
+          <heap size="64m" max-size="128m"/>
+           <jvm-options><option value="-ea"/></jvm-options>
+       </jvm>
+	</jvms>
+
+    <servers directory-grouping="by-type">
+        <server name="other-three" group="other-server-group">
+            <socket-bindings socket-binding-group="standard-sockets" port-offset="350"/>
+            <jvm name="default"/>
+        </server>
+        <server name="other-four" group="other-server-group" auto-start="false">
+            <socket-bindings port-offset="450"/>
+            <jvm name="default">
+                <heap size="64m" max-size="256m"/>
+            </jvm>
+        </server>
+    </servers>
+
+
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+    </profile>
+</host>


### PR DESCRIPTION
Calling /core-service=management/service=configuration-changes:add() will only return a warning and nothing happen on DC or HC.
Activating configuration-changes on DC/HC will propagate to its managed servers.
Starting a managed server on a HC with configuration-changes enabled will enable it on the maanged server.

Jira: https://issues.jboss.org/browse/WFCORE-1642
Analysis Document: https://developer.jboss.org/wiki/DesignNotesForConfigurationChangesInDomainMode
EAP7 issue: https://issues.jboss.org/browse/EAP7-575