### PR TITLE
[WFCORE-2270] Only allow a single registration of a runtime (not 'possible') capabi…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
@@ -151,14 +151,8 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
             RegistrationPoint rp = capabilityRegistration.getOldestRegistrationPoint();
             RuntimeCapabilityRegistration currentRegistration = capabilities.get(capabilityId);
             if (currentRegistration != null) {
-                // The actual capability must be the same, and we must not already have a registration
-                // from this resource
-                if (!Objects.equals(capabilityRegistration.getCapability(), currentRegistration.getCapability())
-                        || !currentRegistration.addRegistrationPoint(rp)) {
-                    throw ControllerLogger.MGMT_OP_LOGGER.capabilityAlreadyRegisteredInContext(capabilityId.getName(),
-                            capabilityId.getScope().getName());
-                }
-                // else it was ok, and we just recorded the additional registration point
+                throw ControllerLogger.MGMT_OP_LOGGER.capabilityAlreadyRegisteredInContext(capabilityId.getName(),
+                            rp, capabilityId.getScope().getName(), currentRegistration.getRegistrationPoints());
             } else {
                 capabilities.put(capabilityId, capabilityRegistration);
             }

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/RegistrationPoint.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/RegistrationPoint.java
@@ -58,4 +58,13 @@ public class RegistrationPoint {
     public String getAttribute() {
         return attribute;
     }
+
+    @Override
+    public String toString() {
+        if (attribute == null) {
+            return address.toString();
+        } else {
+            return "address=" + address.toString() +";attribute=" + attribute;
+        }
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -54,6 +54,7 @@ import org.jboss.as.controller.UnauthorizedException;
 import org.jboss.as.controller._private.OperationCancellationException;
 import org.jboss.as.controller._private.OperationFailedRuntimeException;
 import org.jboss.as.controller.access.rbac.UnknowRoleException;
+import org.jboss.as.controller.capability.registry.RegistrationPoint;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.interfaces.InterfaceCriteria;
 import org.jboss.as.controller.notification.Notification;
@@ -3417,9 +3418,9 @@ public interface ControllerLogger extends BasicLogger {
      * A message indicating the {@code value} parameter is invalid and must have a maximum bytes length, represented by the
      * {@code length} parameter.
      *
-     * @param value the invalid value.
-     * @param name the name of the parameter.
-     * @param length the maximum length.
+     * @param str the invalid value.
+     * @param parameterName the name of the parameter.
+     * @param max the maximum length.
      *
      * @return the message.
      */
@@ -3489,4 +3490,9 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = NONE, value = "Couldn't convert %s to %s")
     String typeConversionError(ModelNode value, Collection<ModelType> validTypes);
+
+    @Message(id = 436, value = "Cannot register capability '%s' at location '%s' as it is already registered in " +
+            "context '%s' at location(s) '%s'")
+    OperationFailedRuntimeException capabilityAlreadyRegisteredInContext(String capability, RegistrationPoint newPoint,
+                                                                         String context,Set<RegistrationPoint> oldPoints);
 }

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
@@ -436,9 +436,19 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
         ModelNode addOp4 = createOperation(ADD, TEST_ADDRESS4);
         addOp4.get("test").set("some test value");
         addOp4.get("other").set("other value");
+        executeCheckForFailure(addOp4); // Should rollback due to conflict with TEST_RESOURCE1
+        Assert.assertEquals(2, capabilityRegistry.getCapabilities().size());
+
+        // Remove the conflict
+        executeCheckNoFailure(createOperation(REMOVE, TEST_ADDRESS1));
+        Assert.assertEquals(0, capabilityRegistry.getCapabilities().size());
+
+        addOp4 = createOperation(ADD, TEST_ADDRESS4);
+        addOp4.get("test").set("some test value");
+        addOp4.get("other").set("other value");
         addOp4.get("fail").set("true");
-        executeCheckForFailure(addOp4); //Rollbacking
-        Assert.assertEquals(2, capabilityRegistry.getCapabilities().size()); //Should remove the new RegistrationPoints
+        executeCheckForFailure(addOp4); // Op designed to roll back
+        Assert.assertEquals(0, capabilityRegistry.getCapabilities().size()); //Should remove the new RegistrationPoints
 
         addOp4 = createOperation(ADD, TEST_ADDRESS4);
         addOp4.get("test").set("some test value");
@@ -447,8 +457,6 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
         Assert.assertEquals(2, capabilityRegistry.getCapabilities().size());
 
         executeCheckNoFailure(createOperation(REMOVE, TEST_ADDRESS4));
-        Assert.assertEquals(2, capabilityRegistry.getCapabilities().size());
-        executeCheckNoFailure(createOperation(REMOVE, TEST_ADDRESS1));
         Assert.assertEquals(0, capabilityRegistry.getCapabilities().size());
     }
 


### PR DESCRIPTION
…lity with the same name and scope

This will require updates in full to clean out some subsystem test stuff that does duplicate registration, plus to fix a clustering issue where some items are duplicated.