### PR TITLE
Fix for WFCORE-1992, undefined empty object

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/parsing/arguments/ArgumentValueCallbackHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/arguments/ArgumentValueCallbackHandler.java
@@ -426,8 +426,11 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
 
         @Override
         public ModelNode getValue() {
-            if(obj == null) {
-                return new ModelNode();
+            if (obj == null) {
+                // An empty Object "{}". Calling the constructor
+                // makes the ModelNode undefined.
+                obj = new ModelNode();
+                obj.setEmptyObject();
             }
             return obj;
         }

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/ArgumentValueConverterTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/ArgumentValueConverterTestCase.java
@@ -52,6 +52,21 @@ public class ArgumentValueConverterTestCase {
     }
 
     @Test
+    public void testEmptyObject() throws Exception {
+        final ModelNode value = parseObject("{}");
+        assertNotNull(value);
+        assertEquals(ModelType.OBJECT, value.getType());
+    }
+
+    @Test
+    public void testNestedEmptyObject() throws Exception {
+        final ModelNode value = parseObject("{toto={}}");
+        final List<Property> list = value.asPropertyList();
+        Property prop = list.get(0);
+        assertEquals(ModelType.OBJECT, prop.getValue().getType());
+    }
+
+    @Test
     public void testDefault_List() throws Exception {
         final ModelNode value = parseObject("[\"item1\",\"item2\"]");
         assertNotNull(value);


### PR DESCRIPTION
Empty Object nested in Object was parsed as an UNDEFINED value.
Added unit test.