### PR TITLE
WFCORE-1715: Reset HostRunningModeControl.RestartMode to its RestartMode.SERVERS default value once the HC has been restarted

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/StartServersHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/StartServersHandler.java
@@ -98,6 +98,7 @@ public class StartServersHandler implements OperationStepHandler {
                     final ModelNode servers = hostModel.get(SERVER_CONFIG).clone();
                     if (hostControllerEnvironment.isRestart() || runningModeControl.getRestartMode() == RestartMode.HC_ONLY){
                         restartedHcStartOrReconnectServers(servers, domainModel, context);
+                        runningModeControl.setRestartMode(RestartMode.SERVERS);
                     } else {
                         cleanStartServers(servers, domainModel, context);
                     }


### PR DESCRIPTION
Issue is described in https://issues.jboss.org/browse/WFCORE-1715

Due to StartServersHandler L99, it is not possible reset the HostRunningModeControl.RestartMode to its default in doReload() of HostProcessReloadHandler, because the RestartMode.HC_ONLY is used out of the scope of doReload().
The simplest change to resolve this issue is reset it after a HC reload, for this reason I propose add it to StartServersHandler. More elaborated solutions can be done instead, for example maybe use the hostControllerEnvironment.isRestart() flag only for the if in StartServersHandler L99 (but it seems this flag is for a for a different purpose, changed only if the HC has been respawned by process controller) or use a specific flag for this if as a new instance variable in HostRunningModeControl, allowing remove the check of RestartMode.HC_ONLY in that if
But initially I would propose the simplest change.

