### PR TITLE
WFCORE-1374 - use posix syntax for --add-exports that works with launcher

### DIFF
--- a/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
+++ b/launcher/src/test/java/org/wildfly/core/launcher/CommandBuilderTest.java
@@ -70,6 +70,9 @@ public class CommandBuilderTest {
                 .addJavaOption("-Djava.security.manager")
                 .addJavaOption("-Djava.net.preferIPv4Stack=true")
                 .addJavaOption("-Djava.net.preferIPv4Stack=false")
+                .addJavaOption("--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED")
+                .addJavaOption("--add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED")
+                .addJavaOption("--add-modules=java.base, java.annotation.common")
                 .setBindAddressHint("management", "0.0.0.0");
 
         // Get all the commands
@@ -86,6 +89,9 @@ public class CommandBuilderTest {
         Assert.assertTrue("Missing server configuration file override", commands.contains("-c=standalone-full.xml"));
 
         Assert.assertTrue("Missing -secmgr option", commands.contains("-secmgr"));
+
+        Assert.assertTrue("Missing --add-exports option", commands.contains("--add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED"));
+
 
         // A system property should only be added ones
         Assert.assertEquals("There should be only one java.net.preferIPv4Stack system property", 1, commandBuilder.getJavaOptions().stream()

--- a/pom.xml
+++ b/pom.xml
@@ -1535,10 +1535,10 @@
             </activation>
             <properties>
                 <!-- [WFCORE-1431] remove SASL workaround -->
-                <modular.jdk.args>--add-exports java.security.sasl/com.sun.security.sasl.digest=ALL-UNNAMED
-                    --add-exports java.security.sasl/com.sun.security.sasl=ALL-UNNAMED
-                    --add-exports jdk.unsupported/sun.reflect=ALL-UNNAMED
-                    --add-exports jdk.unsupported/sun.misc=ALL-UNNAMED
+                <modular.jdk.args>--add-exports=java.security.sasl/com.sun.security.sasl.digest=ALL-UNNAMED
+                    --add-exports=java.security.sasl/com.sun.security.sasl=ALL-UNNAMED
+                    --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
+                    --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED
                 </modular.jdk.args>
                 <!-- [WFCORE-1494] remove JUL workaround -->
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true</modular.jdk.props>


### PR DESCRIPTION
This way launcher doesn't choke on parameters and most of testsuite runs.