### PR TITLE
Fix for WFCORE-1794. Attachment, option and batch issues

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/AttachmentHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/AttachmentHandler.java
@@ -192,6 +192,22 @@ public class AttachmentHandler extends BatchModeCommandHandler {
         headers.addRequiredPreceding(operation);
     }
 
+    @Override
+    protected void recognizeArguments(CommandContext ctx) throws CommandFormatException {
+        String act = getAction(ctx);
+        if (DISPLAY.equals(act)) {
+            if (targetFile.isPresent(ctx.getParsedCommandLine())) {
+                throw new CommandFormatException(targetFile.getFullName()
+                        + " can't be used with display action");
+            }
+            if (overwrite.isPresent(ctx.getParsedCommandLine())) {
+                throw new CommandFormatException(overwrite.getFullName()
+                        + " can't be used with display action");
+            }
+        }
+        super.recognizeArguments(ctx);
+    }
+
     private String getAction(CommandContext ctx) {
         final String originalLine = ctx.getParsedCommandLine().getOriginalLine();
         if (originalLine == null || originalLine.isEmpty()) {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
@@ -104,6 +104,7 @@ public class BatchRunHandler extends BaseOperationCommand {
                         if (cmd.getResponseHandler() != null) {
                             cmd.getResponseHandler().handleResponse(step, response);
                         }
+                        i += 1;
                     }
                 }
             }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/AttachmentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/AttachmentTestCase.java
@@ -98,8 +98,7 @@ public class AttachmentTestCase {
                     + "read-attribute(name=stream) --file=" + f.getAbsolutePath());
             cli.sendLine("run-batch");
             assertTrue(f.exists() && f.length() != 0);
-            // Same streams, second consumer deals with a consumed stream
-            assertTrue(f2.exists() && f2.length() == 0);
+            assertTrue(f2.exists() && f2.length() != 0);
         } finally {
             f.delete();
             f2.delete();
@@ -123,8 +122,7 @@ public class AttachmentTestCase {
         try {
             cli.sendLine("run-batch --file=" + batchFile + " -v");
             assertTrue(f.exists() && f.length() != 0);
-            // Same streams, second consumer deals with a consumed stream
-            assertTrue(f2.exists() && f2.length() == 0);
+            assertTrue(f2.exists() && f2.length() != 0);
         } finally {
             batchFile.delete();
             f.delete();
@@ -196,6 +194,67 @@ public class AttachmentTestCase {
             String output = cli.readOutput();
             assertTrue(output.contains("jboss.home.dir"));
         } finally {
+            cli.quit();
+        }
+    }
+
+    @Test
+    public void testDisplayWrongOptions() throws Exception {
+        CLIWrapper cli = new CLIWrapper(true);
+        boolean failed = false;
+
+        try {
+            cli.sendLine("attachment display --operation=/subsystem=logging/"
+                    + "log-file=server.log:read-attribute(name=stream) --overwrite");
+        } catch (Throwable ex) {
+            // XXX OK.
+            failed = true;
+        }
+
+        try {
+            cli.sendLine("attachment display --operation=/subsystem=logging/"
+                    + "log-file=server.log:read-attribute(name=stream) --file=toto");
+        } catch (Throwable ex) {
+            // XXX OK.
+            failed = true;
+        } finally {
+            cli.quit();
+        }
+        if (!failed) {
+            throw new Exception("Should have failed");
+        }
+    }
+
+    @Test
+    public void testBatchIncrementalDeployment() throws Exception {
+        CLIWrapper cli = new CLIWrapper(true);
+        File f = new File(System.currentTimeMillis() + "batch_attachment.log");
+        File f2 = new File(System.currentTimeMillis() + "batch_attachment2.log");
+        File source = new File(System.currentTimeMillis() + "todeploy.log");
+        String expected = "HelloWorld";
+        Files.write(source.toPath(), expected.getBytes());
+        assertFalse(f.exists());
+        assertFalse(f2.exists());
+        try {
+            cli.sendLine("/deployment=AttachedFileTestCase.war:add(content=[{empty=true}])");
+            cli.sendLine("batch");
+            cli.sendLine("/deployment=AttachedFileTestCase.war:add-content(content=[{input-stream-index="
+                    + source.getName() + ", target-path=batch.text.file1}])");
+            cli.sendLine("/deployment=AttachedFileTestCase.war:add-content(content=[{input-stream-index="
+                    + source.getName() + ", target-path=batch.text.file2}])");
+            cli.sendLine("attachment save --operation=/deployment=AttachedFileTestCase.war:"
+                    + "read-content(path=batch.text.file1) --file=" + f.getAbsolutePath());
+            cli.sendLine("attachment save --operation=/deployment=AttachedFileTestCase.war:"
+                    + "read-content(path=batch.text.file2) --file=" + f2.getAbsolutePath());
+            cli.sendLine("run-batch");
+            assertTrue(f.exists() && f.length() != 0);
+            assertTrue(Files.readAllLines(f.toPath()).get(0).equals(expected));
+            assertTrue(f2.exists() && f2.length() != 0);
+            assertTrue(Files.readAllLines(f2.toPath()).get(0).equals(expected));
+        } finally {
+            f.delete();
+            f2.delete();
+            source.delete();
             cli.quit();
         }
     }


### PR DESCRIPTION
Batch step index was not incremented. Reject options that are invalid with display.
Added unit tests.