### PR TITLE
Fix for WFCORE-1580. CLI dependency on logmanager is an hard one

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -164,7 +164,6 @@
         <dependency>
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Make log manager dependency an hard one. Required by embedded-server commands.
