### PR TITLE
[WFCORE-1228]: Follow up on WFCORE-1202 and make the configuration available in the management model.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -332,6 +332,7 @@ public class ModelDescriptionConstants {
     public static final String OUTCOME = "outcome";
     public static final String OVERWRITE = "overwrite";
     public static final String OWNER = "owner";
+    public static final String PARSE_ROLES_FROM_DN = "parse-group-name-from-dn";
     public static final String PASSWORD = "password";
     public static final String PATH = "path";
     public static final String PATHS = "paths";

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -136,6 +136,7 @@ public enum Attribute {
     NAME("name"),
     NATIVE("native"),
     ORGANIZATION("organization"),
+    PARSE_ROLES_FROM_DN("parse-group-name-from-dn"),
     PASSWORD("password"),
     PATH("path"),
     PATTERN("pattern"),

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -179,6 +179,7 @@ core.management.security-realm.authorization.ldap.group-search.principal-to-grou
 core.management.security-realm.authorization.ldap.group-search.principal-to-group.group-name-attribute=Which attribute on a group entry is it's simple name.
 core.management.security-realm.authorization.ldap.group-search.principal-to-group.search-by=Should searches be performed using simple names or distinguished names?
 core.management.security-realm.authorization.ldap.group-search.principal-to-group.group-attribute=The attribute on the principal which references the group the principal is a member of.
+core.management.security-realm.authorization.ldap.group-search.principal-to-group.parse-group-name-from-dn=Should the group name be extracted from the distinguished name.
 core.management.security-realm.authorization.ldap.group-search.principal-to-group.prefer-original-connection=After following a referral should subsequent searches prefer the original connection or use the connection of the last referral.
 core.management.security-realm.authorization.ldap.group-search.principal-to-group.skip-missing-groups=If a non-existent group is referenced should it be quietly ignored.
 core.management.security-realm.ldap.cache=A cache to hold the results of previous LDAP interactions.

--- a/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
@@ -1249,6 +1249,9 @@ public interface DomainManagementLogger extends BasicLogger {
     @Message(id = 139, value = "No SubjectIdentity found for %s/%s.")
     GeneralSecurityException noSubjectIdentityForProtocolAndHost(final String protocol, final String host);
 
+    @Message(id = 140, value = "You shouldn't use the system property \"%s\" as it is deprecated. Use the management model configuration instead.")
+    StartException usingDeprecatedSystemProperty(String propertyName);
+
     /**
      * Information message saying the username and password must be different.
      *

--- a/domain-management/src/main/java/org/jboss/as/domain/management/parsing/ManagementXml_5.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/parsing/ManagementXml_5.java
@@ -1716,6 +1716,10 @@ class ManagementXml_5 extends ManagementXml {
                         PrincipalToGroupResourceDefinition.SKIP_MISSING_GROUPS.parseAndSetParameter(value, addOp, reader);
                         break;
                     }
+                    case PARSE_ROLES_FROM_DN: {
+                        PrincipalToGroupResourceDefinition.PARSE_ROLES_FROM_DN.parseAndSetParameter(value, addOp, reader);
+                        break;
+                    }
                     default: {
                         throw unexpectedAttribute(reader, i);
                     }
@@ -2284,6 +2288,7 @@ class ManagementXml_5 extends ManagementXml {
                     PrincipalToGroupResourceDefinition.GROUP_ATTRIBUTE.marshallAsAttribute(principalToGroup, writer);
                     PrincipalToGroupResourceDefinition.PREFER_ORIGINAL_CONNECTION.marshallAsAttribute(principalToGroup, writer);
                     PrincipalToGroupResourceDefinition.SKIP_MISSING_GROUPS.marshallAsAttribute(principalToGroup, writer);
+                    PrincipalToGroupResourceDefinition.PARSE_ROLES_FROM_DN.marshallAsAttribute(principalToGroup, writer);
                     writer.writeEndElement();
                 }
                 writer.writeEndElement();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PrincipalToGroupResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PrincipalToGroupResourceDefinition.java
@@ -54,8 +54,14 @@ public class PrincipalToGroupResourceDefinition extends BaseLdapGroupSearchResou
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
+    public static final SimpleAttributeDefinition PARSE_ROLES_FROM_DN =
+            new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PARSE_ROLES_FROM_DN, ModelType.BOOLEAN, true)
+                    .setDefaultValue(new ModelNode(false))
+                    .setAllowExpression(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+                    .build();
 
-    private static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = {GROUP_NAME, ITERATIVE, GROUP_DN_ATTRIBUTE, GROUP_NAME_ATTRIBUTE, GROUP_ATTRIBUTE, PREFER_ORIGINAL_CONNECTION, SKIP_MISSING_GROUPS};
+    private static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = {GROUP_NAME, ITERATIVE, GROUP_DN_ATTRIBUTE, GROUP_NAME_ATTRIBUTE, GROUP_ATTRIBUTE, PREFER_ORIGINAL_CONNECTION, SKIP_MISSING_GROUPS, PARSE_ROLES_FROM_DN};
 
     public static final ResourceDefinition INSTANCE = new PrincipalToGroupResourceDefinition();
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -524,8 +524,8 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
             String groupNameAttribute = PrincipalToGroupResourceDefinition.GROUP_NAME_ATTRIBUTE.resolveModelAttribute(context, principalToGroup).asString();
             iterative = PrincipalToGroupResourceDefinition.ITERATIVE.resolveModelAttribute(context, principalToGroup).asBoolean();
             boolean skipMissingGroups = PrincipalToGroupResourceDefinition.SKIP_MISSING_GROUPS.resolveModelAttribute(context, principalToGroup).asBoolean();
-
-            groupSearcher = LdapGroupSearcherFactory.createForPrincipalToGroup(groupAttribute, groupNameAttribute, preferOriginalConnection, skipMissingGroups, GroupName.SIMPLE == groupName);
+            boolean shouldParseGroupFromDN = PrincipalToGroupResourceDefinition.PARSE_ROLES_FROM_DN.resolveModelAttribute(context, principalToGroup).asBoolean();
+            groupSearcher = LdapGroupSearcherFactory.createForPrincipalToGroup(groupAttribute, groupNameAttribute, preferOriginalConnection, skipMissingGroups, GroupName.SIMPLE == groupName, shouldParseGroupFromDN);
         }
 
         LdapCacheService<LdapEntry[], LdapEntry> groupCacheService = createCacheService(context, groupSearcher, groupCache);

--- a/server/src/main/resources/schema/wildfly-config_5_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_5_0.xsd
@@ -1241,6 +1241,13 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
+                        <xs:attribute name="parse-group-name-from-dn" type="xs:boolean" default="false">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Extract the groupe name from the distinguished name instead of requesting it.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>


### PR DESCRIPTION
Making the parseGroupNameFromDn available through the DMR.
The legacy System property still works.

Jira: https://issues.jboss.org/browse/WFCORE-1228