### PR TITLE
WFCORE-1980, add an option to ignore unresolved expression to resolve…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/ArgumentValueConverter.java
+++ b/cli/src/main/java/org/jboss/as/cli/ArgumentValueConverter.java
@@ -47,7 +47,7 @@ public interface ArgumentValueConverter {
                 return new ModelNode();
             }
             if(ctx.isResolveParameterValues()) {
-                value = CLIExpressionResolver.resolveOrOriginal(value);
+                value = CLIExpressionResolver.resolveLax(value);
             }
             try {
                 return ModelNode.fromString(value);
@@ -66,7 +66,7 @@ public interface ArgumentValueConverter {
                 return new ModelNode();
             }
             if(ctx.isResolveParameterValues()) {
-                value = CLIExpressionResolver.resolveOrOriginal(value);
+                value = CLIExpressionResolver.resolveLax(value);
             }
             ModelNode toSet = null;
             try {

--- a/cli/src/main/java/org/jboss/as/cli/util/CLIExpressionResolver.java
+++ b/cli/src/main/java/org/jboss/as/cli/util/CLIExpressionResolver.java
@@ -84,6 +84,23 @@ public class CLIExpressionResolver {
         }
     }
 
+    /**
+     * Attempts to substitute all the found expressions in the input with their corresponding resolved values. If any of the
+     * found expressions failed to resolve, try to resolve expressions as more as possible and return the resolved value. If the
+     * input does not contain any expression, the input is returned as is. see https://issues.jboss.org/browse/WFCORE-1980,
+     *
+     * @param input the input string
+     * @return the input with resolved expressions or the original input in case the input didn't contain any expressions
+     */
+    public static String resolveLax(String input) {
+        try {
+            return resolve(input, false);
+        } catch (UnresolvedExpressionException e) {
+            // XXX OK. It should not reach here as exceptionIfNotResolved is false.
+            return input;
+        }
+    }
+
     private static String resolve(String input, boolean exceptionIfNotResolved)
             throws UnresolvedExpressionException {
 

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/PropertyReplacementTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/PropertyReplacementTestCase.java
@@ -109,6 +109,8 @@ public class PropertyReplacementTestCase {
         assertEquals("test-op", CLIExpressionResolver.resolve("${unknown:${test.op-name}}"));
         assertEquals("test-op", CLIExpressionResolver.resolve("${test.op-name:${unknown}}"));
         assertEquals("${unknown1:${unknown2}}", CLIExpressionResolver.resolveOrOriginal("${unknown1:${unknown2}}"));
+        assertEquals("test-op${unknown1}", CLIExpressionResolver.resolveLax("${test.op-name}${unknown1}"));
+        assertEquals("${unknown1}test-op", CLIExpressionResolver.resolveLax("${unknown1}${test.op-name}"));
     }
 
     @Test


### PR DESCRIPTION
… as more as possible for argument value expressions.

https://issues.jboss.org/browse/WFCORE-1980

Hi @jfdenise, Could you review this? I found out the problem as I comment in Jira, but I'm not sure if this is the best way to fix it.   