### PR TITLE
[WFCORE-1731] Where we bind an existing client to the CommandContext create a ConnectionInfoBean to track the time.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -1186,7 +1186,9 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
 
     @Override
     public void bindClient(ModelControllerClient newClient) {
-        initNewClient(newClient, null, null);
+        ConnectionInfoBean conInfo = new ConnectionInfoBean();
+        conInfo.setLoggedSince(new Date());
+        initNewClient(newClient, null, conInfo);
     }
 
     private void initNewClient(ModelControllerClient newClient, ControllerAddress address, ConnectionInfoBean conInfo) {


### PR DESCRIPTION
This eliminates a NullPointerException calling connection-info when running an embedded server.
