### PR TITLE
[WFCORE-1928] Do normal validation of 'validate-operation' op's 'valu…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -1126,7 +1126,7 @@ public interface ControllerLogger extends BasicLogger {
      *
      * @return the exception.
      */
-    @Message(id = 97, value = "Wrong type for %s. Expected %s but was %s")
+    @Message(id = 97, value = "Wrong type for '%s'. Expected %s but was %s")
     OperationFailedException incorrectType(String name, Collection<ModelType> validTypes, ModelType invalidType);
 
     /**
@@ -1790,7 +1790,7 @@ public interface ControllerLogger extends BasicLogger {
      *
      * @return the exception.
      */
-    @Message(id = 155, value = "%s may not be null")
+    @Message(id = 155, value = "'%s' may not be null")
     OperationFailedException nullNotAllowed(String name);
 
     // id = 156; redundant parameter null check message

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ValidateOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ValidateOperationHandler.java
@@ -88,7 +88,7 @@ public class ValidateOperationHandler implements OperationStepHandler {
 
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-        ModelNode op = operation.require(VALUE.getName());
+        ModelNode op = VALUE.validateOperation(operation);
         PathAddress addr = PathAddress.pathAddress(op.get(OP_ADDR));
         if (slave) {
             op = op.clone();


### PR DESCRIPTION
…e' param

I also tweak the error messages used by our standard validator code to quote the name of the 'broken' attribute/param. Makes it a bit clearer when the name of the param is 'value'.