### PR TITLE
[WFCORE-1686] distinguish abort reason in order to log message properly.

### DIFF
--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
@@ -422,7 +422,7 @@ public class EmbeddedHostControllerFactory {
             // this used to be set in the embedded-hc specific env setup, WFCORE-938 will add support for --admin-only=false
             cmds.add("--admin-only");
 
-            return Main.determineEnvironment(cmds.toArray(new String[cmds.size()]), startTime, ProcessType.EMBEDDED_HOST_CONTROLLER);
+            return Main.determineEnvironment(cmds.toArray(new String[cmds.size()]), startTime, ProcessType.EMBEDDED_HOST_CONTROLLER).getHostControllerEnvironment();
         }
     }
 }

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
@@ -268,7 +268,7 @@ public class EmbeddedStandaloneServerFactory {
                 }
 
                 // Determine the ServerEnvironment
-                ServerEnvironment serverEnvironment = Main.determineEnvironment(cmdargs, systemProps, systemEnv, ServerEnvironment.LaunchType.EMBEDDED, startTime);
+                ServerEnvironment serverEnvironment = Main.determineEnvironment(cmdargs, systemProps, systemEnv, ServerEnvironment.LaunchType.EMBEDDED, startTime).getServerEnvironment();
 
                 bootstrap = Bootstrap.Factory.newInstance();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironmentWrapper.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironmentWrapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.host.controller;
