### PR TITLE
[WFCORE-673] Elytron Core Integration

### DIFF
--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -329,6 +329,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.security.elytron-web</groupId>
+            <artifactId>undertow-server</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-self-contained</artifactId>
         </dependency>

--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/service/service.bat
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/service/service.bat
@@ -115,7 +115,7 @@ rem defaults
 set SHORTNAME=Wildfly
 set DISPLAYNAME=WildFly
 rem NO quotes around the description here !
-set DESCRIPTION="WildFly Application Server"
+set DESCRIPTION=WildFly Application Server
 set CONTROLLER=localhost:9990
 set DC_HOST=master
 set IS_DOMAIN=false

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server/main/module.xml
@@ -22,23 +22,15 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="org.wildfly.security.elytron">
-
-    <exports>
-        <exclude path="org/wildfly/security/_private"/>
-        <exclude path="org/wildfly/wildfly/security/manager/_private"/>
-    </exports>
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.security.elytron-web.undertow-server">
 
     <resources>
-        <artifact name="${org.wildfly.security:wildfly-elytron}"/>
+        <artifact name="${org.wildfly.security.elytron-web:undertow-server}"/>
     </resources>
 
     <dependencies>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.modules"/>
-        <module name="org.jboss.threads"/>
-        <module name="javax.api" />
-        <module name="sun.jdk"/>
-        <module name="org.wildfly.common"/>
+        <module name="org.wildfly.security.elytron"/>
+        <module name="io.undertow.core"/>
+        <module name="org.wildfly.common" />
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <version.org.wildfly.build-tools>1.1.6.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.common>1.2.0.Beta1</version.org.wildfly.common>
         <version.org.wildfly.legacy.test>2.0.2.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.security.elytron>1.1.0.Beta7</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.1.0.Beta8</version.org.wildfly.security.elytron>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.security.elytron-web.undertow-server>1.0.0.Beta2</version.org.wildfly.security.elytron-web.undertow-server>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->

--- a/pom.xml
+++ b/pom.xml
@@ -124,15 +124,16 @@
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.mockito>1.9.5</version.org.mockito>
-        <version.org.picketbox>4.9.7.Final</version.org.picketbox>
+        <version.org.picketbox>5.0.0.Alpha2</version.org.picketbox>
         <version.org.slf4j>1.7.7.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
         <version.org.wildfly.build-tools>1.1.6.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.common>1.2.0.Beta1</version.org.wildfly.common>
         <version.org.wildfly.legacy.test>2.0.2.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.security.elytron>1.0.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.1.0.Beta7</version.org.wildfly.security.elytron>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
+        <version.org.wildfly.security.elytron-web.undertow-server>1.0.0.Beta2</version.org.wildfly.security.elytron-web.undertow-server>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
         <!-- Non-default maven plugin versions and configuration -->
         <version.org.zanata.plugin>3.1.1</version.org.zanata.plugin>
@@ -1407,6 +1408,18 @@
                 <groupId>org.wildfly.security</groupId>
                 <artifactId>wildfly-elytron</artifactId>
                 <version>${version.org.wildfly.security.elytron}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>*</artifactId>
+                        <groupId>*</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.security.elytron-web</groupId>
+                <artifactId>undertow-server</artifactId>
+                <version>${version.org.wildfly.security.elytron-web.undertow-server}</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>*</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.mockito>1.9.5</version.org.mockito>
-        <version.org.picketbox>5.0.0.Alpha2</version.org.picketbox>
+        <version.org.picketbox>5.0.0.Alpha3</version.org.picketbox>
         <version.org.slf4j>1.7.7.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <version.org.jboss.aesh>0.66.8</version.org.jboss.aesh>
         <version.org.jboss.byteman>3.0.3</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.1.2.Final</version.org.jboss.classfilewriter>
-        <version.org.jboss.invocation>1.4.1.Final</version.org.jboss.invocation>
+        <version.org.jboss.invocation>1.5.0.Beta1</version.org.jboss.invocation>
         <version.org.jboss.jandex>2.0.2.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.4.0.Beta1</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.12.Final</version.org.jboss.jboss-vfs>


### PR DESCRIPTION
:exclamation: Commits from this branch are used in numerous other topic branches so please do not cherry-pick or rebase. :exclamation:

This pull request is a foundation for making it possible to enable Elytron backed security for the EJB and Undertow subsystems for in-VM invocations and invocations over HTTP.  

Although the Elytron web module is not used directly by core as a result of this pull request it will be in a subsequent pull request where it will be used for management HTTP authentication so the module is added here rather than to WildFly.

This pull request will break the WildFly build, I will follow up with two pull requests to the WildFly repository: -
 1 - A minimal PR that makes WildFly compatible with this PR.

https://github.com/wildfly/wildfly/pull/9160

 2 - A more complete PR that makes it possible to enable Elytron for EJB and Undertow and also incorporates the commits from 1.

https://github.com/wildfly/wildfly/pull/9161

