### PR TITLE
Fix for WFCORE-1857. No completion for invalid operation

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/operation/OperationRequestCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/OperationRequestCompleter.java
@@ -142,7 +142,14 @@ public class OperationRequestCompleter implements CommandLineCompleter {
             final Collection<CommandArgument> allArgs = candidatesProvider.getProperties(ctx, parsedCmd.getOperationName(), parsedCmd.getAddress());
             if (allArgs.isEmpty()) {
                 final CommandLineFormat format = parsedCmd.getFormat();
-                if (format != null && format.getPropertyListEnd() != null && format.getPropertyListEnd().length() > 0) {
+                // If no arguments are provided, the only valid case is that the operation
+                // has no arguments. Invalid cases are (wrong operation, exception, ..
+                // In the valid case the operation should be closed.
+                // If some properties are already typed, something is wrong, do not complete
+                if (!parsedCmd.hasProperties()
+                        && format != null
+                        && format.getPropertyListEnd() != null
+                        && format.getPropertyListEnd().length() > 0) {
                     candidates.add(format.getPropertyListEnd());
                 }
                 return buffer.length();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -1252,4 +1252,22 @@ public class CliCompletionTestCase {
             ctx.terminateSession();
         }
     }
+
+    @Test
+    public void testInvalidOperation() throws Exception {
+        CommandContext ctx = CLITestUtil.getCommandContext(testSupport,
+                System.in, System.out);
+        ctx.connectController();
+        try {
+            {
+                String cmd = "/subsystem=ohnoabug:dodo(cc";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertTrue(candidates.toString(), candidates.isEmpty());
+            }
+        } finally {
+            ctx.terminateSession();
+        }
+    }
 }


### PR DESCRIPTION
When the candidates provider returns an empty list of arguments it can be caused by:
- No arguments in the operation
- An error occurred (invalid operation)

If the provider returns an empty list BUT the user has typed some content, then there is a mismatch. The empty list must have been caused by an error, so do not complete.
