### PR TITLE
WFCORE-2188 WFCORE-2159 WFCORE-2187 WFCORE-1622 WFCORE-2195 IO subsystem fixes

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemTransformers.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemTransformers.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.io;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.transform.ExtensionTransformerRegistration;
+import org.jboss.as.controller.transform.SubsystemTransformerRegistration;
+import org.jboss.as.controller.transform.description.AttributeConverter;
+import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+
+/**
+ * @author Tomaz Cerar (c) 2017 Red Hat Inc.
+ */
+public class IOSubsystemTransformers implements ExtensionTransformerRegistration {
+    static final ModelVersion VERSION_2_0 = ModelVersion.create(2, 0);
+
+
+    @Override
+    public String getSubsystemName() {
+        return IOExtension.SUBSYSTEM_NAME;
+    }
+
+    @Override
+    public void registerTransformers(SubsystemTransformerRegistration registration) {
+        ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(registration.getCurrentSubsystemVersion());
+
+        // Current 3.0.0 to 2.0.0, aka EAP 7.0.0
+        buildTransformers_2_0(chainedBuilder.createBuilder(registration.getCurrentSubsystemVersion(), VERSION_2_0));
+
+        chainedBuilder.buildAndRegister(registration, new ModelVersion[]{VERSION_2_0});
+    }
+
+    private void buildTransformers_2_0(ResourceTransformationDescriptionBuilder builder) {
+        builder.addChildResource(WorkerResourceDefinition.INSTANCE.getPathElement()).getAttributeBuilder()
+                .setValueConverter(
+                        new AttributeConverter.DefaultValueAttributeConverter(WorkerResourceDefinition.WORKER_TASK_KEEPALIVE),
+                        WorkerResourceDefinition.WORKER_TASK_KEEPALIVE
+                )
+                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS,
+                        WorkerResourceDefinition.STACK_SIZE,
+                        WorkerResourceDefinition.WORKER_IO_THREADS,
+                        WorkerResourceDefinition.WORKER_TASK_KEEPALIVE,
+                        WorkerResourceDefinition.WORKER_TASK_MAX_THREADS
+                )
+        ;
+
+
+    }
+}

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/OptionAttributeDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/OptionAttributeDefinition.java
@@ -55,6 +55,10 @@ public class OptionAttributeDefinition extends SimpleAttributeDefinition {
         return option;
     }
 
