### PR TITLE
[WFCORE-2203]: Outcome from /host=x/server-config=y:remove() operation in managed domain with multiple hosts lists out all the steps in result

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1368,4 +1368,7 @@ public interface HostControllerLogger extends BasicLogger {
     @LogMessage(level = Level.ERROR)
     @Message(id = 200, value = "Reporting instability of server '%s' to Domain Controller failed.")
     void failedReportingServerInstabilityToMaster(@Cause Exception e, String serverName);
+
+    @Message(id = 201, value = "Error synchronizing the host model with the domain controller model with failure : %s.")
+    String hostDomainSynchronizationError(String failureDescription);
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SlaveSynchronizationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SlaveSynchronizationTestCase.java
@@ -1,0 +1,208 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STOP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.extension.ExtensionSetup;
+import org.jboss.as.test.integration.domain.management.util.DomainControllerClientConfig;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.domain.management.util.WildFlyManagedConfiguration;
+import org.jboss.as.test.integration.management.extension.error.ErrorExtension;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class SlaveSynchronizationTestCase {
+    private static final Logger log = Logger.getLogger(SlaveSynchronizationTestCase.class.getName());
+
+    private static DomainClient masterClient;
+
+    private static String[] HOSTS = new String[] {"master", "hc1", "hc2"};
+    private static int[] MGMT_PORTS = new int[] {9999, 9989, 19999};
+    private static final String masterAddress = System.getProperty("jboss.test.host.master.address");
+    private static final String slaveAddress = System.getProperty("jboss.test.host.slave.address");
+
+    private static final ModelNode hc1RemovedServer = new ModelNode();
+    private static final ModelNode hc2RemovedServer = new ModelNode();
+    private static final ModelNode hc1RemovedServerConfig = new ModelNode();
+    private static final ModelNode hc2RemovedServerConfig = new ModelNode();
+
+    static {
+        hc1RemovedServerConfig.add("host", "hc1");
+        hc1RemovedServerConfig.add("server-config", "server-one");
+        hc1RemovedServer.add("host", "hc1");
+        hc1RemovedServer.add("server", "server-one");
+        hc2RemovedServerConfig.add("host", "hc1");
+        hc2RemovedServerConfig.add("server-config", "server-two");
+        hc2RemovedServer.add("host", "hc1");
+        hc2RemovedServer.add("server", "server-two");
+    }
+
+    private static DomainControllerClientConfig domainControllerClientConfig;
+    private static DomainLifecycleUtil[] hostUtils = new DomainLifecycleUtil[3];
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        DomainTestSupport testSupport = DomainTestSupport.create(
+                        DomainTestSupport.Configuration.create(SlaveSynchronizationTestCase.class.getSimpleName(), "domain-configs/domain-synchronization.xml", "host-configs/host-synchronization-master.xml", "host-configs/host-synchronization-hc2.xml"));
+        ExtensionSetup.initializeErrorExtension(testSupport);
+        testSupport = null;
+        domainControllerClientConfig = DomainControllerClientConfig.create();
+        for (int k = 0; k < HOSTS.length; k++) {
+            hostUtils[k] = new DomainLifecycleUtil(getHostConfiguration(k), domainControllerClientConfig);
+            hostUtils[k].start();
+        }
+        masterClient = hostUtils[0].createDomainClient();
+                ModelNode addSubsystem = Util.createAddOperation(PathAddress.pathAddress(
+                PathElement.pathElement(PROFILE, "failure"),
+                PathElement.pathElement(SUBSYSTEM, ErrorExtension.SUBSYSTEM_NAME)));
+        DomainTestUtils.executeForResult(addSubsystem, masterClient);
+    }
+
+    @AfterClass
+    public static void shutdownDomain() throws IOException {
+        try {
+            int i = 0;
+            for (; i < hostUtils.length; i++) {
+                try {
+                    hostUtils[i].stop();
+                } catch (Exception e) {
+                    log.error("Failed closing host util " + i, e);
+                }
+            }
+        } finally {
+            if (domainControllerClientConfig != null) {
+                domainControllerClientConfig.close();
+            }
+        }
+    }
+
+    private static WildFlyManagedConfiguration getHostConfiguration(int host) throws Exception {
+        final String testName = SlaveSynchronizationTestCase.class.getSimpleName();
+        File domains = new File("target" + File.separator + "domains" + File.separator + testName);
+        final File hostDir = new File(domains, HOSTS[host]);
+        final File hostConfigDir = new File(hostDir, "configuration");
+        assert hostConfigDir.mkdirs() || hostConfigDir.isDirectory();
+
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        final WildFlyManagedConfiguration hostConfig = new WildFlyManagedConfiguration();
+        hostConfig.setHostControllerManagementAddress(host == 0 ? masterAddress : slaveAddress);
+        hostConfig.setHostCommandLineProperties("-Djboss.test.host.master.address=" + masterAddress + " -Djboss.test.host.slave.address=" + slaveAddress);
+        hostConfig.setHostCommandLineProperties("-D" + ErrorExtension.FAIL_REMOVAL + "=true " +
+                        hostConfig.getHostCommandLineProperties());
+        URL url = tccl.getResource("domain-configs/domain-synchronization.xml");
+        assert url != null;
+        hostConfig.setDomainConfigFile(new File(url.toURI()).getAbsolutePath());
+        url = tccl.getResource("host-configs/host-synchronization-" + HOSTS[host] + ".xml");
+        assert url != null;
+        hostConfig.setHostConfigFile(new File(url.toURI()).getAbsolutePath());
+        hostConfig.setDomainDirectory(hostDir.getAbsolutePath());
+        hostConfig.setHostName(HOSTS[host]);
+        hostConfig.setHostControllerManagementPort(MGMT_PORTS[host]);
+        hostConfig.setStartupTimeoutInSeconds(120);
+        hostConfig.setBackupDC(true);
+        File usersFile = new File(hostConfigDir, "mgmt-users.properties");
+        Files.write(usersFile.toPath(),
+                ("slave=" + new UsernamePasswordHashUtil().generateHashedHexURP("slave", "ManagementRealm", "slave_user_password".toCharArray())+"\n").getBytes(StandardCharsets.UTF_8));
+        StringBuilder modulePath = new StringBuilder();
+        hostConfig.setModulePath(modulePath.append(DomainTestSupport.getAddedModulesDir(testName).getAbsolutePath()).append(File.pathSeparatorChar).append(hostConfig.getModulePath()).toString());
+        return hostConfig;
+    }
+
+    @Test
+    public void testRemoveServer() throws Exception {
+        Assert.assertTrue(exists(masterClient, hc1RemovedServerConfig));
+        Assert.assertTrue(exists(masterClient, hc1RemovedServer));
+        Assert.assertTrue(exists(masterClient, hc2RemovedServerConfig));
+        Assert.assertTrue(exists(masterClient, hc2RemovedServer));
+
+        stopServer(masterClient, hc1RemovedServerConfig);
+        ModelNode result = removeServer(masterClient, hc1RemovedServerConfig);
+        DomainTestSupport.validateResponse(result);
+        Assert.assertFalse(exists(masterClient, hc1RemovedServerConfig));
+        Assert.assertFalse(exists(masterClient, hc1RemovedServer));
+
+        stopServer(masterClient, hc2RemovedServerConfig);
+        result = removeServer(masterClient, hc2RemovedServerConfig);
+        DomainTestSupport.validateFailedResponse(result);
+        Assert.assertTrue(exists(masterClient, hc2RemovedServer));
+        Assert.assertTrue(exists(masterClient, hc2RemovedServerConfig));
+    }
+
+    private ModelNode removeServer(final ModelControllerClient client, final ModelNode address) throws IOException, MgmtOperationException {
+        ModelNode removeServer = new ModelNode();
+        removeServer.get(OP).set(REMOVE);
+        removeServer.get(OP_ADDR).set(address);
+        return client.execute(removeServer);
+    }
+
+    private void stopServer(final ModelControllerClient client, final ModelNode address) throws IOException, MgmtOperationException {
+        final ModelNode stopServer = new ModelNode();
+        stopServer.get(OP_ADDR).set(address);
+        stopServer.get(OP).set(STOP);
+        stopServer.get(BLOCKING).set(true);
+        ModelNode result = client.execute(stopServer);
+        DomainTestSupport.validateResponse(result);
+        Assert.assertEquals("STOPPED", DomainTestUtils.getServerState(masterClient, address));
+    }
+
+    private boolean exists(final ModelControllerClient client, final ModelNode address) throws IOException, MgmtOperationException {
+        PathAddress pathAddress = PathAddress.pathAddress(address);
+        final ModelNode childrenNamesOp = new ModelNode();
+        childrenNamesOp.get(OP).set(READ_CHILDREN_NAMES_OPERATION);
+        childrenNamesOp.get(OP_ADDR).set(pathAddress.getParent().toModelNode());
+        childrenNamesOp.get(CHILD_TYPE).set(pathAddress.getLastElement().getKey());
+        final ModelNode result = DomainTestUtils.executeForResult(childrenNamesOp, client);
+        return result.asList().contains(new ModelNode(pathAddress.getLastElement().getValue()));
+    }
+
+}

