### PR TITLE
[WFCORE-1015] jconsole Wildfly CLI tab not loading when using remote

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/gui/JConsoleCLIPlugin.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/JConsoleCLIPlugin.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.management.MBeanServerConnection;
 import javax.swing.ImageIcon;
 import javax.swing.JInternalFrame;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingWorker;
 
@@ -62,6 +63,7 @@ import com.sun.tools.jconsole.JConsolePlugin;
  */
 public class JConsoleCLIPlugin extends JConsolePlugin {
 
+    private static final String MSG_CANNOT_ESTABLISH_CONNECTION = "Cannot establish a remote connection to the application server";
     private static final int DEFAULT_MAX_THREADS = 6;
     private static final String LABEL = "WildFly CLI";
 
@@ -118,7 +120,11 @@ public class JConsoleCLIPlugin extends JConsolePlugin {
 
         if (mbeanServerConn instanceof RemotingMBeanServerConnection) {
             final CommandContext cmdCtx = CommandContextFactory.getInstance().newCommandContext();
-            isConnected = connectUsingRemoting(cmdCtx, (RemotingMBeanServerConnection)mbeanServerConn);
+            if(connectUsingRemoting(cmdCtx, (RemotingMBeanServerConnection)mbeanServerConn)) {
+                 init(cmdCtx);
+            } else {
+                 JOptionPane.showInternalMessageDialog(jconsolePanel, MSG_CANNOT_ESTABLISH_CONNECTION);
+            }
         } else {
             //show dialog
             dialog.start();


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFCORE-1015

initialize the jpanel once the connection is established.
added error for https://github.com/wildfly/wildfly-core/pull/1123