### PR TITLE
fix deployment repository test failures on windows

### DIFF
--- a/deployment-repository/src/test/java/org/jboss/as/repository/PathUtilTest.java
+++ b/deployment-repository/src/test/java/org/jboss/as/repository/PathUtilTest.java
@@ -149,9 +149,8 @@ public class PathUtilTest {
     }
 
     private String readFileContent(Path path) throws Exception {
-        try (InputStream in = Files.newInputStream(path)) {
-            return readFileContent(in);
-        }
+        byte[] bytes = Files.readAllBytes(path);
+        return new String(bytes, "UTF-8");
     }
 
     private String readFileContent(InputStream in) throws Exception {


### PR DESCRIPTION
Without this changes certain windows systems would get this failures:

```
ContentRepositoryTest.testChangeExplodedContent:228 » ExplodedContent WFLYDR00...
ContentRepositoryTest.testExplodeContent:133 » ExplodedContent WFLYDR0018: Err...
ContentRepositoryTest.testExplodeSubContent:155 » ExplodedContent WFLYDR0018: ...
ContentRepositoryTest.testListContents:279 » ExplodedContent WFLYDR0018: Error...
DeletionCollisionTest.testFileLockByReadContent:77 » ExplodedContent WFLYDR002...
DeletionCollisionTest.testFileLockByRemoveContent:100 » ExplodedContent WFLYDR...
PathUtilTest.testReadFile:141 » AccessDenied target\temp\pathutil\unarchive148...
```

Which is result of "wrongly" setting permissions when creating temporary directory.