### PR TITLE
WFCORE-1814 Move to woodstox 5.0.3

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -201,8 +201,8 @@
 
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -55,8 +55,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
         </dependency>
 
         <dependency>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/woodstox/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/woodstox/main/module.xml
@@ -27,7 +27,7 @@
     </properties>
 
     <resources>
-        <artifact name="${org.codehaus.woodstox:woodstox-core-asl}"/>
+        <artifact name="${com.fasterxml.woodstox:woodstox-core}"/>
         <artifact name="${org.codehaus.woodstox:stax2-api}"/>
     </resources>
 

--- a/core-model-test/pom.xml
+++ b/core-model-test/pom.xml
@@ -54,8 +54,8 @@
         </dependency>
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -179,8 +179,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/patching/pom.xml
+++ b/patching/pom.xml
@@ -163,8 +163,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <version.org.apache.xerces>2.11.0.SP5</version.org.apache.xerces>
         <version.org.codehaus.plexus.plexus-utils>3.0.21</version.org.codehaus.plexus.plexus-utils>
         <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
-        <version.org.codehaus.woodstox.woodstox-core-asl>4.4.1</version.org.codehaus.woodstox.woodstox-core-asl>
+        <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.fusesource.jansi>1.11</version.org.fusesource.jansi>
         <version.org.jboss.aesh>0.66.11</version.org.jboss.aesh>
         <version.org.jboss.byteman>3.0.3</version.org.jboss.byteman>
@@ -1020,10 +1020,24 @@
                 <version>${version.org.codehaus.plexus.plexus-utils}</version>
             </dependency>
 
+            <!-- TODO: remove, here only till WildFly full moves to new GAV -->
             <dependency>
                 <groupId>org.codehaus.woodstox</groupId>
                 <artifactId>woodstox-core-asl</artifactId>
-                <version>${version.org.codehaus.woodstox.woodstox-core-asl}</version>
+                <version>4.4.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.xml.stream</groupId>
+                        <artifactId>stax-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>${version.org.codehaus.woodstox.woodstox-core}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>javax.xml.stream</groupId>

--- a/remoting/tests/pom.xml
+++ b/remoting/tests/pom.xml
@@ -51,8 +51,8 @@
         <!-- Test deps -->
 
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -161,8 +161,8 @@
         -->
         <!-- Test Dependencies -->
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/subsystem-test/framework/pom.xml
+++ b/subsystem-test/framework/pom.xml
@@ -92,8 +92,8 @@
          should probably be removed once we have proper solution on how to handle JAXP on jigsaw
          -->
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
         </dependency>
         <dependency>
             <groupId>xerces</groupId>

--- a/subsystem-test/tests/pom.xml
+++ b/subsystem-test/tests/pom.xml
@@ -52,8 +52,8 @@
            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
             <scope>test</scope> <!-- here to test WFCORE-1136 -->
         </dependency>
     </dependencies>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -183,8 +183,8 @@
         </dependency>
         <!-- needed to make JAXP work properly -->
         <dependency>
-            <groupId>org.codehaus.woodstox</groupId>
-            <artifactId>woodstox-core-asl</artifactId>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This will come handy in future wrt JDK9

Changelist vs 4.4.x we ware using before 

5.0.3 (23-Aug-2016)

- 13: `BasicStreamReader.getElementText()` behavior doesn't match Java documentation
- 15: `BasicStreamReader` should use `WstxUnexpectedCharException` instead of WstxParsingException
- 16: Incorrect validation error(s) only using Stax2 writer
- 21: 500 characters limit when calling XMLStreamReader#getText() after CDATA event

5.0.2 (10-Dec-2015)

- 10: Stax 4.0.0 is not compatible with Woodstox 5.0.1

5.0.1 (02-Apr-2015)
- 3: Initial 5.0.0 release did not contain class files (d'oh!)
- 4: Fix validation of text for an XMLStreamWriter

5.0.0 
- Attempted initial release under new home on github with new GAV