### PR TITLE
[WFCORE-1952]: Change byteman listening port to avoid conflicts with TeamCity.

### DIFF
--- a/deployment-repository/pom.xml
+++ b/deployment-repository/pom.xml
@@ -36,11 +36,6 @@
 
     <name>WildFly: Deployment Repository</name>
 
-    <properties>
-        <byteman.host>127.0.0.1</byteman.host>
-        <byteman.port>9091</byteman.port>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/deployment-scanner/pom.xml
+++ b/deployment-scanner/pom.xml
@@ -36,11 +36,6 @@
 
     <name>WildFly: Deployment Scanner</name>
 
-    <properties>
-        <byteman.host>127.0.0.1</byteman.host>
-        <byteman.port>9091</byteman.port>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -37,11 +37,6 @@
 
     <name>WildFly: Logging Subsystem</name>
 
-    <properties>
-        <byteman.host>127.0.0.1</byteman.host>
-        <byteman.port>9091</byteman.port>
-    </properties>
-
     <build>
         <plugins>
             <!-- this is only needed on windows -->

--- a/patching/pom.xml
+++ b/patching/pom.xml
@@ -36,11 +36,6 @@
 
     <name>WildFly: Patching Core</name>
 
-    <properties>
-        <byteman.host>127.0.0.1</byteman.host>
-        <byteman.port>9091</byteman.port>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,9 @@
         <org.jboss.model.test.cache.root>[pom.xml,testsuite]</org.jboss.model.test.cache.root>
         <!-- Location relative to root that will be used for the cached legacy classpaths used by subsystem-test and core-model-test-->
         <org.jboss.model.test.classpath.cache>target/model-test-cache</org.jboss.model.test.classpath.cache>
+        <!-- Byteman -->
+        <byteman.host>127.0.0.1</byteman.host>
+        <byteman.port>17091</byteman.port>
     </properties>
 
     <modules>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -146,10 +146,10 @@
                             <systemPropertyVariables combine.children="append">
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                                 <byteman.server.ipaddress>${node0}</byteman.server.ipaddress>
-                                <byteman.server.port>9091</byteman.server.port>
+                                <byteman.server.port>${byteman.port}</byteman.server.port>
                                 <jboss.home>${wildfly.home}</jboss.home>
                                 <module.path>${wildfly.home}/modules/</module.path>
-                                <jvm.args>-javaagent:${org.jboss.byteman:byteman:jar}=port:9091,boot:${org.jboss.byteman:byteman:jar},sys:${org.wildfly.core:wildfly-core-testsuite-shared:jar} -Dorg.jboss.byteman.transform.all -Dorg.jboss.byteman.verbose=true -Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
+                                <jvm.args>-javaagent:${org.jboss.byteman:byteman:jar}=port:${byteman.port},address:${byteman.host},boot:${org.jboss.byteman:byteman:jar},sys:${org.wildfly.core:wildfly-core-testsuite-shared:jar} -Dorg.jboss.byteman.transform.all -Dorg.jboss.byteman.verbose=true -Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
                                 <cli.jvm.args>${modular.jdk.args}</cli.jvm.args>
                                 <cli.args>-Dmaven.repo.local=${settings.localRepository}</cli.args>
                                 <javax.net.ssl.trustStore>${basedir}/src/test/resources/ssl/jbossClient.truststore</javax.net.ssl.trustStore>


### PR DESCRIPTION
Moving the Byteman port configuration to the parent pom.xml.
Changing the value from 9091 to 17091.

Jira: https://issues.jboss.org/browse/WFCORE-1952