### PR TITLE
[WFCORE-2229]: Create serverside operations to redeploy deployments affected by an overlay.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -130,8 +130,10 @@ public class ModelDescriptionConstants {
     public static final String DEPTH = "depth";
     public static final String DEPLOY = "deploy";
     public static final String DEPLOYMENT = "deployment";
+    public static final String DEPLOYMENTS = "deployments";
     public static final String DEPLOYMENT_DEPLOYED_NOTIFICATION = "deployment-deployed";
     public static final String DEPLOYMENT_OVERLAY = "deployment-overlay";
+    public static final String DEPLOYMENT_OVERLAY_LINK_REMOVAL = "deployment-overlay-link-removal";
     public static final String DEPLOYMENT_UNDEPLOYED_NOTIFICATION = "deployment-undeployed";
     public static final String DEPRECATED = "deprecated";
     public static final String DESCRIBE = "describe";
@@ -384,6 +386,8 @@ public class ModelDescriptionConstants {
     public static final String RECURSIVE_DEPTH = "recursive-depth";
     public static final String RECYCLE = "recycle";
     public static final String REDEPLOY = "redeploy";
+    public static final String REDEPLOY_AFFECTED = "redeploy-affected";
+    public static final String REDEPLOY_LINKS = "redeploy-links";
     public static final String RELATIVE_ADDRESS = "relative-address";
     public static final String RELATIVE_TO = "relative-to";
     public static final String RELEASE_CODENAME = "release-codename";

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -606,12 +606,15 @@ core.resolve-expression.reply=The resolved expression, or the string form of the
 # deployment overlays
 deployment-overlay=A deployment overlay
 deployment-overlay.add=Adds a deployment overlay
+deployment-overlay.redeploy-links=Redeploys the deployments affected by this overlay.
+deployment-overlay.redeploy-links.deployments=List of deployment runtime names to be redeployed. If this list is empty or 'undefined' then all affected deployments will be redeployed.
 deployment-overlay.remove=Removes a deployment overlay
 deployment-overlay.override=An override for an individual content item
 deployment-overlay.content=The content of the deployment overlay
 deployment-overlay.deployment=The deployment that this deployment overlay is linked to
 deployment-overlay.deployment.add=Adds a deployment overlay link
 deployment-overlay.deployment.remove=Removes a deployment overlay link
+deployment-overlay.deployment.remove.redeploy-affected=If set to 'true', redeploy the deployments affected by this overlay after removal.
 deployment-overlay.deployment.regular-expression=If the deployment name is a regular expression
 deployment-overlay.content.add=Adds a piece of content to a deployment overlay
 deployment-overlay.content.remove=Removes a piece of content

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
@@ -802,4 +802,7 @@ public interface DomainControllerLogger extends BasicLogger {
 
     @Message(id = 97, value = "Cannot explode a subdeployment of an unexploded deployment")
     OperationFailedException cannotExplodeSubDeploymentOfUnexplodedDeployment();
+
+    @Message(id = 98, value = "You are trying to redeploy %s which are deployments not affected by the overlay")
+    OperationFailedException redeployingUnaffactedDeployments(Collection<String> deployments);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainDeploymentOverlayRedeployLinksHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainDeploymentOverlayRedeployLinksHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.domain.controller.operations;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENTS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_OVERLAY_LINK_REMOVAL;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REDEPLOY_LINKS;
+import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.domain.controller.logging.DomainControllerLogger;
+import org.jboss.as.server.deploymentoverlay.AffectedDeploymentOverlay;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Handler to redeploy deployments linked to an overlay in domain mode.
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class DomainDeploymentOverlayRedeployLinksHandler implements OperationStepHandler {
+
+    public static final StringListAttributeDefinition RUNTIME_NAMES_DEFINITION =
+            new StringListAttributeDefinition.Builder(DEPLOYMENTS)
+                            .setRequired(false)
+                            .build();
+
+    public static final OperationDefinition REDEPLOY_LINKS_DEFINITION = new SimpleOperationDefinitionBuilder(
+            REDEPLOY_LINKS, ControllerResolver.getResolver(ModelDescriptionConstants.DEPLOYMENT_OVERLAY))
+            .addParameter(RUNTIME_NAMES_DEFINITION)
+            .build();
+
+    private final boolean domainRoot;
+
+    public DomainDeploymentOverlayRedeployLinksHandler(boolean domainRoot) {
+        this.domainRoot = domainRoot;
+    }
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        Set<String> runtimeNames = domainRoot ? AffectedDeploymentOverlay.listAllLinks(context, context.getCurrentAddressValue()) : AffectedDeploymentOverlay.listLinks(context, context.getCurrentAddress());
+        if(operation.hasDefined(RUNTIME_NAMES_DEFINITION.getName())) {
+            Set<String> requiredRuntimeNames = new HashSet<>(RUNTIME_NAMES_DEFINITION.unwrap(context, operation));
+            Set<String> unaffectedDeployments = AffectedDeploymentOverlay.checkRequiredNames(requiredRuntimeNames, runtimeNames);
+            if(!unaffectedDeployments.isEmpty() && !isRedeployAfterRemoval(operation)) {
+                throw DomainControllerLogger.ROOT_LOGGER.redeployingUnaffactedDeployments(unaffectedDeployments);
+            }
+            runtimeNames = requiredRuntimeNames;
+        }
+        ModelNode removeOperation = null;
+        if(isRedeployAfterRemoval(operation)) {
+            removeOperation = Operations.createRemoveOperation(context.getCurrentAddress().append(DEPLOYMENT, runtimeNames.iterator().next()).toModelNode());
+        }
+        if (domainRoot) {
+            AffectedDeploymentOverlay.redeployLinksAndTransformOperationForDomain(context, runtimeNames, removeOperation);
+        } else {
+            AffectedDeploymentOverlay.redeployLinksAndTransformOperation(context, removeOperation, context.getCurrentAddress().getParent(), runtimeNames);
+        }
+    }
+
+    /**
+     * @param operation the current operation.
+     * @return true if this is a redeploy after the removal of a link.
+     * @see org.jboss.as.server.deploymentoverlay.DeploymentOverlayDeploymentRemoveHandler
+     */
+    private boolean isRedeployAfterRemoval(ModelNode operation) {
+        return operation.hasDefined(DEPLOYMENT_OVERLAY_LINK_REMOVAL) &&
+                operation.get(DEPLOYMENT_OVERLAY_LINK_REMOVAL).asBoolean();
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainDeploymentOverlayDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainDeploymentOverlayDefinition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.domain.controller.resources;
+
+import org.jboss.as.domain.controller.operations.DomainDeploymentOverlayRedeployLinksHandler;
+import org.jboss.as.repository.ContentRepository;
+import org.jboss.as.repository.DeploymentFileRepository;
+import org.jboss.as.server.deploymentoverlay.DeploymentOverlayDefinition;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class DomainDeploymentOverlayDefinition extends DeploymentOverlayDefinition {
+
+    public DomainDeploymentOverlayDefinition(boolean domainLevel, ContentRepository contentRepo, DeploymentFileRepository fileRepository) {
+        super(domainLevel, contentRepo, fileRepository);
+        addOperation(DomainDeploymentOverlayRedeployLinksHandler.REDEPLOY_LINKS_DEFINITION,
+                new DomainDeploymentOverlayRedeployLinksHandler(domainLevel));
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -105,7 +105,6 @@ import org.jboss.as.server.controller.descriptions.ServerDescriptionConstants;
 import org.jboss.as.server.controller.resources.DeploymentAttributes;
 import org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition;
 import org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition.Location;
-import org.jboss.as.server.deploymentoverlay.DeploymentOverlayDefinition;
 import org.jboss.as.server.operations.ServerVersionOperations.DefaultEmptyListAttributeHandler;
 import org.jboss.as.server.operations.WriteConfigHandler;
 import org.jboss.as.server.services.net.InterfaceAddHandler;
@@ -329,7 +328,7 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
                 ? DomainDeploymentResourceDefinition.createForDomainMaster(contentRepo)
                 : DomainDeploymentResourceDefinition.createForDomainSlave(environment.isBackupDomainFiles(), fileRepository, contentRepo);
         resourceRegistration.registerSubModel(domainDeploymentDefinition);
-        resourceRegistration.registerSubModel(new DeploymentOverlayDefinition(true, contentRepo, fileRepository));
+        resourceRegistration.registerSubModel(new DomainDeploymentOverlayDefinition(true, contentRepo, fileRepository));
 
         if(isMaster || environment.isBackupDomainFiles()) {
             resourceRegistration.registerSubModel(new ServerGroupResourceDefinition(isMaster, hostControllerInfo, fileRepository));

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
@@ -54,7 +54,6 @@ import org.jboss.as.repository.HostFileRepository;
 import org.jboss.as.server.controller.resources.DeploymentAttributes;
 import org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition;
 import org.jboss.as.server.controller.resources.SystemPropertyResourceDefinition.Location;
-import org.jboss.as.server.deploymentoverlay.DeploymentOverlayDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -145,7 +144,7 @@ public class ServerGroupResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(JvmResourceDefinition.GLOBAL);
         resourceRegistration.registerSubModel(DomainDeploymentResourceDefinition.createForServerGroup(fileRepository, contentRepository));
         resourceRegistration.registerSubModel(SystemPropertyResourceDefinition.createForDomainOrHost(Location.SERVER_GROUP));
-        resourceRegistration.registerSubModel(new DeploymentOverlayDefinition(false, null, null));
+        resourceRegistration.registerSubModel(new DomainDeploymentOverlayDefinition(false, null, null));
     }
 
     @Override

--- a/host-controller/src/main/resources/org/jboss/as/domain/controller/resources/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/domain/controller/resources/LocalDescriptions.properties
@@ -103,10 +103,13 @@ server-group.resume-servers=Resumes operations on all servers in the server grou
 
 server-group.deployment-overlay=Links between a defined deployment overlay and deployments in this server group
 server-group.deployment-overlay.add=Adds a link to a deployment overlay
+server-group.deployment-overlay.redeploy-links=Redeploys the deployments affected by this overlay
+server-group.deployment-overlay.redeploy-links.deployments=List of deployment runtime names to be redeployed. If this list is empty or 'undefined' then all affected deployments will be redeployed.
 server-group.deployment-overlay.remove=Removes a link to a deployment overlay
 server-group.deployment-overlay.deployment=A deployment that this overlay is applied to
 server-group.deployment-overlay.deployment.add=Adds a link between a deployment and this overlay
 server-group.deployment-overlay.deployment.remove=Removes a link between a deployment and this overlay
+server-group.deployment-overlay.deployment.remove.redeploy-affected=If set to 'true', redeploy the deployments affected by this overlay after removal.
 server-group.deployment-overlay.deployment.regular-expression=If this deployment name should be treated as a regular expression
 
 host-exclude=Configuration of resources that should be hidden by the Domain Controller from a slave Host Controller that is running a particular version.

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/AffectedDeploymentOverlay.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/AffectedDeploymentOverlay.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.server.deploymentoverlay;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_OVERLAY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REDEPLOY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REDEPLOY_AFFECTED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REDEPLOY_LINKS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBDEPLOYMENT;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.operations.DomainOperationTransformer;
+import org.jboss.as.controller.operations.OperationAttachments;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.server.logging.ServerLogger;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Utility class for finding and updating deployments affected by an overlay change. This is where the magic of getting
+ * deployments affected by an overlay is happening.
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class AffectedDeploymentOverlay {
+
+    private AffectedDeploymentOverlay() {
+    }
+
+    /**
+     * Returns all the deployment runtime names associated with an overlay accross all server groups.
+     *
+     * @param context the current OperationContext.
+     * @param overlay the name of the overlay.
+     * @return all the deployment runtime names associated with an overlay accross all server groups.
+     */
+    public static Set<String> listAllLinks(OperationContext context, String overlay) {
+        Set<String> serverGoupNames = listServerGroupsReferencingOverlay(context, overlay);
+        Set<String> links = new HashSet<>();
+        for (String serverGoupName : serverGoupNames) {
+            links.addAll(listLinks(context, PathAddress.pathAddress(
+                    PathElement.pathElement(SERVER_GROUP, serverGoupName),
+                    PathElement.pathElement(DEPLOYMENT_OVERLAY, overlay))));
+        }
+        return links;
+    }
+
+    /**
+     * Returns all the deployment runtime names associated with an overlay.
+     *
+     * @param context the current OperationContext.
+     * @param overlayAddress the address for the averlay.
+     * @return all the deployment runtime names associated with an overlay.
+     */
+    public static Set<String> listLinks(OperationContext context, PathAddress overlayAddress) {
+        Resource overlayResource = context.readResourceFromRoot(overlayAddress);
+        if (overlayResource.hasChildren(DEPLOYMENT)) {
+            return overlayResource.getChildrenNames(DEPLOYMENT);
+        }
+        return Collections.emptySet();
+    }
+
+    /**
+     * We are adding a redeploy operation step for each specified deployment runtime name.
+     *
+     * @param context
+     * @param deploymentsRootAddress
+     * @param runtimeNames
+     * @throws OperationFailedException
+     */
+    public static void redeployLinks(OperationContext context, PathAddress deploymentsRootAddress, Set<String> runtimeNames) throws OperationFailedException {
+        Set<String> deploymentNames = listDeploymentNames(context, deploymentsRootAddress, runtimeNames.stream().map(wildcardExpr -> DeploymentOverlayIndex.getPattern(wildcardExpr)).collect(Collectors.toSet()));
+        for (String deploymentName : deploymentNames) {
+            PathAddress address = deploymentsRootAddress.append(DEPLOYMENT, deploymentName);
+            OperationStepHandler handler = context.getRootResourceRegistration().getOperationHandler(address, REDEPLOY);
+            ModelNode operation = addRedeployStep(address);
+            ServerLogger.AS_ROOT_LOGGER.debugf("Redeploying %s at address %s with handler %s", deploymentName, address, handler);
+            assert handler != null;
+            assert operation.isDefined();
+            context.addStep(operation, handler, OperationContext.Stage.MODEL);
+        }
+    }
+
+    /**
+     * It will look for all the deployments (in every server-group) with a runtimeName in the specified list of runtime
+     * names and then transform the operation so that every server in those server groups will redeploy the affected
+     * deployments.
+     *
+     * @see #transformOperation
+     * @param context
+     * @param serverGroupNames
+     * @param runtimeNames
+     * @throws OperationFailedException
+     */
+    public static void redeployLinksAndTransformOperationForDomain(OperationContext context, Set<String> runtimeNames, ModelNode removeOperation) throws OperationFailedException {
+        Set<String> serverGroupNames = listServerGroupsReferencingOverlay(context, context.getCurrentAddressValue());
+        Map<String, Set<String>> deploymentPerServerGroup = new HashMap<>();
+        for (String serverGoupName : serverGroupNames) {
+            deploymentPerServerGroup.put(serverGoupName,
+                    listDeploymentNames(context, PathAddress.pathAddress(PathElement.pathElement(SERVER_GROUP, serverGoupName)),runtimeNames
+                            .stream()
+                            .map(wildcardExpr -> DeploymentOverlayIndex.getPattern(wildcardExpr))
+                            .collect(Collectors.toSet())));
+        }
+        if (deploymentPerServerGroup.isEmpty()) {
+            runtimeNames.forEach(s -> ServerLogger.ROOT_LOGGER.debugf("We haven't found any server-group for %s", s));
+            throw ServerLogger.ROOT_LOGGER.redeployingUnaffactedDeployments(runtimeNames);
+        }
+        //Add a deploy step for each affected deployment in its server-group.
+        Operations.CompositeOperationBuilder opBuilder = Operations.CompositeOperationBuilder.create();
+        deploymentPerServerGroup.entrySet().stream().filter((entry) -> (!entry.getValue().isEmpty())).forEach((entry) -> {
+            entry.getValue().forEach((deploymentName) -> opBuilder.addStep(addRedeployStep(context.getCurrentAddress().getParent().append(SERVER_GROUP, entry.getKey()).append(DEPLOYMENT, deploymentName))));
+        });
+        if(removeOperation != null) {
+             opBuilder.addStep(removeOperation);
+        }
+        // Add the domain op transformer
+        List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
+        if (transformers == null) {
+            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS, transformers = new ArrayList<>());
+        }
+        final ModelNode slave = opBuilder.build().getOperation();
+        transformers.add(new OverlayOperationTransformer(slave));
+    }
+
+    /**
+     * It will look for all the deployments under the deploymentsRootAddress with a runtimeName in the specified list of
+     * runtime names and then transform the operation so that every server having those deployments will redeploy the
+     * affected deployments.
+     *
+     * @see #transformOperation
+     * @param context
+     * @param deploymentsRootAddress
+     * @param runtimeNames
+     * @throws OperationFailedException
+     */
+     public static void redeployLinksAndTransformOperation(OperationContext context, ModelNode removeOperation, PathAddress deploymentsRootAddress, Set<String> runtimeNames) throws OperationFailedException {
+        Set<String> deploymentNames = listDeploymentNames(context, deploymentsRootAddress, runtimeNames
+                .stream()
+                .map(wildcardExpr -> DeploymentOverlayIndex.getPattern(wildcardExpr))
+                .collect(Collectors.toSet()));
+        if (deploymentNames.isEmpty()) {
+            runtimeNames.forEach(s -> ServerLogger.ROOT_LOGGER.debugf("We haven't found any deployment for %s in server-group %s", s, deploymentsRootAddress.getLastElement().getValue()));
+            throw ServerLogger.ROOT_LOGGER.redeployingUnaffactedDeployments(runtimeNames);
+        }
+        Operations.CompositeOperationBuilder opBuilder = Operations.CompositeOperationBuilder.create();
+
+        for (String deploymentName : deploymentNames) {
+            opBuilder.addStep(addRedeployStep(deploymentsRootAddress.append(DEPLOYMENT, deploymentName)));
+        }
+        if(removeOperation != null) {
+             opBuilder.addStep(removeOperation);
+        }
+        List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
+        if (transformers == null) {
+            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS, transformers = new ArrayList<>());
+        }
+        final ModelNode slave = opBuilder.build().getOperation();
+        transformers.add(new OverlayOperationTransformer(slave));
+    }
+
+
+    /**
+     * Returns the deployment names with the specified runtime names.
+     *
+     * @param context
+     * @param runtimeNames
+     * @return
+     */
+    private static Set<String> listDeploymentNames(OperationContext context, PathAddress deploymentRootAddress, Set<Pattern> patterns) {
+        Set<String> deploymentNames = new HashSet<>();
+        Resource deploymentRootResource = context.readResourceFromRoot(deploymentRootAddress);
+        if (deploymentRootResource.hasChildren(DEPLOYMENT)) {
+            for (Resource.ResourceEntry deploymentResource : deploymentRootResource.getChildren(DEPLOYMENT)) {
+                if (isAcceptableDeployment(deploymentResource.getModel(), patterns)) {
+                    deploymentNames.add(deploymentResource.getName());
+                } else if (deploymentResource.hasChildren(SUBDEPLOYMENT)) {
+                    for (Resource.ResourceEntry subdeploymentResource : deploymentResource.getChildren(SUBDEPLOYMENT)) {
+                        if (isAcceptableDeployment(subdeploymentResource.getModel(), patterns)) {
+                            deploymentNames.add(deploymentResource.getName());
+                        }
+                    }
+                }
+            }
+        }
+        return deploymentNames;
+    }
+
+    private static boolean isAcceptableDeployment(ModelNode deploymentNode, Set<Pattern> patterns) {
+        return deploymentNode.get(ENABLED).asBoolean()
+                && patterns.stream().anyMatch(pattern -> pattern.matcher(deploymentNode.require(RUNTIME_NAME).asString()).matches());
+    }
+
+    private static ModelNode addRedeployStep(PathAddress address) {
+        return Operations.createOperation(REDEPLOY, address.toModelNode());
+    }
+
+    private static Set<String> listServerGroupsReferencingOverlay(OperationContext context, String overlayName) {
+        final Resource rootResource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
+        final PathElement overlayPath = PathElement.pathElement(DEPLOYMENT_OVERLAY, overlayName);
+        if (rootResource.hasChildren(SERVER_GROUP)) {
+            return rootResource.getChildrenNames(SERVER_GROUP).stream().filter(
+                    serverGroupName -> rootResource.getChild(PathElement.pathElement(SERVER_GROUP, serverGroupName)).hasChild(overlayPath)).collect(Collectors.toSet());
+        }
+        return Collections.emptySet();
+    }
+
+    public static Set<String> checkRequiredNames(Set<String> requiredNames, Set<String> runtimeNames) {
+        return requiredNames.stream()
+                .map(wildcardExpr -> DeploymentOverlayIndex.getPattern(wildcardExpr))
+                .filter(pattern -> {
+                    return !runtimeNames.stream().anyMatch(runtimeName -> pattern.matcher(runtimeName).matches());
+                })
+                .map(Pattern::toString)
+                .collect(Collectors.toSet());
+    }
+
+    private static final class OverlayOperationTransformer implements DomainOperationTransformer {
+
+        private final ModelNode newOperation;
+
+        public OverlayOperationTransformer(ModelNode newOperation) {
+            this.newOperation = newOperation;
+        }
+
+        @Override
+        public ModelNode transform(final OperationContext context, final ModelNode operation) {
+            if (operation.get(OP).asString().equals(COMPOSITE)) {
+                ModelNode ret = operation.clone();
+                final List<ModelNode> list = new ArrayList<ModelNode>();
+                ListIterator<ModelNode> it = ret.get(STEPS).asList().listIterator();
+                while (it.hasNext()) {
+                    final ModelNode subOperation = it.next();
+                    list.add(transform(context, subOperation));
+                }
+                ret.get(STEPS).set(list);
+                return ret;
+            } else {
+                if (matches(operation)) {
+                    ServerLogger.AS_ROOT_LOGGER.debugf("Transforming operation %s into %s", operation, newOperation);
+                    return newOperation.clone();
+                } else {
+                    return operation;
+                }
+            }
+        }
+
+        protected boolean matches(final ModelNode operation) {
+            return (REDEPLOY_LINKS.equals(operation.get(OP).asString()) ||
+                    (REMOVE.equals(operation.get(OP).asString()) && operation.hasDefined(REDEPLOY_AFFECTED) && operation.get(REDEPLOY_AFFECTED).asBoolean()))
+                    && operation.get(OP_ADDR).asList().size() >= 1;
+        }
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayContentDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayContentDefinition.java
@@ -22,7 +22,9 @@
 
 package org.jboss.as.server.deploymentoverlay;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTACHED_STREAMS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FILESYSTEM_PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HASH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UUID;
@@ -65,6 +67,8 @@ public class DeploymentOverlayContentDefinition extends SimpleResourceDefinition
             new ObjectTypeAttributeDefinition.Builder(ModelDescriptionConstants.CONTENT,
                     new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.INPUT_STREAM_INDEX, ModelType.INT, true)
                             .setValidator(new StringLengthValidator(0, true))
+                            .addArbitraryDescriptor(FILESYSTEM_PATH, new ModelNode(true))
+                            .addArbitraryDescriptor(ATTACHED_STREAMS, new ModelNode(true))
                             .build(),
                     new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.HASH, ModelType.BYTES, true)
                             .setValidator(new HashValidator(true))

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentDefinition.java
@@ -19,32 +19,33 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.jboss.as.server.deploymentoverlay;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_OVERLAY;
+import static org.jboss.as.server.deploymentoverlay.DeploymentOverlayModel.DEPLOYMENT_OVERRIDE_DEPLOYMENT_PATH;
+
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 
 /**
  * Links a deployment overlay to a deployment
+ *
  * @author Stuart Douglas
  */
 public class DeploymentOverlayDeploymentDefinition extends SimpleResourceDefinition {
 
-    private static final AttributeDefinition[] ATTRIBUTES = {  };
+    private static final AttributeDefinition[] ATTRIBUTES = {};
 
     public static AttributeDefinition[] attributes() {
         return ATTRIBUTES.clone();
     }
 
     public DeploymentOverlayDeploymentDefinition() {
-        super(DeploymentOverlayModel.DEPLOYMENT_OVERRIDE_DEPLOYMENT_PATH,
-                ControllerResolver.getResolver(ModelDescriptionConstants.DEPLOYMENT_OVERLAY + "." + ModelDescriptionConstants.DEPLOYMENT),
-                new DeploymentOverlayDeploymentAdd(), ModelOnlyRemoveStepHandler.INSTANCE);
+        super(new Parameters(DEPLOYMENT_OVERRIDE_DEPLOYMENT_PATH, ControllerResolver.getResolver(DEPLOYMENT_OVERLAY + '.' + DEPLOYMENT))
+                .setAddHandler(new DeploymentOverlayDeploymentAdd()));
     }
 
     @Override
@@ -52,5 +53,11 @@ public class DeploymentOverlayDeploymentDefinition extends SimpleResourceDefinit
         for (AttributeDefinition attr : ATTRIBUTES) {
             resourceRegistration.registerReadOnlyAttribute(attr, null);
         }
+    }
+
+    @Override
+    public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+        super.registerOperations(resourceRegistration);
+        resourceRegistration.registerOperationHandler(DeploymentOverlayDeploymentRemoveHandler.REMOVE_DEFINITION, DeploymentOverlayDeploymentRemoveHandler.INSTANCE);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentRemoveHandler.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.server.deploymentoverlay;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENTS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_OVERLAY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_OVERLAY_LINK_REMOVAL;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REDEPLOY_AFFECTED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REDEPLOY_LINKS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+
+import java.util.Collections;
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * Handler to remove a link between an overlay and a deployment with support to redeploy deployments thus affected.
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class DeploymentOverlayDeploymentRemoveHandler extends AbstractRemoveStepHandler {
+
+    public static final AttributeDefinition REDEPLOY_AFFECTED_DEFINITION
+            = SimpleAttributeDefinitionBuilder.create(REDEPLOY_AFFECTED, ModelType.BOOLEAN)
+                    .setRequired(false)
+                    .setDefaultValue(new ModelNode(false))
+                    .build();
+    public static final OperationDefinition REMOVE_DEFINITION
+            = new SimpleOperationDefinitionBuilder(REMOVE, ControllerResolver.getResolver(DEPLOYMENT_OVERLAY + '.' + DEPLOYMENT))
+                    .addParameter(REDEPLOY_AFFECTED_DEFINITION)
+                    .build();
+
+    public static final DeploymentOverlayDeploymentRemoveHandler INSTANCE = new DeploymentOverlayDeploymentRemoveHandler();
+
+    @Override
+    protected void performRemove(OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+        final String runtimeName = context.getCurrentAddressValue();
+        if (REDEPLOY_AFFECTED_DEFINITION.resolveModelAttribute(context, operation).asBoolean()) {
+            if (SERVER_GROUP.equals(context.getCurrentAddress().getElement(0).getKey())) {
+                PathAddress overlayAddress = context.getCurrentAddress().getParent();
+                OperationStepHandler handler = context.getRootResourceRegistration().getOperationHandler(overlayAddress, REDEPLOY_LINKS);
+                ModelNode redeployAffectedOperation = Util.createOperation(REDEPLOY_LINKS, overlayAddress);
+                redeployAffectedOperation.get(DEPLOYMENTS).setEmptyList().add(runtimeName);
+                redeployAffectedOperation.get(DEPLOYMENT_OVERLAY_LINK_REMOVAL).set(true);
+                assert handler != null;
+                assert redeployAffectedOperation.isDefined();
+                context.addStep(redeployAffectedOperation, handler, OperationContext.Stage.MODEL);
+            } else {
+                AffectedDeploymentOverlay.redeployLinks(context, PathAddress.EMPTY_ADDRESS, Collections.singleton(runtimeName));
+            }
+        }
+        super.performRemove(context, operation, model);
+    }
+
+    /**
+     * Throws {@link UnsupportedOperationException}.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Throws {@link UnsupportedOperationException}.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns {@code false}.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    protected final boolean requiresRuntime(OperationContext context) {
+        return false;
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayIndex.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayIndex.java
@@ -114,7 +114,7 @@ public class DeploymentOverlayIndex {
         return name.contains("*") || name.contains("?");
     }
 
-    private static Pattern getPattern(String name) {
+    static Pattern getPattern(String name) {
         return Pattern.compile(wildcardToJavaRegexp(name));
     }
 

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayModel.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayModel.java
@@ -29,9 +29,6 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
  * @author Stuart Douglas
  */
 public class DeploymentOverlayModel {
-
-    private static final String RESOURCE_NAME = DeploymentOverlayModel.class.getPackage().getName() + ".LocalDescriptions";
-
     protected static final PathElement CONTENT_PATH = PathElement.pathElement(ModelDescriptionConstants.CONTENT);
     protected static final PathElement DEPLOYMENT_OVERRIDE_PATH = PathElement.pathElement(ModelDescriptionConstants.DEPLOYMENT_OVERLAY);
     protected static final PathElement DEPLOYMENT_OVERRIDE_DEPLOYMENT_PATH = PathElement.pathElement(ModelDescriptionConstants.DEPLOYMENT);

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayRedeployLinksHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayRedeployLinksHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.server.deploymentoverlay;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REDEPLOY_LINKS;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.server.logging.ServerLogger;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Handler that will redeploy the deployments linked to an overlay.
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class DeploymentOverlayRedeployLinksHandler implements OperationStepHandler {
+
+    private static final StringListAttributeDefinition RUNTIME_NAMES_DEFINITION
+            = new StringListAttributeDefinition.Builder("deployments")
+                    .setRequired(false)
+                    .build();
+
+    public static final OperationDefinition REDEPLOY_LINKS_DEFINITION = new SimpleOperationDefinitionBuilder(
+            REDEPLOY_LINKS, ControllerResolver.getResolver(ModelDescriptionConstants.DEPLOYMENT_OVERLAY))
+            .addParameter(RUNTIME_NAMES_DEFINITION)
+            .build();
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        Set<String> runtimeNames = AffectedDeploymentOverlay.listLinks(context, context.getCurrentAddress());
+        if (operation.hasDefined(RUNTIME_NAMES_DEFINITION.getName())) {
+            Set<String> requiredRuntimeNames = new HashSet<>(RUNTIME_NAMES_DEFINITION.unwrap(context, operation));
+            Set<String> unaffectedDeployments = AffectedDeploymentOverlay.checkRequiredNames(requiredRuntimeNames, runtimeNames);
+            if (!unaffectedDeployments.isEmpty()) {
+                throw ServerLogger.ROOT_LOGGER.redeployingUnaffactedDeployments(unaffectedDeployments);
+            }
+            runtimeNames = requiredRuntimeNames;
+        }
+        // Adding a redeploy operation step for each runtime.
+        AffectedDeploymentOverlay.redeployLinks(context, context.getCurrentAddress().getParent(), runtimeNames);
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -35,6 +35,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -1270,6 +1271,9 @@ public interface ServerLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 265, value = "Invalid value '%s' for system property '%s' -- value must be a non-negative integer")
     void invalidPoolCoreSize(String val, String configSysProp);
+
+    @Message(id = 266, value = "You are trying to redeploy %s which are deployments not affected by the overlay")
+    OperationFailedException redeployingUnaffactedDeployments(Collection<String> deployments);
 
     ////////////////////////////////////////////////
     //Messages without IDs

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
@@ -1,0 +1,337 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.DEPLOYMENT;
+import static org.jboss.as.controller.client.helpers.ClientConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ARCHIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BYTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_OVERLAY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_DEFAULTS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INPUT_STREAM_INDEX;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEPLOY;
+import static org.jboss.as.test.deployment.trivial.ServiceActivatorDeployment.PROPERTIES_RESOURCE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.jboss.as.controller.PathAddress;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.deployment.trivial.ServiceActivatorDeploymentUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.threads.AsyncFuture;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2015 Red Hat, inc.
+ */
+public class DeploymentOverlayTestCase {
+
+    private static final int TIMEOUT = TimeoutUtil.adjust(20000);
+    private static final String DEPLOYMENT_NAME = "deployment.jar";
+    private static final String MAIN_RUNTIME_NAME = "main-deployment.jar";
+    private static final String OTHER_RUNTIME_NAME = "other-deployment.jar";
+    private static final PathElement DEPLOYMENT_PATH = PathElement.pathElement(DEPLOYMENT, DEPLOYMENT_NAME);
+    private static final PathElement DEPLOYMENT_OVERLAY_PATH = PathElement.pathElement(DEPLOYMENT_OVERLAY, "test-overlay");
+    private static final PathElement MAIN_SERVER_GROUP = PathElement.pathElement(SERVER_GROUP, "main-server-group");
+    private static final PathElement OTHER_SERVER_GROUP = PathElement.pathElement(SERVER_GROUP, "other-server-group");
+    private static DomainTestSupport testSupport;
+    private static DomainClient masterClient;
+    private static DomainClient slaveClient;
+
+    private static final Properties properties = new Properties();
+    private static final Properties properties2 = new Properties();
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(DeploymentOverlayTestCase.class.getSimpleName());
+        masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+        slaveClient = testSupport.getDomainSlaveLifecycleUtil().getDomainClient();
+        properties.clear();
+        properties.put("service", "is new");
+
+        properties2.clear();
+        properties2.put("service", "is added");
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        testSupport = null;
+        masterClient.close();
+        masterClient = null;
+        slaveClient.close();
+        slaveClient = null;
+        DomainTestSuite.stopSupport();
+    }
+
+    @After
+    public void cleanup() throws IOException {
+        try {
+            cleanDeployment();
+        } catch (MgmtOperationException e) {
+            // ignored
+        }
+    }
+
+    @Test
+    public void testInstallAndOverlayDeploymentOnDC() throws IOException, MgmtOperationException {
+        final JavaArchive archive = ServiceActivatorDeploymentUtil.createServiceActivatorDeploymentArchive("test-deployment.jar", properties);
+        ModelNode result;
+        try (InputStream is = archive.as(ZipExporter.class).exportAsInputStream()){
+            AsyncFuture<ModelNode> future = masterClient.executeAsync(addDeployment(is), null);
+            result = awaitSimpleOperationExecution(future);
+        }
+        assertTrue(Operations.isSuccessfulOutcome(result));
+        ModelNode contentNode = readDeploymentResource(PathAddress.pathAddress(DEPLOYMENT_PATH)).require(CONTENT).require(0);
+        assertTrue(contentNode.get(ARCHIVE).asBoolean(true));
+        //Let's deploy it on main-server-group
+        executeAsyncForResult(masterClient, deployOnServerGroup(MAIN_SERVER_GROUP, MAIN_RUNTIME_NAME));
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "main-three")), properties);
+        executeAsyncForResult(masterClient, deployOnServerGroup(OTHER_SERVER_GROUP, OTHER_RUNTIME_NAME));
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties);
+        executeAsyncForResult(masterClient, Operations.createOperation(ADD, PathAddress.pathAddress(DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        //Add some content
+        executeAsyncForResult(masterClient, addOverlayContent(properties2, "Overlay content"));
+        //Add overlay on server-groups
+        executeAsyncForResult(masterClient, Operations.createOperation(ADD, PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        executeAsyncForResult(masterClient, Operations.createOperation(ADD, PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH, PathElement.pathElement(DEPLOYMENT, MAIN_RUNTIME_NAME)).toModelNode()));
+        executeAsyncForResult(masterClient, Operations.createOperation(ADD, PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        executeAsyncForResult(masterClient, Operations.createOperation(ADD, PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH, PathElement.pathElement(DEPLOYMENT, OTHER_RUNTIME_NAME)).toModelNode()));
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "master"),
+                PathElement.pathElement(SERVER, "main-one")), properties);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "main-three")), properties);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties);
+        ModelNode failingOp = Operations.createOperation("redeploy-links", PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode());
+        failingOp.get("deployments").setEmptyList();
+        failingOp.get("deployments").add(OTHER_RUNTIME_NAME);
+        failingOp.get("deployments").add("inexisting.jar");
+        executeAsyncForDomainFailure(masterClient, failingOp, "WFLYDC0098: You are trying to redeploy rutimes not affected by the overlay");
+        executeAsyncForResult(masterClient, Operations.createOperation("redeploy-links", PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "master"),
+                PathElement.pathElement(SERVER, "main-one")), properties2);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "main-three")), properties2);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties);
+        ServiceActivatorDeploymentUtil.validateProperties(slaveClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties);
+        executeAsyncForResult(masterClient, Operations.createOperation(REMOVE, PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH, PathElement.pathElement(DEPLOYMENT, MAIN_RUNTIME_NAME)).toModelNode()));
+        executeAsyncForResult(masterClient, Operations.createOperation(REMOVE, PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH, PathElement.pathElement(DEPLOYMENT, OTHER_RUNTIME_NAME)).toModelNode()));
+        executeAsyncForResult(masterClient, Operations.createOperation(ADD, PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH, PathElement.pathElement(DEPLOYMENT, OTHER_RUNTIME_NAME)).toModelNode()));
+        executeAsyncForResult(masterClient, Operations.createOperation("redeploy-links", PathAddress.pathAddress(DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "main-three")), properties2);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties2);
+        failingOp = Operations.createOperation("redeploy-links", PathAddress.pathAddress(DEPLOYMENT_OVERLAY_PATH).toModelNode());
+        failingOp.get("deployments").setEmptyList();
+        failingOp.get("deployments").add(OTHER_RUNTIME_NAME);
+        failingOp.get("deployments").add("inexisting.jar");
+        executeAsyncForDomainFailure(masterClient, failingOp, "WFLYDC0098: You are trying to redeploy rutimes not affected by the overlay");
+        failingOp = Operations.createOperation("redeploy-links", PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode());
+        failingOp.get("deployments").setEmptyList();
+        failingOp.get("deployments").add(OTHER_RUNTIME_NAME);
+        executeAsyncForFailure(slaveClient, failingOp, "WFLYDC0032: Operation redeploy-links for address " + PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode().toString() + " can only be handled by the master Domain Controller; this host is not the master Domain Controller");
+        ModelNode removeLinkOp = Operations.createOperation(REMOVE, PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH, PathElement.pathElement(DEPLOYMENT, OTHER_RUNTIME_NAME)).toModelNode());
+        removeLinkOp.get("redeploy-affected").set(true);
+        executeAsyncForResult(masterClient, removeLinkOp);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "main-three")), properties2);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties);
+        ServiceActivatorDeploymentUtil.validateProperties(slaveClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties);
+        executeAsyncForResult(masterClient, Operations.createOperation(ADD, PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH, PathElement.pathElement(DEPLOYMENT, OTHER_RUNTIME_NAME)).toModelNode()));
+        executeAsyncForResult(masterClient, Operations.createOperation(ADD, PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH, PathElement.pathElement(DEPLOYMENT, MAIN_RUNTIME_NAME)).toModelNode()));
+        ModelNode redeployOp = Operations.createOperation("redeploy-links", PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode());
+        redeployOp.get("deployments").setEmptyList();
+        redeployOp.get("deployments").add(MAIN_RUNTIME_NAME);
+        executeAsyncForResult(masterClient, redeployOp);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "main-three")), properties2);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties);
+        ServiceActivatorDeploymentUtil.validateProperties(slaveClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties);
+        redeployOp = Operations.createOperation("redeploy-links", PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode());
+        redeployOp.get("deployments").setEmptyList();
+        redeployOp.get("deployments").add(OTHER_RUNTIME_NAME);
+        executeAsyncForResult(masterClient, redeployOp);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "main-three")), properties2);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties2);
+        ServiceActivatorDeploymentUtil.validateProperties(slaveClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties2);
+    }
+
+    private void executeAsyncForResult(DomainClient client, ModelNode op) {
+        AsyncFuture<ModelNode> future = client.executeAsync(op, null);
+        ModelNode response = awaitSimpleOperationExecution(future);
+        assertTrue(response.toJSONString(true), Operations.isSuccessfulOutcome(response));
+    }
+
+    private void executeAsyncForDomainFailure(DomainClient client, ModelNode op, String failureDescription) {
+        AsyncFuture<ModelNode> future = client.executeAsync(op, null);
+        ModelNode response = awaitSimpleOperationExecution(future);
+        assertFalse(response.toJSONString(true), Operations.isSuccessfulOutcome(response));
+        assertTrue(response.toJSONString(true), Operations.getFailureDescription(response).hasDefined("domain-failure-description"));
+        assertEquals(response.toJSONString(true),failureDescription, Operations.getFailureDescription(response).get("domain-failure-description").asString());
+    }
+
+    private void executeAsyncForFailure(DomainClient client, ModelNode op, String failureDescription) {
+        AsyncFuture<ModelNode> future = client.executeAsync(op, null);
+        ModelNode response = awaitSimpleOperationExecution(future);
+        assertFalse(response.toJSONString(true), Operations.isSuccessfulOutcome(response));
+        assertEquals(failureDescription, Operations.getFailureDescription(response).asString());
+    }
+
+    private ModelNode addOverlayContent(Properties props, String comment) throws IOException {
+        ModelNode op = Operations.createOperation(ADD, PathAddress.pathAddress(DEPLOYMENT_OVERLAY_PATH).append(CONTENT, PROPERTIES_RESOURCE).toModelNode());
+        try (StringWriter writer = new StringWriter()) {
+            props.store(writer, comment);
+            op.get(CONTENT).get(BYTES).set(writer.toString().getBytes(StandardCharsets.UTF_8));
+        }
+        return op;
+    }
+
+    private ModelNode readDeploymentResource(PathAddress address) {
+        ModelNode operation = Operations.createReadResourceOperation(address.toModelNode());
+        operation.get(INCLUDE_RUNTIME).set(true);
+        operation.get(INCLUDE_DEFAULTS).set(true);
+        AsyncFuture<ModelNode> future = masterClient.executeAsync(operation, null);
+        ModelNode result = awaitSimpleOperationExecution(future);
+        assertTrue(Operations.isSuccessfulOutcome(result));
+        return Operations.readResult(result);
+    }
+
+    private ModelNode awaitSimpleOperationExecution(Future<ModelNode> future) {
+        try {
+            return future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Operation addDeployment(InputStream attachment) throws MalformedURLException {
+        ModelNode operation = Operations.createAddOperation(PathAddress.pathAddress(DEPLOYMENT_PATH).toModelNode());
+        ModelNode content = new ModelNode();
+        content.get(INPUT_STREAM_INDEX).set(0);
+        operation.get(CONTENT).add(content);
+        return Operation.Factory.create(operation, Collections.singletonList(attachment));
+    }
+
+    private ModelNode deployOnServerGroup(PathElement group, String runtimeName) throws MalformedURLException {
+        ModelNode operation = Operations.createOperation(ADD, PathAddress.pathAddress(group, DEPLOYMENT_PATH).toModelNode());
+        operation.get(RUNTIME_NAME).set(runtimeName);
+        operation.get(ENABLED).set(true);
+        return operation;
+    }
+
+    private ModelNode undeployAndRemoveOp() throws MalformedURLException {
+        ModelNode op = new ModelNode();
+        op.get(OP).set(COMPOSITE);
+        ModelNode steps = op.get(STEPS);
+        ModelNode sgDep = PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_PATH).toModelNode();
+        steps.add(Operations.createOperation(UNDEPLOY, sgDep));
+        steps.add(Operations.createRemoveOperation(sgDep));
+        sgDep = PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_PATH).toModelNode();
+        steps.add(Operations.createOperation(UNDEPLOY, sgDep));
+        steps.add(Operations.createRemoveOperation(sgDep));
+        steps.add(Operations.createRemoveOperation(PathAddress.pathAddress(DEPLOYMENT_PATH).toModelNode()));
+        steps.add(Operations.createRemoveOperation(PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        steps.add(Operations.createRemoveOperation(PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        steps.add(Operations.createRemoveOperation(PathAddress.pathAddress(DEPLOYMENT_OVERLAY_PATH).toModelNode()));
+        return op;
+    }
+
+    private void cleanDeployment() throws IOException, MgmtOperationException {
+        DomainTestUtils.executeForResult(undeployAndRemoveOp(), masterClient);
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
@@ -74,8 +74,17 @@ public class DomainTestSupport {
      */
     public static DomainTestSupport createAndStartDefaultSupport(final String testName) {
         try {
-            final Configuration configuration = DomainTestSupport.Configuration.create(testName,
+            final Configuration configuration;
+            if(Boolean.getBoolean("wildfly.master.debug")) {
+                 configuration = DomainTestSupport.Configuration.createDebugMaster(testName,
                     "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
+            } else if (Boolean.getBoolean("wildfly.slave.debug")) {
+                configuration = DomainTestSupport.Configuration.createDebugSlave(testName,
+                    "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
+            } else {
+                configuration = DomainTestSupport.Configuration.create(testName,
+                    "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
+            }
             final DomainTestSupport testSupport = DomainTestSupport.create(configuration);
             // Start!
             testSupport.start();
@@ -441,6 +450,15 @@ public class DomainTestSupport {
         public static Configuration create(final String testName, final String domainConfig, final String masterConfig, final String slaveConfig) {
             return create(testName, domainConfig, masterConfig, slaveConfig, false, false, false);
         }
+
+        public static Configuration createDebugMaster(final String testName, final String domainConfig, final String masterConfig, final String slaveConfig) {
+            return create(testName, domainConfig, masterConfig, slaveConfig, false, false, true, false, false);
+        }
+
+        public static Configuration createDebugSlave(final String testName, final String domainConfig, final String masterConfig, final String slaveConfig) {
+            return create(testName, domainConfig, masterConfig, slaveConfig, false, false, false, false, true);
+        }
+
         public static Configuration create(final String testName, final String domainConfig, final String masterConfig,
                                            final String slaveConfig, boolean readOnlyMasterDomain, boolean readOnlyMasterHost, boolean readOnlySlaveHost) {
             return create(testName, domainConfig, masterConfig, slaveConfig, readOnlyMasterDomain, readOnlyMasterHost, false, readOnlySlaveHost, false);


### PR DESCRIPTION
Adding support for a new redeploy-affected method on deployment-overlays.
Adding a flag to redeploy affected when removing an overlay link.

Jira: https://issues.jboss.org/browse/WFCORE-2229
This is blocking https://issues.jboss.org/browse/WFCORE-1752