### PR TITLE
[WFCORE-1547] Iniital CredentialStore Integration

### DIFF
--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -86,6 +86,10 @@
             <groupId>org.jboss</groupId>
             <artifactId>staxmapper</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
 
 
         <!-- Test Dependencies -->

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3449,33 +3449,33 @@ public interface ControllerLogger extends BasicLogger {
 
     // ---- Credential Store related messages -----------
 
-    @Message(id = 450, value = "Credential store \"%s\" doesn't support credential type \"%s\" ")
+    @Message(id = 423, value = "Credential store \"%s\" doesn't support credential type \"%s\" ")
     UnsupportedCredentialTypeException unsupportedCredentialType(String credentialStore, String credentialType);
 
-    @Message(id = 451, value = "Supposed Credential Store URI has no scheme or different from '" + CredentialStoreURIParser.CR_STORE_SCHEME + "://' ('%s')")
+    @Message(id = 424, value = "Supposed Credential Store URI has no scheme or different from '" + CredentialStoreURIParser.CR_STORE_SCHEME + "://' ('%s')")
     IllegalArgumentException credentialStoreURIWrongScheme(String uri);
 
-    @Message(id = 452, value = "Credential Store URI has to be absolute '%s'")
+    @Message(id = 425, value = "Credential Store URI has to be absolute '%s'")
     IllegalArgumentException credentialStoreURIisNotAbsolute(String uri);
 
-    @Message(id = 453, value = "More than one fragment defined for Credential Store URI")
+    @Message(id = 426, value = "More than one fragment defined for Credential Store URI")
     String moreThanOneFragmentDefined();
 
-    @Message(id = 454, value = "Credential Store name has to be defined '%s'")
+    @Message(id = 427, value = "Credential Store name has to be defined '%s'")
     IllegalArgumentException credentialStoreHasNoName(String uri);
 
-    @Message(id = 455, value = "Attribute name is defined, but empty '%s'")
+    @Message(id = 428, value = "Attribute name is defined, but empty '%s'")
     IllegalArgumentException credentialStoreURIAttributeEmpty(String uri);
 
-    @Message(id = 456, value = "Opening quote has to be the first character in parameter value '%s'")
+    @Message(id = 429, value = "Opening quote has to be the first character in parameter value '%s'")
     IllegalArgumentException credentialStoreURIParameterOpeningQuote(String uri);
 
-    @Message(id = 457, value = "Closing quote has to be the last character of parameter value '%s'")
+    @Message(id = 430, value = "Closing quote has to be the last character of parameter value '%s'")
     IllegalArgumentException credentialStoreURIParameterClosingQuote(String uri);
 
-    @Message(id = 458, value = "Unexpected end of parameter part of '%s'")
+    @Message(id = 431, value = "Unexpected end of parameter part of '%s'")
     IllegalArgumentException credentialStoreURIParameterUnexpectedEnd(String uri);
 
-    @Message(id = 459, value = "Parameter name expected, but is missing '%s'")
+    @Message(id = 432, value = "Parameter name expected, but is missing '%s'")
     IllegalArgumentException credentialStoreURIParameterNameExpected(String uri);
 }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -62,6 +62,7 @@ import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.security.CredentialStoreURIParser;
 import org.jboss.as.protocol.mgmt.RequestProcessingException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -78,6 +79,7 @@ import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleNotFoundException;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
+import org.wildfly.security.credential.store.UnsupportedCredentialTypeException;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -3444,4 +3446,36 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = 422, value = "Could not load module '%s' for transformers")
     RuntimeException couldNotLoadModuleForTransformers(String name, @Cause ModuleLoadException e);
+
+    // ---- Credential Store related messages -----------
+
+    @Message(id = 450, value = "Credential store \"%s\" doesn't support credential type \"%s\" ")
+    UnsupportedCredentialTypeException unsupportedCredentialType(String credentialStore, String credentialType);
+
+    @Message(id = 451, value = "Supposed Credential Store URI has no scheme or different from '" + CredentialStoreURIParser.CR_STORE_SCHEME + "://' ('%s')")
+    IllegalArgumentException credentialStoreURIWrongScheme(String uri);
+
+    @Message(id = 452, value = "Credential Store URI has to be absolute '%s'")
+    IllegalArgumentException credentialStoreURIisNotAbsolute(String uri);
+
+    @Message(id = 453, value = "More than one fragment defined for Credential Store URI")
+    String moreThanOneFragmentDefined();
+
+    @Message(id = 454, value = "Credential Store name has to be defined '%s'")
+    IllegalArgumentException credentialStoreHasNoName(String uri);
+
+    @Message(id = 455, value = "Attribute name is defined, but empty '%s'")
+    IllegalArgumentException credentialStoreURIAttributeEmpty(String uri);
+
+    @Message(id = 456, value = "Opening quote has to be the first character in parameter value '%s'")
+    IllegalArgumentException credentialStoreURIParameterOpeningQuote(String uri);
+
+    @Message(id = 457, value = "Closing quote has to be the last character of parameter value '%s'")
+    IllegalArgumentException credentialStoreURIParameterClosingQuote(String uri);
+
+    @Message(id = 458, value = "Unexpected end of parameter part of '%s'")
+    IllegalArgumentException credentialStoreURIParameterUnexpectedEnd(String uri);
+
+    @Message(id = 459, value = "Parameter name expected, but is missing '%s'")
+    IllegalArgumentException credentialStoreURIParameterNameExpected(String uri);
 }

