### PR TITLE
[WFCORE-2320] Execute internal domain management calls as privileged calls with full RBAC perms

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -43,9 +43,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUC
 import static org.jboss.as.domain.controller.HostConnectionInfo.Events.create;
 import static org.jboss.as.host.controller.logging.HostControllerLogger.DOMAIN_LOGGER;
 import static org.jboss.as.host.controller.logging.HostControllerLogger.ROOT_LOGGER;
-import static org.jboss.as.remoting.Protocol.REMOTE_HTTPS;
-import static org.jboss.as.remoting.Protocol.REMOTE_HTTP;
 import static org.jboss.as.remoting.Protocol.REMOTE;
+import static org.jboss.as.remoting.Protocol.REMOTE_HTTP;
+import static org.jboss.as.remoting.Protocol.REMOTE_HTTPS;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -70,6 +70,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
@@ -97,6 +98,7 @@ import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.ProxyOperationAddressTranslator;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.TransformingProxyController;
+import org.jboss.as.controller.access.InVmAccess;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
 import org.jboss.as.controller.access.management.ManagementSecurityIdentitySupplier;
 import org.jboss.as.controller.audit.ManagedAuditLogger;
@@ -1337,14 +1339,26 @@ public class DomainModelControllerService extends AbstractControllerService impl
         @Override
         public ModelNode execute(Operation operation, OperationMessageHandler handler, OperationTransactionControl control,
                 OperationStepHandler step) {
-            return internalExecute(operation, handler, control, step).getResponseNode();
+            Function<DomainModelControllerService, OperationResponse> function = new Function<DomainModelControllerService, OperationResponse>() {
+                @Override
+                public OperationResponse apply(DomainModelControllerService controllerService) {
+                    return InVmAccess.runInVm((PrivilegedAction<OperationResponse>) () -> controllerService.internalExecute(operation, handler, control, step));
+                }
+            };
+            return SecurityActions.privilegedExecution(function, DomainModelControllerService.this).getResponseNode();
         }
 
         @Override
         public ModelNode installSlaveExtensions(List<ModelNode> extensions) {
             Operation operation = ApplyExtensionsHandler.getOperation(extensions);
             OperationStepHandler stepHandler = modelNodeRegistration.getOperationHandler(PathAddress.EMPTY_ADDRESS, ApplyExtensionsHandler.OPERATION_NAME);
-            return internalExecute(operation, OperationMessageHandler.logging, OperationTransactionControl.COMMIT, stepHandler, false, true).getResponseNode();
+            Function<DomainModelControllerService, OperationResponse> function = new Function<DomainModelControllerService, OperationResponse>() {
+                @Override
+                public OperationResponse apply(DomainModelControllerService controllerService) {
+                    return InVmAccess.runInVm((PrivilegedAction<OperationResponse>) () -> controllerService.internalExecute(operation, OperationMessageHandler.logging, OperationTransactionControl.COMMIT, stepHandler, false, true));
+                }
+            };
+            return SecurityActions.privilegedExecution(function, DomainModelControllerService.this).getResponseNode();
         }
 
         @Override
