### PR TITLE
Fix for WFCORE-1856. Fix for set command completion.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/SetVariableHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/SetVariableHandler.java
@@ -53,12 +53,18 @@ public class SetVariableHandler extends CommandHandlerWithHelp {
                     return -1;
                 }
                 // the problem is splitting values with whitespaces, e.g. for command substitution
-                final String value = buffer.substring(equals + 1);
-                final int valueIndex = ctx.getDefaultCommandCompleter().complete(ctx, value, cursor, candidates);
-                if(valueIndex < 0) {
+                String value = buffer.substring(equals + 1);
+                if (value.startsWith("`")) {
+                    value = value.substring(1);
+                    final int valueIndex = ctx.getDefaultCommandCompleter().complete(ctx, value, cursor, candidates);
+                    if (valueIndex < 0) {
+                        return -1;
+                    }
+                    // + 1 for '=', +1 for '`'
+                    return equals + 1 + valueIndex + 1;
+                } else {
                     return -1;
                 }
-                return equals + 1 + valueIndex;
             }}, Integer.MAX_VALUE, "--variable") {
             @Override
             public boolean canAppearNext(CommandContext ctx) throws CommandFormatException {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -788,6 +788,33 @@ public class CliCompletionTestCase {
             }
 
             {
+                String cmd = "set toto=l";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertTrue(candidates.toString(), candidates.isEmpty());
+            }
+
+            {
+                String cmd = "set toto=`";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertFalse(candidates.toString(), candidates.isEmpty());
+                assertTrue(candidates.toString(), candidates.contains(":"));
+                assertTrue(candidates.toString(), candidates.contains("ls"));
+            }
+
+            {
+                String cmd = "set toto=`l";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertFalse(candidates.toString(), candidates.isEmpty());
+                assertTrue(candidates.toString(), candidates.contains("ls"));
+            }
+
+            {
                 String cmd = "unset toto ";
                 List<String> candidates = new ArrayList<>();
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,


### PR DESCRIPTION
set command completion should only propose commands/operations if value starts with ` character.
Unit tests added.