### PR TITLE
return abort instead of exiting on a registration exception

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -898,9 +898,6 @@ public class DomainModelControllerService extends AbstractControllerService impl
                             CommandLineConstants.CACHED_DC);
 
                 }
-                SystemExiter.abort(ExitCodes.HOST_CONTROLLER_ABORT_EXIT_CODE);
-                // If we got here, the Exiter didn't really exit. Must be embedded.
-                // Inform the caller so it knows not to proceed with boot.
                 return DomainConnectResult.ABORT;
             } else if (!adminOnly) {
                 // Register a service that will try again once we reach RUNNING state


### PR DESCRIPTION
this allows the ServiceContainer to run a normal shutdown. If the Exiter is called here, the SC appears to wait forever as the service remains in STARTING.