### PR TITLE
Fix for WFCORE-2002. Handle '~' in options

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -37,6 +37,7 @@ import org.jboss.as.cli.CommandContextFactory;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.gui.GuiMain;
+import org.jboss.as.cli.handlers.FilenameTabCompleter;
 import org.jboss.as.cli.handlers.VersionHandler;
 import org.jboss.as.protocol.StreamUtils;
 import org.wildfly.security.manager.WildFlySecurityManager;
@@ -89,8 +90,8 @@ public class CliLauncher {
 
                     final String fileName = arg.startsWith("--") ? arg.substring(7) : arg.substring(5);
                     if(!fileName.isEmpty()) {
-                        file = new File(fileName);
-                        if(!file.exists()) {
+                        file = new File(FilenameTabCompleter.expand(fileName));
+                        if (!file.exists()) {
                             argError = "File " + file.getAbsolutePath() + " doesn't exist.";
                             break;
                         }
@@ -188,7 +189,7 @@ public class CliLauncher {
                     commands = Collections.singletonList("help");
                 } else if (arg.startsWith("--properties=")) {
                     final String value  = arg.substring(13);
-                    final File propertiesFile = new File(value);
+                    final File propertiesFile = new File(FilenameTabCompleter.expand(value));
                     if(!propertiesFile.exists()) {
                         argError = "File doesn't exist: " + propertiesFile.getAbsolutePath();
                         break;

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliConfigTestCase.java
@@ -134,6 +134,56 @@ public class CliConfigTestCase {
     }
 
     @Test
+    public void testOptionFile() throws Exception {
+        testFileOption("file");
+        testFileOption("properties");
+    }
+
+    private void testFileOption(String optionName) throws Exception {
+        File f = new File(temporaryUserHome.getRoot(), "a-script"
+                + System.currentTimeMillis() + ".cli");
+        f.createNewFile();
+        f.deleteOnExit();
+        {
+            CliProcessWrapper cli = new CliProcessWrapper()
+                    .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString())
+                    .addCliArgument("--" + optionName + "=" + "~" + File.separator + f.getName());
+            try {
+                cli.executeNonInteractive();
+                assertFalse(cli.getOutput(), cli.getOutput().contains(f.getName()));
+            } finally {
+                cli.destroyProcess();
+            }
+        }
+
+        {
+            CliProcessWrapper cli = new CliProcessWrapper()
+                    .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString())
+                    .addCliArgument("--" + optionName + "=" + "~"
+                            + temporaryUserHome.getRoot().getName() + File.separator + f.getName());
+            try {
+                cli.executeNonInteractive();
+                assertFalse(cli.getOutput(), cli.getOutput().contains(f.getName()));
+            } finally {
+                cli.destroyProcess();
+            }
+        }
+
+        {
+            String invalidPath = "~" + System.currentTimeMillis() + "@testOptionFile" + File.separator + f.getName();
+            CliProcessWrapper cli = new CliProcessWrapper()
+                    .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString())
+                    .addCliArgument("--" + optionName + "=" + invalidPath);
+            try {
+                cli.executeNonInteractive();
+                assertTrue(cli.getOutput(), cli.getOutput().contains(f.getName()));
+            } finally {
+                cli.destroyProcess();
+            }
+        }
+    }
+
+    @Test
     public void testNegativeConfigTimeoutCommand() throws Exception {
         File f = createConfigFile(false, -1);
         CliProcessWrapper cli = new CliProcessWrapper()


### PR DESCRIPTION
Fix for --file and --properties options to support '~' character.
Added unit tests.