### PR TITLE
service.bat - fix quotes around domain BASE path

### DIFF
--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/service/service.bat
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/service/service.bat
@@ -462,7 +462,7 @@ if "%STOP_PATH%"=="" set STOP_PATH="%JBOSS_HOME%\bin"
 if "%STOP_SCRIPT%"=="" set STOP_SCRIPT=jboss-cli.bat
 
 if /I "%IS_DOMAIN%" == "true" (
-  if "%BASE%"=="" set BASE="%JBOSS_HOME%\domain"
+  if "%BASE%"=="" set "BASE=%JBOSS_HOME%\domain"
   if "%CONFIG%"=="" set CONFIG=domain.xml
   if "%START_SCRIPT%"=="" set START_SCRIPT=domain.bat
   set STARTPARAM="/c#set#NOPAUSE=Y#&&#!START_SCRIPT!#-Djboss.domain.base.dir=!BASE!#--domain-config=!CONFIG!#--host-config=!HOSTCONFIG!"


### PR DESCRIPTION
This was causing an extra pair of double quotes to appear in the call to wildfly-service.exe, breaking the installation for domain mode.