### PR TITLE
[WFCORE-2230] Associate the SecurityRealm name with the Principal of the SecurityIdentity for legacy realm integration and use for role mapping.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/access/Caller.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/Caller.java
@@ -23,6 +23,7 @@
 package org.jboss.as.controller.access;
 
 import java.security.Permission;
+import java.security.Principal;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -31,6 +32,7 @@ import java.util.stream.StreamSupport;
 import javax.security.auth.Subject;
 
 import org.jboss.as.controller.security.ControllerPermission;
+import org.jboss.as.core.security.api.RealmPrincipal;
 import org.wildfly.security.auth.server.SecurityIdentity;
 
 /**
@@ -83,11 +85,17 @@ public final class Caller {
      * @return The name of the realm used for authentication.
      */
     public String getRealm() {
-        if (UNDEFINED.equals(realm) && securityIdentity!= null && securityIdentity.getAttributes().size("realm") > 0) {
-            realm = securityIdentity.getAttributes().get("realm", 0);
+        if (UNDEFINED.equals(realm)) {
+            Principal principal = securityIdentity.getPrincipal();
+            String realm = null;
+            if (principal instanceof RealmPrincipal) {
+                realm = ((RealmPrincipal)principal).getRealm();
+            }
+            this.realm = realm;
+
         }
 
-        return realm;
+        return this.realm;
     }
 
     /**

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmService.java
@@ -183,7 +183,7 @@ public class SecurityRealmService implements Service<SecurityRealm>, SecurityRea
                 // If additional configuration is added it needs to be added to the duplication for Kerberos authentication for both HTTP and SASL below.
                 configurationMap.put(mechanism,
                         MechanismConfiguration.builder()
-                            .setPreRealmRewriter(currentService.getPrincipalMapper())
+                            .setPreRealmRewriter(currentService.getPrincipalMapper().andThen(p -> new RealmUser(this.name, p.getName())))
                             .setRealmMapper((p, e) -> mechanism.toString())
                             .addMechanismRealm(MechanismRealmConfiguration.builder().setRealmName(name).build())
                             .build());

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/WhoAmIOperation.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/WhoAmIOperation.java
@@ -25,10 +25,12 @@ package org.jboss.as.domain.management.security;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.ATTRIBUTES;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.IDENTITY;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.MAPPED_ROLES;
+import static org.jboss.as.domain.management.ModelDescriptionConstants.REALM;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.ROLES;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.USERNAME;
 import static org.jboss.as.domain.management.ModelDescriptionConstants.WHOAMI;
 
+import java.security.Principal;
 import java.util.Set;
 
 import org.jboss.as.controller.OperationContext;
@@ -41,6 +43,7 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.access.Authorizer;
 import org.jboss.as.controller.access.rbac.RunAsRoleMapper;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.core.security.api.RealmPrincipal;
 import org.jboss.as.domain.management.ModelDescriptionConstants;
 import org.jboss.as.domain.management.logging.DomainManagementLogger;
 import org.jboss.dmr.ModelNode;
@@ -93,12 +96,14 @@ public class WhoAmIOperation implements OperationStepHandler {
 
         ModelNode result = context.getResult();
         ModelNode identity = result.get(IDENTITY);
-        identity.get(USERNAME).set(securityIdentity.getPrincipal().getName());
-        // TODO Elytron - We don't currently expose the equivalent of a realm.
-        //String realm = caller.getRealm();
-        //if (realm != null) {
-        //    identity.get(REALM).set(realm);
-        //}
+        Principal principal = securityIdentity.getPrincipal();
+        identity.get(USERNAME).set(principal.getName());
+        if (principal instanceof RealmPrincipal) {
+            String realm = ((RealmPrincipal)principal).getRealm();
+            if (realm != null) {
+                identity.get(REALM).set(realm);
+            }
+        }
 
         if (verbose) {
             Roles roles = securityIdentity.getRoles();


### PR DESCRIPTION
:bangbang: Commits from this branch are used in numerous other topic branches so please do not cherry-pick or rebase. :bangbang:

https://issues.jboss.org/browse/WFCORE-2230