### PR TITLE
[WFCORE-1741]:  read-content operation does not return the uuid of thstream as the operation result

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ExplodedDeploymentReadContentHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ExplodedDeploymentReadContentHandler.java
@@ -15,6 +15,7 @@
  */
 package org.jboss.as.domain.controller.operations.deployment;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UUID;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_HASH;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_PATH;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.getContentItem;
@@ -69,7 +70,8 @@ public class ExplodedDeploymentReadContentHandler implements OperationStepHandle
         }
         try {
             TypedInputStream inputStream = contentRepository.readContent(deploymentHash, path);
-            context.attachResultStream(inputStream.getContentType(), inputStream);
+            String uuid = context.attachResultStream(inputStream.getContentType(), inputStream);
+            context.getResult().get(UUID).set(uuid);
         } catch (ExplodedContentException ex) {
             throw new OperationFailedException(ex.getMessage());
         }

--- a/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
@@ -27,6 +27,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEP
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_UNDEPLOYED_NOTIFICATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILESYSTEM_PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELATIVE_TO;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UUID;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WEB_URL;
 
 import java.util.Arrays;
@@ -346,6 +347,7 @@ public class DeploymentAttributes {
             .build();
     public static final OperationDefinition DEPLOYMENT_READ_CONTENT_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.READ_CONTENT, DEPLOYMENT_RESOLVER)
             .setParameters(DEPLOYMENT_CONTENT_PATH)
+            .setReplyParameters(new SimpleAttributeDefinitionBuilder(UUID, ModelType.STRING, false).build())
             .withFlags(Flag.READ_ONLY)
             .build();
     public static final OperationDefinition DEPLOYMENT_BROWSE_CONTENT_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.BROWSE_CONTENT, DEPLOYMENT_RESOLVER)

--- a/server/src/main/java/org/jboss/as/server/deployment/ExplodedDeploymentReadContentHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/ExplodedDeploymentReadContentHandler.java
@@ -15,6 +15,7 @@
  */
 package org.jboss.as.server.deployment;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UUID;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_HASH;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_PATH;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.getContentItem;
@@ -70,7 +71,8 @@ public class ExplodedDeploymentReadContentHandler implements OperationStepHandle
         }
         try {
             TypedInputStream inputStream = contentRepository.readContent(deploymentHash, path);
-            context.attachResultStream(inputStream.getContentType(), inputStream);
+            String uuid = context.attachResultStream(inputStream.getContentType(), inputStream);
+            context.getResult().get(UUID).set(uuid);
         } catch (ExplodedContentException ex) {
             throw createFailureException(ex.toString());
         }

--- a/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
+++ b/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
@@ -235,6 +235,7 @@ deployment.deploy.name=The name of the new content.
 deployment.deploy.to-replace=The name of the content that is to be replaced.
 deployment.read-content=Read the content of an existing deployment.
 deployment.read-content.path=The relative path of the content to be read from an existing deployment.
+deployment.read-content.reply.uuid=The uuid of the attached stream.
 deployment.remove-content=Remove contents from an existing deployment.
 deployment.remove-content.paths=List of paths of content to be removed from the deployment.
 deployment.replace-deployment=Replace existing content in the runtime with new content. The new content must have been previously uploaded to the deployment content repository.

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ExplodedDeploymentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ExplodedDeploymentTestCase.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.DEPLOYMENT;
 import static org.jboss.as.controller.client.helpers.ClientConstants.OP;
 import static org.jboss.as.controller.client.helpers.ClientConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UUID;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -182,6 +183,7 @@ public class ExplodedDeploymentTestCase {
                 try {
                     OperationResponse response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
                     Assert.assertTrue(Operations.isSuccessfulOutcome(response.getResponseNode()));
+                    Assert.assertTrue(Operations.readResult(response.getResponseNode()).hasDefined(UUID));
                     List<OperationResponse.StreamEntry> streams = response.getInputStreams();
                     Assert.assertThat(streams, is(notNullValue()));
                     Assert.assertThat(streams.size(), is(1));
@@ -333,6 +335,7 @@ public class ExplodedDeploymentTestCase {
                 try {
                     OperationResponse response = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
                     Assert.assertTrue(Operations.isSuccessfulOutcome(response.getResponseNode()));
+                    Assert.assertTrue(Operations.readResult(response.getResponseNode()).hasDefined(UUID));
                     List<OperationResponse.StreamEntry> streams = response.getInputStreams();
                     Assert.assertThat(streams, is(notNullValue()));
                     Assert.assertThat(streams.size(), is(1));


### PR DESCRIPTION
Adding the stream uuid in the reponse node.

Jira: https://issues.jboss.org/browse/WFCORE-1741