### PR TITLE
Fix for WFCORE-2123. node path completion

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/operation/OperationRequestCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/OperationRequestCompleter.java
@@ -46,7 +46,7 @@ public class OperationRequestCompleter implements CommandLineCompleter {
     public static final OperationRequestCompleter INSTANCE = new OperationRequestCompleter();
 
     public static final CommandLineCompleter ARG_VALUE_COMPLETER = new CommandLineCompleter(){
-        final DefaultCallbackHandler parsedOp = new DefaultCallbackHandler();
+        final DefaultCallbackHandler parsedOp = new DefaultCallbackHandler(false);
         @Override
         public int complete(CommandContext ctx, String buffer, int cursor, List<String> candidates) {
             try {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -289,6 +289,15 @@ public class CliCompletionTestCase {
             }
 
             {
+                String cmd = "cd /deployment-";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertTrue(candidates.toString(), candidates.size() == 1);
+                assertTrue(candidates.toString(), candidates.contains("deployment-overlay="));
+            }
+
+            {
                 String cmd = "clear";
                 List<String> candidates = new ArrayList<>();
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,
@@ -699,6 +708,15 @@ public class CliCompletionTestCase {
             }
 
             {
+                String cmd = "read-attribute --node=/deployment-";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertTrue(candidates.toString(), candidates.size() == 1);
+                assertTrue(candidates.toString(), candidates.contains("deployment-overlay="));
+            }
+
+            {
                 String cmd = "read-attribute --verbose";
                 List<String> candidates = new ArrayList<>();
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,
@@ -750,6 +768,15 @@ public class CliCompletionTestCase {
                         cmd.length(), candidates);
                 assertTrue(candidates.toString(), candidates.size() > 1);
                 assertTrue(candidates.toString(), candidates.contains("read-resource"));
+            }
+
+            {
+                String cmd = "read-operation --node=/deployment-";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertTrue(candidates.toString(), candidates.size() >= 1);
+                assertTrue(candidates.toString(), candidates.contains("deployment-overlay="));
             }
 
             {
@@ -1100,6 +1127,15 @@ public class CliCompletionTestCase {
             assertTrue(candidates.toString(), candidates.contains("--min"));
             assertTrue(candidates.toString(), candidates.contains("--description"));
             assertTrue(candidates.toString(), candidates.contains("--nillable"));
+        }
+
+        {
+            String cmd = "ls /deployment-";
+            List<String> candidates = new ArrayList<>();
+            ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                    cmd.length(), candidates);
+            assertTrue(candidates.toString(), candidates.size() == 1);
+            assertTrue(candidates.toString(), candidates.contains("deployment-overlay="));
         }
     }
 


### PR DESCRIPTION
Disable validation of the node path completer. Added unit tests to complete deployment-<TAB>