### PR TITLE
[WFCORE-2176]:  ProcessStateListener execution isn't cancelled when timeout is reached.

### DIFF
--- a/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/ProcessStateListenerService.java
+++ b/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/ProcessStateListenerService.java
@@ -173,6 +173,7 @@ public class ProcessStateListenerService implements Service<Void> {
             Thread.currentThread().interrupt();
             CoreManagementLogger.ROOT_LOGGER.processStateInvokationError(ex, name);
         } catch (TimeoutException ex) {
+            controlledProcessStateTransition.cancel(true);
             CoreManagementLogger.ROOT_LOGGER.processStateTimeoutError(ex, name);
         } catch (ExecutionException | RuntimeException t) {
             CoreManagementLogger.ROOT_LOGGER.processStateInvokationError(t, name);
@@ -226,6 +227,7 @@ public class ProcessStateListenerService implements Service<Void> {
             Thread.currentThread().interrupt();
             CoreManagementLogger.ROOT_LOGGER.processStateInvokationError(ex, name);
         } catch (TimeoutException ex) {
+            suspendStateTransition.cancel(true);
             CoreManagementLogger.ROOT_LOGGER.processStateTimeoutError(ex, name);
         } catch (ExecutionException | RuntimeException t) {
             CoreManagementLogger.ROOT_LOGGER.processStateInvokationError(t, name);


### PR DESCRIPTION
Cancelling task when Timeout is reached.

Jira: https://issues.jboss.org/browse/WFCORE-2176
JBEAP: https://issues.jboss.org/browse/JBEAP-8184