+    public Class<?> getOptionType() {
+        return optionType;
+    }
+
     @SuppressWarnings("unchecked")
     public OptionMap.Builder resolveOption(final ExpressionResolver context, final ModelNode model, OptionMap.Builder builder) throws OperationFailedException {
         ModelNode value = resolveModelAttribute(context, model);
@@ -72,7 +76,7 @@ public class OptionAttributeDefinition extends SimpleAttributeDefinition {
             } else if (getType() == ModelType.STRING) {
                 builder.set(option, value.asString());
             } else {
-                throw new OperationFailedException("Dont know how to handle: " + option + " with value: " + value);
+                throw new OperationFailedException("Don't know how to handle: " + option + " with value: " + value);
             }
         }
         return builder;

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
@@ -72,17 +72,21 @@ class WorkerResourceDefinition extends PersistentResourceDefinition {
 
     static final OptionAttributeDefinition WORKER_TASK_MAX_THREADS = new OptionAttributeDefinition.Builder(Constants.WORKER_TASK_MAX_THREADS, Options.WORKER_TASK_MAX_THREADS)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setAllowExpression(true)
             .build();
     static final OptionAttributeDefinition WORKER_TASK_KEEPALIVE = new OptionAttributeDefinition.Builder(Constants.WORKER_TASK_KEEPALIVE, Options.WORKER_TASK_KEEPALIVE)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setDefaultValue(new ModelNode(60))
+            .setAllowExpression(true)
             .build();
     static final OptionAttributeDefinition STACK_SIZE = new OptionAttributeDefinition.Builder(Constants.STACK_SIZE, Options.STACK_SIZE)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setDefaultValue(new ModelNode(0L))
+            .setAllowExpression(true)
             .build();
     static final OptionAttributeDefinition WORKER_IO_THREADS = new OptionAttributeDefinition.Builder(Constants.WORKER_IO_THREADS, Options.WORKER_IO_THREADS)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setAllowExpression(true)
             .build();
 
     static OptionAttributeDefinition[] ATTRIBUTES = new OptionAttributeDefinition[]{

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
@@ -77,7 +77,7 @@ class WorkerResourceDefinition extends PersistentResourceDefinition {
             .build();
     static final OptionAttributeDefinition WORKER_TASK_KEEPALIVE = new OptionAttributeDefinition.Builder(Constants.WORKER_TASK_KEEPALIVE, Options.WORKER_TASK_KEEPALIVE)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setDefaultValue(new ModelNode(60))
+            .setDefaultValue(new ModelNode(60_000))
             .setAllowExpression(true)
             .build();
     static final OptionAttributeDefinition STACK_SIZE = new OptionAttributeDefinition.Builder(Constants.STACK_SIZE, Options.STACK_SIZE)

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerService.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerService.java
@@ -54,7 +54,6 @@ public class WorkerService implements Service<XnioWorker> {
         } catch (IOException e) {
             throw new StartException(e);
         }
-
     }
 
     @Override

--- a/io/subsystem/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
+++ b/io/subsystem/src/main/resources/META-INF/services/org.jboss.as.controller.transform.ExtensionTransformerRegistration
@@ -1,0 +1,19 @@
+#
+# JBoss, Home of Professional Open Source
+# Copyright 2017, Red Hat, Inc., and individual contributors as indicated
+# by the @authors tag.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.wildfly.extension.io.IOSubsystemTransformers

--- a/io/subsystem/src/main/resources/org/wildfly/extension/io/LocalDescriptions.properties
+++ b/io/subsystem/src/main/resources/org/wildfly/extension/io/LocalDescriptions.properties
@@ -5,7 +5,8 @@ io.worker=Defines workers
 io.worker.add=Adds new worker
 io.worker.remove=Removes worker
 io.worker.task-max-threads=Specify the maximum number of threads for the worker task thread pool.\
-  If not set, default value used which is calculated by formula cpuCount * 16
+  If not set, default value used which is calculated by formula cpuCount * 16,\
+  as long as MaxFileDescriptorCount jmx property allows that number, otherwise calculation takes max into account to adjust it accordingly.
 io.worker.stack-size=The stack size (in bytes) to attempt to use for worker threads.
 io.worker.io-threads=Specify the number of I/O threads to create for the worker.  \
   If not specified, a default will be chosen, which is calculated by cpuCount * 2

--- a/io/subsystem/src/main/resources/schema/wildfly-io_1_1.xsd
+++ b/io/subsystem/src/main/resources/schema/wildfly-io_1_1.xsd
@@ -46,32 +46,92 @@
         </xs:choice>
     </xs:complexType>
     <xs:complexType name="workerType">
-        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="name" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        Name of worker
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="io-threads" type="xs:int">
             <xs:annotation>
                 <xs:documentation>
                     <![CDATA[
-                        Default value for io threads is cpu count * 2
+                        Specify the number of I/O threads to create for the worker.
+                        If not specified, a default will be chosen, which is calculated by cpuCount * 2
                     ]]>
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="task-keepalive" type="xs:int" default="60"/>
+        <xs:attribute name="task-keepalive" type="xs:int" default="60000">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                       Specify the number of milliseconds to keep non-core task threads alive.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="task-max-threads" type="xs:int">
             <xs:annotation>
                 <xs:documentation>
                     <![CDATA[
-                        Default value for io threads is cpu count * 16
+                        Specify the maximum number of threads for the worker task thread pool.
+                        If not set, default value used which is calculated by formula cpuCount * 16,
+                        as long as MaxFileDescriptorCount jmx property allows that number,
+                        otherwise calculation takes max into account to adjust it accordingly.
                     ]]>
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="stack-size" type="xs:long" default="0"/>
+        <xs:attribute name="stack-size" type="xs:long" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        The stack size (in bytes) to attempt to use for worker threads.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="bufferPoolType">
-        <xs:attribute name="name" use="required" type="xs:string"/>
-        <xs:attribute name="buffer-size" use="optional" type="xs:int" />
-        <xs:attribute name="buffers-per-slice" use="optional" type="xs:int" />
-        <xs:attribute name="direct-buffers" use="optional" type="xs:boolean" />
+        <xs:attribute name="name" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        Name of buffer pool
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="buffer-size" use="optional" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        The size of each buffer slice in bytes, if not set optimal value is calculated based on available RAM resources in your system.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="buffers-per-slice" use="optional" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        How many buffers per slice, if not set optimal value is calculated based on available RAM resources in your system.
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="direct-buffers" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        Does the buffer pool use direct buffers, some platforms don't support direct buffers
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 </xs:schema>

--- a/io/tests/src/test/java/org/wildfly/extension/io/IOSubsystemTestCase.java
+++ b/io/tests/src/test/java/org/wildfly/extension/io/IOSubsystemTestCase.java
@@ -109,7 +109,7 @@ public class IOSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     protected static final OptionAttributeDefinition ENABLED_PROTOCOLS = OptionAttributeDefinition.builder("enabled-protocols", Options.SSL_ENABLED_PROTOCOLS)
-            .setAllowNull(true)
+            .setRequired(false)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .build();

--- a/io/tests/src/test/java/org/wildfly/extension/io/IOSubsystemTransformerTestCase.java
+++ b/io/tests/src/test/java/org/wildfly/extension/io/IOSubsystemTransformerTestCase.java
@@ -1,0 +1,125 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors as indicated
+ * by the @authors tag.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.extension.io;
+
+import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_7_0_0;
+import static org.junit.Assert.assertTrue;
+import static org.wildfly.extension.io.IOExtension.SUBSYSTEM_PATH;
+import static org.wildfly.extension.io.IOExtension.WORKER_PATH;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.model.test.FailedOperationTransformationConfig;
+import org.jboss.as.model.test.ModelTestControllerVersion;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
+ */
+public class IOSubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
+
+    public IOSubsystemTransformerTestCase() {
+        super(IOExtension.SUBSYSTEM_NAME, new IOExtension());
+    }
+
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("io-1.1-transformer.xml");
+    }
+
+
+    @Test
+    public void testTransformerEAP700() throws Exception {
+        testTransformation(ModelTestControllerVersion.EAP_7_0_0);
+    }
+
+    private KernelServices buildKernelServices(ModelTestControllerVersion controllerVersion, ModelVersion version, String... mavenResourceURLs) throws Exception {
+        return this.buildKernelServices(this.getSubsystemXml(), controllerVersion, version, mavenResourceURLs);
+    }
+
+    private KernelServices buildKernelServices(String xml, ModelTestControllerVersion controllerVersion, ModelVersion version, String... mavenResourceURLs) throws Exception {
+        KernelServicesBuilder builder = this.createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT).setSubsystemXml(xml);
+
+        builder.createLegacyKernelServicesBuilder(AdditionalInitialization.MANAGEMENT, controllerVersion, version)
+                .addMavenResourceURL(mavenResourceURLs)
+                .skipReverseControllerCheck()
+                .dontPersistXml();
+
+        KernelServices services = builder.build();
+        Assert.assertTrue(ModelTestControllerVersion.MASTER + " boot failed", services.isSuccessfulBoot());
+        Assert.assertTrue(controllerVersion.getMavenGavVersion() + " boot failed", services.getLegacyServices(version).isSuccessfulBoot());
+        return services;
+    }
+
+    private void testTransformation(final ModelTestControllerVersion controller) throws Exception {
+        final ModelVersion version = ModelVersion.create(2,0);
+
+        KernelServices services = this.buildKernelServices(controller, version,
+                controller.getCoreMavenGroupId()+":wildfly-io:"+controller.getCoreVersion());
+
+        // check that both versions of the legacy model are the same and valid
+        checkSubsystemModelTransformation(services, version, null, false);
+
+        ModelNode transformed = services.readTransformedModel(version);
+
+
+    }
+
+    @Test
+        public void testRejectingTransformersEAP_7_0_0() throws Exception {
+            testRejectingTransformers(EAP_7_0_0, IOSubsystemTransformers.VERSION_2_0);
+        }
+
+    private void testRejectingTransformers(ModelTestControllerVersion controllerVersion, ModelVersion messagingVersion) throws Exception {
+            //Boot up empty controllers with the resources needed for the ops coming from the xml to work
+            KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
+            builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, messagingVersion)
+                    .addMavenResourceURL(controllerVersion.getCoreMavenGroupId()+":wildfly-io:"+controllerVersion.getCoreVersion())
+                    .dontPersistXml();
+
+            KernelServices mainServices = builder.build();
+            assertTrue(mainServices.isSuccessfulBoot());
+            assertTrue(mainServices.getLegacyServices(messagingVersion).isSuccessfulBoot());
+
+            List<ModelNode> ops = builder.parseXmlResource("io-1.1-reject.xml");
+            PathAddress subsystemAddress = PathAddress.pathAddress(SUBSYSTEM_PATH);
+            ModelTestUtils.checkFailedTransformedBootOperations(mainServices, messagingVersion, ops, new FailedOperationTransformationConfig()
+                    .addFailedAttribute(subsystemAddress.append(WORKER_PATH),
+                            new FailedOperationTransformationConfig.RejectExpressionsConfig(
+                                    WorkerResourceDefinition.STACK_SIZE,
+                                    WorkerResourceDefinition.WORKER_IO_THREADS,
+                                    WorkerResourceDefinition.WORKER_TASK_KEEPALIVE,
+                                    WorkerResourceDefinition.WORKER_TASK_MAX_THREADS
+                                    )
+                    )
+            );
+        }
+
+}