+
+/**
+ * @author wangc
+ *
+ */
+public class HostControllerEnvironmentWrapper {
+
+    enum HostControllerEnvironmentStatus {
+        NORMAL, // expected abort
+        ERROR // problematic abort
+    }
+
+    private HostControllerEnvironment hostControllerEnvironment;
+    private HostControllerEnvironmentStatus hostControllerEnvironmentStatus;
+
+    private HostControllerEnvironmentWrapper(HostControllerEnvironment hostControllerEnvironment, HostControllerEnvironmentStatus hostControllerEnvironmentStatus) {
+        this.hostControllerEnvironment = hostControllerEnvironment;
+        this.hostControllerEnvironmentStatus = hostControllerEnvironmentStatus;
+    }
+
+    protected HostControllerEnvironmentWrapper(HostControllerEnvironment hostControllerEnvironment) {
+        this(hostControllerEnvironment, null);
+    }
+
+    protected HostControllerEnvironmentWrapper(HostControllerEnvironmentStatus hostControllerEnvironmentStatus) {
+        this(null, hostControllerEnvironmentStatus);
+    }
+
+    public HostControllerEnvironment getHostControllerEnvironment() {
+        return hostControllerEnvironment;
+    }
+
+    public HostControllerEnvironmentStatus getHostControllerEnvironmentStatus() {
+        return hostControllerEnvironmentStatus;
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -48,6 +48,7 @@ import org.jboss.as.process.ExitCodes;
 import org.jboss.as.process.ProcessController;
 import org.jboss.as.process.protocol.StreamUtils;
 import org.jboss.as.process.stdin.Base64InputStream;
+import org.jboss.as.server.SystemExiter;
 import org.jboss.as.version.ProductConfig;
 import org.jboss.logging.MDC;
 import org.jboss.logmanager.Level;
@@ -130,14 +131,18 @@ public final class Main {
         try {
             // TODO make this settable via an embedding process
             final long startTime = Module.getStartTime();
-            final HostControllerEnvironment config = determineEnvironment(args, startTime);
-            if (config == null) {
+            final HostControllerEnvironmentWrapper hostControllerEnvironmentWrapper = determineEnvironment(args, startTime);
+            if (hostControllerEnvironmentWrapper.getHostControllerEnvironment() == null) {
                 usage(); // In case there was an error determining the environment print the usage
-                abort();
+                if (hostControllerEnvironmentWrapper.getHostControllerEnvironmentStatus() == HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR) {
+                    abort();
+                } else {
+                    SystemExiter.safeAbort();
+                }
                 return null;
             } else {
                 try {
-                    final HostControllerBootstrap hc = new HostControllerBootstrap(config, authCode);
+                    final HostControllerBootstrap hc = new HostControllerBootstrap(hostControllerEnvironmentWrapper.getHostControllerEnvironment(), authCode);
                     hc.bootstrap();
                     return hc;
                 } catch(Throwable t) {
@@ -188,11 +193,11 @@ public final class Main {
         CommandLineArgumentUsageImpl.printUsage(STDOUT);
     }
 
-    public static HostControllerEnvironment determineEnvironment(String[] args, long startTime) {
+    public static HostControllerEnvironmentWrapper determineEnvironment(String[] args, long startTime) {
         return determineEnvironment(args, startTime, ProcessType.HOST_CONTROLLER);
     }
 
-    public static HostControllerEnvironment determineEnvironment(String[] args, long startTime, ProcessType processType) {
+    public static HostControllerEnvironmentWrapper determineEnvironment(String[] args, long startTime, ProcessType processType) {
         Integer pmPort = null;
         InetAddress pmAddress = null;
         final PCSocketConfig pcSocketConfig = new PCSocketConfig();
@@ -223,22 +228,22 @@ public final class Main {
                         || CommandLineConstants.SHORT_PROPERTIES.equals(arg)) {
                     // Set system properties from url/file
                     if (!processProperties(arg, args[++i], hostSystemProperties)) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.PROPERTIES)) {
                     String urlSpec = parseValue(arg, CommandLineConstants.PROPERTIES);
                     if (urlSpec == null || !processProperties(arg, urlSpec, hostSystemProperties)) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.SHORT_PROPERTIES)) {
                     String urlSpec = parseValue(arg, CommandLineConstants.SHORT_PROPERTIES);
                     if (urlSpec == null || !processProperties(arg, urlSpec, hostSystemProperties)) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 }  else if (arg.startsWith(CommandLineConstants.OLD_PROPERTIES)) {
                     String urlSpec = parseValue(arg, CommandLineConstants.OLD_PROPERTIES);
                     if (urlSpec == null || !processProperties(arg, urlSpec, hostSystemProperties)) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (CommandLineConstants.PROCESS_CONTROLLER_BIND_PORT.equals(arg)) {
                     final String port = args[++i];
@@ -246,16 +251,16 @@ public final class Main {
                         pmPort = Integer.valueOf(port);
                     } catch (NumberFormatException e) {
                         STDERR.println(HostControllerLogger.ROOT_LOGGER.invalidValue(CommandLineConstants.PROCESS_CONTROLLER_BIND_PORT, "Integer", port, usageNote()));
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.PROCESS_CONTROLLER_BIND_PORT)) {
                     String val = parseValue(arg, CommandLineConstants.PROCESS_CONTROLLER_BIND_PORT);
                     if (val == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     final Integer port = parsePort(val, CommandLineConstants.PROCESS_CONTROLLER_BIND_PORT);
                     if (port == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     pmPort = port;
                 } else if (CommandLineConstants.PROCESS_CONTROLLER_BIND_ADDR.equals(arg)) {
@@ -264,21 +269,21 @@ public final class Main {
                         pmAddress = InetAddress.getByName(addr);
                     } catch (UnknownHostException e) {
                         STDERR.println(HostControllerLogger.ROOT_LOGGER.unknownHostValue(CommandLineConstants.PROCESS_CONTROLLER_BIND_ADDR, addr, usageNote()));
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.PROCESS_CONTROLLER_BIND_ADDR)) {
                     final String val = parseValue(arg, CommandLineConstants.PROCESS_CONTROLLER_BIND_ADDR);
                     if (val == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     final InetAddress addr = parseAddress(val, arg);
                     if (addr == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     pmAddress = addr;
                 } else if (pcSocketConfig.processPCSocketConfigArgument(arg, args, i)) {
                     if (pcSocketConfig.isParseFailed()) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     i += pcSocketConfig.getArgIncrement();
                 } else if (CommandLineConstants.RESTART_HOST_CONTROLLER.equals(arg)) {
@@ -290,70 +295,70 @@ public final class Main {
                 } else if(CommandLineConstants.DEFAULT_JVM.equals(arg) || CommandLineConstants.OLD_DEFAULT_JVM.equals(arg)) {
                     defaultJVM = checkValueIsNotAnArg(arg, args[++i]);
                     if (defaultJVM == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (CommandLineConstants.DOMAIN_CONFIG.equals(arg)
                         || CommandLineConstants.SHORT_DOMAIN_CONFIG.equals(arg)
                         || CommandLineConstants.OLD_DOMAIN_CONFIG.equals(arg)) {
                     domainConfig = checkValueIsNotAnArg(arg, args[++i]);
                     if (domainConfig == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.DOMAIN_CONFIG)) {
                     String val = parseValue(arg, CommandLineConstants.DOMAIN_CONFIG);
                     if (val == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     domainConfig = val;
                 } else if (arg.startsWith(CommandLineConstants.SHORT_DOMAIN_CONFIG)) {
                     String val = parseValue(arg, CommandLineConstants.SHORT_DOMAIN_CONFIG);
                     if (val == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     domainConfig = val;
                 } else if (arg.startsWith(CommandLineConstants.OLD_DOMAIN_CONFIG)) {
                     String val = parseValue(arg, CommandLineConstants.OLD_DOMAIN_CONFIG);
                     if (val == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     domainConfig = val;
                 } else if (arg.startsWith(CommandLineConstants.READ_ONLY_DOMAIN_CONFIG)) {
                     initialDomainConfig = parseValue(arg, CommandLineConstants.READ_ONLY_DOMAIN_CONFIG);
                     if (initialDomainConfig == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (CommandLineConstants.HOST_CONFIG.equals(arg) || CommandLineConstants.OLD_HOST_CONFIG.equals(arg)) {
                     hostConfig = checkValueIsNotAnArg(arg, args[++i]);
                     if (hostConfig == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.HOST_CONFIG)) {
                     String val = parseValue(arg, CommandLineConstants.HOST_CONFIG);
                     if (val == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     hostConfig = val;
                 } else if (arg.startsWith(CommandLineConstants.OLD_HOST_CONFIG)) {
                     String val = parseValue(arg, CommandLineConstants.OLD_HOST_CONFIG);
                     if (val == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     hostConfig = val;
                 } else if (arg.startsWith(CommandLineConstants.READ_ONLY_HOST_CONFIG)) {
                     initialHostConfig = parseValue(arg, CommandLineConstants.READ_ONLY_HOST_CONFIG);
                     if (initialHostConfig == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.MASTER_ADDRESS)) {
 
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
                         STDERR.println(HostControllerLogger.ROOT_LOGGER.argumentExpected(arg, usageNote()));
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     String value = idx > -1 ? arg.substring(idx + 1) : checkValueIsNotAnArg(arg, args[++i]);
                     if (value == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     value = fixPossibleIPv6URL(value);
                     hostSystemProperties.put(HostControllerEnvironment.JBOSS_DOMAIN_MASTER_ADDRESS, value);
@@ -363,12 +368,12 @@ public final class Main {
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
                         STDERR.println(HostControllerLogger.ROOT_LOGGER.argumentExpected(arg, usageNote()));
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     String value = idx > -1 ? arg.substring(idx + 1) : args[++i];
                     final Integer port = parsePort(value, CommandLineConstants.MASTER_PORT);
                     if (port == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
 
                     hostSystemProperties.put(HostControllerEnvironment.JBOSS_DOMAIN_MASTER_PORT, value);
@@ -397,11 +402,11 @@ public final class Main {
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
                         STDERR.println(HostControllerLogger.ROOT_LOGGER.argumentExpected(arg, usageNote()));
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     String value = idx > -1 ? arg.substring(idx + 1) : checkValueIsNotAnArg(arg, args[++i]);
                     if (value == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     value = fixPossibleIPv6URL(value);
                     String propertyName;
@@ -422,11 +427,11 @@ public final class Main {
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
                         STDERR.println(HostControllerLogger.ROOT_LOGGER.argumentExpected(arg, usageNote()));
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     String value = idx > -1 ? arg.substring(idx + 1) : checkValueIsNotAnArg(arg, args[++i]);
                     if (value == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     value = fixPossibleIPv6URL(value);
                     hostSystemProperties.put(HostControllerEnvironment.JBOSS_DEFAULT_MULTICAST_ADDRESS, value);
@@ -434,26 +439,26 @@ public final class Main {
                 } else if (arg.equals(CommandLineConstants.MODULE_PATH)) {
                     modulePath = checkValueIsNotAnArg(arg, args[++i]);
                     if (modulePath == null) {
-                        return null;
+                        return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.equals(CommandLineConstants.SECMGR)) {
                     // Enable the security manager
                     securityManagerEnabled = true;
                 } else {
                     STDERR.println(HostControllerLogger.ROOT_LOGGER.invalidOption(arg, usageNote()));
-                    return null;
+                    return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                 }
             } catch (IndexOutOfBoundsException e) {
                 STDERR.println(HostControllerLogger.ROOT_LOGGER.argumentExpected(arg, usageNote()));
-                return null;
+                return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
             }
         }
         productConfig = ProductConfig.fromFilesystemSlot(Module.getBootModuleLoader(), WildFlySecurityManager.getPropertyPrivileged(HostControllerEnvironment.HOME_DIR, null), hostSystemProperties);
 
-        return new HostControllerEnvironment(hostSystemProperties, isRestart, modulePath, pmAddress, pmPort,
-                pcSocketConfig.getBindAddress(), pcSocketConfig.getBindPort(), defaultJVM,
-                domainConfig, initialDomainConfig, hostConfig, initialHostConfig, initialRunningMode, backupDomainFiles,
-                cachedDc, productConfig, securityManagerEnabled, startTime, processType);
+        return new HostControllerEnvironmentWrapper(new HostControllerEnvironment(hostSystemProperties, isRestart, modulePath,
+                pmAddress, pmPort, pcSocketConfig.getBindAddress(), pcSocketConfig.getBindPort(), defaultJVM, domainConfig,
+                initialDomainConfig, hostConfig, initialHostConfig, initialRunningMode, backupDomainFiles, cachedDc,
+                productConfig, securityManagerEnabled, startTime, processType));
     }
 
     private static String parseValue(final String arg, final String key) {

--- a/server/src/main/java/org/jboss/as/server/Main.java
+++ b/server/src/main/java/org/jboss/as/server/Main.java
@@ -91,14 +91,18 @@ public final class Main {
             }
 
             Module.registerURLStreamHandlerFactoryModule(Module.getBootModuleLoader().loadModule(ModuleIdentifier.create("org.jboss.vfs")));
-            ServerEnvironment serverEnvironment = determineEnvironment(args, WildFlySecurityManager.getSystemPropertiesPrivileged(),
+            ServerEnvironmentWrapper serverEnvironmentWrapper = determineEnvironment(args, WildFlySecurityManager.getSystemPropertiesPrivileged(),
                     WildFlySecurityManager.getSystemEnvironmentPrivileged(), ServerEnvironment.LaunchType.STANDALONE,
                     Module.getStartTime());
-            if (serverEnvironment == null) {
-                abort(null);
+            if (serverEnvironmentWrapper.getServerEnvironment() == null) {
+                if (serverEnvironmentWrapper.getServerEnvironmentStatus() == ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR) {
+                    abort(null);
+                } else {
+                    SystemExiter.safeAbort();
+                }
             } else {
                 final Bootstrap bootstrap = Bootstrap.Factory.newInstance();
-                final Bootstrap.Configuration configuration = new Bootstrap.Configuration(serverEnvironment);
+                final Bootstrap.Configuration configuration = new Bootstrap.Configuration(serverEnvironmentWrapper.getServerEnvironment());
                 configuration.setModuleLoader(Module.getBootModuleLoader());
                 bootstrap.bootstrap(configuration, Collections.<ServiceActivator>emptyList()).get();
                 return;
@@ -120,7 +124,7 @@ public final class Main {
 
     /** @deprecated use {@link #determineEnvironment(String[], Properties, Map, ServerEnvironment.LaunchType, long)}  */
     @Deprecated
-    public static ServerEnvironment determineEnvironment(String[] args, Properties systemProperties, Map<String, String> systemEnvironment,
+    public static ServerEnvironmentWrapper determineEnvironment(String[] args, Properties systemProperties, Map<String, String> systemEnvironment,
                                                          ServerEnvironment.LaunchType launchType) {
         return determineEnvironment(args, systemProperties, systemEnvironment, launchType, Module.getStartTime());
     }
@@ -134,7 +138,7 @@ public final class Main {
      * @param startTime time in ms since the epoch when the process was considered to be started
      * @return the ServerEnvironment object
      */
-    public static ServerEnvironment determineEnvironment(String[] args, Properties systemProperties, Map<String, String> systemEnvironment,
+    public static ServerEnvironmentWrapper determineEnvironment(String[] args, Properties systemProperties, Map<String, String> systemEnvironment,
                                                          ServerEnvironment.LaunchType launchType, long startTime) {
         final int argsLength = args.length;
         String serverConfig = null;
@@ -149,10 +153,10 @@ public final class Main {
                         || CommandLineConstants.OLD_VERSION.equals(arg) || CommandLineConstants.OLD_SHORT_VERSION.equals(arg)) {
                     productConfig = ProductConfig.fromFilesystemSlot(Module.getBootModuleLoader(), WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.HOME_DIR, null), null);
                     STDOUT.println(productConfig.getPrettyVersionString());
-                    return null;
+                    return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.NORMAL);
                 } else if (CommandLineConstants.HELP.equals(arg) || CommandLineConstants.SHORT_HELP.equals(arg) || CommandLineConstants.OLD_HELP.equals(arg)) {
                     usage();
-                    return null;
+                    return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.NORMAL);
                 } else if (CommandLineConstants.SERVER_CONFIG.equals(arg) || CommandLineConstants.SHORT_SERVER_CONFIG.equals(arg)
                         || CommandLineConstants.OLD_SERVER_CONFIG.equals(arg)) {
                     assertSingleConfig(serverConfig);
@@ -161,25 +165,25 @@ public final class Main {
                     assertSingleConfig(serverConfig);
                     serverConfig = parseValue(arg, CommandLineConstants.SERVER_CONFIG);
                     if (serverConfig == null) {
-                        return null;
+                        return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.SHORT_SERVER_CONFIG)) {
                     assertSingleConfig(serverConfig);
                     serverConfig = parseValue(arg, CommandLineConstants.SHORT_SERVER_CONFIG);
                     if (serverConfig == null) {
-                        return null;
+                        return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.READ_ONLY_SERVER_CONFIG)) {
                     assertSingleConfig(serverConfig);
                     serverConfig = parseValue(arg, CommandLineConstants.READ_ONLY_SERVER_CONFIG);
                     if (serverConfig == null) {
-                        return null;
+                        return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                     configInteractionPolicy = ConfigurationFile.InteractionPolicy.READ_ONLY;
                 } else if (arg.startsWith(CommandLineConstants.OLD_SERVER_CONFIG)) {
                     serverConfig = parseValue(arg, CommandLineConstants.OLD_SERVER_CONFIG);
                     if (serverConfig == null) {
-                        return null;
+                        return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith("--internal-empty-config")) {
                     assert launchType == ServerEnvironment.LaunchType.EMBEDDED;
@@ -194,22 +198,22 @@ public final class Main {
                         || CommandLineConstants.SHORT_PROPERTIES.equals(arg)) {
                     // Set system properties from url/file
                     if (!processProperties(arg, args[++i],systemProperties)) {
-                        return null;
+                        return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.PROPERTIES)) {
                     String urlSpec = parseValue(arg, CommandLineConstants.PROPERTIES);
                     if (urlSpec == null || !processProperties(arg, urlSpec,systemProperties)) {
-                        return null;
+                        return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.SHORT_PROPERTIES)) {
                     String urlSpec = parseValue(arg, CommandLineConstants.SHORT_PROPERTIES);
                     if (urlSpec == null || !processProperties(arg, urlSpec,systemProperties)) {
-                        return null;
+                        return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                 }  else if (arg.startsWith(CommandLineConstants.OLD_PROPERTIES)) {
                     String urlSpec = parseValue(arg, CommandLineConstants.OLD_PROPERTIES);
                     if (urlSpec == null || !processProperties(arg, urlSpec,systemProperties)) {
-                        return null;
+                        return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                 } else if (arg.startsWith(CommandLineConstants.SYS_PROP)) {
 
@@ -230,7 +234,7 @@ public final class Main {
                     if (idx == arg.length() - 1) {
                         STDERR.println(ServerLogger.ROOT_LOGGER.noArgValue(arg));
                         usage();
-                        return null;
+                        return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                     String value = idx > -1 ? arg.substring(idx + 1) : args[++i];
                     value = fixPossibleIPv6URL(value);
@@ -252,7 +256,7 @@ public final class Main {
                     if (idx == arg.length() - 1) {
                         STDERR.println(ServerLogger.ROOT_LOGGER.valueExpectedForCommandLineOption(arg));
                         usage();
-                        return null;
+                        return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                     String value = idx > -1 ? arg.substring(idx + 1) : args[++i];
                     value = fixPossibleIPv6URL(value);
@@ -283,19 +287,19 @@ public final class Main {
                 } else {
                     STDERR.println(ServerLogger.ROOT_LOGGER.invalidCommandLineOption(arg));
                     usage();
-                    return null;
+                    return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                 }
             } catch (IndexOutOfBoundsException e) {
                 STDERR.println(ServerLogger.ROOT_LOGGER.valueExpectedForCommandLineOption(arg));
                 usage();
-                return null;
+                return new ServerEnvironmentWrapper(ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
             }
         }
 
         String hostControllerName = null; // No host controller unless in domain mode.
         productConfig = ProductConfig.fromFilesystemSlot(Module.getBootModuleLoader(), WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.HOME_DIR, null), systemProperties);
-        return new ServerEnvironment(hostControllerName, systemProperties, systemEnvironment, serverConfig,
-                configInteractionPolicy, launchType, runningMode, productConfig, startTime);
+        return new ServerEnvironmentWrapper(new ServerEnvironment(hostControllerName, systemProperties, systemEnvironment,
+                serverConfig, configInteractionPolicy, launchType, runningMode, productConfig, startTime));
     }
 
     private static void assertSingleConfig(String serverConfig) {

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironmentWrapper.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironmentWrapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.server;
+
+/**
+ * @author wangc
+ *
+ */
+public class ServerEnvironmentWrapper {
+
+    enum ServerEnvironmentStatus {
+        NORMAL, // expected abort
+        ERROR // problematic abort
+    }
+
+    private ServerEnvironment serverEnvironment;
+    private ServerEnvironmentStatus serverEnvironmentStatus;
+
+    private ServerEnvironmentWrapper(ServerEnvironment serverEnvironment, ServerEnvironmentStatus serverEnvironmentStatus) {
+        this.serverEnvironment = serverEnvironment;
+        this.serverEnvironmentStatus = serverEnvironmentStatus;
+    }
+
+    protected ServerEnvironmentWrapper(ServerEnvironment serverEnvironment) {
+        this(serverEnvironment, null);
+    }
+
+    protected ServerEnvironmentWrapper(ServerEnvironmentStatus serverEnvironmentStatus) {
+        this(null, serverEnvironmentStatus);
+    }
+
+    public ServerEnvironment getServerEnvironment() {
+        return serverEnvironment;
+    }
+
+    public ServerEnvironmentStatus getServerEnvironmentStatus() {
+        return serverEnvironmentStatus;
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/SystemExiter.java
+++ b/server/src/main/java/org/jboss/as/server/SystemExiter.java
@@ -59,6 +59,15 @@ public class SystemExiter {
         }, status);
     }
 
+    public static void safeAbort() {
+        logAndExit(new ExitLogger() {
+            @Override
+            public void logExit() {
+                // no-op
+            }
+        }, 0);
+    }
+
     /** @deprecated use {@link #logAndExit(ExitLogger, int)} or {@link #abort(int)} */
     @Deprecated
     public static void exit(final int status) {


### PR DESCRIPTION
please see https://issues.jboss.org/browse/WFCORE-1686
As suggested in Jira above, this differentiates between "real" abort and "harmless" abort. In case of  parameter -v and --help, it does not show any fatal message. For other incomplete server environment cases, it adds the message into log. 