### PR TITLE
Fix for WFCORE-1901. Don't swallow exception in try/catch/finally

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -1187,6 +1187,17 @@ public class Util {
             }
             t1 = t1.getCause();
         }
+
+        // Add the suppressed exceptions attached to the passed exception.
+        // suppressed exceptions can contain valuable information to help trace
+        // exception path.
+        for (Throwable suppressed : t.getSuppressed()) {
+            if (suppressed.getLocalizedMessage() != null) {
+                buf.append("\n").append(suppressed.getLocalizedMessage());
+            } else {
+                buf.append("\n").append(suppressed.getClass().getName());
+            }
+        }
         return buf.toString();
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/handlers/trycatch/TryCatchFinallyControlFlow.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/trycatch/TryCatchFinallyControlFlow.java
@@ -186,7 +186,14 @@ class TryCatchFinallyControlFlow implements CommandLineRedirection {
 
             try {
                 executeBlock(ctx, finallyList, "finally");
-            } catch(CommandLineException eFinally) {
+            } catch (CommandLineException eFinally) {
+                // Try or catch exception are hidden by the finally exception.
+                // Make them an exception suppressed by the finally one.
+                // Doing so, they will be part of the error message displayed by
+                // the CLI.
+                if (error != null) {
+                    eFinally.addSuppressed(error);
+                }
                 error = eFinally;
             }
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/TryCatchFinallyTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/TryCatchFinallyTestCase.java
@@ -28,6 +28,8 @@ import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.test.integration.management.cli.ifelse.CLISystemPropertyTestBase;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.WildflyTestRunner;
@@ -53,6 +55,56 @@ public class TryCatchFinallyTestCase extends CLISystemPropertyTestBase {
             cliOut.reset();
             ctx.handle(getReadPropertyReq());
             assertEquals("try", getValue());
+        } finally {
+            ctx.handleSafe(getRemovePropertyReq());
+            ctx.terminateSession();
+            cliOut.reset();
+        }
+    }
+
+    @Test
+    public void testCatchException() throws Exception {
+        cliOut.reset();
+        final CommandContext ctx = CLITestUtil.getCommandContext(cliOut);
+        try {
+            ctx.connectController();
+            ctx.handle("try");
+            ctx.handle("echo try block");
+            ctx.handle("fail try");
+            ctx.handle("catch");
+            ctx.handle("echo catch block");
+            ctx.handle("fail catch");
+            ctx.handle("finally");
+            ctx.handle("echo finally block");
+            ctx.handle("fail finally");
+            ctx.handleSafe("end-try");
+            String out = cliOut.toString();
+            assertFalse(out.contains("fail try"));
+            assertTrue(out.contains("fail catch"));
+            assertTrue(out.contains("fail finally"));
+        } finally {
+            ctx.handleSafe(getRemovePropertyReq());
+            ctx.terminateSession();
+            cliOut.reset();
+        }
+    }
+
+    @Test
+    public void testTryException() throws Exception {
+        cliOut.reset();
+        final CommandContext ctx = CLITestUtil.getCommandContext(cliOut);
+        try {
+            ctx.connectController();
+            ctx.handle("try");
+            ctx.handle("echo try block");
+            ctx.handle("fail try");
+            ctx.handle("finally");
+            ctx.handle("echo finally block");
+            ctx.handle("fail finally");
+            ctx.handleSafe("end-try");
+            String out = cliOut.toString();
+            assertTrue(out.contains("fail try"));
+            assertTrue(out.contains("fail finally"));
         } finally {
             ctx.handleSafe(getRemovePropertyReq());
             ctx.terminateSession();


### PR DESCRIPTION
I am proposing to use the "suppressed Exception" feature of the Exception class.
When the Finally exception is thrown, it is suppressing the try or catch exception that could have been previously thrown.
When an Exception is printed to the console, the suppressed exceptions are also printed.
Added unit tests to cover this feature.
