### PR TITLE
Fix for WFCORE-1970, WFCORE-1918, WFCORE-1909. Aesh 0.66.13, quote pa…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -496,7 +496,6 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         settings.historyFilePermission(permissions);
 
         settings.parseOperators(false);
-        settings.parsingQuotes(false);
 
         settings.interruptHook(
                 new InterruptHook() {

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.fusesource.jansi>1.11</version.org.fusesource.jansi>
-        <version.org.jboss.aesh>0.66.11</version.org.jboss.aesh>
+        <version.org.jboss.aesh>0.66.13</version.org.jboss.aesh>
         <version.org.jboss.byteman>3.0.3</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.1.2.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.0.Beta1</version.org.jboss.invocation>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCommentsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCommentsTestCase.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.as.test.integration.management.cli;
 
-import org.jboss.as.test.integration.management.util.CLIWrapper;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,20 +32,26 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  */
 @RunWith(WildflyTestRunner.class)
 public class CliCommentsTestCase {
+
+    /**
+     * In comments, " and ' are not parsed. Outside comments, they are and the
+     * '>' prompt is shown.
+     *
+     * @throws Exception
+     */
     @Test
     public void test() throws Exception {
-        CLIWrapper cli = new CLIWrapper(true);
-        cli.sendLine("# Hello ' sdcds ");
-        cli.sendLine("version");
-        assertTrue(cli.readOutput().contains("JBOSS_HOME"));
-        cli.sendLine("# Hello ' sdcds ' ");
-        cli.sendLine("version");
-        assertTrue(cli.readOutput().contains("JBOSS_HOME"));
-        cli.sendLine("# Hello \" sdcds ");
-        cli.sendLine("version");
-        assertTrue(cli.readOutput().contains("JBOSS_HOME"));
-        cli.sendLine("# Hello \" sdcds \"");
-        cli.sendLine("version");
-        assertTrue(cli.readOutput().contains("JBOSS_HOME"));
+        CliProcessWrapper cli = new CliProcessWrapper();
+        cli.executeInteractive();
+        try {
+            assertTrue(cli.pushLineAndWaitForResults("# Hello \" sdcds ", null));
+            assertTrue(cli.pushLineAndWaitForResults("# Hello \' sdcds ", null));
+            assertTrue(cli.pushLineAndWaitForResults("version", null));
+            assertTrue(cli.getOutput().contains("JBOSS_HOME"));
+            assertTrue(cli.pushLineAndWaitForResults("ls \"", ">"));
+            assertTrue(cli.pushLineAndWaitForResults("-l \"", null));
+        } finally {
+            cli.destroyProcess();
+        }
     }
 }


### PR DESCRIPTION
Aesh 0.66.13
- Fixes '\0' char kept in typed input.
- Fixes quotes handling
- Aesh is back to parsing quotes.

Made changes to the comments test to test the right behaviour.