@@ -1352,23 +1366,48 @@ public class DomainModelControllerService extends AbstractControllerService impl
         public ModelNode joinActiveOperation(ModelNode operation, OperationMessageHandler handler,
                                              OperationTransactionControl control,
                                              OperationStepHandler step, int permit) {
-            return executeReadOnlyOperation(operation, handler, control, step, permit);
+            Function<DomainModelControllerService, ModelNode> function = new Function<DomainModelControllerService, ModelNode>() {
+                @Override
+                public ModelNode apply(DomainModelControllerService controllerService) {
+                    return InVmAccess.runInVm((PrivilegedAction<ModelNode>) () -> controllerService.executeReadOnlyOperation(operation, handler, control, step, permit));
+                }
+            };
+            return SecurityActions.privilegedExecution(function, DomainModelControllerService.this);
         }
 
         @Override
         public OperationResponse executeAndAttemptLock(Operation operation, OperationMessageHandler handler,
                 OperationTransactionControl control, OperationStepHandler step) {
-            return internalExecute(operation, handler, control, step, true);
+            Function<DomainModelControllerService, OperationResponse> function = new Function<DomainModelControllerService, OperationResponse>() {
+                @Override
+                public OperationResponse apply(DomainModelControllerService controllerService) {
+                    return InVmAccess.runInVm((PrivilegedAction<OperationResponse>) () -> controllerService.internalExecute(operation, handler, control, step, true));
+                }
+            };
+            return SecurityActions.privilegedExecution(function, DomainModelControllerService.this);
         }
 
         @Override
         public ModelNode executeReadOnly(ModelNode operation, OperationStepHandler handler, OperationTransactionControl control) {
-            return executeReadOnlyOperation(operation, control, handler);
+
+            Function<DomainModelControllerService, ModelNode> function = new Function<DomainModelControllerService, ModelNode>() {
+                @Override
+                public ModelNode apply(DomainModelControllerService controllerService) {
+                    return InVmAccess.runInVm((PrivilegedAction<ModelNode>) () -> controllerService.executeReadOnlyOperation(operation, control,  handler));
+                }
+            };
+            return SecurityActions.privilegedExecution(function, DomainModelControllerService.this);
         }
 
         @Override
         public ModelNode executeReadOnly(ModelNode operation, Resource model, OperationStepHandler handler, OperationTransactionControl control) {
-            return executeReadOnlyOperation(operation, model, control, handler);
+            Function<DomainModelControllerService, ModelNode> function = new Function<DomainModelControllerService, ModelNode>() {
+                @Override
+                public ModelNode apply(DomainModelControllerService controllerService) {
+                    return InVmAccess.runInVm((PrivilegedAction<ModelNode>) () -> controllerService.executeReadOnlyOperation(operation, model, control, handler));
+                }
+            };
+            return SecurityActions.privilegedExecution(function, DomainModelControllerService.this);
         }
 
         @Override
@@ -1383,7 +1422,6 @@ public class DomainModelControllerService extends AbstractControllerService impl
             Assert.checkNotNullParam("operationID", operationID);
             releaseReadLock(operationID);
         }
