### PR TITLE
WFCORE-2500 Elytron: setting reload-required on http-server-mechanism…

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
@@ -96,7 +96,7 @@ class AuthenticationFactoryDefinitions {
 
     static final SimpleAttributeDefinition HTTP_SERVER_MECHANISM_FACTORY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.HTTP_SERVER_MECHANISM_FACTORY, ModelType.STRING, false)
             .setMinSize(1)
-            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .setRestartAllServices()
             .setCapabilityReference(HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY, HTTP_AUTHENTICATION_FACTORY_CAPABILITY, true)
             .build();
 


### PR DESCRIPTION
…-factory of http-authentication-factory

Issue: https://issues.jboss.org/browse/WFCORE-2500