### PR TITLE
[WFCORE-2330] JBoss-CLI "deploy -l" always returns exit code 1

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeploymentHandler.java
@@ -82,7 +82,7 @@ public abstract class DeploymentHandler extends BatchModeCommandHandler {
                 table.nextRow();
             }
         }
-        throw new CommandFormatException(table.toString());
+        ctx.printLine(table.toString());
     }
 
     protected ModelNode getDeploymentDescriptions(CommandContext ctx, List<String> names) throws CommandFormatException {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2330

DeploymentHandler.listDeployments() should not always throw CommandFormatException.