### PR TITLE
[WFCORE-254] Switch to using an Apache Commons Logging implementation…

### DIFF
--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -108,6 +108,11 @@
 
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
         </dependency>
 

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/commons/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/commons/logging/main/module.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.3" name="org.apache.commons.logging">
+
+    <properties>
+        <property name="jboss.api" value="public"/>
+    </properties>
+
+    <dependencies>
+        <!-- This allows the org.jboss.logmanager.commons.logging module to be private while keeping this module public -->
+        <module name="org.jboss.logmanager.commons.logging" export="true"/>
+    </dependencies>
+</module>
+

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/commons/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/commons/logging/main/module.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2016 Red Hat, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.logmanager.commons.logging">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.jboss.logmanager:commons-logging-jboss-logmanager}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.logmanager"/>
+    </dependencies>
+</module>
+

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <version.org.jboss.jboss-vfs>3.2.12.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.0.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
         <version.org.jboss.logmanager.jboss-logmanager>2.0.4.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>1.4.11.Final</version.org.jboss.marshalling.jboss-marshalling>
@@ -1131,6 +1132,12 @@
 
             <dependency>
                 <groupId>org.jboss.logmanager</groupId>
+                <artifactId>commons-logging-jboss-logmanager</artifactId>
+                <version>${version.org.jboss.logmanager.commons-logging-jboss-logmanager}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.logmanager</groupId>
                 <artifactId>jboss-logmanager</artifactId>
                 <version>${version.org.jboss.logmanager.jboss-logmanager}</version>
             </dependency>
@@ -1324,12 +1331,6 @@
                         <artifactId>infinispan-core</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>${version.org.slf4j}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -83,8 +83,8 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>commons-logging-jboss-logmanager</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
… which writes directly to JBoss Log Manager.

JIRA https://issues.jboss.org/browse/WFCORE-254

We currently use `org.slf4j:jcl-over-slf4j` as the Apache Commons Logging implementation. This implementation uses a static map of loggers which could lead to loggers being shared across deployments. I've created a new[ implementation](https://github.com/jboss-logging/commons-logging-jboss-logmanager) which writes directly to JBoss Log Manager.

Currently the `org.apache.commons.logging` module is defined in WildFly Full. I think it should in core since the logging subsystem does automatically add the dependency. I'll follow up with a WildFly Full PR that removes the module from there.