### PR TITLE
WFCORE-1307 rollback on failure to persist changes to config files

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -694,6 +694,11 @@ class ModelControllerImpl implements ModelController {
         return new ConfigurationPersister.PersistenceResource() {
 
             @Override
+            public void prepare() throws ConfigurationPersistenceException {
+                delegate.prepare();
+            }
+
+            @Override
             public void commit() {
                 // Discard the tracker first, so if there's any race the new OperationContextImpl
                 // gets a cleared tracker

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3510,4 +3510,13 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = 438, value = "Couldn't convert '%s' into proper warning level, threshold falling back to 'ALL'. Possible values: SEVERE,WARNING,INFO,CONFIG,FINE,FINER,FINEST,ALL,OFF")
     String couldntConvertWarningLevel(String level);
+
+    @Message(id = 439, value = "Failed to commit configuration to %s")
+    RuntimeException failedToCommitPersistentConfiguration(@Cause Throwable cause, String name);
+
+    @Message(id = 440, value = "Failed to store configuration to %s")
+    ConfigurationPersistenceException failedToStorePersistentConfiguration(@Cause Throwable cause, String name);
+
+    @Message(id = 441, value = "Permission denied writing to file or directory: %s")
+    ConfigurationPersistenceException fileOrDirectoryWritePermissionDenied(String name);
 }

--- a/controller/src/main/java/org/jboss/as/controller/persistence/AbstractFilePersistenceResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/AbstractFilePersistenceResource.java
@@ -51,11 +51,19 @@ public abstract class AbstractFilePersistenceResource implements ConfigurationPe
     }
 
     @Override
+    public void prepare() throws ConfigurationPersistenceException {
+        if (marshalled == null) {
+            throw ControllerLogger.ROOT_LOGGER.rollbackAlreadyInvoked();
+        }
+        doPrepare(marshalled);
+    }
+
+    @Override
     public void commit() {
         if (marshalled == null) {
             throw ControllerLogger.ROOT_LOGGER.rollbackAlreadyInvoked();
         }
-        doCommit(marshalled);
+        doCommit();
     }
 
     @Override
@@ -63,5 +71,6 @@ public abstract class AbstractFilePersistenceResource implements ConfigurationPe
         marshalled = null;
     }
 
-    protected abstract void doCommit(ExposedByteArrayOutputStream marshalled);
+    protected abstract void doCommit();
+    protected abstract void doPrepare(final ExposedByteArrayOutputStream marshalled) throws ConfigurationPersistenceException;
 }

--- a/controller/src/main/java/org/jboss/as/controller/persistence/BackupXmlConfigurationPersister.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/BackupXmlConfigurationPersister.java
@@ -99,9 +99,11 @@ public class BackupXmlConfigurationPersister extends XmlConfigurationPersister {
     public PersistenceResource store(final ModelNode model, Set<PathAddress> affectedAddresses) throws ConfigurationPersistenceException {
         if(!successfulBoot.get()) {
             return new PersistenceResource() {
+                @Override
                 public void commit() {
                 }
 
+                @Override
                 public void rollback() {
                 }
             };

--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationPersister.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationPersister.java
@@ -42,7 +42,6 @@ public interface ConfigurationPersister {
      * to control whether the stored model should be flushed to permanent storage.
      */
     interface PersistenceResource {
-
         /**
          * Flush the stored model to permanent storage.
          */
@@ -52,6 +51,16 @@ public interface ConfigurationPersister {
          * Discard the changes.
          */
         void rollback();
+
+        /**
+         * Perform any needed pre-commit checks / preparation
+         * This method can be used to create temporary resources, and perform
+         * any required checks for appropriate permissions and persistence before commit() is called.
+         * @throws ConfigurationPersistenceException on any failure
+         */
+        default void prepare() throws ConfigurationPersistenceException {
+            // does nothing
+        }
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
@@ -101,11 +101,7 @@ class FilePersistenceUtils {
     static File writeToTempFile(ExposedByteArrayOutputStream marshalled, File tempFileName, File fileName) throws IOException {
         Path targetPath = tempFileName.toPath();
         deleteFile(tempFileName);
-        try {
-            createTempFileWithAttributes(targetPath, fileName);
-        } catch (IOException ioex) {
-           ioex.printStackTrace();
-        }
+        createTempFileWithAttributes(targetPath, fileName);
         try (InputStream is = marshalled.getInputStream()) {
             Files.copy(is, targetPath, StandardCopyOption.REPLACE_EXISTING);
         }

--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistanceResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistanceResourceTestCase.java
@@ -895,7 +895,9 @@ public class PersistanceResourceTestCase {
     }
 
     private void store(TestConfigurationPersister persister, String s) throws Exception {
-        persister.store(new ModelNode(s), Collections.<PathAddress>emptySet()).commit();
+        final ConfigurationPersister.PersistenceResource res = persister.store(new ModelNode(s), Collections.<PathAddress>emptySet());
+        res.prepare();
+        res.commit();
     }
 
     private File createDir(File dir, String name) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerConfigurationPersister.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerConfigurationPersister.java
@@ -175,6 +175,16 @@ public class HostControllerConfigurationPersister implements ExtensibleConfigura
                     delegates[1].rollback();
                 }
             }
+
+            @Override
+            public void prepare() throws ConfigurationPersistenceException {
+                if (delegates[0] != null) {
+                    delegates[0].prepare();
+                }
+                if (delegates[1] != null) {
+                    delegates[1].prepare();
+                }
+            }
         };
     }
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -248,6 +248,7 @@ final class SubsystemTestDelegate {
         extension.initialize(outputExtensionRegistry.getExtensionContext("Test", MOCK_RESOURCE_REG, ExtensionRegistryType.SLAVE));
 
         ConfigurationPersister.PersistenceResource resource = persister.store(model, Collections.<PathAddress>emptySet());
+        resource.prepare();
         resource.commit();
         return persister.getMarshalled();
     }


### PR DESCRIPTION
This turned out a little on the hacky side, but unless we prepare() the persistence when we're still executing Stage.Model, the changes will get applied & committed on domain servers, but rolled back on the hostcontroller(s).

This can probably be cleaned up a little, for example the OSH for the prepare could be moved somewhere else, but I couldn't find anything doing much similar to this.