### PR TITLE
[WFCORE-2288] There can be multiple registrations for a given child t…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -914,9 +914,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
                 if (orderedChildTypes.size() == 1) {
                     orderedChildTypes = new HashSet<>(orderedChildTypes);
                 }
-                if (!orderedChildTypes.add(type)) {
-                    throw alreadyRegistered("Ordered child", type);
-                }
+                orderedChildTypes.add(type);
             }
         } finally {
             writeLock.unlock();


### PR DESCRIPTION
…ype so a parent MRR shouldn't reject an order-child config just because it has already gotten one

This is option #1 that Paul describes on https://issues.jboss.org/browse/WFCORE-2288