### PR TITLE
Fix for WFCORE-2005. Better filesystem path completion. Reworked file…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -36,10 +36,8 @@ import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.handlers.CommandHandlerWithHelp;
-import org.jboss.as.cli.handlers.DefaultFilenameTabCompleter;
 import org.jboss.as.cli.handlers.FilenameTabCompleter;
 import org.jboss.as.cli.handlers.SimpleTabCompleter;
-import org.jboss.as.cli.handlers.WindowsFilenameTabCompleter;
 import org.jboss.as.cli.impl.ArgumentWithValue;
 import org.jboss.as.cli.impl.FileSystemPathArgument;
 import org.jboss.as.cli.operation.ParsedCommandLine;
@@ -77,7 +75,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
 
     static EmbedHostControllerHandler create(final AtomicReference<EmbeddedProcessLaunch> hostControllerReference, final CommandContext ctx, final boolean modular) {
         EmbedHostControllerHandler result = new EmbedHostControllerHandler(hostControllerReference);
-        final FilenameTabCompleter pathCompleter = Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+        final FilenameTabCompleter pathCompleter = FilenameTabCompleter.newCompleter(ctx);
         if (!modular) {
             result.jbossHome = new FileSystemPathArgument(result, pathCompleter, "--jboss-home");
         }

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
@@ -36,10 +36,8 @@ import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.handlers.CommandHandlerWithHelp;
-import org.jboss.as.cli.handlers.DefaultFilenameTabCompleter;
 import org.jboss.as.cli.handlers.FilenameTabCompleter;
 import org.jboss.as.cli.handlers.SimpleTabCompleter;
-import org.jboss.as.cli.handlers.WindowsFilenameTabCompleter;
 import org.jboss.as.cli.impl.ArgumentWithValue;
 import org.jboss.as.cli.impl.ArgumentWithoutValue;
 import org.jboss.as.cli.impl.FileSystemPathArgument;
@@ -78,7 +76,7 @@ class EmbedServerHandler extends CommandHandlerWithHelp {
 
     static EmbedServerHandler create(final AtomicReference<EmbeddedProcessLaunch> serverReference, CommandContext ctx, boolean modular) {
         EmbedServerHandler result = new EmbedServerHandler(serverReference);
-        final FilenameTabCompleter pathCompleter = Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+        final FilenameTabCompleter pathCompleter = FilenameTabCompleter.newCompleter(ctx);
         if (!modular) {
             result.jbossHome = new FileSystemPathArgument(result, pathCompleter, "--jboss-home");
         }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ArchiveHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ArchiveHandler.java
@@ -60,7 +60,7 @@ public class ArchiveHandler extends BatchModeCommandHandler {
 
     public ArchiveHandler(CommandContext ctx) {
         super(ctx, "archive", true);
-        final FilenameTabCompleter pathCompleter = Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+        final FilenameTabCompleter pathCompleter = FilenameTabCompleter.newCompleter(ctx);
         path = new FileSystemPathArgument(this, pathCompleter, 0, "--path");
 
         script = new ArgumentWithValue(this, "--script");

--- a/cli/src/main/java/org/jboss/as/cli/handlers/AttachmentHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/AttachmentHandler.java
@@ -165,8 +165,7 @@ public class AttachmentHandler extends BatchModeCommandHandler {
         };
 
         operation.addRequiredPreceding(action);
-        final FilenameTabCompleter pathCompleter = Util.isWindows()
-                ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+        final FilenameTabCompleter pathCompleter = FilenameTabCompleter.newCompleter(ctx);
         targetFile = new FileSystemPathArgument(this, pathCompleter, "--file") {
             @Override
             public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
@@ -104,7 +104,7 @@ public class DeployHandler extends DeploymentHandler {
                 .requirement(fullReplacePermission)
                 .build();
 
-        final FilenameTabCompleter pathCompleter = Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+        final FilenameTabCompleter pathCompleter = FilenameTabCompleter.newCompleter(ctx);
         path = new FileSystemPathArgument(this, pathCompleter, 0, "--path");
         path.addCantAppearAfter(l);
         path.setAccessRequirement(addOrReplacePermission);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentOverlayHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentOverlayHandler.java
@@ -158,7 +158,7 @@ public class DeploymentOverlayHandler extends BatchModeCommandHandler {//Command
                 .requirement(redeployPermission)
                 .build());
 
-        pathCompleter = Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+        pathCompleter = FilenameTabCompleter.newCompleter(ctx);
         content = new ArgumentWithListValue(this, new CommandLineCompleter(){
             @Override
             public int complete(CommandContext ctx, String buffer, int cursor, List<String> candidates) {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/FilenameTabCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/FilenameTabCompleter.java
@@ -23,11 +23,17 @@ package org.jboss.as.cli.handlers;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineCompleter;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.ArgumentWithValue;
+import org.jboss.as.cli.parsing.ExpressionBaseState;
+import org.jboss.as.cli.parsing.WordCharacterHandler;
 
 /**
  *
@@ -44,11 +50,10 @@ public abstract class FilenameTabCompleter implements CommandLineCompleter {
         this.ctx = ctx;
     }
 
-    protected abstract boolean startsWithRoot(String path);
-
     protected int getCandidates(String buffer, List<String> candidates) {
-
-        final String translated = translatePath(buffer);
+        //First clear the path
+        String clearedPath = clearPath(buffer);
+        String translated = translatePath(clearedPath);
 
         final File f = new File(translated);
         final File dir;
@@ -62,15 +67,29 @@ public abstract class FilenameTabCompleter implements CommandLineCompleter {
         return matchFiles(buffer, translated, entries, candidates);
     }
 
+    public static FilenameTabCompleter newCompleter(CommandContext ctx) {
+        return Util.isWindows() ? new WindowsFilenameTabCompleter(ctx)
+                : new DefaultFilenameTabCompleter(ctx);
+    }
+    /**
+     * Translate a path that has previously been unescaped and unquoted.
+     * That is called at command execution when the calue is retrieved prior to be
+     * used as ModelNode value.
+     * @param path The unquoted, unescaped path.
+     * @return A path with ~ and default dir expanded.
+     */
     public String translatePath(String path) {
-        final String translated;
+        String translated;
         // special character: ~ maps to the user's home directory
         if (path.startsWith("~" + File.separator)) {
             translated = System.getProperty("user.home") + path.substring(1);
         } else if (path.startsWith("~")) {
-            translated = new File(System.getProperty("user.home"))
-                    .getParentFile().getAbsolutePath();
-        } else if (!startsWithRoot(path)) {
+            String userName = path.substring(1);
+            translated = new File(new File(System.getProperty("user.home")).getParent(),
+                    userName).getAbsolutePath();
+            // Keep the path separator in translated or add one if no user home specified
+            translated = userName.isEmpty() || path.endsWith(File.separator) ? translated + File.separator : translated;
+        } else if (!new File(path).isAbsolute()) {
             translated = ctx.getCurrentDir().getAbsolutePath() + File.separator + path;
         } else {
             translated = path;
@@ -78,29 +97,34 @@ public abstract class FilenameTabCompleter implements CommandLineCompleter {
         return translated;
     }
 
-   private static String unescapeName(String name) {
-       for(int i = 0; i < name.length(); ++i) {
-           char ch = name.charAt(i);
-           if(ch == '\\') {
-               StringBuilder builder = new StringBuilder();
-               builder.append(name, 0, i);
-               boolean escaped = true;
-               for(int j = i + 1; j < name.length(); ++j) {
-                   ch = name.charAt(j);
-                   if(escaped) {
-                       builder.append(ch);
-                       escaped = false;
-                   } else if(ch == '\\') {
-                       escaped = true;
-                   } else {
-                       builder.append(ch);
-                   }
-               }
-               return builder.toString();
-           }
-       }
-       return name;
-   }
+    /**
+     * Unescape and unquote the path. Ready for translation.
+     */
+    private static String clearPath(String path) {
+        try {
+            ExpressionBaseState state = new ExpressionBaseState("EXPR", true, false);
+            if (Util.isWindows()) {
+                // to not require escaping FS name separator
+                state.setDefaultHandler(WordCharacterHandler.IGNORE_LB_ESCAPE_OFF);
+            } else {
+                state.setDefaultHandler(WordCharacterHandler.IGNORE_LB_ESCAPE_ON);
+            }
+            // Remove escaping characters
+            path = ArgumentWithValue.resolveValue(path, state);
+        } catch (CommandFormatException ex) {
+            // XXX OK, continue translation
+        }
+        // Remove quote to retrieve candidates.
+        if (path.startsWith("\"")) {
+            path = path.substring(1);
+        }
+        // Could be an escaped " character. We don't take into account this corner case.
+        // concider it the end of the quoted part.
+        if (path.endsWith("\"")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
 
    /**
     * Match the specified <i>buffer</i> to the array of <i>entries</i> and
@@ -124,30 +148,26 @@ public abstract class FilenameTabCompleter implements CommandLineCompleter {
            return -1;
        }
 
-       int matches = 0;
-
-       // first pass: just count the matches
+       boolean isDirectory = false;
        for (int i = 0; i < entries.length; i++) {
            if (entries[i].getAbsolutePath().startsWith(translated)) {
-               matches++;
+               isDirectory = entries[i].isDirectory();
+               candidates.add(entries[i].getName());
            }
        }
 
-       for (int i = 0; i < entries.length; i++) {
-           if (entries[i].getAbsolutePath().startsWith(translated)) {
-
-               final String name;
-               if(matches == 1 && entries[i].isDirectory()) {
-                   name = entries[i].getName() + File.separatorChar;
-               } else {
-                   name = entries[i].getName();
-               }
-               candidates.add(name);
+       // Append File.separator for inlined directory.
+       if (candidates.size() == 1) {
+           String candidate = candidates.get(0);
+           if (isDirectory) {
+               candidate = candidate + File.separator;
            }
+           candidates.set(0, candidate);
        }
 
-       final int index = buffer.lastIndexOf(File.separatorChar);
-       return index + 1 /* - separator character */;
+       // inline only the subpath from last File.separator or 0.
+       int index = buffer.lastIndexOf(File.separatorChar) + 1;
+       return index;
    }
 
     public static String expand(String path) throws IOException {
@@ -174,11 +194,30 @@ public abstract class FilenameTabCompleter implements CommandLineCompleter {
         return path;
     }
 
-   public static void main(String[] args) throws Exception {
-       String name = "../../../../my\\ dir/";
-//        System.out.println(name);
-//        name = escapeName(name);
-//        System.out.println(name);
-       System.out.println(unescapeName(name));
-   }
+    void postProcess(String buffer, List<String> candidates) {
+        if (candidates.size() == 1) {
+            String candidate = candidates.get(0);
+            if (!buffer.contains(File.separator)) {
+                if (buffer.startsWith("\"~")) {
+                    candidate = "\"~" + candidate;
+                } else if (buffer.startsWith("\"")) {
+                    candidate = "\"" + candidate;
+                } else if (buffer.startsWith("~")) {
+                    candidate = "~" + candidate;
+                }
+            }
+            candidates.set(0, candidate);
+        }
+    }
+
+    @Override
+    public int complete(CommandContext ctx, String buffer, int cursor, List<String> candidates) {
+        int result = getCandidates(buffer, candidates);
+        Collections.sort(candidates);
+        completeCandidates(ctx, buffer, cursor, candidates);
+        postProcess(buffer, candidates);
+        return result;
+    }
+
+    abstract void completeCandidates(CommandContext ctx, String buffer, int cursor, List<String> candidates);
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
@@ -185,7 +185,7 @@ public class UndeployHandler extends DeploymentHandler {
         keepContent.addRequiredPreceding(name);
         keepContent.setAccessRequirement(undeployPermission);
 
-        final FilenameTabCompleter pathCompleter = Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+        final FilenameTabCompleter pathCompleter = FilenameTabCompleter.newCompleter(ctx);
         path = new FileSystemPathArgument(this, pathCompleter, "--path");
         path.addCantAppearAfter(l);
         path.setAccessRequirement(removeOrUndeployPermission);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchHandler.java
@@ -35,14 +35,11 @@ import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineCompleter;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandLineException;
-import org.jboss.as.cli.Util;
 import org.jboss.as.cli.batch.Batch;
 import org.jboss.as.cli.batch.BatchManager;
 import org.jboss.as.cli.batch.BatchedCommand;
 import org.jboss.as.cli.handlers.CommandHandlerWithHelp;
-import org.jboss.as.cli.handlers.DefaultFilenameTabCompleter;
 import org.jboss.as.cli.handlers.FilenameTabCompleter;
-import org.jboss.as.cli.handlers.WindowsFilenameTabCompleter;
 import org.jboss.as.cli.impl.ArgumentWithValue;
 import org.jboss.as.cli.impl.ArgumentWithoutValue;
 import org.jboss.as.cli.impl.FileSystemPathArgument;
@@ -93,7 +90,7 @@ public class BatchHandler extends CommandHandlerWithHelp {
             }}, 0, "--name");
         name.setExclusive(true);
 
-        final FilenameTabCompleter pathCompleter = Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+        final FilenameTabCompleter pathCompleter = FilenameTabCompleter.newCompleter(ctx);
         file = new FileSystemPathArgument(this, pathCompleter, "--file");
         file.setExclusive(true);
     }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
@@ -39,9 +39,7 @@ import org.jboss.as.cli.batch.Batch;
 import org.jboss.as.cli.batch.BatchManager;
 import org.jboss.as.cli.batch.BatchedCommand;
 import org.jboss.as.cli.handlers.BaseOperationCommand;
-import org.jboss.as.cli.handlers.DefaultFilenameTabCompleter;
 import org.jboss.as.cli.handlers.FilenameTabCompleter;
-import org.jboss.as.cli.handlers.WindowsFilenameTabCompleter;
 import org.jboss.as.cli.impl.ArgumentWithValue;
 import org.jboss.as.cli.impl.ArgumentWithoutValue;
 import org.jboss.as.cli.impl.FileSystemPathArgument;
@@ -64,7 +62,7 @@ public class BatchRunHandler extends BaseOperationCommand {
     public BatchRunHandler(CommandContext ctx) {
         super(ctx, "batch-run", true);
 
-        final FilenameTabCompleter pathCompleter = Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+        final FilenameTabCompleter pathCompleter = FilenameTabCompleter.newCompleter(ctx);
         file = new FileSystemPathArgument(this, pathCompleter, "--file");
 
         verbose = new ArgumentWithoutValue(this, "--verbose", "-v");

--- a/cli/src/main/java/org/jboss/as/cli/handlers/module/ASModuleHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/module/ASModuleHandler.java
@@ -131,7 +131,7 @@ public class ASModuleHandler extends CommandHandlerWithHelp {
     public ASModuleHandler(CommandContext ctx) {
         super("module", false);
 
-        final FilenameTabCompleter pathCompleter = Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+        final FilenameTabCompleter pathCompleter = FilenameTabCompleter.newCompleter(ctx);
 
         moduleRootDir = new FileSystemPathArgument(this, pathCompleter, "--module-root-dir");
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/ValueTypeCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ValueTypeCompleter.java
@@ -33,8 +33,7 @@ import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineCompleter;
 import org.jboss.as.cli.Util;
-import org.jboss.as.cli.handlers.DefaultFilenameTabCompleter;
-import org.jboss.as.cli.handlers.WindowsFilenameTabCompleter;
+import org.jboss.as.cli.handlers.FilenameTabCompleter;
 import org.jboss.as.cli.operation.OperationRequestAddress;
 import org.jboss.as.cli.operation.impl.CapabilityReferenceCompleter;
 import org.jboss.as.cli.operation.impl.DefaultOperationRequestAddress;
@@ -403,9 +402,7 @@ public class ValueTypeCompleter implements CommandLineCompleter {
             List<String> candidates = null;
             if (propType.has(Util.FILESYSTEM_PATH)
                     && propType.get(Util.FILESYSTEM_PATH).asBoolean()) {
-                CommandLineCompleter completer = Util.isWindows()
-                        ? new WindowsFilenameTabCompleter(ctx)
-                        : new DefaultFilenameTabCompleter(ctx);
+                CommandLineCompleter completer = FilenameTabCompleter.newCompleter(ctx);
                 candidates = new ArrayList<>();
                 completer.complete(ctx, path, offset, candidates);
                 // candidates only contain the last part of a path.

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
@@ -32,9 +32,8 @@ import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineCompleter;
 import org.jboss.as.cli.Util;
-import org.jboss.as.cli.handlers.DefaultFilenameTabCompleter;
+import org.jboss.as.cli.handlers.FilenameTabCompleter;
 import org.jboss.as.cli.handlers.SimpleTabCompleter;
-import org.jboss.as.cli.handlers.WindowsFilenameTabCompleter;
 import org.jboss.as.cli.impl.AttributeNamePathCompleter;
 import org.jboss.as.cli.impl.DeploymentItemCompleter;
 import org.jboss.as.cli.impl.ValueTypeCompleter;
@@ -368,7 +367,7 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
             }
         }
         if (attrDescr.has(Util.FILESYSTEM_PATH) && attrDescr.get(Util.FILESYSTEM_PATH).asBoolean()) {
-            return Util.isWindows() ? new WindowsFilenameTabCompleter(ctx) : new DefaultFilenameTabCompleter(ctx);
+            return FilenameTabCompleter.newCompleter(ctx);
         }
         if (attrDescr.has(Util.RELATIVE_TO) && attrDescr.get(Util.RELATIVE_TO).asBoolean()) {
             return new DeploymentItemCompleter(address);

--- a/cli/src/test/java/org/jboss/as/cli/AttachmentTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/AttachmentTestCase.java
@@ -31,7 +31,11 @@ import org.junit.Test;
  */
 public class AttachmentTestCase {
 
-    private static final String PATH = "/a/nice/attachment/path";
+    private static final String PATH = Util.isWindows()
+            ? "c:\\\\a\\\\nice\\\\attachment\\\\path" : "/a/nice/attachment/path";
+
+    private static final String EXPECTED_PATH = Util.isWindows()
+            ? "c:\\a\\nice\\attachment\\path" : PATH;
 
     private static final String VAULT_ADD_DESCRIPTION = "{\n"
             + "          \"request-properties\" : {\n"
@@ -151,7 +155,7 @@ public class AttachmentTestCase {
     private static final String VALUE = "{\n"
             + "    \"toto\": [\"a\", \"b\", \"c\"],\n"
             + "    \"titi_a\": \"" + PATH + "0\",\n"
-            + "    \"tata_a\": [\"" + PATH + "1\", \"" + PATH + "2\", \"/a/nice/attachment/path3\"],\n"
+            + "    \"tata_a\": [\"" + PATH + "1\", \"" + PATH + "2\", \"" + PATH + "3\"],\n"
             + "    \"tutu\": {\n"
             + "        \"p1_a\": \"" + PATH + "4\",\n"
             + "        \"p2_a\": \"" + PATH + "5\",\n"
@@ -231,14 +235,15 @@ public class AttachmentTestCase {
         ModelNode expected = ModelNode.fromJSONString(RESULT);
         ModelNode req = description.get(Util.REQUEST_PROPERTIES).asObject();
         Attachments attachments = new Attachments();
+        CommandContext ctx = CommandContextFactory.getInstance().newCommandContext();
         for (String k : value.keys()) {
-            Util.applyReplacements(k, value.get(k), req.get(k), req.get(k).get(Util.TYPE).asType(), attachments);
+            Util.applyReplacements(ctx, k, value.get(k), req.get(k), req.get(k).get(Util.TYPE).asType(), attachments);
         }
         Assert.assertEquals("Should be equal", expected, value);
         Assert.assertEquals(11, attachments.getAttachedFiles().size());
         for (int i = 0; i < attachments.getAttachedFiles().size(); i++) {
             String p = attachments.getAttachedFiles().get(i);
-            Assert.assertEquals(p, PATH + i);
+            Assert.assertEquals(p, EXPECTED_PATH + i);
         }
     }
 
@@ -249,8 +254,9 @@ public class AttachmentTestCase {
         ModelNode value = ModelNode.fromJSONString(VAULT_ADD_VALUE);
         ModelNode req = description.get(Util.REQUEST_PROPERTIES).asObject();
         Attachments attachments = new Attachments();
+        CommandContext ctx = CommandContextFactory.getInstance().newCommandContext();
         for (String k : value.keys()) {
-            Util.applyReplacements(k, value.get(k), req.get(k), req.get(k).get(Util.TYPE).asType(), attachments);
+            Util.applyReplacements(ctx, k, value.get(k), req.get(k), req.get(k).get(Util.TYPE).asType(), attachments);
         }
     }
 }

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/FileCompletionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/FileCompletionTestCase.java
@@ -1,0 +1,378 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.parsing.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.as.cli.CliInitializationException;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContextFactory;
+import org.jboss.as.cli.CommandLineCompleter;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.handlers.FilenameTabCompleter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class FileCompletionTestCase {
+
+    @Rule
+    public final TemporaryFolder temporaryUserHome = new TemporaryFolder();
+
+    private File file1;
+    private File file_ws;
+    private File file_q;
+    private File dir1;
+
+    private File sub_file1;
+    private File sub_file_ws;
+    private File sub_file_q;
+    private File sub_dir1;
+
+    private File dot_sub_file1;
+
+    private final List<String> allFileNames = new ArrayList<>();
+    private final List<String> allSubFileNames = new ArrayList<>();
+    private final String escapedWSFile = "spaces\\ file.txt";
+    private final String escapedQuotedFile = "quotes\\\"file.txt";
+
+    private final String escapedWSFile2 = "spaces\\ file2.txt";
+    private final String escapedQuotedFile2 = "quotes\\\"file2.txt";
+
+    private CommandContext ctx;
+    private CommandLineCompleter completer;
+
+    @Before
+    public void setup() throws IOException, CliInitializationException {
+        System.setProperty("user.home", temporaryUserHome.getRoot().getAbsolutePath());
+        ctx = CommandContextFactory.getInstance().newCommandContext();
+        completer = FilenameTabCompleter.newCompleter(ctx);
+        file1 = temporaryUserHome.newFile();
+        file_ws = temporaryUserHome.newFile("spaces file.txt");
+        if (!Util.isWindows()) {
+            file_q = temporaryUserHome.newFile("quotes\"file.txt");
+            allFileNames.add(file_q.getName());
+        }
+        dir1 = temporaryUserHome.newFolder("adirectory");
+        allFileNames.add(file1.getName());
+        allFileNames.add(file_ws.getName());
+        allFileNames.add(dir1.getName());
+
+        ctx.setCurrentDir(dir1);
+
+        dot_sub_file1 = new File(dir1, ".file2.txt");
+        dot_sub_file1.createNewFile();
+
+        sub_file1 = new File(dir1, "file2.txt");
+        sub_file1.createNewFile();
+
+        sub_file_ws = new File(dir1, "spaces file2.txt");
+        sub_file_ws.createNewFile();
+
+        if (!Util.isWindows()) {
+            sub_file_q = new File(dir1, "quotes\"file2.txt");
+            sub_file_q.createNewFile();
+            allSubFileNames.add(sub_file_q.getName());
+        }
+        sub_dir1 = new File(dir1, "adirectory2");
+        sub_dir1.mkdir();
+
+        allSubFileNames.add(dot_sub_file1.getName());
+        allSubFileNames.add(sub_file1.getName());
+        allSubFileNames.add(sub_file_ws.getName());
+        allSubFileNames.add(sub_dir1.getName());
+    }
+
+    @Test
+    public void testQuotedHomeDirectoryCompletion() throws Exception {
+
+        {
+            List<String> candidates = new ArrayList<>();
+            int i = completer.complete(ctx, "\"~", 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.toString(),
+                    candidates.contains(temporaryUserHome.getRoot().getName()));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            int i = completer.complete(ctx, "\"~"
+                    + temporaryUserHome.getRoot().getName().substring(0, 2), 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.toString(),
+                    candidates.contains("\"~" + temporaryUserHome.getRoot().getName() + File.separator));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            int i = completer.complete(ctx, "\"~"
+                    + temporaryUserHome.getRoot().getName(), 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.toString(),
+                    candidates.contains("\"~" + temporaryUserHome.getRoot().getName() + File.separator));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            String path = "\"~" + temporaryUserHome.getRoot().getName() + File.separator;
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(path.length(), i);
+            Assert.assertTrue(candidates.toString(), candidates.containsAll(allFileNames));
+        }
+
+        if (!Util.isWindows()) {
+            {
+                //Quoted path requires escaped quote.
+                List<String> candidates = new ArrayList<>();
+                String path = "\"~" + File.separator + file_q.getName().substring(0, 2);
+                int i = completer.complete(ctx,
+                        path, 0, candidates);
+                Assert.assertEquals(3, i);
+                Assert.assertTrue(candidates.toString(), candidates.contains(escapedQuotedFile));
+            }
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            int i = completer.complete(ctx, "\"~" + File.separator, 0, candidates);
+            Assert.assertEquals(3, i);
+            Assert.assertTrue(candidates.toString(), candidates.containsAll(allFileNames));
+        }
+
+        {
+            //Quoted path doesn't require escaped spaces.
+            List<String> candidates = new ArrayList<>();
+            String path = "\"~" + File.separator + file_ws.getName().substring(0, 2);
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(3, i);
+            Assert.assertTrue(candidates.toString(), candidates.contains(file_ws.getName()));
+        }
+
+    }
+
+    @Test
+    public void testHomeDirectoryCompletion() throws Exception {
+
+        {
+            List<String> candidates = new ArrayList<>();
+            int i = completer.complete(ctx, "~", 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.toString(),
+                    candidates.contains(temporaryUserHome.getRoot().getName()));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            int i = completer.complete(ctx, "~"
+                    + temporaryUserHome.getRoot().getName().substring(0, 2), 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.toString(),
+                    candidates.contains("~" + temporaryUserHome.getRoot().getName() + File.separator));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            int i = completer.complete(ctx, "~"
+                    + temporaryUserHome.getRoot().getName(), 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.toString(),
+                    candidates.contains("~" + temporaryUserHome.getRoot().getName() + File.separator));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            String path = "~" + temporaryUserHome.getRoot().getName() + File.separator;
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(path.length(), i);
+            Assert.assertTrue(candidates.toString(), candidates.containsAll(allFileNames));
+        }
+
+        if (!Util.isWindows()) {
+            {
+                //Not quoted path requires escaped spaces.
+                List<String> candidates = new ArrayList<>();
+                String path = "~" + File.separator + file_ws.getName().substring(0, 2);
+                int i = completer.complete(ctx,
+                        path, 0, candidates);
+                Assert.assertEquals(2, i);
+                Assert.assertTrue(candidates.toString(), candidates.contains(escapedWSFile));
+            }
+
+            {
+                //Not quoted path requires escaped quote.
+                List<String> candidates = new ArrayList<>();
+                String path = "~" + File.separator + file_q.getName().substring(0, 2);
+                int i = completer.complete(ctx,
+                        path, 0, candidates);
+                Assert.assertEquals(2, i);
+                Assert.assertTrue(candidates.toString(), candidates.contains(escapedQuotedFile));
+            }
+
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            int i = completer.complete(ctx, "~" + File.separator, 0, candidates);
+            Assert.assertEquals(2, i);
+            Assert.assertTrue(candidates.toString(), candidates.containsAll(allFileNames));
+        }
+    }
+
+    @Test
+    public void testWorkDirectoryCompletion() throws Exception {
+        {
+            List<String> candidates = new ArrayList<>();
+            String path = "";
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.toString(), candidates.containsAll(allSubFileNames));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            String path = "." + File.separator;
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(2, i);
+            Assert.assertTrue(candidates.toString(), candidates.containsAll(allSubFileNames));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            String path = ".";
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.size() == 1);
+            Assert.assertTrue(candidates.toString(), candidates.contains(dot_sub_file1.getName()));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            String path = sub_dir1.getName();
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.size() == 1);
+            Assert.assertTrue(candidates.toString(),
+                    candidates.contains(sub_dir1.getName() + File.separator));
+        }
+
+        if (!Util.isWindows()) {
+            {
+                //Not quoted path requires escaped spaces.
+                List<String> candidates = new ArrayList<>();
+                String path = sub_file_ws.getName().substring(0, 2);
+                int i = completer.complete(ctx,
+                        path, 0, candidates);
+                Assert.assertEquals(0, i);
+                Assert.assertTrue(candidates.toString(), candidates.contains(escapedWSFile2));
+            }
+
+            {
+                //Not quoted path requires escaped quote.
+                List<String> candidates = new ArrayList<>();
+                String path = sub_file_q.getName().substring(0, 2);
+                int i = completer.complete(ctx,
+                        path, 0, candidates);
+                Assert.assertEquals(0, i);
+                Assert.assertTrue(candidates.toString(), candidates.contains(escapedQuotedFile2));
+            }
+        }
+    }
+
+    @Test
+    public void testQuotedWorkDirectoryCompletion() throws Exception {
+        {
+            List<String> candidates = new ArrayList<>();
+            String path = "\"";
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.toString(), candidates.containsAll(allSubFileNames));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            String path = "\"." + File.separator;
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(3, i);
+            Assert.assertTrue(candidates.toString(), candidates.containsAll(allSubFileNames));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            String path = "\".";
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.size() == 1);
+            Assert.assertTrue(candidates.toString(), candidates.contains("\"" + dot_sub_file1.getName()));
+        }
+
+        {
+            List<String> candidates = new ArrayList<>();
+            String path = "\"" + sub_dir1.getName();
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.size() == 1);
+            Assert.assertTrue(candidates.toString(),
+                    candidates.contains("\"" + sub_dir1.getName() + File.separator));
+        }
+
+        {
+            //Quoted path requires escaped spaces.
+            List<String> candidates = new ArrayList<>();
+            String path = "\"" + sub_file_ws.getName().substring(0, 2);
+            int i = completer.complete(ctx,
+                    path, 0, candidates);
+            Assert.assertEquals(0, i);
+            Assert.assertTrue(candidates.toString(), candidates.contains("\"" + sub_file_ws.getName()));
+        }
+
+        if (!Util.isWindows()) {
+            {
+                //Quoted path requires escaped quote.
+                List<String> candidates = new ArrayList<>();
+                String path = "\"" + sub_file_q.getName().substring(0, 2);
+                int i = completer.complete(ctx,
+                        path, 1, candidates);
+                Assert.assertEquals(0, i);
+                Assert.assertTrue(candidates.toString(), candidates.contains("\"" + escapedQuotedFile2));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Took the opportunity of this fix to rework and fix the File completers. 
- Escaping and quotes handling during completion.
- '~' support.
- Fixed path translation for attachments.
- Small improvements.

Added unit tests.