### PR TITLE
Move CLI to use aesh-readline.

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -104,8 +104,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.aesh</groupId>
-            <artifactId>aesh</artifactId>
+            <groupId>org.aesh</groupId>
+            <artifactId>aesh-readline</artifactId>
         </dependency>
 
         <dependency>

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
@@ -27,7 +27,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.List;
-import org.jboss.aesh.console.Config;
+import org.aesh.utils.Config;
 import org.jboss.as.cli.Attachments;
 
 import org.jboss.as.cli.CommandContext;

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -73,16 +73,8 @@ import javax.security.auth.login.Configuration;
 import javax.security.sasl.RealmCallback;
 import javax.security.sasl.RealmChoiceCallback;
 import javax.security.sasl.SaslException;
+import org.aesh.util.FileAccessPermission;
 
-import org.jboss.aesh.console.AeshConsoleCallback;
-import org.jboss.aesh.console.ConsoleCallback;
-import org.jboss.aesh.console.ConsoleOperation;
-import org.jboss.aesh.console.Process;
-import org.jboss.aesh.console.helper.InterruptHook;
-import org.jboss.aesh.console.settings.FileAccessPermission;
-import org.jboss.aesh.console.settings.Settings;
-import org.jboss.aesh.console.settings.SettingsBuilder;
-import org.jboss.aesh.edit.actions.Action;
 import org.jboss.as.cli.Attachments;
 import org.jboss.as.cli.CliConfig;
 import org.jboss.as.cli.CliEvent;
@@ -162,6 +154,8 @@ import org.jboss.as.cli.handlers.trycatch.CatchHandler;
 import org.jboss.as.cli.handlers.trycatch.EndTryHandler;
 import org.jboss.as.cli.handlers.trycatch.FinallyHandler;
 import org.jboss.as.cli.handlers.trycatch.TryHandler;
+import org.jboss.as.cli.impl.ReadlineConsole.Settings;
+import org.jboss.as.cli.impl.ReadlineConsole.SettingsBuilder;
 import org.jboss.as.cli.operation.CommandLineParser;
 import org.jboss.as.cli.operation.NodePathFormatter;
 import org.jboss.as.cli.operation.OperationCandidatesProvider;
@@ -322,6 +316,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     private int configTimeout;
     private ControllerAddress connectionAddress;
 
+    private boolean redefinedOutput;
     /**
      * Version mode - only used when --version is called from the command line.
      *
@@ -378,7 +373,10 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         configTimeout = config.getCommandTimeout() == null ? DEFAULT_TIMEOUT : config.getCommandTimeout();
         setCommandTimeout(configTimeout);
         resolveParameterValues = config.isResolveParameterValues();
-        cliPrintStream = configuration.getConsoleOutput() == null ? new CLIPrintStream() : new CLIPrintStream(configuration.getConsoleOutput());
+        redefinedOutput = configuration.getConsoleOutput() != null;
+        cliPrintStream = !redefinedOutput ? new CLIPrintStream() : new CLIPrintStream(configuration.getConsoleOutput());
+        // System.out has been captured prior IO been replaced. That is required due to embed-server use case
+        // that will replace output.
         initStdIO();
         try {
             initCommands();
@@ -410,9 +408,6 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         shutdownHook = new CliShutdownHook.Handler() {
             @Override
             public void shutdown() {
-                if (CommandContextImpl.this.console != null) {
-                    CommandContextImpl.this.console.interrupt();
-                }
                 terminateSession();
             }};
         CliShutdownHook.add(shutdownHook);
@@ -427,76 +422,28 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         assert console == null : "the console has already been initialized";
         Settings settings = createSettings(consoleInput);
         this.console = Console.Factory.getConsole(this, settings);
-        console.setCallback(initCallback());
-        if(start) {
-            console.start();
-        }
-    }
-
-    private ConsoleCallback initCallback() {
-        return new CLIAeshConsoleCallback() {
-
-            @Override
-            public int execute(ConsoleOperation output) throws InterruptedException {
-                // Track the active process
-                setActiveProcess(true);
-
-                try {
-                    // Actual work stuff
-                    if (cmdCompleter == null) {
-                        throw new IllegalStateException("The console hasn't been initialized at construction time.");
-                    }
-                    if (output.getBuffer() == null)
-                        terminateSession();
-                    else {
-                        handleSafe(output.getBuffer().trim());
-                        if (INTERACT && terminate == RUNNING) {
-                            console.setPrompt(getPrompt());
-                        }
-                    }
-                    return 0;
-
-                }finally{
-                    setActiveProcess(false);
-                }
+        this.console.setActionCallback((line) -> {
+            handleSafe(line);
+            if (console != null) {
+                console.setPrompt(getPrompt());
             }
-
-        };
-    }
-
-    abstract class CLIAeshConsoleCallback extends AeshConsoleCallback{
-
-        private Process process;
-
-        public boolean hasActiveProcess() {
-            return activeProcess;
-        }
-
-        public void setActiveProcess(boolean activeProcess) {
-            this.activeProcess = activeProcess;
-        }
-
-        private boolean activeProcess = false;
-
-        @Override
-        public void setProcess(org.jboss.aesh.console.Process process){
-            this.process = process;
-        }
-
-        public int getProcessPID(){
-            return process.getPID();
+        });
+        if (start) {
+            try {
+                console.start();
+            } catch (IOException ex) {
+                throw new CliInitializationException(ex);
+            }
         }
     }
 
     private Settings createSettings(InputStream consoleInput) {
         SettingsBuilder settings = new SettingsBuilder();
-        if(consoleInput != null) {
+        if (consoleInput != null) {
             settings.inputStream(consoleInput);
         }
         settings.outputStream(cliPrintStream);
-
-        settings.enableExport(false);
-
+        settings.outputRedefined(redefinedOutput);
         settings.disableHistory(!config.isHistoryEnabled());
         settings.historyFile(new File(config.getHistoryFileDir(), config.getHistoryFileName()));
         settings.historySize(config.getHistoryMaxSize());
@@ -506,22 +453,6 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         permissions.setReadableOwnerOnly(true);
         permissions.setWritableOwnerOnly(true);
         settings.historyFilePermission(permissions);
-
-        settings.parseOperators(false);
-
-        settings.interruptHook(
-                new InterruptHook() {
-                    @Override
-                    public void handleInterrupt(org.jboss.aesh.console.Console console, Action action) {
-                        if(shutdownHook != null ){
-                            shutdownHook.shutdown();
-                        }else {
-                            terminateSession();
-                        }
-                        Thread.currentThread().interrupt();
-                    }
-                }
-        );
 
         return settings.create();
     }
@@ -1010,15 +941,17 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         }
 
         if (console == null) {
-            initBasicConsole(null);
-        } else if(!console.running()) {
-            console.start();
+            initBasicConsole(null, false);
         }
 
-        if (password) {
-            return console.readLine(prompt, (char) 0x00);
-        } else {
-            return console.readLine(prompt);
+        try {
+            if (password) {
+                return console.readLine(prompt, (char) 0x00);
+            } else {
+                return console.readLine(prompt);
+            }
+        } catch (IOException ex) {
+            throw new CommandLineException(ex);
         }
 
     }
@@ -1274,9 +1207,9 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         for (;;) {
             String response;
             if (trustManager.isModifyTrustStore()) {
-                response = prompt("Accept certificate? [N]o, [T]emporarily, [P]ermanently : ", false);
+                response = readLine("Accept certificate? [N]o, [T]emporarily, [P]ermanently : ", false);
             } else {
-                response = prompt("Accept certificate? [N]o, [T]emporarily : ", false);
+                response = readLine("Accept certificate? [N]o, [T]emporarily : ", false);
             }
             if (response == null)
                 break;
@@ -1294,24 +1227,6 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                         }
                 }
             }
-        }
-    }
-
-    private String prompt(String prompt, boolean mask) throws CliInitializationException,
-            CommandLineException {
-        if (console == null) {
-            if (ERROR_ON_INTERACT) {
-                interactionDisabled();
-            }
-            initBasicConsole(null);
-        }
-        console.setCompletion(false);
-        console.getHistory().setUseHistory(false);
-        try {
-            return readLine(prompt, mask);
-        } finally {
-            console.getHistory().setUseHistory(true);
-            console.setCompletion(true);
         }
     }
 
@@ -1639,29 +1554,14 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         }
 
         console.setPrompt(getPrompt());
-        if(!console.running()) {
-            console.start();
-        }
-        // if console is already running before we have started interacting, we need to
-        // make sure that the prompt is correctly displayed
-        else {
-            console.redrawPrompt();
-        }
-
-        // We unlock the console for it to continue process inputstream.
-        // Could have been put in controlled mode during username/password prompt.
-        if(console.isControlled()) {
-            console.continuous();
-        }
-
-        while(/*!isTerminated() && */console.running()){
+        if (!console.running()) {
             try {
-                Thread.sleep(10);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
+                // This call is blocking.
+                console.start();
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
             }
         }
-
         INTERACT = false;
     }
 
