### PR TITLE
[WFCORE-1998] Support NameService customization via system property

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -92,5 +92,6 @@
         <module name="org.picketbox" optional="true"/>
         <module name="io.undertow.core" />
         <module name="org.wildfly.common"/>
+        <module name="sun.jdk" services="export" export="true"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
@@ -89,6 +89,8 @@
                 <path name="sun/font"/>
                 <path name="sun/misc"/>
                 <path name="sun/io"/>
+                <path name="sun/net/spi/nameservice"/>
+                <path name="sun/net/spi/nameservice/dns"/>
                 <path name="sun/nio"/>
                 <path name="sun/nio/ch"/>
                 <path name="sun/nio/cs"/>


### PR DESCRIPTION
sun.net.spi.nameservice.NameService can be customize via system property "sun.net.spi.nameservice.provider.<n>" but it was not working on WildFly. To make it work, module classloader "org.jboss.as.server:main" need to export module "sun.jdk:main".

Some <path> are added in "sun.jdk:main" to be able to use the original implementation as well.