### PR TITLE
[WFCORE-1507][WFCORE-2327] Clean up in VM ModelControllerClient handling

### DIFF
--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -51,7 +51,9 @@ public interface ModelControllerClient extends Closeable {
      * @return the result of the operation
      * @throws IOException if an I/O error occurs while executing the operation
      */
-    ModelNode execute(ModelNode operation) throws IOException;
+    default ModelNode execute(ModelNode operation) throws IOException{
+        return execute(Operation.Factory.create(operation), OperationMessageHandler.DISCARD);
+    }
 
     /**
      * Execute an operation synchronously.
@@ -63,7 +65,9 @@ public interface ModelControllerClient extends Closeable {
      * @return the result of the operation
      * @throws IOException if an I/O error occurs while executing the operation
      */
-    ModelNode execute(Operation operation) throws IOException;
+    default ModelNode execute(Operation operation) throws IOException{
+        return execute(operation, OperationMessageHandler.DISCARD);
+    }
 
     /**
      * Execute an operation synchronously, optionally receiving progress reports.
@@ -73,7 +77,9 @@ public interface ModelControllerClient extends Closeable {
      * @return the result of the operation
      * @throws IOException if an I/O error occurs while executing the operation
      */
-    ModelNode execute(ModelNode operation, OperationMessageHandler messageHandler) throws IOException;
+    default ModelNode execute(ModelNode operation, OperationMessageHandler messageHandler) throws IOException {
+        return execute(Operation.Factory.create(operation), messageHandler);
+    }
 
     /**
      * Execute an operation synchronously, optionally receiving progress reports.
@@ -86,7 +92,11 @@ public interface ModelControllerClient extends Closeable {
      * @return the result of the operation
      * @throws IOException if an I/O error occurs while executing the operation
      */
-    ModelNode execute(Operation operation, OperationMessageHandler messageHandler) throws IOException;
+    default ModelNode execute(Operation operation, OperationMessageHandler messageHandler) throws IOException {
+        try (OperationResponse or = executeOperation(operation, messageHandler)) {
+            return or.getResponseNode();
+        }
+    }
 
     /**
      * Execute an operation synchronously, optionally receiving progress reports, with the response
@@ -103,13 +113,38 @@ public interface ModelControllerClient extends Closeable {
     OperationResponse executeOperation(Operation operation, OperationMessageHandler messageHandler) throws IOException;
 
     /**
+     * Execute an operation in another thread.
+     *
+     * @param operation the operation to execute
+     * @return the future result of the operation
+     */
+    default AsyncFuture<ModelNode> executeAsync(ModelNode operation) {
+        return executeAsync(Operation.Factory.create(operation), OperationMessageHandler.DISCARD);
+    }
+
+    /**
      * Execute an operation in another thread, optionally receiving progress reports.
      *
      * @param operation the operation to execute
      * @param messageHandler the message handler to use for operation progress reporting, or {@code null} for none
      * @return the future result of the operation
      */
-    AsyncFuture<ModelNode> executeAsync(ModelNode operation, OperationMessageHandler messageHandler);
+    default AsyncFuture<ModelNode> executeAsync(ModelNode operation, OperationMessageHandler messageHandler) {
+        return executeAsync(Operation.Factory.create(operation), messageHandler);
+    }
+
+    /**
+     * Execute an operation in another thread.
+     * <p>
+     * Note that associated input-streams have to be closed by the caller, after the
+     * operation completed {@link OperationAttachments#isAutoCloseStreams()}.
+     *
+     * @param operation the operation to execute
+     * @return the future result of the operation
+     */
+    default AsyncFuture<ModelNode> executeAsync(Operation operation) {
+        return executeAsync(operation, OperationMessageHandler.DISCARD);
+    }
 
     /**
      * Execute an operation in another thread, optionally receiving progress reports.

--- a/controller/src/main/java/org/jboss/as/controller/LocalModelControllerClient.java
+++ b/controller/src/main/java/org/jboss/as/controller/LocalModelControllerClient.java
@@ -1,0 +1,69 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.client.OperationResponse;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * A {@link ModelControllerClient} subinterface that does not throw {@link java.io.IOException}.
+ * Used for clients that operate in the same VM as the target {@link ModelController} and hence
+ * are not subject to IO failures associated with remote calls.
+ *
+ * @author Brian Stansberry
+ */
+public interface LocalModelControllerClient extends ModelControllerClient {
+
+    @Override
+    default ModelNode execute(ModelNode operation) {
+        return execute(Operation.Factory.create(operation), OperationMessageHandler.DISCARD);
+    }
+
+    @Override
+    default ModelNode execute(Operation operation) {
+        return execute(operation, OperationMessageHandler.DISCARD);
+    }
+
+    @Override
+    default ModelNode execute(ModelNode operation, OperationMessageHandler messageHandler) {
+        return execute(Operation.Factory.create(operation), messageHandler);
+    }
+
+    @Override
+    default ModelNode execute(Operation operation, OperationMessageHandler messageHandler) {
+        OperationResponse or = executeOperation(operation, messageHandler);
+        ModelNode result = or.getResponseNode();
+        try {
+            or.close();
+        } catch (IOException e) {
+            ControllerLogger.MGMT_OP_LOGGER.debugf(e, "Failed closing response to %s", operation);
+        }
+        return result;
+    }
+
+    @Override
+    OperationResponse executeOperation(Operation operation, OperationMessageHandler messageHandler);
+
+    @Override
+    void close();
+}

--- a/controller/src/main/java/org/jboss/as/controller/ModelController.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelController.java
@@ -76,13 +76,27 @@ public interface ModelController {
     OperationResponse execute(Operation operation, OperationMessageHandler handler, OperationTransactionControl control);
 
     /**
-     * Create an in-VM client.
+     * Create an in-VM client whose operations are executed as if they were invoked by a user in the
+     * RBAC {@code SuperUser} role, regardless of any security identity that is or isn't associated
+     * with the calling thread when the client is invoked. <strong>This client generally should not
+     * be used to handle requests from external callers, and if it is used great care should be
+     * taken to ensure such use is not suborning the intended access control scheme.</strong>
+     * <p>
+     * In a VM with a {@link java.lang.SecurityManager SecurityManager} installed, invocations
+     * against the returned client can only occur from a calling context with the
+     * {@link org.jboss.as.controller.security.ControllerPermission#PERFORM_IN_VM_CALL PERFORM_IN_VM_CALL}
+     * permission. Without this permission a {@link SecurityException} will be thrown.
      *
-     * @param executor the executor to use for asynchronous operation execution
-     * @return the client
+     * @param executor the executor to use for asynchronous operation execution. Cannot be {@code null}
+     * @return the client. Will not return {@code null}
      *
-     * @throws SecurityException if the caller does not have {@link #ACCESS_PERMISSION}
+     * @throws SecurityException if the caller does not have the
+     *            {@link org.jboss.as.controller.security.ControllerPermission#CAN_ACCESS_MODEL_CONTROLLER CAN_ACCESS_MODEL_CONTROLLER}
+     *            permission
+     *
+     * @deprecated Use {@link ModelControllerClientFactory}. Will be removed in the next major or minor release.
      */
+    @Deprecated
     ModelControllerClient createClient(Executor executor);
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerClientFactory.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerClientFactory.java
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Factory for obtaining a {@link org.jboss.as.controller.client.ModelControllerClient}
+ * for use in the same VM as the target {@link ModelController}.
+ *
+ * @author Brian Stansberry
+ */
+public interface ModelControllerClientFactory {
+
+    /**
+     * Create an in-VM client whose operations are executed with authorization checks performed
+     * based on the security identity that is associated with the calling thread when the
+     * client is invoked. Operations are not automatically treated as if invoked by a user
+     * in the RBAC {@code SuperUser} role, and thus may be rejected due to failed authorization
+     * checks.
+     *
+     * @param executor the executor to use for asynchronous operation execution. Cannot be {@code null}
+     * @return the client. Will not return {@code null}
+     *
+     * @throws SecurityException if the caller does not have the
+     *            {@link org.jboss.as.controller.security.ControllerPermission#CAN_ACCESS_MODEL_CONTROLLER CAN_ACCESS_MODEL_CONTROLLER}
+     *            permission
+     */
+    LocalModelControllerClient createClient(Executor executor);
+
+    /**
+     * Create an in-VM client whose operations are executed as if they were invoked by a user in the
+     * RBAC {@code SuperUser} role, regardless of any security identity that is or isn't associated
+     * with the calling thread when the client is invoked. <strong>This client generally should not
+     * be used to handle requests from external callers, and if it is used great care should be
+     * taken to ensure such use is not suborning the intended access control scheme.</strong>
+     * <p>
+     * In a VM with a {@link java.lang.SecurityManager SecurityManager} installed, invocations
+     * against the returned client can only occur from a calling context with the
+     * {@link org.jboss.as.controller.security.ControllerPermission#PERFORM_IN_VM_CALL PERFORM_IN_VM_CALL}
+     * permission. Without this permission a {@link SecurityException} will be thrown.
+     *
+     * @param executor the executor to use for asynchronous operation execution. Cannot be {@code null}
+     * @return the client. Will not return {@code null}
+     *
+     * @throws SecurityException if the caller does not have the
+     *            {@link org.jboss.as.controller.security.ControllerPermission#CAN_ACCESS_MODEL_CONTROLLER CAN_ACCESS_MODEL_CONTROLLER}
+     *            permission
+     */
+    LocalModelControllerClient createSuperUserClient(Executor executor);
+}

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerClientFactoryImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerClientFactoryImpl.java
@@ -1,0 +1,274 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CANCELLED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
+
+import java.io.IOException;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import org.jboss.as.controller.access.InVmAccess;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.OperationAttachments;
+import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.client.OperationResponse;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.dmr.ModelNode;
+import org.jboss.threads.AsyncFuture;
+import org.jboss.threads.AsyncFutureTask;
+import org.wildfly.security.auth.server.SecurityIdentity;
+
+/**
+ * Standard implementation of {@link ModelControllerClientFactory}.
+ *
+ * @author Brian Stansberry
+ */
+final class ModelControllerClientFactoryImpl implements ModelControllerClientFactory {
+
+    private final ModelController modelController;
+    private final Supplier<SecurityIdentity> securityIdentitySupplier;
+
+    ModelControllerClientFactoryImpl(ModelController modelController, Supplier<SecurityIdentity> securityIdentitySupplier) {
+        this.modelController = modelController;
+        this.securityIdentitySupplier = securityIdentitySupplier;
+    }
+
+    @Override
+    public LocalModelControllerClient createClient(Executor executor) {
+        return createLocalClient(executor);
+    }
+
+    @Override
+    public LocalModelControllerClient createSuperUserClient(Executor executor) {
+        // Wrap a standard LocalClient returned for non-SuperUser calls with
+        // one that provides superuser privileges
+        final LocalClient delegate = createLocalClient(executor);
+        return new LocalModelControllerClient() {
+            @Override
+            public OperationResponse executeOperation(final Operation operation, final OperationMessageHandler messageHandler) {
+                return executeInVm(delegate::executeOperation, operation, messageHandler);
+            }
+
+            @Override
+            public AsyncFuture<ModelNode> executeAsync(final Operation operation, final OperationMessageHandler messageHandler) {
+                return executeInVm(delegate::executeAsync, operation, messageHandler);
+            }
+
+            @Override
+            public AsyncFuture<OperationResponse> executeOperationAsync(final Operation operation, final OperationMessageHandler messageHandler) {
+                return executeInVm(delegate::executeOperationAsync, operation, messageHandler);
+            }
+
+            @Override
+            public void close() {
+                delegate.close();
+            }
+        };
+    }
+
+    private LocalClient createLocalClient(Executor executor) {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(ModelController.ACCESS_PERMISSION);
+        }
+
+        return new LocalClient(modelController, securityIdentitySupplier, executor);
+    }
+
+    /**
+     * A client that does not automatically grant callers SuperUser rights.
+     */
+    private static class LocalClient implements LocalModelControllerClient {
+
+        private final ModelController modelController;
+        private final Supplier<SecurityIdentity> securityIdentitySupplier;
+        private final Executor executor;
+
+        private LocalClient(ModelController modelController, Supplier<SecurityIdentity> securityIdentitySupplier, Executor executor) {
+            this.modelController = modelController;
+            this.securityIdentitySupplier = securityIdentitySupplier;
+            this.executor = executor;
+        }
+
+        @Override
+        public void close()  {
+            // whatever
+        }
+
+        @Override
+        public OperationResponse executeOperation(Operation operation, OperationMessageHandler messageHandler) {
+            return modelController.execute(operation, messageHandler, ModelController.OperationTransactionControl.COMMIT);
+        }
+
+        @Override
+        public AsyncFuture<ModelNode> executeAsync(final Operation operation, final OperationMessageHandler messageHandler) {
+            return executeAsync(operation.getOperation(), messageHandler, operation, ResponseConverter.TO_MODEL_NODE);
+        }
+
+        @Override
+        public AsyncFuture<OperationResponse> executeOperationAsync(Operation operation, OperationMessageHandler messageHandler) {
+            return executeAsync(operation.getOperation(), messageHandler, operation, ResponseConverter.TO_OPERATION_RESPONSE);
+        }
+
+        private <T> AsyncFuture<T> executeAsync(final ModelNode operation, final OperationMessageHandler messageHandler,
+                                                final OperationAttachments attachments,
+                                                final ResponseConverter<T> responseConverter) {
+            if (executor == null) {
+                throw ControllerLogger.ROOT_LOGGER.nullAsynchronousExecutor();
+            }
+
+            final AtomicReference<Thread> opThread = new AtomicReference<Thread>();
+            final ResponseFuture<T> responseFuture = new ResponseFuture<T>(opThread, responseConverter, executor);
+
+            final SecurityIdentity securityIdentity = securityIdentitySupplier.get();
+            final boolean inVmCall = SecurityActions.isInVmCall();
+
+            executor.execute(new Runnable() {
+                public void run() {
+                    try {
+                        if (opThread.compareAndSet(null, Thread.currentThread())) {
+                            // We need the AccessAuditContext as that will make any inflowed SecurityIdentity available.
+                            OperationResponse response = AccessAuditContext.doAs(securityIdentity, null, new PrivilegedAction<OperationResponse>() {
+
+                                @Override
+                                public OperationResponse run() {
+                                    Operation op = attachments == null ? Operation.Factory.create(operation) : Operation.Factory.create(operation, attachments.getInputStreams(),
+                                            attachments.isAutoCloseStreams());
+                                    if (inVmCall) {
+                                        return SecurityActions.runInVm(() -> modelController.execute(op, messageHandler, ModelController.OperationTransactionControl.COMMIT));
+                                    } else {
+                                        return modelController.execute(op, messageHandler, ModelController.OperationTransactionControl.COMMIT);
+                                    }
+                                }
+                            });
+                            responseFuture.handleResult(response);
+                        }
+                    } finally {
+                        synchronized (opThread) {
+                            opThread.set(null);
+                            opThread.notifyAll();
+                        }
+                    }
+                }
+            });
+            return responseFuture;
+        }
+    }
+
+    /**
+     * {@link AsyncFuture} implementation returned by the {@code executeAsync} and {@code executeOperationAsync}
+     * methods of clients produced by this factory.
+     *
+     * @param <T> the type of response object returned by the future ({@link ModelNode} or {@link OperationResponse})
+     */
+    private static class ResponseFuture<T> extends AsyncFutureTask<T> {
+
+        private final AtomicReference<Thread> opThread;
+        private final ResponseConverter<T> responseConverter;
+
+        private ResponseFuture(final AtomicReference<Thread> opThread,
+                               final ResponseConverter<T> responseConverter, final Executor executor) {
+            super(executor);
+            this.opThread = opThread;
+            this.responseConverter = responseConverter;
+        }
+
+        public void asyncCancel(final boolean interruptionDesired) {
+            Thread thread = opThread.getAndSet(Thread.currentThread());
+            if (thread == null) {
+                setCancelled();
+            } else {
+                // Interrupt the request execution
+                thread.interrupt();
+                // Wait for the cancellation to clear opThread
+                boolean interrupted = false;
+                synchronized (opThread) {
+                    while (opThread.get() != null) {
+                        try {
+                            opThread.wait();
+                        } catch (InterruptedException ie) {
+                            interrupted = true;
+                        }
+                    }
+                }
+                setCancelled();
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        void handleResult(final OperationResponse result) {
+            ModelNode responseNode = result == null ? null : result.getResponseNode();
+            if (responseNode != null && responseNode.hasDefined(OUTCOME) && CANCELLED.equals(responseNode.get(OUTCOME).asString())) {
+                setCancelled();
+            } else {
+                setResult(responseConverter.fromOperationResponse(result));
+            }
+        }
+    }
+
+    private interface ResponseConverter<T> {
+
+        T fromOperationResponse(OperationResponse or);
+
+        ResponseConverter<ModelNode> TO_MODEL_NODE = new ResponseConverter<ModelNode>() {
+            @Override
+            public ModelNode fromOperationResponse(OperationResponse or) {
+                ModelNode result = or.getResponseNode();
+                try {
+                    or.close();
+                } catch (IOException e) {
+                    ROOT_LOGGER.debugf(e, "Caught exception closing %s whose associated streams, "
+                            + "if any, were not wanted", or);
+                }
+                return result;
+            }
+        };
+
+        ResponseConverter<OperationResponse> TO_OPERATION_RESPONSE = new ResponseConverter<OperationResponse>() {
+            @Override
+            public OperationResponse fromOperationResponse(final OperationResponse or) {
+                return or;
+            }
+        };
+    }
+
+    private static <T, U, R> R executeInVm(BiFunction<T, U, R> function, T t, U u) {
+        try {
+            return InVmAccess.runInVm((PrivilegedExceptionAction<R>) () -> function.apply(t, u) );
+        } catch (PrivilegedActionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else if (cause instanceof Error) {
+                throw (Error) cause;
+            } else {
+                // Not really possible as BiFunction doesn't throw checked exceptions
+                throw new RuntimeException(cause);
+            }
+        }
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
@@ -669,6 +669,11 @@ public abstract class AbstractProxyControllerTest {
                     ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
         }
 
+        @Override
+        protected boolean isExposingClientFactoryAllowed() {
+            return false; // don't install or it will conflict with the one from MainModelControllerService
+        }
+
         protected void initModel(ManagementModel managementModel, Resource modelControllerResource) {
             ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
             GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerAdd.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerAdd.java
@@ -51,8 +51,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.jboss.as.controller.ControlledProcessStateService;
 
+import org.jboss.as.controller.ControlledProcessStateService;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -63,7 +63,6 @@ import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.server.deployment.scanner.api.DeploymentOperations;
 import org.jboss.as.server.deployment.scanner.logging.DeploymentScannerLogger;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceTarget;
 import org.jboss.threads.JBossThreadFactory;
 
 /**
@@ -230,8 +229,7 @@ class DeploymentScannerAdd implements OperationStepHandler {
         final Boolean autoDeployXml = AUTO_DEPLOY_XML.resolveModelAttribute(context, model).asBoolean();
         final Long deploymentTimeout = DEPLOYMENT_TIMEOUT.resolveModelAttribute(context, model).asLong();
         final Boolean rollback = RUNTIME_FAILURE_CAUSES_ROLLBACK.resolveModelAttribute(context, model).asBoolean();
-        final ServiceTarget serviceTarget = context.getServiceTarget();
-        DeploymentScannerService.addService(serviceTarget, address, relativeTo, path, interval, TimeUnit.MILLISECONDS,
+        DeploymentScannerService.addService(context, address, relativeTo, path, interval, TimeUnit.MILLISECONDS,
                 autoDeployZip, autoDeployExp, autoDeployXml, enabled, deploymentTimeout, rollback, bootTimeScanner, executorService);
 
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -50,7 +50,6 @@ import org.jboss.as.server.BootstrapListener;
 import org.jboss.as.server.ExternalManagementRequestExecutor;
 import org.jboss.as.server.FutureServiceContainer;
 import org.jboss.as.server.Services;
-import org.jboss.as.server.deployment.ContentCleanerService;
 import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.as.version.ProductConfig;
 import org.jboss.msc.service.Service;
@@ -194,7 +193,6 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
                 .install();
         DomainModelControllerService.addService(serviceTarget, environment, runningModeControl, processState,
                 bootstrapListener, hostPathManagerService, capabilityRegistry);
-        ContentCleanerService.addServiceOnHostController(serviceTarget, DomainModelControllerService.SERVICE_NAME, HC_EXECUTOR_SERVICE_NAME, HC_SCHEDULED_EXECUTOR_SERVICE_NAME);
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -150,7 +150,7 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         } else {
             RemoteFileRepositoryService.addService(serviceTarget, serverEnvironment.getServerContentDir(), serverEnvironment.getServerTempDir());
         }
-        ContentCleanerService.addService(serviceTarget, ServerService.JBOSS_SERVER_SCHEDULED_EXECUTOR);
+        ContentCleanerService.addService(serviceTarget, ServerService.JBOSS_SERVER_CLIENT_FACTORY, ServerService.JBOSS_SERVER_SCHEDULED_EXECUTOR);
         DeploymentMountProvider.Factory.addService(serviceTarget);
         ServiceModuleLoader.addService(serviceTarget, configuration);
         ExternalModuleService.addService(serviceTarget);

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -144,6 +144,8 @@ import org.wildfly.security.manager.WildFlySecurityManager;
 public final class ServerService extends AbstractControllerService {
 
     /** Service is not for general use, so the service name is not declared in the more visible {@code Services} */
+    public static final ServiceName JBOSS_SERVER_CLIENT_FACTORY = CLIENT_FACTORY_CAPABILITY.getCapabilityServiceName();
+    /** Service is not for general use, so the service name is not declared in the more visible {@code Services} */
     public static final ServiceName JBOSS_SERVER_SCHEDULED_EXECUTOR = Services.JBOSS_SERVER_EXECUTOR.append("scheduled");
 
     private final InjectedValue<DeploymentMountProvider> injectedDeploymentRepository = new InjectedValue<DeploymentMountProvider>();

--- a/server/src/main/java/org/jboss/as/server/deployment/client/ModelControllerServerDeploymentManager.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/client/ModelControllerServerDeploymentManager.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.jboss.as.controller.LocalModelControllerClient;
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.Operation;
@@ -38,8 +39,14 @@ public class ModelControllerServerDeploymentManager extends AbstractServerDeploy
 
     private final ModelControllerClient client;
 
+    /** @deprecated Use {@link #ModelControllerServerDeploymentManager(LocalModelControllerClient)}. Will be removed in the next major or minor release. */
+    @Deprecated
     public ModelControllerServerDeploymentManager(final ModelController controller) {
         this.client = controller.createClient(Executors.newCachedThreadPool());
+    }
+
+    public ModelControllerServerDeploymentManager(final LocalModelControllerClient client) {
+        this.client = client;
     }
 
     /**

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -1090,13 +1090,15 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 216, value = "Error cleaning obsolete content %s ")
     void failedToCleanObsoleteContent(String failure);
 
-    @LogMessage(level = ERROR)
-    @Message(id = 217, value = "Error cleaning obsolete content")
-    void failedToCleanObsoleteContent(@Cause Exception e);
+    // No longer used
+//    @LogMessage(level = ERROR)
+//    @Message(id = 217, value = "Error cleaning obsolete content")
+//    void failedToCleanObsoleteContent(@Cause Exception e);
 
-    @LogMessage(level = ERROR)
-    @Message(id = 218, value = "Error stopping content repository cleaner")
-    void failedToStopRepositoryCleaner(@Cause Exception e);
+    // No longer used
+//    @LogMessage(level = ERROR)
+//    @Message(id = 218, value = "Error stopping content repository cleaner")
+//    void failedToStopRepositoryCleaner(@Cause Exception e);
 
     @LogMessage(level = WARN)
     @Message(id = 219, value = "%s deployment has been re-deployed, its content will not be removed. You will need to restart it.")

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedHostControllerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedHostControllerTestCase.java
@@ -425,6 +425,16 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
         }
     }
 
+    @Test
+    public void testRBACEnabled() throws IOException, InterruptedException {
+        String line = "embed-host-controller  --host-config=host-cli.xml --domain-config=domain-cli.xml  " + JBOSS_HOME;
+        cli.sendLine(line);
+        cli.sendLine("/core-service=management/access=authorization:write-attribute(name=provider,value=rbac");
+        assertState("reload-required", 0);
+        cli.sendLine("reload --host=master --admin-only=true");
+        assertState("running", TimeoutUtil.adjust(30000));
+    }
+
     private void assertProperty(final String propertyName, final String expected, final boolean notPresent) throws IOException, InterruptedException {
         cli.sendLine("/system-property=" + propertyName + " :read-attribute(name=value)", true);
         CLIOpResult result = cli.readAllAsOpResult();

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
@@ -662,6 +662,16 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
         }
     }
 
+    @Test
+    public void testRBACEnabled() throws IOException, InterruptedException {
+        String line = "embed-server --admin-only=false --server-config=standalone-cli.xml " + JBOSS_HOME;
+        cli.sendLine(line);
+        cli.sendLine("/core-service=management/access=authorization:write-attribute(name=provider,value=rbac");
+        assertState("reload-required", 0);
+        cli.sendLine("reload --admin-only=true");
+        assertState("running", TimeoutUtil.adjust(30000));
+    }
+
     private void assertPath(final String path, final String expected) throws IOException, InterruptedException {
             cli.sendLine("/path=" + path + " :read-attribute(name=path)", true);
             CLIOpResult result = cli.readAllAsOpResult();

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
@@ -72,7 +72,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -98,7 +97,6 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
 
     public static final String JBOSS_SERVER_BASE_DIR = "jboss.server.base.dir";
     public static final String JBOSS_SERVER_CONFIG_DIR = "jboss.server.config.dir";
-    public static final String JBOSS_SERVER_CONTENT_DIR = "jboss.server.content.dir";
     public static final String JBOSS_SERVER_DEPLOY_DIR = "jboss.server.deploy.dir";
     public static final String JBOSS_SERVER_TEMP_DIR = "jboss.server.temp.dir";
     public static final String JBOSS_SERVER_LOG_DIR = "jboss.server.log.dir";
@@ -296,7 +294,6 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
     }
 
     @Test
-    @Ignore
     public void testTimeout() throws Exception {
         cli.sendLine("command-timeout set 60");
         String line = "embed-server --server-config=standalone-cli.xml " + JBOSS_HOME;
@@ -424,7 +421,6 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
 
     /**
      * Test not specifying a server config works.
-     * @throws IOException
      */
     @Test
     public void testDefaultServerConfig() throws IOException {
@@ -433,7 +429,6 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
 
     /**
      * Test the -c shorthand for specifying a server config works.
-     * @throws IOException
      */
     @Test
     public void testDashC() throws IOException {
@@ -516,7 +511,6 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
 
     /** Tests that the quit command stops any embedded server */
     @Test
-    @Ignore
     public void testStopServerOnQuit() throws IOException {
         validateServerConnectivity();
         cli.sendLine("quit");
@@ -535,7 +529,6 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
 
     /**
      * Tests the --help param works.
-     * @throws IOException
      */
     @Test
     public void testHelp() throws IOException {
@@ -686,7 +679,7 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
         ModelNode resp = result.getResponseNode();
         ModelNode stateNode = result.isIsOutcomeSuccess() ? resp.get(RESULT) : resp.get(FAILURE_DESCRIPTION);
         if (notPresent) {
-            assertTrue(stateNode.asString().indexOf("WFLYCTL0216") != -1);
+            assertTrue(stateNode.asString().contains("WFLYCTL0216"));
         } else {
             assertEquals(expected, stateNode.asString());
         }
@@ -807,7 +800,7 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
                     assertPath(propName, ROOT + File.separator + newStandalone + File.separator + value);
                 } else {
                     // just make sure the unchanged property has the default basedir
-                    //assertTrue(WildFlySecurityManager.getPropertyPrivileged(prop, "").indexOf(currBaseDir) != -1);
+                    assertTrue(WildFlySecurityManager.getPropertyPrivileged(prop, "").indexOf(currBaseDir) != -1);
                 }
             }
         } finally {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1507
https://issues.jboss.org/browse/WFCORE-2327

[WFCORE-1507] Expose in-vm ModelControllerClient creation via a capability
Also addresses [WFCORE-2327] by creating a standardized way of establishing a client that acts as SuperUser.

The real driver here was WFCORE-2327 but it seemed obvious the right way to fix that was by doing what was needed for WFCORE-1507.

I also added a commit that cleans up some unrelated stuff in one of the test classes touched by the main WFCORE-2327 work