### PR TITLE
Fix for WFCORE-1919. CLI frozen after removal of local auth

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/RemoveManagementRealmTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/RemoveManagementRealmTestCase.java
@@ -1,0 +1,138 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.management.cli;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import javax.inject.Inject;
+import org.jboss.as.test.integration.management.cli.CliProcessWrapper;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.After;
+import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class RemoveManagementRealmTestCase {
+
+    @Inject
+    private ServerController container;
+
+    @Rule
+    public final TemporaryFolder temporaryUserHome = new TemporaryFolder();
+    private Path target;
+    private Path source;
+
+    @Before
+    public void beforeTest() throws Exception {
+        container.start();
+        String jbossDist = TestSuiteEnvironment.getSystemProperty("jboss.dist");
+        source = Paths.get(jbossDist, "standalone", "configuration", "standalone.xml");
+        target = Paths.get(temporaryUserHome.getRoot().getAbsolutePath(), "standalone.xml");
+        Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    @After
+    public void afterTest() throws Exception {
+        try {
+            container.stop();
+        } finally {
+            Files.copy(target, source, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    @Test
+    public void testReload() throws Exception {
+        CliProcessWrapper cli = new CliProcessWrapper().
+                addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString()).
+                addCliArgument("--controller=remote+http://"
+                        + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort()).
+                addCliArgument("--connect");
+        cli.executeInteractive();
+        cli.clearOutput();
+        cli.pushLineAndWaitForResults("/core-service=management/security-realm=ManagementRealm/authentication=local:remove");
+        cli.clearOutput();
+        cli.pushLineAndWaitForResults("reload");
+        assertTrue(cli.ctrlCAndWaitForClose());
+    }
+
+    @Test
+    public void testShutdown() throws Exception {
+        CliProcessWrapper cli = new CliProcessWrapper().
+                addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString()).
+                addCliArgument("--controller=remote+http://"
+                        + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort()).
+                addCliArgument("--connect");
+        cli.executeInteractive();
+        cli.clearOutput();
+        cli.pushLineAndWaitForResults("/core-service=management/security-realm=ManagementRealm/authentication=local:remove");
+        cli.clearOutput();
+        cli.pushLineAndWaitForResults("shutdown --reload");
+        assertTrue(cli.ctrlCAndWaitForClose());
+    }
+
+    @Test
+    public void testAnyCommand() throws Exception {
+        CliProcessWrapper cli1 = new CliProcessWrapper().
+                addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString()).
+                addCliArgument("--controller=remote+http://"
+                        + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort()).
+                addCliArgument("--connect");
+        cli1.executeInteractive();
+        cli1.clearOutput();
+
+        CliProcessWrapper cli2 = new CliProcessWrapper().
+                addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString()).
+                addCliArgument("--controller=remote+http://"
+                        + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort()).
+                addCliArgument("--connect");
+        cli2.executeInteractive();
+        cli2.clearOutput();
+
+        cli1.pushLineAndWaitForResults("/core-service=management/security-realm=ManagementRealm/authentication=local:remove");
+        cli1.clearOutput();
+        cli1.pushLineAndWaitForResults("reload");
+        assertTrue(cli1.ctrlCAndWaitForClose());
+
+        // Send ls from cli2.
+        cli2.pushLineAndWaitForResults("ls");
+        cli2.clearOutput();
+        assertTrue(cli2.ctrlCAndWaitForClose());
+    }
+}


### PR DESCRIPTION
This is a change in the locking strategy of CLIModelControllerClient. It has been observed that the CLI could deadlock in case one abort (Ctrl-C) an already connected CLI that ts getting reloaded after a removal of the local auth authentication with default user $local-user. This could occur using shutdown --restart, reload or any command issued from an already connected CLI to a reconfigured server.

The connection is now done unlocked, allowing the close method to change the state of the ControllerClient to MUST_CLOSE in a locked block. 

The validity of the checks 'strategy == null' that are done in locked blocks has been preserved. strategy is set to a non null strategy in a locked block at the end of the connection. strategy != null still means "connection is done".

A simpler fix would have been to not change the locking, do a check in close for CONNECTING without acquiring the lock and returns if in CONNECTING state. This would let the door open for a client just being reconnected but state not being yet changed to CONNECTED (line 202 of CLIModelControllerClient). Very small window but still possible.

I have added unit tests to cover the 3 cases.