### PR TITLE
[WFCORE-1891] / [WFCORE-2240] Elytron module private API flags.

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -53,7 +53,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.as.controller-client"/>
         <module name="org.jboss.as.protocol"/>
-        <module name="org.wildfly.security.elytron" services="import"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
         <module name="org.jboss.as.patching.cli" optional="true" services="import"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
@@ -39,7 +39,7 @@
         <module name="org.jboss.as.core-security"/>
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.version"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.wildfly.common"/>
         <module name="org.jboss.dmr" export="true"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-scanner/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-scanner/main/module.xml
@@ -45,7 +45,7 @@
         <module name="org.jboss.threads"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.wildfly.common"/>
-        <module name="org.wildfly.security.elytron" />
+        <module name="org.wildfly.security.elytron-private" />
         <module name="org.jboss.as.server" />
         <module name="org.jboss.as.deployment-repository"/>
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
@@ -37,7 +37,7 @@
 
     <dependencies>
         <module name="io.undertow.core"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.controller"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-management/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-management/main/module.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <module name="org.wildfly.openssl" />
         <module name="org.wildfly.common" />
-        <module name="org.wildfly.security.elytron" />
+        <module name="org.wildfly.security.elytron-private" />
         <module name="org.jboss.as.controller" />
         <module name="org.jboss.as.core-security"/>
         <module name="org.jboss.logging" />

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
@@ -59,7 +59,7 @@
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.remoting"/>
         <module name="org.wildfly.common"/>
-        <module name="org.wildfly.security.elytron" services="import"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
         <module name="org.jboss.as.server" services="import"/>
         <module name="org.jboss.as.version"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
@@ -44,7 +44,7 @@
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.remoting" />
         <module name="org.wildfly.common"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.server" />
         <module name="org.jboss.remoting" />
         <module name="org.jboss.msc"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
@@ -35,7 +35,7 @@
         <module name="javax.api"/>
         <module name="org.apache.log4j"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.msc"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
@@ -33,7 +33,7 @@
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.wildfly.common"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging" />

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/patching/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/patching/main/module.xml
@@ -42,6 +42,6 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.wildfly.common"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/platform-mbean/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/platform-mbean/main/module.xml
@@ -39,7 +39,7 @@
         <module name="javax.api"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.controller-client"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/process-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/process-controller/main/module.xml
@@ -40,7 +40,7 @@
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="org.wildfly.security.elytron" services="import"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
         <module name="org.wildfly.common"/>
         <module name="org.jboss.as.version" export="true"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
@@ -42,6 +42,6 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.remoting"/>
         <module name="org.jboss.threads"/>
-        <module name="org.wildfly.security.elytron" />
+        <module name="org.wildfly.security.elytron-private" />
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
@@ -43,7 +43,7 @@
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.server"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.security" optional="true"/>
         <module name="org.jboss.as.threads"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -86,7 +86,7 @@
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.self-contained" optional="true"/>
-        <module name="org.wildfly.security.elytron" services="import"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
         <module name="org.jboss.as.security" optional="true" services="import"/>
         <module name="org.jboss.as.version"/>
         <module name="org.picketbox" optional="true"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
@@ -57,6 +57,6 @@
         <module name="org.jboss.as.jmx" services="import"/>
         <module name="org.jboss.as.server" export="true"/>
         <module name="org.jboss.vfs" services="import"/>
-        <module name="org.wildfly.security.elytron" services="import"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/threads/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/threads/main/module.xml
@@ -34,7 +34,7 @@
     <dependencies>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting-jmx/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting-jmx/main/module.xml
@@ -31,7 +31,7 @@
         <module name="javax.api"/>
         <module name="org.jboss.remoting"/>
         <module name="org.jboss.logging"/>
-        <module name="org.wildfly.security.elytron" services="import"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.client.config"/>
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
@@ -34,7 +34,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.xnio" export="true"/>
         <module name="org.jboss.xnio.nio" services="import"/>
-        <module name="org.wildfly.security.elytron" services="import"/>
+        <module name="org.wildfly.security.elytron-private" services="import"/>
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.client.config"/>
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/embedded/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/embedded/main/module.xml
@@ -38,7 +38,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.wildfly.common"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.controller"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
@@ -42,7 +42,7 @@
         <module name="sun.jdk"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.security" optional="true"/>
         <module name="org.jboss.msc"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/request-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/request-controller/main/module.xml
@@ -42,7 +42,7 @@
         <module name="sun.jdk"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.security" optional="true"/>
         <module name="org.jboss.msc"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,22 +21,31 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.invocation">
-
+<module xmlns="urn:jboss:module:1.5" name="org.wildfly.security.elytron-private">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
+    <exports>
+        <exclude path="org/wildfly/security/_private"/>
+        <exclude path="org/wildfly/security/manager/_private"/>
+        <exclude path="org/wildfly/security/sasl/digest/_private"/>
+        <exclude path="org/wildfly/security/util/_private"/>
+    </exports>
+
     <resources>
