### PR TITLE
[i18n] Updates to the Zanata plugin and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ local-repo-eap
 #OS X index files
 .DS_Store
 testsuite-core/standalone/cli_output
+
+# Zanata files
+**/.zanata-cache/

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,12 @@
                                 <JBossAS-Release-Codename>${wildfly.core.release.codename}</JBossAS-Release-Codename>
                             </manifestEntries>
                         </archive>
+                        <!-- Do not package the generated logging properties as the generated binaries will be packaged -->
+                        <!-- These files are not required at runtime -->
+                        <excludes>
+                            <exclude>**/*.i18n.properties</exclude>
+                            <exclude>**/*.i18n_*.properties</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
         <version.org.wildfly.security.elytron-web.undertow-server>1.0.0.Beta3</version.org.wildfly.security.elytron-web.undertow-server>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
         <!-- Non-default maven plugin versions and configuration -->
-        <version.org.zanata.plugin>3.1.1</version.org.zanata.plugin>
+        <version.org.zanata.plugin>3.9.1</version.org.zanata.plugin>
         <version.xml.plugin>1.0</version.xml.plugin>
 
         <!-- Modularized JDK support (various workarounds) - activated via profile -->
@@ -225,6 +225,8 @@
                  <srcDir>target/classes</srcDir>
                  <transDir>src/main/resources</transDir>
                  <includes>**/*.i18n.properties,**/LocalDescriptions.properties</includes>
+                 <!-- In previous versions, 3.8.0 and lower, this defaulted to true -->
+                 <copyTrans>true</copyTrans>
               </configuration>
             </plugin>
             <plugin>

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <config xmlns="http://zanata.org/namespace/config/">
     <url>https://translate.jboss.org/</url>
-    <project>jboss_as</project>
-    <project-version>master</project-version>
+    <project>jboss-eap-core</project>
+    <project-version>3.0</project-version>
     <project-type>properties</project-type>
-
-    <locales mapping="java">
-       <locale>de</locale>
-       <locale>es</locale>
-       <locale>fr</locale>
-       <locale>ja</locale>
-       <locale>pt-BR</locale>
-       <locale map-from="zh-CN">zh-Hans</locale>
-    </locales>
 
 </config>


### PR DESCRIPTION
The first commit just upgrades the Zanata plugin to align with the version the server is on as well as make the configuration changes necessary for the 3.0 repository.

The second commit is not required, but help help reduce the size of the final distribution a bit. It simply just excludes the files needed for the logging tooling to generate the i18n loggers and message bundles. These files are only required at compile time and not used at run time.

If the second commit is not desirable I can remove it.

Just to keep things linked together https://github.com/wildfly/wildfly-checkstyle-config/pull/8 will be needed once we start pulling down translations. Some of the files pulled down have trailing spaces which fails the build. Previously I just went through and fixed them, but I think this is a better solution as we don't have much control over what is pulled down.