-
     }
 
     private static final class DomainHostControllerInfoAccessor implements RuntimeHostControllerInfoAccessor {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/SecurityActions.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/SecurityActions.java
@@ -1,0 +1,121 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.host.controller;
+
+import static java.security.AccessController.doPrivileged;
+
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * Security manager related utilities for use in this package.
+ * DO NOT EXPOSE THIS CLASS OUTSIDE THIS PACKAGE.
+ *
+ * @author Brian Stansberry
+ */
+final class SecurityActions {
+
+    private SecurityActions() {}
+
+    /**
+     * Execute the given function, in a privileged block if a security manager is checking.
+     * @param function the function
+     * @param t        the argument to the function
+     * @param <T>      the type of the argument to the function
+     * @param <R>      the type of the function return value
+     * @return         the return value of the function
+     */
+    static <T, R> R privilegedExecution(Function<T, R> function, T t) {
+        return privilegedExecution().execute(function, t);
+    }
+
+    /**
+     * Execute the given function, in a privileged block if a security manager is checking.
+     * @param function the function
+     * @param t        the first argument to the function
+     * @param u        the second argument to the function
+     * @param <T>      the type of the first argument to the function
+     * @param <U>      the type of the second argument to the function
+     * @param <R>      the type of the function return value
+     * @return         the return value of the function
+     */
+    static <T, U, R> R privilegedExecution(BiFunction<T, U, R> function, T t, U u) {
+        return privilegedExecution().execute(function, t, u);
+    }
+
+    /** Provides function execution in a doPrivileged block if a security manager is checking privileges */
+    private static Execution privilegedExecution() {
+        return WildFlySecurityManager.isChecking() ? Execution.PRIVILEGED : Execution.NON_PRIVILEGED;
+    }
+
+    /** Executes a function */
+    private interface Execution {
+        <T, R> R execute(Function<T, R> function, T t);
+        <T, U, R> R execute(BiFunction<T, U, R> function, T t, U u);
+
+        Execution NON_PRIVILEGED = new Execution() {
+            @Override
+            public <T, R> R execute(Function<T, R> function, T t) {
+                return function.apply(t);
+            }
+            @Override
+            public <T, U, R> R execute(BiFunction<T, U, R> function, T t, U u) {
+                return function.apply(t, u);
+            }
+        };
+
+        Execution PRIVILEGED = new Execution() {
+            @Override
+            public <T, R> R execute(Function<T, R> function, T t) {
+                try {
+                    return doPrivileged((PrivilegedExceptionAction<R>) () -> NON_PRIVILEGED.execute(function, t) );
+                } catch (PrivilegedActionException e) {
+                    throwConverted(e);
+                    // Not reachable
+                    throw new IllegalStateException();
+                }
+            }
+            @Override
+            public <T, U, R> R execute(BiFunction<T, U, R> function, T t, U u) {
+                try {
+                    return doPrivileged((PrivilegedExceptionAction<R>) () -> NON_PRIVILEGED.execute(function, t, u) );
+                } catch (PrivilegedActionException e) {
+                    throwConverted(e);
+                    // Not reachable
+                    throw new IllegalStateException();
+                }
+            }
+        };
+
+        static void throwConverted(PrivilegedActionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else if (cause instanceof Error) {
+                throw (Error) cause;
+            } else {
+                // Not possible as Function/BiFunction don't throw any checked exception
+                throw new RuntimeException(cause);
+            }
+        }
+
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml_5.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml_5.java
@@ -306,6 +306,7 @@ class DomainXml_5 extends CommonXml implements ManagementXmlDelegate {
     }
 
     protected void readDomainElementAttributes(XMLExtendedStreamReader reader, ModelNode address, List<ModelNode> list) throws XMLStreamException {
+        boolean hasDomainOrg = false;
         final int count = reader.getAttributeCount();
         for (int i = 0; i < count; i++) {
             Namespace ns = Namespace.forUri(reader.getAttributeNamespace(i));
@@ -336,12 +337,18 @@ class DomainXml_5 extends CommonXml implements ManagementXmlDelegate {
                         list.add(op);
                         break;
                     }
+                    case  ORGANIZATION: { // not in the xsd but let's be forgiving to ease migration
+                        if (hasDomainOrg) {
+                            throw unexpectedAttribute(reader, i);
+                        } // else drop down into the domain-organization handling
+                    }
                     case  DOMAIN_ORGANIZATION: {
                         ModelNode op = new ModelNode();
                         op.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
                         op.get(NAME).set(DOMAIN_ORGANIZATION);
                         op.get(VALUE).set(ParseUtils.parsePossibleExpression(reader.getAttributeValue(i)));
                         list.add(op);
+                        hasDomainOrg = true;
                         break;
                     }
                     default:

--- a/server/src/main/resources/schema/wildfly-config_5_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_5_0.xsd
@@ -61,6 +61,13 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="domain-organization" type="xs:string" use="optional">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the organization running this domain.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 
@@ -105,7 +112,7 @@
             <xs:attribute name="organization" type="xs:string" use="optional">
                 <xs:annotation>
                     <xs:documentation>
-                        The name of the organization running this server.
+                        The name of the organization running this host.
                     </xs:documentation>
                 </xs:annotation>
             </xs:attribute>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyModeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyModeTestCase.java
@@ -42,7 +42,7 @@ import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -51,7 +51,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Tests of running domain hosts in admin-only move.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class AdminOnlyModeTestCase {
 
     private static DomainTestSupport testSupport;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
@@ -53,13 +53,13 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * Tests of running domain hosts in admin-only move.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class AdminOnlyPolicyTestCase {
 
     private static DomainTestSupport testSupport;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultInterfaceOveridingDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultInterfaceOveridingDomainTestCase.java
@@ -46,7 +46,7 @@ import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
 
@@ -58,7 +58,7 @@ import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
  *
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2014 Red Hat, inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class DefaultInterfaceOveridingDomainTestCase {
 
     private static final Logger log = Logger.getLogger(DefaultInterfaceOveridingDomainTestCase.class.getName());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DomainControllerMigrationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DomainControllerMigrationTestCase.java
@@ -53,7 +53,7 @@ import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
 
@@ -62,7 +62,7 @@ import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
  *
  * @author <a href="dpospisi@redhat.com">Dominik Pospisil</a>
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class DomainControllerMigrationTestCase {
 
     private static final Logger log = Logger.getLogger(DomainControllerMigrationTestCase.class.getName());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ProductInfoUnitTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ProductInfoUnitTestCase.java
@@ -55,7 +55,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -63,7 +63,7 @@ import org.junit.Test;
  *
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class ProductInfoUnitTestCase {
 
     private static DomainTestSupport testSupport;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ServerManagementTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ServerManagementTestCase.java
@@ -85,13 +85,13 @@ import org.jboss.dmr.Property;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Emanuel Muckenhuber
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class ServerManagementTestCase {
 
     private static DomainTestSupport testSupport;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SimpleDomainControllerMigrationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SimpleDomainControllerMigrationTestCase.java
@@ -54,7 +54,7 @@ import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
 
@@ -62,7 +62,7 @@ import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
  * Test of migration of the domain controller from one host to another.
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a>  (c) 2015 Red Hat, inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class SimpleDomainControllerMigrationTestCase {
 
     private static final Logger log = Logger.getLogger(SimpleDomainControllerMigrationTestCase.class.getName());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/HierarchicalCompositionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/HierarchicalCompositionTestCase.java
@@ -28,7 +28,7 @@ import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,7 +44,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Marek Kopecky <mkopecky@redhat.com>
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class HierarchicalCompositionTestCase extends AbstractCliTestBase {
 
     private static Logger log = Logger.getLogger(HierarchicalCompositionTestCase.class);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/IncludeAllRoleTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/IncludeAllRoleTestCase.java
@@ -52,13 +52,13 @@ import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetup
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class IncludeAllRoleTestCase extends AbstractRbacTestCase {
     private static final String NEW_ROLE = "NewTestRole";
     private static final String NEW_USER = "NewTestUser";

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/JmxRBACProviderHostScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/JmxRBACProviderHostScopedRolesTestCase.java
@@ -66,7 +66,7 @@ import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
 import org.wildfly.test.jmx.JMXServiceDeploymentSetupTask;
@@ -76,7 +76,7 @@ import org.wildfly.test.jmx.JMXServiceDeploymentSetupTask;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class JmxRBACProviderHostScopedRolesTestCase extends AbstractHostScopedRolesTestCase {
     private static JMXServiceDeploymentSetupTask jmxTask = new JMXServiceDeploymentSetupTask();
     public static final String  OBJECT_NAME = "jboss.test:service=testdeployments";

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/JmxRBACProviderServerGroupScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/JmxRBACProviderServerGroupScopedRolesTestCase.java
@@ -64,7 +64,7 @@ import org.jboss.dmr.ModelNode;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
 import org.wildfly.test.jmx.JMXServiceDeploymentSetupTask;
@@ -74,7 +74,7 @@ import org.wildfly.test.jmx.JMXServiceDeploymentSetupTask;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class JmxRBACProviderServerGroupScopedRolesTestCase extends AbstractServerGroupScopedRolesTestCase {
     private static JMXServiceDeploymentSetupTask jmxTask = new JMXServiceDeploymentSetupTask();
     public static final String  OBJECT_NAME = "jboss.test:service=testdeployments";

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/ListRoleNamesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/ListRoleNamesTestCase.java
@@ -51,13 +51,13 @@ import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetup
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class ListRoleNamesTestCase extends AbstractRbacTestCase {
     private static final String NEW_HOST_SCOPED_ROLE = "NewHostScopedTestRole";
     private static final String NEW_SERVER_GROUP_SCOPED_ROLE = "NewServerGroupScopedTestRole";

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/PermissionsCoverageTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/PermissionsCoverageTestCase.java
@@ -34,13 +34,13 @@ import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetup
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class PermissionsCoverageTestCase extends AbstractRbacTestCase {
     @BeforeClass
     public static void setupDomain() throws Exception {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/PropertiesRoleMappingHostScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/PropertiesRoleMappingHostScopedRolesTestCase.java
@@ -33,14 +33,14 @@ import org.jboss.as.test.integration.management.rbac.GroupRolesMappingServerSetu
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 
 /**
  * Tests of host scoped roles authorized against .properties file using the "rbac" access control provider.
  *
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class PropertiesRoleMappingHostScopedRolesTestCase extends AbstractHostScopedRolesTestCase {
     @BeforeClass
     public static void setupDomain() throws Exception {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/PropertiesRoleMappingServerGroupScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/PropertiesRoleMappingServerGroupScopedRolesTestCase.java
@@ -33,14 +33,14 @@ import org.jboss.as.test.integration.management.rbac.GroupRolesMappingServerSetu
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 
 /**
  * Tests of server group scoped roles authorized against .properties file using the "rbac" access control provider.
  *
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class PropertiesRoleMappingServerGroupScopedRolesTestCase extends AbstractServerGroupScopedRolesTestCase {
     @BeforeClass
     public static void setupDomain() throws Exception {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/PropertiesRoleMappingStandardRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/PropertiesRoleMappingStandardRolesTestCase.java
@@ -48,14 +48,14 @@ import org.jboss.as.test.integration.management.rbac.GroupRolesMappingServerSetu
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 
 /**
  * Tests of the standard roles authorized against .properties file using the "rbac" access control provider.
  *
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class PropertiesRoleMappingStandardRolesTestCase extends AbstractStandardRolesTestCase {
     @BeforeClass
     public static void setupDomain() throws Exception {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderHostScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderHostScopedRolesTestCase.java
@@ -33,14 +33,14 @@ import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetup
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 
 /**
  * Tests of host scoped roles using the "rbac" access control provider.
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class RBACProviderHostScopedRolesTestCase extends AbstractHostScopedRolesTestCase {
 
     @BeforeClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderRunAsHostScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderRunAsHostScopedRolesTestCase.java
@@ -35,7 +35,7 @@ import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetup
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 
 /**
  * Tests of host scoped roles using the "rbac" access control provider but with
@@ -43,7 +43,7 @@ import org.junit.Ignore;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class RBACProviderRunAsHostScopedRolesTestCase extends AbstractHostScopedRolesTestCase {
 
     @BeforeClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderRunAsServerGroupScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderRunAsServerGroupScopedRolesTestCase.java
@@ -35,7 +35,7 @@ import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetup
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 
 /**
  * Tests of server group scoped roles using the "rbac" access control provider but with
@@ -43,7 +43,7 @@ import org.junit.Ignore;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class RBACProviderRunAsServerGroupScopedRolesTestCase extends AbstractServerGroupScopedRolesTestCase {
 
     @BeforeClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderRunAsStandardRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderRunAsStandardRolesTestCase.java
@@ -30,7 +30,7 @@ import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetup
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 
 /**
  * Tests of the standard roles using the "rbac" access control provider but with
@@ -38,7 +38,7 @@ import org.junit.Ignore;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class RBACProviderRunAsStandardRolesTestCase extends AbstractStandardRolesTestCase {
 
     @BeforeClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderServerGroupScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderServerGroupScopedRolesTestCase.java
@@ -33,14 +33,14 @@ import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetup
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 
 /**
  * Tests of server group scoped roles using the "rbac" access control provider.
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class RBACProviderServerGroupScopedRolesTestCase extends AbstractServerGroupScopedRolesTestCase {
 
     @BeforeClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderStandardRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACProviderStandardRolesTestCase.java
@@ -28,14 +28,14 @@ import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetup
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 
 /**
  * Tests of the standard roles using the "rbac" access control provider.
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class RBACProviderStandardRolesTestCase extends AbstractStandardRolesTestCase {
 
     @BeforeClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACSensitivityConstraintUtilizationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RBACSensitivityConstraintUtilizationTestCase.java
@@ -30,7 +30,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.test.integration.domain.rbac.AbstractRbacTestCase.testSupport;
 import static org.jboss.as.test.integration.management.rbac.RbacUtil.MONITOR_USER;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
 
@@ -46,7 +45,7 @@ import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -54,7 +53,7 @@ import org.junit.Test;
  *
  * @author Emmanuel Hugonnet (c) 2016 Red Hat, inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class RBACSensitivityConstraintUtilizationTestCase extends AbstractRbacTestCase {
 
     @BeforeClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RolesIntegrityCheckingTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RolesIntegrityCheckingTestCase.java
@@ -49,7 +49,7 @@ import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetup
 import org.jboss.dmr.ModelNode;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -57,7 +57,7 @@ import org.junit.Test;
  *
  * @author Ladislav Thon <lthon@redhat.com>
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class RolesIntegrityCheckingTestCase extends AbstractRbacTestCase {
     private static final String NEW_ROLE = "NewScopedRole";
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/WildcardReadsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/WildcardReadsTestCase.java
@@ -65,7 +65,7 @@ import org.jboss.dmr.ModelType;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
+//import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -73,7 +73,7 @@ import org.junit.Test;
  *
  * @author Brian Stansberry (c) 2015 Red Hat Inc.
  */
-@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class WildcardReadsTestCase extends AbstractRbacTestCase {
 
     @BeforeClass

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderPropertiesRoleMappingTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderPropertiesRoleMappingTestSuite.java
@@ -68,7 +68,7 @@ public class FullRbacProviderPropertiesRoleMappingTestSuite {
 
     private static synchronized void start(final String name) {
         try {
-            if (true) return; // [WFCORE-1958] Clean up testsuite Elytron registration.
+            //if (true) return; // [WFCORE-1958] Clean up testsuite Elytron registration.
             support = createAndStartDefaultSupport(name);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderRunAsTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderRunAsTestSuite.java
@@ -70,7 +70,7 @@ public class FullRbacProviderRunAsTestSuite {
 
     private static synchronized void start(final String name) {
         try {
-            if (true) return; // [WFCORE-1958] Clean up testsuite Elytron registration.
+            //if (true) return; // [WFCORE-1958] Clean up testsuite Elytron registration.
             support = createAndStartDefaultSupport(name);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/FullRbacProviderTestSuite.java
@@ -83,7 +83,7 @@ public class FullRbacProviderTestSuite {
 
     private static synchronized void start(final String name) {
         try {
-            if (true) return; // [WFCORE-1958] Clean up testsuite Elytron registration.
+            //if (true) return; // [WFCORE-1958] Clean up testsuite Elytron registration.
             support = createAndStartDefaultSupport(name);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-minimal.xml
@@ -21,7 +21,7 @@
   -->
 
 <domain xmlns="urn:jboss:domain:5.0"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" organization="wildfly-core">
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" domain-organization="wildfly-core">
 
     <extensions>
         <extension module="org.jboss.as.logging"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2320

Also reenables the large number of testsuite/domain tests that had been @Ignored with ref to WFCORE-1958. Many of these related to rbac, hence our not knowing RBAC was broken in domain mode. Some others are not related to RBAC, but since they pass I see no reason to have them disabled.

Also tweaks some stuff re: WFCORE-2139 that we would have noticed if the disabled tests had been running.