### PR TITLE
Change shebang to work with debian-based distributions

### DIFF
--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/systemd/launch.sh
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/systemd/launch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "x$WILDFLY_HOME" = "x" ]; then
     WILDFLY_HOME="/opt/wildfly"


### PR DESCRIPTION
In RedHat-based distributions sh is a symbolic link to `bash`, but in Debian-based distributions it points to `dash`.

I have been maintaining a Puppet Module [1] to manage Wildfly and this change was enough to make it work with debian-based distributions with systemd.

[1] https://github.com/biemond/biemond-wildfly/