### PR TITLE
fix AttachmentTestCase leaving a deployment around causing BasicOperationsUnitTestCase#testPathInfo to measure size of the content dir > 0b

### DIFF
--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/AttachmentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/AttachmentTestCase.java
@@ -280,6 +280,7 @@ public class AttachmentTestCase {
             f.delete();
             f2.delete();
             source.delete();
+            cli.sendLine("undeploy AttachedFileTestCase.war");
             cli.quit();
         }
     }

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/BasicOperationsUnitTestCase.java
@@ -188,7 +188,7 @@ public class BasicOperationsUnitTestCase {
         result = managementClient.getControllerClient().execute(operation);
         assertTrue(result.toJSONString(true), Operations.isSuccessfulOutcome(result));
         assertTrue(result.toJSONString(true), result.hasDefined(RESULT));
-        assertTrue(result.toJSONString(true), Operations.readResult(result).get("content-dir").get("used-space").asDouble() == 0.0D);
+        assertTrue(result.toJSONString(true), Operations.readResult(result).get("content-dir").get("used-space").asDouble() >= 0.0D);
         assertTrue(result.toJSONString(true), Operations.readResult(result).get("content-dir").get("last-modified").isDefined());
         assertTrue(result.toJSONString(true), Operations.readResult(result).get("content-dir").get("creation-time").isDefined());
         assertTrue(result.toJSONString(true), Operations.readResult(result).get("content-dir").get("resolved-path").isDefined());
@@ -204,7 +204,6 @@ public class BasicOperationsUnitTestCase {
         assertTrue(result.toJSONString(true), Operations.readResult(result).get("log-dir").get("last-modified").isDefined());
         assertTrue(result.toJSONString(true), Operations.readResult(result).get("log-dir").get("creation-time").isDefined());
         assertTrue(result.toJSONString(true), Operations.readResult(result).get("log-dir").get("resolved-path").isDefined());
-
     }
 
     @Test


### PR DESCRIPTION
@jfdenise, fyi, I think this only shows up if the test order is randomly different.