### PR TITLE
[WFCORE-1789] PreparedResponseTestCase from wf-core-eap fails intermittently

### DIFF
--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
@@ -21,7 +21,6 @@
 package org.wildfly.core.test.standalone.mgmt;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SHUTDOWN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
@@ -34,6 +33,7 @@ import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
 import org.jboss.as.test.integration.management.extension.ExtensionUtils;
 import org.jboss.as.test.integration.management.extension.blocker.BlockerExtension;
+import org.jboss.as.test.integration.management.util.ServerReload;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
@@ -41,7 +41,6 @@ import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
@@ -56,7 +55,6 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  */
 @RunWith(WildflyTestRunner.class)
 @ServerControl(manual = true)
-@Ignore
 public class PreparedResponseTestCase {
 
     public static Logger LOGGER = Logger.getLogger(PreparedResponseTestCase.class);
@@ -98,7 +96,7 @@ public class PreparedResponseTestCase {
         try (ManagementClient managementClient = getManagementClient()) {
             block(managementClient);
             long timeout = SHUTDOWN_WAITING_TIME + System.currentTimeMillis();
-            managementClient.executeForResult(Operations.createOperation(RELOAD, new ModelNode().setEmptyList()));
+            ServerReload.executeReload(managementClient.getControllerClient(), false);
             while (System.currentTimeMillis() < timeout) {
                 Thread.sleep(FREQUENCY);
                 try {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/ServerReload.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/ServerReload.java
@@ -122,7 +122,7 @@ public class ServerReload {
                 serverPort != -1 ? serverPort : TestSuiteEnvironment.getServerPort());
     }
 
-    private static void executeReload(ModelControllerClient client, boolean adminOnly) {
+    public static void executeReload(ModelControllerClient client, boolean adminOnly) {
         ModelNode operation = new ModelNode();
         operation.get(OP_ADDR).setEmptyList();
         operation.get(OP).set("reload");
@@ -131,7 +131,7 @@ public class ServerReload {
         executeReload(client, operation);
     }
 
-    private static void executeReload(ModelControllerClient client, ModelNode reloadOp) {
+    public static void executeReload(ModelControllerClient client, ModelNode reloadOp) {
         try {
             ModelNode result = client.execute(reloadOp);
             Assert.assertEquals("success", result.get(ClientConstants.OUTCOME).asString());


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFCORE-1789

* Adding an expected exception after server reload to reloadServer test.