### PR TITLE
[WFCORE-379 WFCORE-380] Operations to browse and read content from the content repository

### DIFF
--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/DeploymentOperationsTestCase.java
@@ -23,11 +23,13 @@ package org.wildfly.core.test.standalone.mgmt.api.core;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD_CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ARCHIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BROWSE_CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BYTES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPTH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXPLODE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INPUT_STREAM_INDEX;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGED;
@@ -58,6 +60,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
@@ -75,9 +78,14 @@ import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentManager
 import org.jboss.as.test.deployment.trivial.ServiceActivatorDeploymentUtil;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.base.path.BasicPath;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -98,6 +106,7 @@ public class DeploymentOperationsTestCase {
 
     private static final int TIMEOUT = TimeoutUtil.adjust(20000);
     private static final String TEST_DEPLOYMENT_NAME = "test-deployment.jar";
+    private static final String PROPERTIES_RESOURCE = "service-activator-deployment.properties";
 
     @Before
     public void cleanEnv() {
@@ -142,6 +151,30 @@ public class DeploymentOperationsTestCase {
     }
 
     @Test
+    public void testManagedOperationsFailWithUnmanagedArchiveDeployment() throws Exception {
+        deployUnmanagedDeployment(TEST_DEPLOYMENT_NAME, true);
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, ""), "WFLYSRV0255");
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, "abc"), "WFLYSRV0255");
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, "META-INF/"), "WFLYSRV0255");
+        assertOperationFailedWithCode(browseContentFromDeploymentAndGetResult(TEST_DEPLOYMENT_NAME, ""), "WFLYSRV0255");
+        assertOperationFailedWithCode(browseContentFromDeploymentAndGetResult(TEST_DEPLOYMENT_NAME, "abc"), "WFLYSRV0255");
+        assertOperationFailedWithCode(browseContentFromDeploymentAndGetResult(TEST_DEPLOYMENT_NAME, "META-INF/"), "WFLYSRV0255");
+        undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
+    }
+
+    @Test
+    public void testManagedOperationsFailWithUnmanagedExplodedDeployment() throws Exception {
+        deployUnmanagedDeployment(TEST_DEPLOYMENT_NAME, false);
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, ""), "WFLYSRV0255");
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, "abc"), "WFLYSRV0255");
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, "META-INF/"), "WFLYSRV0255");
+        assertOperationFailedWithCode(browseContentFromDeploymentAndGetResult(TEST_DEPLOYMENT_NAME, ""), "WFLYSRV0255");
+        assertOperationFailedWithCode(browseContentFromDeploymentAndGetResult(TEST_DEPLOYMENT_NAME, "abc"), "WFLYSRV0255");
+        assertOperationFailedWithCode(browseContentFromDeploymentAndGetResult(TEST_DEPLOYMENT_NAME, "META-INF/"), "WFLYSRV0255");
+        undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
+    }
+
+    @Test
     public void testManagedExplodedOperationsFailWithUnmanagedArchiveDeployment() throws Exception {
         deployUnmanagedDeployment(TEST_DEPLOYMENT_NAME, true);
         Assert.assertFalse(explodeDeploymentAndGetOutcome(TEST_DEPLOYMENT_NAME));
@@ -149,7 +182,6 @@ public class DeploymentOperationsTestCase {
         Assert.assertTrue(addContentByInputStreamAndGetOutcome(TEST_DEPLOYMENT_NAME, true).get(ROLLED_BACK).asBoolean());
         Assert.assertTrue(addContentByUrlAndGetOutcome(TEST_DEPLOYMENT_NAME, true).get(ROLLED_BACK).asBoolean());
         Assert.assertFalse(removeContentFromDeploymentAndGetOutcome(TEST_DEPLOYMENT_NAME));
-        Assert.assertFalse(readContentFromDeploymentAndGetOutcome(TEST_DEPLOYMENT_NAME));
         undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
     }
 
@@ -161,7 +193,6 @@ public class DeploymentOperationsTestCase {
         Assert.assertTrue(addContentByInputStreamAndGetOutcome(TEST_DEPLOYMENT_NAME, true).get(ROLLED_BACK).asBoolean());
         Assert.assertTrue(addContentByUrlAndGetOutcome(TEST_DEPLOYMENT_NAME, true).get(ROLLED_BACK).asBoolean());
         Assert.assertFalse(removeContentFromDeploymentAndGetOutcome(TEST_DEPLOYMENT_NAME));
-        Assert.assertFalse(readContentFromDeploymentAndGetOutcome(TEST_DEPLOYMENT_NAME));
         undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
     }
 
@@ -173,7 +204,6 @@ public class DeploymentOperationsTestCase {
         Assert.assertTrue(addContentByInputStreamAndGetOutcome(TEST_DEPLOYMENT_NAME, true).get(ROLLED_BACK).asBoolean());
         Assert.assertTrue(addContentByUrlAndGetOutcome(TEST_DEPLOYMENT_NAME, true).get(ROLLED_BACK).asBoolean());
         Assert.assertFalse(removeContentFromDeploymentAndGetOutcome(TEST_DEPLOYMENT_NAME));
-        Assert.assertFalse(readContentFromDeploymentAndGetOutcome(TEST_DEPLOYMENT_NAME));
         undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
     }
 
@@ -198,6 +228,42 @@ public class DeploymentOperationsTestCase {
         undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
     }
 
+    @Test
+    public void testBrowseContentFailsNonexistentPath() throws Exception {
+        deployManagedDeployment(TEST_DEPLOYMENT_NAME, true);
+        assertOperationFailedWithCode(browseContentFromDeploymentAndGetResult(TEST_DEPLOYMENT_NAME, "nonexistent.file"), "WFLYDR0020");
+        undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
+        deployManagedDeployment(TEST_DEPLOYMENT_NAME, false);
+        assertOperationFailedWithCode(browseContentFromDeploymentAndGetResult(TEST_DEPLOYMENT_NAME, "nonexistent.file"), "WFLYDR0020");
+        undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
+    }
+
+    @Test
+    public void testBrowseContentParameters() throws Exception {
+        testBrowseContentParameterCombinations(true);
+        testBrowseContentParameterCombinations(false);
+    }
+
+    @Test
+    public void testReadContentFailsNonExistentPath() throws Exception {
+        deployManagedDeployment(TEST_DEPLOYMENT_NAME, true);
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, "nonexistent.file"), "WFLYDR0020");
+        undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
+        deployManagedDeployment(TEST_DEPLOYMENT_NAME, false);
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, "nonexistent.file"), "WFLYDR0020");
+        undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
+    }
+
+    @Test
+    public void testReadContentFailsDirectory() throws Exception {
+        deployManagedDeployment(TEST_DEPLOYMENT_NAME, true);
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, "META_INF/"), "WFLYDR0020");
+        undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
+        deployManagedDeployment(TEST_DEPLOYMENT_NAME, false);
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, "META_INF/"), "WFLYDR0020");
+        assertOperationFailedWithCode(readContentFromDeployment(TEST_DEPLOYMENT_NAME, ""), "WFLYDR0020");
+        undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
+    }
 
     private boolean getManagedAttribute(String deploymentName) {
         ModelNode op = new ModelNode();
@@ -215,6 +281,10 @@ public class DeploymentOperationsTestCase {
             throw new RuntimeException(e.getCause());
         } catch (TimeoutException e) {
             throw new RuntimeException(e);
+        } finally {
+            if (!future.isDone()) {
+                future.cancel(true);
+            }
         }
     }
 
