### PR TITLE
[WFCORE-2055] Preserve any caller-type header associated with domain composite op steps

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainRolloutStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainRolloutStepHandler.java
@@ -419,7 +419,17 @@ public class DomainRolloutStepHandler implements OperationStepHandler {
     }
 
     private ModelNode incorporateServerOperationHeaders(ModelNode op) {
-        op.get(OPERATION_HEADERS).set(serverOperationHeaders);
+        if (serverOperationHeaders.isDefined()) {
+            if (op.hasDefined(OPERATION_HEADERS)) {
+                // WFCORE-2055 -- preserve any existing headers not declared at the server level
+                ModelNode headers = op.get(OPERATION_HEADERS);
+                for (Property prop : serverOperationHeaders.asPropertyList()) {
+                    headers.get(prop.getName()).set(prop.getValue());
+                }
+            } else {
+                op.get(OPERATION_HEADERS).set(serverOperationHeaders);
+            }
+        }
         return op;
     }
 


### PR DESCRIPTION
Also fixes the test that would have caught this regression.

https://issues.jboss.org/browse/WFCORE-2055
https://issues.jboss.org/browse/WFCORE-2053