### PR TITLE
Fix for WFCORE-2142. Fix unknown overlay error messages.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentOverlayHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentOverlayHandler.java
@@ -526,7 +526,7 @@ public class DeploymentOverlayHandler extends BatchModeCommandHandler {//Command
         assertNotPresent(deployments, args);
         assertNotPresent(redeployAffected, args);
 
-        final String overlay = name.getValue(args, true);
+        final String overlay = getName(ctx, false);
         final ModelControllerClient client = ctx.getModelControllerClient();
 
         final ModelNode redeployOp = new ModelNode();
@@ -557,6 +557,25 @@ public class DeploymentOverlayHandler extends BatchModeCommandHandler {//Command
 */
     }
 
+    /**
+     * Validate that the overlay exists. If it doesn't exist, throws an
+     * exception if not in batch mode or if failInBatch is true. In batch mode,
+     * we could be in the case that the overlay doesn't exist yet.
+     */
+    private String getName(CommandContext ctx, boolean failInBatch) throws CommandLineException {
+        final ParsedCommandLine args = ctx.getParsedCommandLine();
+        final String name = this.name.getValue(args, true);
+        if (name == null) {
+            throw new CommandFormatException(this.name + " is missing value.");
+        }
+        if (!ctx.isBatchMode() || failInBatch) {
+            if (!Util.isValidPath(ctx.getModelControllerClient(), Util.DEPLOYMENT_OVERLAY, name)) {
+                throw new CommandFormatException("Deployment overlay " + name + " does not exist.");
+            }
+        }
+        return name;
+    }
+
     protected void listLinks(CommandContext ctx) throws CommandLineException {
 
         final ModelControllerClient client = ctx.getModelControllerClient();
@@ -566,10 +585,8 @@ public class DeploymentOverlayHandler extends BatchModeCommandHandler {//Command
         assertNotPresent(deployments, args);
         assertNotPresent(redeployAffected, args);
 
-        final String name = this.name.getValue(args, true);
-        if(name == null) {
-            throw new CommandFormatException(this.name + " is missing value.");
-        }
+        final String name = getName(ctx, true);
+
         final String sg = serverGroups.getValue(ctx.getParsedCommandLine());
         if(ctx.isDomainMode()) {
             final List<String> groups;
@@ -613,10 +630,7 @@ public class DeploymentOverlayHandler extends BatchModeCommandHandler {//Command
         assertNotPresent(content, args);
         assertNotPresent(redeployAffected, args);
 
-        final String name = this.name.getValue(args, true);
-        if(name == null) {
-            throw new CommandFormatException(this.name.getFullName() + " is missing value.");
-        }
+        final String name = getName(ctx, true);
         final List<String> content = loadContentFor(client, name);
         if(l.isPresent(args)) {
             for(String contentPath : content) {
@@ -634,10 +648,7 @@ public class DeploymentOverlayHandler extends BatchModeCommandHandler {//Command
         final ParsedCommandLine args = ctx.getParsedCommandLine();
         assertNotPresent(allServerGroups, args);
 
-        final String name = this.name.getValue(args, true);
-        if(name == null) {
-            throw new CommandFormatException(this.name + " is missing value.");
-        }
+        final String name = getName(ctx, false);
         final String contentStr = content.getValue(args);
         String deploymentStr = deployments.getValue(args);
         final String sgStr = serverGroups.getValue(args);
@@ -894,7 +905,7 @@ public class DeploymentOverlayHandler extends BatchModeCommandHandler {//Command
         final ParsedCommandLine args = ctx.getParsedCommandLine();
         assertNotPresent(allRelevantServerGroups, args);
 
-        final String name = this.name.getValue(args, true);
+        final String name = getName(ctx, false);
         final String[] deployments = getLinks(this.deployments, args);
         if(deployments == null) {
             throw new CommandFormatException(this.deployments.getFullName() + " is required.");
@@ -937,10 +948,7 @@ public class DeploymentOverlayHandler extends BatchModeCommandHandler {//Command
 
         final ParsedCommandLine args = ctx.getParsedCommandLine();
 
-        final String name = this.name.getValue(args, true);
-        if(!Util.isValidPath(ctx.getModelControllerClient(), Util.DEPLOYMENT_OVERLAY, name)) {
-            throw new CommandLineException("Deployment overlay " + name + " does not exist.");
-        }
+        final String name = getName(ctx, false);
         final String contentStr = content.getValue(args, true);
 
         final String[] contentPairs = contentStr.split(",+");

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentOverlayTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeploymentOverlayTestCase.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import java.io.File;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContextFactory;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+public class DeploymentOverlayTestCase {
+
+    @Test
+    public void testInvalidName() throws Exception {
+        CommandContext ctx = CommandContextFactory.getInstance().newCommandContext();
+        ctx.connectController("remote+http://" + TestSuiteEnvironment.getServerAddress()
+                + ":" + TestSuiteEnvironment.getServerPort());
+        try {
+            expectException(ctx, "deployment-overlay remove --name=toto");
+            expectException(ctx, "deployment-overlay list-content --name=toto");
+            expectException(ctx, "deployment-overlay list-links --name=toto");
+            expectException(ctx, "deployment-overlay redeploy-affected --name=toto");
+            expectException(ctx, "deployment-overlay link --name=toto");
+            expectException(ctx, "deployment-overlay upload --name=toto");
+
+            ctx.handle("batch");
+            expectException(ctx, "deployment-overlay list-content --name=toto");
+            expectException(ctx, "deployment-overlay list-links --name=toto");
+
+            File f = File.createTempFile("deploymentOverlay", null);
+            f.createNewFile();
+            f.deleteOnExit();
+            ctx.handle("deployment-overlay link --name=toto --deployments=tutu");
+            ctx.handle("deployment-overlay upload --name=toto --content=tutu="
+                    + f.getAbsolutePath());
+        } finally {
+            ctx.terminateSession();
+        }
+
+    }
+    private void expectException(CommandContext ctx, String cmd) throws Exception {
+        try {
+            ctx.handle(cmd);
+            throw new Exception(cmd + " should have failed");
+        } catch (CommandLineException ex) {
+            if (!ex.getMessage().contains("toto does not exist")) {
+                throw new Exception("Unexpected exception " + ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Check the overlay name prior to make a request. In batch mode the name is only checked for actions that are not added to the batch (list-links, list-content).
The side effect is that upload action can now be added to a batch if the overlay doesn't exist (overlay could be added in the same batch, in a previous step).
Unit tests added.
