### PR TITLE
[deterministic-resume]: SuspendController resume is called properly on boot end without relying on notifications.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/BootstrapImpl.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapImpl.java
@@ -110,6 +110,8 @@ final class BootstrapImpl implements Bootstrap {
         shutdownHook.setControlledProcessState(processState);
         ControlledProcessStateService controlledProcessStateService = ControlledProcessStateService.addService(tracker, processState).getValue();
         final SuspendController suspendController = new SuspendController();
+        //Instantiating the suspendcontroller here to be able to get a reference to it in RunningStateJmx
+        //Note that the SuspendController service will be started in the ServerService during the boot of the server.
         RunningStateJmx.registerMBean(
                 controlledProcessStateService, suspendController,
                 configuration.getRunningModeControl(),

--- a/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
+++ b/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
@@ -7,10 +7,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.notification.Notification;
-import org.jboss.as.controller.notification.NotificationFilter;
-import org.jboss.as.controller.notification.NotificationHandler;
 import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -66,6 +62,7 @@ public class SuspendController implements Service<SuspendController> {
     }
 
     public void setStartSuspended(boolean startSuspended) {
+        //TODO: it is not very clear what this boolean stands for now.
         this.startSuspended = startSuspended;
         state = State.SUSPENDED;
     }
@@ -149,19 +146,7 @@ public class SuspendController implements Service<SuspendController> {
 
     @Override
     public synchronized void start(StartContext startContext) throws StartException {
-        if(!startSuspended) {
-            final NotificationFilter filter = notification -> notification.getType().equals(ModelDescriptionConstants.BOOT_COMPLETE_NOTIFICATION);
-            NotificationHandler handler = new NotificationHandler() {
-                @Override
-                public void handleNotification(Notification notification) {
-                    resume();
-                    modelControllerInjectedValue.getValue().getNotificationRegistry().unregisterNotificationHandler(NOTIFICATION_ADDRESS, this, filter);
-                }
-            };
-            modelControllerInjectedValue.getValue().getNotificationRegistry().registerNotificationHandler(NOTIFICATION_ADDRESS, handler, filter);
-            //if the service bounces we don't want to auto resume if we are suspended
-            startSuspended = true;
-        } else {
+        if(startSuspended) {
             ServerLogger.AS_ROOT_LOGGER.startingServerSuspended();
         }
     }


### PR DESCRIPTION
SuspendController resume was called on bott when it received a BOOT_COMPLETE_NOTIFICATION.
But notifications are non deterministic so we could get a ControlledServerState change (which relies on the same notification) while the resume hasn't been called yet.

This should fix all the intermittent failures with server state listeners.