### PR TITLE
Typo mistakes in jboss-as-deployment-scanner_x_y.xsd files

### DIFF
--- a/deployment-scanner/src/main/resources/schema/jboss-as-deployment-scanner_1_0.xsd
+++ b/deployment-scanner/src/main/resources/schema/jboss-as-deployment-scanner_1_0.xsd
@@ -98,7 +98,7 @@
         <xs:attribute default="60" name="deployment-timeout" type="xs:int" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                   Timout used. in seconds, for deployment operations.  If an individual deployment operation
+                   Timeout used. in seconds, for deployment operations.  If an individual deployment operation
                    takes longer than this timeout it will be canceled and marked as failed.
                 </xs:documentation>
             </xs:annotation>

--- a/deployment-scanner/src/main/resources/schema/jboss-as-deployment-scanner_1_1.xsd
+++ b/deployment-scanner/src/main/resources/schema/jboss-as-deployment-scanner_1_1.xsd
@@ -106,7 +106,7 @@
         <xs:attribute name="deployment-timeout" type="xs:int" use="optional" default="600">
             <xs:annotation>
                 <xs:documentation>
-                   Timout used, in seconds, for deployment operations.  If an individual deployment operation
+                   Timeout used, in seconds, for deployment operations.  If an individual deployment operation
                    takes longer than this timeout it will be canceled and marked as failed.
                 </xs:documentation>
             </xs:annotation>

--- a/deployment-scanner/src/main/resources/schema/jboss-as-deployment-scanner_2_0.xsd
+++ b/deployment-scanner/src/main/resources/schema/jboss-as-deployment-scanner_2_0.xsd
@@ -106,7 +106,7 @@
         <xs:attribute name="deployment-timeout" type="xs:int" use="optional" default="600">
             <xs:annotation>
                 <xs:documentation>
-                   Timout used, in seconds, for deployment operations.  If an individual deployment operation
+                   Timeout used, in seconds, for deployment operations.  If an individual deployment operation
                    takes longer than this timeout it will be canceled and marked as failed.
                 </xs:documentation>
             </xs:annotation>


### PR DESCRIPTION
Just typo mistakes found in jboss-as-deployment-scanner .xsd documentation files

There is no jira issue related.