### PR TITLE
[WFCORE-2332] ReloadRedirectTestCase stuck on HP-UX

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadRedirectTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadRedirectTestCase.java
@@ -226,7 +226,7 @@ public class ReloadRedirectTestCase {
             promptFound = cliProc.pushLineAndWaitForResults("reload", "Accept certificate");
             assertTrue("No certificate prompt " + cliProc.getOutput(), promptFound);
         } finally {
-            cliProc.destroyProcess();
+            cliProc.ctrlCAndWaitForClose();
         }
     }
 }


### PR DESCRIPTION
cliProcess.destroy() does stuck on HP-UX if cliProcess is waiting for input from user (accept certificate dialogue)

https://issues.jboss.org/browse/WFCORE-2332 - ReloadRedirectTestCase stuck on HP-UX