### PR TITLE
[WFCORE-2189]: JmxControlledStateNotificationsTestCase fails on IBM JDK (domain module).

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/JmxControlledStateNotificationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/JmxControlledStateNotificationsTestCase.java
@@ -25,8 +25,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Consumer;
 
 import org.jboss.as.controller.operations.common.Util;
@@ -50,8 +53,10 @@ public class JmxControlledStateNotificationsTestCase {
 
     private static DomainTestSupport testSupport;
     private static DomainLifecycleUtil domainMasterLifecycleUtil;
+    private static final boolean IS_IBM = AccessController.doPrivileged((PrivilegedAction<Boolean>) ()
+            -> System.getProperty("java.vendor.url", "whatever").toLowerCase(Locale.ENGLISH).contains("ibm.com"));
 
-    static final Path DATA = Paths.get("target/wildfly-core/target/notifications/data");
+    static final Path DATA = IS_IBM ? Paths.get("target/domains/JmxControlledStateNotificationsTestCase/master/target/notifications/data") : Paths.get("target/wildfly-core/target/notifications/data");
 
     static final File JMX_FACADE_RUNNING = DATA.resolve(JMX_FACADE_FILE).resolve(RUNNING_FILENAME).toAbsolutePath().toFile();
     static final File JMX_FACADE_RUNTIME = DATA.resolve(JMX_FACADE_FILE).resolve(RUNTIME_CONFIGURATION_FILENAME).toAbsolutePath().toFile();


### PR DESCRIPTION
Base path is not resolved in the same way as with the Oracle JDK.

Jira: https://issues.jboss.org/browse/WFCORE-2189

IBM build: https://ci.wildfly.org/viewLog.html?buildId=40845