### PR TITLE
[WFCORE-2270] Part 2 -- Change the default behavior to only allow a single registration of a runtime (not 'possible') capability with the same name and scope

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/capability/RuntimeCapability.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/RuntimeCapability.java
@@ -70,9 +70,7 @@ public class RuntimeCapability<T> extends AbstractCapability  {
     }
 
     // Default value for allowMultipleRegistrations.
-    // I use this constant because I intend to shortly change the
-    // default and don't want to risk mistake by changing many places
-    private static final boolean ALLOW_MULTIPLE = true;
+    private static final boolean ALLOW_MULTIPLE = false;
 
     private final Class<?> serviceValueType;
     private final ServiceName serviceName;

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
@@ -436,9 +436,19 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
         ModelNode addOp4 = createOperation(ADD, TEST_ADDRESS4);
         addOp4.get("test").set("some test value");
         addOp4.get("other").set("other value");
+        executeCheckForFailure(addOp4); // Should rollback due to conflict with TEST_RESOURCE1
+        Assert.assertEquals(2, capabilityRegistry.getCapabilities().size());
+
+        // Remove the conflict
+        executeCheckNoFailure(createOperation(REMOVE, TEST_ADDRESS1));
+        Assert.assertEquals(0, capabilityRegistry.getCapabilities().size());
+
+        addOp4 = createOperation(ADD, TEST_ADDRESS4);
+        addOp4.get("test").set("some test value");
+        addOp4.get("other").set("other value");
         addOp4.get("fail").set("true");
-        executeCheckForFailure(addOp4); //Rollbacking
-        Assert.assertEquals(2, capabilityRegistry.getCapabilities().size()); //Should remove the new RegistrationPoints
+        executeCheckForFailure(addOp4); // Op designed to roll back
+        Assert.assertEquals(0, capabilityRegistry.getCapabilities().size()); //Should remove the new RegistrationPoints
 
         addOp4 = createOperation(ADD, TEST_ADDRESS4);
         addOp4.get("test").set("some test value");
@@ -447,8 +457,6 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
         Assert.assertEquals(2, capabilityRegistry.getCapabilities().size());
 
         executeCheckNoFailure(createOperation(REMOVE, TEST_ADDRESS4));
-        Assert.assertEquals(2, capabilityRegistry.getCapabilities().size());
-        executeCheckNoFailure(createOperation(REMOVE, TEST_ADDRESS1));
         Assert.assertEquals(0, capabilityRegistry.getCapabilities().size());
     }
 

--- a/server/src/main/java/org/jboss/as/server/services/net/InterfaceResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/InterfaceResourceDefinition.java
@@ -37,7 +37,12 @@ import org.jboss.as.network.NetworkInterfaceBinding;
 public class InterfaceResourceDefinition extends InterfaceDefinition {
 
     public static final RuntimeCapability<Void> INTERFACE_CAPABILITY =
-            RuntimeCapability.Builder.of(INTERFACE_CAPABILITY_NAME, true, NetworkInterfaceBinding.class).build();
+            RuntimeCapability.Builder.of(INTERFACE_CAPABILITY_NAME, true, NetworkInterfaceBinding.class)
+                    .setAllowMultipleRegistrations(true) // both /host=master/interface=x and /interface=x are legal and in the same scope
+                                                         // In a better world we'd only set this true in an HC process
+                                                         // but that's more trouble than I want to take. Adding an
+                                                         // interface twice in a server will fail in MODEL due to the dup resource anyway
+                    .build();
 
     public InterfaceResourceDefinition(InterfaceAddHandler addHandler, InterfaceRemoveHandler removeHandler,
                                        boolean updateRuntime, boolean resolvable) {

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ConfigurationChangesHistoryTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ConfigurationChangesHistoryTestCase.java
@@ -179,6 +179,6 @@ public class ConfigurationChangesHistoryTestCase extends AbstractConfigurationCh
         add.get("max-history").set(MAX_HISTORY_SIZE);
         ModelNode response = client.execute(add);
         Assert.assertFalse(Operations.isSuccessfulOutcome(response));
-        assertThat(Operations.getFailureDescription(response).asString(), containsString("WFLYCTL0158"));
+        assertThat(Operations.getFailureDescription(response).asString(), containsString("WFLYCTL0436"));
     }
 }

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/LegacyConfigurationChangesHistoryTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/LegacyConfigurationChangesHistoryTestCase.java
@@ -185,7 +185,7 @@ public class LegacyConfigurationChangesHistoryTestCase extends AbstractConfigura
             add.get("max-history").set(MAX_HISTORY_SIZE);
             ModelNode response = client.execute(add);
             Assert.assertFalse(response.toString(), Operations.isSuccessfulOutcome(response));
-            assertThat(Operations.getFailureDescription(response).asString(), containsString("WFLYCTL0158"));
+            assertThat(Operations.getFailureDescription(response).asString(), containsString("WFLYCTL0436"));
         } finally {
             client.execute(Util.createRemoveOperation(PathAddress.pathAddress(PathAddress.pathAddress()
                     .append(PathElement.pathElement(SUBSYSTEM, "core-management"))


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2270

This is a follow up to #2154 with a second commit changing default behavior.

The expectation is #2154  would be merged, then a release performed, then uses in full that need to use the new API in #2154 would do so, and then this would be merged.

This will fail CI until the full changes are made.

https://github.com/wildfly/wildfly/pull/9645 has the full changes. https://ci.wildfly.org/viewLog.html?buildId=46237&tab=buildResultsDiv&buildTypeId=WF_WildFlyCoreIntegrationExperiments is a custom job testing this in combination with that PR.