--- a/testsuite/domain/src/test/resources/domain-configs/domain-synchronization.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-synchronization.xml
@@ -1,0 +1,125 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<domain xmlns="urn:jboss:domain:5.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <extensions>
+        <extension module="org.jboss.as.logging"/>
+        <extension module="org.wildfly.extension.error-test"/>
+    </extensions>
+
+    <profiles>
+        <profile name="default">
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                </console-handler>
+
+                <periodic-rotating-file-handler name="FILE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                </periodic-rotating-file-handler>
+
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+            </subsystem>
+        </profile>
+        <profile name="failure">
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                </console-handler>
+
+                <periodic-rotating-file-handler name="FILE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                </periodic-rotating-file-handler>
+
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+            </subsystem>
+        </profile>
+    </profiles>
+
+    <!--
+         Named interfaces that can be referenced elsewhere. Different
+         mechanisms for associating an IP address with the interface
+         are shown.
+    -->
+    <interfaces>
+        <interface name="management"/>
+        <interface name="public"/>
+    </interfaces>
+
+    <socket-binding-groups>
+        <socket-binding-group name="standard-sockets" default-interface="public">
+            <socket-binding name="jmx-connector-registry" interface="management" port="1090"/>
+            <socket-binding name="jmx-connector-server" interface="management" port="1091"/>
+            <socket-binding name="remoting" port="4447"/>
+            <socket-binding name="txn-recovery-environment" port="4712"/>
+            <socket-binding name="txn-status-manager" port="4713"/>
+            <socket-binding name="messaging" port="5445" />
+            <socket-binding name="messaging-throughput" port="5455"/>
+            <socket-binding name="http" port="8080"/>
+            <socket-binding name="https" port="8443"/>
+            <outbound-socket-binding name="mail-smtp">
+                <remote-destination host="localhost" port="25"/>
+            </outbound-socket-binding>
+        </socket-binding-group>
+    </socket-binding-groups>
+
+    <server-groups>
+        <server-group name="main-server-group" profile="default">
+            <socket-binding-group ref="standard-sockets"/>
+        </server-group>
+        <server-group name="other-server-group" profile="failure">
+            <socket-binding-group ref="standard-sockets"/>
+        </server-group>
+    </server-groups>
+
+
+</domain>