-        <artifact name="${org.jboss.invocation:jboss-invocation}"/>
+        <artifact name="${org.wildfly.security:wildfly-elytron}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.interceptor.api"/>
-        <module name="org.jboss.classfilewriter"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.marshalling"/>
-        <module name="org.wildfly.security.elytron-private"/>
+        <module name="org.jboss.modules"/>
+        <module name="org.jboss.threads"/>
+        <module name="javax.api" />
+        <module name="javax.json.api" optional="true"/>
+        <module name="javax.security.jacc.api" optional="true"/>
+        <module name="sun.jdk"/>
+        <module name="org.wildfly.common"/>
+        <module name="org.wildfly.client.config"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server/main/module.xml
@@ -32,7 +32,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.wildfly.security.elytron"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="io.undertow.core"/>
         <module name="org.wildfly.common" />
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server/main/module.xml
@@ -23,6 +23,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.5" name="org.wildfly.security.elytron-web.undertow-server">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <resources>
         <artifact name="${org.wildfly.security.elytron-web:undertow-server}"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
@@ -67,6 +67,6 @@
     -->
 
     <dependencies>
-        <module name="org.wildfly.security.elytron-private" export="true"/>
+        <module name="org.wildfly.security.elytron-private" services="export" export="true"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -24,26 +24,49 @@
 
 <module xmlns="urn:jboss:module:1.5" name="org.wildfly.security.elytron">
 
+    <!--
     <exports>
-        <exclude path="org/wildfly/security/_private"/>
-        <exclude path="org/wildfly/security/manager/_private"/>
-        <exclude path="org/wildfly/security/sasl/digest/_private"/>
-        <exclude path="org/wildfly/security/util/_private"/>
+        <exclude path="org/wildfly/security/asn1"/>
+        <exclude path="org/wildfly/security/auth/realm"/>
+        <exclude path="org/wildfly/security/auth/realm/jdbc"/>
+        <exclude path="org/wildfly/security/auth/realm/jdbc/mapper"/>
+        <exclude path="org/wildfly/security/auth/realm/ldap"/>
+        <exclude path="org/wildfly/security/auth/realm/token"/>
+        <exclude path="org/wildfly/security/auth/realm/token/validator"/>
+        <exclude path="org/wildfly/security/authz/jacc"/>
+        <exclude path="org/wildfly/security/cache"/>
+        <exclude path="org/wildfly/security/credential/store/impl"/>
+        <exclude path="org/wildfly/security/digest"/>
+        <exclude path="org/wildfly/security/http/impl"/>
+        <exclude path="org/wildfly/security/http/util/sso"/>
+        <exclude path="org/wildfly/security/keystore"/>
+        <exclude path="org/wildfly/security/mechanism/digest"/>
+        <exclude path="org/wildfly/security/mechanism/oauth2"/>
+        <exclude path="org/wildfly/security/mechanism/scram"/>
+        <exclude path="org/wildfly/security/password/impl"/>
+        <exclude path="org/wildfly/security/password/util"/>
+        <exclude path="org/wildfly/security/pem"/>
+        <exclude path="org/wildfly/security/sasl"/>
+        <exclude path="org/wildfly/security/sasl/anonymous"/>
+        <exclude path="org/wildfly/security/sasl/digest"/>
+        <exclude path="org/wildfly/security/sasl/digest_private"/>
+        <exclude path="org/wildfly/security/sasl/entity"/>
+        <exclude path="org/wildfly/security/sasl/external"/>
+        <exclude path="org/wildfly/security/sasl/gs2"/>
+        <exclude path="org/wildfly/security/sasl/gssapi"/>
+        <exclude path="org/wildfly/security/sasl/localuser"/>
+        <exclude path="org/wildfly/security/sasl/oauth2"/>
+        <exclude path="org/wildfly/security/sasl/otp"/>
+        <exclude path="org/wildfly/security/sasl/plain"/>
+        <exclude path="org/wildfly/security/sasl/scram"/>
+        <exclude path="org/wildfly/security/util"/>
+        <exclude path="org/wildfly/security/util_private"/>
+        <exclude path="org/wildfly/security/x500"/>
+        <exclude path="org/wildfly/security/x500/cert"/>
     </exports>
-
-    <resources>
-        <artifact name="${org.wildfly.security:wildfly-elytron}"/>
-    </resources>
+    -->
 
     <dependencies>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.modules"/>
-        <module name="org.jboss.threads"/>
-        <module name="javax.api" />
-        <module name="javax.json.api" optional="true"/>
-        <module name="javax.security.jacc.api" optional="true"/>
-        <module name="sun.jdk"/>
-        <module name="org.wildfly.common"/>
-        <module name="org.wildfly.client.config"/>
+        <module name="org.wildfly.security.elytron-private" export="true"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/manager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/manager/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <dependencies>
-        <module name="org.wildfly.security.elytron" export="true">
+        <module name="org.wildfly.security.elytron-private" export="true">
             <exports>
                 <include-set>
                     <path name="org/wildfly/security/manager"/>


### PR DESCRIPTION
:bangbang: Commits from this branch are used in numerous other topic branches so please do not cherry-pick or rebase. :bangbang:

:warning: The excludes in the elytron module are currently commented out, this is to allow time for Wildfly to be updated to a core release containing these changes so module references in wildfly can be updated and then the filtering can be applied.

This PR resolves: -
  https://issues.jboss.org/browse/WFCORE-2240

The following issue should be left open so the second stage of change can be applied: -
  https://issues.jboss.org/browse/WFCORE-1891