### PR TITLE
[WFCORE-1949]: Typos in /subsystem=logging resource descriptions.

### DIFF
--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -31,7 +31,7 @@ logging.use-deployment-logging-config=Indicates whether or not deployments shoul
   deployment.
 
 # Logging profiles
-logging.logging-profile=A profile that can be assigned to a deployment for it's logging configuration.
+logging.logging-profile=A profile that can be assigned to a deployment for its logging configuration.
 logging.logging-profile.add=Adds a logging profile.
 logging.logging-profile.remove=Removes the logging profile and all associated loggers and handlers.
 
@@ -118,7 +118,7 @@ logging.logger.unassign-handler.deprecated=Use the remove-handler operation.
 logging.logger.unassign-handler.name=The name of the handler to remove.
 # Attributes
 logging.logger.name=Name of the logger
-logging.logger.use-parent-handlers=Specifies whether or not this logger should send its output to it's parent Logger.
+logging.logger.use-parent-handlers=Specifies whether or not this logger should send its output to its parent Logger.
 logging.logger.category=Specifies the category for the logger.
 logging.logger.handlers=The handlers associated with the logger.
 logging.logger.handlers.handler=The name of the log handler.


### PR DESCRIPTION
[WFCORE-1949] : https://issues.jboss.org/browse/WFCORE-1949