### PR TITLE
[WFCORE-2253] Fix attributes that have a default value but also say the user must configure them

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinitionBuilder.java
@@ -62,7 +62,7 @@ public class SimpleAttributeDefinitionBuilder extends AbstractAttributeDefinitio
         ModelType type = node.get(ModelDescriptionConstants.TYPE).asType();
         boolean nillable = node.get(ModelDescriptionConstants.NILLABLE).asBoolean(true);
         boolean expressionAllowed = node.get(ModelDescriptionConstants.EXPRESSIONS_ALLOWED).asBoolean(false);
-        ModelNode defaultValue = node.get(ModelDescriptionConstants.DEFAULT);
+        ModelNode defaultValue = nillable ? node.get(ModelDescriptionConstants.DEFAULT) : new ModelNode();
         return SimpleAttributeDefinitionBuilder.create(name, type, nillable)
                 .setDefaultValue(defaultValue)
                 .setAllowExpression(expressionAllowed);

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalInstallationReportHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalInstallationReportHandler.java
@@ -113,8 +113,7 @@ public class GlobalInstallationReportHandler extends GlobalOperationHandlers.Abs
             SimpleAttributeDefinitionBuilder.create(HOSTNAME, ModelType.STRING, true).build(),
             SimpleAttributeDefinitionBuilder.create(INSTANCE_ID, ModelType.STRING, true).build(),
             SimpleAttributeDefinitionBuilder.create(PRODUCT_NAME, ModelType.STRING, true).build(),
-            SimpleAttributeDefinitionBuilder.create(PRODUCT_COMMUNITY_IDENTIFIER, ModelType.STRING, false)
-                    .setDefaultValue(new ModelNode(PROJECT_TYPE))
+            SimpleAttributeDefinitionBuilder.create(PRODUCT_COMMUNITY_IDENTIFIER, ModelType.STRING)
                     .setAllowedValues(PRODUCT_TYPE, PROJECT_TYPE).build(),
             SimpleAttributeDefinitionBuilder.create(PRODUCT_VERSION, ModelType.STRING, true).build(),
             SimpleAttributeDefinitionBuilder.create(PRODUCT_HOME, ModelType.STRING, true).build(),