@@ -225,7 +295,7 @@ public class DeploymentOperationsTestCase {
         op.get(NAME).set(MANAGED);
         op.get(VALUE).set(newValue);
 
-        return Operations.isSuccessfulOutcome(awaitOperationExecutionAndReturnOutcome(op));
+        return Operations.isSuccessfulOutcome(awaitOperationExecutionAndReturnResult(op));
     }
 
     private boolean explodeDeploymentAndGetOutcome(String deploymentName) {
@@ -233,14 +303,14 @@ public class DeploymentOperationsTestCase {
         op.get(OP).set(EXPLODE);
         op.get(OP_ADDR).add(DEPLOYMENT, deploymentName);
 
-        return Operations.isSuccessfulOutcome(awaitOperationExecutionAndReturnOutcome(op));
+        return Operations.isSuccessfulOutcome(awaitOperationExecutionAndReturnResult(op));
     }
 
     private ModelNode addContentByByteArrayAndGetOutcome(String deploymentName, boolean overwrite) throws Exception {
         final Properties addedContentProperties = new Properties();
         addedContentProperties.put(deploymentName + "Service", "isReplaced");
         ModelNode addedContentNode = new ModelNode();
-        addedContentNode.get(TARGET_PATH).set("SimpleTest.properties");
+        addedContentNode.get(TARGET_PATH).set(PROPERTIES_RESOURCE);
         String addedContentString;
         try (StringWriter writer = new StringWriter()) {
             addedContentProperties.store(writer, "Added with add-content op");
@@ -252,9 +322,9 @@ public class DeploymentOperationsTestCase {
         addContentOp.get(OP_ADDR).set(DEPLOYMENT, deploymentName);
         addContentOp.get(CONTENT).setEmptyList();
         addContentOp.get(CONTENT).add(addedContentNode);
-        addContentOp.get(OVERWRITE).add(overwrite);
+        addContentOp.get(OVERWRITE).set(overwrite);
 
-        return awaitOperationExecutionAndReturnOutcome(addContentOp);
+        return awaitOperationExecutionAndReturnResult(addContentOp);
     }
 
     private ModelNode addContentByInputStreamAndGetOutcome(String deploymentName, boolean overwrite) throws Exception {
@@ -269,7 +339,7 @@ public class DeploymentOperationsTestCase {
         }
         try (InputStream is = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8))) {
             ModelNode addedContentNode = new ModelNode();
-            addedContentNode.get(TARGET_PATH).set("SimpleTest.properties");
+            addedContentNode.get(TARGET_PATH).set(PROPERTIES_RESOURCE);
             addedContentNode.get(INPUT_STREAM_INDEX).set(0);
             attachments.add(is);
             ModelNode addContentOp = new ModelNode();
@@ -277,7 +347,7 @@ public class DeploymentOperationsTestCase {
             addContentOp.get(OP_ADDR).set(DEPLOYMENT, deploymentName);
             addContentOp.get(CONTENT).setEmptyList();
             addContentOp.get(CONTENT).add(addedContentNode);
-            addContentOp.get(OVERWRITE).add(overwrite);
+            addContentOp.get(OVERWRITE).set(overwrite);
 
             Future<ModelNode> future = client.executeAsync(Operation.Factory.create(addContentOp, attachments), null);
             ModelNode response;
@@ -290,6 +360,10 @@ public class DeploymentOperationsTestCase {
                 throw new RuntimeException(e.getCause());
             } catch (TimeoutException e) {
                 throw new RuntimeException(e);
+            } finally {
+                if (!future.isDone()) {
+                    future.cancel(true);
+                }
             }
 
             Assert.assertNotNull(response);
@@ -301,9 +375,9 @@ public class DeploymentOperationsTestCase {
         final Properties addedContentProperties = new Properties();
         addedContentProperties.put(deploymentName + "Service", "isReplaced");
         ModelNode addedContentNode = new ModelNode();
-        addedContentNode.get(TARGET_PATH).set("SimpleTest.properties");
+        addedContentNode.get(TARGET_PATH).set(PROPERTIES_RESOURCE);
         File archivesDir = new File("target", "archives");
-        File addedContentFile = new File(archivesDir, "simpleTest.properties");
+        File addedContentFile = new File(archivesDir, PROPERTIES_RESOURCE);
         if (addedContentFile.exists()) {
             addedContentFile.delete();
         }
@@ -318,9 +392,9 @@ public class DeploymentOperationsTestCase {
         addContentOp.get(OP_ADDR).set(DEPLOYMENT, TEST_DEPLOYMENT_NAME);
         addContentOp.get(CONTENT).setEmptyList();
         addContentOp.get(CONTENT).add(addedContentNode);
-        addContentOp.get(OVERWRITE).add(overwrite);
+        addContentOp.get(OVERWRITE).set(overwrite);
 
-        return awaitOperationExecutionAndReturnOutcome(addContentOp);
+        return awaitOperationExecutionAndReturnResult(addContentOp);
     }
 
     private boolean removeContentFromDeploymentAndGetOutcome(String deploymentName) throws Exception {
@@ -328,18 +402,184 @@ public class DeploymentOperationsTestCase {
         op.get(OP).set(REMOVE_CONTENT);
         op.get(OP_ADDR).add(DEPLOYMENT, deploymentName);
         op.get(PATHS).setEmptyList();
-        op.get(PATHS).add("simpleTest.properties");
+        op.get(PATHS).add(PROPERTIES_RESOURCE);
 
-        return Operations.isSuccessfulOutcome(awaitOperationExecutionAndReturnOutcome(op));
+        return Operations.isSuccessfulOutcome(awaitOperationExecutionAndReturnResult(op));
     }
 
-    private boolean readContentFromDeploymentAndGetOutcome(String deploymentName) throws Exception {
+    private ModelNode readContentFromDeployment(String deploymentName, String path) throws Exception {
         ModelNode op = new ModelNode();
         op.get(OP).set(READ_CONTENT);
         op.get(OP_ADDR).add(DEPLOYMENT, deploymentName);
-        op.get(PATH).set("simpleTest.properties");
+        if (!path.isEmpty()) {
+            op.get(PATH).set(path);
+        }
 
-        return Operations.isSuccessfulOutcome(awaitOperationExecutionAndReturnOutcome(op));
+        return awaitOperationExecutionAndReturnResult(op);
+    }
+
+    private ModelNode browseContentFromDeploymentAndGetResult(String deploymentName, String path) throws Exception {
+        return browseContentFromDeploymentAndGetResult(deploymentName, path, false, -1);
+    }
+
+    private ModelNode browseContentFromDeploymentAndGetResult(String deploymentName, String path, boolean archive, int depth) throws Exception {
+        ModelNode op = new ModelNode();
+        op.get(OP).set(BROWSE_CONTENT);
+        op.get(OP_ADDR).add(DEPLOYMENT, deploymentName);
+        if (archive) {
+            op.get(ARCHIVE).set(archive);
+        }
+        if (depth > 0) {
+            op.get(DEPTH).set(depth);
+        }
+        if (!path.isEmpty()) {
+            op.get(PATH).set(path);
+        }
+
+        return awaitOperationExecutionAndReturnResult(op);
+    }
+
+    private void assertBrowseContentReturnsExpectedResult(
+            List<String> expected, String deploymentName, String path, boolean archive, int depth) throws Exception {
+        ModelNode result = browseContentFromDeploymentAndGetResult(deploymentName, path, archive, depth);
+
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.fail("Operation browse content should be successful, but failed: "
+                    + Operations.getFailureDescription(result).toString());
+        }
+
+        List<String> unexpected = new ArrayList<>();
+
+        if (expected.isEmpty()) {
+            Assert.assertEquals("Expected an empty result with /deployment=" + deploymentName+ ":browse-content(" +
+                            "path=\"" + path + "\", archive=" + archive + ", depth=" + depth + "), actual result was: "
+                            + result.toString(),
+                    new ModelNode(), Operations.readResult(result));
+        } else {
+            List<ModelNode> contents = Operations.readResult(result).asList();
+            for (ModelNode content : contents) {
+                Assert.assertTrue(content.hasDefined("path"));
+                String contentPath = content.get("path").asString();
+                Assert.assertTrue(content.hasDefined("directory"));
+                if (!content.get("directory").asBoolean()) {
+                    Assert.assertTrue(content.hasDefined("file-size"));
+                }
+                if (!expected.contains(contentPath)) {
+                    unexpected.add(contentPath);
+                }
+                expected.remove(contentPath);
+            }
+        }
+        Assert.assertTrue("Unexpected files listed by /deployment=" + deploymentName+ ":browse-content(" +
+                        "path=\"" + path + "\", archive=" + archive + ", depth=" + depth + ") : " + unexpected.toString(),
+                        unexpected.isEmpty());
+        Assert.assertTrue("Expected files not listed by /deployment=" + deploymentName+ ":browse-content(" +
+                        "path=\"" + path + "\", archive=" + archive + ", depth=" + depth + ") : " + expected.toString(),
+                        expected.isEmpty());
+
+    }
+
+    private void testBrowseContentParameterCombinations(boolean archive) throws Exception {
+        deployManagedDeploymentWithArchives(TEST_DEPLOYMENT_NAME, true);
+        ArrayList<String> expected = new ArrayList<>(Arrays.asList("misc/", "other/", "lib/",
+                "misc/text.txt", "web.war", "lib/lib.jar"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "", false, -1);
+        expected = new ArrayList<>(Arrays.asList("web.war", "lib/lib.jar"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "", true, -1);
+        expected = new ArrayList<>(Arrays.asList("misc/", "other/", "lib/", "web.war"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "", false, 1);
+        expected = new ArrayList<>(Arrays.asList("web.war"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "", true, 1);
+        expected = new ArrayList<>(Arrays.asList("lib.jar"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "lib/", true, -1);
+        expected = new ArrayList<>(Arrays.asList("page.html", "lib/", "lib/inner-lib.jar"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "web.war/", false, -1);
+        expected = new ArrayList<>(Arrays.asList("lib/inner-lib.jar"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "web.war/", true, -1);
+        expected = new ArrayList<>(Arrays.asList("page.html", "lib/"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "web.war/", false, 1);
+        expected = new ArrayList<>();
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "web.war/", true, 1);
+        expected = new ArrayList<>(Arrays.asList("inner-lib.jar"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "web.war/lib/", false, -1);
+        expected = new ArrayList<>(Arrays.asList("inner-lib.jar"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "web.war/lib/", true, -1);
+        expected = new ArrayList<>(Arrays.asList("META-INF/", "META-INF/MANIFEST.MF",
+                "META-INF/services/", "META-INF/services/org.jboss.msc.service.ServiceActivator",
+                "org/","org/jboss/","org/jboss/as/", "org/jboss/as/test/", "org/jboss/as/test/deployment/",
+                "org/jboss/as/test/deployment/trivial/", "service-activator-deployment.properties",
+                "org/jboss/as/test/deployment/trivial/ServiceActivatorDeployment.class"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "web.war/lib/inner-lib.jar/", false, -1);
+        expected = new ArrayList<>();
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "web.war/lib/inner-lib.jar/", true, -1);
+        expected = new ArrayList<>(Arrays.asList("META-INF/", "org/", "service-activator-deployment.properties"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "web.war/lib/inner-lib.jar/", false, 1);
+        expected = new ArrayList<>();
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "web.war/lib/inner-lib.jar/", true, 1);
+        expected = new ArrayList<>(Arrays.asList("META-INF/", "META-INF/MANIFEST.MF",
+                "META-INF/services/", "META-INF/services/org.jboss.msc.service.ServiceActivator",
+                "org/","org/jboss/","org/jboss/as/", "org/jboss/as/test/", "org/jboss/as/test/deployment/",
+                "org/jboss/as/test/deployment/trivial/", "service-activator-deployment.properties",
+                "org/jboss/as/test/deployment/trivial/ServiceActivatorDeployment.class", "inner-lib.jar"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "lib/lib.jar/", false, -1);
+        expected = new ArrayList<>(Arrays.asList("inner-lib.jar"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "lib/lib.jar/", true, -1);
+        expected = new ArrayList<>(Arrays.asList("META-INF/", "org/", "inner-lib.jar", "service-activator-deployment.properties"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "lib/lib.jar/", false, 1);
+        expected = new ArrayList<>(Arrays.asList("inner-lib.jar"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "lib/lib.jar/", true, 1);
+        expected = new ArrayList<>(Arrays.asList("META-INF/", "META-INF/MANIFEST.MF",
+                "META-INF/services/", "META-INF/services/org.jboss.msc.service.ServiceActivator",
+                "org/","org/jboss/","org/jboss/as/", "org/jboss/as/test/", "org/jboss/as/test/deployment/",
+                "org/jboss/as/test/deployment/trivial/", "service-activator-deployment.properties",
+                "org/jboss/as/test/deployment/trivial/ServiceActivatorDeployment.class"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "lib/lib.jar/inner-lib.jar/", false, -1);
+        expected = new ArrayList<>();
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "lib/lib.jar/inner-lib.jar/", true, -1);
+        expected = new ArrayList<>(Arrays.asList("META-INF/", "org/", "service-activator-deployment.properties"));
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "lib/lib.jar/inner-lib.jar/", false, 1);
+        expected = new ArrayList<>();
+        assertBrowseContentReturnsExpectedResult(expected, TEST_DEPLOYMENT_NAME, "lib/lib.jar/inner-lib.jar/", true, 1);
+        undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
+    }
+
+    private void deployManagedDeploymentWithArchives(String deploymentName, boolean archived) throws Exception {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "web.war");
+        war.addAsWebResource(new StringAsset(deploymentName + " Test Deployment Web"), "page.html");
+        war.addAsDirectory("/lib");
+        final Properties properties = new Properties();
+        properties.put("lib.jar" + "Service", "isNew");
+        final JavaArchive innerJar = ServiceActivatorDeploymentUtil.createServiceActivatorDeploymentArchive("inner-lib.jar", properties);
+        final JavaArchive jar = ServiceActivatorDeploymentUtil.createServiceActivatorDeploymentArchive("lib.jar", properties);
+        jar.add(innerJar, new BasicPath("/"), ZipExporter.class);
+        war.add(innerJar, new BasicPath("/lib"), ZipExporter.class);
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, deploymentName);
+        ear.addAsDirectory("/misc");
+        ear.addAsDirectory("/other");
+        ear.addAsDirectory("/lib");
+        ear.add(new StringAsset("just a misc file"), "/misc/text.txt");
+        ear.add(war, new BasicPath("/"), ZipExporter.class);
+        ear.add(jar, new BasicPath("/lib"), ZipExporter.class);
+
+        final ModelControllerClient client = managementClient.getControllerClient();
+        final ServerDeploymentManager manager = ServerDeploymentManager.Factory.create(client);
+
+        try (InputStream is = ear.as(ZipExporter.class).exportAsInputStream()) {
+            if (archived) {
+                Future<?> future = manager.execute(manager.newDeploymentPlan()
+                        .add(deploymentName, is)
+                        .deploy(deploymentName)
+                        .build());
+                awaitDeploymentExecution(future);
+            } else {
+                Future<?> future = manager.execute(manager.newDeploymentPlan()
+                        .add(deploymentName, is)
+                        .explodeDeployment(deploymentName)
+                        .deploy(deploymentName)
+                        .build());
+                awaitDeploymentExecution(future);
+            }
+        }
     }
 
     private void deployManagedDeployment(String deploymentName, boolean archived) throws Exception {
@@ -436,10 +676,14 @@ public class DeploymentOperationsTestCase {
             throw new RuntimeException(e.getCause());
         } catch (TimeoutException e) {
             throw new RuntimeException(e);
+        } finally {
+            if (!future.isDone()) {
+                future.cancel(true);
+            }
         }
     }
 
-    private ModelNode awaitOperationExecutionAndReturnOutcome(ModelNode op) {
+    private ModelNode awaitOperationExecutionAndReturnResult(ModelNode op) {
         Future<ModelNode> future = managementClient.getControllerClient().executeAsync(OperationBuilder.create(op, false).build(), null);
         try {
             return future.get(TIMEOUT, TimeUnit.MILLISECONDS);
@@ -450,6 +694,10 @@ public class DeploymentOperationsTestCase {
             throw new RuntimeException(e.getCause());
         } catch (TimeoutException e) {
             throw new RuntimeException(e);
+        } finally {
+            if (!future.isDone()) {
+                future.cancel(true);
+            }
         }
     }
 
@@ -463,7 +711,19 @@ public class DeploymentOperationsTestCase {
             throw new RuntimeException(e.getCause());
         } catch (TimeoutException e) {
             throw new RuntimeException(e);
+        } finally {
+            if (!future.isDone()) {
+                future.cancel(true);
+            }
         }
+    }
+
+    private void assertOperationFailedWithCode(ModelNode result, String failureCode) {
+        Assert.assertFalse("Operation should not be successful, expected operation failure with code " + failureCode,
+                Operations.isSuccessfulOutcome(result));
+        String failureDescription = Operations.getFailureDescription(result).toString();
+        Assert.assertTrue("Operation should fail with code " + failureCode + ", but instead fails with " + failureDescription,
+                failureDescription.contains(failureCode));
     }
 
     private static void cleanFile(File toClean) {
@@ -481,7 +741,7 @@ public class DeploymentOperationsTestCase {
         ModelNode op = new ModelNode();
         op.get(OP).set(READ_RESOURCE_OPERATION);
         op.get(OP_ADDR).set(DEPLOYMENT, TEST_DEPLOYMENT_NAME);
-        ModelNode result = awaitOperationExecutionAndReturnOutcome(op);
+        ModelNode result = awaitOperationExecutionAndReturnResult(op);
         if (Operations.isSuccessfulOutcome(result)) {
             undeployAndRemoveDeployment(TEST_DEPLOYMENT_NAME);
         }


### PR DESCRIPTION
* Adding browse-content and read-content operations to workflow of DeploymentTestCase and ExplodedDeploymentTestCase.
* Adding negative tests for browse-content and read-content operations to DeploymentOperationsTestCase.