@@ -1818,17 +1718,8 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                     public void run() {
                         try {
                             if (username == null || password == null) {
-                                // Only control the console if not already interacting.
-                                if (!INTERACT) {
-                                    if (console == null) {
-                                        initBasicConsole(null, false);
-                                    }
-                                    // That is required to stop the console from executing any command
-                                    // before to be done with credentials.
-                                    console.controlled();
-                                    if (!console.running()) {
-                                        console.start();
-                                    }
+                                if (console == null) {
+                                    initBasicConsole(null, false);
                                 }
                             }
                             dohandle(callbacks);
@@ -1887,25 +1778,23 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                         // use cached name
                         ncb.setName(username);
                         connInfoBean.setUsername(username);
+                    } else if (defaultName != null) {
+                        // accept suggested name but do not set our cached name
+                        ncb.setName(defaultName);
+                        connInfoBean.setUsername(defaultName);
                     } else {
-                        if (defaultName != null) {
-                            // accept suggested name but do not set our cached name
-                            ncb.setName(defaultName);
-                            connInfoBean.setUsername(defaultName);
-                        } else {
-                            showRealm();
-                            try {
-                                username = prompt("Username: ", false);
-                            } catch (CommandLineException e) {
-                                // the messages of the cause are lost if nested here
-                                throw new IOException("Failed to read username: " + e.getLocalizedMessage());
-                            }
-                            if (username == null || username.length() == 0) {
-                                throw new SaslException("No username supplied.");
-                            }
-                            ncb.setName(username);
-                            connInfoBean.setUsername(username);
+                        showRealm();
+                        try {
+                            username = readLine("Username: ", false);
+                        } catch (CommandLineException e) {
+                            // the messages of the cause are lost if nested here
+                            throw new IOException("Failed to read username: " + e.getLocalizedMessage());
                         }
+                        if (username == null || username.length() == 0) {
+                            throw new SaslException("No username supplied.");
+                        }
+                        ncb.setName(username);
+                        connInfoBean.setUsername(username);
                     }
                 } else if (current instanceof PasswordCallback && digest == null) {
                     // If a digest had been set support for PasswordCallback is disabled.
@@ -1913,7 +1802,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                         showRealm();
                         String temp;
                         try {
-                            temp = prompt("Password: ", true);
+                            temp = readLine("Password: ", true);
                         } catch (CommandLineException e) {
                             // the messages of the cause are lost if nested here
                             throw new IOException("Failed to read password: " + e.getLocalizedMessage());
@@ -1931,7 +1820,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                             showRealm();
                             String temp;
                             try {
-                                temp = prompt("Password: ", true);
+                                temp = readLine("Password: ", true);
                             } catch (CommandLineException e) {
                                 // the messages of the cause are lost if nested here
                                 throw new IOException("Failed to read password: " + e.getLocalizedMessage());
@@ -2271,6 +2160,10 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     @Override
     public void captureOutput(PrintStream captor) {
         assert captor != null;
+        // For now make this invalid. Want to be sure that we don't have such case
+        if (INTERACT) {
+            throw new RuntimeException("Can't replace outputStream in interactive mode");
+        }
         cliPrintStream.captureOutput(captor);
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/Console.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Console.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -24,20 +24,14 @@ package org.jboss.as.cli.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.function.Consumer;
 
-import org.jboss.aesh.complete.CompleteOperation;
-import org.jboss.aesh.complete.Completion;
-import org.jboss.aesh.console.ConsoleCallback;
-import org.jboss.aesh.console.Prompt;
-import org.jboss.aesh.console.settings.Settings;
-import org.jboss.aesh.parser.Parser;
 import org.jboss.as.cli.CliInitializationException;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandHistory;
 import org.jboss.as.cli.CommandLineCompleter;
+import org.jboss.as.cli.impl.ReadlineConsole.Settings;
 
 /**
  *
@@ -47,11 +41,7 @@ public interface Console {
 
     void addCompleter(CommandLineCompleter completer);
 
-    boolean isUseHistory();
-
     CommandHistory getHistory();
-
-    void setCompletion(boolean complete);
 
     void clearScreen();
 
@@ -61,44 +51,17 @@ public interface Console {
 
     void printNewLine();
 
-    String readLine(String prompt);
+    String readLine(String prompt) throws IOException;
 
-    String readLine(String prompt, Character mask);
+    String readLine(String prompt, Character mask) throws IOException;
 
     int getTerminalWidth();
 
     int getTerminalHeight();
 
-    /**
-     * Checks whether the tab-completion is enabled.
-     *
-     * @return  true if tab-completion is enabled, false - otherwise
-     */
-    boolean isCompletionEnabled();
+    void setActionCallback(Consumer<String> cons);
 
-    /**
-     * Enables or disables the tab-completion.
-     *
-     * @param completionEnabled  true will enable the tab-completion, false will disable it
-     */
-    // void setCompletionEnabled(boolean completionEnabled);
-
-    /**
-     * Interrupts blocking readLine method.
-     *
-     * Added as solution to BZ-1149099.
-     */
-    void interrupt();
-
-    void controlled();
-
-    boolean isControlled();
-
-    void continuous();
-
-    void setCallback(ConsoleCallback consoleCallback);
-
-    void start();
+    void start() throws IOException;
 
     void stop();
 
@@ -106,255 +69,19 @@ public interface Console {
 
     void setPrompt(String prompt);
 
-    void setPrompt(String prompt, Character mask);
-
-    void redrawPrompt();
-
     static final class Factory {
 
         public static Console getConsole(CommandContext ctx, Settings settings) throws CliInitializationException {
             return getConsole(ctx, null, null, settings);
         }
 
-        public static Console getConsole(final CommandContext ctx, InputStream is, OutputStream os, final Settings settings) throws CliInitializationException {
-
-            org.jboss.aesh.console.Console aeshConsole = null;
+        public static Console getConsole(final CommandContext ctx, InputStream is, OutputStream os, Settings settings) throws CliInitializationException {
+            ReadlineConsole console;
             try {
-                aeshConsole = new org.jboss.aesh.console.Console(settings);
-            } catch (Throwable e) {
-                throw new CliInitializationException("Failed to initialize Aesh console", e);
+                console = new ReadlineConsole(ctx, settings);
+            } catch (IOException ex) {
+                throw new CliInitializationException(ex);
             }
-
-            final org.jboss.aesh.console.Console finalAeshConsole = aeshConsole;
-
-            Console console =  new Console() {
-
-                private CommandContext cmdCtx = ctx;
-                private org.jboss.aesh.console.Console console = finalAeshConsole;
-                private CommandHistory history = new HistoryImpl();
-                private boolean controlled;
-
-                @Override
-                public void addCompleter(final CommandLineCompleter completer) {
-                    console.addCompletion(new Completion() {
-                        @Override
-                        public void complete(CompleteOperation co) {
-                            List<String> candidates = new ArrayList<>();
-                            int offset = completer.complete(cmdCtx,
-                                    co.getBuffer(), co.getCursor(), candidates);
-                            co.setOffset(offset);
-                            co.setCompletionCandidates(candidates);
-                            String buffer = cmdCtx.getArgumentsString() == null ? co.getBuffer() : ctx.getArgumentsString() + co.getBuffer();
-                            if (co.getCompletionCandidates().size() == 1
-                                    && co.getCompletionCandidates().get(0).getCharacters().startsWith(buffer))
-                                co.doAppendSeparator(true);
-                            else
-                                co.doAppendSeparator(false);
-                        }
-                    });
-                }
-
-                @Override
-                public boolean isUseHistory() {
-                    return !settings.isHistoryDisabled();
-                }
-
-                @Override
-                public CommandHistory getHistory() {
-                    return history;
-                }
-
-                @Override
-                public void setCompletion(boolean complete){
-                    console.setCompletionEnabled(complete);
-                }
-
-                @Override
-                public void clearScreen() {
-                    try {
-                        console.clear();
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
-                }
-
-                @Override
-                public void printColumns(Collection<String> list) {
-                    String[] newList = new String[list.size()];
-                    list.toArray(newList);
-                    console.getShell().out().println(
-                            Parser.formatDisplayList(newList,
-                                    console.getTerminalSize().getHeight(),
-                                    console.getTerminalSize().getWidth()));
-                }
-
-                @Override
-                public void print(String line) {
-                    console.getShell().out().print(line);
-                }
-
-                @Override
-                public void printNewLine() {
-                    console.getShell().out().println();
-                }
-
-                @Override
-                public String readLine(String prompt) {
-                    return read(prompt, null);
-                }
-
-                @Override
-                public String readLine(String prompt, Character mask) {
-                    return read(prompt, mask);
-                }
-
-                private String read(String prompt, Character mask) {
-                    int PID = -1;
-
-                    try {
-                        ConsoleCallback callback = console.getConsoleCallback();
-                        if (callback instanceof CommandContextImpl.CLIAeshConsoleCallback) {
-                            CommandContextImpl.CLIAeshConsoleCallback cliCallback = ((CommandContextImpl.CLIAeshConsoleCallback) callback);
-
-                            if (cliCallback.hasActiveProcess()) {
-                                PID = cliCallback.getProcessPID();
-                                console.putProcessInBackground(PID);
-                            }
-
-                        }
-                        Prompt origPrompt = null;
-                        if(!console.getPrompt().getPromptAsString().equals(prompt)) {
-                            origPrompt = console.getPrompt();
-                            console.setPrompt(new Prompt(prompt, mask));
-                            redrawPrompt();
-                        }
-                        try {
-                            return console.getInputLine();
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            throw new RuntimeException(e);
-                        } finally {
-                            if(origPrompt != null) {
-                                console.setPrompt(origPrompt);
-                            }
-                        }
-                    } finally {
-                        if( PID != -1) {
-                            console.putProcessInForeground(PID);
-                        }
-                    }
-                }
-
-                @Override
-                public int getTerminalWidth() {
-                    return console.getTerminalSize().getWidth();
-                }
-
-                @Override
-                public int getTerminalHeight() {
-                    return console.getTerminalSize().getHeight();
-                }
-
-                @Override
-                public boolean isCompletionEnabled(){
-                    return settings.isCompletionDisabled();
-                }
-
-                @Override
-                public void interrupt() {
-                }
-
-                @Override
-                public void controlled() {
-                    console.controlled();
-                    controlled = true;
-                }
-
-                @Override
-                public void continuous() {
-                    console.continuous();
-                    controlled = false;
-                }
-
-                @Override
-                public boolean isControlled() {
-                    return controlled;
-                }
-
-                @Override
-                public void setCallback(ConsoleCallback consoleCallback) {
-                    if(console != null)
-                        console.setConsoleCallback(consoleCallback);
-                }
-
-                @Override
-                public void start(){
-                    if(console != null)
-                        console.start();
-                }
-
-                @Override
-                public void stop() {
-                    if(console != null) {
-                        console.stop();
-                    }
-                }
-
-                @Override
-                public boolean running() {
-                    return console != null && (console.isRunning() || console.hasRunningProcesses());
-                }
-
-                @Override
-                public void setPrompt(String prompt){
-                    setPrompt(prompt, null);
-                }
-
-                @Override
-                public void setPrompt(String prompt, Character mask) {
-                    if(!prompt.equals(console.getPrompt().getPromptAsString())) {
-                        console.setPrompt(new Prompt(prompt, mask));
-                    }
-                }
-
-                @Override
-                public void redrawPrompt() {
-                    console.clearBufferAndDisplayPrompt();
-                }
-
-                class HistoryImpl implements CommandHistory {
-
-                    @Override
-                    public List<String> asList() {
-                        return console.getHistory().getAll();
-                    }
-
-                    @Override
-                    public boolean isUseHistory() {
-                        return console.getHistory().isEnabled();
-                    }
-
-                    @Override
-                    public void setUseHistory(boolean useHistory) {
-                        if(useHistory){
-                            console.getHistory().enable();
-                        }else{
-                            console.getHistory().disable();
-                        }
-                    }
-
-                    @Override
-                    public void clear() {
-                        console.getHistory().clear();
-                    }
-
-                    @Override
-                    public int getMaxSize() {
-                        return settings.getHistorySize();
-                    }
-                }
-            };
-
             return console;
         }
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/ReadlineConsole.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ReadlineConsole.java
@@ -1,0 +1,811 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.cli.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.logging.Level;
+import org.aesh.readline.Prompt;
+import org.aesh.readline.Readline;
+import org.aesh.readline.ReadlineFlag;
+import org.aesh.readline.alias.AliasCompletion;
+import org.aesh.readline.alias.AliasManager;
+import org.aesh.readline.alias.AliasPreProcessor;
+import org.aesh.readline.completion.CompleteOperation;
+import org.aesh.readline.completion.Completion;
+import org.aesh.readline.history.FileHistory;
+import org.aesh.terminal.Terminal;
+import org.aesh.readline.terminal.TerminalBuilder;
+import org.aesh.terminal.tty.Signal;
+import org.aesh.readline.tty.terminal.TerminalConnection;
+import org.aesh.terminal.Attributes;
+import org.aesh.utils.ANSI;
+import org.aesh.utils.Config;
+import org.aesh.util.FileAccessPermission;
+import org.aesh.util.Parser;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandHistory;
+import org.jboss.as.cli.CommandLineCompleter;
+import org.jboss.logmanager.Logger;
+
+/**
+ * Integration point with aesh-readline. There are multiple paths when the CLI
+ * exits.
+ * <ul>
+ * <li>quit command: Command ctx is terminated, console is closed, terminal
+ * connection reading thread is interrupted, Main thread exit, jvm exit handlers
+ * are called</li>
+ * <li>Ctrl-C: can be received as an OS signal or parsed by aesh. In both cases
+ * interruptHandler is called, the connection is closed, terminal connection
+ * reading thread is interrupted, Main thread exit, jvm exit handlers are
+ * called. If a prompt is in progress, the reading thread will be interrupted
+ * too.</li>
+ * <li>Ctrl-D (without characters typed): Only parsed by aesh, no native signal
+ * raised. In both cases, the connection is closed by aesh, terminal connection
+ * reading thread is interrupted, Main thread exit, jvm exit handlers are
+ * called. If a prompt is in progress, the reading thread will be interrupted
+ * too. Because Ctrl-D is not a native signal, it can't be handled during the
+ * execution of a command. Only Ctrl-C can be used to interrupt the CLI.</li>
+ * </ul>
+ *
+ * @author jdenise@redhat.com
+ */
+public class ReadlineConsole implements Console {
+
+    private static final Logger LOG = Logger.getLogger(ReadlineConsole.class.getName());
+
+    public interface Settings {
+
+        /**
+         * @return the inStream
+         */
+        InputStream getInStream();
+
+        /**
+         * @return the outStream
+         */
+        OutputStream getOutStream();
+
+        /**
+         * @return the disableHistory
+         */
+        boolean isDisableHistory();
+
+        /**
+         * @return the outputRedefined
+         */
+        boolean isOutputRedefined();
+
+        /**
+         * @return the historyFile
+         */
+        File getHistoryFile();
+
+        /**
+         * @return the historySize
+         */
+        int getHistorySize();
+
+        /**
+         * @return the permission
+         */
+        FileAccessPermission getPermission();
+
+        /**
+         * @return the interrupt
+         */
+        Runnable getInterrupt();
+    }
+
+    /**
+     *
+     * All chars printed by commands and prompts go through this class that log
+     * any printed content. What is received by inputstream is echoed in the
+     * outputstream.
+     */
+    private static class CLITerminalConnection extends TerminalConnection {
+
+        private final Consumer<int[]> interceptor;
+        private Thread connectionThread;
+
+        CLITerminalConnection(Terminal terminal) {
+            super(terminal);
+            interceptor = (int[] ints) -> {
+                if (LOG.isLoggable(Level.FINER)) {
+                    LOG.log(Level.FINER, "Writing {0}",
+                            Parser.stripAwayAnsiCodes(Parser.fromCodePoints(ints)));
+                }
+                CLITerminalConnection.super.stdoutHandler().accept(ints);
+            };
+        }
+
+        @Override
+        public Consumer<int[]> stdoutHandler() {
+            return interceptor;
+        }
+
+        /**
+         * Required to close the connection reading on the terminal, otherwise
+         * it can't be interrupted.
+         *
+         * @throws InterruptedException
+         */
+        public void openBlockingInterruptable()
+                throws InterruptedException {
+            // We need to thread this call in order to interrupt it (when Ctrl-C occurs).
+            connectionThread = new Thread(() -> {
+                // This thread can't be interrupted from another thread.
+                // Will stay alive until System.exit is called.
+                Thread thr = new Thread(() -> super.openBlocking(),
+                        "CLI Terminal Connection (uninterruptable)");
+                thr.start();
+                try {
+                    thr.join();
+                } catch (InterruptedException ex) {
+                    // XXX OK, interrupted, just leaving.
+                }
+            }, "CLI Terminal Connection (interruptable)");
+            connectionThread.start();
+            connectionThread.join();
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            if (connectionThread != null) {
+                connectionThread.interrupt();
+            }
+        }
+    }
+
+    private static class SettingsImpl implements Settings {
+
+        private final InputStream inStream;
+        private final OutputStream outStream;
+        private final boolean disableHistory;
+        private final File historyFile;
+        private final int historySize;
+        private final FileAccessPermission permission;
+        private final Runnable interrupt;
+        private final boolean outputRedefined;
+
+        private SettingsImpl(InputStream inStream,
+                OutputStream outStream,
+                boolean outputRedefined,
+                boolean disableHistory,
+                File historyFile,
+                int historySize,
+                FileAccessPermission permission,
+                Runnable interrupt) {
+            this.inStream = inStream;
+            this.outStream = outStream;
+            this.outputRedefined = outputRedefined;
+            this.disableHistory = disableHistory;
+            this.historyFile = historyFile;
+            this.historySize = historySize;
+            this.permission = permission;
+            this.interrupt = interrupt;
+        }
+
+        /**
+         * @return the inStream
+         */
+        @Override
+        public InputStream getInStream() {
+            return inStream;
+        }
+
+        /**
+         * @return the outStream
+         */
+        @Override
+        public OutputStream getOutStream() {
+            return outStream;
+        }
+
+        /**
+         * @return the disableHistory
+         */
+        @Override
+        public boolean isDisableHistory() {
+            return disableHistory;
+        }
+
+        /**
+         * @return the outputRedefined
+         */
+        @Override
+        public boolean isOutputRedefined() {
+            return outputRedefined;
+        }
+
+        /**
+         * @return the historyFile
+         */
+        @Override
+        public File getHistoryFile() {
+            return historyFile;
+        }
+
+        /**
+         * @return the historySize
+         */
+        @Override
+        public int getHistorySize() {
+            return historySize;
+        }
+
+        /**
+         * @return the permission
+         */
+        @Override
+        public FileAccessPermission getPermission() {
+            return permission;
+        }
+
+        /**
+         * @return the interrupt
+         */
+        @Override
+        public Runnable getInterrupt() {
+            return interrupt;
+        }
+    }
+
+    public static class SettingsBuilder {
+
+        private InputStream inStream;
+        private OutputStream outStream;
+        private boolean disableHistory;
+        private File historyFile;
+        private int historySize;
+        private FileAccessPermission permission;
+        private Runnable interrupt;
+        private boolean outputRedefined;
+
+        public SettingsBuilder inputStream(InputStream inStream) {
+            this.inStream = inStream;
+            return this;
+        }
+
+        public SettingsBuilder outputStream(OutputStream outStream) {
+            this.outStream = outStream;
+            return this;
+        }
+
+        public SettingsBuilder disableHistory(boolean disableHistory) {
+            this.disableHistory = disableHistory;
+            return this;
+        }
+
+        public SettingsBuilder historyFile(File historyFile) {
+            this.historyFile = historyFile;
+            return this;
+        }
+
+        public SettingsBuilder historySize(int historySize) {
+            this.historySize = historySize;
+            return this;
+        }
+
+        public SettingsBuilder historyFilePermission(FileAccessPermission permission) {
+            this.permission = permission;
+            return this;
+        }
+
+        public SettingsBuilder interruptHook(Runnable interrupt) {
+            this.interrupt = interrupt;
+            return this;
+        }
+
+        public SettingsBuilder outputRedefined(boolean outputRedefined) {
+            this.outputRedefined = outputRedefined;
+            return this;
+        }
+
+        public Settings create() {
+            return new SettingsImpl(inStream, outStream, outputRedefined,
+                    disableHistory, historyFile, historySize, permission, interrupt);
+        }
+    }
+
+    class HistoryImpl implements CommandHistory {
+
+        @Override
+        public List<String> asList() {
+            List<String> lst = new ArrayList<>();
+            for (int[] l : readlineHistory.getAll()) {
+                lst.add(Parser.stripAwayAnsiCodes(Parser.fromCodePoints(l)));
+            }
+            return lst;
+        }
+
+        @Override
+        public boolean isUseHistory() {
+            return readlineHistory.isEnabled();
+        }
+
+        @Override
+        public void setUseHistory(boolean useHistory) {
+            if (useHistory) {
+                readlineHistory.enable();
+            } else {
+                readlineHistory.disable();
+            }
+
+        }
+
+        @Override
+        public void clear() {
+            readlineHistory.clear();
+        }
+
+        @Override
+        public int getMaxSize() {
+            return readlineHistory.size();
+        }
+    }
+    private final CommandContext cmdCtx;
+    private final List<Completion> completions = new ArrayList<>();
+    private final Readline readline;
+    private final CLITerminalConnection connection;
+    private final CommandHistory history = new HistoryImpl();
+    private final FileHistory readlineHistory;
+    private String prompt;
+    private final Settings settings;
+    private volatile boolean started;
+    private volatile boolean closed;
+    private Thread startThread;
+    private Thread readingThread;
+    private Consumer<String> callback;
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(1,
+            (r) -> new Thread(r, "CLI command"));
+
+    private final AliasManager aliasManager;
+    private final List<Function<String, Optional<String>>> preProcessors = new ArrayList<>();
+
+    private static final EnumMap<ReadlineFlag, Integer> READLINE_FLAGS = new EnumMap<>(ReadlineFlag.class);
+
+    static {
+        READLINE_FLAGS.put(ReadlineFlag.NO_PROMPT_REDRAW_ON_INTR, Integer.MAX_VALUE);
+    }
+
+    private final Consumer<Signal> interruptHandler;
+
+    ReadlineConsole(CommandContext cmdCtx, Settings settings) throws IOException {
+        this.cmdCtx = cmdCtx;
+        this.settings = settings;
+        readlineHistory = new FileHistory(settings.getHistoryFile(),
+                settings.getHistorySize(), settings.getPermission(), false);
+        if (settings.isDisableHistory()) {
+            readlineHistory.disable();
+        } else {
+            readlineHistory.enable();
+        }
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.log(Level.FINER, "History is enabled? {0}", !settings.isDisableHistory());
+        }
+        connection = newConnection();
+        interruptHandler = signal -> {
+            if (signal == Signal.INT) {
+                if (LOG.isLoggable(Level.FINER)) {
+                    LOG.finer("Calling InterruptHandler");
+                }
+                connection.write(Config.getLineSeparator());
+                connection.close();
+            }
+        };
+        connection.setSignalHandler(interruptHandler);
+        // Do not display ^C
+        Attributes attr = connection.getAttributes();
+        attr.setLocalFlag(Attributes.LocalFlag.ECHOCTL, false);
+        connection.setAttributes(attr);
+
+        aliasManager = new AliasManager(new File(Config.getHomeDir()
+                + Config.getPathSeparator() + ".aesh_aliases"), true);
+        AliasPreProcessor aliasPreProcessor = new AliasPreProcessor(aliasManager);
+        preProcessors.add(aliasPreProcessor);
+        completions.add(new AliasCompletion(aliasManager));
+        readline = new Readline();
+    }
+
+    @Override
+    public void setActionCallback(Consumer<String> callback) {
+        this.callback = callback;
+    }
+
+    private CLITerminalConnection newConnection() throws IOException {
+        CLIPrintStream stream = (CLIPrintStream) settings.getOutStream();
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.finer("Creating terminal connection ");
+        }
+
+        // The choice of the outputstream to use is ruled by the following rules:
+        // - If the output is redefined in CLIPrintStream, the terminal use the CLIPrintStream
+        // - If some redirection have been establised ( <, or remote process), CLIPrintStream is to be used.
+        //   That is required to protect the CLI against embed-server I/O handling.
+        // - Otherwise, a system terminal is used. system terminals don't use System.out
+        //   so are protected against embed-server I/O handling.
+        Terminal terminal = TerminalBuilder.builder()
+                .input(settings.getInStream() == null
+                        ? System.in : settings.getInStream())
+                // Use CLI stream if not a system terminal, it protects against
+                // embed-server I/O redefinition
+                .output(stream)
+                .nativeSignals(true)
+                .name("CLI Terminal")
+                // We ask for a system terminal only if the Output has not been redefined.
+                // If the IO context is redirected ( <, or remote process usage),
+                // then, whatever the output being redefined or not, the terminal
+                // will be NOT a system terminal, that is the TerminalBuilder behavior.
+                .system(!settings.isOutputRedefined())
+                .build();
+        CLITerminalConnection c = new CLITerminalConnection(terminal);
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.log(Level.FINER, "New Terminal {0}", terminal.getClass());
+        }
+        return c;
+    }
+
+    @Override
+    public void addCompleter(CommandLineCompleter completer) {
+        completions.add((Completion) (CompleteOperation co) -> {
+            List<String> candidates = new ArrayList<>();
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.log(Level.FINER, "Completing {0}", co.getBuffer());
+            }
+            int offset = completer.complete(cmdCtx,
+                    co.getBuffer(), co.getCursor(), candidates);
+            co.setOffset(offset);
+            co.addCompletionCandidates(candidates);
+            String buffer = cmdCtx.getArgumentsString() == null
+                    ? co.getBuffer() : cmdCtx.getArgumentsString() + co.getBuffer();
+            if (co.getCompletionCandidates().size() == 1
+                    && co.getCompletionCandidates().get(0).
+                    getCharacters().startsWith(buffer)) {
+                co.doAppendSeparator(true);
+            } else {
+                co.doAppendSeparator(false);
+            }
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.log(Level.FINER, "Completion candidates {0}",
+                        co.getCompletionCandidates());
+            }
+        });
+    }
+
+    @Override
+    public CommandHistory getHistory() {
+        return history;
+    }
+
+    @Override
+    public void clearScreen() {
+        connection.stdoutHandler().accept(ANSI.CLEAR_SCREEN);
+    }
+
+    @Override
+    public void printColumns(Collection<String> list) {
+        String[] newList = new String[list.size()];
+        list.toArray(newList);
+        connection.write(
+                Parser.formatDisplayList(newList,
+                        getHeight(),
+                        getWidth()));
+    }
+
+    @Override
+    public void print(String line) {
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.log(Level.FINER, "Print {0}", line);
+        }
+        connection.write(line);
+    }
+
+    @Override
+    public void printNewLine() {
+        print(Config.getLineSeparator());
+    }
+
+    @Override
+    public String readLine(String prompt) throws IOException {
+        return readLine(prompt, null);
+    }
+
+    /**
+     * Prompt a user. The complexity of this method is implied by the Ctrl-C
+     * handling. When Ctrl-C occurs, the Exit hook will call this.close that
+     * interrupts the thread calling this operation.<p>
+     * We have 2 cases.
+     * <p>
+     * 1) prompting prior to have started the console: - Must start a new
+     * connection. - Make it non blocking. - Wait on latch to resync and to
+     * catch Thread.interrupt.
+     * <p>
+     * 2) prompting after to have started the console: - No need to open the
+     * connection. - Wait on latch to resync and to catch Thread.interrupt.
+     *
+     * @param prompt
+     * @param mask
+     * @return
+     * @throws IOException
+     */
+    @Override
+    public String readLine(String prompt, Character mask) throws IOException {
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.log(Level.FINER, "Prompt {0} mask {1}", new Object[]{prompt, mask});
+        }
+        // Keep a reference on the caller thread in case Ctrl-C is pressed
+        // and thread needs to be interrupted.
+        readingThread = Thread.currentThread();
+        try {
+            if (!started) {
+                // That is the case of the CLI connecting prior to start the terminal.
+                // No Terminal waiting in Main thread yet.
+                // We are opening the connection to the terminal until we have read
+                // something from prompt.
+                return promptFromNonStartedConsole(prompt, mask);
+            } else {
+                return promptFromStartedConsole(prompt, mask);
+            }
+        } finally {
+            readingThread = null;
+        }
+    }
+
+    private String promptFromNonStartedConsole(String prompt, Character mask) {
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.finer("Not started");
+        }
+        String[] out = new String[1];
+        if (connection.suspended()) {
+            connection.awake();
+        }
+        readline.readline(connection, new Prompt(prompt, mask), newLine -> {
+            out[0] = newLine;
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.finer("Got some input");
+            }
+            // We must call stopReading to stop reading from terminal
+            // and release this thread.
+            connection.stopReading();
+        }, null, null, null, null, READLINE_FLAGS);
+        try {
+            connection.openBlockingInterruptable();
+        } catch (InterruptedException ex) {
+            interrupted(ex);
+        }
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.finer("Done for prompt");
+        }
+        return out[0];
+    }
+
+    private String promptFromStartedConsole(String prompt, Character mask) {
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.log(Level.FINER, "Prompt {0} mask {1}", new Object[]{prompt, mask});
+        }
+        String[] out = new String[1];
+        // We must be called from another Thread. connection is reading in Main thread.
+        // calling readline will wakeup the Main thread that will execute
+        // the Prompt handling.
+        // We can safely wait.
+        if (readingThread == startThread) {
+            throw new RuntimeException("Can't prompt from the Thread that is "
+                    + "reading terminal input");
+        }
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // We need to set the interrupt SignalHandler to interrupt the CLI.
+        Consumer<Signal> prevHandler = connection.getSignalHandler();
+        connection.setSignalHandler(interruptHandler);
+        readline.readline(connection, new Prompt(prompt, mask), newLine -> {
+            out[0] = newLine;
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.finer("Got some input");
+            }
+            latch.countDown();
+        }, null, null, null, null, READLINE_FLAGS);
+        try {
+            latch.await();
+        } catch (InterruptedException ex) {
+            interrupted(ex);
+        } finally {
+            connection.setSignalHandler(prevHandler);
+        }
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.finer("Done for prompt");
+        }
+        return out[0];
+    }
+
+    private void interrupted(InterruptedException ex) {
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.finer("Thread interrupted");
+        }
+        // Ctrl-C, interrupt and throw exception to cancel prompting.
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(ex);
+    }
+
+    @Override
+    public int getTerminalWidth() {
+        return getWidth();
+    }
+
+    @Override
+    public int getTerminalHeight() {
+        return getHeight();
+    }
+
+    private int getHeight() {
+        if (connection instanceof TerminalConnection) {
+            return ((TerminalConnection) connection).getTerminal().getSize().getHeight();
+        }
+        return connection.size().getHeight();
+    }
+
+    private int getWidth() {
+        if (connection instanceof TerminalConnection) {
+            return ((TerminalConnection) connection).getTerminal().getSize().getWidth();
+        }
+        return connection.size().getWidth();
+    }
+
+    @Override
+    public void start() throws IOException {
+        if (closed) {
+            throw new IllegalStateException("Console has already been closed");
+        }
+        if (!started) {
+            startThread = Thread.currentThread();
+            started = true;
+            loop();
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.log(Level.FINER, "Started in thread {0}. Waiting...",
+                        startThread.getName());
+            }
+            try {
+                connection.openBlockingInterruptable();
+            } catch (InterruptedException ex) {
+                // OK leaving
+            }
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.finer("Leaving console");
+            }
+        } else if (LOG.isLoggable(Level.FINER)) {
+            LOG.finer("Already started");
+        }
+    }
+
+    private void loop() {
+        if (LOG.isLoggable(Level.FINER)) {
+            LOG.log(Level.FINER, "Set a readline callback with prompt {0}", prompt);
+        }
+        // Console could have been closed during a command execution.
+        if (!closed) {
+            readline.readline(connection, new Prompt(prompt), line -> {
+                // All commands can lead to prompting the user. So require
+                // to be executed in a dedicated thread.
+                // This can happen if a security configuration occurs
+                // on the remote server.
+                if (LOG.isLoggable(Level.FINER)) {
+                    LOG.log(Level.FINER,
+                            "Executing command {0} in a new thread.", line);
+                }
+                if (line == null || line.trim().length() == 0 || handleAlias(line)) {
+                    loop();
+                    return;
+                }
+                executor.submit(() -> {
+                    Consumer<Signal> handler = connection.getSignalHandler();
+                    Thread callingThread = Thread.currentThread();
+                    connection.setSignalHandler((signal) -> {
+                        // Interrupting the current command thread.
+                        switch (signal) {
+                            case INT: {
+                                if (LOG.isLoggable(Level.FINER)) {
+                                    LOG.log(Level.FINER, "Interrupting command: " + line,
+                                            line);
+                                }
+                                callingThread.interrupt();
+                            }
+                        }
+                    });
+                    try {
+                        callback.accept(line);
+                    } finally {
+                        // The current thread could have been interrupted.
+                        // Clear the flag to safely interact with aesh-readline
+                        Thread.interrupted();
+                        connection.setSignalHandler(handler);
+                        if (LOG.isLoggable(Level.FINER)) {
+                            LOG.log(Level.FINER, "Done Executing command {0}",
+                                    line);
+                        }
+                        loop();
+                    }
+                });
+            }, completions, preProcessors, readlineHistory, null, READLINE_FLAGS);
+        }
+    }
+
+    private boolean handleAlias(String line) {
+        if (line.startsWith("alias ") || line.equals("alias")) {
+            String out = aliasManager.parseAlias(line.trim());
+            if (out != null) {
+                connection.write(out);
+            }
+            return true;
+        } else if (line.startsWith("unalias ") || line.equals("unalias")) {
+            String out = aliasManager.removeAlias(line.trim());
+            if (out != null) {
+                connection.write(out);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void stop() {
+        if (!closed) {
+            if (LOG.isLoggable(Level.FINER)) {
+                LOG.finer("Stopping.");
+            }
+            closed = true;
+            if (readingThread != null) {
+                if (LOG.isLoggable(Level.FINER)) {
+                    LOG.finer("Interrupting reading thread");
+                }
+                readingThread.interrupt();
+            }
+            if (started) {
+                readlineHistory.stop();
+                aliasManager.persist();
+            }
+            executor.shutdown();
+            connection.close();
+        }
+    }
+
+    @Override
+    public boolean running() {
+        return started;
+    }
+
+    @Override
+    public void setPrompt(String prompt) {
+        this.prompt = prompt;
+    }
+}

--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -118,8 +118,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.aesh</groupId>
-            <artifactId>aesh</artifactId>
+            <groupId>org.aesh</groupId>
+            <artifactId>aesh-readline</artifactId>
         </dependency>
 
         <dependency>

--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli-logging.properties
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli-logging.properties
@@ -21,11 +21,13 @@
 #
 
 # Additional logger names to configure (root logger is always configured)
-loggers=org,javax,org.jboss.as.cli
+loggers=org,javax,org.jboss.as.cli,org.aesh
 logger.org.level=OFF
 logger.javax.level=OFF
 # assign a lower level to enable CLI logging
 logger.org.jboss.as.cli.level=OFF
+# assign a lower level to enable aesh logging
+logger.org.aesh.level=OFF
 
 # Root logger level
 logger.level=${jboss.cli.log.level:INFO}

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/aesh/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/aesh/main/module.xml
@@ -22,16 +22,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.aesh">
+<module xmlns="urn:jboss:module:1.5" name="org.aesh">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${org.jboss.aesh:aesh}"/>
+        <artifact name="${org.aesh:aesh-readline}"/>
     </resources>
 
     <dependencies>
         <module name="org.fusesource.jansi" />
+        <!-- required to handle native signals -->
+        <module name="sun.jdk" />
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -49,7 +49,7 @@
         <module name="org.codehaus.woodstox" services="import"/>
         <!-- END JAXP default dependencies -->
 
-        <module name="org.jboss.aesh"/>
+        <module name="org.aesh"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.as.controller-client"/>
         <module name="org.jboss.as.protocol"/>

--- a/patching/src/test/java/org/jboss/as/patching/cli/LocalPatchInfoPatchIdUnitTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/cli/LocalPatchInfoPatchIdUnitTestCase.java
@@ -65,8 +65,6 @@ public class LocalPatchInfoPatchIdUnitTestCase extends AbstractTaskTestCase {
     @Before
     public void before() throws Exception {
         bytesOs = new ByteArrayOutputStream();
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         ctx = CommandContextFactory.getInstance().newCommandContext(null, null, null, System.in, bytesOs);
     }
 

--- a/patching/src/test/java/org/jboss/as/patching/cli/PatchInspectUnitTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/cli/PatchInspectUnitTestCase.java
@@ -77,8 +77,6 @@ public class PatchInspectUnitTestCase extends AbstractTaskTestCase {
     @Before
     public void before() throws Exception {
         bytesOs = new ByteArrayOutputStream();
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         ctx = CommandContextFactory.getInstance().newCommandContext(null, null, null, System.in, bytesOs);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.fusesource.jansi>1.16</version.org.fusesource.jansi>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
-        <version.org.jboss.aesh>0.66.18</version.org.jboss.aesh>
+        <version.org.aesh-readline>1.0-CR17-SNAPSHOT</version.org.aesh-readline>
         <version.org.jboss.byteman>3.0.6</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.1.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.0.Beta4</version.org.jboss.invocation>
@@ -946,9 +946,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.aesh</groupId>
-                <artifactId>aesh</artifactId>
-                <version>${version.org.jboss.aesh}</version>
+                <groupId>org.aesh</groupId>
+                <artifactId>aesh-readline</artifactId>
+                <version>${version.org.aesh-readline}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>junit</groupId>

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchInfoTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchInfoTestCase.java
@@ -232,8 +232,6 @@ public class PatchInfoTestCase extends PatchInfoTestBase {
             line += " --verbose";
         }
 
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.terminal", "org.jboss.aesh.terminal.TestTerminal");
         final CommandContext ctx = CommandContextFactory.getInstance().newCommandContext(null, null, null, System.in, bytesOs);
 
         if(!offline) {

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchStreamsUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/PatchStreamsUnitTestCase.java
@@ -97,8 +97,6 @@ public class PatchStreamsUnitTestCase extends PatchInfoTestBase {
         moduleBDir = createModule("layerB");
         moduleCDir = createModule("layerC");
 
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.terminal", "org.jboss.aesh.terminal.TestTerminal");
         cli = CommandContextFactory.getInstance().newCommandContext(null, null, null, System.in, bytesOs);
 
         final ModelControllerClient client = ModelControllerClient.Factory.create(TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort());

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoPatchIdUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoPatchIdUnitTestCase.java
@@ -77,8 +77,6 @@ public class RemotePatchInfoPatchIdUnitTestCase extends AbstractPatchingTestCase
     @Before
     public void before() throws Exception {
         bytesOs = new ByteArrayOutputStream();
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
 
         String controller = "remote+http://" + TestSuiteEnvironment.getHttpAddress() + ":9990";
         ctx = CommandContextFactory.getInstance().newCommandContext(controller, null, null, System.in, bytesOs);

--- a/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoUnitTestCase.java
+++ b/testsuite/patching/src/test/java/org/jboss/as/test/patching/RemotePatchInfoUnitTestCase.java
@@ -79,8 +79,6 @@ public class RemotePatchInfoUnitTestCase extends AbstractPatchingTestCase {
     @Before
     public void before() throws Exception {
         bytesOs = new ByteArrayOutputStream();
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         String controller =   "remote+http://" + NetworkUtils.formatPossibleIpv6Address(System.getProperty("node0", "127.0.0.1")) + ":9990";
         ctx = CommandContextFactory.getInstance().newCommandContext(controller, null, null, System.in, bytesOs);
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/cli/CliProcessBuilder.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/cli/CliProcessBuilder.java
@@ -52,7 +52,6 @@ abstract class CliProcessBuilder{
         String jbossDist = TestSuiteEnvironment.getSystemProperty("jboss.dist");
         cliCommandBuilder = CliCommandBuilder.of(jbossDist);
         cliCommandBuilder.addJavaOptions(System.getProperty("cli.jvm.args", "").split("\\s+"));
-        //cliCommandBuilder.addJavaOption("-Daesh.ansi=false");
     }
 
     public CliProcessWrapper addCliArgument(String argument){
@@ -87,8 +86,6 @@ abstract class CliProcessBuilder{
         // the process to attach to a waiting debugger listening on the specified port.
         // If uncommented during normal testing, causes all sorts of failures.
         //cliCommandBuilder.addJavaOption("-agentlib:jdwp=transport=dt_socket,server=n,address=localhost.localdomain:8765,suspend=y");
-
-        cliCommandBuilder.addJavaOption("-Daesh.terminal=org.jboss.aesh.terminal.TestTerminal");
 
         if (cliConfigFile != null) {
             cliCommandBuilder.addJavaOption("-Djboss.cli.config=" + cliConfigFile);

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
@@ -54,7 +54,6 @@ public class CLITestUtil {
     private static final boolean isRemote = Boolean.parseBoolean(System.getProperty("org.jboss.as.test.integration.remote", "false"));
 
     public static CommandContext getCommandContext() throws CliInitializationException {
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         setJBossCliConfig();
         return CommandContextFactory.getInstance().newCommandContext(constructUri("remote+http", serverAddr , serverPort), isRemote ? username : null, isRemote ? password.toCharArray() : null);
     }
@@ -64,7 +63,6 @@ public class CLITestUtil {
     }
 
     public static CommandContext getCommandContext(WildFlyManagedConfiguration config) throws CliInitializationException {
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         setJBossCliConfig();
         return CommandContextFactory.getInstance().newCommandContext(
                 constructUri(config.getHostControllerManagementProtocol(),
@@ -74,16 +72,12 @@ public class CLITestUtil {
 
     public static CommandContext getCommandContext(String address, int port, InputStream in, OutputStream out)
             throws CliInitializationException {
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         setJBossCliConfig();
         return CommandContextFactory.getInstance().newCommandContext(address + ":" + port, isRemote ? username : null, isRemote ? password.toCharArray() : null, in, out);
     }
 
     public static CommandContext getCommandContext(String address, int port, InputStream in, OutputStream out, int connectionTimeout)
             throws CliInitializationException {
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         setJBossCliConfig();
         return CommandContextFactory.getInstance().newCommandContext(new CommandContextConfiguration.Builder()
                 .setController(address + ":" + port)
@@ -99,24 +93,16 @@ public class CLITestUtil {
 
     public static CommandContext getCommandContext(String protocol, String address, int port)
             throws CliInitializationException {
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         setJBossCliConfig();
         return CommandContextFactory.getInstance().newCommandContext(constructUri(protocol, address, port), isRemote ? username : null, isRemote ? password.toCharArray() : null);
     }
 
     public static CommandContext getCommandContext(OutputStream out) throws CliInitializationException {
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.ansi","false");
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         setJBossCliConfig();
         return CommandContextFactory.getInstance().newCommandContext(constructUri(null, serverAddr , serverPort), isRemote ? username : null, isRemote ? password.toCharArray() : null, null, out);
     }
 
     public static CommandContext getCommandContext(DomainTestSupport domainTestSupport, InputStream in, OutputStream out) throws CliInitializationException {
-        // to avoid the need to reset the terminal manually after the tests, e.g. 'stty sane'
-        System.setProperty("aesh.ansi", "false");
-        System.setProperty("aesh.terminal", "org.jboss.aesh.terminal.TestTerminal");
         setJBossCliConfig();
         WildFlyManagedConfiguration config = domainTestSupport.getDomainMasterConfiguration();
         return CommandContextFactory.getInstance().

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
@@ -111,7 +111,6 @@ public class CLIWrapper implements AutoCloseable {
     public CLIWrapper(boolean connect, String cliAddress, InputStream consoleInput, int connectionTimeout) throws CliInitializationException {
 
         consoleOut = new ByteArrayOutputStream();
-        System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         ctx = CLITestUtil.getCommandContext(
                 TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(),
                 consoleInput, consoleOut, connectionTimeout);

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliAliasTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliAliasTestCase.java
@@ -64,7 +64,6 @@ public class CliAliasTestCase {
     @Test
     public void testValidAliasCommandInteractive() throws Exception {
         CliProcessWrapper cli = new CliProcessWrapper()
-                .addCliArgument("-Daesh.terminal=org.jboss.aesh.terminal.TestTerminal")
                 .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString())
                 .addCliArgument("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString());
         try {
@@ -105,7 +104,6 @@ public class CliAliasTestCase {
         final String INVALID_ALIAS_NAME = "TMP-DEBUG123-INVALID456-ALIAS789"; //does not match [a-zA-Z0-9_]+ regex
         final String INVALID_ALIAS_COMMAND = "'/subsystem=notfound:invalid-command'";
         CliProcessWrapper cli = new CliProcessWrapper()
-                .addCliArgument("-Daesh.terminal=org.jboss.aesh.terminal.TestTerminal")
                 .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString())
                 .addCliArgument("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString());
         try {
@@ -144,7 +142,6 @@ public class CliAliasTestCase {
             fail(ex.getLocalizedMessage());
         }
         CliProcessWrapper cli = new CliProcessWrapper()
-                .addCliArgument("-Daesh.terminal=org.jboss.aesh.terminal.TestTerminal")
                 .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString())
                 .addCliArgument("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString());
         try {
@@ -171,7 +168,6 @@ public class CliAliasTestCase {
     public void testAliasPersistence() throws Exception {
         final File aliasFile = temporaryUserHome.newFile(".aesh_aliases");
         CliProcessWrapper cli = new CliProcessWrapper()
-                .addCliArgument("-Daesh.terminal=org.jboss.aesh.terminal.TestTerminal")
                 .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString())
                 .addCliArgument("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString());
         try {
@@ -196,7 +192,6 @@ public class CliAliasTestCase {
     public void testAliasPersistenceCtrlC() throws Exception {
         final File aliasFile = temporaryUserHome.newFile(".aesh_aliases");
         CliProcessWrapper cli = new CliProcessWrapper()
-                .addCliArgument("-Daesh.terminal=org.jboss.aesh.terminal.TestTerminal")
                 .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString())
                 .addCliArgument("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString());
         try {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliConfigTestCase.java
@@ -60,9 +60,13 @@ public class CliConfigTestCase {
         CliProcessWrapper cli = new CliProcessWrapper()
                 .setCliConfig(f.getAbsolutePath())
                 .addCliArgument("--command=version");
-        final String result = cli.executeNonInteractive();
-        assertNotNull(result);
-        assertTrue(result, result.contains("[disconnected /] version"));
+        try {
+            final String result = cli.executeNonInteractive();
+            assertNotNull(result);
+            assertTrue(result, result.contains("[disconnected /] version"));
+        } finally {
+            cli.destroyProcess();
+        }
     }
 
     @Test
@@ -71,9 +75,13 @@ public class CliConfigTestCase {
         CliProcessWrapper cli = new CliProcessWrapper()
                 .setCliConfig(f.getAbsolutePath())
                 .addCliArgument("--command=version");
-        final String result = cli.executeNonInteractive();
-        assertNotNull(result);
-        assertFalse(result, result.contains("[disconnected /] version"));
+        try {
+            final String result = cli.executeNonInteractive();
+            assertNotNull(result);
+            assertFalse(result, result.contains("[disconnected /] version"));
+        } finally {
+            cli.destroyProcess();
+        }
     }
 
     @Test
@@ -87,23 +95,27 @@ public class CliConfigTestCase {
                         TestSuiteEnvironment.getServerAddress() + ":" +
                         TestSuiteEnvironment.getServerPort())
                 .addCliArgument("--connect");
-        final String result = cli.executeNonInteractive();
-        assertNotNull(result);
-        assertTrue(result, result.contains(":read-attribute(name=foo)"));
-        assertTrue(result, result.contains("/system-property=catch:add(value=bar)"));
-        assertTrue(result, result.contains("/system-property=finally:add(value=bar)"));
-        assertTrue(result, result.contains("/system-property=finally2:add(value=bar)"));
-        assertTrue(result, result.contains("if (outcome == success) of /system-property=catch:read-attribute(name=value)"));
-        assertTrue(result, result.contains("set prop=Catch\\ block\\ was\\ executed"));
-        assertTrue(result, result.contains("/system-property=finally:write-attribute(name=value, value=if)"));
+        try {
+            final String result = cli.executeNonInteractive();
+            assertNotNull(result);
+            assertTrue(result, result.contains(":read-attribute(name=foo)"));
+            assertTrue(result, result.contains("/system-property=catch:add(value=bar)"));
+            assertTrue(result, result.contains("/system-property=finally:add(value=bar)"));
+            assertTrue(result, result.contains("/system-property=finally2:add(value=bar)"));
+            assertTrue(result, result.contains("if (outcome == success) of /system-property=catch:read-attribute(name=value)"));
+            assertTrue(result, result.contains("set prop=Catch\\ block\\ was\\ executed"));
+            assertTrue(result, result.contains("/system-property=finally:write-attribute(name=value, value=if)"));
 
-        assertFalse(result, result.contains("/system-property=catch2:add(value=bar)"));
-        assertFalse(result, result.contains("set prop=Catch\\ block\\ wasn\\'t\\ executed"));
-        assertFalse(result, result.contains("/system-property=finally:write-attribute(name=value, value=else)"));
+            assertFalse(result, result.contains("/system-property=catch2:add(value=bar)"));
+            assertFalse(result, result.contains("set prop=Catch\\ block\\ wasn\\'t\\ executed"));
+            assertFalse(result, result.contains("/system-property=finally:write-attribute(name=value, value=else)"));
 
-        assertTrue(result, result.contains("/system-property=catch:remove()"));
-        assertTrue(result, result.contains("/system-property=finally:remove()"));
-        assertTrue(result, result.contains("/system-property=finally2:remove()"));
+            assertTrue(result, result.contains("/system-property=catch:remove()"));
+            assertTrue(result, result.contains("/system-property=finally:remove()"));
+            assertTrue(result, result.contains("/system-property=finally2:remove()"));
+        } finally {
+            cli.destroyProcess();
+        }
     }
 
     @Test
@@ -116,9 +128,13 @@ public class CliConfigTestCase {
                         + TestSuiteEnvironment.getServerAddress() + ":"
                         + TestSuiteEnvironment.getServerPort())
                 .addCliArgument("--connect");
-        cli.executeInteractive();
-        cli.clearOutput();
-        testTimeout(cli, 1);
+        try {
+            cli.executeInteractive();
+            cli.clearOutput();
+            testTimeout(cli, 1);
+        } finally {
+            cli.destroyProcess();
+        }
     }
 
     @Test
@@ -130,9 +146,13 @@ public class CliConfigTestCase {
                         + TestSuiteEnvironment.getServerPort())
                 .addCliArgument("--connect")
                 .addCliArgument("--command-timeout=77");
-        cli.executeInteractive();
-        cli.clearOutput();
-        testTimeout(cli, 77);
+        try {
+            cli.executeInteractive();
+            cli.clearOutput();
+            testTimeout(cli, 77);
+        } finally {
+            cli.destroyProcess();
+        }
     }
 
     @Test
@@ -202,8 +222,12 @@ public class CliConfigTestCase {
                         + TestSuiteEnvironment.getServerAddress() + ":"
                         + TestSuiteEnvironment.getServerPort())
                 .addCliArgument("--connect");
-        String output = cli.executeNonInteractive();
-        assertTrue(output, output.contains("The command-timeout must be a valid positive integer"));
+        try {
+            String output = cli.executeNonInteractive();
+            assertTrue(output, output.contains("The command-timeout must be a valid positive integer"));
+        } finally {
+            cli.destroyProcess();
+        }
     }
 
     @Test
@@ -214,8 +238,12 @@ public class CliConfigTestCase {
                         + TestSuiteEnvironment.getServerPort())
                 .addCliArgument("--connect")
                 .addCliArgument("--command-timeout=-1");
-        String output = cli.executeNonInteractive();
-        assertTrue(output, output.contains("The command-timeout must be a valid positive integer"));
+        try {
+            String output = cli.executeNonInteractive();
+            assertTrue(output, output.contains("The command-timeout must be a valid positive integer"));
+        } finally {
+            cli.destroyProcess();
+        }
     }
 
     @Test
@@ -229,9 +257,13 @@ public class CliConfigTestCase {
                         + TestSuiteEnvironment.getServerAddress() + ":"
                         + TestSuiteEnvironment.getServerPort())
                 .addCliArgument("--connect");
-        final String result = cli.executeNonInteractive();
-        assertNotNull(result);
-        assertTrue(result, result.contains("Timeout exception for run-batch"));
+        try {
+            final String result = cli.executeNonInteractive();
+            assertNotNull(result);
+            assertTrue(result, result.contains("Timeout exception for run-batch"));
+        } finally {
+            cli.destroyProcess();
+        }
     }
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliEmbedServerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliEmbedServerTestCase.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Start an embedded server in the CLI remote process.
+ * embedded server updates System I/O in a way that impacts CLI output.
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+public class CliEmbedServerTestCase {
+
+    @Rule
+    public final TemporaryFolder temporaryUserHome = new TemporaryFolder();
+
+    @Test
+    public void testEmbedServerInRemoteCliProcess() throws Exception {
+        CliProcessWrapper cli = new CliProcessWrapper()
+                .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString());
+        try {
+            cli.executeInteractive();
+            cli.clearOutput();
+            boolean ret = cli.pushLineAndWaitForResults("embed-server", "[standalone@embedded /]");
+            assertTrue("Invalid output " + cli.getOutput(), ret);
+            ret = cli.pushLineAndWaitForResults("stop-embedded-server", "[disconnected /]");
+            assertTrue("Invalid output " + cli.getOutput(), ret);
+        } finally {
+            cli.destroyProcess();
+        }
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/FileInputTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/FileInputTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import org.jboss.as.cli.Util;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Emulate jboss-cli.sh process with input coming from a file. This activates
+ * aesh-readline ExtTerminal in an intensive multi-thread context.
+ *
+ */
+@RunWith(WildflyTestRunner.class)
+public class FileInputTestCase {
+
+    @Rule
+    public final TemporaryFolder temporaryUserHome = new TemporaryFolder();
+
+    @Test
+    public void test() throws Exception {
+        // test with a new CLI process and variable line length
+        for (int i = 1; i < 10; i++) {
+            String output = null;
+            CliProcessWrapper cli = new CliProcessWrapper()
+                    .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString())
+                    .addCliArgument("--controller="
+                            + TestSuiteEnvironment.getServerAddress() + ":"
+                            + TestSuiteEnvironment.getServerPort())
+                    .addCliArgument("--connect");
+            try {
+                cli.executeInteractive();
+                StringBuilder builder = new StringBuilder();
+                // Create a bunch of commands send them all in a single line.
+                for (int j = 0; j < i * 100; j++) {
+                    builder.append(":read-attribute(name=name" + j + ")").append(Util.isWindows() ? "\r\n" : "\n");
+                }
+                builder.append("quit").append(Util.isWindows() ? "\r\n" : "\n");
+                boolean ret = cli.pushLineAndWaitForClose(builder.toString());
+                output = cli.getOutput();
+                assertTrue("Process not terminated correctly: ", ret);
+                assertEquals("Invalid exit value " + cli.getProcessExitValue(), 0, cli.getProcessExitValue());
+                // Check that all command have been executed
+                assertTrue(output.contains("quit"));
+                for (int j = 0; j < i * 100; j++) {
+                    assertTrue(output.contains("name" + j));
+                }
+            } catch (Throwable ex) {
+                System.out.println("Iteration " + i + " Failure " + ex);
+                System.out.println("CLI output:\n " + output == null ? cli.getOutput() : output);
+                throw ex;
+            } finally {
+                cli.destroyProcess();
+            }
+        }
+    }
+
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/CliExtCommandHandler.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/extensions/CliExtCommandHandler.java
@@ -58,8 +58,7 @@ public class CliExtCommandHandler extends CommandHandlerWithHelp {
         ClassLoader cl = WildFlySecurityManager.getClassLoaderPrivileged(CliExtCommandHandler.class);
         InputStream helpInput = cl.getResourceAsStream(filename);
         if (helpInput != null) {
-            try (final BufferedReader reader = new BufferedReader(new InputStreamReader(helpInput, StandardCharsets.UTF_8))){
-                System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
+            try (final BufferedReader reader = new BufferedReader(new InputStreamReader(helpInput, StandardCharsets.UTF_8))) {
                 HelpFormatter.format(ctx, reader);
             } catch (java.io.IOException e) {
                 throw new CommandFormatException("Failed to read help/help.txt: " + e.getLocalizedMessage());


### PR DESCRIPTION
This is a a preliminary PR based on ash-readline 1.0-SNAPSHOT.
- faster CLI, startup, execution and shutdown, no more aesh threads.
- no more active CLI polling, aesh-readline is blocking.
- simpler handling of prompting (name, password, certificate).
- simpler handling of CTRL-C
