### PR TITLE
[WFCORE-2081]: Confusing description of scan-enabled attribute in deployment scanner XSD.

### DIFF
--- a/core-feature-pack/src/main/resources/content/standalone/deployments/README.txt
+++ b/core-feature-pack/src/main/resources/content/standalone/deployments/README.txt
@@ -36,9 +36,9 @@ of command telling the scanner to deploy, undeploy or redeploy content.
 
 
 Auto-deploy mode and manual deploy mode can be independently configured for
-zipped deployment content and exploded deployment content. This is done
-via the "auto-deploy" attributes on the deployment-scanner element in the
-standalone.xml configuration file:
+zipped deployment content and exploded deployment content. This is done by
+editing the appropriate "auto-deploy" attributes on the deployment-scanner
+element in the standalone.xml configuration file:
 
 <deployment-scanner scan-interval="5000" relative-to="jboss.server.base.dir"
     path="deployments" auto-deploy-zipped="true" auto-deploy-exploded="false"/>

--- a/deployment-scanner/src/main/resources/schema/jboss-as-deployment-scanner_2_0.xsd
+++ b/deployment-scanner/src/main/resources/schema/jboss-as-deployment-scanner_2_0.xsd
@@ -64,7 +64,7 @@
             <xs:annotation>
                 <xs:documentation>
                     Flag indicating that all scanning (including initial scanning at startup)
-                    should be disabled.
+                    should be enabled or disabled.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>


### PR DESCRIPTION
[WFCORE-2082]: Outdated deployment-scanner xml snippet in deployments readme.txt.

Updating the comments for a better UX.

Jira: https://issues.jboss.org/browse/WFCORE-2081
Jira: https://issues.jboss.org/browse/WFCORE-2082