### PR TITLE
[WFCORE-1429] Allow the log manager check to skipped

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -926,4 +926,15 @@ public interface LoggingLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 88, value = "Could not determine %s had any children resources.")
     void errorDeterminingChildrenExist(@Cause Throwable cause, String childType);
+
+    /**
+     * Logs a warning message indicating the log manager does not appear to the {@link org.jboss.logmanager.LogManager}.
+     *
+     * @param logManagerName the log manager system property value
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 89, value = "The log manager check was skipped and the log manager system property, " +
+            "\"java.util.logging.manager\", does not appear to be set to \"org.jboss.logmanager.LogManager\". The " +
+            "current value is \"%s\". Some behavior of the logged output such as MDC and NDC may not work as expected.")
+    void unknownLogManager(String logManagerName);
 }


### PR DESCRIPTION
The log manager may be wrapped which shouldn't stop the subsystem from working as long as it's a JUL based log manager.

This is a fix for https://issues.jboss.org/browse/WFCORE-1429. I've tried to think of the consequences of wrapping the log manager. The only possible issues I could come up with MDC and NDC. However the jboss-logging binding provider does seem to be the JBoss Log Manager provider. This should work as should the logging subsystem configuration. Since the configuration doesn't directly use the `org.jboss.logmanager.LogManager` directly. 

One cause for concern would be boot strap logging might not be configured correctly. This is likely okay though as care was taken to get around using the correct log manager and allowing WildFly to boot with the logging subsystem and not check the log manager.