--- a/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc1.xml
@@ -1,0 +1,83 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<host xmlns="urn:jboss:domain:5.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:5.0 wildfly-config_5_0.xsd"
+      name="hc1">
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                     <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA==" />
+                </server-identities>
+                <authentication>
+                     <local default-user="$local" skip-group-loading="true" />
+                     <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true" />
+                    <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="9989"/>
+            </native-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+        <!-- Remote domain controller configuration with a host and port -->
+        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm" ignore-unused-configuration="true">
+        </remote>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="128m"/>
+            <jvm-options>
+                <option value="-ea"/>
+            </jvm-options>
+        </jvm>
+    </jvms>
+
+    <servers>
+        <server name="server-one" group="main-server-group"/>
+        <server name="server-two" group="other-server-group">
+            <socket-bindings port-offset="150"/>
+        </server>
+    </servers>
+</host>

--- a/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc2.xml
@@ -1,0 +1,83 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<host xmlns="urn:jboss:domain:5.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:5.0 wildfly-config_5_0.xsd"
+      name="hc2">
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                     <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA==" />
+                </server-identities>
+                <authentication>
+                     <local default-user="$local" skip-group-loading="true" />
+                     <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true" />
+                    <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="19999"/>
+            </native-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+        <!-- Remote domain controller configuration with a host and port -->
+        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm" ignore-unused-configuration="true">
+        </remote>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="128m"/>
+            <jvm-options>
+                <option value="-ea"/>
+            </jvm-options>
+        </jvm>
+    </jvms>
+
+    <servers>
+        <server name="server-one" group="main-server-group"/>
+        <server name="server-two" group="other-server-group">
+            <socket-bindings port-offset="150"/>
+        </server>
+    </servers>
+</host>

