### PR TITLE
WFCORE-2026 source-port is wrongly offsetted when configured to 0, i.e. ephemeral port; results in "Permission denied (Bind failed)"

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/registry/Resource.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/Resource.java
@@ -385,7 +385,7 @@ public interface Resource extends Cloneable {
         }
 
         /**
-         * Navigate from a parent {@code resource} to the descendant resource at the given relative {@code addresss}.
+         * Navigate from a parent {@code resource} to the descendant resource at the given relative {@code address}.
          * <p>
          * {@link Resource#navigate(PathAddress)} implementations can use this as a standard implementation.
          * </p>

--- a/network/src/main/java/org/jboss/as/network/OutboundSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/OutboundSocketBinding.java
@@ -200,7 +200,7 @@ public class OutboundSocketBinding {
 
     /**
      * Returns the source address of this outbound socket binding if one is configured. If no explicit source address
-     * is specified for this binding, then this method returns {@code null}. Use {@link org.jboss.as.network.OutboundSocketBinding#getSourceAddress()}
+     * is specified for this binding, then this method returns {@code null}. Use {@link #getSourceAddress()}
      * instead to obtain the default interface of the socket binding manager if none is specified for this binding.
      *
      * @return source address of this outbound socket binding if specified,
@@ -215,10 +215,10 @@ public class OutboundSocketBinding {
      * this outbound socket binding has a port offset. To get the absolute source port, use the {@link #getAbsoluteSourcePort()}
      * method.
      *
-     * @return the source port for this outbound socket binding
+     * @return the source port for this outbound socket binding not accounting for port offset/fixation; {@code null} if an ephemeral port should be used
      */
     public Integer getSourcePort() {
-        return this.sourcePort;
+        return (this.sourcePort == null || this.sourcePort == 0) ? null : this.sourcePort;
     }
 
     /**
@@ -226,10 +226,10 @@ public class OutboundSocketBinding {
      * if the outbound socket binding is marked for "fixed source port". Else, it is the sum of {@link #getSourcePort()}
      * and the port offset configured on the {@link SocketBindingManager}.
      *
-     * @return the absolute source port accounting for port offset/fixation
+     * @return the absolute source port accounting for port offset/fixation; {@code null} if an ephemeral port should be used
      */
     public Integer getAbsoluteSourcePort() {
-        if (this.sourcePort == null) {
+        if (this.getSourcePort() == null) {
             return null;
         }
         if (this.fixedSourcePort) {

--- a/server/src/main/resources/schema/jboss-as-config_1_1.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_1.xsd
@@ -1353,11 +1353,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/jboss-as-config_1_1.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_1.xsd
@@ -1356,7 +1356,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_1_2.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_2.xsd
@@ -1379,7 +1379,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_1_2.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_2.xsd
@@ -1376,11 +1376,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/jboss-as-config_1_3.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_3.xsd
@@ -1513,11 +1513,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/jboss-as-config_1_3.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_3.xsd
@@ -1516,7 +1516,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_1_4.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_4.xsd
@@ -1537,7 +1537,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_1_4.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_4.xsd
@@ -1534,11 +1534,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/jboss-as-config_1_5.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_5.xsd
@@ -2209,7 +2209,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_1_5.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_5.xsd
@@ -2206,11 +2206,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/jboss-as-config_1_6.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_6.xsd
@@ -2674,11 +2674,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses a ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/jboss-as-config_1_6.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_6.xsd
@@ -2677,7 +2677,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses a ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_1_7.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_7.xsd
@@ -2914,7 +2914,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses a ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_1_7.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_7.xsd
@@ -2911,11 +2911,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses a ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/jboss-as-config_1_8.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_8.xsd
@@ -2966,7 +2966,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses a ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_1_8.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_1_8.xsd
@@ -2963,11 +2963,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses a ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/jboss-as-config_2_0.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_2_0.xsd
@@ -2521,11 +2521,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/jboss-as-config_2_0.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_2_0.xsd
@@ -2524,7 +2524,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_2_1.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_2_1.xsd
@@ -2710,11 +2710,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/jboss-as-config_2_1.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_2_1.xsd
@@ -2713,7 +2713,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_2_2.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_2_2.xsd
@@ -2746,7 +2746,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/jboss-as-config_2_2.xsd
+++ b/server/src/main/resources/schema/jboss-as-config_2_2.xsd
@@ -2743,11 +2743,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/wildfly-config_3_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_3_0.xsd
@@ -3041,7 +3041,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/wildfly-config_3_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_3_0.xsd
@@ -3038,11 +3038,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/wildfly-config_4_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_4_0.xsd
@@ -3154,11 +3154,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/wildfly-config_4_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_4_0.xsd
@@ -3157,7 +3157,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/wildfly-config_4_1.xsd
+++ b/server/src/main/resources/schema/wildfly-config_4_1.xsd
@@ -3206,11 +3206,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/wildfly-config_4_1.xsd
+++ b/server/src/main/resources/schema/wildfly-config_4_1.xsd
@@ -3209,7 +3209,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/wildfly-config_4_2.xsd
+++ b/server/src/main/resources/schema/wildfly-config_4_2.xsd
@@ -3218,11 +3218,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>

--- a/server/src/main/resources/schema/wildfly-config_4_2.xsd
+++ b/server/src/main/resources/schema/wildfly-config_4_2.xsd
@@ -3221,7 +3221,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/wildfly-config_5_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_5_0.xsd
@@ -3300,7 +3300,7 @@
         <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The port number that will be used for setting the source addresss of the outbound socket. If the
+                    The port number that will be used for setting the source address of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>

--- a/server/src/main/resources/schema/wildfly-config_5_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_5_0.xsd
@@ -3297,11 +3297,11 @@
             </xs:annotation>
 
         </xs:attribute>
-        <xs:attribute name="source-port" type="xs:positiveInteger" use="optional">
+        <xs:attribute name="source-port" type="xs:nonNegativeInteger" use="optional">
             <xs:annotation>
                 <xs:documentation>
                     The port number that will be used for setting the source address of the outbound socket. If the
-                    source-interface attribute has been specified and the source-port attribute is absent,
+                    source-interface attribute has been specified and the source-port attribute equals 0 or is absent,
                     then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFCORE-2026

Causes 
https://issues.jboss.org/browse/WFLY-6915