### PR TITLE
Fix for WFCORE-1829, added CLI reload support

### DIFF
--- a/cli/src/main/resources/help/reload.txt
+++ b/cli/src/main/resources/help/reload.txt
@@ -2,7 +2,7 @@ SYNOPSIS
 
    Standalone mode:
 
-      reload [--admin-only=true|false]
+      reload [--start-mode=admin-only|normal|suspend]
              [--use-current-server-config=true|false]
              [--server-config=new_server_config_file_name]
 
@@ -41,7 +41,8 @@ DESCRIPTION
 
 ARGUMENTS
 
- --admin-only  - whether the controller should start in running mode ADMIN_ONLY
+--admin-only   - Domain mode only, deprecated for standalone.
+                 Whether the controller should start in running mode ADMIN_ONLY
                  when it restarts. An ADMIN_ONLY controller will start any
                  configured management interfaces and accept management
                  requests, but will not start servers or, if this host
@@ -49,6 +50,22 @@ ARGUMENTS
                  connections from slave host controllers. For embedded host
                  controllers, this value is required and must be set to true.
                  If not present, false value is assumed.
+
+--start-mode   - Standalone mode only.
+                 The state the server will be once reloaded. Can be one of the
+                 following values: admin-only, normal, suspend.
+                 - admin-only: Whether the controller should start in running
+                 mode ADMIN_ONLY when it restarts.
+                 An ADMIN_ONLY controller will start any configured management
+                 interfaces and accept management requests, but will not start
+                 servers or, if this host controller is the master for the domain,
+                 accept incoming connections from slave host controllers.
+                 For embedded host controllers, this value is required.
+                 - normal: Whether the controller should start in running
+                 mode NORMAL when it restarts.
+                 - suspend: Whether the controller should start in suspend state
+                 SUSPENDED when it restarts. A SUSPENDED controller allows
+                 modifications to be made before it starts accepting requests.
 
  --host        - is allowed and required only in the domain mode, specifies
                  the host name to reload.

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -753,6 +753,14 @@ public class CliCompletionTestCase {
             }
 
             {
+                String cmd = "reload ";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertFalse(candidates.contains("--start-mode"));
+            }
+
+            {
                 String cmd = "reload --admin-only";
                 List<String> candidates = new ArrayList<>();
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.test.integration.management.util.CLITestUtil;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+public class CliCompletionTestCase {
+
+    @Test
+    public void test() throws Exception {
+        CommandContext ctx = CLITestUtil.getCommandContext(TestSuiteEnvironment.getServerAddress(),
+                TestSuiteEnvironment.getServerPort(), System.in, System.out);
+        ctx.connectController();
+        try {
+            {
+                String cmd = "reload ";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertTrue(candidates.contains("--start-mode"));
+                assertFalse(candidates.contains("--admin-only"));
+            }
+
+            {
+                String cmd = "reload --start-mode=";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertTrue(candidates.toString(), candidates.size() == 3);
+                assertEquals(candidates.toString(), Arrays.asList("admin-only",
+                        "normal", "suspend"), candidates);
+            }
+        } finally {
+            ctx.terminateSession();
+        }
+    }
+}


### PR DESCRIPTION
--start-mode for reload command.
--admin-only has been deprecated. No more proposed by completion but still usable.
Added unit test and updated help.

Follows up on #1841

https://issues.jboss.org/browse/WFCORE-1829