--- a/testsuite/domain/src/test/resources/host-configs/host-synchronization-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-synchronization-master.xml
@@ -1,0 +1,103 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<host xmlns="urn:jboss:domain:5.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:5.0 wildfly-config_5_0.xsd"
+      name="master">
+
+    <extensions>
+        <extension module="org.jboss.as.jmx"/>
+        <extension module="org.wildfly.extension.core-management"/>
+    </extensions>
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <authentication>
+                     <local default-user="$local" skip-group-loading="true"/>
+                     <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
+                     <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="host-file" formatter="json-formatter" relative-to="jboss.domain.data.dir" path="audit-log.log"/>
+                <file-handler name="server-file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="host-file"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="server-file"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="9999"/>
+            </native-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+       <local/>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.master.address}"/>
+        </interface>
+        <!-- AS7-4177 specify the "public" interface in each server to test that handling -->
+    </interfaces>
+
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="128m"/>
+            <jvm-options>
+                <option value="-ea"/>
+            </jvm-options>
+        </jvm>
+    </jvms>
+
+    <profile>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+            <expose-resolved-model/>
+            <expose-expression-model/>
+            <remoting-connector/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:core-management:1.0">
+        </subsystem>
+    </profile>
+</host>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
@@ -74,8 +74,17 @@ public class DomainTestSupport {
      */
     public static DomainTestSupport createAndStartDefaultSupport(final String testName) {
         try {
-            final Configuration configuration = DomainTestSupport.Configuration.create(testName,
+            final Configuration configuration;
+            if(Boolean.getBoolean("wildfly.master.debug")) {
+                 configuration = DomainTestSupport.Configuration.createDebugMaster(testName,
                     "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
+            } else if (Boolean.getBoolean("wildfly.slave.debug")) {
+                configuration = DomainTestSupport.Configuration.createDebugSlave(testName,
+                    "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
+            } else {
+                configuration = DomainTestSupport.Configuration.create(testName,
+                    "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml");
+            }
             final DomainTestSupport testSupport = DomainTestSupport.create(configuration);
             // Start!
             testSupport.start();
@@ -441,6 +450,15 @@ public class DomainTestSupport {
         public static Configuration create(final String testName, final String domainConfig, final String masterConfig, final String slaveConfig) {
             return create(testName, domainConfig, masterConfig, slaveConfig, false, false, false);
         }
+
+        public static Configuration createDebugMaster(final String testName, final String domainConfig, final String masterConfig, final String slaveConfig) {
+            return create(testName, domainConfig, masterConfig, slaveConfig, false, false, true, false, false);
+        }
+
+        public static Configuration createDebugSlave(final String testName, final String domainConfig, final String masterConfig, final String slaveConfig) {
+            return create(testName, domainConfig, masterConfig, slaveConfig, false, false, false, false, true);
+        }
+
         public static Configuration create(final String testName, final String domainConfig, final String masterConfig,
                                            final String slaveConfig, boolean readOnlyMasterDomain, boolean readOnlyMasterHost, boolean readOnlySlaveHost) {
             return create(testName, domainConfig, masterConfig, slaveConfig, readOnlyMasterDomain, readOnlyMasterHost, false, readOnlySlaveHost, false);


### PR DESCRIPTION
The synchronization model operation after an operation  between the HC and the DC shouldn't use the current operation's response.

Jira: https://issues.jboss.org/browse/WFCORE-2203