### PR TITLE
[WFCORE-2258] If the identity is not found within LDAP return the EMPTY identity instead of causing an internal server error.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/UserLdapCallbackHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/UserLdapCallbackHandler.java
@@ -334,10 +334,10 @@ public class UserLdapCallbackHandler implements Service<CallbackHandlerService>,
                 SearchResult<LdapEntry> searchResult = userSearcherInjector.getValue().search(ldapConnectionHandler, name);
 
                 return new RealmIdentityImpl(new NamePrincipal(name), ldapConnectionHandler, searchResult, SecurityRealmService.SharedStateSecurityRealm.getSharedState());
-            } catch (IllegalStateException e) {
+            } catch (IllegalStateException | NamingException e) {
                 safeClose(ldapConnectionHandler);
                 return RealmIdentity.NON_EXISTENT;
-            } catch (IOException | NamingException e) {
+            } catch (IOException e) {
                 safeClose(ldapConnectionHandler);
                 throw new RealmUnavailableException(e);
             }


### PR DESCRIPTION
:bangbang: Commits from this branch are used in numerous other topic branches so please do not cherry-pick or rebase. :bangbang:

Resolves https://issues.jboss.org/browse/WFCORE-2258