### PR TITLE
[WFCORE-2022] fix read-resource-description for multitarget address

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -892,7 +892,9 @@ public class GlobalOperationHandlers {
                 if (childType != null && !childType.equals(path.getKey())) {
                     continue;
                 }
-                if (path.getKey().equals(RUNNING_SERVER) && path.isWildcard() && newRemaining.size() > 0) {
+                // matches /host=xxx/server=*/... address
+                final boolean isHostWildcardServerAddress = base.size() > 0 && base.getLastElement().getKey().equals(HOST) && path.getKey().equals(RUNNING_SERVER) && path.isWildcard();
+                if (isHostWildcardServerAddress && newRemaining.size() > 0) {
                     //Trying to get e.g. /host=xxx/server=*/interface=public will fail, so make sure if there are remaining elements for
                     //a /host=master/server=* that we don't attempt to get those
                     continue;

--- a/controller/src/test/java/org/jboss/as/controller/test/WildcardReadResourceDescriptionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WildcardReadResourceDescriptionUnitTestCase.java
@@ -65,6 +65,8 @@ public class WildcardReadResourceDescriptionUnitTestCase  extends AbstractContro
     private static final PathElement statistics = PathElement.pathElement("statistics", "test");
 
     private static final PathElement otherSubsystem = PathElement.pathElement("subsystem", "other");
+    private static final PathElement server = PathElement.pathElement("server");
+    private static final PathElement resource = PathElement.pathElement("resource");
 
     @Test
     public void testReadResourceDescription() throws Exception {
@@ -314,6 +316,17 @@ public class WildcardReadResourceDescriptionUnitTestCase  extends AbstractContro
         //validateFailedResponse(response, PathAddress.pathAddress(address).getParent().getParent());
         // That's not perfect but is acceptable
         validateFailedResponse(response, address);
+
+        // WFCORE-2022 multitarget address with a server resource
+        address = new ModelNode();
+        address.add("subsystem", "other");
+        address.add("server", "*");
+        address.add("resource", "*");
+
+        read.get(OP_ADDR).set(address);
+
+        response = controller.execute(read, null, null, null);
+        assertEquals(response.toString(), "success", response.get("outcome").asString());
     }
 
     private boolean validateNode(ModelNode fullResult, ModelNode node) {
@@ -428,6 +441,9 @@ public class WildcardReadResourceDescriptionUnitTestCase  extends AbstractContro
                         new NonResolvingResourceDescriptionResolver()));
         stats.registerReadOnlyAttribute(TestUtils.createNillableAttribute("7", ModelType.STRING), null);
 
-        root.registerSubModel(new SimpleResourceDefinition(otherSubsystem, new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration otherSubsystemModel = root.registerSubModel(new SimpleResourceDefinition(otherSubsystem, new NonResolvingResourceDescriptionResolver()));
+        ManagementResourceRegistration serverModel = otherSubsystemModel.registerSubModel(new SimpleResourceDefinition(server, new NonResolvingResourceDescriptionResolver()));
+        serverModel.registerSubModel(new SimpleResourceDefinition(resource, new NonResolvingResourceDescriptionResolver()));
+
     }
 }


### PR DESCRIPTION
Constrain the check for WFCORE-948 by checking if the base path
corresponds to a /host=xxx/ in executeMultiTargetChildren to avoid
breaking the loop if the address contains a resource whose key is server
(e.g. /subsystem=undertow/server=*/http-listener=*)

JIRA: https://issues.jboss.org/browse/WFCORE-2022