### PR TITLE
WFCORE-1957 ProfileCloneHandler needs to handle rollbacked failure de…

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileCloneHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ProfileCloneHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.domain.controller.operations;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CLONE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
@@ -140,6 +141,15 @@ public class ProfileCloneHandler implements OperationStepHandler {
         }, OperationContext.Stage.MODEL, true);
 
         context.addStep(result, describeOp, handler, OperationContext.Stage.MODEL, true);
+
+        context.completeStep(new OperationContext.RollbackHandler() {
+            @Override
+            public void handleRollback(OperationContext context, ModelNode operation) {
+                if (!context.hasFailureDescription()) {
+                    context.getFailureDescription().set(result.get(FAILURE_DESCRIPTION));
+                }
+            }
+        });
     }
 
     private void addOperation(OperationContext context, ModelNode op) {


### PR DESCRIPTION
…scription from ProfileModelDescribeHandler.
https://issues.jboss.org/browse/WFCORE-1957

This gives: 
```
[domain@localhost:9990 /] /profile=non-existing-profile:clone(to-profile=whatever)
{
    "outcome" => "failed",
    "failure-description" => {"domain-failure-description" => "WFLYCTL0216: Management resource '[(\"profile\" => \"non-existing-profile\")]' not found"},
    "rolled-back" => true
}
```