### PR TITLE
WFCORE-2066  Kill and destroy operations on the server-group

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -326,6 +326,7 @@ public class ModelDescriptionConstants {
     public static final String ORGANIZATION = "organization";
     public static final String OPERATION_DATE = "operation-date";
     public static final String OPERATION_HEADERS = "operation-headers";
+    public static final String OPERATION_ID = "operation-id";
     public static final String OPERATION_NAME = "operation-name";
     public static final String OPERATIONS = "operations";
     public static final String OPTIONS = "options";

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -140,6 +140,7 @@ public class ModelDescriptionConstants {
     public static final String DESCRIPTION = "description";
     public static final String DETAILS = "details";
     public static final String DESTINATION_ADDRESS = "destination-address";
+    public static final String DESTROY_SERVERS = "destroy-servers";
     public static final String DESTINATION_PORT = "destination-port";
     public static final String DIRECTORY = "directory";
     public static final String DIRECTORY_GROUPING = "directory-grouping";
@@ -260,6 +261,7 @@ public class ModelDescriptionConstants {
     public static final String KEYSTORE_PROVIDER = "keystore-provider";
     public static final String KEYSTORE_RELATIVE_TO = "keystore-relative-to";
     public static final String KEYTAB = "keytab";
+    public static final String KILL_SERVERS = "kill-servers";
     public static final String LEVEL = "level";
     public static final String LDAP = "ldap";
     public static final String LDAP_CONNECTION = "ldap-connection";

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -31,6 +31,7 @@ import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSI
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_3_0;
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_4_0;
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_4_1;
+import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.VERSION_5_0;
 import static org.jboss.as.domain.controller.transformers.KernelAPIVersion.toModelVersions;
 
 import java.util.EnumSet;
@@ -117,7 +118,7 @@ public class DomainTransformers {
 
 
         // NEXT:  We've registered all the versions that have special transformation needs.
-        // Now, we register a transfomer for every other version that discards host-exclude
+        // Now, we register a transformer for every other version that discards host-exclude
         builder = TransformationDescriptionBuilder.Factory.createInstance(null);
         builder.discardChildResource(HostExcludeResourceDefinition.PATH_ELEMENT);
         for (KernelAPIVersion version : allOthers) {
@@ -141,7 +142,7 @@ public class DomainTransformers {
 
     private static void registerChainedServerGroupTransformers(TransformerRegistry registry) {
         ChainedTransformationDescriptionBuilder builder = ServerGroupTransformers.buildTransformerChain();
-        registerChainedTransformer(registry, builder, VERSION_1_5, VERSION_1_6, VERSION_1_7, VERSION_1_8);
+        registerChainedTransformer(registry, builder, VERSION_5_0, VERSION_4_1, VERSION_4_0, VERSION_3_0, VERSION_2_1, VERSION_2_0, VERSION_1_8, VERSION_1_7, VERSION_1_6, VERSION_1_5);
     }
 
     private static void registerProfileTransformers(TransformerRegistry registry) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
@@ -267,7 +267,7 @@ public class ServerInventoryImpl implements ServerInventory {
             return ServerStatus.STOPPED;
         }
         Integer currentOperationID = CurrentOperationIdHolder.getCurrentOperationID();
-        server.stop(currentOperationID == null ? -1 : currentOperationID, gracefulTimeout);
+        server.stop(currentOperationID == null ? null : gracefulTimeout);
         if(blocking) {
             server.awaitState(ManagedServer.InternalState.STOPPED);
         }
@@ -350,7 +350,7 @@ public class ServerInventoryImpl implements ServerInventory {
     public void stopServers(final int gracefulTimeout, final boolean blockUntilStopped) {
         for(final ManagedServer server : servers.values()) {
             Integer currentOperationID = CurrentOperationIdHolder.getCurrentOperationID();
-            server.stop(currentOperationID == null ? -1 : currentOperationID, gracefulTimeout);
+            server.stop(currentOperationID == null ? null : gracefulTimeout);
         }
         if(blockUntilStopped) {
             synchronized (shutdownCondition) {

--- a/host-controller/src/main/resources/org/jboss/as/domain/controller/resources/LocalDescriptions.properties
+++ b/host-controller/src/main/resources/org/jboss/as/domain/controller/resources/LocalDescriptions.properties
@@ -100,6 +100,8 @@ server-group.stop-servers.timeout=The graceful shutdown timeout. If this is zero
 server-group.suspend-servers=Suspends operations on all servers in the server group. All current operations will be allowed to finish, and new operations will be rejected.
 server-group.suspend-servers.timeout=Timeout in seconds. If this is zero the operation will return immediately, -1 means that it will wait indefinitely. Note that the operation will not roll back if the timeout is exceeded, it just means that not all current requests completed in the specified timeout.
 server-group.resume-servers=Resumes operations on all servers in the server group
+server-group.kill-servers=Kill all server processes in the server group. In case the server is not in the stopping state, it will attempt to stop the server first. This operation may not work on all platforms and will try to destroy the process if not available.
+server-group.destroy-servers=Destroy the server processes in the server group. In case the server is not in the stopping state, it will attempt to stop the server first.
 
 server-group.deployment-overlay=Links between a defined deployment overlay and deployments in this server group
 server-group.deployment-overlay.add=Adds a link to a deployment overlay

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -327,7 +327,7 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
             final ServerResumeHandler resumeHandler = new ServerResumeHandler();
             resourceRegistration.registerOperationHandler(ServerResumeHandler.DOMAIN_DEFINITION, resumeHandler, false);
 
-            resourceRegistration.registerOperationHandler(ServerDomainProcessShutdownHandler.DOMAIN_DEFINITION, new ServerDomainProcessShutdownHandler(operationIDUpdater), false);
+            resourceRegistration.registerOperationHandler(ServerDomainProcessShutdownHandler.DOMAIN_DEFINITION, new ServerDomainProcessShutdownHandler(), false);
 
 
 //            // Trick the resource-description for domain servers to be included in the server-resource

--- a/server/src/main/java/org/jboss/as/server/operations/ServerDomainProcessShutdownHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerDomainProcessShutdownHandler.java
@@ -36,7 +36,6 @@ import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.OperationEntry;
-import org.jboss.as.server.DomainServerCommunicationServices;
 import org.jboss.as.server.GracefulShutdownService;
 import org.jboss.as.server.controller.descriptions.ServerDescriptions;
 import org.jboss.as.server.suspend.SuspendController;
@@ -67,18 +66,9 @@ public class ServerDomainProcessShutdownHandler implements OperationStepHandler 
             .withFlags(OperationEntry.Flag.HOST_CONTROLLER_ONLY, OperationEntry.Flag.RUNTIME_ONLY)
             .build();
 
-    private final DomainServerCommunicationServices.OperationIDUpdater operationIDUpdater;
-
-    public ServerDomainProcessShutdownHandler(DomainServerCommunicationServices.OperationIDUpdater operationIDUpdater) {
-        this.operationIDUpdater = operationIDUpdater;
-    }
-
     @Override
     public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
         context.acquireControllerLock();
-        // Update the operation permit
-        final int permit = operation.require("operation-id").asInt();
-        operationIDUpdater.updateOperationID(permit);
         final int timeout = TIMEOUT.resolveModelAttribute(context, operation).asInt(); //in milliseconds, as this is what is passed in from the HC
         // Acquire the controller lock to prevent new write ops and wait until current ones are done
         context.acquireControllerLock();


### PR DESCRIPTION
This issue adds Kill and Destroy operations at server-group level. It adds some refactored code in ManagedServer#ServerStopTask and removes an unused operation-id from it.

Jira issue is:
https://issues.jboss.org/browse/WFCORE-2066