### PR TITLE
[WFCORE-1756]: Adding content to an exploded deployment with overwrite to false should fail if file already exists

### DIFF
--- a/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepositoryImpl.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepositoryImpl.java
@@ -595,7 +595,11 @@ public class ContentRepositoryImpl implements ContentRepository, Service<Content
                         if(in == null) {
                             Files.createDirectory(targetFile);
                         } else {
-                            Files.copy(in, targetFile, StandardCopyOption.REPLACE_EXISTING);
+                            if(overwrite) {
+                                Files.copy(in, targetFile, StandardCopyOption.REPLACE_EXISTING);
+                            } else {
+                                Files.copy(in, targetFile);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Taking overwrite into account when adding content.

Jira: https://issues.jboss.org/browse/WFCORE-1756