### PR TITLE
Fix for WFCORE-2250. Random insane tty caused by aesh console running…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.fusesource.jansi>1.11</version.org.fusesource.jansi>
-        <version.org.jboss.aesh>0.66.13</version.org.jboss.aesh>
+        <version.org.jboss.aesh>0.66.14</version.org.jboss.aesh>
         <version.org.jboss.byteman>3.0.6</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.1.2.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.0.Beta1</version.org.jboss.invocation>


### PR DESCRIPTION
Updated dependency to aesh 0.66.14
No unit test, manual testing of CTRL-C.