--- a/controller/src/main/java/org/jboss/as/controller/security/CredentialReference.java
+++ b/controller/src/main/java/org/jboss/as/controller/security/CredentialReference.java
@@ -1,0 +1,417 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.controller.security;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Collections;
+import java.util.Set;
+
+import javax.security.auth.DestroyFailedException;
+import javax.security.auth.Destroyable;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.AttributeParser;
+import org.jboss.as.controller.ObjectTypeAttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.store.CredentialStore;
+import org.wildfly.security.credential.store.CredentialStoreException;
+import org.wildfly.security.credential.store.CredentialStoreSpi;
+import org.wildfly.security.credential.store.UnsupportedCredentialTypeException;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.interfaces.ClearPassword;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+
+/**
+ * Class unifying access to credentials defined through {@link org.wildfly.security.credential.store.CredentialStore}
+ * or holding simply {@code char[]} as a secret.
+ *
+ * It defines credential reference attribute that other subsystems can use to reference external credentials of various
+ * types.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+public final class CredentialReference implements Destroyable {
+
+    /**
+     * Definition of id used in model
+     */
+    public static final String CREDENTIAL_REFERENCE = "credential-reference";
+    /**
+     * Definition of id used in model
+     */
+    public static final String STORE = "store";
+    /**
+     * Definition of id used in model
+     */
+    public static final String ALIAS = "alias";
+    /**
+     * Definition of id used in model
+     */
+    public static final String TYPE = "type";
+    /**
+     * Definition of id used in model
+     */
+    public static final String CLEAR_TEXT = "clear-text";
+
+    static final SimpleAttributeDefinition credentialStoreAttribute;
+    static final SimpleAttributeDefinition credentialAliasAttribute;
+    static final SimpleAttributeDefinition credentialTypeAttribute;
+    static final SimpleAttributeDefinition clearTextAttribute;
+
+    static ObjectTypeAttributeDefinition credentialReferenceAttributeDefinition;
+
+    private final String credentialStoreName;
+    private final String alias;
+    private final String credentialType;
+    private char[] secret;
+
+    static {
+        credentialStoreAttribute = new SimpleAttributeDefinitionBuilder(STORE, ModelType.STRING, true)
+                .setXmlName(STORE)
+                .build();
+        credentialAliasAttribute = new SimpleAttributeDefinitionBuilder(ALIAS, ModelType.STRING, true)
+                .setXmlName(ALIAS)
+                .build();
+        credentialTypeAttribute = new SimpleAttributeDefinitionBuilder(TYPE, ModelType.STRING, true)
+                .setXmlName(TYPE)
+                .build();
+        clearTextAttribute = new SimpleAttributeDefinitionBuilder(CLEAR_TEXT, ModelType.STRING, true)
+                .setXmlName(CLEAR_TEXT)
+                .build();
+        credentialReferenceAttributeDefinition = new ObjectTypeAttributeDefinition.Builder(CREDENTIAL_REFERENCE, credentialStoreAttribute, credentialAliasAttribute, credentialTypeAttribute, clearTextAttribute)
+                .setXmlName(CREDENTIAL_REFERENCE)
+                .build();
+    }
+
+    private CredentialReference(String credentialStoreName, String alias, String credentialType, char[] secret) {
+        this.credentialStoreName = credentialStoreName;
+        this.alias = alias;
+        this.credentialType = credentialType;
+        if (secret != null) {
+            this.secret = secret.clone();
+        } else {
+            this.secret = null;
+        }
+    }
+
+    /**
+     * Get the credential store name part of this reference.
+     * @return credential store name
+     */
+    public String getCredentialStoreName() {
+        return credentialStoreName;
+    }
+
+    /**
+     * Get the credential alias which denotes credential stored inside named credential store.
+     * @return alias of the referenced credential
+     */
+    public String getAlias() {
+        return alias;
+    }
+
+    /**
+     * Get credential type which narrows selection of the credential stored under the alias in the credential store.
+     * @return credential type (class name of desired credential type)
+     */
+    public String getCredentialType() {
+        return credentialType;
+    }
+
+    /**
+     * Get the secret stored as clear text in this reference.
+     * @return secret value as clear text
+     */
+    public char[] getSecret() {
+        return secret;
+    }
+
+
+    /**
+     * Destroy this {@code Object}.
+     * <p>
+     * <p> Sensitive information associated with this {@code Object}
+     * is destroyed or cleared.  Subsequent calls to certain methods
+     * on this {@code Object} will result in an
+     * {@code IllegalStateException} being thrown.
+     * <p>
+     * <p>
+     * The default implementation throws {@code DestroyFailedException}.
+     *
+     * @throws DestroyFailedException if the destroy operation fails. <p>
+     * @throws SecurityException      if the caller does not have permission
+     *                                to destroy this {@code Object}.
+     */
+    @Override
+    public void destroy() throws DestroyFailedException {
+        if (secret != null) {
+            for (int i = 0; i < secret.length; i++) {
+                secret[i] = 0;
+            }
+            secret = null;
+        }
+    }
+
+    /**
+     * Determine if this {@code Object} has been destroyed.
+     * <p>
+     * <p>
+     * The default implementation returns false.
+     *
+     * @return true if this {@code Object} has been destroyed,
+     * false otherwise.
+     */
+    @Override
+    public boolean isDestroyed() {
+        return secret == null;
+    }
+
+    // factory static methods
+
+    /**
+     * Method to create new {@link CredentialReference} based on {@link #secret} attribute only.
+     * @param secret to reference
+     * @return new {@link CredentialReference}
+     */
+    public static CredentialReference createCredentialReference(char[] secret) {
+        return new CredentialReference(CredentialReference.class.getName(), null, null, secret);
+    }
+
+    /**
+     * Method to create new {@link CredentialReference} based on params
+     * @param credentialStoreName credential store name
+     * @param alias denoting the credential
+     * @param credentialType type of credential (can be {@code null})
+     * @return new {@link CredentialReference}
+     */
+    public static CredentialReference createCredentialReference(String credentialStoreName, String alias, String credentialType) {
+        return new CredentialReference(credentialStoreName, alias, credentialType, null);
+    }
+
+    // utility static methods
+
+    /**
+     * Returns new definition for credential reference attribute.
+     *
+     * @return credential reference attribute definition
+     */
+    public static ObjectTypeAttributeDefinition getAttributeDefinition() {
+        return credentialReferenceAttributeDefinition;
+    }
+
+    /**
+     * Utility method to return part of {@link ObjectTypeAttributeDefinition} for credential reference attribute.
+     *
+     * {@see CredentialReference#getAttributeDefinition}
+     * @param context operational context
+     * @param attributeDefinition attribute definition
+     * @param model model
+     * @param name name of part to return (supported names: {@link #STORE} {@link #ALIAS} {@link #TYPE}
+     *    {@link #CLEAR_TEXT}
+     * @return value of part as {@link String}
+     * @throws OperationFailedException when something goes wrong
+     */
+    public static String credentialReferencePartAsStringIfDefined(OperationContext context, ObjectTypeAttributeDefinition attributeDefinition, ModelNode model, String name) throws OperationFailedException {
+        ModelNode value = attributeDefinition.resolveModelAttribute(context, model);
+        if (value.isDefined()) {
+            ModelNode namedNode = value.get(name);
+            if (namedNode != null && namedNode.isDefined()) {
+                return namedNode.asString();
+            }
+            return null;
+        }
+        return null;
+    }
+
+    /**
+     * Replace injection with new one referencing the same {@link org.wildfly.security.credential.store.CredentialStore} but
+     * based of new values of {@link CredentialReference}
+     * @param injectedCredentialStoreClient {@link InjectedValue} to replace the credential reference
+     * @param credentialReference new credential reference
+     * @throws ClassNotFoundException when credential reference holding credential type which cannot be resolved using current providers
+     */
+    public static void reinjectCredentialStoreClient(InjectedValue<CredentialStoreClient> injectedCredentialStoreClient,
+            CredentialReference credentialReference) throws ClassNotFoundException {
+
+        CredentialStoreClient originalCredentialStoreClient = injectedCredentialStoreClient.getOptionalValue();
+        final CredentialStoreClient updatedCredentialStoreClient;
+        if (originalCredentialStoreClient != null) {
+            updatedCredentialStoreClient =
+                    credentialReference.getCredentialType() != null
+                            ?
+                            new CredentialStoreClient(
+                                    originalCredentialStoreClient.getCredentialStore(),
+                                    credentialReference.getCredentialStoreName(),
+                                    credentialReference.getAlias(),
+                                    credentialReference.getCredentialType())
+                            :
+                            new CredentialStoreClient(
+                                    originalCredentialStoreClient.getCredentialStore(),
+                                    credentialReference.getCredentialStoreName(),
+                                    credentialReference.getAlias());
+        } else {
+            final CredentialStore credentialStore = new ClearTextCredentialStore(credentialReference);
+            updatedCredentialStoreClient = new CredentialStoreClient(credentialStore, CredentialReference.class.getName(), null);
+        }
+        injectedCredentialStoreClient.setValue(() -> updatedCredentialStoreClient);
+    }
+
+    /**
+     * Marshall the value from {@code credentialReferenceModelNode} as an xml element into the given {@code writer}.
+     * @param credentialReferenceModelNode he model, a non-null node of {@link org.jboss.dmr.ModelType#OBJECT}.
+     * @param writer stream writer to use for writing the attribute
+     * @throws XMLStreamException if thrown by {@code writer}
+     */
+    public static void marshallAsElement(ModelNode credentialReferenceModelNode, XMLExtendedStreamWriter writer) throws XMLStreamException {
+        writer.writeStartElement(CredentialReference.CREDENTIAL_REFERENCE);
+        if (credentialReferenceModelNode.hasDefined(clearTextAttribute.getName())) {
+            clearTextAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
+        } else {
+            credentialStoreAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
+            credentialAliasAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
+            credentialTypeAttribute.marshallAsAttribute(credentialReferenceModelNode, writer);
+        }
+        writer.writeEndElement();
+
+    }
+
+    /**
+     * Parse {@link CredentialReference} from {@code XMLStreamReader} and set addOperation.
+     * @param addOperation to set
+     * @param reader stream reader to parse
+     * @throws XMLStreamException if thrown by {@code reader}
+     */
+    public static void readCredentialReference(ModelNode addOperation, XMLExtendedStreamReader reader) throws XMLStreamException {
+        AttributeParser.OBJECT_PARSER.parseElement(CredentialReference.getAttributeDefinition(), reader, addOperation);
+    }
+
+    static class ClearTextCredentialStore extends CredentialStore {
+        private static String TYPE = "ClearTextCredentialStore";
+        private CredentialReference credentialReference;
+
+        ClearTextCredentialStore(CredentialReference credentialReference) {
+            super(null, null, TYPE);
+            this.credentialReference = credentialReference;
+        }
+
+        /**
+         * Checks whether underlying credential store is initialized.
+         *
+         * @return {@code true} in case of initialization passed successfully, {@code false} otherwise.
+         */
+        @Override
+        public boolean isInitialized() {
+            return true;
+        }
+
+        /**
+         * Check if credential store supports modification of actual store
+         *
+         * @return true in case of modification of store is supported
+         */
+        @Override
+        public boolean isModifiable() {
+            return false;
+        }
+
+        /**
+         * Check whether credential store has an entry associated with the given credential alias of specified credential type.
+         *
+         * @param credentialAlias alias to check existence
+         * @param credentialType  to check existence in the credential store
+         * @return true in case key exist in store
+         * @throws CredentialStoreException           when there is a problem with credential store
+         * @throws UnsupportedCredentialTypeException when the credentialType is not supported
+         */
+        @Override
+        public <C extends Credential> boolean exists(String credentialAlias, Class<C> credentialType) throws CredentialStoreException, UnsupportedCredentialTypeException {
+            return false;
+        }
+
+        /**
+         * Store credential to the store under the given alias. If given alias already contains specific credential type type the credential
+         * replaces older one. <em>Note:</em> {@link CredentialStoreSpi} supports storing of multiple entries (credential types) per alias.
+         * Each must be of different credential type.
+         *
+         * @param credentialAlias to store the credential to the store
+         * @param credential      instance of {@link Credential} to store
+         * @throws CredentialStoreException           when the credential cannot be stored
+         * @throws UnsupportedCredentialTypeException when the credentialType is not supported
+         */
+        @Override
+        public <C extends Credential> void store(String credentialAlias, C credential) throws CredentialStoreException, UnsupportedCredentialTypeException {
+            throw new RuntimeException("method not implemented");
+        }
+
+        /**
+         * Retrieve credential stored in the store under the key and of the credential type
+         *
+         * @param credentialAlias to find the credential in the store
+         * @param credentialType  - credential type to retrieve from under the credentialAlias from the store
+         * @return instance of {@link Credential} stored in the store
+         * @throws CredentialStoreException           - if credentialAlias credentialType combination doesn't exist or credentialAlias cannot be retrieved
+         * @throws UnsupportedCredentialTypeException when the credentialType is not supported
+         */
+        @Override
+        public <C extends Credential> C retrieve(String credentialAlias, Class<C> credentialType) throws CredentialStoreException, UnsupportedCredentialTypeException {
+            try {
+                PasswordFactory passwordFactory = PasswordFactory.getInstance(ClearPassword.ALGORITHM_CLEAR);
+                return credentialType.cast(new PasswordCredential(passwordFactory.generatePassword(new ClearPasswordSpec(credentialReference.getSecret()))));
+            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+                throw new CredentialStoreException(e);
+            }
+        }
+
+        /**
+         * Remove the credentialType with from given alias from the store.
+         *
+         * @param credentialAlias alias to remove
+         * @param credentialType  - credential type to be removed from under the credentialAlias from the store
+         * @throws CredentialStoreException           - if credentialAlias credentialType combination doesn't exist or credentialAlias cannot be removed
+         * @throws UnsupportedCredentialTypeException when the credentialType is not supported
+         */
+        @Override
+        public <C extends Credential> void remove(String credentialAlias, Class<C> credentialType) throws CredentialStoreException, UnsupportedCredentialTypeException {
+            throw new RuntimeException("method not implemented");
+        }
+
+        /**
+         * Returns {@code Set<String>} stored in this store.
+         *
+         * @return {@code Set<String>} of all keys stored in this store
+         * @throws UnsupportedOperationException when this method is not supported by the underlying credential store
+         * @throws CredentialStoreException      if there is any problem with internal store
+         */
+        @Override
+        public Set<String> getAliases() throws UnsupportedOperationException, CredentialStoreException {
+            return Collections.emptySet();
+        }
+    }
+
+}

