### PR TITLE
[WFCORE-2294] Improve timeouts in WF-CORE TS

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/cli/CliProcessWrapper.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/cli/CliProcessWrapper.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.integration.management.cli;
 
+import org.jboss.as.test.shared.TimeoutUtil;
+
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -203,7 +205,7 @@ public class CliProcessWrapper extends CliProcessBuilder {
         }
     }
 
-    private int resultTimeout = 10000;
+    private int resultTimeout = TimeoutUtil.adjust(20000);
     private int resultInterval = 100;
 
     private boolean waitForPrompt(String prompt) {

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/suspend/web/SuspendResumeTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/suspend/web/SuspendResumeTestCase.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -110,7 +111,7 @@ public class SuspendResumeTestCase {
             op.get(NAME).set(SUSPEND_STATE);
             Assert.assertEquals("SUSPENDING", serverController.getClient().executeForResult(op).asString());
 
-            HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", 10, TimeUnit.SECONDS);
+            HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(30), TimeUnit.SECONDS);
             Assert.assertEquals(SuspendResumeHandler.TEXT, result.get());
             Assert.assertEquals("SUSPENDED", serverController.getClient().executeForResult(op).asString());
 

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -55,6 +55,10 @@ public class Server {
     private final String managementAddress = System.getProperty("management.address", "localhost");
     private final String managementProtocol = System.getProperty("management.protocol", "remote+http");
 
+    // timeouts
+    private final int startupTimeout = Integer.getInteger("server.startup.timeout", 30);
+    private final int stopTimeout = Integer.getInteger("server.stop.timeout", 10);
+
     private final String serverDebug = "wildfly.debug";
     private final int serverDebugPort = Integer.getInteger("wildfly.debug.port", 8787);
     private StartMode startMode = StartMode.NORMAL;
@@ -142,7 +146,6 @@ public class Server {
 
             createClient();
 
-            long startupTimeout = 30;
             long timeout = startupTimeout * 1000;
             boolean serverAvailable = false;
             long sleep = 1000;
@@ -177,7 +180,7 @@ public class Server {
         try {
             if (process != null) {
                 Thread shutdown = new Thread(() -> {
-                    long timeout = System.currentTimeMillis() + 10000;
+                    long timeout = System.currentTimeMillis() + (stopTimeout * 1000);
                     while (process != null && System.currentTimeMillis() < timeout) {
                         try {
                             process.exitValue();


### PR DESCRIPTION
Improve timeouts in WF-CORE TS
* SuspendResumeTestCase.java should use TimeoutUtil for timeout
* Parametrize timeouts in TestRunner 
* CliProcessWrapper.java should use TimeoutUtil for timeout

This stabilizes TS on slower machines.