### PR TITLE
[WFCORE-1606]: Server reload is needed for modified security-realm even if {allow-resource-service-restart=true} is used

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/AbstractPlugInAuthResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/AbstractPlugInAuthResourceDefinition.java
@@ -50,8 +50,15 @@ public abstract class AbstractPlugInAuthResourceDefinition extends SimpleResourc
             SecurityRealmChildAddHandler securityRealmChildAddHandler,
             SecurityRealmChildRemoveHandler securityRealmChildRemoveHandler, Flag restartResourceServices,
             Flag restartResourceServices2) {
-        super(pathElement, resourceDescriptionResolver, securityRealmChildAddHandler, securityRealmChildRemoveHandler,
-                restartResourceServices, restartResourceServices2);
+        this(new Parameters(pathElement, resourceDescriptionResolver)
+                .setAddHandler(securityRealmChildAddHandler)
+                .setAddRestartLevel(restartResourceServices)
+                .setRemoveHandler(securityRealmChildRemoveHandler)
+                .setRemoveRestartLevel(restartResourceServices2));
+    }
+
+    AbstractPlugInAuthResourceDefinition(Parameters params) {
+        super(params);
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/JaasAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/JaasAuthenticationResourceDefinition.java
@@ -59,12 +59,14 @@ public class JaasAuthenticationResourceDefinition extends SimpleResourceDefiniti
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = { NAME, ASSIGN_GROUPS };
 
     public JaasAuthenticationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.JAAS),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.JAAS),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authentication.jaas"),
-                new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS), new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.authentication.jaas"))
+                .setAddHandler(new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/KerberosAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/KerberosAuthenticationResourceDefinition.java
@@ -55,12 +55,14 @@ public class KerberosAuthenticationResourceDefinition extends SimpleResourceDefi
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = { REMOVE_REALM };
 
     public KerberosAuthenticationResourceDefinition() {
-        super(PathElement.pathElement(AUTHENTICATION, KERBEROS),
+        super(new Parameters(PathElement.pathElement(AUTHENTICATION, KERBEROS),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authentication.kerberos"),
-                new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS), new SecurityRealmChildRemoveHandler(false),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.authentication.kerberos"))
+                .setAddHandler(new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(false))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/KerberosServerIdentityResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/KerberosServerIdentityResourceDefinition.java
@@ -41,13 +41,13 @@ public class KerberosServerIdentityResourceDefinition extends SimpleResourceDefi
 
 
     KerberosServerIdentityResourceDefinition() {
-        super(PathElement.pathElement(SERVER_IDENTITY, KERBEROS),
-                ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY, "core.management.security-realm.server-identity.kerberos"),
-                new SecurityRealmChildAddHandler(false, false),
-                new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_NONE,
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+        super(new Parameters(PathElement.pathElement(SERVER_IDENTITY, KERBEROS),
+                ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY, "core.management.security-realm.server-identity.kerberos"))
+                .setAddHandler(new SecurityRealmChildAddHandler(false, false))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/KeytabResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/KeytabResourceDefinition.java
@@ -75,14 +75,14 @@ public class KeytabResourceDefinition extends SimpleResourceDefinition {
     private static AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { PATH, RELATIVE_TO, FOR_HOSTS, DEBUG };
 
     KeytabResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.KEYTAB),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.KEYTAB),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.server-identity.kerberos.keytab"),
-                new SecurityRealmChildAddHandler(false, false, ATTRIBUTES),
-                new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES,
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.server-identity.kerberos.keytab"))
+                .setAddHandler(new SecurityRealmChildAddHandler(false, false, ATTRIBUTES))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthenticationResourceDefinition.java
@@ -101,12 +101,14 @@ public class LdapAuthenticationResourceDefinition extends LdapResourceDefinition
     };
 
     public LdapAuthenticationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.LDAP),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.LDAP),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authentication.ldap"),
-                new LdapAuthenticationAddHandler(), new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.authentication.ldap"))
+                .setAddHandler(new LdapAuthenticationAddHandler())
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthorizationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapAuthorizationResourceDefinition.java
@@ -57,12 +57,14 @@ public class LdapAuthorizationResourceDefinition extends LdapResourceDefinition 
     static final LdapAuthorizationChildRemoveHandler REMOVE_INSTANCE = new LdapAuthorizationChildRemoveHandler();
 
     public LdapAuthorizationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHORIZATION, ModelDescriptionConstants.LDAP),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.AUTHORIZATION, ModelDescriptionConstants.LDAP),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authorization.ldap"),
