### PR TITLE
Update to VDX 1.1.1

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/persistence/XmlConfigurationPersister.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/XmlConfigurationPersister.java
@@ -46,7 +46,7 @@ import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLElementWriter;
 import org.jboss.staxmapper.XMLMapper;
 import org.projectodd.vdx.core.XMLStreamValidationException;
-import org.projectodd.vdx.wildfly.ErrorReporter;
+import org.projectodd.vdx.wildfly.WildFlyErrorReporter;
 
 /**
  * A configuration persister which uses an XML file for backing storage.
@@ -148,13 +148,9 @@ public class XmlConfigurationPersister extends AbstractConfigurationPersister {
     }
 
     private boolean reportValidationError(final XMLStreamException exception) {
-        final String jbossHome = System.getProperty("jboss.home.dir");
-
-        return jbossHome != null &&
-                new ErrorReporter(this.fileName,
-                                  new File(jbossHome, "docs/schema"),
-                                  ControllerLogger.ROOT_LOGGER)
-                        .report(exception);
+        return new WildFlyErrorReporter(this.fileName,
+                                        ControllerLogger.ROOT_LOGGER)
+                .report(exception);
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.mockito>1.9.5</version.org.mockito>
         <version.org.picketbox>5.0.0.Alpha3</version.org.picketbox>
-        <version.org.projectodd.vdx>1.1.0</version.org.projectodd.vdx>
+        <version.org.projectodd.vdx>1.1.1</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.7.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>


### PR DESCRIPTION
VDX 1.1.1 includes changes that will make it possible for WildFly Swarm
to use it.

The only visible change for WildFly is a wording change in the output when the schemas can't be found:

```
-no_schemas_available=%s: No schemas available at %s - disabling validation error pretty printing
 +no_schemas_available=%s: No schemas available from %s - disabling validation error pretty printing
```