### PR TITLE
Unignore test failing due to WFCORE-1853 that should be fixed.

### DIFF
--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliAliasTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliAliasTestCase.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.WildflyTestRunner;
-import org.junit.Ignore;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -193,7 +192,6 @@ public class CliAliasTestCase {
      *
      * @throws Exception
      */
-    @Ignore("WFCORE-1853")
     @Test
     public void testAliasPersistenceCtrlC() throws Exception {
         final File aliasFile = temporaryUserHome.newFile(".aesh_aliases");


### PR DESCRIPTION
The root cause seems to have been WFCORE-2250 that has already been fixed.