### PR TITLE
[WFCORE-1728] Use VDX to pretty-print config errors

### DIFF
--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -87,6 +87,10 @@
             <artifactId>staxmapper</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.projectodd.vdx</groupId>
+            <artifactId>vdx-wildfly</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -39,6 +39,15 @@
     <packaging>pom</packaging>
 
     <dependencies>
+        <dependency>
+            <groupId>org.projectodd.vdx</groupId>
+            <artifactId>vdx-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectodd.vdx</groupId>
+            <artifactId>vdx-wildfly</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>io.undertow</groupId>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
@@ -49,6 +49,7 @@
         <module name="org.jboss.remoting"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.threads"/>
+        <module name="org.projectodd.vdx"/>
         <!-- Needed to load up com.sun.security.auth.PolicyFile.
              Not exported because org.jboss.as.domain-management already exports it and that should suffice
              for use in other core modules -->

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/projectodd/vdx/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/projectodd/vdx/main/module.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2016, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.3" name="org.projectodd.vdx">
+  <properties>
+    <property name="jboss.api" value="private"/>
+  </properties>
+
+  <resources>
+    <artifact name="${org.projectodd.vdx:vdx-core}"/>
+    <artifact name="${org.projectodd.vdx:vdx-wildfly}"/>
+  </resources>
+
+  <dependencies>
+    <module name="javax.api"/>
+    <module name="org.jboss.logging"/>
+  </dependencies>
+</module>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -170,6 +170,14 @@
         </dependency>
 
         <!-- Test dependencies -->
+
+        <!-- Would be brought in transitively by wildfly-controller normally. Required for ParseUtils -->
+        <dependency>
+            <groupId>org.projectodd.vdx</groupId>
+            <artifactId>vdx-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>woodstox-core-asl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.mockito>1.9.5</version.org.mockito>
         <version.org.picketbox>5.0.0.Alpha3</version.org.picketbox>
+        <version.org.projectodd.vdx>1.0.1</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.7.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>
@@ -1292,6 +1293,18 @@
                 <artifactId>mockito-all</artifactId>
                 <version>${version.org.mockito}</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.projectodd.vdx</groupId>
+                <artifactId>vdx-core</artifactId>
+                <version>${version.org.projectodd.vdx}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.projectodd.vdx</groupId>
+                <artifactId>vdx-wildfly</artifactId>
+                <version>${version.org.projectodd.vdx}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This includes the following changes:

- brings in VDX (https://github.com/projectodd/vdx) as a private module
- wraps the XMLStreamExceptions created by ParseUtils with a
  VDX-provided XMLStreamException subclass that holds more context about
  the failure
- catches XMLStreamExceptions when reading configuration in
  XmlConfigurationPersister, and hands off the exception to VDX's
  printer

VDX needs the schemas from `$JBOSS_HOME/docs/schema`. If those aren't
available (or VDX fails to print the failure due to an internal error),
XmlConfigurationPersister will fall back to the old behavior of throwing
ControllerLogger.ROOT_LOGGER.failedToParseConfiguration with the
original exception.