### PR TITLE
Optional/interdependent deployment fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <!-- this is test only dependancy -->
         <version.org.jboss.metadata.jboss-metadata-common>10.0.0.Final</version.org.jboss.metadata.jboss-metadata-common>
         <version.org.jboss.modules.jboss-modules>1.6.0.Beta4</version.org.jboss.modules.jboss-modules>
-        <version.org.jboss.msc.jboss-msc>1.2.7.Final</version.org.jboss.msc.jboss-msc>
+        <version.org.jboss.msc.jboss-msc>1.2.7.SP1</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.0.Beta12</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.0.Beta2</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnitPhaseService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentUnitPhaseService.java
@@ -67,6 +67,24 @@ final class DeploymentUnitPhaseService<T> implements Service<T> {
      */
     private final AtomicBoolean runOnce = new AtomicBoolean();
 
+    /**
+     * If this is true then when a deployment goes down due to a dependency restart it will immediately attempt redeployment,
+     * otherwise it will wait till the dependency is available before doing the restart.
+     *
+     * At present this behaviour has a high chance of hitting MSC race conditions, that are only prevented at this stage
+     * by using the new directional executor. As this executor is only enabled via the <code>org.jboss.msc.directionalExecutor</code>
+     * system property this new restart behaviour is also only enabled if this system property is set.
+     *
+     * Once these MSC issues are fixed this should be removed, and immediate deployment restart should be made the default,
+     * as the current behaviour can cause infinite MSC looping in some circumstances if optional dependencies are in use
+     * between deployments.
+     */
+    private static final boolean immediateDeploymentRestart;
+
+    static {
+        immediateDeploymentRestart = Boolean.getBoolean("org.jboss.msc.directionalExecutor");
+    }
+
     private DeploymentUnitPhaseService(final DeploymentUnit deploymentUnit, final Phase phase, final AttachmentKey<T> valueKey) {
         this.deploymentUnit = deploymentUnit;
         this.phase = phase;
@@ -84,7 +102,7 @@ final class DeploymentUnitPhaseService<T> implements Service<T> {
     @SuppressWarnings("unchecked")
     public synchronized void start(final StartContext context) throws StartException {
         boolean allowRestart = restartAllowed();
-        if(runOnce.get() && !allowRestart) {
+        if(!immediateDeploymentRestart && runOnce.get() && !allowRestart) {
             ServerLogger.DEPLOYMENT_LOGGER.deploymentRestartDetected(deploymentUnit.getName());
             //this only happens on deployment restart, which we don't support at the moment.
             //instead we are going to restart the complete deployment.
@@ -221,6 +239,40 @@ final class DeploymentUnitPhaseService<T> implements Service<T> {
     }
 
     public synchronized void stop(final StopContext context) {
+        if(immediateDeploymentRestart && !restartAllowed()) {
+            final DeploymentUnit topDeployment = deploymentUnit.getParent() != null ? deploymentUnit.getParent() : deploymentUnit;
+            final ServiceName top = topDeployment.getServiceName();
+            final ServiceController<?> topController = context.getController().getServiceContainer().getService(top);
+            final Mode mode = topController.getMode();
+            if (mode != Mode.REMOVE && mode != Mode.NEVER && !context.getController().getServiceContainer().isShutdown()) {
+                //the deployment is going down, but it has not been explicitly stopped or removed
+                //so it must be because of a missing dependency. Unfortunately these phase services cannot fully restart
+                //as the data they require no longer exists, so instead we trigger a complete redeployment
+                //the redeployment will likely not fully complete, but will be waiting on whatever missing dependency
+                //caused this stop
+
+                //add a listener to perform a restart when the service goes down
+                //then stop the deployment unit service
+                final AbstractServiceListener<Object> serviceListener = new AbstractServiceListener<Object>() {
+
+                    @Override
+                    public void transition(final ServiceController<?> controller, final ServiceController.Transition transition) {
+                        if (transition.getAfter().equals(ServiceController.Substate.DOWN)) {
+                            //its possible an undeploy happened in the meantime
+                            //so we use compareAndSetMode to make sure the mode is still NEVER and not REMOVE
+                            controller.compareAndSetMode(Mode.NEVER, mode);
+                            controller.removeListener(this);
+                        }
+                    }
+                };
+                topController.addListener(serviceListener);
+                if (topController.compareAndSetMode(mode, Mode.NEVER)) {
+                    ServerLogger.DEPLOYMENT_LOGGER.deploymentRestartDetected(topDeployment.getName());
+                } else {
+                    topController.removeListener(serviceListener);
+                }
+            }
+        }
         final DeploymentUnit deploymentUnitContext = deploymentUnit;
         final DeployerChains chains = deployerChainsInjector.getValue();
         final List<RegisteredDeploymentUnitProcessor> list = chains.getChain(phase);

--- a/testsuite/shared/src/main/java/org/jboss/as/test/deployment/trivial/ServiceActivatorDeployment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/deployment/trivial/ServiceActivatorDeployment.java
@@ -49,16 +49,27 @@ public class ServiceActivatorDeployment implements ServiceActivator, Service<Voi
     public static final String DEFAULT_SYS_PROP_NAME = "test.deployment.trivial.prop";
     public static final String DEFAULT_SYS_PROP_VALUE = "default-value";
 
-    @Override
-    public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
-        serviceActivatorContext.getServiceTarget().addService(SERVICE_NAME, this).install();
+    private final Properties properties = new Properties();
+    private final ServiceName serviceName;
+    private final String propertiesResource;
+
+    public ServiceActivatorDeployment() {
+        this(SERVICE_NAME, PROPERTIES_RESOURCE);
     }
 
-    private final Properties properties = new Properties();
+    public ServiceActivatorDeployment(ServiceName serviceName, String propertiesResource) {
+        this.serviceName = serviceName;
+        this.propertiesResource = propertiesResource;
+    }
+
+    @Override
+    public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        serviceActivatorContext.getServiceTarget().addService(serviceName, this).install();
+    }
 
     @Override
     public synchronized void start(StartContext context) throws StartException {
-        InputStream is = getClass().getResourceAsStream("/" + PROPERTIES_RESOURCE);
+        InputStream is = getClass().getResourceAsStream("/" + propertiesResource);
         if (is != null) {
             try {
                 System.out.println("Properties found");

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/InterdependentDeploymentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/InterdependentDeploymentTestCase.java
@@ -1,0 +1,270 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.wildfly.core.test.standalone.mgmt;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.deployment.trivial.ServiceActivatorDeployment;
+import org.jboss.as.test.deployment.trivial.ServiceActivatorDeploymentUtil;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Test of deployment ops for deployments that depend on other deployments.
+ * Smoke test for issues like MSC-155/MSC-156.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(WildflyTestRunner.class)
+public class InterdependentDeploymentTestCase {
+
+    @Inject
+    private ManagementClient managementClient;
+
+    @Test
+    public void test() throws Exception {
+
+        final JavaArchive deplA = ServiceActivatorDeploymentUtil.createServiceActivatorDeploymentArchive("interrelated-a.jar",
+                Collections.singletonMap("interrelated-a.jar", "a"));
+        Map<String, JavaArchive> dependents = new HashMap<>();
+        dependents.put("b", getDependentDeployment("b", ServiceActivatorDeploymentB.class, "interrelated-a.jar"));
+        dependents.put("c", getDependentDeployment("c", ServiceActivatorDeploymentC.class, "interrelated-a.jar"));
+        dependents.put("d", getDependentDeployment("d", ServiceActivatorDeploymentD.class, "interrelated-a.jar","interrelated-b.jar"));
+        dependents.put("e", getDependentDeployment("e", ServiceActivatorDeploymentE.class, "interrelated-a.jar","interrelated-d.jar"));
+        dependents.put("f", getDependentDeployment("f", ServiceActivatorDeploymentF.class, "interrelated-a.jar","interrelated-c.jar","interrelated-d.jar"));
+
+        List<InputStream> streams = new ArrayList<>();
+        ModelNode add = Util.createEmptyOperation("composite", PathAddress.EMPTY_ADDRESS);
+        ModelNode steps = add.get("steps");
+        streams.add(deplA.as(ZipExporter.class).exportAsInputStream());
+        steps.add(createDeployStep("a", streams.size() - 1));
+        for (Map.Entry<String, JavaArchive> entry : dependents.entrySet()) {
+            streams.add(entry.getValue().as(ZipExporter.class).exportAsInputStream());
+            steps.add(createDeployStep(entry.getKey(), streams.size() - 1));
+        }
+
+        ModelNode response = managementClient.getControllerClient().execute(Operation.Factory.create(add, streams, true));
+        Assert.assertEquals(response.toString(), "success", response.get("outcome").asString());
+
+        validateDeployment("a", "a");
+
+        for (String dependent : dependents.keySet()) {
+            validateDeployment(dependent, dependent);
+        }
+
+        managementClient.executeForResult(Util.createEmptyOperation("undeploy", PathAddress.pathAddress("deployment", "interrelated-a.jar")));
+
+        validateNoDeployment("a");
+
+        for (String dependent : dependents.keySet()) {
+            validateNoDeployment(dependent);
+        }
+
+        managementClient.executeForResult(Util.createEmptyOperation("deploy", PathAddress.pathAddress("deployment", "interrelated-a.jar")));
+
+        validateDeployment("a", "a");
+
+        for (String dependent : dependents.keySet()) {
+            validateDeployment(dependent, dependent);
+        }
+
+        // USE A SYSTEM PROPERTY TO EXECUTE full-replace-deployment repeatedly
+        int loops = Integer.parseInt(System.getProperty("InterdependentDeploymentTestCase.count", "1"));
+        int blockingTime = TimeoutUtil.adjust(30); // set this to fail faster if it fails
+        for (int i = 0; i < loops; i++) {
+
+            try {
+                String newVal = "a" + i;
+                final JavaArchive replA = ServiceActivatorDeploymentUtil.createServiceActivatorDeploymentArchive("interrelated-a.jar",
+                        Collections.singletonMap("interrelated-a.jar", newVal));
+
+                ModelNode frd = Util.createEmptyOperation("full-replace-deployment", PathAddress.EMPTY_ADDRESS);
+                frd.get("name").set("interrelated-a.jar");
+                frd.get("content").add().get("input-stream-index").set(0);
+                frd.get("enabled").set(true);
+                frd.get("operation-headers", "blocking-timeout").set(blockingTime);
+
+                response = managementClient.getControllerClient().execute(Operation.Factory.create(frd,
+                        Collections.singletonList(replA.as(ZipExporter.class).exportAsInputStream()), true));
+                Assert.assertEquals("Response to iteration " + i + " -- " + response.toString(), "success", response.get("outcome").asString());
+
+                validateDeployment("a", newVal);
+
+                for (String dependent : dependents.keySet()) {
+                    validateDeployment(dependent, dependent);
+                }
+            } catch (AssertionError ae) {
+                dumpServiceDetails();
+                throw ae;
+            }
+        }
+
+        ModelNode undeploy = Util.createEmptyOperation("composite", PathAddress.EMPTY_ADDRESS);
+        steps = undeploy.get("steps");
+        steps.add(Util.createEmptyOperation("undeploy", PathAddress.pathAddress("deployment", "interrelated-a.jar")));
+        for (String dependent : dependents.keySet()) {
+            steps.add(Util.createEmptyOperation("undeploy", PathAddress.pathAddress("deployment", "interrelated-" + dependent + ".jar")));
+        }
+
+        managementClient.executeForResult(undeploy);
+
+        validateNoDeployment("a");
+
+        for (String dependent : dependents.keySet()) {
+            validateNoDeployment(dependent);
+        }
+
+        ModelNode remove = Util.createEmptyOperation("composite", PathAddress.EMPTY_ADDRESS);
+        steps = remove.get("steps");
+        steps.add(Util.createEmptyOperation("remove", PathAddress.pathAddress("deployment", "interrelated-a.jar")));
+        for (String dependent : dependents.keySet()) {
+            steps.add(Util.createEmptyOperation("remove", PathAddress.pathAddress("deployment", "interrelated-" + dependent + ".jar")));
+        }
+
+        managementClient.executeForResult(remove);
+
+    }
+
+    private void dumpServiceDetails() {
+        ModelNode op = Util.createEmptyOperation("dump-services",
+                PathAddress.pathAddress("core-service", "service-container")
+        );
+        try {
+            System.out.println(managementClient.executeForResult(op));
+        } catch (UnsuccessfulOperationException e) {
+            System.out.println("Failed to dump service details -- " + e.toString());
+        }
+    }
+
+    private ModelNode createDeployStep(String name, int inputStreamIndex) {
+        ModelNode result = Util.createAddOperation(PathAddress.pathAddress("deployment", "interrelated-" + name + ".jar"));
+        result.get("enabled").set(true);
+        result.get("content").add().get("input-stream-index").set(inputStreamIndex);
+        return  result;
+    }
+
+    private void validateDeployment(String name, String value) throws IOException, MgmtOperationException {
+        ServiceActivatorDeploymentUtil.validateProperties(managementClient.getControllerClient(),
+                Collections.singletonMap("interrelated-" + name + ".jar", value));
+    }
+
+    private void validateNoDeployment(String name) throws IOException, MgmtOperationException {
+        ServiceActivatorDeploymentUtil.validateNoProperties(managementClient.getControllerClient(),
+                Collections.singleton("interrelated-" + name + ".jar"));
+    }
+
+    private JavaArchive getDependentDeployment(String name, Class clazz, String... dependencies) {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, name);
+        archive.addClass(clazz);
+        archive.addAsServiceProvider(ServiceActivator.class, clazz);
+        archive.addAsManifestResource(new StringAsset("Dependencies: org.jboss.msc\n"), "MANIFEST.MF");
+
+        String propFileContent = "interrelated-" + name + ".jar=" + name + '\n';
+        archive.addAsResource(new StringAsset(propFileContent), name + ".properties");
+
+        archive.addAsResource(new StringAsset(getJBossDeploymentStructure(dependencies)), "META-INF/jboss-deployment-structure.xml");
+
+        return archive;
+    }
+
+    private String getJBossDeploymentStructure(String... dependencies) {
+        StringBuilder sb = new StringBuilder(
+                "<jboss-deployment-structure>\n" +
+                "  <deployment>\n" +
+                "    <dependencies>\n");
+        for (String dep : dependencies) {
+            sb.append(
+                    "      <module name=\"deployment.").append(dep).append("\"");
+            if (dep.equals("interrelated-c.jar")) {
+                sb.append(" optional=\"true\"");
+            }
+            sb.append("/>\n");
+        }
+        sb.append(
+                "    </dependencies>\n" +
+                "  </deployment>\n" +
+                "</jboss-deployment-structure>");
+
+        return sb.toString();
+    }
+
+    public static class ServiceActivatorDeploymentB extends ServiceActivatorDeployment {
+
+        public ServiceActivatorDeploymentB() {
+            super(ServiceName.of(ServiceActivatorDeployment.class.getSimpleName(), "b"), "b.properties");
+        }
+    }
+
+    public static class ServiceActivatorDeploymentC extends ServiceActivatorDeployment {
+
+        public ServiceActivatorDeploymentC() {
+            super(ServiceName.of(ServiceActivatorDeployment.class.getSimpleName(), "c"), "c.properties");
+        }
+    }
+
+    public static class ServiceActivatorDeploymentD extends ServiceActivatorDeployment {
+
+        private final ServiceActivatorDeploymentB imported = new ServiceActivatorDeploymentB();
+
+        public ServiceActivatorDeploymentD() {
+            super(ServiceName.of(ServiceActivatorDeployment.class.getSimpleName(), "d"), "d.properties");
+        }
+    }
+
+    public static class ServiceActivatorDeploymentE extends ServiceActivatorDeployment {
+
+        private final ServiceActivatorDeploymentD imported = new ServiceActivatorDeploymentD();
+
+        public ServiceActivatorDeploymentE() {
+            super(ServiceName.of(ServiceActivatorDeployment.class.getSimpleName(), "e"), "e.properties");
+        }
+    }
+
+    public static class ServiceActivatorDeploymentF extends ServiceActivatorDeployment {
+
+        //private final ServiceActivatorDeploymentC importedC = new ServiceActivatorDeploymentC();
+        private final ServiceActivatorDeploymentD importedD = new ServiceActivatorDeploymentD();
+
+        public ServiceActivatorDeploymentF() {
+            super(ServiceName.of(ServiceActivatorDeployment.class.getSimpleName(), "f"), "f.properties");
+        }
+    }
+}


### PR DESCRIPTION
This PR brings together commits from a number of other PRs all related to the issues we've been attacking re: problems handling interdependent deployments, particularly when those dependencies are optional. It has:

1) https://issues.jboss.org/browse/WFCORE-2192. Fix for how deployment unit phase services react to stop/start events. Replaces #2095
2) https://issues.jboss.org/browse/WFCORE-2208 -- MSC upgrade to bring in MSC-159 workaround fix. Replaces #2098
3) An integration test we used when developing the above. Replaces #2062 
4) A commit moving said test to manualmode as the solution currently requires setting a system property to take effect.