### PR TITLE
[WFCORE-2025] Correct the priority when selecting the SSLContext to use with the CLI.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -252,6 +252,8 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     private final char[] password;
     /** flag to disable the local authentication mechanism */
     private final boolean disableLocalAuth;
+    /** Flag to indicate that the SSLContext was the defailt context and not configured */
+    private boolean defaultSslContext;
     /** The SSLContext when managed by the CLI */
     private SSLContext sslContext;
     /** The TrustManager in use by the SSLContext, a reference is kept to rejected certificates can be captured. */
@@ -713,6 +715,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(keyManagers, trustManagers, null);
 
+            this.defaultSslContext = sslConfig == null;
             this.sslContext = sslContext;
         } catch (GeneralSecurityException e) {
             throw new CliInitializationException(e);
@@ -1137,7 +1140,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                     log.debug("connecting to " + address.getHost() + ':' + address.getPort() + " as " + username);
                 }
                 ModelControllerClient tempClient = ModelControllerClientFactory.CUSTOM.getClient(address, cbh,
-                        disableLocalAuth, sslContext, config.getConnectionTimeout(), this, timeoutHandler, clientBindAddress);
+                        disableLocalAuth, sslContext, defaultSslContext, config.getConnectionTimeout(), this, timeoutHandler, clientBindAddress);
                 retry = false;
                 connInfoBean = new ConnectionInfoBean();
                 tryConnection(tempClient, address);

