### PR TITLE
Fix for WFCORE-1878. Use * to identify all disabled deployments.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
@@ -84,7 +84,7 @@ public class DeployHandler extends DeploymentHandler {
     private AccessRequirement deployPermission;
     private PerNodeOperationAccess serverGroupAddPermission;
 
-    private static final String ALL = "<all>";
+    private static final String ALL = "*";
 
     public DeployHandler(CommandContext ctx) {
         super(ctx, "deploy", true);

--- a/cli/src/main/resources/help/deploy.txt
+++ b/cli/src/main/resources/help/deploy.txt
@@ -12,7 +12,8 @@ DESCRIPTION
 
   Deploys the application designated by the file_path or enables an already
   existing but disabled in the repository deployment designated by the name
-  argument. <all> can be used to identify all existing but disabled deployments. 
+  argument. '*' can be used to identify all existing but disabled deployments.
+  NB: '*' is not a pattern but identifies "all disabled deployments".
   If executed w/o arguments, will list all the existing deployments.
 
 ARGUMENTS
@@ -40,8 +41,8 @@ ARGUMENTS
                      argument isn't specified then the command is supposed to
                      enable an already existing but disabled deployment, and in
                      this case the name argument is required.
-                     In order to identify all disabled deployments, <all>
-                     can be used as name value. <all> can be used both in standalone 
+                     In order to identify all disabled deployments, '*'
+                     can be used as name value. '*' can be used both in standalone 
                      and domain mode.
 
  --runtime-name    - optional, the runtime name for the deployment. This will

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeployAllDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeployAllDomainTestCase.java
@@ -147,7 +147,7 @@ public class DeployAllDomainTestCase {
         checkDeployment(sgTwo, cliTestApp2War.getName(), false);
         checkDeployment(sgTwo, cliTestAppEar.getName(), false);
         // Deploy them all.
-        ctx.handle("deploy --name=<all> --server-groups=" + sgTwo + ',' + sgOne);
+        ctx.handle("deploy --name=* --server-groups=" + sgTwo + ',' + sgOne);
         checkDeployment(sgOne, cliTestApp1War.getName(), true);
         checkDeployment(sgOne, cliTestAnotherWar.getName(), true);
         checkDeployment(sgOne, cliTestAppEar.getName(), true);
@@ -155,15 +155,6 @@ public class DeployAllDomainTestCase {
         checkDeployment(sgTwo, cliTestApp2War.getName(), true);
         checkDeployment(sgTwo, cliTestAppEar.getName(), true);
 
-    }
-
-    private void disableDeployment(String serverGroup, String name) throws CommandFormatException, IOException {
-        ModelNode mn = ctx.buildRequest("/server-group=" + serverGroup
-                + "/deployment=" + name + ":undeploy()");
-        ModelNode response = ctx.getModelControllerClient().execute(mn);
-        if (!response.hasDefined(Util.OUTCOME) || !response.get(Util.OUTCOME).asString().equals(Util.SUCCESS)) {
-            throw new CommandFormatException(name + " can't be dosabled");
-        }
     }
 
     private void checkDeployment(String serverGroup, String name, boolean enabled) throws CommandFormatException, IOException {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeployTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeployTestCase.java
@@ -107,7 +107,7 @@ public class DeployTestCase {
         checkDeployment(cliTestAnotherWar.getName(), false);
         checkDeployment(cliTestApp2War.getName(), false);
         // Deploy them all.
-        ctx.handle("deploy --name=<all>");
+        ctx.handle("deploy --name=*");
         checkDeployment(cliTestApp1War.getName(), true);
         checkDeployment(cliTestAnotherWar.getName(), true);
         checkDeployment(cliTestApp2War.getName(), true);
@@ -120,27 +120,18 @@ public class DeployTestCase {
             List<String> candidates = new ArrayList<>();
             ctx.getDefaultCommandCompleter().complete(ctx, cmd,
                     cmd.length(), candidates);
-            assertTrue(candidates.toString(), candidates.contains("<all>"));
+            assertTrue(candidates.toString(), candidates.contains("*"));
             assertTrue(candidates.toString(), candidates.contains(cliTestApp1War.getName()));
             assertTrue(candidates.toString(), candidates.contains(cliTestAnotherWar.getName()));
             assertTrue(candidates.toString(), candidates.contains(cliTestApp2War.getName()));
         }
 
         {
-            String cmd = "deploy --name=<";
+            String cmd = "deploy --name=*";
             List<String> candidates = new ArrayList<>();
             ctx.getDefaultCommandCompleter().complete(ctx, cmd,
                     cmd.length(), candidates);
-            assertTrue(candidates.toString(), candidates.contains("<all> "));
-            assertTrue(candidates.toString(), candidates.size() == 1);
-        }
-
-        {
-            String cmd = "deploy --name=<all>";
-            List<String> candidates = new ArrayList<>();
-            ctx.getDefaultCommandCompleter().complete(ctx, cmd,
-                    cmd.length(), candidates);
-            assertTrue(candidates.toString(), candidates.contains("<all> "));
+            assertTrue(candidates.toString(), candidates.contains("* "));
             assertTrue(candidates.toString(), candidates.size() == 1);
         }
 


### PR DESCRIPTION
Replace '<all>' with '*'. '<' and '>' characters could conflict with future CLI developments.