### PR TITLE
un-deprecate DeprecatedResourceDescriptionResolver

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/DeprecatedResourceDescriptionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/DeprecatedResourceDescriptionResolver.java
@@ -28,7 +28,6 @@ import java.util.ResourceBundle;
  * This is useful when you need to deprecate whole subsystem and don't want to add deprecated key entries for each any every resource / attribute / operation
  * @author Tomaz Cerar (c) 2015 Red Hat Inc.
  */
-@Deprecated
 public class DeprecatedResourceDescriptionResolver extends StandardResourceDescriptionResolver {
     private final String DEPRECATED_KEY;
 


### PR DESCRIPTION
 this class is used to help with deprecating subsystems, but itself is not really deprecated, it was just producing useless warnings in all subsystems that are using it