### PR TITLE
Fix for WFCORE-1920. Completion for list of capability references

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/CapabilityReferenceCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/CapabilityReferenceCompleter.java
@@ -44,6 +44,11 @@ import org.jboss.dmr.Property;
  */
 public class CapabilityReferenceCompleter extends DefaultCompleter {
 
+    // For testing purpose.
+    public CapabilityReferenceCompleter(CandidatesProvider provider) {
+        super(provider);
+    }
+
     public CapabilityReferenceCompleter(OperationRequestAddress address, String staticPart) {
         super((ctx) -> {
             ModelNode mn;
@@ -75,6 +80,12 @@ public class CapabilityReferenceCompleter extends DefaultCompleter {
             }
         }
         return mn;
+    }
+
+    public List<String> getCapabilityReferenceNames(CommandContext ctx,
+            OperationRequestAddress address,
+            String staticPart) {
+        return getCapabilityNames(ctx, address, staticPart);
     }
 
     public static List<String> getCapabilityNames(CommandContext ctx,


### PR DESCRIPTION
Enhanced ValueTypeCompleter with support for list of Capability references. Only propose what the user has not already provided, propose ',' and ']' when appropriate.

Redesigned lightly ValueTypeCompleter/CapabilityReferenceCompleter to be testable without capabilities retrieved from server capability registry.

Fixed a ValueTypeCompleter issue that was making the OperationRequestCompleter to not complete the operation (with ')' character) when all arguments were present and the last one was associated to the ValueTypeCompleter.

Added unit tests.
