### PR TITLE
Fix for WFCORE-2223, removed check of jboss.modules.dir value.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -406,8 +406,6 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
             File tmp = getFileFromProperty(MODULES_DIR, props);
             if (tmp == null) {
                 tmp = new File(homeDir, "modules");
-            } else if (!tmp.exists() || !tmp.isDirectory()) {
-                throw ServerLogger.ROOT_LOGGER.modulesDirectoryDoesNotExist(tmp);
             }
             modulesDir = tmp;
 

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -770,9 +770,6 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 117, value = "Unable to initialise a basic SSLContext '%s'")
     IllegalStateException unableToInitialiseSSLContext(String message);
 
-    @Message(id = 118, value = "Determined modules directory does not exist: %s")
-    IllegalStateException modulesDirectoryDoesNotExist(File f);
-
     @Message(id = 119, value = "Home directory does not exist: %s")
     IllegalStateException homeDirectoryDoesNotExist(File f);
 


### PR DESCRIPTION
Trivial removal of jboss.modules.dir value check. This fix allows to start multiple embedded server in CLI  from a JBOSS home not containing modules directory (JBOSS_MODULEPATH being set).
No unit tests added. Manual testing.
