### PR TITLE
WFCORE-2160 - Incorrect JBOSS_HOME warning in vault.sh

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/vault.sh
+++ b/core-feature-pack/src/main/resources/content/bin/vault.sh
@@ -53,7 +53,7 @@ if [ "x$JBOSS_HOME" = "x" ]; then
     JBOSS_HOME=$RESOLVED_JBOSS_HOME
 else
  SANITIZED_JBOSS_HOME=`cd "$JBOSS_HOME"; pwd`
- if [ "$RESOLVED_JBOSS" != "$SANITIZED_JBOSS_HOME" ]; then
+ if [ "$RESOLVED_JBOSS_HOME" != "$SANITIZED_JBOSS_HOME" ]; then
    echo "WARNING JBOSS_HOME may be pointing to a different installation - unpredictable results may occur."
    echo ""
  fi


### PR DESCRIPTION
Issue: [JBEAP-8135](https://issues.jboss.org/browse/JBEAP-8135)
Upstream Issue: [WFCORE-2160](https://issues.jboss.org/browse/WFCORE-2160)

No upstream PR required.