### PR TITLE
WFCORE-316: --cached-dc additional fixes

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -334,7 +334,7 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
         //TODO socket-binding-group currently lives in controller and the child RDs live in domain so they currently need passing in from here
         resourceRegistration.registerSubModel(SocketBindingGroupResourceDefinition.INSTANCE);
 
-        //TODO perhaps all these desriptions and the validator log messages should be moved into management-client-content?
+        //TODO perhaps all these descriptions and the validator log messages should be moved into management-client-content?
         resourceRegistration.registerSubModel(
                 new ManagedDMRContentTypeResourceDefinition(contentRepo, ROLLOUT_PLAN,
                 PathElement.pathElement(MANAGEMENT_CLIENT_CONTENT, ROLLOUT_PLANS), new RolloutPlanValidator(), DomainResolver.getResolver(ROLLOUT_PLANS), DomainResolver.getResolver(ROLLOUT_PLAN)));

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -45,7 +45,6 @@ import static org.jboss.as.remoting.Protocol.REMOTE;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.io.File;
 import java.io.IOException;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -710,12 +709,6 @@ public class DomainModelControllerService extends AbstractControllerService impl
                 if (useLocalDomainXml) {
                     if (!hostControllerInfo.isMasterDomainController() && isCachedDc) {
                         ROOT_LOGGER.usingCachedDC(CommandLineConstants.CACHED_DC, ConfigurationPersisterFactory.CACHED_DOMAIN_XML);
-                        remoteFileRepository.setRemoteFileRepositoryExecutor(new RemoteDomainConnectionService.RemoteFileRepositoryExecutor() {
-                            @Override
-                            public File getFile(String relativePath, byte repoId, HostFileRepository localFileRepository) {
-                                return localFileRepository.getFile(relativePath);
-                            }
-                        });
                     }
 
                     // parse the domain.xml and load the steps
@@ -887,11 +880,9 @@ public class DomainModelControllerService extends AbstractControllerService impl
                 domainModelComplete);
         MasterDomainControllerClient masterDomainControllerClient = getFuture(clientFuture);
         //Registers us with the master and gets down the master copy of the domain model to our DC
-        //TODO make sure that the RDCS checks env.isUseCachedDC, and if true falls through to that
-        // BES 2012/02/04 Comment ^^^ implies the semantic is to use isUseCachedDC as a fallback to
-        // a failure to connect as opposed to being an instruction to not connect at all. I believe
-        // the current impl is the latter. Don't change this without a discussion first, as the
-        // current semantic is a reasonable one.
+        // if --cached-dc is used and the DC is unavailable, we'll use a cached copy of the domain config
+        // (if available), and poll for reconnection to the DC. Once the DC becomes available again, the domain
+        // config will be re-synchronized.
         try {
             masterDomainControllerClient.register();
             return DomainConnectResult.CONNECTED;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
@@ -775,7 +775,14 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
                     throw HostControllerLogger.ROOT_LOGGER.failedToGetFileFromRemoteRepository(e);
                 }
             } else {
-                return localFileRepository.getFile(relativePath);
+                final File file = localFileRepository.getFile(relativePath);
+                // using --cached-dc and the DC is unavailable, make sure the content exists locally.
+                if (localHostInfo.isUsingCachedDc()) {
+                    if (! file.exists()) {
+                        throw HostControllerLogger.ROOT_LOGGER.failedToGetFileFromRemoteRepository(new RuntimeException("Content hash " + relativePath + " not found."));
+                    }
+                }
+                return file;
             }
         }
     };

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1350,4 +1350,8 @@ public interface HostControllerLogger extends BasicLogger {
     @LogMessage(level = Level.ERROR)
     @Message( id = 195, value = "Failed getting the response from the resume listener for server: %s")
     void resumeListenerFailed(@Cause ExecutionException cause, String serverName);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 196, value = "Cannot move the file %s to %s, unable to persist domain configuration changes: %s ")
+    void cannotRenameCachedDomainXmlOnBoot(String tmpFilename, String destFilename, String reason);
 }


### PR DESCRIPTION
 - keep the remote file repository so it's available when the DC becomes available again
 - parse domain.cached-remote.xml to a temporary file until boot is successful to prevent any boot errors leaving it in a clobbered state
 - if any remote content is unavailable from an offline DC during boot, and not present in the local repository, abort the boot.