### PR TITLE
WFCORE-2329: Include ServerAutoStartTestCase and ServerStartFailureTestCase tests in surefire

### DIFF
--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -196,7 +196,8 @@
                          <include>org/jboss/as/test/integration/domain/events/*TestCase.java</include>
                          <include>org/jboss/as/test/integration/domain/suites/*TestSuite.java</include>
                          <include>org/jboss/as/test/integration/domain/suspendresume/*TestCase.java</include>
-                        <include>org/jboss/as/test/integration/domain/slavereconnect/*TestCase.java</include>
+                         <include>org/jboss/as/test/integration/domain/slavereconnect/*TestCase.java</include>
+                         <include>org/jboss/as/test/integration/domain/management/*TestCase.java</include>
                     </includes>
                 </configuration>
             </plugin>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-failure.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-failure.xml
@@ -19,10 +19,9 @@
 ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
-
-<host xmlns="urn:jboss:domain:3.0"
+<host xmlns="urn:jboss:domain:5.0"
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="urn:jboss:domain:3.0 wildfly-config_3_0.xsd"
+      xsi:schemaLocation="urn:jboss:domain:5.0 wildfly-config_5_0.xsd"
       name="slave">
 
     <extensions>


### PR DESCRIPTION
I have included test/integration/domain/management/*TestCase.java in surefire to enable the missing tests for this issue.

Additionally, it was necessary to change host-slave-failure.xml XSD version from 3.0 to 5.0, due to an error in ServerStartFailureTestCase parsing this file. The file was using the element `<http-upgrade enabled="true" />` which was invalid for its XSD version.

Jira issue is:
https://issues.jboss.org/browse/WFCORE-2329