### PR TITLE
Revert "Reenable last remaining test disabled with WFCORE-1958 comment"

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/vault/VaultPasswordsInCLITestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/vault/VaultPasswordsInCLITestCase.java
@@ -50,7 +50,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-//import org.junit.Ignore;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
@@ -70,7 +70,7 @@ import org.wildfly.test.api.Authentication.CallbackHandler;
 
 @RunWith(WildflyTestRunner.class)
 @ServerControl(manual = true)
-//@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
+@Ignore("[WFCORE-1958] Clean up testsuite Elytron registration.")
 public class VaultPasswordsInCLITestCase {
 
     private static Logger LOGGER = Logger.getLogger(VaultPasswordsInCLITestCase.class);


### PR DESCRIPTION
Reverts wildfly/wildfly-core#2218

The test is failing intermittently so it seems reenabling it was premature.