### PR TITLE
Update to VDX 1.1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.mockito>2.5.5</version.org.mockito>
         <version.org.picketbox>5.0.0.Alpha3</version.org.picketbox>
-        <version.org.projectodd.vdx>1.1.4</version.org.projectodd.vdx>
+        <version.org.projectodd.vdx>1.1.5</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.22</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>


### PR DESCRIPTION
This improves the handling of an empty configuration file. VDX will now
print:

14:17:33,783 INFO  [org.jboss.as.controller] (Controller Boot Thread) OPVDX004: Failed to pretty print validation error: standalone.xml has no content

instead of:

14:17:33,783 INFO  [org.jboss.as.controller] (Controller Boot Thread) OPVDX001: Failed to pretty print validation error: Index: 0, Size: 0