-                new LdapAuthorizationChildAddHandler(true, ATTRIBUTE_DEFINITIONS), new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.authorization.ldap"))
+                .setAddHandler(new LdapAuthorizationChildAddHandler(true, ATTRIBUTE_DEFINITIONS))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapCacheResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapCacheResourceDefinition.java
@@ -73,7 +73,7 @@ import org.jboss.msc.service.ServiceRegistry;
  */
 public class LdapCacheResourceDefinition extends SimpleResourceDefinition {
 
-    private static final CacheDefintionValidatingHandler VALIDATION_INSTANCE = new CacheDefintionValidatingHandler();
+    private static final CacheDefinitionValidatingHandler VALIDATION_INSTANCE = new CacheDefinitionValidatingHandler();
 
     /*
      * Configuration Attributes
@@ -163,17 +163,17 @@ public class LdapCacheResourceDefinition extends SimpleResourceDefinition {
     private LdapCacheResourceDefinition(final PathElement pathElement,
             final SimpleAttributeDefinition[] configurationAttributes, final SimpleAttributeDefinition[] runtimeAttributes,
             final SimpleOperationDefinition[] runtimeOperations, final OperationStepHandler runtimeStepHandler) {
-        super(pathElement,
-                ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.ldap.cache"),
-                new CacheChildAddHandler(configurationAttributes), new SecurityRealmChildRemoveHandler(
-                        false), OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-
+        super(new Parameters(pathElement, ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
+                        "core.management.security-realm.ldap.cache"))
+                .setAddHandler(new CacheChildAddHandler(configurationAttributes))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(false))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
         this.configurationAttributes = configurationAttributes;
         this.runtimeAttributes = runtimeAttributes;
         this.runtimeOperations = runtimeOperations;
         this.runtimeStepHandler = runtimeStepHandler;
-        setDeprecated(ModelVersion.create(1, 7));
     }
 
     private static ResourceDefinition create(final PathElement pathElement, final CacheFor cacheFor) {
@@ -444,7 +444,7 @@ public class LdapCacheResourceDefinition extends SimpleResourceDefinition {
         }
     }
 
-    private static class CacheDefintionValidatingHandler implements OperationStepHandler {
+    private static class CacheDefinitionValidatingHandler implements OperationStepHandler {
 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapResourceDefinition.java
@@ -49,7 +49,14 @@ public abstract class LdapResourceDefinition extends SimpleResourceDefinition {
 
     public LdapResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver,
             OperationStepHandler addHandler, OperationStepHandler removeHandler, Flag addRestartLevel, Flag removeRestartLevel) {
-        super(pathElement, descriptionResolver, addHandler, removeHandler, addRestartLevel, removeRestartLevel);
+        this(new Parameters(pathElement, descriptionResolver)
+                .setAddHandler(addHandler)
+                .setAddRestartLevel(addRestartLevel)
+                .setRemoveHandler(removeHandler)
+                .setRemoveRestartLevel(removeRestartLevel));
     }
 
+    public LdapResourceDefinition(final Parameters parameters) {
+        super(parameters);
+    }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LocalAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LocalAuthenticationResourceDefinition.java
@@ -67,12 +67,14 @@ public class LocalAuthenticationResourceDefinition extends SimpleResourceDefinit
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = { DEFAULT_USER, ALLOWED_USERS, SKIP_GROUP_LOADING };
 
     public LocalAuthenticationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.LOCAL),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.LOCAL),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authentication.local"),
-                new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS), new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.authentication.local"))
+                .setAddHandler(new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PlugInAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PlugInAuthenticationResourceDefinition.java
@@ -55,12 +55,14 @@ public class PlugInAuthenticationResourceDefinition extends AbstractPlugInAuthRe
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = { NAME, MECHANISM };
 
     public PlugInAuthenticationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.PLUG_IN),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.PLUG_IN),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authentication.plug-in"),
-                new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS), new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.authentication.plug-in"))
+                .setAddHandler(new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PlugInAuthorizationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PlugInAuthorizationResourceDefinition.java
@@ -36,12 +36,14 @@ import org.jboss.as.domain.management.ModelDescriptionConstants;
 public class PlugInAuthorizationResourceDefinition extends AbstractPlugInAuthResourceDefinition {
 
     public PlugInAuthorizationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHORIZATION, ModelDescriptionConstants.PLUG_IN),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.AUTHORIZATION, ModelDescriptionConstants.PLUG_IN),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authorization.plug-in"),
-                new SecurityRealmChildAddHandler(false, true, NAME), new SecurityRealmChildRemoveHandler(false),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.authorization.plug-in"))
+                .setAddHandler(new SecurityRealmChildAddHandler(false, true, NAME))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(false))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PlugInResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PlugInResourceDefinition.java
@@ -38,12 +38,13 @@ import org.jboss.as.controller.registry.OperationEntry;
 public class PlugInResourceDefinition extends SimpleResourceDefinition {
 
     public PlugInResourceDefinition() {
-        super(PathElement.pathElement(PLUG_IN),
-                ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY, "core.management.security-realm.plug-in"),
-                new SecurityRealmChildAddHandler(false, false),
-                new SecurityRealmChildRemoveHandler(true), OperationEntry.Flag.RESTART_NONE,
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+        super(new Parameters(PathElement.pathElement(PLUG_IN),
+                ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY, "core.management.security-realm.plug-in"))
+                .setAddHandler(new SecurityRealmChildAddHandler(false, false))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesAuthenticationResourceDefinition.java
@@ -50,12 +50,14 @@ public class PropertiesAuthenticationResourceDefinition extends PropertiesFileRe
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = { PATH, RELATIVE_TO, PLAIN_TEXT };
 
     public PropertiesAuthenticationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.PROPERTIES),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.PROPERTIES),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authentication.properties"),
-                new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS), new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.authentication.properties"))
+                .setAddHandler(new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesAuthorizationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesAuthorizationResourceDefinition.java
@@ -39,12 +39,14 @@ public class PropertiesAuthorizationResourceDefinition extends PropertiesFileRes
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = { PATH, RELATIVE_TO };
 
     public PropertiesAuthorizationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHORIZATION, ModelDescriptionConstants.PROPERTIES),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.AUTHORIZATION, ModelDescriptionConstants.PROPERTIES),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authorization.properties"),
-                new SecurityRealmChildAddHandler(false, true, ATTRIBUTE_DEFINITIONS), new SecurityRealmChildRemoveHandler(false),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                          "core.management.security-realm.authorization.properties"))
+                .setAddHandler(new SecurityRealmChildAddHandler(false, true, ATTRIBUTE_DEFINITIONS))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(false))
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesFileResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesFileResourceDefinition.java
@@ -60,7 +60,15 @@ public abstract class PropertiesFileResourceDefinition extends SimpleResourceDef
             final ResourceDescriptionResolver descriptionResolver, final OperationStepHandler addHandler,
             final OperationStepHandler removeHandler, final OperationEntry.Flag addRestartLevel,
             final OperationEntry.Flag removeRestartLevel) {
-        super(pathElement, descriptionResolver, addHandler, removeHandler, addRestartLevel, removeRestartLevel);
+        this(new Parameters(pathElement, descriptionResolver)
+                .setAddHandler(addHandler)
+                .setAddRestartLevel(addRestartLevel)
+                .setRemoveHandler(removeHandler)
+                .setRemoveRestartLevel(removeRestartLevel));
+    }
+
+    public PropertiesFileResourceDefinition(final Parameters parameters) {
+        super(parameters);
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertyResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertyResourceDefinition.java
@@ -46,12 +46,12 @@ public class PropertyResourceDefinition extends SimpleResourceDefinition {
             .setRequired(false).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
 
     public PropertyResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.PROPERTY),
-                ControllerResolver.getResolver("core.management.security-realm.property"),
-                new SecurityRealmChildAddHandler(true, false, VALUE),
-                new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES,
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.PROPERTY),
+                ControllerResolver.getResolver("core.management.security-realm.property"))
+                .setAddHandler(new SecurityRealmChildAddHandler(true, false, VALUE))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SSLServerIdentityResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SSLServerIdentityResourceDefinition.java
@@ -83,13 +83,13 @@ public class SSLServerIdentityResourceDefinition extends SimpleResourceDefinitio
     };
 
     public SSLServerIdentityResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.SERVER_IDENTITY, ModelDescriptionConstants.SSL),
-                ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY, "core.management.security-realm.server-identity.ssl"),
-                new SecurityRealmChildAddHandler(false, false, ATTRIBUTE_DEFINITIONS),
-                new SecurityRealmChildRemoveHandler(false),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES,
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.SERVER_IDENTITY, ModelDescriptionConstants.SSL),
+                ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY, "core.management.security-realm.server-identity.ssl"))
+                .setAddHandler(new SecurityRealmChildAddHandler(false, false, ATTRIBUTE_DEFINITIONS))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(false))
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecretServerIdentityResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecretServerIdentityResourceDefinition.java
@@ -60,12 +60,14 @@ public class SecretServerIdentityResourceDefinition extends SimpleResourceDefini
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = {VALUE, CREDENTIAL_REFERENCE};
 
     public SecretServerIdentityResourceDefinition() {
-        super(PathElement.pathElement(SERVER_IDENTITY, SECRET),
+        super(new Parameters(PathElement.pathElement(SERVER_IDENTITY, SECRET),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core", "management", "security-realm", "server-identity", "secret"),
-                new SecurityRealmChildAddHandler(false, false, ATTRIBUTE_DEFINITIONS), new SecurityRealmChildRemoveHandler(false),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES, OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core", "management", "security-realm", "server-identity", "secret"))
+                .setAddHandler(new SecurityRealmChildAddHandler(false, false, ATTRIBUTE_DEFINITIONS))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(false))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmChildAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmChildAddHandler.java
@@ -31,6 +31,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
 
 /**
  * Add handler for a child resource of a management security realm.
@@ -53,6 +54,11 @@ public class SecurityRealmChildAddHandler extends SecurityRealmParentRestartHand
         this.validateAuthentication = validateAuthentication;
         this.validateAuthorization = validateAuthorization;
         this.attributeDefinitions = attributeDefinitions == null ? new AttributeDefinition[0] : attributeDefinitions;
+    }
+
+    @Override
+    protected boolean isResourceServiceRestartAllowed(OperationContext context, ServiceController<?> service) {
+        return false;
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmChildRemoveHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmChildRemoveHandler.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
 
 /**
  * Remove handler for a child resource of a management security realm.
@@ -49,6 +50,11 @@ public class SecurityRealmChildRemoveHandler extends SecurityRealmParentRestartH
     public SecurityRealmChildRemoveHandler(boolean validateAuthentication, RuntimeCapability... capabilities) {
         super(capabilities);
         this.validateAuthentication = validateAuthentication;
+    }
+
+    @Override
+    protected boolean isResourceServiceRestartAllowed(OperationContext context, ServiceController<?> service) {
+        return false;
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/TruststoreAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/TruststoreAuthenticationResourceDefinition.java
@@ -44,14 +44,14 @@ public class TruststoreAuthenticationResourceDefinition extends SimpleResourceDe
     };
 
     public TruststoreAuthenticationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.TRUSTSTORE),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.TRUSTSTORE),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authentication.truststore"),
-                new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS),
-                new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES,
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.authentication.truststore"))
+                .setAddHandler(new SecurityRealmChildAddHandler(true, false, ATTRIBUTE_DEFINITIONS))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/XmlAuthenticationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/XmlAuthenticationResourceDefinition.java
@@ -38,14 +38,14 @@ import org.jboss.as.controller.registry.OperationEntry;
 public class XmlAuthenticationResourceDefinition extends SimpleResourceDefinition {
 
     public XmlAuthenticationResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.USERS),
+        super(new Parameters(PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.USERS),
                 ControllerResolver.getDeprecatedResolver(SecurityRealmResourceDefinition.DEPRECATED_PARENT_CATEGORY,
-                        "core.management.security-realm.authentication.xml"),
-                new SecurityRealmChildAddHandler(true, false),
-                new SecurityRealmChildRemoveHandler(true),
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES,
-                OperationEntry.Flag.RESTART_RESOURCE_SERVICES);
-        setDeprecated(ModelVersion.create(1, 7));
+                        "core.management.security-realm.authentication.xml"))
+                .setAddHandler(new SecurityRealmChildAddHandler(true, false))
+                .setRemoveHandler(new SecurityRealmChildRemoveHandler(true))
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setDeprecatedSince(ModelVersion.create(1, 7)));
     }
 
     @Override


### PR DESCRIPTION
Updating metadata and handlers to require for server reload as restarting the SecurityRealm is not sufficient.

Jira: https://issues.jboss.org/browse/WFCORE-1606
JBEAP: https://issues.jboss.org/browse/JBEAP-5073
Full 'fix':  https://github.com/wildfly/wildfly/pull/10097 
Experimental build https://ci.wildfly.org/viewType.html?buildTypeId=WF_WildFlyCoreIntegrationExperiments&branch_WF=%2Fpre-WFCORE-1606%3B%2Fehsavoie%3A%2FWFCORE-1606%3B%2Fehsavoie