### PR TITLE
[WFCORE-2519] Upgrade jboss-logmanager from 2.0.5.Final to 2.0.6.Final.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
@@ -72,6 +72,7 @@ import org.jboss.logmanager.config.LoggerConfiguration;
 import org.jboss.logmanager.config.PojoConfiguration;
 import org.jboss.logmanager.config.PropertyConfigurable;
 import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.handlers.AsyncHandler;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoadException;
 import org.jboss.modules.ModuleLoader;
@@ -322,6 +323,10 @@ final class HandlerOperations {
                     configuration = logContextConfiguration.addHandlerConfiguration(moduleName, className, name);
                 } else {
                     configuration = logContextConfiguration.addHandlerConfiguration(moduleName, className, name, constructionProperties);
+                }
+                // If this is an AsyncHandler we need to setCloseChildren() to false
+                if (AsyncHandler.class.getName().equals(className)) {
+                    configuration.setPropertyValueString("closeChildren", "false");
                 }
             }
             return configuration;

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.0.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
-        <version.org.jboss.logmanager.jboss-logmanager>2.0.5.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.0.6.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.0.Beta5</version.org.jboss.marshalling.jboss-marshalling>
         <!-- this is test only dependancy -->


### PR DESCRIPTION
[WFCORE-1585] Ensure the async-handler does not close children handlers.

https://issues.jboss.org/browse/WFCORE-2519
https://issues.jboss.org/browse/WFCORE-1585

The fix for WFCORE-1585 requires the jboss-logmanager upgrade.