### PR TITLE
WFCORE-1665 Improve usability on default value for gc logging

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/common.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/common.ps1
@@ -34,7 +34,7 @@ $global:SECMGR = Get-Env-Boolean SECMGR $false
 $global:DEBUG_MODE=Get-Env DEBUG $false
 $global:DEBUG_PORT=Get-Env DEBUG_PORT 8787
 $global:RUN_IN_BACKGROUND=$false
-$global:GC_LOG=Get-Env GC_LOG $false
+$GC_LOG=Get-Env GC_LOG
 #module opts that are passed to jboss modules
 $global:MODULE_OPTS = @()
 
@@ -135,9 +135,12 @@ Param(
   $PROG_ARGS += "-Djboss.server.base.dir=$global:JBOSS_BASE_DIR"
   $PROG_ARGS += "-Djboss.server.config.dir=$global:JBOSS_CONFIG_DIR"
 
-  if ($global:GC_LOG){
+  if ($GC_LOG -eq $true){
     if ($PROG_ARGS -notcontains "-verbose:gc"){
         Rotate-GC-Logs
+		if (-not(Test-Path $JBOSS_LOG_DIR)) {
+			$dir = New-Item $JBOSS_LOG_DIR -type directory -ErrorAction SilentlyContinue
+		}
         $PROG_ARGS += "-verbose:gc"
         $PROG_ARGS += "-XX:+PrintGCDetails"
         $PROG_ARGS += "-XX:+PrintGCDateStamps"
@@ -280,7 +283,7 @@ Function Rotate-GC-Logs {
 }
 
 Function Check-For-GC-Log {
-	if ($global:GC_LOG){
+	if (GC_LOG){
 		$args = (,'-verbose:gc',"-Xloggc:$JBOSS_LOG_DIR/gc.log","-XX:+PrintGCDetails","-XX:+PrintGCDateStamps","-XX:+UseGCLogFileRotation","-XX:NumberOfGCLogFiles=5","-XX:GCLogFileSize=3M","-XX:-TraceClassUnloading",'-version')
 		$OutputVariable = (&$JAVA $args )  | Out-String
 	}

--- a/core-feature-pack/src/main/resources/content/bin/standalone.bat
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.bat
@@ -12,21 +12,15 @@ rem         standalone.bat --debug 9797
 
 rem By default debug mode is disable.
 set DEBUG_MODE=false
-set DEBUG_PORT_VAR=8787
-set GC_LOG_VAR=false
+set DEBUG_PORT=8787
 rem Set to all parameters by default
 set "SERVER_OPTS=%*"
+
 
 if NOT "x%DEBUG%" == "x" (
   set "DEBUG_MODE=%DEBUG%
 )
-if NOT "x%DEBUG_PORT%" == "x" (
-  set "DEBUG_PORT_VAR=%DEBUG_PORT%
-)
 
-if NOT "x%GC_LOG%" == "x" (
-  set "GC_LOG_VAR=%GC_LOG%
-)
 
 rem Get the program name before using shift as the command modify the variable ~nx0
 if "%OS%" == "Windows_NT" (
@@ -67,7 +61,7 @@ set DEBUG_ARG="%2"
 if not %DEBUG_ARG% == "" (
    if x%DEBUG_ARG:-=%==x%DEBUG_ARG% (
       shift
-      set DEBUG_PORT_VAR=%DEBUG_ARG%
+      set DEBUG_PORT=%DEBUG_ARG%
    )
    shift
    goto READ-ARGS
@@ -108,12 +102,20 @@ if exist "%STANDALONE_CONF%" (
    echo Config file not found "%STANDALONE_CONF%"
 )
 
+if NOT "x%DEBUG_PORT%" == "x" (
+  set "DEBUG_PORT=%DEBUG_PORT%
+)
+
+if NOT "x%GC_LOG%" == "x" (
+  set "GC_LOG=%GC_LOG%
+)
+
 
 rem Set debug settings if not already set
 if "%DEBUG_MODE%" == "true" (
    echo "%JAVA_OPTS%" | findstr /I "\-agentlib:jdwp" > nul
   if errorlevel == 1 (
-     set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT_VAR%,server=y,suspend=n"
+     set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_socket,address=%DEBUG_PORT%,server=y,suspend=n"
   ) else (
      echo Debug already enabled in JAVA_OPTS, ignoring --debug argument
   )
@@ -151,7 +153,7 @@ if not "%PRESERVE_JAVA_OPTS%" == "true" (
 
 
 if not "%PRESERVE_JAVA_OPTS%" == "true" (
-    if "%GC_LOG_VAR%" == "true" (
+    if "%GC_LOG%" == "true" (
       rem Add rotating GC logs, if supported, and not already defined
       echo "%JAVA_OPTS%" | findstr /I "\-verbose:gc" > nul
       if errorlevel == 1 (

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf
@@ -1,6 +1,6 @@
 ## -*- shell-script -*- ######################################################
 ##                                                                          ##
-##  JBoss Bootstrap Script Configuration                                    ##
+##  WildFly bootstrap Script Configuration                                    ##
 ##                                                                          ##
 ##############################################################################
 
@@ -71,3 +71,6 @@ fi
 # Uncomment this in order to be able to run WildFly on FreeBSD
 # when you get "epoll_create function not implemented" message in dmesg output
 #JAVA_OPTS="$JAVA_OPTS -Djava.nio.channels.spi.SelectorProvider=sun.nio.ch.PollSelectorProvider"
+
+# Uncomment this out to control garbage collection logging
+# GC_LOG="true"

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf.bat
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf.bat
@@ -64,7 +64,15 @@ rem set "JAVA_OPTS=%JAVA_OPTS% -agentlib:jdwp=transport=dt_shmem,address=jboss,s
 rem # Use JBoss Modules lockless mode
 rem set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.lockless=true"
 
+
+rem # Uncomment to run server in debug mode
+rem set "DEBUG_MODE=true"
+rem set "DEBUG_PORT=8787"
+
 rem # Uncomment this to run with a security manager enabled
 rem set "SECMGR=true"
+
+rem # Uncomment this out to control garbage collection logging
+rem set "GC_LOG=true"
 
 :JAVA_OPTS_SET

--- a/core-feature-pack/src/main/resources/content/bin/standalone.conf.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.conf.ps1
@@ -72,4 +72,5 @@ $JAVA_OPTS += "-Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS"
 # Uncomment this to run with a security manager enabled
 # $SECMGR=$true
 
+# Uncomment this out to control garbage collection logging
 # $GC_LOG=$true

--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -7,7 +7,7 @@
 # By default debug mode is disabled.
 DEBUG_MODE="${DEBUG:-false}"
 DEBUG_PORT="${DEBUG_PORT:-8787}"
-GC_LOG="${GC_LOG:-false}"
+GC_LOG="$GC_LOG"
 SERVER_OPTS=""
 while [ "$#" -gt 0 ]
 do


### PR DESCRIPTION
Mostly improve usabilty for enabling/disabling GC_LOG so you can also configure it in .conf/.conf.ps1/.conf.bat config file.

With this change changing default for gc logging is one simpler, so downstream project doesn't need to do lots of changes to whole script.