### PR TITLE
[WFCORE-2094] Domain server notifies HC upon controller instability

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -122,6 +122,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
     private final ControlledProcessState processState;
     private final OperationStepHandler prepareStep;
     private final InjectedValue<ExecutorService> injectedExecutorService = new InjectedValue<ExecutorService>();
+    private final InjectedValue<ControllerInstabilityListener> injectedInstabilityListener = new InjectedValue<ControllerInstabilityListener>();
     private final ExpressionResolver expressionResolver;
     private volatile ModelControllerImpl controller;
     private ConfigurationPersister configurationPersister;
@@ -296,7 +297,8 @@ public abstract class AbstractControllerService implements Service<ModelControll
                 new ContainerStateMonitor(container),
                 configurationPersister, processType, runningModeControl, prepareStep,
                 processState, executorService, expressionResolver, authorizer, securityIdentitySupplier, auditLogger, notificationSupport,
-                bootErrorCollector, createExtraValidationStepHandler(), capabilityRegistry, getPartialModelIndicator());
+                bootErrorCollector, createExtraValidationStepHandler(), capabilityRegistry, getPartialModelIndicator(),
+                injectedInstabilityListener.getOptionalValue());
 
         // Initialize the model
         initModel(controller.getManagementModel(), controller.getModelControllerResource());
@@ -550,6 +552,10 @@ public abstract class AbstractControllerService implements Service<ModelControll
         return injectedExecutorService;
     }
 
+    protected InjectedValue<ControllerInstabilityListener> getContainerInstabilityInjector() {
+        return injectedInstabilityListener;
+    }
+
     protected void setConfigurationPersister(final ConfigurationPersister persister) {
         this.configurationPersister = persister;
     }
@@ -698,6 +704,19 @@ public abstract class AbstractControllerService implements Service<ModelControll
         default boolean isModelPartial() {
             return false;
         }
