### PR TITLE
Use %n instead of \n in XXXLogger messages and in LocalDescriptions.p…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3449,7 +3449,7 @@ public interface ControllerLogger extends BasicLogger {
 
     // ---- Credential Store related messages -----------
 
-    @Message(id = 423, value = "Masked password command has the wrong format.\nUsage: MASK-<encoded secret>;<salt>;<iteration count> where <salt>=UTF-8 characters, <iteration count>=reasonable sized positive integer")
+    @Message(id = 423, value = "Masked password command has the wrong format.%nUsage: MASK-<encoded secret>;<salt>;<iteration count> where <salt>=UTF-8 characters, <iteration count>=reasonable sized positive integer")
     IOException wrongMaskedPasswordFormat();
 
     @Message(id = 424, value = "Supposed Credential Store URI has no scheme or different from '" + CredentialStoreURIParser.CR_STORE_SCHEME + "://' ('%s')")

--- a/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
@@ -1161,7 +1161,7 @@ public interface DomainManagementLogger extends BasicLogger {
     @Message(id = 112, value = "Failed to generate self signed certificate")
     RuntimeException failedToGenerateSelfSignedCertificate(@Cause Exception e);
 
-    @Message(id = 113, value = "Generated self signed certificate at %s. Please note that self signed certificates are not secure, and should only be used for testing purposes. Do not use this self signed certificate in production.\nSHA-1 fingerprint of the generated key is %s\nSHA-256 fingerprint of the generated key is %s")
+    @Message(id = 113, value = "Generated self signed certificate at %s. Please note that self signed certificates are not secure, and should only be used for testing purposes. Do not use this self signed certificate in production.%nSHA-1 fingerprint of the generated key is %s%nSHA-256 fingerprint of the generated key is %s")
     @LogMessage(level = WARN)
     void keystoreHasBeenCreated(String file, String sha1, String sha256);
 


### PR DESCRIPTION
…roperties

@jamezp please approve. I did a search for \n in the Logger and .properties files and this is what I found.