### PR TITLE
[WFCORE-1793]: add-content operation fails to overwrite existing content with overwrite=true set when passing content by file path.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/ExplodedDeploymentAddContentHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/ExplodedDeploymentAddContentHandler.java
@@ -87,7 +87,7 @@ public class ExplodedDeploymentAddContentHandler implements OperationStepHandler
         final String managementName = context.getCurrentAddress().getLastElement().getValue();
         final PathAddress address = PathAddress.pathAddress(DEPLOYMENT, managementName);
         final byte[] oldHash = CONTENT_HASH.resolveModelAttribute(context, contentItemNode).asBytes();
-        final boolean overwrite = OVERWRITE.resolveModelAttribute(context, contentItemNode).asBoolean(true);
+        final boolean overwrite = OVERWRITE.resolveModelAttribute(context, operation).asBoolean(true);
         List<ModelNode> contents = EXPLODED_CONTENT.resolveModelAttribute(context, operation).asList();
         final List<ExplodedContent> addedFiles = new ArrayList<>(contents.size());
         final byte[] newHash;


### PR DESCRIPTION
The bug was in 2 parts : path wasn't a correct attribute, and overwrite wasn't looked in the correct part of the operation.
The overwrite is part of the operation, not of the content node.