+    }
+
+    /**
+     * Listener for notifications that the {@link ModelController} is unstable and a
+     * process restart is necessary.
+     */
+    public interface ControllerInstabilityListener {
+        /**
+         * Notification that the {@link ModelController} should be considered to be unstable,
+         * e.g. due to the service container managed by the {@code ModelController}
+         * not being able to reach stability or due to some unhandled error.
+         */
+        void controllerUnstable();
     }
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -1180,13 +1180,18 @@ final class OperationContextImpl extends AbstractOperationContext {
                 try {
                     modelController.awaitContainerStability(timeout, TimeUnit.MILLISECONDS, true);
                 }  catch (InterruptedException e) {
+                    // Cancelled in some way
                     interrupted = true;
-                    MGMT_OP_LOGGER.interruptedWaitingStability();
+                    // Cancellation prevented us ensuring that MSC will be stable when this operation completes.
+                    // We can no longer have any sense of MSC state or how the model relates to the runtime and
+                    // we need to start from a fresh service container. Notify the controller of this.
+                    modelController.containerCannotStabilize();
+                    MGMT_OP_LOGGER.interruptedWaitingStability(activeStep.operationId.name, activeStep.operationId.address);
                 } catch (TimeoutException te) {
                     // If we can't attain stability on the way out after rollback ops have run,
                     // we can no longer have any sense of MSC state or how the model relates to the runtime and
-                    // we need to start from a fresh service container.
-                    processState.setRestartRequired(); // don't use our restartRequired() method as this is not reversible in rollback
+                    // we need to start from a fresh service container. Notify the controller of this.
+                    modelController.containerCannotStabilize();
                     // Just log; this doesn't change the result of the op. And if we're not stable here
                     // it's almost certain we never stabilized during execution or we are rolling back and destabilized there.
                     // Either one means there is already a failure message associated with this op.

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -417,9 +417,9 @@ public interface ControllerLogger extends BasicLogger {
     /**
      * Logs a warning message indicating that an operation was interrupted before service stability was reached
      */
-    @LogMessage(level = Level.WARN)
-    @Message(id = 27, value = "Operation was interrupted before stability could be reached")
-    void interruptedWaitingStability();
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 27, value = "Operation was interrupted before service container stability could be reached. Process should be restarted. Step that first updated the service container was '%s' at address '%s'")
+    void interruptedWaitingStability(String operation, PathAddress address);
 
     @LogMessage(level = Level.INFO)
     @Message(id = 28, value = "Attribute '%s' in the resource at address '%s' is deprecated, and may be removed in " +

--- a/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolClient.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolClient.java
@@ -161,6 +161,13 @@ public interface TransactionalProtocolClient {
         boolean isFailed();
 
         /**
+         * Check if prepare timed out.
+         *
+         * @return whether the operation failed due to timeout
+         */
+        boolean isTimedOut();
+
+        /**
          * Is done.
          *
          * @return whether the operation is complete (done or failed).

--- a/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolClientImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolClientImpl.java
@@ -547,6 +547,11 @@ class TransactionalProtocolClientImpl implements ManagementRequestHandlerFactory
         }
 
         @Override
+        public boolean isTimedOut() {
+            return false;
+        }
+
+        @Override
         public boolean isDone() {
             return finalResult.isDone();
         }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainController.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainController.java
@@ -122,6 +122,14 @@ public interface DomainController {
     void unregisterRunningServer(String serverName);
 
     /**
+     * Report to the domain controller that a server has been reported as unstable.
+     * @param serverName  the name of the server
+     */
+    default void reportServerInstability(String serverName) {
+        // default no-op because I'm tired of writing no-op impls in testsuite classes
+    }
+
+    /**
      * Get the operations needed to create the given profile.
      *
      * @param profileName the name of the profile

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/plan/AbstractServerGroupRolloutTask.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/plan/AbstractServerGroupRolloutTask.java
@@ -117,7 +117,8 @@ abstract class AbstractServerGroupRolloutTask implements Runnable {
         final ModelNode failureNode = new ModelNode();
         failureNode.get(OUTCOME).set(FAILED);
         failureNode.get(FAILURE_DESCRIPTION).set(failureMsg);
-        final BlockingQueueOperationListener.FailedOperation<ServerTaskExecutor.ServerOperation> prepared = new BlockingQueueOperationListener.FailedOperation<>(serverOperation, failureNode);
+        final BlockingQueueOperationListener.FailedOperation<ServerTaskExecutor.ServerOperation> prepared =
+                new BlockingQueueOperationListener.FailedOperation<>(serverOperation, failureNode, true);
 
         final ModelNode preparedResult = prepared.getPreparedResult();
         updatePolicy.recordServerResult(identity, preparedResult);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/plan/ServerTaskExecutor.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/plan/ServerTaskExecutor.java
@@ -237,6 +237,11 @@ public abstract class ServerTaskExecutor {
             return getServerIdentity().getServerGroupName();
         }
 
+        /** Gets whether the response represents a timeout */
+        public boolean isTimedOut() {
+            return preparedOperation.isTimedOut();
+        }
+
         /**
          * Finalize the transaction. This will return {@code false} in case the local operation failed,
          * but the overall state of the operation is commit=true.

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -242,6 +242,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
 
     private volatile ScheduledExecutorService pingScheduler;
     private volatile ManagementResourceRegistration hostModelRegistration;
+    private volatile MasterDomainControllerClient masterDomainControllerClient;
 
     static ServiceController<ModelController> addService(final ServiceTarget serviceTarget,
                                                             final HostControllerEnvironment environment,
@@ -461,6 +462,14 @@ public class DomainModelControllerService extends AbstractControllerService impl
         ManagementResourceRegistration hostRegistration = modelNodeRegistration.getSubModel(pa);
         hostRegistration.unregisterProxyController(pe);
         serverProxies.remove(serverName);
+    }
+
+    @Override
+    public void reportServerInstability(String serverName) {
+        MasterDomainControllerClient mdc = masterDomainControllerClient;
+        if (mdc != null) {
+            mdc.reportServerInstability(serverName);
+        }
     }
 
     @Override
@@ -890,7 +899,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
                 currentRunningMode,
                 serverProxies,
                 domainModelComplete);
-        MasterDomainControllerClient masterDomainControllerClient = getFuture(clientFuture);
+        masterDomainControllerClient = getFuture(clientFuture);
         //Registers us with the master and gets down the master copy of the domain model to our DC
         // if --cached-dc is used and the DC is unavailable, we'll use a cached copy of the domain config
         // (if available), and poll for reconnection to the DC. Once the DC becomes available again, the domain

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -1090,20 +1090,29 @@ public class DomainModelControllerService extends AbstractControllerService impl
             return result;
         }
 
+        @Override
         public ProxyController serverCommunicationRegistered(String serverProcessName, ManagementChannelHandler channelHandler) {
             return getServerInventory().serverCommunicationRegistered(serverProcessName, channelHandler);
         }
 
+        @Override
         public boolean serverReconnected(String serverProcessName, ManagementChannelHandler channelHandler) {
             return getServerInventory().serverReconnected(serverProcessName, channelHandler);
         }
 
+        @Override
         public void serverProcessAdded(String serverProcessName) {
             getServerInventory().serverProcessAdded(serverProcessName);
         }
 
+        @Override
         public void serverStartFailed(String serverProcessName) {
             getServerInventory().serverStartFailed(serverProcessName);
+        }
+
+        @Override
+        public void serverUnstable(String serverProcessName) {
+            getServerInventory().serverUnstable(serverProcessName);
         }
 
         @Override
@@ -1111,14 +1120,17 @@ public class DomainModelControllerService extends AbstractControllerService impl
             getServerInventory().serverStarted(serverProcessName);
         }
 
+        @Override
         public void serverProcessStopped(String serverProcessName) {
             getServerInventory().serverProcessStopped(serverProcessName);
         }
 
+        @Override
         public String getServerProcessName(String serverName) {
             return getServerInventory().getServerProcessName(serverName);
         }
 
+        @Override
         public String getProcessServerName(String processName) {
             return getServerInventory().getProcessServerName(processName);
         }
@@ -1128,22 +1140,27 @@ public class DomainModelControllerService extends AbstractControllerService impl
             return getServerInventory().reloadServer(serverName, blocking, suspend);
         }
 
+        @Override
         public void processInventory(Map<String, ProcessInfo> processInfos) {
             getServerInventory().processInventory(processInfos);
         }
 
+        @Override
         public Map<String, ProcessInfo> determineRunningProcesses() {
             return getServerInventory().determineRunningProcesses();
         }
 
+        @Override
         public Map<String, ProcessInfo> determineRunningProcesses(boolean serversOnly) {
             return getServerInventory().determineRunningProcesses(serversOnly);
         }
 
+        @Override
         public ServerStatus determineServerStatus(String serverName) {
             return getServerInventory().determineServerStatus(serverName);
         }
 
+        @Override
         public ServerStatus startServer(String serverName, ModelNode domainModel) {
             return getServerInventory().startServer(serverName, domainModel);
         }
@@ -1153,10 +1170,12 @@ public class DomainModelControllerService extends AbstractControllerService impl
             return getServerInventory().startServer(serverName, domainModel, blocking, suspend);
         }
 
+        @Override
         public void reconnectServer(String serverName, ModelNode domainModel, String authKey, boolean running, boolean stopping) {
             getServerInventory().reconnectServer(serverName, domainModel, authKey, running, stopping);
         }
 
+        @Override
         public ServerStatus restartServer(String serverName, int gracefulTimeout, ModelNode domainModel) {
             return getServerInventory().restartServer(serverName, gracefulTimeout, domainModel);
         }
@@ -1166,6 +1185,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
             return getServerInventory().restartServer(serverName, gracefulTimeout, domainModel, blocking, suspend);
         }
 
+        @Override
         public ServerStatus stopServer(String serverName, int gracefulTimeout) {
             return getServerInventory().stopServer(serverName, gracefulTimeout);
         }
@@ -1175,6 +1195,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
             return getServerInventory().stopServer(serverName, gracefulTimeout, blocking);
         }
 
+        @Override
         public CallbackHandler getServerCallbackHandler() {
             return getServerInventory().getServerCallbackHandler();
         }
@@ -1519,6 +1540,11 @@ public class DomainModelControllerService extends AbstractControllerService impl
 
             @Override
             public void serverStartFailed(String serverProcessName) {
+            }
+
+            @Override
+            public void serverUnstable(String serverProcessName) {
+
             }
 
             @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServer.java
@@ -397,12 +397,16 @@ class ManagedServer {
 
     /**
      * Notification that the process has become unstable.
+     *
+     * @return {@code true} if this is a change in status
      */
-    void processUnstable() {
-        if (!unstable) {  // Only once until the process is removed. A process is unstable until removed.
+    boolean processUnstable() {
+        boolean change = !unstable;
+        if (change) {  // Only once until the process is removed. A process is unstable until removed.
             unstable = true;
             HostControllerLogger.ROOT_LOGGER.managedServerUnstable(serverName);
         }
+        return change;
     }
 
     synchronized TransactionalProtocolClient channelRegistered(final ManagementChannelHandler channelAssociation) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/MasterDomainControllerClient.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/MasterDomainControllerClient.java
@@ -81,4 +81,12 @@ public interface MasterDomainControllerClient extends ModelControllerClient {
      * @return handle to allow polling to be cancelled
      */
     Cancellable pollForConnect();
+
+    /**
+     * Report to the domain controller that a server has been reported as unstable.
+     * @param serverName  the name of the server
+     */
+    default void reportServerInstability(String serverName) {
+        // default no-op because I'm tired of writing no-op impls in testsuite classes
+    }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventory.java
@@ -248,6 +248,13 @@ public interface ServerInventory {
     void serverStartFailed(String serverProcessName);
 
     /**
+     * Notification that a server process has become unstable.
+     *
+     * @param serverProcessName the name of the server process
+     */
+    void serverUnstable(String serverProcessName);
+
+    /**
      * Notification that a server has stopped.
      *
      * @param serverProcessName the name of the server process

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
@@ -692,8 +692,13 @@ public class ServerInventoryImpl implements ServerInventory {
     public void serverUnstable(final String serverProcessName) {
         final String serverName = ManagedServer.getServerName(serverProcessName);
         final ManagedServer server = servers.get(serverName);
+        boolean change = true;
         if (server != null) {
-            server.processUnstable();
+            change = server.processUnstable();
+        }
+        if (change) {
+            // Pass the news on to the DC
+            domainController.reportServerInstability(serverName);
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
@@ -689,6 +689,15 @@ public class ServerInventoryImpl implements ServerInventory {
     }
 
     @Override
+    public void serverUnstable(final String serverProcessName) {
+        final String serverName = ManagedServer.getServerName(serverProcessName);
+        final ManagedServer server = servers.get(serverName);
+        if (server != null) {
+            server.processUnstable();
+        }
+    }
+
+    @Override
     public void serverProcessRemoved(final String serverProcessName) {
         final String serverName = ManagedServer.getServerName(serverProcessName);
         final ManagedServer server = servers.remove(serverName);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1355,4 +1355,8 @@ public interface HostControllerLogger extends BasicLogger {
             "so the 'kill' operation may be required to terminate the server process.")
     void managedServerUnstable(String serverName);
 
+    @LogMessage(level = Level.WARN)
+    @Message(id = 199, value = "Server '%s' (managed by host '%s') has not responded to an operation request within the configured timeout. This may mean the server has become unstable.")
+    void serverSuspected(String serverName, String hostName);
+
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1356,7 +1356,15 @@ public interface HostControllerLogger extends BasicLogger {
     void managedServerUnstable(String serverName);
 
     @LogMessage(level = Level.WARN)
+    @Message( id = Message.INHERIT, value = "Server '%s' (managed by host '%s') is unstable and should be stopped or restarted. An unstable server may not stop normally, " +
+            "so the 'kill' operation may be required to terminate the server process.")
+    void managedServerUnstable(String serverName, String hostName);
+
+    @LogMessage(level = Level.WARN)
     @Message(id = 199, value = "Server '%s' (managed by host '%s') has not responded to an operation request within the configured timeout. This may mean the server has become unstable.")
     void serverSuspected(String serverName, String hostName);
 
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 200, value = "Reporting instability of server '%s' to Domain Controller failed.")
+    void failedReportingServerInstabilityToMaster(@Cause Exception e, String serverName);
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1350,4 +1350,9 @@ public interface HostControllerLogger extends BasicLogger {
     @Message(id = 197, value = "If attribute %s is defined one of ssl-context or security-realm must also be defined")
     OperationFailedException attributeRequiresSSLContext(String attribute);
 
+    @LogMessage(level = Level.WARN)
+    @Message( id = 198, value = "Server '%s' is unstable and should be stopped or restarted. An unstable server may not stop normally, " +
+            "so the 'kill' operation may be required to terminate the server process.")
+    void managedServerUnstable(String serverName);
+
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/DomainControllerProtocol.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/DomainControllerProtocol.java
@@ -33,6 +33,7 @@ public interface DomainControllerProtocol extends ModelControllerProtocol {
     byte REGISTER_HOST_CONTROLLER_REQUEST = 0x51;
     byte UNREGISTER_HOST_CONTROLLER_REQUEST = 0x53;
     byte GET_FILE_REQUEST = 0x55;
+    byte SERVER_INSTABILITY_REQUEST = 0x56;
     byte FETCH_DOMAIN_CONFIGURATION_REQUEST = 0x57;
     byte COMPLETE_HOST_CONTROLLER_REGISTRATION = 0x58;
     byte REQUEST_SUBSYSTEM_VERSIONS = 0x59;
@@ -49,4 +50,6 @@ public interface DomainControllerProtocol extends ModelControllerProtocol {
     byte FILE_START = 0x30;
     byte PARAM_FILE_SIZE = 0x31;
     byte FILE_END = 0x32;
+    byte PARAM_SERVER_ID = 0x33;
+
 }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -645,6 +645,11 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         }
 
         @Override
+        public void serverUnstable(String serverProcessName) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
         public void serverProcessStopped(String serverProcessName) {
             throw new UnsupportedOperationException("Not supported yet.");
         }

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -117,6 +117,7 @@ import org.jboss.as.server.deployment.reflect.InstallReflectionIndexProcessor;
 import org.jboss.as.server.deployment.service.ServiceActivatorDependencyProcessor;
 import org.jboss.as.server.deployment.service.ServiceActivatorProcessor;
 import org.jboss.as.server.logging.ServerLogger;
+import org.jboss.as.server.mgmt.domain.HostControllerConnectionService;
 import org.jboss.as.server.moduleservice.ExtensionIndexService;
 import org.jboss.as.server.moduleservice.ExternalModuleService;
 import org.jboss.as.server.moduleservice.ServiceModuleLoader;
@@ -246,6 +247,10 @@ public final class ServerService extends AbstractControllerService {
         serviceBuilder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, service.injectedPathManagerService);
         if (configuration.getServerEnvironment().isAllowModelControllerExecutor()) {
             serviceBuilder.addDependency(Services.JBOSS_SERVER_EXECUTOR, ExecutorService.class, service.getExecutorServiceInjector());
+        }
+        if (configuration.getServerEnvironment().getLaunchType() == ServerEnvironment.LaunchType.DOMAIN) {
+            serviceBuilder.addDependency(HostControllerConnectionService.SERVICE_NAME, ControllerInstabilityListener.class,
+                    service.getContainerInstabilityInjector());
         }
 
         serviceBuilder.install();

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/DomainServerProtocol.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/DomainServerProtocol.java
@@ -30,6 +30,7 @@ public interface DomainServerProtocol {
     byte REGISTER_REQUEST = 0x00;
     byte SERVER_STARTED_REQUEST = 0x02;
     byte SERVER_RECONNECT_REQUEST = 0x03;
+    byte SERVER_INSTABILITY_REQUEST = 0x04;
 
 
     byte PARAM_SERVER_NAME = 0x01;

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
@@ -141,7 +141,8 @@ public class HostControllerConnectionService implements Service<HostControllerCl
                     }
                 }
             });
-            this.client = new HostControllerClient(serverName, connection.getChannelHandler(), connection, managementSubsystemEndpoint);
+            this.client = new HostControllerClient(serverName, connection.getChannelHandler(), connection,
+                    managementSubsystemEndpoint, executorInjector.getValue());
         } catch (Exception e) {
             throw new StartException(e);
         }


### PR DESCRIPTION
This commit introduces a notification mechanism via which a listener for "controller instability" notifications can be created and wired into the ModelController.

In a domain server, such a listener is registered. In this case it's an additional function of HostControllerClient, which responds to notifications by asynchronously sending a message back to the managing HC.

Currently the managing HC simply logs a WARN when receiving such a message. In the future it could also do something else with the data, e.g. expose it over the management API for use by the admin console.

Notifications are currently sent in two cases:

1) An OperationContext is interrupted or times out waiting for MSC stability during operation finalization. This means MSC was not stable at the time of finalization and the state of the system is no longer knowable.
2) An Error is thrown during operation execution. Again in such a situation the state of the system is no longer knowable.

In the latter case, there is no guarantee that the listener will be able to send the message to the HC. For example if the Error is an OOME sending a message may not be possible. So this is not a foolproof means of ensuring the HC is aware of server instability. Possible future work to cover that kind of scenario could be to have the HC send some sort of health check request to the server when it detects that an operation has timed out.

This also doesn't send a notification if the server fails to shut down properly, e.g. from problems with the MSC ServiceContainer not stopping. That would be detected by the bootstrap shutdown hook, which has no relationship to this logic.