### PR TITLE
Fix for WFCORE-2554. CLI Batch file with comments and empty lines

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchHandler.java
@@ -152,8 +152,11 @@ public class BatchHandler extends CommandHandlerWithHelp {
                 String line = reader.readLine();
                 batchManager.activateNewBatch();
                 final Batch batch = batchManager.getActiveBatch();
-                while(line != null) {
-                    batch.add(ctx.toBatchedCommand(line));
+                while (line != null) {
+                    line = line.trim();
+                    if (!line.isEmpty() && line.charAt(0) != '#') {
+                        batch.add(ctx.toBatchedCommand(line));
+                    }
                     line = reader.readLine();
                 }
             } catch(IOException e) {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
@@ -226,7 +226,7 @@ public class BatchRunHandler extends BaseOperationCommand {
                 String line = reader.readLine();
                 batchManager.activateNewBatch();
                 while(line != null) {
-                    ctx.handle(line);
+                    ctx.handle(line.trim());
                     line = reader.readLine();
                 }
                 final ModelNode request = batchManager.getActiveBatch().toRequest();

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BatchFileTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BatchFileTestCase.java
@@ -152,9 +152,12 @@ public class BatchFileTestCase {
         }
 
         try (Writer writer = Files.newBufferedWriter(TMP_FILE.toPath(), StandardCharsets.UTF_8)){
-            for(String line : cmd) {
+            for (String line : cmd) {
+                writer.write("# Some comment\n");
                 writer.write(line);
                 writer.write('\n');
+                writer.write("     \n");
+                writer.write("\n");
             }
         } catch (IOException e) {
             fail("Failed to write to " + TMP_FILE.getAbsolutePath() + ": " + e.getLocalizedMessage());


### PR DESCRIPTION
batch --file and run-batch --file should better resist to comments, empty lines and lines with whitespace only.
Updated unit tests.