### PR TITLE
[WFCORE-2270] Part 1. Make it configurable by the capability designer…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
@@ -151,12 +151,13 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
             RegistrationPoint rp = capabilityRegistration.getOldestRegistrationPoint();
             RuntimeCapabilityRegistration currentRegistration = capabilities.get(capabilityId);
             if (currentRegistration != null) {
-                // The actual capability must be the same, and we must not already have a registration
-                // from this resource
+                // The actual capability must be the same, the capability must allow multiple registrations
+                // and we must not already have a registration from this same resource
                 if (!Objects.equals(capabilityRegistration.getCapability(), currentRegistration.getCapability())
+                        || !currentRegistration.getCapability().isAllowMultipleRegistrations()
                         || !currentRegistration.addRegistrationPoint(rp)) {
                     throw ControllerLogger.MGMT_OP_LOGGER.capabilityAlreadyRegisteredInContext(capabilityId.getName(),
-                            capabilityId.getScope().getName());
+                                rp, capabilityId.getScope().getName(), currentRegistration.getRegistrationPoints());
                 }
                 // else it was ok, and we just recorded the additional registration point
             } else {

--- a/controller/src/main/java/org/jboss/as/controller/capability/RuntimeCapability.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/RuntimeCapability.java
@@ -69,9 +69,15 @@ public class RuntimeCapability<T> extends AbstractCapability  {
         return base.fromBaseCapability(dynamicElement);
     }
 
+    // Default value for allowMultipleRegistrations.
+    // I use this constant because I intend to shortly change the
+    // default and don't want to risk mistake by changing many places
+    private static final boolean ALLOW_MULTIPLE = true;
+
     private final Class<?> serviceValueType;
     private final ServiceName serviceName;
     private final T runtimeAPI;
+    private final boolean allowMultipleRegistrations;
 
     /**
      * Creates a new capability
@@ -88,6 +94,7 @@ public class RuntimeCapability<T> extends AbstractCapability  {
         this.runtimeAPI = runtimeAPI;
         this.serviceValueType = null;
         this.serviceName = null;
+        this.allowMultipleRegistrations = ALLOW_MULTIPLE;
     }
 
     /**
@@ -118,6 +125,7 @@ public class RuntimeCapability<T> extends AbstractCapability  {
         this.runtimeAPI = runtimeAPI;
         this.serviceValueType = null;
         this.serviceName = null;
+        this.allowMultipleRegistrations = ALLOW_MULTIPLE;
     }
 
     /**
@@ -129,6 +137,7 @@ public class RuntimeCapability<T> extends AbstractCapability  {
         this.runtimeAPI = builder.runtimeAPI;
         this.serviceValueType = builder.serviceValueType;
         this.serviceName = ServiceName.parse(builder.baseName);
+        this.allowMultipleRegistrations = builder.allowMultipleRegistrations;
     }
 
     /**
@@ -137,12 +146,14 @@ public class RuntimeCapability<T> extends AbstractCapability  {
     private RuntimeCapability(String baseName, String dynamicElement, Class<?> serviceValueType, T runtimeAPI,
                               Set<String> requirements, Set<String> optionalRequirements,
                               Set<String> runtimeOnlyRequirements, Set<String> dynamicRequirements,
-                              Set<String> dynamicOptionalRequirements) {
+                              Set<String> dynamicOptionalRequirements,
+                              boolean allowMultipleRegistrations) {
         super(buildDynamicCapabilityName(baseName, dynamicElement), false, requirements,
                 optionalRequirements, runtimeOnlyRequirements, dynamicRequirements, dynamicOptionalRequirements);
         this.runtimeAPI = runtimeAPI;
         this.serviceValueType = serviceValueType;
         this.serviceName = dynamicElement == null ? ServiceName.parse(baseName) : ServiceName.parse(baseName).append(dynamicElement);
+        this.allowMultipleRegistrations = allowMultipleRegistrations;
     }
 
     /**
@@ -230,6 +241,17 @@ public class RuntimeCapability<T> extends AbstractCapability  {
     }
 
     /**
+     * Gets whether this capability can be registered at more than one point within the same
+     * overall scope.
+     *
+     * @return {@code true} if the capability can legally be registered in more than one location in the same scope;
+     *         {@code false} if an attempt to do this should result in an exception
+     */
+    public boolean isAllowMultipleRegistrations() {
+        return allowMultipleRegistrations;
+    }
+
+    /**
      * Creates a fully named capability from a {@link #isDynamicallyNamed() dynamically named} base
      * capability. Capability providers should use this method to generate fully named capabilities in logic
      * that handles dynamically named resources.
@@ -245,7 +267,8 @@ public class RuntimeCapability<T> extends AbstractCapability  {
         assert dynamicElement.length() > 0;
         return new RuntimeCapability<T>(getName(), dynamicElement, serviceValueType, runtimeAPI,
                 getRequirements(), getOptionalRequirements(),
-                getRuntimeOnlyRequirements(), getDynamicRequirements(), getDynamicOptionalRequirements());
+                getRuntimeOnlyRequirements(), getDynamicRequirements(), getDynamicOptionalRequirements(),
+                allowMultipleRegistrations);
 
     }
 
@@ -264,6 +287,7 @@ public class RuntimeCapability<T> extends AbstractCapability  {
         private Set<String> runtimeOnlyRequirements;
         private Set<String> dynamicRequirements;
         private Set<String> dynamicOptionalRequirements;
+        private boolean allowMultipleRegistrations = ALLOW_MULTIPLE;
 
         /**
          * Create a builder for a non-dynamic capability with no custom runtime API.
@@ -436,6 +460,19 @@ public class RuntimeCapability<T> extends AbstractCapability  {
                 this.dynamicOptionalRequirements = new HashSet<>(requirements.length);
             }
             Collections.addAll(this.dynamicOptionalRequirements, requirements);
+            return this;
+        }
+
+        /**
+         * Sets whether this capability can be registered at more than one point within the same
+         * overall scope.
+         * @param allowMultipleRegistrations {@code true} if the capability can legally be registered in more than
+         *                                               one location in the same scope; {@code false} if an attempt
+         *                                               to do this should result in an exception
+         * @return the builder
+         */
+        public Builder<T> setAllowMultipleRegistrations(boolean allowMultipleRegistrations) {
+            this.allowMultipleRegistrations = allowMultipleRegistrations;
             return this;
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/RegistrationPoint.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/RegistrationPoint.java
@@ -58,4 +58,13 @@ public class RegistrationPoint {
     public String getAttribute() {
         return attribute;
     }
+
+    @Override
+    public String toString() {
+        if (attribute == null) {
+            return address.toString();
+        } else {
+            return "address=" + address.toString() +";attribute=" + attribute;
+        }
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -54,6 +54,7 @@ import org.jboss.as.controller.UnauthorizedException;
 import org.jboss.as.controller._private.OperationCancellationException;
 import org.jboss.as.controller._private.OperationFailedRuntimeException;
 import org.jboss.as.controller.access.rbac.UnknowRoleException;
+import org.jboss.as.controller.capability.registry.RegistrationPoint;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.interfaces.InterfaceCriteria;
 import org.jboss.as.controller.notification.Notification;
@@ -3417,9 +3418,9 @@ public interface ControllerLogger extends BasicLogger {
      * A message indicating the {@code value} parameter is invalid and must have a maximum bytes length, represented by the
      * {@code length} parameter.
      *
-     * @param value the invalid value.
-     * @param name the name of the parameter.
-     * @param length the maximum length.
+     * @param str the invalid value.
+     * @param parameterName the name of the parameter.
+     * @param max the maximum length.
      *
      * @return the message.
      */
@@ -3489,4 +3490,9 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = NONE, value = "Couldn't convert %s to %s")
     String typeConversionError(ModelNode value, Collection<ModelType> validTypes);
+
+    @Message(id = 436, value = "Cannot register capability '%s' at location '%s' as it is already registered in " +
+            "context '%s' at location(s) '%s'")
+    OperationFailedRuntimeException capabilityAlreadyRegisteredInContext(String capability, RegistrationPoint newPoint,
+                                                                         String context,Set<RegistrationPoint> oldPoints);
 }


### PR DESCRIPTION
… whether to allow multiple registrations of a runtime (not 'possible') capability with the same name and scope

https://issues.jboss.org/browse/WFCORE-2270

In this commit, the default remains 'true', to allow existing cases that need that behavior to still work (see WFLY-8040). However the expectation is those use cases will take advantage of this new API to explicitly configure 'true', and then the default behavior will be switched to 'false' in a later commit.