### PR TITLE
WFCORE-2160 - Incorrect JBOSS_HOME warning in vault.sh

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/vault.sh
+++ b/core-feature-pack/src/main/resources/content/bin/vault.sh
@@ -52,7 +52,7 @@ if [ "x$JBOSS_HOME" = "x" ]; then
     # get the full path (without any relative bits)
     JBOSS_HOME=$RESOLVED_JBOSS_HOME
 else
- SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME/.."; pwd`
+ SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
  if [ "$RESOLVED_JBOSS" != "$SANITIZED_JBOSS_HOME" ]; then
    echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""


### PR DESCRIPTION
Upstream Issue: https://issues.jboss.org/browse/WFCORE-2160
EAP Issue: https://issues.jboss.org/browse/JBEAP-8135

No downstream to EAP required as the branch (in core) related to 7.1.x has not been created (AFAIU).