### PR TITLE
[WFCORE-2223] Drop pointless validation of jboss.modules.dir

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -352,8 +352,6 @@ public class HostControllerEnvironment extends ProcessEnvironment {
         File tmp = getFileFromProperty(MODULES_DIR);
         if (tmp == null) {
             tmp = new File(this.homeDir, "modules");
-        } else if (!tmp.exists() || !tmp.isDirectory()) {
-            throw HostControllerLogger.ROOT_LOGGER.modulesDirectoryDoesNotExist(tmp);
         }
         this.modulesDir = tmp;
         @SuppressWarnings("deprecation")

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -923,8 +923,9 @@ public interface HostControllerLogger extends BasicLogger {
     @Message(id = 95, value = "Home directory does not exist: %s")
     IllegalStateException homeDirectoryDoesNotExist(File f);
 
-    @Message(id = 96, value = "Determined modules directory does not exist: %s")
-    IllegalStateException modulesDirectoryDoesNotExist(File f);
+    // WFCORE-2223 no longer used
+//    @Message(id = 96, value = "Determined modules directory does not exist: %s")
+//    IllegalStateException modulesDirectoryDoesNotExist(File f);
 
     @Message(id = 97, value = "Domain base directory does not exist: %s")
     IllegalStateException domainBaseDirectoryDoesNotExist(File f);

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -406,8 +406,6 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
             File tmp = getFileFromProperty(MODULES_DIR, props);
             if (tmp == null) {
                 tmp = new File(homeDir, "modules");
-            } else if (!tmp.exists() || !tmp.isDirectory()) {
-                throw ServerLogger.ROOT_LOGGER.modulesDirectoryDoesNotExist(tmp);
             }
             modulesDir = tmp;
 

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -770,8 +770,9 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 117, value = "Unable to initialise a basic SSLContext '%s'")
     IllegalStateException unableToInitialiseSSLContext(String message);
 
-    @Message(id = 118, value = "Determined modules directory does not exist: %s")
-    IllegalStateException modulesDirectoryDoesNotExist(File f);
+    // WFCORE-2223 no longer used
+//    @Message(id = 118, value = "Determined modules directory does not exist: %s")
+//    IllegalStateException modulesDirectoryDoesNotExist(File f);
 
     @Message(id = 119, value = "Home directory does not exist: %s")
     IllegalStateException homeDirectoryDoesNotExist(File f);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2223

The only use of this system property is to drive the value of a deprecated attribute in the core-service=[server|host]-environment resource. There is no good reason to validate it and doing so breaks some embedded use cases.