### PR TITLE
[WFCORE-2231] Deprecate the 'realm' attribute for 'role-mapping' definitions.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/PrincipalResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/PrincipalResourceDefinition.java
@@ -25,6 +25,7 @@ package org.jboss.as.domain.management.access;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXCLUDE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE;
 
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -56,7 +57,7 @@ public class PrincipalResourceDefinition extends SimpleResourceDefinition {
             ModelType.STRING, false).setValidator(new EnumValidator<>(Type.class, false, false)).build();
 
     public static final SimpleAttributeDefinition REALM = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.REALM,
-            ModelType.STRING, true).build();
+            ModelType.STRING, true).setDeprecated(ModelVersion.create(5)).build();
 
     public static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.NAME,
             ModelType.STRING, false).build();

--- a/domain-management/src/main/resources/org/jboss/as/domain/management/_private/LocalDescriptions.properties
+++ b/domain-management/src/main/resources/org/jboss/as/domain/management/_private/LocalDescriptions.properties
@@ -87,7 +87,7 @@ core.access-control.role-mapping.principal.add=Add a new principal to role mappi
 core.access-control.role-mapping.principal.remove=Remove an existing principal to role mapping.
 core.access-control.role-mapping.principal.type=The type of the Principal being mapped, either 'group' or 'user'.
 core.access-control.role-mapping.principal.realm=An optional attribute to map based on the realm used for authentication.
-core.access-control.role-mapping.principal.realm.deprecated=This attribute is no longer used once migrated to Elytron based security.
+core.access-control.role-mapping.principal.realm.deprecated=This attribute is no longer used once management security is migrated to Elytron based security.
 core.access-control.role-mapping.principal.name=The name of the user or group being mapped.
 
 core.identity=Identity definition for management actions.

--- a/domain-management/src/main/resources/org/jboss/as/domain/management/_private/LocalDescriptions.properties
+++ b/domain-management/src/main/resources/org/jboss/as/domain/management/_private/LocalDescriptions.properties
@@ -87,6 +87,7 @@ core.access-control.role-mapping.principal.add=Add a new principal to role mappi
 core.access-control.role-mapping.principal.remove=Remove an existing principal to role mapping.
 core.access-control.role-mapping.principal.type=The type of the Principal being mapped, either 'group' or 'user'.
 core.access-control.role-mapping.principal.realm=An optional attribute to map based on the realm used for authentication.
+core.access-control.role-mapping.principal.realm.deprecated=This attribute is no longer used once migrated to Elytron based security.
 core.access-control.role-mapping.principal.name=The name of the user or group being mapped.
 
 core.identity=Identity definition for management actions.

--- a/server/src/main/resources/schema/wildfly-config_5_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_5_0.xsd
@@ -4418,6 +4418,8 @@
                 <xs:documentation>
                     <![CDATA[
                         The name of the realm the user used to authenticate.
+
+                        This attribute is deprecated and should not be used once management security is migrated to WildFly Elytron. 
                     ]]>
                 </xs:documentation>
             </xs:annotation>


### PR DESCRIPTION
:bangbang: Commits from this branch are used in numerous other topic branches so please do not cherry-pick or rebase. :bangbang:

https://issues.jboss.org/browse/WFCORE-2231