### PR TITLE
[WFCORE-2360]:  Outcome from /host=x/server-config=y:remove() operation in managed domain with multiple hosts lists out all the steps in result.

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
@@ -478,7 +478,7 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
                         if (resultAction == OperationContext.ResultAction.KEEP) {
                             preparedOperation.commit();
                         } else {
-                            if (syncResponse.hasDefined(FAILURE_DESCRIPTION)) {
+                            if (syncResponse.hasDefined(FAILURE_DESCRIPTION) && !context.hasFailureDescription()) {
                                 context.getFailureDescription().set(HostControllerLogger.ROOT_LOGGER.hostDomainSynchronizationError(syncResponse.get(FAILURE_DESCRIPTION).asString()));
                             }
                             preparedOperation.rollback();


### PR DESCRIPTION
If we already have a failure-description then te synchronization failure isn't meaningful.

Jira: https://issues.jboss.org/browse/WFCORE-2360
JBEAP: https://issues.jboss.org/browse/JBEAP-9296