### PR TITLE
[WFCORE-1765]: unclear NullPointerException if the deployment-scanner element is removed from the configuration.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationStepHandler.java
@@ -348,6 +348,16 @@ public class ParallelBootOperationStepHandler implements OperationStepHandler {
             boolean interrupted = false;
             ParallelBootOperationContext operationContext = null;
             try {
+                if(bootOperations == null || bootOperations.isEmpty()) {
+                    transactionControl.operationPrepared(new ModelController.OperationTransaction() {
+                        @Override
+                        public void commit() {}
+
+                        @Override
+                        public void rollback() {}
+                    }, new ModelNode());
+                    return;
+                }
                 operationContext = new ParallelBootOperationContext(transactionControl, processState,
                         primaryContext, runtimeOps, controllingThread, controller, lockId, controller.getAuditLogger(),
                         controller.getManagementModel().getRootResource(), extraValidationStepHandler);
@@ -355,7 +365,6 @@ public class ParallelBootOperationStepHandler implements OperationStepHandler {
                     final OperationStepHandler osh = op.handler == null ? rootRegistration.getOperationHandler(op.address, op.operationName) : op.handler;
                     operationContext.addStep(op.response, op.operation, osh, executionStage);
                 }
-
                 operationContext.executeOperation();
             } catch (Throwable t) {
                 interrupted = (t instanceof InterruptedException);


### PR DESCRIPTION
This occurs when the list of operations to be run on boot after adding the subsystem is empty.

Jira: https://issues.jboss.org/browse/WFCORE-1765