### PR TITLE
[WFCORE-1807] fix trimmed vault-option name and value.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/VaultConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/VaultConfig.java
@@ -165,7 +165,7 @@ class VaultConfig {
                                 "' is not found for element " +
                                 VAULT_OPTION + "' at " + reader.getLocation());
                     }
-                    config.addOption(name.trim(), value.trim());
+                    config.addOption(name, value);
                     CliConfigImpl.CliConfigReader.requireNoContent(reader);
                 } else {
                     throw new XMLStreamException("Unexpected element: " + localName);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1807 https://issues.jboss.org/browse/JBEAP-5690

Trimmed vault-option _name_ and _value_ makes problem when custom vault implementation which prepends string to an executable command.

Notice that the [VaultXml.java](https://github.com/wildfly/wildfly-core/blob/bc4988960e9bd245318321a06ae3d001ec661bc5/server/src/main/java/org/jboss/as/server/parsing/VaultXml.java#L172) does not do this trim() call for any vault-option _name_ and _value_.