### PR TITLE
WFCORE-2106 Allow expressions in relative-to of keystore

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/KeystoreAttributes.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/KeystoreAttributes.java
@@ -61,6 +61,7 @@ public class KeystoreAttributes {
 
     public static final SimpleAttributeDefinition KEYSTORE_RELATIVE_TO = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.KEYSTORE_RELATIVE_TO, ModelType.STRING, true)
             .setXmlName(ModelDescriptionConstants.RELATIVE_TO).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, false))
+            .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
 
     public static final SimpleAttributeDefinition KEYSTORE_PROVIDER = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.KEYSTORE_PROVIDER, ModelType.STRING, true)


### PR DESCRIPTION
All attributes on the keystore element including the path element
support expressions with the exception of the relative-to element.
This seem inconsistent and forces us to have a more complicated than
necessary expression in the path element instead of being able to split
it between the path and relative-to element.

https://issues.jboss.org/browse/WFCORE-2106