### PR TITLE
[WFCORE-2511]: overlay, redeploy-links should ignore unknown deployments.

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
@@ -802,7 +802,4 @@ public interface DomainControllerLogger extends BasicLogger {
 
     @Message(id = 97, value = "Cannot explode a subdeployment of an unexploded deployment")
     OperationFailedException cannotExplodeSubDeploymentOfUnexplodedDeployment();
-
-    @Message(id = 98, value = "You are trying to redeploy %s which are deployments not affected by the overlay")
-    OperationFailedException redeployingUnaffactedDeployments(Collection<String> deployments);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainDeploymentOverlayRedeployLinksHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/DomainDeploymentOverlayRedeployLinksHandler.java
@@ -31,7 +31,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEP
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT_OVERLAY_LINK_REMOVAL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REDEPLOY_LINKS;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
-import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.as.server.deploymentoverlay.AffectedDeploymentOverlay;
 import org.jboss.dmr.ModelNode;
 
@@ -80,11 +79,9 @@ public class DomainDeploymentOverlayRedeployLinksHandler implements OperationSte
         Set<String> runtimeNames = domainRoot ? AffectedDeploymentOverlay.listAllLinks(context, context.getCurrentAddressValue()) : AffectedDeploymentOverlay.listLinks(context, context.getCurrentAddress());
         if(operation.hasDefined(RUNTIME_NAMES_DEFINITION.getName())) {
             Set<String> requiredRuntimeNames = new HashSet<>(RUNTIME_NAMES_DEFINITION.unwrap(context, operation));
-            Set<String> unaffectedDeployments = AffectedDeploymentOverlay.checkRequiredNames(requiredRuntimeNames, runtimeNames);
-            if(!unaffectedDeployments.isEmpty() && !isRedeployAfterRemoval(operation)) {
-                throw DomainControllerLogger.ROOT_LOGGER.redeployingUnaffactedDeployments(unaffectedDeployments);
+            if(!requiredRuntimeNames.isEmpty()) {
+                runtimeNames = requiredRuntimeNames;
             }
-            runtimeNames = requiredRuntimeNames;
         }
         return runtimeNames;
     }

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayRedeployLinksHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayRedeployLinksHandler.java
@@ -27,7 +27,6 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
-import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -52,11 +51,9 @@ public class DeploymentOverlayRedeployLinksHandler implements OperationStepHandl
         Set<String> runtimeNames = AffectedDeploymentOverlay.listLinks(context, context.getCurrentAddress());
         if (operation.hasDefined(RUNTIME_NAMES_DEFINITION.getName())) {
             Set<String> requiredRuntimeNames = new HashSet<>(RUNTIME_NAMES_DEFINITION.unwrap(context, operation));
-            Set<String> unaffectedDeployments = AffectedDeploymentOverlay.checkRequiredNames(requiredRuntimeNames, runtimeNames);
-            if (!unaffectedDeployments.isEmpty()) {
-                throw ServerLogger.ROOT_LOGGER.redeployingUnaffactedDeployments(unaffectedDeployments);
+            if (!requiredRuntimeNames.isEmpty()) {
+                runtimeNames = requiredRuntimeNames;
             }
-            runtimeNames = requiredRuntimeNames;
         }
         // Adding a redeploy operation step for each runtime.
         AffectedDeploymentOverlay.redeployLinks(context, context.getCurrentAddress().getParent(), runtimeNames);

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -35,7 +35,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.Attributes;
@@ -1273,9 +1272,6 @@ public interface ServerLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 265, value = "Invalid value '%s' for system property '%s' -- value must be a non-negative integer")
     void invalidPoolCoreSize(String val, String configSysProp);
-
-    @Message(id = 266, value = "You are trying to redeploy %s which are deployments not affected by the overlay")
-    OperationFailedException redeployingUnaffactedDeployments(Collection<String> deployments);
 
     ////////////////////////////////////////////////
     //Messages without IDs

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
@@ -167,11 +167,21 @@ public class DeploymentOverlayTestCase {
         ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
                 PathElement.pathElement(HOST, "slave"),
                 PathElement.pathElement(SERVER, "other-two")), properties);
-        ModelNode failingOp = Operations.createOperation("redeploy-links", PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode());
-        failingOp.get("deployments").setEmptyList();
-        failingOp.get("deployments").add(OTHER_RUNTIME_NAME);
-        failingOp.get("deployments").add("inexisting.jar");
-        executeAsyncForDomainFailure(masterClient, failingOp, "WFLYDC0098:");
+        ModelNode redeployNothingOperation = Operations.createOperation("redeploy-links", PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode());
+        redeployNothingOperation.get("deployments").setEmptyList();
+        redeployNothingOperation.get("deployments").add(OTHER_RUNTIME_NAME);//Doesn't exist
+        redeployNothingOperation.get("deployments").add("inexisting.jar");
+        executeAsyncForResult(masterClient, redeployNothingOperation);
+        //Check that nothing happened
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "master"),
+                PathElement.pathElement(SERVER, "main-one")), properties);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "main-three")), properties);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties);
         executeAsyncForResult(masterClient, Operations.createOperation("redeploy-links", PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode()));
         ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
                 PathElement.pathElement(HOST, "master"),