--- a/controller/src/test/java/org/jboss/as/controller/PropertiesAttributeDefinitionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/PropertiesAttributeDefinitionUnitTestCase.java
@@ -39,7 +39,7 @@ public class PropertiesAttributeDefinitionUnitTestCase {
         ModelNode defaultValue = new ModelNode();
         defaultValue.add("key","value");
         defaultValue.add("key2","value");
-        PropertiesAttributeDefinition ld = new PropertiesAttributeDefinition.Builder("test", false)
+        PropertiesAttributeDefinition ld = new PropertiesAttributeDefinition.Builder("test", true)
                 .setAllowExpression(true)
                 .setDefaultValue(defaultValue)
                 .build();

--- a/controller/src/test/java/org/jboss/as/controller/StringListAttributeDefinitionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/StringListAttributeDefinitionUnitTestCase.java
@@ -35,6 +35,7 @@ import org.junit.Test;
  */
 public class StringListAttributeDefinitionUnitTestCase {
     static final StringListAttributeDefinition LIST_DEFINITION = new StringListAttributeDefinition.Builder("test")
+            .setRequired(false)
             .setAllowExpression(true)
             .setElementValidator(new StringLengthValidator(1, false, true))
             .setDefaultValue(new ModelNode().add("element1").add("element2"))

--- a/controller/src/test/java/org/jboss/as/controller/notification/GlobalNotificationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/notification/GlobalNotificationsTestCase.java
@@ -70,18 +70,22 @@ import org.junit.Test;
  */
 public class GlobalNotificationsTestCase extends AbstractControllerTestBase {
 
-    public static final SimpleAttributeDefinition MY_ATTRIBUTE = create("my-attribute", LONG, true)
+    public static final SimpleAttributeDefinition MY_ATTRIBUTE = create("my-attribute", LONG)
+            .setRequired(false)
             .setDefaultValue(new ModelNode(12345))
             .build();
     public static final SimpleAttributeDefinition MY_RUNTIME_ATTRIBUTE = create("my-runtime-attribute", LONG)
+            .setRequired(false)
             .setDefaultValue(new ModelNode(6789))
             .setAllowNull(true)
             .setStorageRuntime()
             .build();
     public static final SimpleAttributeDefinition FAIL_ADD_OPERATION = create("fail-add-operation", BOOLEAN)
+            .setRequired(false)
             .setDefaultValue(new ModelNode(false))
             .build();
     public static final SimpleAttributeDefinition FAIL_REMOVE_OPERATION = create("fail-remove-operation", BOOLEAN)
+            .setRequired(false)
             .setDefaultValue(new ModelNode(false))
             .build();
 

--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
@@ -1266,7 +1266,8 @@ public class PersistentResourceXMLParserTestCase {
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .build();
 
-            static final SimpleAttributeDefinition USE_RECURSIVE_SEARCH = new SimpleAttributeDefinitionBuilder("use-recursive-search", ModelType.BOOLEAN, false)
+            static final SimpleAttributeDefinition USE_RECURSIVE_SEARCH = new SimpleAttributeDefinitionBuilder("use-recursive-search", ModelType.BOOLEAN)
+                    .setRequired(false)
                     .setDefaultValue(new ModelNode(false))
                     .setAllowExpression(true)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerDefinition.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerDefinition.java
@@ -55,7 +55,6 @@ public class DeploymentScannerDefinition extends SimpleResourceDefinition {
                     .setXmlName(Attribute.NAME.getLocalName())
                     .setAllowExpression(false)
                     .setValidator(new StringLengthValidator(1))
-                    .setDefaultValue(new ModelNode().set(DeploymentScannerExtension.DEFAULT_SCANNER_NAME))
                     .build();
 
     protected static final SimpleAttributeDefinition PATH =

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelNonProgressingOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelNonProgressingOperationHandler.java
@@ -57,7 +57,8 @@ import org.jboss.dmr.ModelType;
  */
 public class CancelNonProgressingOperationHandler implements OperationStepHandler {
 
-    private static final AttributeDefinition STABILITY_TIMEOUT = SimpleAttributeDefinitionBuilder.create("timeout", ModelType.INT, false)
+    private static final AttributeDefinition STABILITY_TIMEOUT = SimpleAttributeDefinitionBuilder.create("timeout", ModelType.INT)
+            .setRequired(false)
             .setDefaultValue(new ModelNode(15))
             .setValidator(new IntRangeValidator(0, true))
             .setMeasurementUnit(MeasurementUnit.SECONDS)

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/FindNonProgressingOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/FindNonProgressingOperationHandler.java
@@ -64,7 +64,8 @@ import org.jboss.dmr.ModelType;
  */
 public class FindNonProgressingOperationHandler implements OperationStepHandler {
 
-    private static final AttributeDefinition STABILITY_TIMEOUT = SimpleAttributeDefinitionBuilder.create("timeout", ModelType.INT, false)
+    private static final AttributeDefinition STABILITY_TIMEOUT = SimpleAttributeDefinitionBuilder.create("timeout", ModelType.INT)
+            .setRequired(false)
             .setDefaultValue(new ModelNode(15))
             .setValidator(new IntRangeValidator(0, true))
             .setMeasurementUnit(MeasurementUnit.SECONDS)

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/UserSearchResourceDefintion.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/UserSearchResourceDefintion.java
@@ -43,7 +43,8 @@ import org.jboss.dmr.ModelType;
  */
 public class UserSearchResourceDefintion extends BaseLdapUserSearchResource {
 
-    public static final SimpleAttributeDefinition ATTRIBUTE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ATTRIBUTE, ModelType.STRING, false)
+    public static final SimpleAttributeDefinition ATTRIBUTE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ATTRIBUTE, ModelType.STRING)
+            .setRequired(false)
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, false))
             .setDefaultValue(new ModelNode("uid"))
             .setAllowExpression(true)

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerResourceDefinition.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerResourceDefinition.java
@@ -207,6 +207,7 @@ public class ModelControllerResourceDefinition extends SimpleResourceDefinition 
                 .setAllowExpression(allowExpressions)
                 .build();
         final SimpleAttributeDefinition param4 = new SimpleAttributeDefinitionBuilder("param4", ModelType.INT)
+                .setRequired(false)
                 .setDefaultValue(new ModelNode(6))
                         //.setValidator(new IntRangeValidator(5,10,true,false)) //todo expressions & min/max dont match well WFLY-3500
                 .setAllowExpression(allowExpressions)

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CommonAttributes.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/CommonAttributes.java
@@ -60,17 +60,20 @@ class CommonAttributes {
             .setAllowNull(false)
             .build();
 
-    static final SimpleAttributeDefinition MAX_DEPTH = new SimpleAttributeDefinitionBuilder(PlatformMBeanConstants.MAX_DEPTH, ModelType.INT, false)
+    static final SimpleAttributeDefinition MAX_DEPTH = new SimpleAttributeDefinitionBuilder(PlatformMBeanConstants.MAX_DEPTH, ModelType.INT)
+            .setRequired(false)
             .setDefaultValue(new ModelNode(0))
             .setMinSize(1)
             .build();
 
 
-    static final SimpleAttributeDefinition LOCKED_MONITORS_FLAG = new SimpleAttributeDefinitionBuilder(PlatformMBeanConstants.LOCKED_MONITORS, ModelType.BOOLEAN, false)
+    static final SimpleAttributeDefinition LOCKED_MONITORS_FLAG = new SimpleAttributeDefinitionBuilder(PlatformMBeanConstants.LOCKED_MONITORS, ModelType.BOOLEAN)
+            .setRequired(false)
             .setDefaultValue(new ModelNode(false))
             .build();
 
-    static final SimpleAttributeDefinition LOCKED_SYNCHRONIZERS_FLAG = new SimpleAttributeDefinitionBuilder(PlatformMBeanConstants.LOCKED_SYNCHRONIZERS, ModelType.BOOLEAN, false)
+    static final SimpleAttributeDefinition LOCKED_SYNCHRONIZERS_FLAG = new SimpleAttributeDefinitionBuilder(PlatformMBeanConstants.LOCKED_SYNCHRONIZERS, ModelType.BOOLEAN)
+            .setRequired(false)
             .setDefaultValue(new ModelNode(false))
             .build();
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2253

No transformers required. Attributes are either not related to domain wide resources or for the two that are, the fix is to remove meaningless default values