### PR TITLE
Fix for WFCORE-2582. ! in file paths

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.bat
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.bat
@@ -1,8 +1,11 @@
 @echo off
 setlocal ENABLEEXTENSIONS
-rem the arguments can contain ')' character, this breaks parser. Delaying 
-rem argument evaluation at script execution fixes it.
-setlocal ENABLEDELAYEDEXPANSION
+
+rem WARNING: Delayed expansion is enabled prior to execute JVM.
+rem Do not enable delayed expansion until the JVM execution.
+rem '!' contained in JBOSS_HOME or JAVA_HOME paths would be removed from variables.
+
+
 rem -------------------------------------------------------------------------
 rem JBoss Admin CLI Script for Windows
 rem -------------------------------------------------------------------------
@@ -73,15 +76,19 @@ if errorlevel == 1 (
   echo logging.configuration already set in JAVA_OPTS
 )
 
+rem the arguments can contain ')' character, this breaks parser. Delaying 
+rem argument evaluation at script execution fixes it.
+setlocal ENABLEDELAYEDEXPANSION
+
 rem script arguments will be evaluated at execution time.
 set ARGS=%*
 
 rem Force following commands to be loaded in memory.
 rem This protects the running script from being rewritten.
 (
-    "%JAVA%" %JAVA_OPTS% %LOGGING_CONFIG% ^
-        -jar "%JBOSS_RUNJAR%" ^
-        -mp "%JBOSS_MODULEPATH%" ^
+    "!JAVA!" !JAVA_OPTS! !LOGGING_CONFIG! ^
+        -jar "!JBOSS_RUNJAR!" ^
+        -mp "!JBOSS_MODULEPATH!" ^
          org.jboss.as.cli ^
          !ARGS!
 


### PR DESCRIPTION
Delaying variable resolution means that variables accessed with %x% have their '!' characters removed.
This patch move delaying expansion when required (just prior to call JVM). All variables after this point are resolved at execution time (!x! instead of %x%).
With this fix we have:
- support for CLI script patching from CLI.
- support for ')' character in commands passed to CLI.
- support for '!' in file paths.
