### PR TITLE
[WFCORE-296]: Switch URI scheme from remoting:// http-remoting:// https-remoting:// to remote:// remote+http:// and remote+https://

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContext.java
@@ -192,7 +192,7 @@ public interface CommandContext {
      *
      * The default controller will be identified as the default specified on starting the CLI will be used, if no controller was
      * specified on start up then the default defined in the CLI configuration will be used, if no default is defined then a
-     * connection to http-remoting://localhost:9990 will be used instead.
+     * connection to remote+http://localhost:9990 will be used instead.
      *
      * @throws CommandLineException in case the attempt to connect failed
      */
@@ -203,7 +203,7 @@ public interface CommandContext {
      *
      * If the controller is null then the default specified on starting the CLI will be used, if no controller was specified on
      * start up then the default defined in the CLI configuration will be used, if no default is defined then a connection to
-     * http-remoting://localhost:9990 will be used instead.
+     * remote+http://localhost:9990 will be used instead.
      *
      * @param controller the controller to connect to
      * @throws CommandLineException in case the attempt to connect failed

--- a/cli/src/main/java/org/jboss/as/cli/ControllerAddressResolver.java
+++ b/cli/src/main/java/org/jboss/as/cli/ControllerAddressResolver.java
@@ -72,14 +72,21 @@ public class ControllerAddressResolver {
         }
 
         if (port < 0) {
-            if ("remote".equals(protocol) || "remoting".equals(protocol)) {
-                port = 9999;
-            } else if ("http-remoting".equals(protocol)) {
-                port = 9990;
-            } else if ("https-remoting".equals(protocol)) {
-                port = 9993;
-            } else {
-                throw new CommandLineException("Unexpected protocol '" + protocol + "'");
+            switch (protocol) {
+                case "remote":
+                case "remoting":
+                    port = 9999;
+                    break;
+                case "remote+http":
+                case "http-remoting":
+                    port = 9990;
+                    break;
+                case "remote+https":
+                case "https-remoting":
+                    port = 9993;
+                    break;
+                default:
+                    throw new CommandLineException("Unexpected protocol '" + protocol + "'");
             }
         }
 

--- a/cli/src/main/java/org/jboss/as/cli/gui/ConnectDialog.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/ConnectDialog.java
@@ -66,7 +66,7 @@ import org.jboss.as.cli.CommandLineException;
  */
 public class ConnectDialog extends JInternalFrame {
 
-    static final String DEFAULT_REMOTE = "http-remoting://localhost:9990"; // TODO - Can this sync up with config somehow?
+    static final String DEFAULT_REMOTE = "remote+http://localhost:9990"; // TODO - Can this sync up with config somehow?
     // NOTE: CLI has no Message IDs assigned, hence Resources.getText(...);
     // This will probably requirean i18n
     static final String HINT_CONNECT = "<protocol>://<hostname>:<port> OR empty";

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -89,7 +89,9 @@ public class CLIModelControllerClient extends AbstractModelControllerClient
             endpoint.addConnectionProvider("remote", new RemoteConnectionProviderFactory(), OptionMap.EMPTY);
             endpoint.addConnectionProvider("remoting", new RemoteConnectionProviderFactory(), OptionMap.EMPTY);
             endpoint.addConnectionProvider("http-remoting", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE));
+            endpoint.addConnectionProvider("remote+http", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE));
             endpoint.addConnectionProvider("https-remoting", new HttpUpgradeConnectionProviderFactory(),  OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE));
+            endpoint.addConnectionProvider("remote+https", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE));
         } catch (IOException e) {
             throw new IllegalStateException("Failed to create remoting endpoint", e);
         }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -213,7 +213,7 @@ class CliConfigImpl implements CliConfig {
     }
 
     private CliConfigImpl() {
-        defaultControllerProtocol = "http-remoting";
+        defaultControllerProtocol = "remote+http";
 
         historyEnabled = true;
         historyFileName = ".jboss-cli-history";

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -1142,12 +1142,12 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
             } catch (RedirectException re) {
                 try {
                     URI location = new URI(re.getLocation());
-                    if ("http-remoting".equals(address.getProtocol()) && "https".equals(location.getScheme())) {
+                    if (("remote+http".equals(address.getProtocol()) || "http-remoting".equals(address.getProtocol())) && "https".equals(location.getScheme())) {
                         int port = location.getPort();
                         if (port < 0) {
                             port = 443;
                         }
-                        address = addressResolver.resolveAddress(new URI("https-remoting", null, location.getHost(), port,
+                        address = addressResolver.resolveAddress(new URI("remote+https", null, location.getHost(), port,
                                 null, null, null).toString());
                         if (visited.add(address) == false) {
                             throw new CommandLineException("Redirect to address already tried encountered Address="

--- a/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
+++ b/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
@@ -140,7 +140,7 @@ public class CLI {
      */
     public void connect(String controllerHost, int controllerPort,
             String username, char[] password) {
-        connect("http-remoting", controllerHost, controllerPort,
+        connect("remote+http", controllerHost, controllerPort,
                 username, password, null);
     }
 
@@ -155,7 +155,7 @@ public class CLI {
      */
     public void connect(String controllerHost, int controllerPort,
             String username, char[] password, String clientBindAddress) {
-        connect("http-remoting", controllerHost, controllerPort,
+        connect("remote+http", controllerHost, controllerPort,
                 username, password, clientBindAddress);
     }
 

--- a/cli/src/main/resources/help/connect.txt
+++ b/cli/src/main/resources/help/connect.txt
@@ -9,13 +9,13 @@ DESCRIPTION
   The default values can be customized by specifying the desired defaults as
   command line arguments when launching the CLI. E.g.
 
-  jboss-cli.sh controller=http-remoting://controller-host.net:1234
+  jboss-cli.sh controller=remote+http://controller-host.net:1234
 
   Or
 
   jboss-cli.sh controller=controller-host.net
 
-  In this case, the default port will be 9990 and the default protocol will be http-remoting.
+  In this case, the default port will be 9990 and the default protocol will be remote+http.
 
   Note, specifying controller argument will only set the default host and port
   values for the connect command but will not automatically connect to the
@@ -27,7 +27,7 @@ DESCRIPTION
   jboss-cli.sh --connect controller=controller-host.net
   jboss-cli.sh --connect controller=controller-host.net:1234
   jboss-cli.sh --connect controller=remote://controller-host.net:1234
-  jboss-cli.sh --connect controller=http-remoting://controller-host.net:1234
+  jboss-cli.sh --connect controller=remote+http://controller-host.net:1234
 
   The host may be any of these formats:
   - a host name, e.g. localhost
@@ -40,7 +40,7 @@ DESCRIPTION
 
 ARGUMENTS
 
-  protocol  - optional, default value is http-remoting.
+  protocol  - optional, default value is remote+http.
 
   host      - optional, default value is localhost.
 

--- a/cli/src/main/resources/schema/wildfly-cli_3_1.xsd
+++ b/cli/src/main/resources/schema/wildfly-cli_3_1.xsd
@@ -33,7 +33,7 @@
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="default-protocol" minOccurs="0" default="http-remoting">
+                <xs:element name="default-protocol" minOccurs="0" default="remote+http">
                     <xs:annotation>
                         <xs:documentation>
                             The default protocol to use when controller addresses are supplied without one.
@@ -46,8 +46,8 @@
                                     <xs:annotation>
                                         <xs:documentation>
                                             The default protocol is used where a connection address is specified and no
-                                            protocol is specified, in previous versions the port 9999 would have been used with the remoting
-                                            protocol - this attribute set to true causes the protocol to default to remoting if the port
+                                            protocol is specified, in previous versions the port 9999 would have been used with the remote
+                                            protocol - this attribute set to true causes the protocol to default to remote if the port
                                             number is 9999.
 
                                             If this attribute is set to false then the specified default is used regardless
@@ -64,7 +64,7 @@
                     <xs:annotation>
                         <xs:documentation>
                             If no default controller is specifed then the default will be assumed to be using host 'localhost'
-                            along with the default-protocol (Which will be http-remoting if not defined) and the port will be whatever
+                            along with the default-protocol (Which will be remote+http if not defined) and the port will be whatever
                             default corresponds to the selected protocol.
                         </xs:documentation>
                     </xs:annotation>

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
@@ -39,7 +39,7 @@ public class MockCliConfig implements CliConfig {
 
     @Override
     public String getDefaultControllerProtocol() {
-        return "http-remoting";
+        return "remote+http";
     }
 
     @Override
@@ -61,7 +61,7 @@ public class MockCliConfig implements CliConfig {
 
     @Override
     public ControllerAddress getDefaultControllerAddress() {
-        return new ControllerAddress("http-remoting", "localhost", 9990);
+        return new ControllerAddress("remote+http", "localhost", 9990);
     }
 
     @Override

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -156,7 +156,7 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port.
          *
-         * @param protocol The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param protocol The prototcol to use. If this is remote+http or remote+https http upgrade will be used rather than the native remote protocol
          * @param address  the address of the remote host
          * @param port     the port
          * @return A model controller client
@@ -189,7 +189,7 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port.
          *
-         * @param protocol The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param protocol The prototcol to use. If this is remote+http or remote+https http upgrade will be used rather than the native remote protocol
          * @param address  the address of the remote host
          * @param port     the port
          * @param handler  CallbackHandler to obtain authentication information for the call.
@@ -227,7 +227,7 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port.
          *
-         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used
+         * @param protocol    The prototcol to use. If this is remote+http or remote+https http upgrade will be used
          * @param address     the address of the remote host
          * @param port        the port
          * @param handler     CallbackHandler to obtain authentication information for the call.
@@ -264,7 +264,7 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port.
          *
-         * @param protocol The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param protocol The prototcol to use. If this is remote+http or remote+https http upgrade will be used rather than the native remote protocol
          * @param hostName the remote host
          * @param port     the port
          * @return A model controller client
@@ -298,7 +298,7 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *
-         * @param protocol The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param protocol The prototcol to use. If this is remote+http or remote+https http upgrade will be used rather than the native remote protocol
          * @param hostName the remote host
          * @param port     the port
          * @param handler  CallbackHandler to obtain authentication information for the call.
@@ -338,7 +338,7 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *
-         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param protocol    The prototcol to use. If this is remote+http or remote+https http upgrade will be used rather than the native remote protocol
          * @param hostName   the remote host
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
@@ -384,7 +384,7 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *
-         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param protocol    The prototcol to use. If this is remote+http or remote+https http upgrade will be used rather than the native remote protocol
          * @param hostName   the remote host
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
@@ -433,7 +433,7 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *
-         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param protocol    The prototcol to use. If this is remote+http or remote+https http upgrade will be used rather than the native remote protocol
          * @param hostName   the remote host
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
@@ -487,7 +487,7 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *
-         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param protocol    The prototcol to use. If this is remote+http or remote+https http upgrade will be used rather than the native remote protocol
          * @param hostName   the remote host
          * @param port       the port
          * @param handler    CallbackHandler to obtain authentication information for the call.
@@ -537,7 +537,7 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *
-         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param protocol    The prototcol to use. If this is remote+http or remote+https http upgrade will be used rather than the native remote protocol
          * @param hostName    the remote host
          * @param port        the port
          * @param handler     CallbackHandler to obtain authentication information for the call.

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/ProtocolConfigurationFactory.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/ProtocolConfigurationFactory.java
@@ -45,7 +45,7 @@ class ProtocolConfigurationFactory {
         URI connURI;
         if(client.getProtocol() == null) {
             // WFLY-1462 for compatibility assume remoting if the standard native port is configured
-            String protocol = client.getPort() == 9999 ? "remote://" : "http-remoting://";
+            String protocol = client.getPort() == 9999 ? "remote://" : "remote+http://";
             connURI = new URI(protocol + formatPossibleIpv6Address(client.getHost()) +  ":" + client.getPort());
         } else  {
             connURI = new URI(client.getProtocol() + "://" + formatPossibleIpv6Address(client.getHost()) +  ":" + client.getPort());

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/RemotingModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/RemotingModelControllerClient.java
@@ -120,7 +120,9 @@ public class RemotingModelControllerClient extends AbstractModelControllerClient
                 endpoint = Remoting.createEndpoint("management-client", OptionMap.EMPTY);
                 endpoint.addConnectionProvider("remote", new RemoteConnectionProviderFactory(), OptionMap.EMPTY);
                 endpoint.addConnectionProvider("http-remoting", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE));
+                endpoint.addConnectionProvider("remote+http", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE));
                 endpoint.addConnectionProvider("https-remoting", new HttpUpgradeConnectionProviderFactory(),  OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE));
+                endpoint.addConnectionProvider("remote+https", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE));
 
                 final ProtocolConnectionConfiguration configuration = ProtocolConfigurationFactory.create(clientConfiguration, endpoint);
 

--- a/core-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/core-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -61,7 +61,7 @@
     <domain-controller>
         <remote security-realm="ManagementRealm">
             <discovery-options>
-                <static-discovery name="primary" protocol="${jboss.domain.master.protocol:http-remoting}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9990}"/>
+                <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote+http}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9990}"/>
             </discovery-options>
         </remote>
     </domain-controller>

--- a/core-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/core-feature-pack/src/main/resources/configuration/host/host.xml
@@ -57,7 +57,7 @@
     <domain-controller>
         <local/>
         <!-- Alternative remote domain controller configuration with a host and port -->
-        <!-- <remote protocol="http-remoting" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm"/> -->
+        <!-- <remote protocol="remote+http" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.xml
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.xml
@@ -5,11 +5,11 @@
 -->
 <jboss-cli xmlns="urn:jboss:cli:3.1">
 
-    <default-protocol use-legacy-override="true">http-remoting</default-protocol>
+    <default-protocol use-legacy-override="true">remote+http</default-protocol>
 
     <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
     <default-controller>
-        <protocol>http-remoting</protocol>
+        <protocol>remote+http</protocol>
         <host>localhost</host>
         <port>9990</port>
     </default-controller>
@@ -17,7 +17,7 @@
     <!-- Example controller alias named 'Test'  
     <controllers>
         <controller name="Test">
-            <protocol>http-remoting</protocol>
+            <protocol>remote+http</protocol>
             <host>localhost</host>
             <port>9990</port>
         </controller>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/host/host-http-remoting-domain-manager.xml
@@ -28,7 +28,7 @@
     </management>
 
     <domain-controller>
-       <remote host="${jboss.domain.master.address:127.0.0.1}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm" protocol="http-remoting" />
+       <remote host="${jboss.domain.master.address:127.0.0.1}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm" protocol="remote+http" />
     </domain-controller>
 
     <interfaces>

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -39,8 +39,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUC
 import static org.jboss.as.domain.controller.HostConnectionInfo.Events.create;
 import static org.jboss.as.host.controller.logging.HostControllerLogger.DOMAIN_LOGGER;
 import static org.jboss.as.host.controller.logging.HostControllerLogger.ROOT_LOGGER;
-import static org.jboss.as.remoting.Protocol.HTTPS_REMOTING;
-import static org.jboss.as.remoting.Protocol.HTTP_REMOTING;
+import static org.jboss.as.remoting.Protocol.REMOTE_HTTPS;
+import static org.jboss.as.remoting.Protocol.REMOTE_HTTP;
 import static org.jboss.as.remoting.Protocol.REMOTE;
 
 import java.beans.PropertyChangeEvent;
@@ -822,7 +822,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
         if (hostControllerInfo.getHttpManagementSecureInterface() != null && !hostControllerInfo.getHttpManagementSecureInterface().isEmpty()
                 && hostControllerInfo.getHttpManagementSecurePort() > 0) {
             return ServerInventoryService.install(serviceTarget, this, runningModeControl, environment, extensionRegistry,
-                    hostControllerInfo.getHttpManagementSecureInterface(), hostControllerInfo.getHttpManagementSecurePort(), HTTPS_REMOTING.toString());
+                    hostControllerInfo.getHttpManagementSecureInterface(), hostControllerInfo.getHttpManagementSecurePort(), REMOTE_HTTPS.toString());
         }
         if (hostControllerInfo.getNativeManagementInterface() != null && !hostControllerInfo.getNativeManagementInterface().isEmpty()
                 && hostControllerInfo.getNativeManagementPort() > 0) {
@@ -833,7 +833,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
             return getPlaceHolderInventory();
         }
         return ServerInventoryService.install(serviceTarget, this, runningModeControl, environment, extensionRegistry,
-                hostControllerInfo.getHttpManagementInterface(), hostControllerInfo.getHttpManagementPort(), HTTP_REMOTING.toString());
+                hostControllerInfo.getHttpManagementInterface(), hostControllerInfo.getHttpManagementPort(), REMOTE_HTTP.toString());
     }
 
     private void installDiscoveryService(final ServiceTarget serviceTarget, List<DiscoveryOption> discoveryOptions) {
@@ -846,12 +846,12 @@ public class DomainModelControllerService extends AbstractControllerService impl
         if (hostControllerInfo.getHttpManagementSecureInterface() != null && !hostControllerInfo.getHttpManagementSecureInterface().isEmpty()
                 && hostControllerInfo.getHttpManagementSecurePort() > 0) {
             interfaces.add(new DomainControllerManagementInterface(hostControllerInfo.getHttpManagementSecurePort(),
-                    hostControllerInfo.getHttpManagementSecureInterface(), HTTPS_REMOTING));
+                    hostControllerInfo.getHttpManagementSecureInterface(), REMOTE_HTTPS));
         }
         if (hostControllerInfo.getHttpManagementInterface() != null && !hostControllerInfo.getHttpManagementInterface().isEmpty()
                 && hostControllerInfo.getHttpManagementPort() > 0) {
             interfaces.add(new DomainControllerManagementInterface(hostControllerInfo.getHttpManagementPort(),
-                    hostControllerInfo.getHttpManagementInterface(), HTTP_REMOTING));
+                    hostControllerInfo.getHttpManagementInterface(), REMOTE_HTTP));
         }
         DiscoveryService.install(serviceTarget, discoveryOptions, interfaces, hostControllerInfo.isMasterDomainController());
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/discovery/DomainControllerData.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/discovery/DomainControllerData.java
@@ -105,9 +105,9 @@ public class DomainControllerData {
     @Override
     public String toString() {
         StringBuilder sb=new StringBuilder();
-        sb.append("master_host=" + getHost());
-        sb.append(",master_port=" + getPort());
-        sb.append(",master_protocol=" + getProtocol());
+        sb.append("master_host=").append(getHost());
+        sb.append(",master_port=").append(getPort());
+        sb.append(",master_protocol=").append(getProtocol());
         return sb.toString();
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/discovery/S3Discovery.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/discovery/S3Discovery.java
@@ -117,11 +117,13 @@ public class S3Discovery implements DiscoveryOption {
             Collections.sort(data, new Comparator<DomainControllerData>() {
                 @Override
                 public int compare(DomainControllerData data, DomainControllerData otherData) {
-                    if (Protocol.REMOTE.toString().equals(data.getProtocol())) {
+                    Protocol protocol = Protocol.forName(data.getProtocol());
+                    if (Protocol.REMOTE == protocol) {
                         return 1;
                     }
-                    if (Protocol.HTTPS_REMOTING.toString().equals(data.getProtocol())) {
-                        if (Protocol.REMOTE.toString().equals(otherData.getProtocol())) {
+                    if (Protocol.HTTPS_REMOTING == protocol || Protocol.REMOTE_HTTPS == protocol) {
+                        Protocol otherProtocol  = Protocol.forName(otherData.getProtocol());
+                        if (Protocol.REMOTE == otherProtocol) {
                             return -1;
                         }
                         return 1;

--- a/host-controller/src/test/java/org/jboss/as/host/controller/discovery/S3UtilTest.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/discovery/S3UtilTest.java
@@ -22,8 +22,8 @@ package org.jboss.as.host.controller.discovery;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.jboss.as.remoting.Protocol.HTTP_REMOTING;
 import static org.jboss.as.remoting.Protocol.REMOTE;
+import static org.jboss.as.remoting.Protocol.REMOTE_HTTP;
 import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -48,10 +48,10 @@ public class S3UtilTest {
      */
     @Test
     public void testDomainControllerDataToByteBuffer() throws Exception {
-        List<DomainControllerData> data = Arrays.asList(new DomainControllerData[]{new DomainControllerData(REMOTE.toString(), "native.example.com", 9999), new DomainControllerData(HTTP_REMOTING.toString(), "http.example.com", 9990)});
+        List<DomainControllerData> data = Arrays.asList(new DomainControllerData[]{new DomainControllerData(REMOTE.toString(), "native.example.com", 9999), new DomainControllerData(REMOTE_HTTP.toString(), "http.example.com", 9990)});
         byte[] bytes = S3Util.domainControllerDataToByteBuffer(data);
         assertThat(bytes, is(notNullValue()));
-        assertThat(bytes.length, is(80));
+        assertThat(bytes.length, is(78));
         List<DomainControllerData> result = S3Util.domainControllerDataFromByteBuffer(bytes);
         assertThat(result, is(notNullValue()));
         assertThat(result.size(), is(2));

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
@@ -80,13 +80,17 @@ public class ProtocolConnectionConfiguration {
     public void setUri(URI uri) {
         this.uri = uri;
         if (uri != null) {
-            String scheme = uri.getScheme();
-            if ("http-remoting".equals(scheme)) {
-                this.sslEnabled = false;
-                this.useStartTLS = false;
-            } else if ("https-remoting".equals(scheme)) {
-                this.sslEnabled = true;
-                this.useStartTLS = false;
+            switch(uri.getScheme()) {
+                case "http-remoting":
+                case "remote+http":
+                    this.sslEnabled = false;
+                    this.useStartTLS = false;
+                    break;
+                case "https-remoting":
+                case "remote+https":
+                    this.sslEnabled = true;
+                    this.useStartTLS = false;
+                    break;
             }
         }
     }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/EndpointService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/EndpointService.java
@@ -75,10 +75,22 @@ public class EndpointService implements Service<Endpoint> {
             endpoint = createEndpoint();
             try {
                 // Reuse the options for the remote connection factory for now
-                endpoint.addConnectionProvider(Protocol.REMOTE.toString(), new RemoteConnectionProviderFactory(), optionMap);
-                endpoint.addConnectionProvider(Protocol.HTTP_REMOTING.toString(), new HttpUpgradeConnectionProviderFactory(), optionMap);
-                endpoint.addConnectionProvider(Protocol.HTTPS_REMOTING.toString(), new HttpUpgradeConnectionProviderFactory(),
-                        OptionMap.builder().set(Options.SSL_ENABLED, true).addAll(optionMap).getMap());
+                for(Protocol protocol : Protocol.values()) {
+                    switch(protocol) {
+                        case REMOTE:
+                            endpoint.addConnectionProvider(protocol.toString(), new RemoteConnectionProviderFactory(), optionMap);
+                            break;
+                        case HTTPS_REMOTING:
+                        case REMOTE_HTTPS:
+                            endpoint.addConnectionProvider(protocol.toString(), new HttpUpgradeConnectionProviderFactory(),
+                                    OptionMap.builder().set(Options.SSL_ENABLED, true).addAll(optionMap).getMap());
+                            break;
+                        case HTTP_REMOTING:
+                        case REMOTE_HTTP:
+                            endpoint.addConnectionProvider(protocol.toString(), new HttpUpgradeConnectionProviderFactory(), optionMap);
+                            break;
+                    }
+                }
                 ok = true;
             } finally {
                 if (! ok) {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/InjectedSocketBindingStreamServerService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/InjectedSocketBindingStreamServerService.java
@@ -52,7 +52,7 @@ public class InjectedSocketBindingStreamServerService extends AbstractStreamServ
     @Override
     public void start(final StartContext context) throws StartException {
         super.start(context);
-        RemotingConnectorBindingInfoService.install(context.getChildTarget(), context.getController().getName().getSimpleName(), getSocketBinding(), Protocol.REMOTE.toString());
+        RemotingConnectorBindingInfoService.install(context.getChildTarget(), context.getController().getName().getSimpleName(), getSocketBinding(), Protocol.REMOTE);
     }
 
     @Override

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/Namespace.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/Namespace.java
@@ -39,7 +39,8 @@ public enum Namespace {
     REMOTING_1_2("urn:jboss:domain:remoting:1.2"),
     REMOTING_2_0("urn:jboss:domain:remoting:2.0"),
     REMOTING_3_0("urn:jboss:domain:remoting:3.0"),
-    REMOTING_4_0("urn:jboss:domain:remoting:4.0")
+    REMOTING_4_0("urn:jboss:domain:remoting:4.0"),
+    REMOTING_5_0("urn:jboss:domain:remoting:5.0")
     ;
 
     /**

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/Protocol.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/Protocol.java
@@ -14,8 +14,10 @@ import org.jboss.dmr.ModelNode;
 public enum Protocol {
 
     REMOTE("remote"),
+    REMOTE_HTTP("remote+http"),
     HTTP_REMOTING("http-remoting"),
-    HTTPS_REMOTING("https-remoting");
+    HTTPS_REMOTING("https-remoting"),
+    REMOTE_HTTPS("remote+https");
 
     private static final Map<String, Protocol> MAP;
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingConnectorBindingInfoService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingConnectorBindingInfoService.java
@@ -49,7 +49,12 @@ public class RemotingConnectorBindingInfoService implements Service<RemotingConn
         return SERVICE_NAME.append(connectorName);
     }
 
+    @Deprecated
     public static void install(final ServiceTarget target, final String connectorName, final SocketBinding binding, final String protocol) {
+        target.addService(serviceName(connectorName), new RemotingConnectorBindingInfoService(new RemotingConnectorInfo(binding, Protocol.forName(protocol)))).install();
+    }
+
+    public static void install(final ServiceTarget target, final String connectorName, final SocketBinding binding, final Protocol protocol) {
         target.addService(serviceName(connectorName), new RemotingConnectorBindingInfoService(new RemotingConnectorInfo(binding, protocol))).install();
     }
 
@@ -68,9 +73,9 @@ public class RemotingConnectorBindingInfoService implements Service<RemotingConn
 
     public static final class RemotingConnectorInfo {
         private final SocketBinding socketBinding;
-        private final String protocol;
+        private final Protocol protocol;
 
-        public RemotingConnectorInfo(SocketBinding socketBinding, String protocol) {
+        public RemotingConnectorInfo(SocketBinding socketBinding, Protocol protocol) {
             this.socketBinding = socketBinding;
             this.protocol = protocol;
         }
@@ -80,7 +85,7 @@ public class RemotingConnectorBindingInfoService implements Service<RemotingConn
         }
 
         public String getProtocol() {
-            return protocol;
+            return protocol.toString();
         }
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -129,6 +129,7 @@ public class RemotingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_2_0.getUriString(), RemotingSubsystem20Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_3_0.getUriString(), RemotingSubsystem30Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_4_0.getUriString(), RemotingSubsystem40Parser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_5_0.getUriString(), RemotingSubsystem50Parser.INSTANCE);
 
         // For servers only as a migration aid we'll install io if it is missing.
         // It is invalid to do this on an HC as the HC needs to support profiles running legacy

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingHttpUpgradeService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingHttpUpgradeService.java
@@ -21,6 +21,9 @@
  */
 package org.jboss.as.remoting;
 
+import static org.jboss.as.remoting.Protocol.REMOTE_HTTP;
+import static org.jboss.as.remoting.Protocol.REMOTE_HTTPS;
+
 import java.io.IOException;
 
 import io.undertow.server.ListenerRegistry;
@@ -118,7 +121,7 @@ public class RemotingHttpUpgradeService implements Service<RemotingHttpUpgradeSe
         ListenerRegistry.Listener listenerInfo = listenerRegistry.getValue().getListener(httpConnectorName);
         assert listenerInfo != null;
         listenerInfo.addHttpUpgradeMetadata(httpUpgradeMetadata = new ListenerRegistry.HttpUpgradeMetadata("jboss-remoting", endpointName));
-        RemotingConnectorBindingInfoService.install(context.getChildTarget(), context.getController().getName().getSimpleName(), (SocketBinding)listenerInfo.getContextInformation("socket-binding"), listenerInfo.getProtocol().equals("https") ? "https-remoting" : "http-remoting");
+        RemotingConnectorBindingInfoService.install(context.getChildTarget(), context.getController().getName().getSimpleName(), (SocketBinding)listenerInfo.getContextInformation("socket-binding"), listenerInfo.getProtocol().equals("https") ? REMOTE_HTTPS : REMOTE_HTTP);
 
         if (connectorPropertiesOptionMap != null) {
             builder.addAll(connectorPropertiesOptionMap);

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem50Parser.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem50Parser.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.remoting;
+
+/**
+ * Parser for version 4.0 of the subsystem schema.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class RemotingSubsystem50Parser extends RemotingSubsystem30Parser {
+
+    static final RemotingSubsystem50Parser INSTANCE = new RemotingSubsystem50Parser();
+
+    private RemotingSubsystem50Parser() {
+    }
+
+
+}

--- a/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
+++ b/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
@@ -79,7 +79,7 @@ remote-outbound-connection.name=Name of the remote:// URI scheme based outbound 
 remote-outbound-connection.outbound-socket-binding-ref=Name of the outbound-socket-binding which will be used to determine the destination address and port for the connection.
 remote-outbound-connection.username=The user name to use when authenticating against the remote server.
 remote-outbound-connection.security-realm=Reference to the security realm to use to obtain the password and SSL configuration.
-remote-outbound-connection.protocol=The protocol to use for the remote connection. Defaults to http-remoting.
+remote-outbound-connection.protocol=The protocol to use for the remote connection. Defaults to remote+http.
 remote-outbound-connection.property=The XNIO Options that will be used during the connection creation.
 
 

--- a/remoting/subsystem/src/main/resources/schema/wildfly-remoting_5_0.xsd
+++ b/remoting/subsystem/src/main/resources/schema/wildfly-remoting_5_0.xsd
@@ -1,0 +1,561 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:domain:remoting:5.0"
+            xmlns="urn:jboss:domain:remoting:5.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="5.0">
+
+    <!-- The remoting subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of the Remoting subsystem.
+
+                The 'worker-thread-pool' element configures the worker thread pool.
+                The nested "connector" element(s) define connectors for this subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element name="worker-thread-pool" type="workerThreadsType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                   Deprecated and replaced with the 'endpoint' configuration that can reference a worker from the IO subsystem.
+                   This is only supported for use in managed domain profiles whose servers are all running on
+                   previous versions that do not support the 'endpoint' configuration. Use in a server
+                   running a version after the introduction of the 'endpoint' configuration will result
+                   in an error.
+               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="endpoint" type="endpointType"></xs:element>
+            </xs:choice>
+            <xs:element name="connector" type="connector" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="http-connector" type="http-connector" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="outbound-connections" minOccurs="0" type="outbound-connectionsType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="workerThreadsType">
+           <xs:annotation>
+               <xs:documentation>
+                   <![CDATA[
+                   Deprecated configuration of the worker thread pool.
+
+                   Only supported for legacy servers in a managed domain.
+               ]]>
+               </xs:documentation>
+           </xs:annotation>
+           <xs:attribute name="read-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="write-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-core-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-max-threads" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-keepalive" type="xs:integer" use="optional"/>
+           <xs:attribute name="task-limit" type="xs:integer" use="optional"/>
+       </xs:complexType>
+
+
+    <xs:complexType name="endpointType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                Configures the remoting endpoint.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="worker" type="xs:string" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                The name of the IO subsystem worker the endpoint should use.
+            ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
+        <xs:attribute name="authorize-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        The SASL authorization ID.  Used as authentication user name to use if no authentication {@code CallbackHandler} is specified
+                                    and the selected SASL mechanism demands a user name.
+                       ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="auth-realm" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    The authentication realm to use if no authentication {@code CallbackHandler} is specified.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sasl-protocol" type="xs:string" default="remote+http">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[Where a SaslServer or SaslClient are created by default the protocol specified it 'remoting', this can be used to override this.
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-message-size" type="xs:long" default="9223372036854775807">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum outbound message size to send.  No messages larger than this well be transmitted; attempting to do so will cause an exception on the writing side.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="buffer-region-size" type="xs:positiveInteger">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The size of allocated buffer regions.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="receive-buffer-size" type="xs:positiveInteger" default="8192">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The size of the largest buffer that this endpoint will accept over a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-retries" type="xs:positiveInteger" default="3">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[Specify the number of times a client is allowed to retry authentication before closing the connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="transmit-window-size" type="xs:positiveInteger" default="131072">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum window size of the transmit direction for connection channels, in bytes.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-messages" type="xs:positiveInteger" default="65535">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of outbound channels to support for a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="send-buffer-size" type="xs:positiveInteger" default="8192">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The size of the largest buffer that this endpoint will transmit over a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-messages" type="xs:positiveInteger" default="80">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of inbound channels to support for a connection.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="receive-window-size" type="xs:positiveInteger" default="131072">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum window size of the receive direction for connection channels, in bytes.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="heartbeat-interval" type="xs:positiveInteger" default="2147483647">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The interval to use for connection heartbeat, in milliseconds.  If the connection is idle in the outbound direction\
+                    for this amount of time, a ping message will be sent, which will trigger a corresponding reply message.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-message-size" type="xs:long" default="9223372036854775807">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum inbound message size to be allowed.  Messages exceeding this size will cause an exception to be thrown on the reading side as well as the writing side.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-outbound-channels" type="xs:positiveInteger" default="40">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of concurrent outbound messages on a channel.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-inbound-channels" type="xs:positiveInteger" default="40">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The maximum number of concurrent inbound messages on a channel.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="server-name">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The server side of the connection passes it's name to the client in the initial greeting, by default the name is automatically discovered from the local address of the connection or it can be overridden using this.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="abstractConnector" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The base configuration of a Remoting connector.
+
+                The "name" attribute specifies the unique name of this connector.
+
+                The optional nested "sasl" element contains the SASL authentication configuration for this connector.
+
+                The optional nested "authentication-provider" element contains the name of the authentication provider to
+                use for incoming connections.
+                
+                The optional server-name attribute specifies the server name that should be used in the initial exchange with
+                the client and within the SASL mechanisms used for authentication.
+
+                The optional sasl-protocol attribute specifies the protocol that should be used within the SASL mechanisms. 
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="sasl" type="sasl" minOccurs="0"/>
+            <xs:element name="authentication-provider" type="ref" minOccurs="0"/>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="security-realm" type="xs:string" use="optional"/>
+        <xs:attribute name="server-name" type="xs:string" use="optional" />
+        <xs:attribute name="sasl-protocol" type="xs:string" default="remote" />
+    </xs:complexType>
+    
+    <xs:complexType name="connector">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of a Remoting connector.
+
+                The "socket-binding" attribute specifies the name of the socket binding to attach to.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstractConnector">
+                <xs:attribute name="socket-binding" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="http-connector">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of a Remoting HTTP upgrade based connector.
+
+                The "connector-ref" specifies the name of the Undertow http connector to use.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="abstractConnector">
+                <xs:attribute name="connector-ref" type="name-list" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sasl">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of the SASL authentication layer for this server.
+
+                The optional nested "include-mechanisms" element contains a whitelist of allowed SASL mechanism names.
+                No mechanisms will be allowed which are not present in this list.
+
+                The optional nested "qop" element contains a list of quality-of-protection values, in decreasing order
+                of preference.
+
+                The optional nested "strength" element contains a list of cipher strength values, in decreasing order
+                of preference.
+
+                The optional nested "reuse-session" boolean element specifies whether or not the server should attempt
+                to reuse previously authenticated session information.  The mechanism may or may not support such reuse,
+                and other factors may also prevent it.
+
+                The optional nested "server-auth" boolean element specifies whether the server should authenticate to the
+                client.  Not all mechanisms may support this setting.
+
+                The optional nested "policy" boolean element specifies a policy to use to narrow down the available set
+                of mechanisms.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="include-mechanisms" type="name-listType" minOccurs="0"/>
+            <xs:element name="qop" type="qop-listType" minOccurs="0"/>
+            <xs:element name="strength" type="strength-listType" minOccurs="0"/>
+            <xs:element name="reuse-session" type="boolean-element" minOccurs="0"/>
+            <xs:element name="server-auth" type="boolean-element" minOccurs="0"/>
+            <xs:element name="policy" type="policy" minOccurs="0"/>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="policy">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                Policy criteria items to use in order to choose a SASL mechanism.
+
+                The optional nested "forward-secrecy" element contains a boolean value which specifies whether mechanisms
+                that implement forward secrecy between sessions are required. Forward secrecy means that breaking into
+                one session will not automatically provide information for breaking into future sessions.
+
+                The optional nested "no-active" element contains a boolean value which specifies whether mechanisms
+                susceptible to active (non-dictionary) attacks are not permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-anonymous" element contains a boolean value which specifies whether mechanisms
+                that accept anonymous login are permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-dictionary" element contains a boolean value which specifies whether mechanisms
+                susceptible to passive dictionary attacks are permitted.  "false" to permit, "true" to deny.
+
+                The optional nested "no-plain-text" element contains a boolean value which specifies whether mechanisms
+                susceptible to simple plain passive attacks (e.g., "PLAIN") are not permitted.    "false" to permit, "true" to deny.
+
+                The optional nested "pass-credentials" element contains a boolean value which specifies whether
+                mechanisms that pass client credentials are required.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="forward-secrecy" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-active" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-anonymous" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-dictionary" type="boolean-element" minOccurs="0"/>
+            <xs:element name="no-plain-text" type="boolean-element" minOccurs="0"/>
+            <xs:element name="pass-credentials" type="boolean-element" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="boolean-element">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                An element specifying a boolean value.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="xs:boolean" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="name-listType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                An element specifying a string list.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="name-list" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="name-list">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A set of string items.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <xs:complexType name="qop-listType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                An element specifying a qop list.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="qop-list" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="qop-list">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The SASL quality-of-protection value list.  See http://download.oracle.com/docs/cd/E17409_01/javase/6/docs/api/javax/security/sasl/Sasl.html#QOP
+                for more information.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="auth"/>
+                    <xs:enumeration value="auth-int"/>
+                    <xs:enumeration value="auth-conf"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
+
+    <xs:complexType name="strength-listType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                An element specifying a strength list.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" type="strength-list" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="strength-list">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The SASL strength value list.  See http://download.oracle.com/docs/cd/E17409_01/javase/6/docs/api/javax/security/sasl/Sasl.html#STRENGTH
+                for more information.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:list>
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="low"/>
+                    <xs:enumeration value="medium"/>
+                    <xs:enumeration value="high"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:list>
+    </xs:simpleType>
+
+    <xs:complexType name="properties">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A set of free-form properties.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="property"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="property">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A free-form property.  The name is required; the value is optional.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="ref">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A reference to another named service.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-connectionsType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="local-outbound-connection" type="local-outbound-connectionType" />
+            <xs:element name="remote-outbound-connection" type="remote-outbound-connectionType" />
+            <xs:element name="outbound-connection" type="outbound-connectionType" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="base-outbound-connectionType">
+        <xs:all>
+            <xs:element name="properties" type="properties" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="uri" type="xs:anyURI" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="local-outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="outbound-socket-binding-ref" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="remote-outbound-connectionType">
+        <xs:complexContent>
+            <xs:extension base="base-outbound-connectionType">
+                <xs:attribute name="outbound-socket-binding-ref" type="xs:string" use="required"/>
+                <xs:attribute name="username" type="xs:string" use="optional"/>
+                <xs:attribute name="security-realm" type="xs:string" use="optional"/>
+                <xs:attribute name="protocol" type="xs:string" use="optional"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+</xs:schema>

--- a/remoting/subsystem/src/main/resources/subsystem-templates/remoting.xml
+++ b/remoting/subsystem/src/main/resources/subsystem-templates/remoting.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.remoting</extension-module>
-   <subsystem xmlns="urn:jboss:domain:remoting:4.0">
+   <subsystem xmlns="urn:jboss:domain:remoting:5.0">
        <endpoint/>
        <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
    </subsystem>

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
@@ -106,7 +106,7 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-remoting_4_0.xsd";
+        return "schema/wildfly-remoting_5_0.xsd";
     }
 
     @Override

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-expressions.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-expressions.xml
@@ -33,7 +33,7 @@
             <property name="org.xnio.Options.SSL_ENABLED" value="${generic.outbound.connection.prop:false}"/>
          </properties>
       </outbound-connection>
-      <remote-outbound-connection name="remote-conn1" outbound-socket-binding-ref="dummy-outbound-socket" username="${remoting.user:myuser}" security-realm="test-realm" protocol="https-remoting">
+      <remote-outbound-connection name="remote-conn1" outbound-socket-binding-ref="dummy-outbound-socket" username="${remoting.user:myuser}" security-realm="test-realm" protocol="remote+https">
          <properties>
             <property name="org.xnio.Options.SSL_ENABLED" value="${remote.outbound.connection.prop:false}"/>
          </properties>

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-outbound-connections.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-outbound-connections.xml
@@ -2,7 +2,7 @@
     <connector name="test-connector" socket-binding="test"/>
 
         <outbound-connections>
-            <remote-outbound-connection name="remote-conn1" outbound-socket-binding-ref="dummy-outbound-socket" protocol="http-remoting">
+            <remote-outbound-connection name="remote-conn1" outbound-socket-binding-ref="dummy-outbound-socket" protocol="remote+http">
                 <properties>
                     <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="false"/>
                     <property name="org.xnio.Options.SSL_ENABLED" value="false"/>

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:remoting:4.0">
+<subsystem xmlns="urn:jboss:domain:remoting:5.0">
     <endpoint
         worker="default-remoting"
         send-buffer-size="8191"

--- a/server/src/main/resources/schema/wildfly-config_5_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_5_0.xsd
@@ -3301,6 +3301,8 @@
             <xs:enumeration value="remote"/>
             <xs:enumeration value="http-remoting"/>
             <xs:enumeration value="https-remoting"/>
+            <xs:enumeration value="remote+http"/>
+            <xs:enumeration value="remote+https"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnHttpTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/RespawnHttpTestCase.java
@@ -73,7 +73,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SHUTDOWN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 
-import org.jboss.as.remoting.Protocol;
 
 /**
  * RespawnTestCase
@@ -103,7 +102,7 @@ public class RespawnHttpTestCase {
     public static void createProcessController() throws IOException, URISyntaxException, NoSuchAlgorithmException {
 
         // Setup client
-        utils = TestControllerUtils.create(Protocol.HTTP_REMOTING.toString(), DomainTestSupport.masterAddress, HC_PORT, getCallbackHandler());
+        utils = TestControllerUtils.create("remote+http", DomainTestSupport.masterAddress, HC_PORT, getCallbackHandler());
         client = new TestControllerClient(utils.getConfiguration(), utils.getExecutor());
 
         final String testName = RespawnHttpTestCase.class.getSimpleName();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/TestControllerUtils.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/respawn/TestControllerUtils.java
@@ -48,7 +48,9 @@ class TestControllerUtils implements Closeable {
         final Endpoint endpoint = Remoting.createEndpoint(ENDPOINT_NAME, OptionMap.EMPTY);
         endpoint.addConnectionProvider("remote", new RemoteConnectionProviderFactory(), OptionMap.EMPTY);
         endpoint.addConnectionProvider("http-remoting", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE));
+        endpoint.addConnectionProvider("remote+http", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE));
         endpoint.addConnectionProvider("https-remoting", new HttpUpgradeConnectionProviderFactory(),  OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE));
+        endpoint.addConnectionProvider("remote+https", new HttpUpgradeConnectionProviderFactory(),  OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE));
         final ProtocolConnectionConfiguration configuration = ProtocolConnectionConfiguration.create(endpoint, uri);
         configuration.setCallbackHandler(callbackHandler);
         return new TestControllerUtils(endpoint, configuration, createDefaultExecutor());

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/JmxAuditLogFieldsOfLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/JmxAuditLogFieldsOfLogTestCase.java
@@ -172,7 +172,7 @@ public class JmxAuditLogFieldsOfLogTestCase {
 
     private MBeanServerConnection setupAndGetConnection() throws Exception {
         String urlString = System.getProperty("jmx.service.url",
-                "service:jmx:http-remoting-jmx://" + container.getClient().getMgmtAddress() + ":" + container.getClient().getMgmtPort());
+                "service:jmx:remote+http://" + container.getClient().getMgmtAddress() + ":" + container.getClient().getMgmtPort());
         JMXServiceURL serviceURL = new JMXServiceURL(urlString);
         connector = JMXConnectorFactory.connect(serviceURL, null);
         return connector.getMBeanServerConnection();

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CommandTimeoutHandlerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CommandTimeoutHandlerTestCase.java
@@ -128,7 +128,7 @@ public class CommandTimeoutHandlerTestCase {
                 EmptySubsystemParser.class.getPackage());
         CommandContextConfiguration config = new CommandContextConfiguration.Builder().
                 setInitConsole(true).setConsoleOutput(consoleOutput).
-                setController("http-remoting://"
+                setController("remote+http://"
                         + TestSuiteEnvironment.getServerAddress() + ":"
                         + TestSuiteEnvironment.getServerPort()).
                 setCommandTimeout(CONFIG_TIMEOUT).build();

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ShutdownTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ShutdownTestCase.java
@@ -46,7 +46,7 @@ public class ShutdownTestCase {
     public void test() throws Exception {
         serverController.start();
         CommandContextConfiguration config = new CommandContextConfiguration.Builder().
-                setController("http-remoting://"
+                setController("remote+http://"
                         + TestSuiteEnvironment.getServerAddress() + ":"
                         + TestSuiteEnvironment.getServerPort()).build();
         CommandContext ctx = CommandContextFactory.getInstance().newCommandContext(config);

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
@@ -147,11 +147,11 @@ public class PreparedResponseTestCase {
     static ManagementClient getManagementClient() {
         ModelControllerClient client = null;
         try {
-            client = ModelControllerClient.Factory.create("http-remoting", InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
+            client = ModelControllerClient.Factory.create("remote+http", InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
                     TestSuiteEnvironment.getServerPort(), new org.wildfly.core.testrunner.Authentication.CallbackHandler());
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);
         }
-        return new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+        return new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
     }
 }

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/RemoveManagementInterfaceTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/RemoveManagementInterfaceTestCase.java
@@ -177,7 +177,7 @@ public class RemoveManagementInterfaceTestCase {
     static ModelControllerClient getHttpModelControllerClient() {
         ModelControllerClient client = null;
         try {
-            client = ModelControllerClient.Factory.create("http-remoting", InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
+            client = ModelControllerClient.Factory.create("remote+http", InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
                     MANAGEMENT_HTTP_PORT, new org.wildfly.core.testrunner.Authentication.CallbackHandler());
         } catch (UnknownHostException e) {
             throw new RuntimeException(e);

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/NativeApiPatchingTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/NativeApiPatchingTestCase.java
@@ -135,7 +135,7 @@ public class NativeApiPatchingTestCase extends AbstractPatchingTestCase {
     }
 
     private ModelControllerClient getControllerClient() throws UnknownHostException {
-        return ModelControllerClient.Factory.create("http-remoting", System.getProperty("node0", "127.0.0.1"), 9990);
+        return ModelControllerClient.Factory.create("remote+http", System.getProperty("node0", "127.0.0.1"), 9990);
     }
 
 }

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoPatchIdUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoPatchIdUnitTestCase.java
@@ -79,7 +79,7 @@ public class RemotePatchInfoPatchIdUnitTestCase extends AbstractPatchingTestCase
         // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
         System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
 
-        String controller = "http-remoting://" + TestSuiteEnvironment.getHttpAddress() + ":9990";
+        String controller = "remote+http://" + TestSuiteEnvironment.getHttpAddress() + ":9990";
         ctx = CommandContextFactory.getInstance().newCommandContext(controller, null, null, System.in, bytesOs);
     }
 

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoUnitTestCase.java
@@ -80,7 +80,7 @@ public class RemotePatchInfoUnitTestCase extends AbstractPatchingTestCase {
         bytesOs = new ByteArrayOutputStream();
         // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
         System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
-        String controller =   "http-remoting://" + NetworkUtils.formatPossibleIpv6Address(System.getProperty("node0", "127.0.0.1")) + ":9990";
+        String controller =   "remote+http://" + NetworkUtils.formatPossibleIpv6Address(System.getProperty("node0", "127.0.0.1")) + ":9990";
         ctx = CommandContextFactory.getInstance().newCommandContext(controller, null, null, System.in, bytesOs);
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainControllerClientConfig.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainControllerClientConfig.java
@@ -40,9 +40,11 @@ import javax.security.auth.callback.CallbackHandler;
 import org.jboss.as.protocol.ProtocolConnectionConfiguration;
 import org.jboss.remoting3.Endpoint;
 import org.jboss.remoting3.Remoting;
+import org.jboss.remoting3.remote.HttpUpgradeConnectionProviderFactory;
 import org.jboss.remoting3.remote.RemoteConnectionProviderFactory;
 import org.jboss.threads.JBossThreadFactory;
 import org.xnio.OptionMap;
+import org.xnio.Options;
 
 /**
  * Shared test configuration where all {@linkplain org.jboss.as.controller.client.ModelControllerClient}s share a common {@linkplain Endpoint} and
@@ -114,6 +116,10 @@ public class DomainControllerClientConfig implements Closeable {
     static DomainControllerClientConfig create(final ExecutorService executorService, boolean destroyExecutor) throws IOException {
         final Endpoint endpoint = Remoting.createEndpoint(ENDPOINT_NAME, OptionMap.EMPTY);
         endpoint.addConnectionProvider("remote", new RemoteConnectionProviderFactory(), OptionMap.EMPTY);
+        endpoint.addConnectionProvider("http-remoting", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE));
+        endpoint.addConnectionProvider("remote+http", new HttpUpgradeConnectionProviderFactory(), OptionMap.create(Options.SSL_ENABLED, Boolean.FALSE));
+        endpoint.addConnectionProvider("https-remoting", new HttpUpgradeConnectionProviderFactory(),  OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE));
+        endpoint.addConnectionProvider("remote+https", new HttpUpgradeConnectionProviderFactory(),  OptionMap.create(Options.SSL_ENABLED, Boolean.TRUE));
         return new DomainControllerClientConfig(endpoint, executorService, destroyExecutor);
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
@@ -50,7 +50,7 @@ public class CLITestUtil {
     public static CommandContext getCommandContext() throws CliInitializationException {
         System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         setJBossCliConfig();
-        return CommandContextFactory.getInstance().newCommandContext(constructUri("http-remoting", serverAddr , serverPort), null, null);
+        return CommandContextFactory.getInstance().newCommandContext(constructUri("remote+http", serverAddr , serverPort), null, null);
     }
 
     public static CommandContext getCommandContext(DomainTestSupport domainTestSupport) throws CliInitializationException {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
@@ -131,7 +131,7 @@ public class CLIWrapper implements AutoCloseable {
     public final boolean sendConnect(String cliAddress) {
         try {
             if (cliAddress!=null) {
-                ctx.connectController(new URI("http-remoting", null, cliAddress, TestSuiteEnvironment.getServerPort(), null, null, null).toString());
+                ctx.connectController(new URI("remote+http", null, cliAddress, TestSuiteEnvironment.getServerPort(), null, null, null).toString());
             }else{
                 ctx.connectController();//use already configured ctx
             }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CustomCLIExecutor.java
@@ -54,11 +54,11 @@ public class CustomCLIExecutor {
     public static final int MANAGEMENT_NATIVE_PORT = 9999;
     public static final int MANAGEMENT_HTTP_PORT = 9990;
     public static final int MANAGEMENT_HTTPS_PORT = 9993;
-    public static final String NATIVE_CONTROLLER = "remoting://" + TestSuiteEnvironment.getServerAddress() + ":"
+    public static final String NATIVE_CONTROLLER = "remote://" + TestSuiteEnvironment.getServerAddress() + ":"
             + MANAGEMENT_NATIVE_PORT;
-    public static final String HTTP_CONTROLLER = "http-remoting://" + TestSuiteEnvironment.getServerAddress() + ":"
+    public static final String HTTP_CONTROLLER = "remote+http://" + TestSuiteEnvironment.getServerAddress() + ":"
             + MANAGEMENT_HTTP_PORT;
-    public static final String HTTPS_CONTROLLER = "https-remoting://" + TestSuiteEnvironment.getServerAddress() + ":"
+    public static final String HTTPS_CONTROLLER = "remote+https://" + TestSuiteEnvironment.getServerAddress() + ":"
             + MANAGEMENT_HTTPS_PORT;
 
     private static Logger LOGGER = Logger.getLogger(CustomCLIExecutor.class);

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/security/common/jboss-cli.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/security/common/jboss-cli.xml
@@ -7,7 +7,7 @@
 
     <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
     <default-controller>
-    	<protocol>http-remoting</protocol>
+	<protocol>remote+http</protocol>
         <host>${hostname}</host>
         <port>9990</port>
     </default-controller>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/JmxAuditLogTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/auditlog/JmxAuditLogTestCase.java
@@ -149,7 +149,7 @@ public class JmxAuditLogTestCase {
 
     private MBeanServerConnection setupAndGetConnection() throws Exception {
         String urlString = System.getProperty("jmx.service.url",
-                "service:jmx:http-remoting-jmx://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
+                "service:jmx:remote+http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
         JMXServiceURL serviceURL = new JMXServiceURL(urlString);
         connector = JMXConnectorFactory.connect(serviceURL, null);
         return connector.getMBeanServerConnection();

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
@@ -227,7 +227,7 @@ public class ModelControllerMBeanTestCase {
     private MBeanServerConnection setupAndGetConnection() throws Exception {
         // Make sure that we can connect to the MBean server
         String urlString = System
-                .getProperty("jmx.service.url", "service:jmx:http-remoting-jmx://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
+                .getProperty("jmx.service.url", "service:jmx:remote+http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
         JMXServiceURL serviceURL = new JMXServiceURL(urlString);
         connector = JMXConnectorFactory.connect(serviceURL, null);
         return connector.getMBeanServerConnection();

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeployTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeployTestCase.java
@@ -61,7 +61,7 @@ public class DeployTestCase {
     public static void before() throws Exception {
         CommandContextConfiguration.Builder configBuilder = new CommandContextConfiguration.Builder();
         configBuilder.setInitConsole(true).setConsoleInput(System.in).setConsoleOutput(System.out).
-                setController("http-remoting://" + TestSuiteEnvironment.getServerAddress()
+                setController("remote+http://" + TestSuiteEnvironment.getServerAddress()
                         + ":" + TestSuiteEnvironment.getServerPort());
         ctx = CommandContextFactory.getInstance().newCommandContext(configBuilder.build());
         ctx.connectController();

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ManagementClient.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ManagementClient.java
@@ -251,12 +251,15 @@ public class ManagementClient implements AutoCloseable, Closeable {
 
     public JMXServiceURL getRemoteJMXURL() {
         try {
-            if (mgmtProtocol.equals("http-remoting")) {
-                return new JMXServiceURL("service:jmx:http-remoting-jmx://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":" + mgmtPort);
-            } else if (mgmtProtocol.equals("https-remoting")) {
-                return new JMXServiceURL("service:jmx:https-remoting-jmx://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":" + mgmtPort);
-            } else {
-                return new JMXServiceURL("service:jmx:remoting-jmx://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":" + mgmtPort);
+            switch (mgmtProtocol) {
+                case "http-remoting":
+                case "remote+http":
+                    return new JMXServiceURL("service:jmx:remote+http://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":" + mgmtPort);
+                case "https-remoting":
+                case "remote+https":
+                    return new JMXServiceURL("service:jmx:remote+https://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":" + mgmtPort);
+                default:
+                    return new JMXServiceURL("service:jmx:remote://" + NetworkUtils.formatPossibleIpv6Address(mgmtAddress) + ":" + mgmtPort);
             }
         } catch (Exception e) {
             throw new RuntimeException("Could not create JMXServiceURL:" + this, e);
@@ -283,7 +286,7 @@ public class ManagementClient implements AutoCloseable, Closeable {
         if (ejbUri == null) {
             URI webUri = getWebUri();
             try {
-                ejbUri = new URI("http-remoting", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(),null,null,null);
+                ejbUri = new URI("remote+http", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(),null,null,null);
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);
             }

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -53,7 +53,7 @@ public class Server {
     private String serverConfig = System.getProperty("server.config", "standalone.xml");
     private final int managementPort = Integer.getInteger("management.port", 9990);
     private final String managementAddress = System.getProperty("management.address", "localhost");
-    private final String managementProtocol = System.getProperty("management.protocol", "http-remoting");
+    private final String managementProtocol = System.getProperty("management.protocol", "remote+http");
 
     private final String serverDebug = "wildfly.debug";
     private final int serverDebugPort = Integer.getInteger("wildfly.debug.port", 8787);


### PR DESCRIPTION
Changing also the URL format for JMX and the default protocol is schemas.

Jira: https://issues.jboss.org/browse/WFCORE-296