--- a/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
@@ -50,13 +50,13 @@ public interface ModelControllerClientFactory {
     }
 
     ModelControllerClient getClient(ControllerAddress address, CallbackHandler handler,
-            boolean disableLocalAuth, SSLContext sslContext, int connectionTimeout,
+            boolean disableLocalAuth, SSLContext sslContext, boolean fallbackSslContext, int connectionTimeout,
             ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler, String clientBindAddress) throws IOException;
 
     ModelControllerClientFactory DEFAULT = new ModelControllerClientFactory() {
         @Override
         public ModelControllerClient getClient(ControllerAddress address, CallbackHandler handler,
-                boolean disableLocalAuth, SSLContext sslContext, int connectionTimeout,
+                boolean disableLocalAuth, SSLContext sslContext, boolean fallbackSslContext, int connectionTimeout,
                 ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler, String clientBindAddress) throws IOException {
             // TODO - Make use of the ProtocolTimeoutHandler
             Map<String, String> saslOptions = disableLocalAuth ? DISABLED_LOCAL_AUTH : ENABLED_LOCAL_AUTH;
@@ -78,10 +78,10 @@ public interface ModelControllerClientFactory {
 
         @Override
         public ModelControllerClient getClient(ControllerAddress address,
-                final CallbackHandler handler, boolean disableLocalAuth, final SSLContext sslContext,
+                final CallbackHandler handler, boolean disableLocalAuth, final SSLContext sslContext, final boolean fallbackSslContext,
                 final int connectionTimeout, final ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler, String clientBindAddress) throws IOException {
             Map<String, String> saslOptions = disableLocalAuth ? DISABLED_LOCAL_AUTH : ENABLED_LOCAL_AUTH;
-            return new CLIModelControllerClient(address, handler, connectionTimeout, closeHandler, saslOptions, sslContext, timeoutHandler, clientBindAddress);
+            return new CLIModelControllerClient(address, handler, connectionTimeout, closeHandler, saslOptions, sslContext, fallbackSslContext, timeoutHandler, clientBindAddress);
         }};
 
 }

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
@@ -43,10 +43,10 @@ public class ProtocolConnectionConfiguration {
 
     private URI uri;
     private Endpoint endpoint;
-    private OptionMap optionMap = OptionMap.EMPTY;
     private long connectionTimeout = DEFAULT_CONNECT_TIMEOUT;
     private CallbackHandler callbackHandler;
     private Map<String, String> saslOptions = Collections.emptyMap();
+    private boolean overrideSslContext;
     private SSLContext sslContext;
     private String clientBindAddress;
     private ProtocolTimeoutHandler timeoutHandler;
@@ -69,7 +69,6 @@ public class ProtocolConnectionConfiguration {
      */
     protected void validate() {
         Assert.checkNotNullParam("endpoint", endpoint);
-        Assert.checkNotNullParam("optionMap", optionMap);
         Assert.checkNotNullParam("uri", uri);
     }
 
@@ -103,12 +102,13 @@ public class ProtocolConnectionConfiguration {
         this.endpoint = endpoint;
     }
 
+    @Deprecated
     public OptionMap getOptionMap() {
-        return optionMap;
+        return OptionMap.EMPTY;
     }
 
+    @Deprecated
     public void setOptionMap(OptionMap optionMap) {
-        this.optionMap = optionMap;
     }
 
     public long getConnectionTimeout() {
@@ -133,6 +133,14 @@ public class ProtocolConnectionConfiguration {
 
     public void setSaslOptions(Map<String, String> saslOptions) {
         this.saslOptions = saslOptions;
+    }
+
+    public boolean isOverrideSslContext() {
+        return overrideSslContext;
+    }
+
+    public void setOverrideSslContext(boolean overrideSslContext) {
+        this.overrideSslContext = overrideSslContext;
     }
 
     public SSLContext getSslContext() {
@@ -197,10 +205,10 @@ public class ProtocolConnectionConfiguration {
                                                 final ProtocolConnectionConfiguration target) {
         target.uri = old.uri;
         target.endpoint = old.endpoint;
-        target.optionMap = old.optionMap;
         target.connectionTimeout = old.connectionTimeout;
         target.callbackHandler = old.callbackHandler;
         target.saslOptions = old.saslOptions;
+        target.overrideSslContext = old.overrideSslContext;
         target.sslContext = old.sslContext;
         target.clientBindAddress = old.clientBindAddress;
         target.timeoutHandler = old.timeoutHandler;

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
@@ -43,10 +43,10 @@ public class ProtocolConnectionConfiguration {
 
     private URI uri;
     private Endpoint endpoint;
+    private OptionMap optionMap = OptionMap.EMPTY;
     private long connectionTimeout = DEFAULT_CONNECT_TIMEOUT;
     private CallbackHandler callbackHandler;
     private Map<String, String> saslOptions = Collections.emptyMap();
-    private boolean overrideSslContext;
     private SSLContext sslContext;
     private String clientBindAddress;
     private ProtocolTimeoutHandler timeoutHandler;
@@ -69,6 +69,7 @@ public class ProtocolConnectionConfiguration {
      */
     protected void validate() {
         Assert.checkNotNullParam("endpoint", endpoint);
+        Assert.checkNotNullParam("optionMap", optionMap);
         Assert.checkNotNullParam("uri", uri);
     }
 
@@ -102,13 +103,12 @@ public class ProtocolConnectionConfiguration {
         this.endpoint = endpoint;
     }
 
-    @Deprecated
     public OptionMap getOptionMap() {
-        return OptionMap.EMPTY;
+        return optionMap;
     }
 
-    @Deprecated
     public void setOptionMap(OptionMap optionMap) {
+        this.optionMap = optionMap;
     }
 
     public long getConnectionTimeout() {
@@ -133,14 +133,6 @@ public class ProtocolConnectionConfiguration {
 
     public void setSaslOptions(Map<String, String> saslOptions) {
         this.saslOptions = saslOptions;
-    }
-
-    public boolean isOverrideSslContext() {
-        return overrideSslContext;
-    }
-
-    public void setOverrideSslContext(boolean overrideSslContext) {
-        this.overrideSslContext = overrideSslContext;
     }
 
     public SSLContext getSslContext() {
@@ -205,10 +197,10 @@ public class ProtocolConnectionConfiguration {
                                                 final ProtocolConnectionConfiguration target) {
         target.uri = old.uri;
         target.endpoint = old.endpoint;
+        target.optionMap = old.optionMap;
         target.connectionTimeout = old.connectionTimeout;
         target.callbackHandler = old.callbackHandler;
         target.saslOptions = old.saslOptions;
-        target.overrideSslContext = old.overrideSslContext;
         target.sslContext = old.sslContext;
         target.clientBindAddress = old.clientBindAddress;
         target.timeoutHandler = old.timeoutHandler;

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionUtils.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionUtils.java
@@ -46,7 +46,6 @@ import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.AuthenticationContextConfigurationClient;
 import org.wildfly.security.auth.client.MatchRule;
 import org.xnio.IoFuture;
-import org.xnio.OptionMap;
 import org.xnio.Options;
 
 /**
@@ -162,11 +161,11 @@ public class ProtocolConnectionUtils {
         authenticationContext = authenticationContext.withSsl(MatchRule.ALL, () -> finalSslContext);
 
         if (clientBindAddress == null) {
-            return endpoint.connect(uri, OptionMap.EMPTY, authenticationContext);
+            return endpoint.connect(uri, configuration.getOptionMap(), authenticationContext);
         } else {
             InetSocketAddress bindAddr = new InetSocketAddress(clientBindAddress, 0);
             // TODO: bind address via connection builder
-            return endpoint.connect(uri, OptionMap.EMPTY, authenticationContext);
+            return endpoint.connect(uri, configuration.getOptionMap(), authenticationContext);
         }
     }
 

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionUtils.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionUtils.java
@@ -22,10 +22,25 @@
 
 package org.jboss.as.protocol;
 
+import static java.security.AccessController.doPrivileged;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+import java.util.Enumeration;
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
 import org.jboss.as.protocol.logging.ProtocolLogger;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.Endpoint;
-import org.jboss.remoting3.RemotingOptions;
 import org.wildfly.security.auth.client.AuthenticationConfiguration;
 import org.wildfly.security.auth.client.AuthenticationContext;
 import org.wildfly.security.auth.client.AuthenticationContextConfigurationClient;
@@ -33,28 +48,6 @@ import org.wildfly.security.auth.client.MatchRule;
 import org.xnio.IoFuture;
 import org.xnio.OptionMap;
 import org.xnio.Options;
-
-import static java.security.AccessController.doPrivileged;
-import static org.xnio.Options.SASL_POLICY_NOANONYMOUS;
-import static org.xnio.Options.SASL_POLICY_NOPLAINTEXT;
-
-import org.xnio.Property;
-import org.xnio.Sequence;
-
-import javax.net.ssl.SSLContext;
-import javax.security.auth.callback.Callback;
-import javax.security.auth.callback.CallbackHandler;
-import javax.security.auth.callback.UnsupportedCallbackException;
-
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.NetworkInterface;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Protocol Connection utils.
@@ -146,50 +139,38 @@ public class ProtocolConnectionUtils {
     private static IoFuture<Connection> connect(final CallbackHandler handler, final ProtocolConnectionConfiguration configuration) throws IOException {
         configuration.validate();
         final Endpoint endpoint = configuration.getEndpoint();
-        final OptionMap options = getOptions(configuration);
-        final SSLContext sslContext = configuration.getSslContext();
         final URI uri = configuration.getUri();
         String clientBindAddress = configuration.getClientBindAddress();
 
         AuthenticationContext captured = AuthenticationContext.captureCurrent();
         AuthenticationConfiguration mergedConfiguration = AUTH_CONFIGURATION_CLIENT.getAuthenticationConfiguration(uri, captured);
         if (handler != null) mergedConfiguration = mergedConfiguration.useCallbackHandler(handler);
+        mergedConfiguration = configureSaslMechnisms(configuration.getSaslOptions(), isLocal(uri), mergedConfiguration);
 
-        // We don't know the original index or the match rule so create a context with a single match all rule.
-        AuthenticationContext context = AuthenticationContext.empty().with(MatchRule.ALL, mergedConfiguration);
-        if (sslContext != null) context = context.withSsl(MatchRule.ALL, () -> sslContext);
+        SSLContext sslContext = configuration.getSslContext();
+        if (sslContext == null) {
+            try {
+                sslContext = AUTH_CONFIGURATION_CLIENT.getSSLContext(uri, captured);
+            } catch (GeneralSecurityException e) {
+                throw ProtocolLogger.ROOT_LOGGER.failedToConnect(uri, e);
+            }
+        }
+
+        AuthenticationContext authenticationContext = AuthenticationContext.empty();
+        authenticationContext = authenticationContext.with(MatchRule.ALL, mergedConfiguration);
+        final SSLContext finalSslContext = sslContext;
+        authenticationContext = authenticationContext.withSsl(MatchRule.ALL, () -> finalSslContext);
 
         if (clientBindAddress == null) {
-            return endpoint.connect(uri, options, context);
+            return endpoint.connect(uri, OptionMap.EMPTY, authenticationContext);
         } else {
             InetSocketAddress bindAddr = new InetSocketAddress(clientBindAddress, 0);
             // TODO: bind address via connection builder
-            return endpoint.connect(configuration.getUri(), options, context);
+            return endpoint.connect(uri, OptionMap.EMPTY, authenticationContext);
         }
     }
 
-    private static OptionMap getOptions(final ProtocolConnectionConfiguration configuration) {
-        final Map<String, String> saslOptions = configuration.getSaslOptions();
-        final OptionMap.Builder builder = OptionMap.builder();
-        builder.set(SASL_POLICY_NOANONYMOUS, Boolean.FALSE);
-        builder.set(SASL_POLICY_NOPLAINTEXT, Boolean.FALSE);
-        builder.addAll(configuration.getOptionMap());
-        configureSaslMechnisms(saslOptions, isLocal(configuration.getUri()), builder);
-        List<Property> tempProperties = new ArrayList<Property>(saslOptions != null ? saslOptions.size() : 1);
-        tempProperties.add(Property.of("jboss.sasl.local-user.quiet-auth", "true"));
-        if (saslOptions != null) {
-            for (String currentKey : saslOptions.keySet()) {
-                tempProperties.add(Property.of(currentKey, saslOptions.get(currentKey)));
-            }
-        }
-        builder.set(Options.SASL_PROPERTIES, Sequence.of(tempProperties));
-        builder.set(Options.SSL_ENABLED, configuration.isSslEnabled());
-        builder.set(Options.SSL_STARTTLS, configuration.isUseStartTLS());
-        builder.set(RemotingOptions.SASL_PROTOCOL, "remote");
-        return builder.getMap();
-    }
-
-    private static void configureSaslMechnisms(Map<String, String> saslOptions, boolean isLocal, OptionMap.Builder builder) {
+    private static AuthenticationConfiguration configureSaslMechnisms(Map<String, String> saslOptions, boolean isLocal, AuthenticationConfiguration authenticationConfiguration) {
         String[] mechanisms = null;
         String listed;
         if (saslOptions != null && (listed = saslOptions.get(Options.SASL_DISALLOWED_MECHANISMS.getName())) != null) {
@@ -206,17 +187,7 @@ public class ProtocolConnectionUtils {
             mechanisms = new String[]{ JBOSS_LOCAL_USER };
         }
 
-        if (mechanisms != null) {
-            builder.set(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of(mechanisms));
-        }
-
-        if (saslOptions != null && (listed = saslOptions.get(Options.SASL_MECHANISMS.getName())) != null) {
-            // SASL mechanisms were passed via the saslOptions map; need to convert to an XNIO option
-            String[] split = listed.split(" ");
-            if (split.length > 0) {
-                builder.set(Options.SASL_MECHANISMS, Sequence.of(split));
-            }
-        }
+        return (mechanisms != null && mechanisms.length > 0) ? authenticationConfiguration.forbidSaslMechanisms(mechanisms) : authenticationConfiguration;
     }
 
     private static boolean isLocal(final URI uri) {

--- a/protocol/src/main/java/org/jboss/as/protocol/logging/ProtocolLogger.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/logging/ProtocolLogger.java
@@ -306,7 +306,7 @@ public interface ProtocolLogger extends BasicLogger {
      * @return a {@link ConnectException} for the error.
      */
     @Message(id = 53, value = "Could not connect to %s. The connection failed")
-    ConnectException failedToConnect(URI uri, @Cause IOException cause);
+    ConnectException failedToConnect(URI uri, @Cause Exception cause);
 
     /**
      * Creates an exception indicating that the channel is closed.


### PR DESCRIPTION
:bangbang: Commits from this branch are used in numerous other topic branches so please do not cherry-pick or rebase. :bangbang:

The SSLContext priority order becomes: -
 1. The SSLContext from jboss-cli.xml
 2. An SSLContext from wildfly-config.xml
 3. The default SSLContext that can prompt for trust decisions.

The following issue can be resolved with this PR: -
  https://issues.jboss.org/browse/WFCORE-2025
