### PR TITLE
WFCORE-773 ArrayIndexOutOfBoundsException occurs when a queue-length is 0 in th…

### DIFF
--- a/threads/src/main/java/org/jboss/as/threads/PoolAttributeDefinitions.java
+++ b/threads/src/main/java/org/jboss/as/threads/PoolAttributeDefinitions.java
@@ -56,7 +56,7 @@ public interface PoolAttributeDefinitions {
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
 
     SimpleAttributeDefinition QUEUE_LENGTH = new SimpleAttributeDefinitionBuilder(CommonAttributes.QUEUE_LENGTH, ModelType.INT, false)
-            .setValidator(new IntRangeValidator(0, Integer.MAX_VALUE, false, true)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
+            .setValidator(new IntRangeValidator(1, Integer.MAX_VALUE, false, true)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
 
     SimpleAttributeDefinition ALLOW_CORE_TIMEOUT = new SimpleAttributeDefinitionBuilder(CommonAttributes.ALLOW_CORE_TIMEOUT, ModelType.BOOLEAN, true)
             .setAllowExpression(true)


### PR DESCRIPTION
Set range validation to avoid ArrayIndexOfBoundsException.

https://issues.jboss.org/browse/WFCORE-773