### PR TITLE
[WFCORE-2532] Add permissions for logging tests when running with a s…

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractLoggingTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractLoggingTestCase.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.Permission;
 import java.util.Collections;
 import java.util.Map;
 import javax.inject.Inject;
@@ -44,6 +45,7 @@ import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper.ServerDeploymentException;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceActivator;
@@ -114,7 +116,12 @@ public abstract class AbstractLoggingTestCase {
             manifest.append("Dependencies: io.undertow.core");
         }
         archive.addAsResource(new StringAsset(manifest.toString()), "META-INF/MANIFEST.MF");
-        return archive;
+        return addPermissions(archive);
+    }
+
+    public static JavaArchive addPermissions(final JavaArchive archive, final Permission... additionalPermissions) {
+        final Permission[] permissions = LoggingServiceActivator.appendPermissions(additionalPermissions);
+        return archive.addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(permissions), "permissions.xml");
     }
 
     public static ModelNode executeOperation(final ModelNode op) throws IOException {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
@@ -23,9 +23,12 @@ package org.jboss.as.test.manualmode.logging;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.LoggingPermission;
+
 import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.syslogserver.BlockedAllProtocolsSyslogServerEventHandler;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,7 +55,11 @@ public class ReconnectSyslogServerTestCase extends AbstractSyslogReconnectionTes
     public void setupContainer() throws Exception {
         container.start();
         host = CoreUtils.stripSquareBrackets(TestSuiteEnvironment.getServerAddress());
-        deploy();
+        // TODO (jrp) remove this once LOGMGR-149 is resolved
+        final JavaArchive deployment = createDeployment();
+        // Add the logging permissions as a workaround for LOGMGR-149
+        addPermissions(deployment, new LoggingPermission("control", null));
+        deploy(deployment);
         SyslogServer.shutdown();
         BlockedAllProtocolsSyslogServerEventHandler.initializeForProtocol(SyslogConstants.UDP);
         BlockedAllProtocolsSyslogServerEventHandler.initializeForProtocol(SyslogConstants.TCP);

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SyslogIsNotAvailableDuringServerBootTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SyslogIsNotAvailableDuringServerBootTestCase.java
@@ -23,9 +23,12 @@ package org.jboss.as.test.manualmode.logging;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.LoggingPermission;
+
 import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.syslogserver.BlockedAllProtocolsSyslogServerEventHandler;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,7 +56,11 @@ public class SyslogIsNotAvailableDuringServerBootTestCase extends AbstractSyslog
     public void setupContainer() throws Exception {
         container.start();
         host = CoreUtils.stripSquareBrackets(TestSuiteEnvironment.getServerAddress());
-        deploy();
+        // TODO (jrp) remove this once LOGMGR-149 is resolved
+        final JavaArchive deployment = createDeployment();
+        // Add the logging permissions as a workaround for LOGMGR-149
+        addPermissions(deployment, new LoggingPermission("control", null));
+        deploy(deployment);
         SyslogServer.shutdown();
         BlockedAllProtocolsSyslogServerEventHandler.initializeForProtocol(SyslogConstants.UDP);
         BlockedAllProtocolsSyslogServerEventHandler.initializeForProtocol(SyslogConstants.TCP);

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/AbstractLoggingTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/AbstractLoggingTestCase.java
@@ -31,6 +31,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.Permission;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -46,6 +47,7 @@ import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper.ServerDeploymentException;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -110,7 +112,12 @@ public abstract class AbstractLoggingTestCase {
             manifest.append("Dependencies: io.undertow.core");
         }
         archive.addAsResource(new StringAsset(manifest.toString()), "META-INF/MANIFEST.MF");
-        return archive;
+        return addPermissions(archive);
+    }
+
+    public static JavaArchive addPermissions(final JavaArchive archive, final Permission... additionalPermissions) {
+        final Permission[] permissions = LoggingServiceActivator.appendPermissions(additionalPermissions);
+        return archive.addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(permissions), "permissions.xml");
     }
 
     public static ModelNode executeOperation(final ModelNode op) throws IOException {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/LoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/LoggingProfilesTestCase.java
@@ -311,6 +311,7 @@ public class LoggingProfilesTestCase extends AbstractLoggingTestCase {
             archive.addAsServiceProviderAndClasses(ServiceActivator.class, LoggingServiceActivator.class);
         }
         archive.addAsResource(new StringAsset("Dependencies: io.undertow.core\nLogging-Profile: " + profileName), "META-INF/MANIFEST.MF");
+        addPermissions(archive);
         deploy(archive, name);
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.LoggingPermission;
 
 import org.apache.http.HttpStatus;
 import org.jboss.as.controller.client.helpers.Operations;
@@ -47,6 +48,7 @@ import org.jboss.as.test.syslogserver.UDPSyslogServerConfig;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.logging.Logger.Level;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -88,7 +90,11 @@ public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
 
     @BeforeClass
     public static void deploy() throws Exception {
-        deploy(createDeployment(Collections.singletonMap("Logging-Profile", "syslog-profile")), DEPLOYMENT_NAME);
+        // TODO (jrp) remove this once LOGMGR-149 is resolved
+        final JavaArchive deployment = createDeployment(Collections.singletonMap("Logging-Profile", "syslog-profile"));
+        // Add the logging permissions as a workaround for LOGMGR-149
+        addPermissions(deployment, new LoggingPermission("control", null));
+        deploy(deployment, DEPLOYMENT_NAME);
     }
 
     @AfterClass

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/modules/ModuleResourceRootPathsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/modules/ModuleResourceRootPathsTestCase.java
@@ -28,6 +28,7 @@ import org.jboss.as.cli.Util;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -116,6 +117,7 @@ public class ModuleResourceRootPathsTestCase extends AbstractCliTestBase {
         archive.addAsServiceProviderAndClasses(ServiceActivator.class, ModulesServiceActivator.class)
                 .addAsManifestResource(new StringAsset("Dependencies: io.undertow.core," + MODULE_RESOURCE_MODULE_NAME
                         + "," + ABSOLUTE_RESOURCE_MODULE_NAME + "\n"), "MANIFEST.MF");
+        archive.addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(ModulesServiceActivator.DEFAULT_PERMISSIONS), "permissions.xml");
         final ServerDeploymentHelper helper = new ServerDeploymentHelper(client.getControllerClient());
         helper.deploy("test-archive.war", archive.as(ZipExporter.class).exportAsInputStream());
     }


### PR DESCRIPTION
…ecurity manager. Added workaround for LOGMGR-149.

https://issues.jboss.org/browse/WFCORE-2532

There is a workaround for https://issues.jboss.org/browse/LOGMGR-149 which is a legitimate failure. I can do a new release of the log manager if we feel it's important. Regardless I will get it fixed in the log manager.