--- a/io/tests/src/test/resources/org/wildfly/extension/io/io-1.1-reject.xml
+++ b/io/tests/src/test/resources/org/wildfly/extension/io/io-1.1-reject.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ /*
+  ~ * JBoss, Home of Professional Open Source.
+  ~ * Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ * as indicated by the @author tags. See the copyright.txt file in the
+  ~ * distribution for a full listing of individual contributors.
+  ~ *
+  ~ * This is free software; you can redistribute it and/or modify it
+  ~ * under the terms of the GNU Lesser General Public License as
+  ~ * published by the Free Software Foundation; either version 2.1 of
+  ~ * the License, or (at your option) any later version.
+  ~ *
+  ~ * This software is distributed in the hope that it will be useful,
+  ~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ * Lesser General Public License for more details.
+  ~ *
+  ~ * You should have received a copy of the GNU Lesser General Public
+  ~ * License along with this software; if not, write to the Free
+  ~ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~ */
+  -->
+
+<subsystem xmlns="urn:jboss:domain:io:1.1">
+    <worker name="default" task-keepalive="100" stack-size="5000"/>
+    <worker name="second-worker" io-threads="${some.property:5}" stack-size="${property.stack:300}" task-keepalive="${property.keepalive:100}" task-max-threads="${prop.max-threads:200}"/>
+    <worker name="third-worker" task-max-threads="50"/>
+    <buffer-pool name="default" buffer-size="2048" buffers-per-slice="2048"/>
+</subsystem>

