### PR TITLE
[2.x] [WCFORE-1845] During boot skip validating/verifying runtime resources

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -54,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -496,7 +497,7 @@ class ModelControllerImpl implements ModelController {
                 //Get the modified resources from the initial operations and add to the resources to be validated by the post operations
                 Set<PathAddress> validateAddresses = new HashSet<PathAddress>();
                 Resource root = managementModel.get().getRootResource();
-                addAllAddresses(PathAddress.EMPTY_ADDRESS, root, validateAddresses);
+                addAllAddresses(managementModel.get().getRootResourceRegistration(), PathAddress.EMPTY_ADDRESS, root, validateAddresses);
 
                 final AbstractOperationContext validateContext = new OperationContextImpl(operationID, POST_EXTENSION_BOOT_OPERATION,
                         EMPTY_ADDRESS, this, processType, runningModeControl.getRunningMode(),
@@ -511,16 +512,34 @@ class ModelControllerImpl implements ModelController {
         return  resultAction == OperationContext.ResultAction.KEEP;
     }
 
-    private void addAllAddresses(PathAddress current, Resource resource, Set<PathAddress> addresses) {
+    private void addAllAddresses(ImmutableManagementResourceRegistration mrr, PathAddress current, Resource resource, Set<PathAddress> addresses) {
         addresses.add(current);
-
-        for (String name : resource.getChildTypes()) {
+        for (String name : getNonIgnoredChildTypes(mrr)) {
             for (ResourceEntry entry : resource.getChildren(name)) {
                 if (!entry.isProxy() && !entry.isRuntime()) {
-                    addAllAddresses(current.append(entry.getPathElement()), entry, addresses);
+                    addAllAddresses(mrr.getSubModel(PathAddress.pathAddress(entry.getPathElement())), current.append(entry.getPathElement()), entry, addresses);
                 }
             }
         }
+    }
+
+    /**
+     * Creates a set of child types that are not {@linkplain ImmutableManagementResourceRegistration#isRemote() remote}
+     * or {@linkplain ImmutableManagementResourceRegistration#isRuntimeOnly() runtime} child types.
+     *
+     * @param mrr the resource registration to process the child types for
+     *
+     * @return a collection of non-remote and non-runtime only child types
+     */
+    private static Set<String> getNonIgnoredChildTypes(ImmutableManagementResourceRegistration mrr) {
+        final Set<String> result = new LinkedHashSet<>();
+        for (PathElement pe : mrr.getChildAddresses(PathAddress.EMPTY_ADDRESS)) {
+            ImmutableManagementResourceRegistration childMrr = mrr.getSubModel(PathAddress.pathAddress(pe));
+            if (childMrr != null && !childMrr.isRemote() && !childMrr.isRuntimeOnly()) {
+                result.add(pe.getKey());
+            }
+        }
+        return result;
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -774,7 +774,7 @@ class ModelControllerImpl implements ModelController {
 
     ConfigurationPersister.PersistenceResource writeModel(final ManagementModelImpl model, Set<PathAddress> affectedAddresses) throws ConfigurationPersistenceException {
         ControllerLogger.MGMT_OP_LOGGER.tracef("persisting %s from %s", model.rootResource, model);
-        final ModelNode newModel = Resource.Tools.readModel(model.rootResource);
+        final ModelNode newModel = Resource.Tools.readModel(model.rootResource, model.resourceRegistration);
         final ConfigurationPersister.PersistenceResource delegate = persister.store(newModel, affectedAddresses);
         return new ConfigurationPersister.PersistenceResource() {
 

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -864,14 +864,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         if(recursive) {
             return model.clone();
         } else {
-            final Resource copy = Resource.Factory.create();
-            copy.writeModel(model.getModel());
-            for(final String childType : model.getChildTypes()) {
-                for(final Resource.ResourceEntry child : model.getChildren(childType)) {
-                    copy.registerChild(child.getPathElement(), PlaceholderResource.INSTANCE);
-                }
-            }
-            return copy;
+            return model.shallowCopy();
         }
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/ValidateModelStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ValidateModelStepHandler.java
@@ -178,15 +178,20 @@ class ValidateModelStepHandler implements OperationStepHandler {
     private Resource loadResource(OperationContext context) {
         final PathAddress address = context.getCurrentAddress();
         PathAddress current = PathAddress.EMPTY_ADDRESS;
+        final ImmutableManagementResourceRegistration mrr = context.getRootResourceRegistration();
         Resource resource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, false);
         for (PathElement element : address) {
             if (resource.isRuntime()){
                 return null;
             }
+            current = current.append(element);
+            final ImmutableManagementResourceRegistration subMrr = mrr.getSubModel(current);
+            if (subMrr == null || subMrr.isRuntimeOnly() || subMrr.isRemote()) {
+                return null;
+            }
             if (!resource.hasChild(element)) {
                 return null;
             }
-            current = current.append(element);
             resource = context.readResourceFromRoot(current, false);
         }
         if (resource.isRuntime()) {

--- a/controller/src/main/java/org/jboss/as/controller/registry/Resource.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/Resource.java
@@ -161,12 +161,49 @@ public interface Resource extends Cloneable {
      */
     Set<String> getOrderedChildTypes();
 
+    /**
+     * Gets whether this resource only exists in the runtime and has no representation in the
+     * persistent configuration model.
+     *
+     * @return {@code true} if the resource has no representation in the
+     * persistent configuration model; {@code false} otherwise
+     */
     boolean isRuntime();
+
+    /**
+     * Gets whether operations against this resource will be proxied to a remote process.
+     *
+     * @return {@code true} if this resource represents a remote resource; {@code false} otherwise
+     */
     boolean isProxy();
 
+    /**
+     * Creates and returns a copy of this resource.
+     *
+     * @return the clone. Will not return {@code null}
+     */
     Resource clone();
 
-    public interface ResourceEntry extends Resource {
+    /**
+     * Creates a shallow copy of this resource, which will only have placeholder resources
+     * for immediate children. Those placeholder resources will return an empty
+     * {@link org.jboss.as.controller.registry.Resource#getModel() model} and will not themselves have any children.
+     * Their presence, however, allows the caller to see what immediate children exist under the target resource.
+     * @return the shallow copy. Will not return {@code null}
+     */
+    default Resource shallowCopy() {
+
+        final Resource copy = Resource.Factory.create();
+        copy.writeModel(getModel());
+        for(final String childType : getChildTypes()) {
+            for(final Resource.ResourceEntry child : getChildren(childType)) {
+                copy.registerChild(child.getPathElement(), PlaceholderResource.INSTANCE);
+            }
+        }
+        return copy;
+    }
+
+    interface ResourceEntry extends Resource {
 
         /**
          * Get the name this resource was registered under.

--- a/controller/src/main/java/org/jboss/as/controller/registry/Resource.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/Resource.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.controller.registry;
 
+import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -221,7 +222,7 @@ public interface Resource extends Cloneable {
 
     }
 
-    public static class Factory {
+    class Factory {
 
         private Factory() { }
 
@@ -258,7 +259,7 @@ public interface Resource extends Cloneable {
         }
     }
 
-    public static class Tools {
+    class Tools {
 
         /**
          * A {@link ResourceFilter} that returns {@code false} for {@link Resource#isRuntime() runtime} and
@@ -300,6 +301,33 @@ public interface Resource extends Cloneable {
         }
 
         /**
+         * Recursively reads an entire resource tree, ignoring runtime-only and proxy resources, and generates
+         * a DMR tree representing all of the non-ignored resources.  This variant can use a resource
+         * registration to help identify runtime-only and proxy resources more efficiently.
+         *
+         * @param resource the root resource
+         * @param mrr the resource registration for {@code resource}, or {@code null}
+         * @return the DMR tree
+         */
+        public static ModelNode readModel(final Resource resource, final ImmutableManagementResourceRegistration mrr) {
+            return readModel(resource, -1, mrr, ALL_BUT_RUNTIME_AND_PROXIES_FILTER);
+        }
+
+        /**
+         * Reads a resource tree, recursing up to the given number of levels but ignoring runtime-only and proxy resources,
+         * and generates a DMR tree representing all of the non-ignored resources.  This variant can use a resource
+         * registration to help identify runtime-only and proxy resources more efficiently.
+         *
+         * @param resource the model
+         * @param level the number of levels to recurse, or {@code -1} for no limit
+         * @param mrr the resource registration for {@code resource}, or {@code null}
+         * @return the DMR tree
+         */
+        public static ModelNode readModel(final Resource resource, final int level, final ImmutableManagementResourceRegistration mrr) {
+            return readModel(resource, level, mrr, ALL_BUT_RUNTIME_AND_PROXIES_FILTER);
+        }
+
+        /**
          * Reads a resource tree, recursing up to the given number of levels but ignoring resources not accepted
          * by the given {@code filter}, and generates a DMR tree representing all of the non-ignored resources.
          *
@@ -309,28 +337,51 @@ public interface Resource extends Cloneable {
          * @return the model
          */
         public static ModelNode readModel(final Resource resource, final int level, final ResourceFilter filter) {
-            if(filter.accepts(PathAddress.EMPTY_ADDRESS, resource)) {
-                return readModel(PathAddress.EMPTY_ADDRESS, resource, level, filter);
+            return readModel(resource, level, null, filter);
+        }
+
+        private static ModelNode readModel(final Resource resource, final int level,
+                                           final ImmutableManagementResourceRegistration mrr, final ResourceFilter filter) {
+            if (filter.accepts(PathAddress.EMPTY_ADDRESS, resource)) {
+                return readModel(PathAddress.EMPTY_ADDRESS, resource, level, mrr, filter);
             } else {
                 return new ModelNode();
             }
         }
 
-        static ModelNode readModel(final PathAddress address, final Resource resource, final int level, final ResourceFilter filter) {
+        private static ModelNode readModel(final PathAddress address, final Resource resource, final int level,
+                                           final ImmutableManagementResourceRegistration mrr, final ResourceFilter filter) {
             final ModelNode model = resource.getModel().clone();
-            final boolean recursive = level == -1 ? true : level > 0;
-            if(recursive) {
+            final boolean recursive = level == -1 || level > 0;
+            if (recursive) {
                 final int newLevel = level == -1 ? -1 : level - 1;
-                for(final String childType : resource.getChildTypes()) {
+                Set<String> validChildTypes = mrr == null ? null : getNonIgnoredChildTypes(mrr);
+                for (final String childType : resource.getChildTypes()) {
+                    if (validChildTypes != null && !validChildTypes.contains(childType)) {
+                        continue;
+                    }
                     model.get(childType).setEmptyObject();
-                    for(final ResourceEntry entry : resource.getChildren(childType)) {
-                        if(filter.accepts(address.append(entry.getPathElement()), resource)) {
-                            model.get(childType, entry.getName()).set(readModel(entry, newLevel));
+                    for (final ResourceEntry entry : resource.getChildren(childType)) {
+                        if (filter.accepts(address.append(entry.getPathElement()), resource)) {
+                            ImmutableManagementResourceRegistration childMrr =
+                                    mrr == null ? null : mrr.getSubModel(address.append(entry.getPathElement()));
+                            model.get(childType, entry.getName()).set(readModel(entry, newLevel, childMrr, filter));
                         }
                     }
                 }
             }
             return model;
+        }
+
+        private static Set<String> getNonIgnoredChildTypes(ImmutableManagementResourceRegistration mrr) {
+            Set<String> result = new HashSet<>();
+            for (PathElement pe : mrr.getChildAddresses(PathAddress.EMPTY_ADDRESS)) {
+                ImmutableManagementResourceRegistration childMrr = mrr.getSubModel(PathAddress.pathAddress(pe));
+                if (childMrr != null && !childMrr.isRemote() && !childMrr.isRuntimeOnly()) {
+                    result.add(pe.getKey());
+                }
+            }
+            return result;
         }
 
         /**
@@ -359,7 +410,7 @@ public interface Resource extends Cloneable {
      * {@link Resource#navigate(PathAddress)} implementations to indicate a client error when invoking a
      * management operation.
      */
-    public static class NoSuchResourceException extends NoSuchElementException implements OperationClientException {
+    class NoSuchResourceException extends NoSuchElementException implements OperationClientException {
 
         private static final long serialVersionUID = -2409240663987141424L;
 

--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -29,6 +29,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.Set;
 import java.util.logging.Handler;
 
 import org.jboss.as.controller.OperationFailedException;
@@ -43,6 +44,7 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.Once;
 import org.jboss.logging.annotations.Transform;
 import org.jboss.logging.annotations.Transform.TransformType;
 import org.jboss.logmanager.Configurator;
@@ -926,4 +928,18 @@ public interface LoggingLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 88, value = "Could not determine %s had any children resources.")
     void errorDeterminingChildrenExist(@Cause Throwable cause, String childType);
+
+    /**
+     * Logs a warning message indicating all the path expressions that could not be resolved while attempting to
+     * determine which log files are available to be read.
+     * <p>
+     * Note this will only be logged once for the life of the JVM.
+     * </p>
+     *
+     * @param unresolvableExpressions the set of expressions that could not be resolved
+     */
+    @Once
+    @LogMessage(level = WARN)
+    @Message(id = 90, value = "The following path expressions could not be resolved while attempting to determine which log files are available to be read: %s")
+    void unresolvablePathExpressions(Set<String> unresolvableExpressions);
 }


### PR DESCRIPTION
During boot runtime resources should be ignored for validation. This also expands the resource to allow for a shallow copy of the resource. This is useful when child values may not be important, but the child key is important.

Master PR https://github.com/wildfly/wildfly-core/pull/1870