### PR TITLE
[WFCORE-2194] StartSuspendedTestCase fails with security manager in WF core

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/StartSuspendedTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/StartSuspendedTestCase.java
@@ -27,6 +27,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUSPEND_STATE;
 
 import java.net.HttpURLConnection;
+import java.net.SocketPermission;
 import java.net.URL;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 
 import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceActivator;
@@ -83,6 +85,11 @@ public class StartSuspendedTestCase {
         war.addPackage(SuspendResumeHandler.class.getPackage());
         war.addAsServiceProvider(ServiceActivator.class, TestSuspendServiceActivator.class);
         war.addAsResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller, io.undertow.core, org.jboss.as.server,org.wildfly.extension.request-controller, org.jboss.as.network\n"), "META-INF/MANIFEST.MF");
+        war.addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+            new RuntimePermission("createXnioWorker"),
+            new SocketPermission(TestSuiteEnvironment.getServerAddress() + ":8080", "listen,resolve"),
+            new SocketPermission("*", "accept,resolve")
+        ), "permissions.xml");
         //helper.deploy(WEB_SUSPEND_JAR, war.as(ZipExporter.class).exportAsInputStream());
         serverController.deploy(war, WEB_SUSPEND_JAR);
     }


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFCORE-2194

This PR depends on #2049 to be merged first.