### PR TITLE
Downgrade remoting jmx snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <version.org.jboss.modules.jboss-modules>1.6.0.Beta4</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.7.SP1</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.0.Beta17</version.org.jboss.remoting>
-        <version.org.jboss.remotingjmx.remoting-jmx>3.0.0.Beta4-SNAPSHOT</version.org.jboss.remotingjmx.remoting-jmx>
+        <version.org.jboss.remotingjmx.remoting-jmx>3.0.0.Beta3</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.3.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>


### PR DESCRIPTION
This seems to have been accidentally introduced by https://github.com/wildfly/wildfly-core/commit/37b8668cd98cdea280858fa24c2abbe9d0506ab5#diff-600376dffeb79835ede4a0b285078036L117 when releasing core