### PR TITLE
Fix for WFCORE-1774. Suggest capabilities and CLI capability completion.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -73,6 +73,8 @@ public class Util {
     public static final String BLOCKING_TIMEOUT = "blocking-timeout";
     public static final String BROWSE_CONTENT = "browse-content";
     public static final String BYTES = "bytes";
+    public static final String CAPABILITY_REFERENCE = "capability-reference";
+    public static final String CAPABILITY_REGISTRY = "capability-registry";
     public static final String CHILDREN = "children";
     public static final String CHILD_TYPE = "child-type";
     public static final String COMBINED_DESCRIPTIONS = "combined-descriptions";

--- a/cli/src/main/java/org/jboss/as/cli/impl/ValueTypeCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ValueTypeCompleter.java
@@ -34,6 +34,7 @@ import org.jboss.as.cli.Util;
 import org.jboss.as.cli.handlers.DefaultFilenameTabCompleter;
 import org.jboss.as.cli.handlers.WindowsFilenameTabCompleter;
 import org.jboss.as.cli.operation.OperationRequestAddress;
+import org.jboss.as.cli.operation.impl.CapabilityReferenceCompleter;
 import org.jboss.as.cli.operation.impl.DefaultOperationRequestAddress;
 import org.jboss.as.cli.parsing.CharacterHandler;
 import org.jboss.as.cli.parsing.DefaultParsingState;
@@ -408,6 +409,12 @@ public class ValueTypeCompleter implements CommandLineCompleter {
                         = new DeploymentItemCompleter(address);
                 candidates = new ArrayList<>();
                 valLength = completer.complete(ctx, path, offset, candidates);
+            } else if (propType.has(Util.CAPABILITY_REFERENCE)) {
+                CapabilityReferenceCompleter completer
+                        = new CapabilityReferenceCompleter(address,
+                                propType.get(Util.CAPABILITY_REFERENCE).asString());
+                candidates = new ArrayList<>();
+                completer.complete(ctx, path, offset, candidates);
             }
             return candidates;
         }

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/AttributeTypeDescrValueCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/AttributeTypeDescrValueCompleter.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.impl.DefaultCompleter;
+import org.jboss.as.cli.operation.OperationRequestAddress;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -42,7 +43,7 @@ public class AttributeTypeDescrValueCompleter extends DefaultCompleter {
 
     private static final List<String> BOOLEAN = Arrays.asList(new String[]{"false", "true"});
 
-    public AttributeTypeDescrValueCompleter(final ModelNode attrDescr) {
+    public AttributeTypeDescrValueCompleter(final ModelNode attrDescr, OperationRequestAddress address) {
         super(new CandidatesProvider(){
 
             @Override
@@ -61,6 +62,9 @@ public class AttributeTypeDescrValueCompleter extends DefaultCompleter {
                         }
                         return values;
                     }
+                } else if (attrDescr.has(Util.CAPABILITY_REFERENCE)) {
+                    return CapabilityReferenceCompleter.getCapabilityNames(ctx, address,
+                            attrDescr.get(Util.CAPABILITY_REFERENCE).asString());
                 }
                 return Collections.emptyList();
             }});

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/CapabilityReferenceCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/CapabilityReferenceCompleter.java
@@ -1,0 +1,150 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.operation.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.DefaultCompleter;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.as.cli.operation.OperationRequestAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class CapabilityReferenceCompleter extends DefaultCompleter {
+
+    public CapabilityReferenceCompleter(OperationRequestAddress address, String staticPart) {
+        super((ctx) -> {
+            ModelNode mn;
+            try {
+                mn = toNode(address);
+            } catch (OperationFormatException ex) {
+                return Collections.emptyList();
+            }
+            return getCapabilityNames(ctx, mn, staticPart);
+        });
+    }
+
+    private static ModelNode toNode(OperationRequestAddress address) throws OperationFormatException {
+        if (address.isEmpty()) {
+            return new ModelNode();
+        }
+        ModelNode mn = new ModelNode();
+        Iterator<OperationRequestAddress.Node> iterator = address.iterator();
+        while (iterator.hasNext()) {
+            OperationRequestAddress.Node node = iterator.next();
+            if (node.getName() != null) {
+                ModelNode value = new ModelNode();
+                value.set(node.getName());
+                mn.add(new Property(node.getType(),value));
+            } else {
+                throw new OperationFormatException(
+                        "The node name is not specified for type '"
+                        + node.getType() + "'");
+            }
+        }
+        return mn;
+    }
+
+    public static List<String> getCapabilityNames(CommandContext ctx,
+            OperationRequestAddress address,
+            String staticPart) {
+        ModelNode mn;
+        try {
+            mn = toNode(address);
+        } catch (OperationFormatException ex) {
+            return Collections.emptyList();
+        }
+        return getCapabilityNames(ctx, mn, staticPart);
+    }
+
+    private static List<String> getCapabilityNames(CommandContext ctx, ModelNode address,
+            String staticPart) {
+        if (ctx.getModelControllerClient() == null) {
+            return Collections.emptyList();
+        }
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        ModelNode request;
+        try {
+            if (ctx.isDomainMode()) {
+                // capabilities registry for each host contains host wide capabilities +
+                // all other capabilities in global and other scopes.
+                // So use the contextual host (if any) capabilities registry
+                // or use the one local to the server.
+                String host = null;
+                Property prop = address.get(0).asProperty();
+                if (prop.getName().equals(Util.HOST)) {
+                    host = prop.getValue().asString();
+                } else {
+                    ModelControllerClient client = ctx.getModelControllerClient();
+                    ModelNode req = Util.buildRequest(ctx,
+                            new DefaultOperationRequestAddress(),
+                            Util.READ_ATTRIBUTE);
+                    req.get(Util.NAME).set(Util.LOCAL_HOST_NAME);
+                    ModelNode outcome = client.execute(req);
+                    if (!Util.isSuccess(outcome) || !outcome.has(Util.RESULT)) {
+                        return Collections.emptyList();
+                    }
+                    host = outcome.get(Util.RESULT).asString();
+                }
+                builder.addNode(Util.HOST, host);
+            }
+            builder.addNode(Util.CORE_SERVICE, Util.CAPABILITY_REGISTRY);
+            builder.setOperationName("suggest-capabilities");
+            builder.addProperty("name", staticPart);
+            request = builder.buildRequest();
+            request.get("dependent-address").set(address);
+        } catch (CommandFormatException | IOException e) {
+            Logger.getLogger(CapabilityReferenceCompleter.class.getName()).log(Level.FINE, null, e);
+            return Collections.emptyList();
+        }
+        List<String> lst = new ArrayList<>();
+        try {
+            ModelNode response = ctx.getModelControllerClient().execute(request);
+            if (Util.isSuccess(response)) {
+                ModelNode result = response.get(Util.RESULT);
+                if (result.isDefined()) {
+                    for (ModelNode mn : result.asList()) {
+                        lst.add(mn.asString());
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            Logger.getLogger(CapabilityReferenceCompleter.class.getName()).log(Level.FINE, null, ex);
+            return Collections.emptyList();
+        }
+        Collections.sort(lst);
+        return lst;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
@@ -366,6 +366,10 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
             if (attrDescr.has(Util.ALLOWED)) {
                 return getAllowedCompleter(prop);
             }
+            if (attrDescr.has(Util.CAPABILITY_REFERENCE)) {
+                return new CapabilityReferenceCompleter(address,
+                        attrDescr.get(Util.CAPABILITY_REFERENCE).asString());
+            }
         }
         return propCompleter;
     }
@@ -452,7 +456,7 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
                     return Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
                 }
 
-                return new AttributeTypeDescrValueCompleter(attrDescr);
+                return new AttributeTypeDescrValueCompleter(attrDescr, address);
             }});
         addGlobalOpPropCompleter(Util.READ_OPERATION_DESCRIPTION, Util.NAME, new CommandLineCompleterFactory(){
             @Override

--- a/controller/src/main/java/org/jboss/as/controller/PathAddress.java
+++ b/controller/src/main/java/org/jboss/as/controller/PathAddress.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -444,6 +444,10 @@ public class PathAddress implements Iterable<PathElement> {
     }
 
     public String toHttpStyleString() {
+        return toString('/');
+    }
+
+    public String toPathStyleString() {
         return toString('/');
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/ImmutableCapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/ImmutableCapabilityRegistry.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2015, Red Hat, Inc., and individual contributors as indicated
+ * Copyright 2016, Red Hat, Inc., and individual contributors as indicated
  * by the @authors tag.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,14 +61,14 @@ public interface ImmutableCapabilityRegistry {
      *
      * @return read only {@link Set} with all runtime capabilities and where ware they registered
      */
-    Set<CapabilityRegistration> getCapabilities();
+    Set<CapabilityRegistration<?>> getCapabilities();
 
     /**
      * Returns set of possible capabilities with there registration points registered in the registry
      *
      * @return read only {@link Set} with all possible capabilities and where ware they registered
      */
-    Set<CapabilityRegistration> getPossibleCapabilities();
+    Set<CapabilityRegistration<?>> getPossibleCapabilities();
 
     /**
      * Gets the name of the service provided by the capability, if there is one.
@@ -99,5 +99,14 @@ public interface ImmutableCapabilityRegistry {
      * @param capabilityId id of capability with its scope.
      * @return CapabilityRegistration or null if none is found
      */
-    CapabilityRegistration getCapability(CapabilityId capabilityId);
+    CapabilityRegistration<?> getCapability(CapabilityId capabilityId);
+
+    /**
+     * Retrieve all the capability names that the passed scope can access
+     * @param referencedCapability The static name of the capability
+     * @param dependentScope The scope from which the capability is referenced
+     * @return A set of capabilities name. Only the dynamic part of the name is returned
+     */
+    Set<String> getDynamicCapabilityNames(String referencedCapability,
+            CapabilityScope dependentScope);
 }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/PossibleCapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/PossibleCapabilityRegistry.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2015, Red Hat, Inc., and individual contributors as indicated
+ * Copyright 2016, Red Hat, Inc., and individual contributors as indicated
  * by the @authors tag.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,6 +47,6 @@ public interface PossibleCapabilityRegistry {
      * @return the capability that was removed, or {@code null} if no matching capability was registered or other
      * registration points for the capability still exist
      */
-    CapabilityRegistration removePossibleCapability(Capability capability, PathAddress registrationPoint);
+    CapabilityRegistration<?> removePossibleCapability(Capability capability, PathAddress registrationPoint);
 
 }

--- a/controller/src/test/java/org/jboss/as/controller/SuggestCapabilitiesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/SuggestCapabilitiesTestCase.java
@@ -1,0 +1,592 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.controller;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.capability.registry.CapabilityScope;
+import org.jboss.as.controller.capability.registry.RegistrationPoint;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import org.jboss.as.controller.registry.Resource;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+
+/**
+ * Test that the capabilities that are reachable from the dependent scope are
+ * actually reachable and suggested as possible capability.Test emulate an Host
+ * controller context. This is the more complex config.
+ * global               capabilities are accessible from any capability
+ * server-group         capabilities are accessible from server-config
+ * server-config        capabilities are accessible from server-config
+ * host                 capabilities are accessible from host and global
+ * s-binding-grp        capabilities are accessible from socket-binding, server-config and server-group
+ * s-binding-grp-child  capabilities are accessible from same child scope, from included scope or from any scope !profile and !server-groups
+ * profiles             capabilities are accessible from profiles or server-group
+ * profiles-child       capabilities are accessible from same child scope or from included profile scope
+ *
+ * @author jdenise@redhat.com
+ */
+public class SuggestCapabilitiesTestCase {
+
+    private static final String HOST = "host";
+
+    private static final PathElement MASTER_HOST = PathElement.pathElement(HOST, "master");
+
+    // global
+    private static final String GLOBAL = "global";
+    private static final String GLOBAL_CAPABILITY_STATIC_NAME = "org.wildfly.global";
+    private static final PathAddress GLOBAL_ALL = PathAddress.pathAddress(GLOBAL, "*");
+
+    // server group
+    private static final String SG_CAPABILITY_STATIC_NAME = "org.wildfly.sg";
+    private static final PathAddress SG_ALL = PathAddress.pathAddress(SERVER_GROUP, "*");
+
+    // server config
+    private static final String SC_CAPABILITY_STATIC_NAME = "org.wildfly.sc";
+    private static final PathAddress SC_ALL = PathAddress.pathAddress(MASTER_HOST,
+            PathElement.pathElement(SERVER_CONFIG, "*"));
+
+    // host
+    private static final String HOST_CAPABILITY_STATIC_NAME = "org.wildfly.host";
+    private static final PathAddress HOST_ALL = PathAddress.pathAddress(MASTER_HOST,
+            PathElement.pathElement(SUBSYSTEM, "*"));
+
+    // socket-binding-group
+    private static final String SBG_CAPABILITY_STATIC_NAME = "org.wildfly.sbg";
+    private static final PathAddress SBG_ALL
+            = PathAddress.pathAddress(SOCKET_BINDING_GROUP, "*");
+
+    // socket-binding-group-child
+    private static final String SBG_CHILD_CAPABILITY_STATIC_NAME = "org.wildfly.sbg.child";
+    private static final PathAddress SBG_CHILD_ALL
+            = PathAddress.pathAddress(SBG_ALL, PathElement.pathElement("somewhere", "*"));
+
+    // profile
+    private static final String PROFILE_CAPABILITY_STATIC_NAME = "org.wildfly.profile";
+    private static final PathAddress PROFILE_ALL
+            = PathAddress.pathAddress(PROFILE, "*");
+
+    // profile-child
+    private static final String PROFILE_CHILD_CAPABILITY_STATIC_NAME = "org.wildfly.profile.child";
+    private static final PathAddress PROFILE_CHILD_ALL
+            = PathAddress.pathAddress(PROFILE_ALL, PathElement.pathElement("somewhere", "*"));
+
+    private Set<String> globals;
+    private Set<String> sgs;
+    private Set<String> scs;
+    private Set<String> hosts;
+    private Set<String> sbgs;
+    private Set<String> sbgsChild;
+    private Set<String> profiles;
+    private Set<String> profilesChild;
+
+    private CapabilityRegistry reg = new CapabilityRegistry(false);
+
+    private void registerPossible(CapabilityRegistry reg, String cap, PathAddress address) {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(cap).build();
+        reg.registerPossibleCapability(capability, address);
+    }
+
+    private void registerCapability(CapabilityRegistry reg, String cap, PathAddress address) {
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(cap).build();
+        CapabilityScope scope = CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER, address);
+        RegistrationPoint rp = new RegistrationPoint(address, null);
+        reg.registerCapability(new RuntimeCapabilityRegistration(capability, scope, rp));
+    }
+
+    @Before
+    public void setup() {
+        reg.clear();
+        // Register all possibles.
+        registerPossible(reg, GLOBAL_CAPABILITY_STATIC_NAME, GLOBAL_ALL);
+        registerPossible(reg, SG_CAPABILITY_STATIC_NAME, SG_ALL);
+        registerPossible(reg, SC_CAPABILITY_STATIC_NAME, SC_ALL);
+        registerPossible(reg, HOST_CAPABILITY_STATIC_NAME, HOST_ALL);
+        registerPossible(reg, SBG_CAPABILITY_STATIC_NAME, SBG_ALL);
+        registerPossible(reg, SBG_CHILD_CAPABILITY_STATIC_NAME, SBG_CHILD_ALL);
+        registerPossible(reg, PROFILE_CAPABILITY_STATIC_NAME, PROFILE_ALL);
+        registerPossible(reg, PROFILE_CHILD_CAPABILITY_STATIC_NAME, PROFILE_CHILD_ALL);
+
+        // Register some concrete ones.
+        globals = registerMultipleCapabilities(reg, GLOBAL_CAPABILITY_STATIC_NAME,
+                (i) -> PathAddress.pathAddress(GLOBAL, "somewhere" + i));
+        sgs = registerMultipleCapabilities(reg, SG_CAPABILITY_STATIC_NAME,
+                (i) -> PathAddress.pathAddress(SERVER_GROUP, "server" + i));
+        scs = registerMultipleCapabilities(reg, SC_CAPABILITY_STATIC_NAME,
+                (i) -> PathAddress.pathAddress(MASTER_HOST,
+                        PathElement.pathElement(SERVER_CONFIG, "conf" + i)));
+        hosts = registerMultipleCapabilities(reg, HOST_CAPABILITY_STATIC_NAME,
+                (i) -> PathAddress.pathAddress(MASTER_HOST,
+                        PathElement.pathElement(SUBSYSTEM, "susbsystem" + i)));
+        sbgs = registerMultipleCapabilities(reg, SBG_CAPABILITY_STATIC_NAME,
+                (i) -> PathAddress.pathAddress(SOCKET_BINDING_GROUP, "socket" + i));
+        sbgsChild = registerMultipleCapabilities(reg, SBG_CHILD_CAPABILITY_STATIC_NAME,
+                (i) -> PathAddress.pathAddress(PathAddress.pathAddress(SOCKET_BINDING_GROUP, "grp" + i),
+                        PathElement.pathElement("somewhere", "child" + i)));
+        profiles = registerMultipleCapabilities(reg, PROFILE_CAPABILITY_STATIC_NAME,
+                (i) -> PathAddress.pathAddress(PROFILE, "profile" + i));
+        profilesChild = registerMultipleCapabilities(reg, PROFILE_CHILD_CAPABILITY_STATIC_NAME,
+                (i) -> PathAddress.pathAddress(PathAddress.pathAddress(PROFILE, "profile" + i),
+                        PathElement.pathElement("somewhere", "child" + i)));
+
+        reg.resolveCapabilities(Resource.Factory.create(), false);
+
+    }
+
+    private Set<String> registerMultipleCapabilities(CapabilityRegistry reg,
+            String cap, Function<Integer, PathAddress> address) {
+        Set<String> set = new HashSet<>();
+        for (int i = 0; i < 3; i++) {
+            String name = "cap-" + i;
+            registerCapability(reg, cap + "." + name, address.apply(i));
+            set.add(name);
+        }
+        return set;
+    }
+
+    private Set<String> suggestFromGlobal(String cap) {
+        return reg.getDynamicCapabilityNames(cap,
+                CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER,
+                        PathAddress.pathAddress("somewhere", "toto")));
+    }
+
+    private Set<String> suggestFromServerGroup(String cap) {
+        return reg.getDynamicCapabilityNames(cap,
+                CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER,
+                        PathAddress.pathAddress(SERVER_GROUP, "toto")));
+    }
+
+    private Set<String> suggestFromServerConfig(String cap) {
+        return reg.getDynamicCapabilityNames(cap,
+                CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER,
+                        PathAddress.pathAddress(MASTER_HOST,
+                                PathElement.pathElement(ModelDescriptionConstants.SERVER_CONFIG, "toto"))));
+    }
+
+    private Set<String> suggestFromHost(String cap) {
+        return reg.getDynamicCapabilityNames(cap,
+                CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER,
+                        PathAddress.pathAddress(MASTER_HOST,
+                                PathElement.pathElement(SUBSYSTEM, "toto"))));
+    }
+
+    private Set<String> suggestFromSocketBindingGroup(String cap) {
+        return reg.getDynamicCapabilityNames(cap,
+                CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER,
+                        PathAddress.pathAddress(SOCKET_BINDING_GROUP, "toto")));
+    }
+
+    private Set<String> suggestFromSocketBindingGroupChild(String cap) {
+        return reg.getDynamicCapabilityNames(cap,
+                CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER,
+                        PathAddress.pathAddress(PathAddress.pathAddress(SOCKET_BINDING_GROUP, "b1"),
+                                PathElement.pathElement("somewhere", "toto"))));
+    }
+
+    private Set<String> suggestFromProfile(String cap) {
+        return reg.getDynamicCapabilityNames(cap,
+                CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER,
+                        PathAddress.pathAddress(PROFILE, "toto")));
+    }
+
+    private Set<String> suggestFromProfileChild(String cap) {
+        return reg.getDynamicCapabilityNames(cap,
+                CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER,
+                        PathAddress.pathAddress(PathAddress.pathAddress(PROFILE, "toto"),
+                                PathElement.pathElement("somewhere", "there"))));
+    }
+
+    @Test
+    public void testGlobalCapability() {
+        {
+            Set<String> ret = suggestFromGlobal(GLOBAL_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(globals, ret);
+        }
+        {
+            Set<String> ret = suggestFromServerGroup(GLOBAL_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(globals, ret);
+
+        }
+        {
+            Set<String> ret = suggestFromServerConfig(GLOBAL_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(globals, ret);
+        }
+        {
+            Set<String> ret = suggestFromHost(GLOBAL_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(globals, ret);
+        }
+        {
+            Set<String> ret = suggestFromSocketBindingGroup(GLOBAL_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(globals, ret);
+        }
+
+        {
+            Set<String> ret = suggestFromSocketBindingGroupChild(GLOBAL_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(globals, ret);
+        }
+
+        {
+            Set<String> ret = suggestFromProfile(GLOBAL_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(globals, ret);
+        }
+
+        {
+            Set<String> ret = suggestFromProfileChild(GLOBAL_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(globals, ret);
+        }
+    }
+
+    @Test
+    public void testServerGroupCapability() {
+        {
+            Set<String> ret = suggestFromGlobal(SG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromServerGroup(SG_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(sgs, ret);
+
+        }
+        {
+            Set<String> ret = suggestFromServerConfig(SG_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(sgs, ret);
+        }
+        {
+            Set<String> ret = suggestFromHost(SG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromSocketBindingGroup(SG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromSocketBindingGroupChild(SG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfile(SG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfileChild(SG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+    }
+
+    @Test
+    public void testServerConfigCapability() {
+        {
+            Set<String> ret = suggestFromGlobal(SC_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromServerGroup(SC_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+
+        }
+        {
+            Set<String> ret = suggestFromServerConfig(SC_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(scs, ret);
+        }
+        {
+            Set<String> ret = suggestFromHost(SC_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromSocketBindingGroup(SC_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromSocketBindingGroupChild(SC_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfile(SC_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfileChild(SC_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+    }
+
+    @Test
+    public void testHostCapability() {
+        {
+            Set<String> ret = suggestFromGlobal(HOST_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(hosts, ret);
+        }
+        {
+            Set<String> ret = suggestFromServerGroup(HOST_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+
+        }
+        {
+            Set<String> ret = suggestFromServerConfig(HOST_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromHost(HOST_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(hosts, ret);
+        }
+        {
+            Set<String> ret = suggestFromSocketBindingGroup(HOST_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromSocketBindingGroupChild(HOST_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfile(HOST_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfileChild(HOST_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+    }
+
+    @Test
+    public void testSBGCapability() {
+        {
+            Set<String> ret = suggestFromGlobal(SBG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromServerGroup(SBG_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(sbgs, ret);
+
+        }
+        {
+            Set<String> ret = suggestFromServerConfig(SBG_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(sbgs, ret);
+        }
+        {
+            Set<String> ret = suggestFromHost(SBG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromSocketBindingGroup(SBG_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(sbgs, ret);
+        }
+
+        {
+            Set<String> ret = suggestFromSocketBindingGroupChild(SBG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfile(SBG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfileChild(SBG_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+    }
+
+    @Test
+    public void testSBGChildCapability() {
+        {
+            Set<String> ret = suggestFromGlobal(SBG_CHILD_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(sbgsChild, ret);
+        }
+        {
+            Set<String> ret = suggestFromServerGroup(SBG_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+
+        }
+        {
+            Set<String> ret = suggestFromServerConfig(SBG_CHILD_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(sbgsChild, ret);
+        }
+        {
+            Set<String> ret = suggestFromHost(SBG_CHILD_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(sbgsChild, ret);
+        }
+        {
+            Set<String> ret = suggestFromSocketBindingGroup(SBG_CHILD_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(sbgsChild, ret);
+        }
+
+        {
+            // Because not called from same binding group
+            Set<String> ret = suggestFromSocketBindingGroupChild(SBG_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = reg.getDynamicCapabilityNames(SBG_CHILD_CAPABILITY_STATIC_NAME,
+                    CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER,
+                            PathAddress.pathAddress(PathAddress.pathAddress(SOCKET_BINDING_GROUP, "grp1"),
+                                    PathElement.pathElement("somewhere", "toto"))));
+            assertTrue(ret.size() == 1);
+            assertTrue(ret.toString(), ret.contains("cap-1"));
+        }
+
+        {
+            Set<String> ret = suggestFromProfile(SBG_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfileChild(SBG_CHILD_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(sbgsChild, ret);
+        }
+    }
+
+    @Test
+    public void testProfileCapability() {
+        {
+            Set<String> ret = suggestFromGlobal(PROFILE_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromServerGroup(PROFILE_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(profiles, ret);
+
+        }
+        {
+            Set<String> ret = suggestFromServerConfig(PROFILE_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromHost(PROFILE_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromSocketBindingGroup(PROFILE_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromSocketBindingGroupChild(PROFILE_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfile(PROFILE_CAPABILITY_STATIC_NAME);
+            assertFalse(ret.isEmpty());
+            assertEquals(profiles, ret);
+        }
+
+        {
+            Set<String> ret = suggestFromProfileChild(PROFILE_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+    }
+
+    @Test
+    public void testProfileChildCapability() {
+        {
+            Set<String> ret = suggestFromGlobal(PROFILE_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromServerGroup(PROFILE_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+
+        }
+        {
+            Set<String> ret = suggestFromServerConfig(PROFILE_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromHost(PROFILE_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+        {
+            Set<String> ret = suggestFromSocketBindingGroup(PROFILE_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromSocketBindingGroupChild(PROFILE_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = suggestFromProfile(PROFILE_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            // Because not called from same child
+            Set<String> ret = suggestFromProfileChild(PROFILE_CHILD_CAPABILITY_STATIC_NAME);
+            assertTrue(ret.isEmpty());
+        }
+
+        {
+            Set<String> ret = reg.getDynamicCapabilityNames(PROFILE_CHILD_CAPABILITY_STATIC_NAME,
+                CapabilityScope.Factory.create(ProcessType.HOST_CONTROLLER,
+                        PathAddress.pathAddress(PathAddress.pathAddress(PROFILE, "profile2"),
+                                PathElement.pathElement("somewhere", "there"))));
+            assertTrue(ret.size() == 1);
+            assertTrue(ret.toString(), ret.contains("cap-2"));
+        }
+    }
+}

--- a/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
+++ b/server/src/main/resources/org/jboss/as/server/controller/descriptions/LocalDescriptions.properties
@@ -161,6 +161,9 @@ core.capability-registry.capability.name=Name of capability
 core.capability-registry.capability.scope=Scope of capability, only important in domain mode, in standalone it is always "global"
 core.capability-registry.capability.dynamic=Tells if capability is dynamic aka wildcard or not.
 core.capability-registry.capability.registration-points=List of addresses where capability is registered at.
+core.capability-registry.suggest-capabilities=Suggest capabilities that a resource can reference.
+core.capability-registry.suggest-capabilities.name=Static name of capability
+core.capability-registry.suggest-capabilities.dependent-address=Address of the dependent resource that references the capability.
 
 
 # Interfaces

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCapabilityCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCapabilityCompletionTestCase.java
@@ -1,0 +1,129 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.domain.management.cli;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.suites.CLITestSuite;
+import org.jboss.as.test.integration.management.util.CLITestUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test that a host capability registry is used to resolve interfaces
+ *
+ * @author jdenise@redhat.com
+ */
+public class CliCapabilityCompletionTestCase {
+
+    private static CommandContext ctx;
+    private static List<String> interfaces;
+    private static List<String> profiles;
+    private static DomainTestSupport testSupport;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        testSupport = CLITestSuite.createSupport(
+                CliCapabilityCompletionTestCase.class.getSimpleName());
+        ctx = CLITestUtil.getCommandContext(testSupport,
+                System.in, System.out);
+        ctx.connectController();
+        interfaces = retrieveChilds("interface");
+        profiles = retrieveChilds("profile");
+    }
+
+    private static List<String> retrieveChilds(String childType) throws Exception {
+        ModelNode req = new ModelNode();
+        req.get(Util.OPERATION).set("read-children-names");
+        req.get("child-type").set(childType);
+        ModelNode response = ctx.getModelControllerClient().execute(req);
+        if (!response.get(Util.OUTCOME).asString().equals(Util.SUCCESS)) {
+            throw new Exception("Can't retrieve interfaces");
+        }
+        if (!response.get(Util.RESULT).isDefined()) {
+            throw new Exception("Can't retrieve cilds");
+        }
+
+        List<ModelNode> itfs = response.get(Util.RESULT).asList();
+        if (itfs.isEmpty()) {
+            throw new Exception("No child found");
+        }
+        List<String> names = new ArrayList<>();
+        for (ModelNode mn : itfs) {
+            names.add(mn.asString());
+        }
+        Collections.sort(names);
+        return names;
+    }
+
+    @AfterClass
+    public static void cleanUp() throws CommandLineException {
+        ctx.terminateSession();
+        CLITestSuite.stopSupport();
+    }
+
+    /**
+     * Activate completion for simple op argument and write-attribute.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testInterfaces() throws Exception {
+        {
+            String cmd = "/socket-binding-group=standard-sockets/socket-binding=toto:add(interface=";
+            List<String> candidates = new ArrayList<>();
+            ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                    cmd.length(), candidates);
+            assertTrue(candidates.toString(), candidates.equals(interfaces));
+        }
+
+        {
+            String cmd = "/socket-binding-group=standard-sockets/socket-binding=toto:write-attribute(name=interface,value=";
+            List<String> candidates = new ArrayList<>();
+            ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                    cmd.length(), candidates);
+            assertTrue(candidates.toString(), candidates.equals(interfaces));
+        }
+    }
+
+    /**
+     * Activate completion for value-type.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testProfiles() throws Exception {
+        String cmd = "/profile=toto:add(includes=[";
+        List<String> candidates = new ArrayList<>();
+        ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                cmd.length(), candidates);
+        assertTrue(candidates.toString(), candidates.equals(profiles));
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
@@ -29,6 +29,7 @@ import java.util.LinkedList;
 import java.util.Map;
 
 import org.jboss.as.test.integration.domain.management.cli.BasicOpsTestCase;
+import org.jboss.as.test.integration.domain.management.cli.CliCapabilityCompletionTestCase;
 import org.jboss.as.test.integration.domain.management.cli.CliCompletionTestCase;
 import org.jboss.as.test.integration.domain.management.cli.CloneProfileTestCase;
 import org.jboss.as.test.integration.domain.management.cli.DeployAllDomainTestCase;
@@ -48,6 +49,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     BasicOpsTestCase.class,
+    CliCapabilityCompletionTestCase.class,
     CliCompletionTestCase.class,
     CloneProfileTestCase.class,
     UndeployWildcardDomainTestCase.class,

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCapabilityCompletionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCapabilityCompletionTestCase.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.test.integration.management.util.CLITestUtil;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+public class CliCapabilityCompletionTestCase {
+
+    private static CommandContext ctx;
+    private static final List<String> interfaces = new ArrayList();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        ctx = CLITestUtil.getCommandContext(TestSuiteEnvironment.getServerAddress(),
+                TestSuiteEnvironment.getServerPort(), System.in, System.out);
+        ctx.connectController();
+        ModelNode req = new ModelNode();
+        req.get(Util.OPERATION).set("read-children-names");
+        req.get("child-type").set("interface");
+        ModelNode response = ctx.getModelControllerClient().execute(req);
+        if (!response.get(Util.OUTCOME).asString().equals(Util.SUCCESS)) {
+            throw new Exception("Can't retrieve interfaces " + response);
+        }
+        if (!response.get(Util.RESULT).isDefined()) {
+            throw new Exception("Can't retrieve interfaces");
+        }
+
+        List<ModelNode> itfs = response.get(Util.RESULT).asList();
+        if (itfs.isEmpty()) {
+            throw new Exception("No interfaces found");
+        }
+        for(ModelNode mn : itfs) {
+            interfaces.add(mn.asString());
+        }
+        Collections.sort(interfaces);
+    }
+
+    @AfterClass
+    public static void cleanUp() throws CommandLineException {
+        ctx.terminateSession();
+    }
+
+    /**
+     * Activate completion for simple op argument and write-attribute.
+     * Value-type completion testing is done in domain (usage of profiles).
+     * @throws Exception
+     */
+    @Test
+    public void testInterfaces() throws Exception {
+        {
+            String cmd = "/socket-binding-group=standard-sockets/socket-binding=toto:add(interface=";
+            List<String> candidates = new ArrayList<>();
+            ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                    cmd.length(), candidates);
+            assertTrue(candidates.toString(), candidates.equals(interfaces));
+        }
+
+        {
+            String cmd = "/socket-binding-group=standard-sockets/socket-binding=toto:write-attribute(name=interface,value=";
+            List<String> candidates = new ArrayList<>();
+            ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                    cmd.length(), candidates);
+            assertTrue(candidates.toString(), candidates.equals(interfaces));
+        }
+    }
+}


### PR DESCRIPTION
This change incorporates cli, controller and server changes.
Something to mention is that I am using the Java FileSystem glob pattern matcher to match the capabilities registration points with the possible registration points. Looking at the /xxx/* kind of syntax, it is compliant with the Filesystem matcher (and avoid to create a special Java Pattern for these paths).

A controller unit test has been added to cover the main combinations of capability resolution according to the existing scopes.
This test is quite long and it could be reduced to cover fewer nominal cases. Let me know if you are OK to keep it or would like it to be reduced even removed if it goes too far in the knowledge of scopes.