### PR TITLE
[WFCORE-1529] Tweak management thread pools to decrease thread churn

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/remote/AbstractModelControllerOperationHandlerFactoryService.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/AbstractModelControllerOperationHandlerFactoryService.java
@@ -96,7 +96,7 @@ public abstract class AbstractModelControllerOperationHandlerFactoryService impl
             }
         });
         ThreadPoolExecutor executor = new ThreadPoolExecutor(POOL_CORE_SIZE, POOL_MAX_SIZE,
-                60L, TimeUnit.SECONDS, workQueue,
+                600L, TimeUnit.SECONDS, workQueue,
                 threadFactory);
         // Allow the core threads to time out as well
         executor.allowCoreThreadTimeOut(true);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -235,7 +235,7 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
 
         @Override
         public synchronized void start(final StartContext context) throws StartException {
-            executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
+            executorService = new ThreadPoolExecutor(1, Integer.MAX_VALUE,
                     5L, TimeUnit.SECONDS,
                     new SynchronousQueue<Runnable>(),
                     threadFactory);

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1267,6 +1267,10 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 264, value = "Cannot specify both admin-only and start-mode")
     OperationFailedException cannotSpecifyBothAdminOnlyAndStartMode();
 
+    @LogMessage(level = WARN)
+    @Message(id = 265, value = "Invalid value '%s' for system property '%s' -- value must be a non-negative integer")
+    void invalidPoolCoreSize(String val, String configSysProp);
+
     ////////////////////////////////////////////////
     //Messages without IDs
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1529

1) Bump managment-handler-thread pool thread timeout from 1 to 10 mins to retain threads during active CLI sessions (see https://issues.jboss.org/browse/WFCORE-2282 for proposed future work related to this.)
2) ServerService pool on a standalone server keeps 1 core thread
3) On a domain server, it keeps 3, as comms with the HC involve more async tasks
4) ServerService core pool size can be set via system property
5) HostControllerService pool keeps 1 core thread

With these settings light CLI activity doesn't produce pool churn. The management-handler-thread pool will still churn if activity is infrequent, with gaps longer than 10 mins.

Repeated complex tasks like deploy ops will still produce churn in ServerService thread pool.

In both cases where churn still happens, the alternative is never releasing threads and wasting resources, which seems worse than a bit of churn.