### PR TITLE
Fix for WFCORE-2268. Returns actual CLI exit code.

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.sh
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.sh
@@ -6,6 +6,8 @@ clean_tty()
     if [ $1 = 137 ]; then
       stty sane
     fi
+    # set the exit status to be the one that has been passed
+    return $1
 }
 
 CLI_OPTS=""


### PR DESCRIPTION
The CLI exit code was lost, returning it.
