### PR TITLE
Fix for WFCORE-2216. Handle redirect in reload and shutdown

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/AwaiterModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/AwaiterModelControllerClient.java
@@ -38,5 +38,5 @@ public interface AwaiterModelControllerClient {
 
     boolean isConnected();
 
-    void ensureConnected(long timeoutMillis) throws CommandLineException;
+    void ensureConnected(long timeoutMillis) throws CommandLineException, IOException;
 }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ReloadHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ReloadHandler.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.dmr.ModelNode;
+import org.xnio.http.RedirectException;
 
 /**
  * @author Alexey Loubyansky
@@ -294,7 +295,23 @@ public class ReloadHandler extends BaseOperationCommand {
                         break;
                     }
                 }
-            } catch (IOException|IllegalStateException e) {
+            } catch (IOException e) {
+                // A Redirect Exception? Need to connect again the Client.
+                Throwable ex = e;
+                while (ex != null) {
+                    if (ex instanceof RedirectException) {
+                        try {
+                            ctx.connectController();
+                            return;
+                        } catch (CommandLineException ce) {
+                            // We could have received redirect caused by the server restarting
+                            // Ignoring exception, will fail at the end of timeout.
+                        }
+                    }
+                    ex = ex.getCause();
+                }
+                // ignore and try again
+            } catch( IllegalStateException ex) {
                 // ignore and try again
                 // IllegalStateException is because the embedded server ModelControllerClient will
                 // throw that when the server-state / host-state is "stopping"

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ShutdownHandler.java
@@ -41,6 +41,7 @@ import org.jboss.as.cli.operation.ParsedCommandLine;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.dmr.ModelNode;
+import org.xnio.http.RedirectException;
 
 /**
  * @author Alexey Loubyansky
@@ -152,6 +153,18 @@ public class ShutdownHandler extends BaseOperationCommand {
             } catch(CommandLineException e) {
                 ctx.disconnectController();
                 throw e;
+            } catch (IOException ex) {
+                if (ex instanceof RedirectException) {
+                    try {
+                        ctx.connectController();
+                    } catch (CommandLineException ce) {
+                        // Can't reconnect, disconnect it.
+                        ctx.disconnectController();
+                        throw ce;
+                    }
+                } else {
+                    throw new CommandLineException(ex);
+                }
             }
         }
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -58,6 +58,7 @@ import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.Endpoint;
 import org.jboss.threads.JBossThreadFactory;
 import org.xnio.OptionMap;
+import org.xnio.http.RedirectException;
 
 /**
  * @author Alexey Loubyansky
@@ -271,10 +272,13 @@ public class CLIModelControllerClient extends AbstractModelControllerClient
     }
 
     @Override
-    public void ensureConnected(long timeoutMillis) throws CommandLineException {
+    public void ensureConnected(long timeoutMillis) throws CommandLineException,
+            IOException {
         boolean doTry = true;
         final long start = System.currentTimeMillis();
         IOException ioe = null;
+
+        boolean timeoutOccured = false;
         while (doTry) {
             try {
                 // Can't be called locked, could create dead lock if close occured.
@@ -297,8 +301,22 @@ public class CLIModelControllerClient extends AbstractModelControllerClient
                 }
 
                 if (System.currentTimeMillis() - start > timeoutMillis) {
-                    throw new CommandLineException("Failed to establish connection in " + (System.currentTimeMillis() - start)
-                            + "ms", ioe);
+                    if (timeoutOccured) {
+                        throw new CommandLineException("Failed to establish connection in " + (System.currentTimeMillis() - start)
+                                + "ms", ioe);
+                    } else {
+                        timeoutOccured = true;
+                    }
+                }
+                // Only propagate RedirectException at the end of timeout.
+                if (timeoutOccured) {
+                    Throwable ex = ioe;
+                    while (ex != null) {
+                        if (ex instanceof RedirectException) {
+                            throw (RedirectException) ex;
+                        }
+                        ex = ex.getCause();
+                    }
                 }
                 ioe = null;
                 try {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandExecutor.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandExecutor.java
@@ -150,7 +150,7 @@ public class CommandExecutor {
             }
 
             @Override
-            public void ensureConnected(long timeoutMillis) throws CommandLineException {
+            public void ensureConnected(long timeoutMillis) throws CommandLineException, IOException {
                 if (!(wrapped instanceof AwaiterModelControllerClient)) {
                     throw new CommandLineException("Unsupported ModelControllerClient implementation " + wrapped.getClass().getName());
                 }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadRedirectTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadRedirectTestCase.java
@@ -1,0 +1,224 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.management.cli;
+
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import static org.junit.Assert.assertTrue;
+
+import java.net.UnknownHostException;
+
+import javax.inject.Inject;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.cli.CliProcessWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class ReloadRedirectTestCase {
+
+    public static final int MANAGEMENT_NATIVE_PORT = 9999;
+
+    @Inject
+    private static ServerController container;
+
+    @BeforeClass
+    public static void initServer() throws Exception {
+        container.start();
+
+        ModelControllerClient client = container.getClient().getControllerClient();
+
+        // Set up native management so we can use it to do cleanup without dealing with https
+
+        // add native socket binding
+        ModelNode operation = createOpNode("socket-binding-group=standard-sockets/socket-binding=management-native", ModelDescriptionConstants.ADD);
+        operation.get("port").set(MANAGEMENT_NATIVE_PORT);
+        operation.get("interface").set("management");
+        CoreUtils.applyUpdate(operation, client);
+
+        // add a temp realm socket binding
+        operation = Util.createEmptyOperation("composite", PathAddress.EMPTY_ADDRESS);
+        operation.get("steps").add(createOpNode("core-service=management/security-realm=native-realm", ModelDescriptionConstants.ADD));
+        ModelNode localAuth = createOpNode("core-service=management/security-realm=native-realm/authentication=local", ModelDescriptionConstants.ADD);
+        localAuth.get("default-user").set("$local");
+        operation.get("steps").add(localAuth);
+        CoreUtils.applyUpdate(operation, client);
+
+        // create native interface
+        operation = createOpNode("core-service=management/management-interface=native-interface", ModelDescriptionConstants.ADD);
+        operation.get("security-realm").set("native-realm");
+        operation.get("socket-binding").set("management-native");
+        CoreUtils.applyUpdate(operation, client);
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        try {
+            // Even though we don't reuse this server, the next test uses the config so we
+            // need to revert the config changes the test made
+            ManagementClient client = getCleanupClient();
+            cleanConfig(client);
+        } finally {
+            container.stop();
+        }
+    }
+
+    private static void cleanConfig(ManagementClient client) throws Exception {
+        Exception e = null;
+        try {
+            removeHttpsMgmt(client);
+        } catch (Exception ex) {
+            e = ex;
+        } finally {
+            try {
+                removeSsl(client);
+            } catch (Exception ex) {
+                if (e == null) e = ex;
+            } finally {
+                try {
+                    removeNativeMgmt(client);
+                } catch (Exception ex) {
+                    if (e == null) e = ex;
+                } finally {
+                    try {
+                        removeNativeRealm(client);
+                    } catch (Exception ex) {
+                        if (e == null) e = ex;
+                    } finally {
+                        try {
+                            remoteNativeMgmtPort(client);
+                        } catch (Exception ex) {
+                            if (e == null) e = ex;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (e != null) {
+            throw e;
+        }
+    }
+
+    private static void removeHttpsMgmt(ManagementClient client) throws UnsuccessfulOperationException {
+        ModelNode undefine = createOpNode("core-service=management/management-interface=http-interface",
+                "undefine-attribute");
+        undefine.get("name").set("secure-socket-binding");
+        client.executeForResult(undefine);
+    }
+
+    private static void removeSsl(ManagementClient client) {
+        String addr = "core-service=management/security-realm=ManagementRealm/server-identity=ssl";
+        try {
+            ModelNode remove = createOpNode(addr,"remove");
+            client.executeForResult(remove);
+        } catch (UnsuccessfulOperationException uoe) {
+            // It's ok if the resource doesn't exist due to failure in the test to create it
+            try {
+                client.executeForResult(createOpNode(addr,"read-resource"));
+                // success means it wasn't a missing resource
+                throw uoe;
+            } catch (UnsuccessfulOperationException ignored) {
+                // assume it's due to no such resource
+            }
+        }
+    }
+
+    private static void removeNativeMgmt(ManagementClient client) throws UnsuccessfulOperationException {
+        ModelNode remove = createOpNode("core-service=management/management-interface=native-interface",
+                "remove");
+        client.executeForResult(remove);
+    }
+
+    private static void removeNativeRealm(ManagementClient client) throws UnsuccessfulOperationException {
+        ModelNode remove = createOpNode("core-service=management/security-realm=native-realm",
+                "remove");
+        client.executeForResult(remove);
+    }
+
+    private static void remoteNativeMgmtPort(ManagementClient client) throws UnsuccessfulOperationException {
+        ModelNode remove = createOpNode("socket-binding-group=standard-sockets/socket-binding=management-native",
+                "remove");
+        client.executeForResult(remove);
+    }
+
+    private static ManagementClient getCleanupClient() throws UnknownHostException {
+        // Use a client that connects to 9999
+        ModelControllerClient mcc = ModelControllerClient.Factory.create("remote", TestSuiteEnvironment.getServerAddress(), MANAGEMENT_NATIVE_PORT);
+        return new ManagementClient(mcc, TestSuiteEnvironment.getServerAddress(), MANAGEMENT_NATIVE_PORT, "remote");
+    }
+
+    /**
+     * We should have the same test with "shutdown --restart" but testing framework
+     * doesn't allow to restart the server (not launched from server script file).
+     * "shutdown --restart" must be tested manually.
+     * @throws Exception
+     */
+    @Test
+    public void testReloadwithRedirect() throws Exception {
+        CliProcessWrapper cliProc = new CliProcessWrapper()
+                .addCliArgument("--connect")
+                .addCliArgument("--controller="
+                        + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort());
+        try {
+            cliProc.executeInteractive();
+            cliProc.clearOutput();
+            boolean promptFound = cliProc.
+                    pushLineAndWaitForResults("/core-service=management/"
+                            + "security-realm=ManagementRealm/"
+                            + "server-identity=ssl:add(keystore-path=management.keystore,"
+                            + "keystore-relative-to=jboss.server.config.dir,"
+                            + "keystore-password=password,alias=server,key-password=password,"
+                            + "generate-self-signed-certificate-host=localhost)", null);
+            assertTrue("Invalid prompt" + cliProc.getOutput(), promptFound);
+            cliProc.clearOutput();
+            promptFound = cliProc.pushLineAndWaitForResults("/core-service=management/"
+                    + "management-interface=http-interface:"
+                    + "write-attribute(name=secure-socket-binding,value=management-https)", null);
+            assertTrue("Invalid prompt" + cliProc.getOutput(), promptFound);
+            cliProc.clearOutput();
+            promptFound = cliProc.pushLineAndWaitForResults("reload", "Accept certificate");
+            assertTrue("No certificate prompt " + cliProc.getOutput(), promptFound);
+        } finally {
+            cliProc.destroyProcess();
+        }
+    }
+}


### PR DESCRIPTION
Second attempt to fix this issue. We were not too far in the previous fix but we were wrongly exiting the reload waiting logic too early.

For reload, when redirect occurs, attempt to reconnect the client. If failure occurs, ignore it (could be caused by exotic Redirect sent during server startup) and carry-on the reload loop. If reconnect succeeds, exit the reload loop.

For shutdown, if IOException occurs, CLIModelControllerClient waits the end of the waiting time then propagate the RedirectException (if any). In turn the shutdown handler catchs the RedirectException and attempt to reconnect. If it fails, it disconnects the client.

Unit test added (the one from reverted commit).