### PR TITLE
[WFCORE-2179]: When in SUSPENDED state we shouldn't suspend on stopping

### DIFF
--- a/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
+++ b/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
@@ -71,6 +71,9 @@ public class SuspendController implements Service<SuspendController> {
     }
 
     public synchronized void suspend(long timeoutMillis) {
+        if(state == State.SUSPENDED) {
+            return;
+        }
         if (timeoutMillis > 0) {
             ServerLogger.ROOT_LOGGER.suspendingServer(timeoutMillis);
         } else {


### PR DESCRIPTION
If in state SUSPENDED when suspend is called, just return.
Jira: https://issues.jboss.org/browse/WFCORE-2179

Please note that this will impact the RunningState listeners (as some transition won't happen anymore)