@@ -195,15 +205,22 @@ public class DeploymentOverlayTestCase {
         ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
                 PathElement.pathElement(HOST, "slave"),
                 PathElement.pathElement(SERVER, "other-two")), properties2);
-        failingOp = Operations.createOperation("redeploy-links", PathAddress.pathAddress(DEPLOYMENT_OVERLAY_PATH).toModelNode());
-        failingOp.get("deployments").setEmptyList();
-        failingOp.get("deployments").add(OTHER_RUNTIME_NAME);
-        failingOp.get("deployments").add("inexisting.jar");
-        executeAsyncForDomainFailure(masterClient, failingOp, "WFLYDC0098:");
-        failingOp = Operations.createOperation("redeploy-links", PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode());
-        failingOp.get("deployments").setEmptyList();
-        failingOp.get("deployments").add(OTHER_RUNTIME_NAME);
-        executeAsyncForFailure(slaveClient, failingOp, "WFLYDC0032: Operation redeploy-links for address " + PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode().toString() + " can only be handled by the master Domain Controller; this host is not the master Domain Controller");
+        redeployNothingOperation = Operations.createOperation("redeploy-links", PathAddress.pathAddress(DEPLOYMENT_OVERLAY_PATH).toModelNode());
+        redeployNothingOperation.get("deployments").setEmptyList();
+        redeployNothingOperation.get("deployments").add(OTHER_RUNTIME_NAME);
+        redeployNothingOperation.get("deployments").add("inexisting.jar");
+        executeAsyncForResult(masterClient, redeployNothingOperation);
+        //Check that nothing happened
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "main-three")), properties2);
+        ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
+                PathElement.pathElement(HOST, "slave"),
+                PathElement.pathElement(SERVER, "other-two")), properties2);
+        ModelNode failingOperation = Operations.createOperation("redeploy-links", PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode());
+        failingOperation.get("deployments").setEmptyList();
+        failingOperation.get("deployments").add(OTHER_RUNTIME_NAME);
+        executeAsyncForFailure(slaveClient, failingOperation, "WFLYDC0032: Operation redeploy-links for address " + PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode().toString() + " can only be handled by the master Domain Controller; this host is not the master Domain Controller");
         ModelNode removeLinkOp = Operations.createOperation(REMOVE, PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH, PathElement.pathElement(DEPLOYMENT, OTHER_RUNTIME_NAME)).toModelNode());
         removeLinkOp.get("redeploy-affected").set(true);
         executeAsyncForResult(masterClient, removeLinkOp);
@@ -221,6 +238,7 @@ public class DeploymentOverlayTestCase {
         ModelNode redeployOp = Operations.createOperation("redeploy-links", PathAddress.pathAddress(MAIN_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode());
         redeployOp.get("deployments").setEmptyList();
         redeployOp.get("deployments").add(MAIN_RUNTIME_NAME);
+        redeployOp.get("deployments").add("inexisting.jar");
         executeAsyncForResult(masterClient, redeployOp);
         ServiceActivatorDeploymentUtil.validateProperties(masterClient, PathAddress.pathAddress(
                 PathElement.pathElement(HOST, "slave"),

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentOverlayTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/DeploymentOverlayTestCase.java
@@ -156,7 +156,14 @@ public class DeploymentOverlayTestCase {
 
             @Override
             public void redeployLinks() throws IOException, MgmtOperationException {
-                ModelNode response = client.execute(Operations.createOperation("redeploy-links", OVERLAY_ADDR.toModelNode()),
+                 ModelNode failingOperation = Operations.createOperation("redeploy-links", OVERLAY_ADDR.toModelNode());
+                failingOperation.get("deployments").setEmptyList();
+                failingOperation.get("deployments").add("*.war");
+                failingOperation.get("deployments").add("test.jar");
+                ModelNode response = client.execute(failingOperation, OperationMessageHandler.DISCARD);
+                Assert.assertTrue(response.toString(), Operations.isSuccessfulOutcome(response));
+                ServiceActivatorDeploymentUtil.validateProperties(client, properties); //Nothing was redeployed
+                response = client.execute(Operations.createOperation("redeploy-links", OVERLAY_ADDR.toModelNode()),
                         OperationMessageHandler.DISCARD);
                 Assert.assertTrue(response.toString(), Operations.isSuccessfulOutcome(response));
                 ServiceActivatorDeploymentUtil.validateProperties(client, properties2);


### PR DESCRIPTION
It was first thought that if the deployment didn't exist we should fail. It appears we were wrong so now we just ignore those deployments.

Jira: https://issues.jboss.org/browse/WFCORE-2511