### PR TITLE
WFCORE-1905 WFCORE-1906 WFCORE-1907 minor script fixes

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/standalone.bat
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.bat
@@ -234,7 +234,7 @@ if not "%PRESERVE_JAVA_OPTS%" == "true" (
           if not exist "%JBOSS_LOG_DIR" > nul 2>&1 (
             mkdir "%JBOSS_LOG_DIR%"
           )
-         set "JAVA_OPTS=-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -Xloggc:"%JBOSS_LOG_DIR%\gc.log" -XX:-TraceClassUnloading %JAVA_OPTS%"
+         set "JAVA_OPTS=-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=3M -Xloggc:%JBOSS_LOG_DIR%\gc.log -XX:-TraceClassUnloading %JAVA_OPTS%"
         )
        )
     )

--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/service/service.bat
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/service/service.bat
@@ -156,8 +156,8 @@ echo(
 echo     /controller ^<host:port^>   : The host:port of the management interface.
 echo                                 default: %CONTROLLER%
 echo(
-echo     /host [^<domainhost^>]      : Indicates that domain mode is to be used with an
-echo                                 optional domain controller name.
+echo     /host [^<domainhost^>]      : Indicates that domain mode is to be used,
+echo                                 with an optional domain/host controller name.
 echo                                 default: %DC_HOST%
 echo                                 Not specifying /host will install JBoss in
 echo                                 standalone mode.

--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/service/service.bat
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/service/service.bat
@@ -450,7 +450,7 @@ if not "%SERVICE_USER%" == "" (
     echo When specifying a user, you need to specify the password
     goto endBatch
   )
-  set RUNAS=--ServiceUser=%SERVICE_USER% --ServicePassword=%SERVICE_PASS%
+  set RUNAS=--ServiceUser="%SERVICE_USER%" --ServicePassword="%SERVICE_PASS%"
 )
 
 if "%STDOUT%"=="" set STDOUT=auto


### PR DESCRIPTION
- WFCORE-1905 windows service (service.bat) failed to install if the value of /serviceuser has a white space inside
- WFCORE-1906 standalone.bat is unable to start from directory "jboss(eap)"
- WFCORE-1907 Win Service Script: Revise help for /host