### PR TITLE
Fix for WFCORE-1771, exception in :composite completion.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/ValueTypeCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ValueTypeCompleter.java
@@ -510,6 +510,10 @@ public class ValueTypeCompleter implements CommandLineCompleter {
             // A piece of name?
             if (last.name != null) {
                 final List<String> candidates = new ArrayList<>();
+                // The propType can be an OBJECT, in such a case, no keys.
+                if (!isObject(propType)) {
+                    return Collections.<String>emptyList();
+                }
                 for (String p : propType.keys()) {
                     if (p.startsWith(last.name) && !currentInstance.contains(p)) {
                         candidates.add(p);
@@ -576,11 +580,16 @@ public class ValueTypeCompleter implements CommandLineCompleter {
                         return candidates;
                     } else {
                         List<String> candidates = null;
-                        if (!mt.equals(ModelType.OBJECT)) {
-                            candidates = getCandidatesFromMetadata(currentInstance.type,
-                                    "");
-                        } else {
+                        if (mt.equals(ModelType.OBJECT)) {
                             candidates = getCandidatesFromMetadata(propType,
+                                    "");
+                            // New instance.
+                            if (candidates == null) {
+                                candidates = new ArrayList<>();
+                                candidates.add("{");
+                            }
+                        } else {
+                            candidates = getCandidatesFromMetadata(currentInstance.type,
                                     "");
                         }
                         if (candidates != null) {

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/ValueTypeCompletionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/ValueTypeCompletionTestCase.java
@@ -44,6 +44,15 @@ import org.junit.Test;
  */
 public class ValueTypeCompletionTestCase {
 
+    private static final String compositeSteps = "{\n"
+            + "            \"type\" => LIST,\n"
+            + "            \"description\" => \"A list of the operation requests that constitute the composite request.\",\n"
+            + "            \"expressions-allowed\" => false,\n"
+            + "            \"required\" => true,\n"
+            + "            \"nillable\" => false,\n"
+            + "            \"value-type\" => OBJECT\n"
+            + "        }";
+
     private static final String jgroupsProtocolsAdd = "{\n" +
 "                \"type\" => LIST,\n" +
 "                \"description\" => \"The list of configured protocols for a protocol stack.\",\n" +
@@ -862,5 +871,31 @@ public class ValueTypeCompletionTestCase {
         i = new ValueTypeCompleter(propDescr).complete(null, "[{", 0, candidates);
         assertEquals(Arrays.asList(new String[]{"properties", "socket-binding", "type"}), candidates);
         assertEquals(2, i);
+    }
+
+    @Test
+    public void testCompositeSteps() throws Exception {
+        final ModelNode propDescr = ModelNode.fromString(compositeSteps);
+        assertTrue(propDescr.isDefined());
+
+        final List<String> candidates = new ArrayList<>();
+
+        int i;
+        i = new ValueTypeCompleter(propDescr).complete(null, "", 0, candidates);
+        assertEquals(Collections.singletonList("["), candidates);
+        assertEquals(0, i);
+
+        candidates.clear();
+        i = new ValueTypeCompleter(propDescr).complete(null, "[", 0, candidates);
+        assertEquals(Arrays.asList(new String[]{"{"}), candidates);
+        assertEquals(1, i);
+
+        candidates.clear();
+        i = new ValueTypeCompleter(propDescr).complete(null, "[{", 0, candidates);
+        assertTrue(candidates.isEmpty());
+
+        candidates.clear();
+        i = new ValueTypeCompleter(propDescr).complete(null, "[{a", 0, candidates);
+        assertTrue(candidates.isEmpty());
     }
 }


### PR DESCRIPTION
Fixed the exception in the case where the List is a List of OBJECT (no specified value type).
Fixed the completion of "[<TAB>" in this case. It was not proposing "{".
Added unit test.
