### PR TITLE
Fix for WFCORE-2107. Clear output prior to start testing

### DIFF
--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCommentsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCommentsTestCase.java
@@ -43,6 +43,7 @@ public class CliCommentsTestCase {
     public void test() throws Exception {
         CliProcessWrapper cli = new CliProcessWrapper();
         cli.executeInteractive();
+        cli.clearOutput();
         try {
             assertTrue(cli.pushLineAndWaitForResults("# Hello \" sdcds ", null));
             assertTrue(cli.pushLineAndWaitForResults("# Hello \' sdcds ", null));

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliConfigTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliConfigTestCase.java
@@ -117,6 +117,7 @@ public class CliConfigTestCase {
                         + TestSuiteEnvironment.getServerPort())
                 .addCliArgument("--connect");
         cli.executeInteractive();
+        cli.clearOutput();
         testTimeout(cli, 1);
     }
 
@@ -130,6 +131,7 @@ public class CliConfigTestCase {
                 .addCliArgument("--connect")
                 .addCliArgument("--command-timeout=77");
         cli.executeInteractive();
+        cli.clearOutput();
         testTimeout(cli, 77);
     }
 
@@ -235,6 +237,7 @@ public class CliConfigTestCase {
                         + TestSuiteEnvironment.getServerPort())
                 .addCliArgument("--connect");
         cli.executeInteractive();
+        cli.clearOutput();
         cli.pushLineAndWaitForResults(":read-children-names(aaaaa,child-type=subsystem");
         String str = cli.getOutput();
         assertTrue(str, str.contains("'aaaaa' is not found among the supported properties:"));
@@ -251,6 +254,7 @@ public class CliConfigTestCase {
                         + TestSuiteEnvironment.getServerPort())
                 .addCliArgument("--connect");
         cli.executeInteractive();
+        cli.clearOutput();
         cli.pushLineAndWaitForResults(":read-children-names(aaaaa,child-type=subsystem");
         String str = cli.getOutput();
         assertTrue(str, str.contains("\"outcome\" => \"success\","));


### PR DESCRIPTION
Some tests require the output to be cleared prior to actually do testing.