### PR TITLE
[WFCORE-192] Allow the known directory system properties to be passed…

### DIFF
--- a/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/AbstractCommandBuilder.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.wildfly.core.launcher.Arguments.Argument;
 import org.wildfly.core.launcher.logger.LauncherMessages;
 
 /**
@@ -286,10 +287,13 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
      */
     public T addServerArgument(final String arg) {
         if (arg != null) {
-            if (SECURITY_MANAGER_ARG.equals(arg)) {
-                setUseSecurityManager(true);
-            } else {
-                serverArgs.add(arg);
+            final Argument argument = Arguments.parse(arg);
+            if (addServerArgument(argument)) {
+                if (SECURITY_MANAGER_ARG.equals(arg)) {
+                    setUseSecurityManager(true);
+                } else {
+                    serverArgs.add(argument);
+                }
             }
         }
         return getThis();
@@ -624,6 +628,17 @@ abstract class AbstractCommandBuilder<T extends AbstractCommandBuilder<T>> imple
     protected String getServerArg(final String key) {
         return serverArgs.get(key);
     }
+
+    /**
+     * Allows the subclass to do additional checking on whether the server argument should be added or not. In some
+     * cases it may be desirable for the argument passed to be added or processed elsewhere.
+     *
+     * @param argument the argument to test
+     *
+     * @return {@code true} if the argument should be added to the server arguments, {@code false} if the argument is
+     * handled by the subclass
+     */
+    abstract boolean addServerArgument(final Argument argument);
 
     @Deprecated
     protected static Path resolveJavaHome(final Path javaHome) {

--- a/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/DomainCommandBuilder.java
@@ -799,6 +799,31 @@ public class DomainCommandBuilder extends AbstractCommandBuilder<DomainCommandBu
         return this;
     }
 
+    @Override
+    boolean addServerArgument(final Argument argument) {
+        switch (argument.getKey()) {
+            case DOMAIN_BASE_DIR:
+                if (argument.getValue() != null) {
+                    setBaseDirectory(argument.getValue());
+                    return false;
+                }
+                break;
+            case DOMAIN_CONFIG_DIR:
+                if (argument.getValue() != null) {
+                    setConfigurationDirectory(argument.getValue());
+                    return false;
+                }
+                break;
+            case DOMAIN_LOG_DIR:
+                if (argument.getValue() != null) {
+                    setLogDirectory(argument.getValue());
+                    return false;
+                }
+                break;
+        }
+        return true;
+    }
+
     private String getHostControllerJavaCommand() {
         if (hostControllerJavaHome != null) {
             return getJavaCommand(hostControllerJavaHome);

--- a/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
@@ -471,4 +471,29 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
     protected StandaloneCommandBuilder getThis() {
         return this;
     }
+
+    @Override
+    boolean addServerArgument(final Argument argument) {
+        switch (argument.getKey()) {
+            case SERVER_BASE_DIR:
+                if (argument.getValue() != null) {
+                    setBaseDirectory(argument.getValue());
+                    return false;
+                }
+                break;
+            case SERVER_CONFIG_DIR:
+                if (argument.getValue() != null) {
+                    setConfigurationDirectory(argument.getValue());
+                    return false;
+                }
+                break;
+            case SERVER_LOG_DIR:
+                if (argument.getValue() != null) {
+                    setLogDirectory(argument.getValue());
+                    return false;
+                }
+                break;
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
… as server arguments and be appropriately set in the VM arguments.

https://issues.jboss.org/browse/WFCORE-192

This closer aligns with how the scripts handle these arguments, for example `-Djboss.server.config.dir=some/path`.