### PR TITLE
[WFCORE-2305] Upgrade JBoss Log Manager from 2.0.4.Final to 2.0.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.0.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
-        <version.org.jboss.logmanager.jboss-logmanager>2.0.4.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.0.5.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.0.Beta5</version.org.jboss.marshalling.jboss-marshalling>
         <!-- this is test only dependancy -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2305

This upgrade has just two fixes. The most important being one that corrects the formatting of the stack traces with suppressed exceptions, https://issues.jboss.org/browse/LOGMGR-146.