### PR TITLE
Fix for WFCORE-2338. Allow to patch CLI scripts from CLI.

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.bat
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.bat
@@ -68,25 +68,30 @@ if errorlevel == 1 (
 ) else (
   echo logging.configuration already set in JAVA_OPTS
 )
-if "x%LOGGING_CONFIG%" == "x" (
-  "%JAVA%" %JAVA_OPTS% ^
-      -jar "%JBOSS_RUNJAR%" ^
-      -mp "%JBOSS_MODULEPATH%" ^
-       org.jboss.as.cli ^
-         %*
-) else (
-  "%JAVA%" %JAVA_OPTS% "%LOGGING_CONFIG%" ^
-      -jar "%JBOSS_RUNJAR%" ^
-      -mp "%JBOSS_MODULEPATH%" ^
-       org.jboss.as.cli ^
-       %*
-)
 
-set /A RC=%errorlevel%
-:END
-if "x%NOPAUSE%" == "x" pause
+rem Force following commands to be loaded in memory.
+rem This protects the running script from being rewritten.
+(
+    if "x%LOGGING_CONFIG%" == "x" (
+      "%JAVA%" %JAVA_OPTS% ^
+          -jar "%JBOSS_RUNJAR%" ^
+          -mp "%JBOSS_MODULEPATH%" ^
+           org.jboss.as.cli ^
+             %*
+    ) else (
+      "%JAVA%" %JAVA_OPTS% "%LOGGING_CONFIG%" ^
+          -jar "%JBOSS_RUNJAR%" ^
+          -mp "%JBOSS_MODULEPATH%" ^
+           org.jboss.as.cli ^
+           %*
+    )
 
-if "x%RC%" == "x" (
-  set /A RC=0
+    set /A RC=%errorlevel%
+    :END
+    if "x%NOPAUSE%" == "x" pause
+
+    if "x%RC%" == "x" (
+      set /A RC=0
+    )
+    exit /B %RC%
 )
-exit /B %RC%

--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.sh
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.sh
@@ -1,27 +1,5 @@
 #!/bin/sh
 
-clean_tty()
-{
-    # Bourne shell, 128 + n, so 137 for Kill -9
-    if [ $1 = 137 ]; then
-      stty sane
-    fi
-    # set the exit status to be the one that has been passed
-    return $1
-}
-
-CLI_OPTS=""
-while [ "$#" -gt 0 ]
-do
-    case "$1" in
-      *)
-          CLI_OPTS="$CLI_OPTS '$1'"
-          ;;
-    esac
-    shift
-done
-
-
 DIRNAME=`dirname "$0"`
 
 # OS specific support (must be 'true' or 'false').
@@ -94,10 +72,8 @@ fi
 
 LOG_CONF=`echo $JAVA_OPTS | grep "logging.configuration"`
 if [ "x$LOG_CONF" = "x" ]; then
-    eval \"$JAVA\" $JAVA_OPTS \"-Dlogging.configuration=file:"$JBOSS_HOME"/bin/jboss-cli-logging.properties\" -jar \""$JBOSS_HOME"/jboss-modules.jar\" -mp \""${JBOSS_MODULEPATH}"\" org.jboss.as.cli "$CLI_OPTS"
-    clean_tty $?
+    exec "$JAVA" $JAVA_OPTS -Dlogging.configuration=file:"$JBOSS_HOME"/bin/jboss-cli-logging.properties -jar "$JBOSS_HOME"/jboss-modules.jar -mp "${JBOSS_MODULEPATH}" org.jboss.as.cli "$@"
 else
     echo "logging.configuration already set in JAVA_OPTS"
-    eval \"$JAVA\" $JAVA_OPTS -jar \""$JBOSS_HOME"/jboss-modules.jar\" -mp \""${JBOSS_MODULEPATH}"\" org.jboss.as.cli "$CLI_OPTS"
-    clean_tty $?
+    exec "$JAVA" $JAVA_OPTS -jar "$JBOSS_HOME"/jboss-modules.jar -mp "${JBOSS_MODULEPATH}" org.jboss.as.cli "$@"
 fi


### PR DESCRIPTION
In .bat script, force load of commands in memory.
In .sh script, use exec instead of eval making the script to be replaced by java process.