### PR TITLE
[WFCORE-1869]: When unregistering a ressource in the MMR, if the address targets an alias then we should just 'ignore' the unregistering of the submodel.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -255,13 +255,15 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
 
             if (subregistry != null) {
                 //we remove also children, effectively doing recursive delete
-                Set<PathElement> children = getChildAddresses(PathAddress.pathAddress(address));
-                if (children != null) {
-                    for (PathElement a : children) {
-                        subregistry.getResourceRegistration(PathAddress.EMPTY_ADDRESS.iterator(), address.getValue()).unregisterSubModel(a);
+                Set<PathElement> childAddresses = getChildAddresses(PathAddress.pathAddress(address));
+                if (childAddresses != null) {
+                    ManagementResourceRegistration registration = subregistry.getResourceRegistration(PathAddress.EMPTY_ADDRESS.iterator(), address.getValue());
+                    if(!registration.isAlias()) {
+                        for (PathElement a : childAddresses) {
+                            registration.unregisterSubModel(a);
+                        }
                     }
                 }
-
                 subregistry.unregisterSubModel(address.getValue());
             }
             if (constraintUtilizationRegistry != null) {


### PR DESCRIPTION
Ignoring the unregistration of an alias children submodel.

Jira: https://issues.jboss.org/browse/WFCORE-1869