### PR TITLE
[WFCORE-1671] security-realms that defer to jaas cannot load login-modules from org.jboss.as.security

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -88,6 +88,7 @@
         <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.self-contained" optional="true"/>
         <module name="org.wildfly.security.elytron" services="import"/>
+        <module name="org.jboss.as.security" optional="true" services="import"/>
         <module name="org.jboss.as.version"/>
         <module name="org.picketbox" optional="true"/>
         <module name="io.undertow.core" />


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-1671

Another related PR: https://github.com/wildfly/wildfly/pull/9067 to remove the AbstractVaultReader services file from full's security module, there is one in core already.