### PR TITLE
WFCORE-1908 Metric attribute is not writable.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -117,6 +117,7 @@ public class Util {
     public static final String MAX_FAILED_SERVERS = "max-failed-servers";
     public static final String MAX_FAILURE_PERCENTAGE = "max-failure-percentage";
     public static final String MAX_OCCURS = "max-occurs";
+    public static final String METRIC = "metric";
     public static final String MIN_OCCURS = "min-occurs";
     public static final String MODULE = "module";
     public static final String MODULE_SLOT = "module-slot";

--- a/cli/src/main/java/org/jboss/as/cli/impl/AttributeNamePathCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/AttributeNamePathCompleter.java
@@ -225,7 +225,11 @@ public class AttributeNamePathCompleter implements CommandLineCompleter {
         }
 
         private boolean isWritable(ModelNode attrDescr) {
-            return !attrDescr.has(Util.ACCESS_TYPE) || !Util.READ_ONLY.equals(attrDescr.get(Util.ACCESS_TYPE).asString());
+            return !isReadOnly(attrDescr);
+        }
+
+        private boolean isReadOnly(ModelNode attrDescr) {
+            return attrDescr.has(Util.ACCESS_TYPE) && (Util.READ_ONLY.equals(attrDescr.get(Util.ACCESS_TYPE).asString()) || Util.METRIC.equals(attrDescr.get(Util.ACCESS_TYPE).asString()));
         }
 
         public int getCandidateIndex() {

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/AttributeNamePathCompletionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/AttributeNamePathCompletionTestCase.java
@@ -55,6 +55,31 @@ public class AttributeNamePathCompletionTestCase {
             "      \"required\" => true," +
             "      \"nillable\" => false" +
             "}," +
+            "\"attr-read-only\" => {" +
+            "      \"type\" => STRING," +
+            "      \"description\" => \"String attribute\"," +
+            "      \"expressions-allowed\" => false," +
+            "      \"required\" => true," +
+            "      \"nillable\" => false," +
+            "      \"access-type\" => \"read-only\""+
+            "}," +
+            "\"attr-read-write\" => {" +
+            "      \"type\" => STRING," +
+            "      \"description\" => \"String attribute\"," +
+            "      \"expressions-allowed\" => false," +
+            "      \"required\" => true," +
+            "      \"nillable\" => false," +
+            "      \"access-type\" => \"read-write\""+
+            "}," +
+            "\"attr-metric\" => {" +
+            "      \"type\" => STRING," +
+            "      \"description\" => \"String attribute\"," +
+            "      \"expressions-allowed\" => false," +
+            "      \"required\" => true," +
+            "      \"nillable\" => false," +
+            "      \"access-type\" => \"metric\""+
+            "}," +
+
             "\"step1\" => {" +
             "      \"type\" => OBJECT," +
             "      \"description\" => \"Object attribute\"," +
@@ -109,7 +134,7 @@ public class AttributeNamePathCompletionTestCase {
 
         int i;
         i = completer.complete(null, "", 0, candidates);
-        assertEquals(Arrays.asList("module-options", "step1", "str", "str2"), candidates);
+        assertEquals(Arrays.asList("attr-metric", "attr-read-only", "attr-read-write", "module-options", "step1", "str", "str2"), candidates);
         assertEquals(0, i);
 
         candidates.clear();
@@ -191,5 +216,26 @@ public class AttributeNamePathCompletionTestCase {
         i = completer.complete(null, "module-options.", 0, candidates);
         assertEquals(Collections.emptyList(), candidates);
         assertEquals(-1, i);
+    }
+
+    @Test
+    public void testAttributeAccessType() throws Exception {
+        // WFCORE-1908
+        final ModelNode propDescr = ModelNode.fromString(attrsDescr);
+        assertTrue(propDescr.isDefined());
+
+        final AttributeNamePathCompleter completer = new AttributeNamePathCompleter(propDescr);
+        final List<String> candidates = new ArrayList<String>();
+
+        // test write-only attribute
+        int i = completer.complete("attr", candidates, propDescr, true);
+        assertEquals(Arrays.asList("attr-read-write"), candidates);
+        assertEquals(0, i);
+
+        // test NOT write-only attribute
+        candidates.clear();
+        i = completer.complete("attr", candidates, propDescr, false);
+        assertEquals(Arrays.asList("attr-metric", "attr-read-only", "attr-read-write"), candidates);
+        assertEquals(0, i);
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1908

METRIC is read-only attribute https://github.com/wildfly/wildfly-core/blob/master/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java#L44