--- a/io/tests/src/test/resources/org/wildfly/extension/io/io-1.1-transformer.xml
+++ b/io/tests/src/test/resources/org/wildfly/extension/io/io-1.1-transformer.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:io:1.1">
+    <worker name="default" task-keepalive="100" stack-size="5000"/>
+    <worker name="second-worker" io-threads="5" stack-size="300" task-keepalive="100" task-max-threads="200"/>
+    <worker name="third-worker" task-max-threads="50"/>
+    <buffer-pool name="default" buffer-size="2048" buffers-per-slice="2048"/>
+</subsystem>

--- a/io/tests/src/test/resources/org/wildfly/extension/io/io-1.1.xml
+++ b/io/tests/src/test/resources/org/wildfly/extension/io/io-1.1.xml
@@ -24,7 +24,7 @@
 
 <subsystem xmlns="urn:jboss:domain:io:1.1">
     <worker name="default" task-keepalive="100" stack-size="5000"/>
-    <worker name="second-worker"/>
+    <worker name="second-worker" io-threads="${some.property:5}" stack-size="${property.stack:300}" task-keepalive="${property.keepalive:100}" task-max-threads="${prop.max-threads:200}"/>
     <worker name="third-worker" task-max-threads="50"/>
     <buffer-pool name="default" buffer-size="2048" buffers-per-slice="2048"/>
 </subsystem>

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -469,8 +469,7 @@ final class SubsystemTestDelegate {
         File dmrFile = getDmrFile(kernelServices, modelVersion);
         try (PrintWriter pw = new PrintWriter(Files.newBufferedWriter(dmrFile.toPath(), StandardCharsets.UTF_8))){
             desc.writeString(pw, false);
-            //Leave this println - it only gets executed when people generate the legacy dmr files, and is useful to know where it has been written.
-            System.out.println("Legacy resource definition dmr written to: " + dmrFile.getAbsolutePath());
+            //System.out.println("Legacy resource definition dmr written to: " + dmrFile.getAbsolutePath());
             return dmrFile;
         }
     }
@@ -540,7 +539,7 @@ final class SubsystemTestDelegate {
             if (!file.exists()) {
                 generateLegacySubsystemResourceRegistrationDmr(kernelServices, modelVersion);
             }
-            System.out.println("Using legacy resource definition dmr: " + file);
+            //System.out.println("Using legacy resource definition dmr: " + file);
             rd = TransformationUtils.loadSubsystemDefinitionFromFile(kernelServices.getTestClass(), mainSubsystemName, modelVersion);
         }
         return rd;


### PR DESCRIPTION
- WFCORE-2187 Description of IO worker task-max-threads attribute is inaccurate
- WFCORE-1622 Worker section in IO subsystem does not allow expressions for io-threads and task-max-threads attributes
- WFCORE-2159 worker=default:read-resource(include-runtime) wrong values in domain mode
- WFCORE-2188 IO subsystem requires reload when increasing size of io-threads or task-max-threads
- WFCORE-2195 XSD of IO subsystem should contain description of all resources and attributes
- fix how undefined metrics
-  WFCORE-2269 Add transformers for IO subsystem