### PR TITLE
WFCORE-1931 fix typo in resource description.

### DIFF
--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -410,8 +410,8 @@ socket-binding.client-mappings.source-network=Source network the client connecti
 socket-binding.client-mappings.destination-address=The destination address that a client should connect to if the source-network matches. This value can either be a hostname or an IP address.
 socket-binding.client-mappings.destination-port=The destination port that a client should connect to if the source-network matches. If omitted this mapping will reuse the effective socket binding port.
 
-socket-binding-group.remote-destination-outbound-socket-binding=Configuration information for a, remote destination, outbound socket binding.
-socket-binding-group.local-destination-outbound-socket-binding=Configuration information for a, local destination, outbound socket binding.
+socket-binding-group.remote-destination-outbound-socket-binding=Configuration information for a remote destination, outbound socket binding.
+socket-binding-group.local-destination-outbound-socket-binding=Configuration information for a local destination, outbound socket binding.
 
 remote-destination-outbound-socket-binding=Configuration information for a remote destination outbound socket binding.
 remote-destination-outbound-socket-binding.name=Name of the outbound socket binding. Services which need to access the socket configuration information will find it using this name.


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1931
Extra commas in descriptions of *-outbound-socket-binding CLI resources