--- a/controller/src/main/java/org/jboss/as/controller/security/CredentialStoreClient.java
+++ b/controller/src/main/java/org/jboss/as/controller/security/CredentialStoreClient.java
@@ -1,0 +1,190 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.controller.security;
+
+import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
+
+import javax.security.auth.DestroyFailedException;
+import javax.security.auth.Destroyable;
+
+import org.jboss.logging.Logger;
+import org.wildfly.common.Assert;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.store.CredentialStore;
+import org.wildfly.security.credential.store.CredentialStoreException;
+import org.wildfly.security.credential.store.UnsupportedCredentialTypeException;
+import org.wildfly.security.password.interfaces.ClearPassword;
+
+/**
+ * Client class used to talk to {@link CredentialStore} to obtain secret value (credential) from it.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
+ */
+public class CredentialStoreClient implements Destroyable {
+
+    private CredentialStore credentialStore;
+    private final String name;
+    private final String alias;
+    private final Class<? extends Credential> type;
+
+    /**
+     * Constructor to create instance of {@link CredentialStoreClient}.
+     * @param credentialStore actual {@link CredentialStore} used by this client
+     * @param name of credential store
+     * @param alias of credential in the store
+     * @param type of credential denoted by this alias
+     */
+    public CredentialStoreClient(final CredentialStore credentialStore, final String name, final String alias, final Class<? extends Credential> type) {
+        Assert.checkNotNullParam("name", name);
+        this.name = name;
+        this.alias = alias;
+        this.type = type;
+        this.credentialStore = credentialStore;
+    }
+
+    /**
+     * Constructor to create instance of {@link CredentialStoreClient}.
+     * @param credentialStore actual {@link CredentialStore} used by this client
+     * @param name of credential store
+     * @param alias of credential in the store
+     */
+    public CredentialStoreClient(final CredentialStore credentialStore, final String name, final String alias) {
+        this(credentialStore, name, alias, (Class) null);
+    }
+
+    /**
+     * Constructor to create instance of {@link CredentialStoreClient}.
+     * @param credentialStore actual {@link CredentialStore} used by this client
+     * @param name of credential store
+     * @param alias of credential in the store
+     * @param className of credential denoted by this alias
+     * @throws ClassNotFoundException when credential reference holding credential type which cannot be resolved using current providers
+     */
+    public CredentialStoreClient(final CredentialStore credentialStore, final String name, final String alias, final String className) throws ClassNotFoundException {
+        this(credentialStore, name, alias, toClass(className, credentialStore.getClass().getClassLoader()));
+    }
+
+    private static Class<? extends Credential> toClass(final String className, final ClassLoader classLoader) throws ClassNotFoundException {
+        return (Class<Credential>) Class.forName(className, true, classLoader);
+    }
+
+    /**
+     * Get the secret in form of clear text.
+     * @return secret as clear text
+     */
+    public char[] getSecret() {
+        if (isDestroyed()) {
+            return null;
+        }
+        PasswordCredential passwordCredential = (PasswordCredential) getCredential();
+        if (passwordCredential != null) {
+            if (passwordCredential.getPassword() instanceof ClearPassword) {
+                return ((ClearPassword) passwordCredential.getPassword()).getPassword();
+            } else {
+                ROOT_LOGGER.log(Logger.Level.DEBUG, ROOT_LOGGER.unsupportedCredentialType(name,
+                        passwordCredential.getPassword().getClass().getName()));
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the {@link Credential} instance from the credential store.
+     * @return Credential instance of proper credential type specified if not available {@code null}
+     */
+    public Credential getCredential() {
+        if (isDestroyed() || alias == null) {
+            return null;
+        }
+        try {
+            if (type != null) {
+                return credentialStore.retrieve(alias, type);
+            } else {
+                return credentialStore.retrieve(alias, PasswordCredential.class);
+            }
+        } catch (UnsupportedCredentialTypeException | CredentialStoreException e) {
+            ROOT_LOGGER.log(Logger.Level.INFO, e);
+        }
+        return null;
+    }
+
+    /**
+     * Retrieve associated {@link CredentialStore}
+     * This method should perform check whether the {@link CredentialStore} can be returned to caller.
+     *
+     * @return associated {@link CredentialStore}
+     */
+    public CredentialStore getCredentialStore() {
+        // TODO: check caller if possible
+        return credentialStore;
+    }
+
+    /**
+     * Get alias used by this credential store client to fetch credential
+     * @return alias
+     */
+    public String getAlias() {
+        return alias;
+    }
+
+    /**
+     * Get type used by this credential store client to fetch credential
+     * @return type of credential
+     */
+    public Class<? extends Credential> getType() {
+        return type;
+    }
+
+    /**
+     * Destroy this {@code Object}.
+     * <p>
+     * <p> Sensitive information associated with this {@code Object}
+     * is destroyed or cleared.  Subsequent calls to certain methods
+     * on this {@code Object} will result in an
+     * {@code IllegalStateException} being thrown.
+     * <p>
+     * <p>
+     * The default implementation throws {@code DestroyFailedException}.
+     *
+     * @throws DestroyFailedException if the destroy operation fails. <p>
+     * @throws SecurityException      if the caller does not have permission
+     *                                to destroy this {@code Object}.
+     */
+    @Override
+    public void destroy() throws DestroyFailedException {
+        if (! isDestroyed()) {
+            credentialStore = null;
+        }
+    }
+
+    /**
+     * Determine if this {@code Object} has been destroyed.
+     * <p>
+     * <p>
+     * The default implementation returns false.
+     *
+     * @return true if this {@code Object} has been destroyed,
+     * false otherwise.
+     */
+    @Override
+    public boolean isDestroyed() {
+        return credentialStore == null;
+    }
+
+}

--- a/controller/src/main/java/org/jboss/as/controller/security/CredentialStoreURIParser.java
+++ b/controller/src/main/java/org/jboss/as/controller/security/CredentialStoreURIParser.java
@@ -1,0 +1,299 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.controller.security;
+
+import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This class provides parsing for URIs with scheme "cr-store".
+ *
+ * <p> Credential Store URI is used for configuring/referencing credential stores.
+ * It can specify complete information about credential store including parameters as well as reference
+ * of stored secured credentials (such  as passwords).
+ *
+ * <h3> Credential Store URI scheme </h3>
+ *
+ * <blockquote>
+ * crStoreURI  =  <i>scheme</i> {@code :} {@code //}<i>store_name</i> [{@code /} <i>storage_file</i>] [?<i>query</i>] [{@code #} <i>attribute_name</i>]
+ *
+ * <i>scheme</i> =  <b>cr-store</b>
+ *
+ * <i>store_name</i> = {@code //} alpha *alphanum
+ *
+ * <i>storage_file</i> = file_name_uri
+ *
+ * <i>query</i> = store_parameter = value *[{@code ;} <i>store_parameter</i> = <i>value</i>]
+ *
+ * <i>store_parameter</i> = alpha *alphanum
+ *
+ * <i>value</i> = {@code '}alpha *alphanum{@code '} {@code |} alpha *alphanum
+ *
+ * <i>attribute_name</i> = alpha *alphanum
+ * </blockquote>
+ *
+ * <p> Credential Store URI has to be absolute with <b>store_name></b> always defined.
+ * <p> parameters to {@code {@link org.wildfly.security.credential.store.CredentialStoreSpi}} implementation are supplied
+ * through <b>query</b> part of URI. In case they need to decode binary value Base64 encoding method should be used.
+ *
+ * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>.
+ */
+public class CredentialStoreURIParser {
+
+    /**
+     * Credential Store URI scheme name ("cr-store").
+     */
+    public static final String CR_STORE_SCHEME = "cr-store";
+
+    private String name;
+    private String storageFile;
+    private final HashMap<String, String> options = new HashMap<>();
+    private String attribute;
+
+    /**
+     * Creates {@link CredentialStoreURIParser} based on given URI
+     *
+     * @param uri URI to parse
+     * @throws URISyntaxException in case of problems parsing given URI
+     */
+    public CredentialStoreURIParser(final String uri) throws URISyntaxException {
+        int schemeInd = 0;
+        if (uri.startsWith(CR_STORE_SCHEME + ":")) {
+            schemeInd = (CR_STORE_SCHEME + ":").length();
+        }
+        int fragmentInd = uri.indexOf('#');
+        URI uriToParse;
+        if (fragmentInd == 0) {
+            throw ROOT_LOGGER.credentialStoreHasNoName(safeCRStoreURI(uri));
+        } else if (fragmentInd > -1) {
+            String fragment = uri.substring(fragmentInd + 1);
+            if (fragment.indexOf('#') > -1) {
+                throw new URISyntaxException(uri, ROOT_LOGGER.moreThanOneFragmentDefined(), fragmentInd + fragment.indexOf('#'));
+            }
+            uriToParse = new URI(CR_STORE_SCHEME, uri.substring(schemeInd, fragmentInd), fragment);
+        } else {
+            uriToParse = new URI(CR_STORE_SCHEME, uri.substring(schemeInd), null);
+        }
+        parse(uriToParse);
+    }
+
+    /**
+     * Creates {@link CredentialStoreURIParser} based on given {@link URI}
+     *
+     * @param uri URI to parse
+     */
+    public CredentialStoreURIParser(final URI uri) {
+        parse(uri);
+    }
+
+    private void parse(final URI uri) {
+        if (! uri.isAbsolute()) {
+            throw ROOT_LOGGER.credentialStoreURIisNotAbsolute(safeCRStoreURI(uri.toString()));
+        }
+        if (! CR_STORE_SCHEME.equals(uri.getScheme())) {
+            throw ROOT_LOGGER.credentialStoreURIWrongScheme(safeCRStoreURI(uri.toString()));
+        }
+
+        String authority = uri.getAuthority();
+        if (authority != null) {
+            name = authority;
+        } else {
+            throw ROOT_LOGGER.credentialStoreHasNoName(safeCRStoreURI(uri.toString()));
+        }
+
+        String path = uri.getPath();
+        if (path != null && path.length() > 1) {
+            storageFile = path.substring(1);
+        } else {
+            storageFile = null;
+        }
+
+        parseQueryParameter(uri.getQuery(), uri.toString());
+
+        String fragment = uri.getFragment();
+        if (fragment != null && fragment.length() >= 0) {
+            if (fragment.isEmpty()) {
+                throw ROOT_LOGGER.credentialStoreURIAttributeEmpty(CredentialStoreURIParser.safeCRStoreURI(uri.toString()));
+            }
+            attribute = fragment;
+        } else {
+            attribute = null;
+        }
+    }
+
+    /**
+     * Parses and creates {@code options} map with all Credential Store URI query parameters separated.
+     * key value pairs are separated by {@code ;} semicolon.
+     * @param query part of the Credential Store URI
+     * @param uri {@code String} for logging and error messages
+     */
+    private void parseQueryParameter(final String query, final String uri) {
+
+        if (query == null) {
+            return;
+        }
+
+        int i = 0;
+        int state = 0; // possible states KEY = 0 | VALUE = 1
+        StringBuilder token = new StringBuilder();
+        String key = null;
+        String value = null;
+        while (i < query.length()) {
+            char c = query.charAt(i);
+            if (state == 0) {   // KEY state
+                if (c == '=') {
+                    state = 1;
+                    key = token.toString();
+                    value = null;
+                    token.setLength(0);
+                } else {
+                    token.append(c);
+                }
+                i++;
+            } else if (state == 1) {  // VALUE state
+                if (c == '\'') {
+                    if (query.charAt(i - 1) != '=') {
+                        throw ROOT_LOGGER.credentialStoreURIParameterOpeningQuote(CredentialStoreURIParser.safeCRStoreURI(uri));
+                    }
+                    int inQuotes = i + 1;
+                    c = query.charAt(inQuotes);
+                    while (inQuotes < query.length() && c != '\'') {
+                        token.append(c);
+                        inQuotes++;
+                        c = query.charAt(inQuotes);
+                    }
+                    if (c == '\'') {
+                        i = inQuotes + 1;
+                        if (i < query.length() && query.charAt(i) != ';') {
+                            throw ROOT_LOGGER.credentialStoreURIParameterClosingQuote(CredentialStoreURIParser.safeCRStoreURI(uri));
+                        }
+                    } else {
+                        throw ROOT_LOGGER.credentialStoreURIParameterUnexpectedEnd(CredentialStoreURIParser.safeCRStoreURI(uri));
+                    }
+                } else if (c == ';') {
+                    value = token.toString();
+                    if (key == null) {
+                        throw ROOT_LOGGER.credentialStoreURIParameterNameExpected(CredentialStoreURIParser.safeCRStoreURI(uri));
+                    }
+                    // put to options and reset key, value and token
+                    options.put(key, value);
+                    i++;
+                    key = null;
+                    value = null;
+                    token.setLength(0);
+                    // set state to KEY
+                    state = 0;
+                } else {
+                    token.append(c);
+                    i++;
+                }
+            }
+        }
+        if (key != null && token.length() > 0) {
+            options.put(key, token.toString());
+        } else {
+            throw ROOT_LOGGER.credentialStoreURIParameterUnexpectedEnd(CredentialStoreURIParser.safeCRStoreURI(uri));
+        }
+
+    }
+
+    /**
+     * Returns parsed credential store name.
+     *
+     * @return credential store name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns scheme handled by this parser.
+     *
+     * @return Credential Store URI scheme (always {@code CR_STORE_SCHEME})
+     */
+    public String getScheme() {
+        return CR_STORE_SCHEME;
+    }
+
+
+    /**
+     * Transforms given parameter to safely displayed {@code String} by stripping potentially sensitive information from the URI.
+     *
+     * @param uri original URI string
+     * @return {@code String} safe to display
+     */
+    public static String safeCRStoreURI(String uri) {
+        // for now, just easy stripping
+        int startOfQuery = uri.indexOf('?');
+        if (startOfQuery > -1) {
+            return uri.substring(0, startOfQuery) + "...";
+        } else {
+            return uri;
+        }
+    }
+
+    /**
+     * If storage file was not specified by the Credential Store URI returns {@code null}
+     * @return storage file as parsed from Credential Store URI as {@code String}
+     */
+    public String getStorageFile() {
+        return storageFile;
+    }
+
+    /**
+     * Returns attribute specified by parsed Credential Store URI
+     *
+     * @return attribute from Credential Store URI, if attribute was not specified then {@code null}
+     */
+    public String getAttribute() {
+        return attribute;
+    }
+
+    /**
+     * Fetch parameter value from query string.
+     *
+     * @param param name of wanted parameter
+     * @return parameter value as a {@code String} or {@code null} if parameter was not specified in query part of the URI
+     */
+    public String getParameter(final String param) {
+        return options.get(param);
+    }
+
+    /**
+     * Returns {@code Set<String>} of parameters specified by the parsed Credential Store URI.
+     * @return set of parameter names
+     */
+    public Set<String> getParameters() {
+        return options.keySet();
+    }
+
+    /**
+     * Returns new {@code Map<String, Object>} for use in {@code {@link org.wildfly.security.credential.store.CredentialStoreSpi}
+     * to initialize it.
+     * @return Map of options parsed from the Credential Store URI
+     */
+    public Map<String, String> getOptionsMap() {
+        return new HashMap<>(options);
+    }
+
+}

--- a/server/src/main/resources/schema/wildfly-config_5_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_5_0.xsd
@@ -4788,4 +4788,49 @@
             <xs:element name="extension" type="extensionType" minOccurs="1" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
+
+    <!-- Credential Reference Types -->
+    <xs:attributeGroup name="credentialReferenceStoreBased">
+        <xs:annotation>
+            <xs:documentation>
+                Group of attributes used when referencing credential through credential store.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="store" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Credential store name used to fetch credential with given 'alias' from.
+                    Credential store name has to be defined elsewhere.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Alias of credential in the credential store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="type" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Type of credential to be fetched from credential store.
+                    It is usually fully qualified class name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+
+    <xs:complexType name="credentialReferenceType">
+        <xs:attributeGroup ref="credentialReferenceStoreBased"/>
+        <xs:attribute name="clear-text" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Credential/password in clear text. Use just for testing purpose.
+                    Otherwise use credential store to mask the actual credential from your configuration.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
 </xs:schema>


### PR DESCRIPTION
:exclamation: Commits from this branch are used in numerous other topic branches so please do not cherry-pick or rebase. :exclamation:

This is initial commit that introduces:

- CredentialReference class unifying access to credentials defined through CredentialStore or holding simple secret value. It defines credential reference attribute that other subsystems can use to reference external credentials of various types.
- CredentialStoreClient class used to talk to CredentialStore to obtain secret value (credential) from it.
- CredentialStoreURIParser class that parses configuration or reference URIs for easier parameter marshaling

These changes are tracked under the following Jira issue: -
  https://issues.jboss.org/browse/WFCORE-1547

This Jira issue can be closed once the PR is merged.

If this PR is accepted is there also any chance of an early tag of WildFly Core, we have subsystem changes to follow up with but first require a tagged release we can reference.

