### PR TITLE
Fix for WFCORE-2174. Move AwaiterModelControllerClient out of .impl p…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/AwaiterModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/AwaiterModelControllerClient.java
@@ -19,13 +19,14 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.cli.impl;
+package org.jboss.as.cli;
 
 import java.io.IOException;
-import org.jboss.as.cli.CommandLineException;
 import org.jboss.dmr.ModelNode;
 
 /**
+ * ModelControllerClient set on CommandContext must implement this interface.
+ * That is required for reload and shutdown commands to be used.
  *
  * @author jdenise@redhat.com
  */

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ReloadHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ReloadHandler.java
@@ -36,7 +36,7 @@ import org.jboss.as.cli.accesscontrol.AccessRequirementBuilder;
 import org.jboss.as.cli.accesscontrol.PerNodeOperationAccess;
 import org.jboss.as.cli.embedded.EmbeddedProcessLaunch;
 import org.jboss.as.cli.impl.ArgumentWithValue;
-import org.jboss.as.cli.impl.AwaiterModelControllerClient;
+import org.jboss.as.cli.AwaiterModelControllerClient;
 import org.jboss.as.cli.impl.CommaSeparatedCompleter;
 import org.jboss.as.cli.impl.DefaultCompleter;
 import org.jboss.as.cli.operation.ParsedCommandLine;

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
@@ -35,7 +35,7 @@ import org.jboss.as.cli.accesscontrol.AccessRequirementBuilder;
 import org.jboss.as.cli.accesscontrol.PerNodeOperationAccess;
 import org.jboss.as.cli.embedded.EmbeddedProcessLaunch;
 import org.jboss.as.cli.impl.ArgumentWithValue;
-import org.jboss.as.cli.impl.AwaiterModelControllerClient;
+import org.jboss.as.cli.AwaiterModelControllerClient;
 import org.jboss.as.cli.impl.CommaSeparatedCompleter;
 import org.jboss.as.cli.operation.ParsedCommandLine;
 import org.jboss.as.controller.client.ModelControllerClient;

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.cli.impl;
 
+import org.jboss.as.cli.AwaiterModelControllerClient;
 import static java.security.AccessController.doPrivileged;
 
 import java.io.IOException;

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandExecutor.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandExecutor.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.cli.impl;
 
+import org.jboss.as.cli.AwaiterModelControllerClient;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;


### PR DESCRIPTION
AwaiterModelControllerClient can be implemented by third party ModelControllerClient.
Should be in org.jboss.as.cli package.
Simple refactoring, no unit tests.
