### PR TITLE
WFCORE-2178 throw exception with failure description if overlay resou…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentOverlayHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentOverlayHandler.java
@@ -1072,7 +1072,7 @@ public class DeploymentOverlayHandler extends BatchModeCommandHandler {//Command
             final String descr = Util.getFailureDescription(response);
             if(descr != null && descr.contains("WFLYCTL0216")) {
                 // resource doesn't exist
-                return Collections.emptyList();
+                throw new CommandLineException(descr);
             }
             throw new CommandLineException("Failed to load the list of deployments for overlay " + overlay + ": " + response);
         }


### PR DESCRIPTION
…rce does not exist.
https://issues.jboss.org/browse/WFCORE-2178
In case of non-existent deployment overlay, CommandLineException with failure description should call attention to user instead of returning an empty list in silence.

On CLI side, print something like:
```
[standalone@localhost:9990 /] deployment-overlay list-links --name=not-existing-overlay   
WFLYCTL0216: Management resource '[("deployment-overlay" => "not-existing-overlay")]' not found

[domain@localhost:9990 /] deployment-overlay list-links --name=not-existing-overlay
WFLYCTL0216: Management resource '[
    ("server-group" => "main-server-group"),
    ("deployment-overlay" => "not-existing-overlay")
]' not found
```
