### PR TITLE
[WFCORE-1844] Avoid blocking cancellation in intra-domain communications

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerUpdateTask.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerUpdateTask.java
@@ -42,7 +42,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Future;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -158,10 +157,6 @@ class HostControllerUpdateTask {
 
         ExecutedHostRequest(AsyncFuture<OperationResponse> futureResult, OperationTransformer.TransformedOperation transformedOperation) {
             this(futureResult, transformedOperation, transformedOperation);
-        }
-
-        public Future<OperationResponse> getFinalResult() {
-            return futureResult;
         }
 
         @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerProxy.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerProxy.java
@@ -70,7 +70,7 @@ class ManagedServerProxy implements TransactionalProtocolClient {
             Set<AsyncFuture<OperationResponse>> inFlight = activeRequests.remove(old);
             if (inFlight != null) {
                 for (AsyncFuture<OperationResponse> future : inFlight) {
-                    future.cancel(true);
+                    future.asyncCancel(true);
                 }
             }
             return true;
@@ -103,7 +103,7 @@ class ManagedServerProxy implements TransactionalProtocolClient {
     private synchronized void registerFuture(TransactionalProtocolClient remoteClient, AsyncFuture<OperationResponse> future) {
         if (this.remoteClient != remoteClient) {
             // We were disconnected. Just cancel this future
-            future.cancel(true);
+            future.asyncCancel(true);
         } else {
             // Track the future for cancellation on disconnect
             Set<AsyncFuture<OperationResponse>> futures = activeRequests.get(remoteClient);


### PR DESCRIPTION
If the reason we are cancelling is because the remote process is not responding, waiting for a remote response to the cancellation request will result in uninterruptible blocking.

Also incorporates fix for WFCORE-1848 which relates to the same general area of better behavior of domain servers in the presence of java.lang.Error.