### PR TITLE
[WFCORE-2598] initModel should use the model CapabilityRegistry to re…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
@@ -394,21 +394,27 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
 
     @Override
     public void capabilityReloadRequired(PathAddress address, ImmutableManagementResourceRegistration resourceRegistration) {
-        writeLock.lock();
-        try {
-            reloadCapabilities.addAll(getCapabilitiesForAddress(address, resourceRegistration));
-        } finally {
-            writeLock.unlock();
+        if (address.size() > 0) { // root resource capabilities are not "reload-required" just because an op
+                                  // targeting the root (e.g. a process name change) triggered reload-required
+            writeLock.lock();
+            try {
+                reloadCapabilities.addAll(getCapabilitiesForAddress(address, resourceRegistration));
+            } finally {
+                writeLock.unlock();
+            }
         }
     }
 
     @Override
     public void capabilityRestartRequired(PathAddress address, ImmutableManagementResourceRegistration resourceRegistration) {
-        writeLock.lock();
-        try {
-            restartCapabilities.addAll(getCapabilitiesForAddress(address, resourceRegistration));
-        } finally {
-            writeLock.unlock();
+        if (address.size() > 0) {  // root resource capabilities are not "restart-required" just because an op
+                                   // targeting the root (e.g. a process name change) triggered restart-required
+            writeLock.lock();
+            try {
+                restartCapabilities.addAll(getCapabilitiesForAddress(address, resourceRegistration));
+            } finally {
+                writeLock.unlock();
+            }
         }
     }
 
@@ -928,6 +934,8 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
         List<PathMatcher> matchers = getPossibleProviderPoints(id).stream().
                 map((possiblePoint) -> FileSystems.getDefault().getPathMatcher("glob:"
                         + possiblePoint.toPathStyleString())).collect(Collectors.toList());
+        // Any dynamic capability registered to the root address matches (e.g. hardcoded path capabilities)
+        matchers.add(FileSystems.getDefault().getPathMatcher("glob:/"));
 
         // Filter the streams of capabilities to extract matching ones
         return getCapabilities().stream().

--- a/controller/src/test/java/org/jboss/as/controller/services/path/PathsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/services/path/PathsTestCase.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.operations.global.GlobalNotifications;
@@ -65,6 +66,8 @@ import org.junit.Test;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class PathsTestCase extends AbstractControllerTestBase {
+
+    private static final ServiceName PATH_MANAGER_SVC = AbstractControllerService.PATH_MANAGER_CAPABILITY.getCapabilityServiceName();
 
     PathManagerService pathManagerService;
 
@@ -356,7 +359,7 @@ public class PathsTestCase extends AbstractControllerTestBase {
     }
 
     private void checkServiceAndPathEntry(String name, String path, String relativeTo) {
-        ServiceController<?> pathManagerService = getContainer().getRequiredService(PathManagerService.SERVICE_NAME);
+        ServiceController<?> pathManagerService = getContainer().getRequiredService(PATH_MANAGER_SVC);
         Assert.assertEquals(State.UP, pathManagerService.getState());
         PathManagerService pathManager = (PathManagerService) pathManagerService.getValue();
 
@@ -374,7 +377,7 @@ public class PathsTestCase extends AbstractControllerTestBase {
 
     @Test
     public void testPathManagerAddNotifications() throws Exception {
-        ServiceController<?> pathManagerService = getContainer().getRequiredService(PathManagerService.SERVICE_NAME);
+        ServiceController<?> pathManagerService = getContainer().getRequiredService(PATH_MANAGER_SVC);
         PathManager pathManager = (PathManager) pathManagerService.getValue();
 
         PerformChangeCallback allCallback1 = new PerformChangeCallback(pathManager, "add1", Event.ADDED, Event.REMOVED, Event.UPDATED);
@@ -434,7 +437,7 @@ public class PathsTestCase extends AbstractControllerTestBase {
     @Test
     public void testPathManagerRemoveNotifications() throws Exception {
         testAddPath();
-        ServiceController<?> pathManagerService = getContainer().getRequiredService(PathManagerService.SERVICE_NAME);
+        ServiceController<?> pathManagerService = getContainer().getRequiredService(PATH_MANAGER_SVC);
         PathManager pathManager = (PathManager) pathManagerService.getValue();
 
         PerformChangeCallback allCallback1 = new PerformChangeCallback(pathManager, "add1", Event.ADDED, Event.REMOVED, Event.UPDATED);
@@ -498,7 +501,7 @@ public class PathsTestCase extends AbstractControllerTestBase {
     @Test
     public void testPathManagerChangeNotifications() throws Exception {
         testAddPath();
-        ServiceController<?> pathManagerService = getContainer().getRequiredService(PathManagerService.SERVICE_NAME);
+        ServiceController<?> pathManagerService = getContainer().getRequiredService(PATH_MANAGER_SVC);
         PathManager pathManager = (PathManager) pathManagerService.getValue();
 
         ModelNode operation = createOperation(ADD);
@@ -575,7 +578,7 @@ public class PathsTestCase extends AbstractControllerTestBase {
     public void testCannotRemoveDependentService() throws Exception {
         testAddPath();
 
-        ServiceController<?> pathManagerService = getContainer().getRequiredService(PathManagerService.SERVICE_NAME);
+        ServiceController<?> pathManagerService = getContainer().getRequiredService(PATH_MANAGER_SVC);
         PathManager pathManager = (PathManager) pathManagerService.getValue();
 
         PerformChangeCallback allCallback1 = new PerformChangeCallback(pathManager, "add2", Event.ADDED, Event.REMOVED, Event.UPDATED);
@@ -597,7 +600,7 @@ public class PathsTestCase extends AbstractControllerTestBase {
 
     @Test
     public void testBadAdd() throws Exception {
-        ServiceController<?> pathManagerService = getContainer().getRequiredService(PathManagerService.SERVICE_NAME);
+        ServiceController<?> pathManagerService = getContainer().getRequiredService(PATH_MANAGER_SVC);
         PathManager pathManager = (PathManager) pathManagerService.getValue();
 
         PerformChangeCallback allCallback1 = new PerformChangeCallback(pathManager, "add1", Event.ADDED, Event.REMOVED, Event.UPDATED);
@@ -623,7 +626,7 @@ public class PathsTestCase extends AbstractControllerTestBase {
 
     @Test
     public void testBadChangeNoNotification() throws Exception {
-        ServiceController<?> pathManagerService = getContainer().getRequiredService(PathManagerService.SERVICE_NAME);
+        ServiceController<?> pathManagerService = getContainer().getRequiredService(PATH_MANAGER_SVC);
         PathManager pathManager = (PathManager) pathManagerService.getValue();
 
         PerformChangeCallback allCallback1 = new PerformChangeCallback(pathManager, "add1", Event.ADDED, Event.REMOVED, Event.UPDATED);
@@ -654,7 +657,7 @@ public class PathsTestCase extends AbstractControllerTestBase {
     public void testChangeDependentServiceNotificationIsCascaded() throws Exception {
         testAddPath();
 
-        ServiceController<?> pathManagerService = getContainer().getRequiredService(PathManagerService.SERVICE_NAME);
+        ServiceController<?> pathManagerService = getContainer().getRequiredService(PATH_MANAGER_SVC);
         PathManager pathManager = (PathManager) pathManagerService.getValue();
 
         PerformChangeCallback allCallback1 = new PerformChangeCallback(pathManager, "add1", Event.ADDED, Event.REMOVED, Event.UPDATED);
@@ -815,7 +818,7 @@ public class PathsTestCase extends AbstractControllerTestBase {
 
         TestServiceListener listener = new TestServiceListener();
         listener.reset(1);
-        getContainer().addService(PathManagerService.SERVICE_NAME, pathManagerService)
+        getContainer().addService(PATH_MANAGER_SVC, pathManagerService)
                 .addListener(listener)
                 .install();
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -72,7 +72,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.PathManager;
-import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.core.security.ServerSecurityManager;
 import org.jboss.as.domain.management.AuthMechanism;
 import org.jboss.as.domain.management.CallbackHandlerFactory;
@@ -100,6 +99,7 @@ import org.jboss.msc.value.InjectedValue;
 public class SecurityRealmAddHandler implements OperationStepHandler {
 
     private static final String ELYTRON_CAPABILITY = "org.wildfly.security.elytron";
+    private static final String PATH_MANAGER_CAPABILITY = "org.wildfly.management.path-manager";
 
     public static final SecurityRealmAddHandler INSTANCE = new SecurityRealmAddHandler();
 
@@ -400,7 +400,8 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
         ServiceBuilder<?> propsBuilder = serviceTarget.addService(propsServiceName, propsCallbackHandler);
 
         if (relativeTo != null) {
-            propsBuilder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, propsCallbackHandler.getPathManagerInjectorInjector());
+            propsBuilder.addDependency(context.getCapabilityServiceName(PATH_MANAGER_CAPABILITY, PathManager.class),
+                    PathManager.class, propsCallbackHandler.getPathManagerInjectorInjector());
             propsBuilder.addDependency(pathName(relativeTo));
         }
 
@@ -423,7 +424,8 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
 
         ServiceBuilder<?> propsBuilder = serviceTarget.addService(propsServiceName, propsSubjectSupplemental);
         if (relativeTo != null) {
-            propsBuilder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, propsSubjectSupplemental.getPathManagerInjectorInjector());
+            propsBuilder.addDependency(context.getCapabilityServiceName(PATH_MANAGER_CAPABILITY, PathManager.class),
+                    PathManager.class, propsSubjectSupplemental.getPathManagerInjectorInjector());
             propsBuilder.addDependency(pathName(relativeTo));
         }
 
@@ -676,7 +678,8 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
             serviceBuilder = serviceTarget.addService(serviceName, keyManagerService);
 
             if (relativeTo != null) {
-                serviceBuilder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, keyManagerService.getPathManagerInjector());
+                serviceBuilder.addDependency(context.getCapabilityServiceName(PATH_MANAGER_CAPABILITY, PathManager.class),
+                        PathManager.class, keyManagerService.getPathManagerInjector());
                 serviceBuilder.addDependency(pathName(relativeTo));
             }
         }
@@ -704,7 +707,8 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
 
             serviceBuilder = serviceTarget.addService(serviceName, trustManagerService);
             if (relativeTo != null) {
-                serviceBuilder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, trustManagerService.getPathManagerInjector());
+                serviceBuilder.addDependency(context.getCapabilityServiceName(PATH_MANAGER_CAPABILITY, PathManager.class),
+                        PathManager.class, trustManagerService.getPathManagerInjector());
                 serviceBuilder.addDependency(pathName(relativeTo));
             }
         }
@@ -761,7 +765,8 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
                  ServiceBuilder<KeytabService> keytabBuilder = serviceTarget.addService(keytabName, ks).setInitialMode(ON_DEMAND);
 
                 if (relativeTo != null) {
-                    keytabBuilder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, ks.getPathManagerInjector());
+                    keytabBuilder.addDependency(context.getCapabilityServiceName(PATH_MANAGER_CAPABILITY, PathManager.class),
+                            PathManager.class, ks.getPathManagerInjector());
                     keytabBuilder.addDependency(pathName(relativeTo));
                 }
 

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/util/ManagementControllerTestBase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/util/ManagementControllerTestBase.java
@@ -25,6 +25,7 @@ package org.jboss.as.domain.management.security.util;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
+import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
@@ -90,7 +91,7 @@ public class ManagementControllerTestBase extends AbstractControllerTestBase {
 
         TestServiceListener listener = new TestServiceListener();
         listener.reset(1);
-        getContainer().addService(PathManagerService.SERVICE_NAME, pathManagerService)
+        getContainer().addService(AbstractControllerService.PATH_MANAGER_CAPABILITY.getCapabilityServiceName(), pathManagerService)
                 .addListener(listener)
                 .install();
 

--- a/jmx/src/test/java/org/jboss/as/jmx/auditlog/JmxAuditLogHandlerTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/auditlog/JmxAuditLogHandlerTestCase.java
@@ -43,6 +43,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.QueryExp;
 
+import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.ManagementModel;
 import org.jboss.as.controller.PathAddress;
@@ -750,7 +751,7 @@ public class JmxAuditLogHandlerTestCase extends AbstractControllerTestBase {
 
         TestServiceListener listener = new TestServiceListener();
         listener.reset(1);
-        getContainer().addService(PathManagerService.SERVICE_NAME, pathManagerService)
+        getContainer().addService(AbstractControllerService.PATH_MANAGER_CAPABILITY.getCapabilityServiceName(), pathManagerService)
                 .addListener(listener)
                 .install();
 

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
@@ -44,6 +44,7 @@ import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AccessAuditContext;
 import org.jboss.as.controller.AttributeDefinition;
@@ -814,7 +815,7 @@ public class JmxFacadeRbacEnabledTestCase extends AbstractControllerTestBase {
 
         TestServiceListener listener = new TestServiceListener();
         listener.reset(1);
-        getContainer().addService(PathManagerService.SERVICE_NAME, pathManagerService)
+        getContainer().addService(AbstractControllerService.PATH_MANAGER_CAPABILITY.getCapabilityServiceName(), pathManagerService)
                 .addListener(listener)
                 .install();
 

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
@@ -47,6 +47,7 @@ import javax.management.NotificationListener;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 
+import org.jboss.as.controller.AbstractControllerService;
 import org.jboss.as.controller.AccessAuditContext;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.CompositeOperationHandler;
@@ -623,7 +624,7 @@ public abstract class JmxRbacTestCase extends AbstractControllerTestBase {
 
         TestServiceListener listener = new TestServiceListener();
         listener.reset(1);
-        getContainer().addService(PathManagerService.SERVICE_NAME, pathManagerService)
+        getContainer().addService(AbstractControllerService.PATH_MANAGER_CAPABILITY.getCapabilityServiceName(), pathManagerService)
                 .addListener(listener)
                 .install();
 

--- a/logging/src/main/java/org/jboss/as/logging/resolvers/FileResolver.java
+++ b/logging/src/main/java/org/jboss/as/logging/resolvers/FileResolver.java
@@ -32,10 +32,10 @@ import java.nio.file.Paths;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.services.path.PathManager;
-import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.logging.logging.LoggingLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 
 /**
  * Used to resolve an absolute path for a file.
@@ -84,8 +84,9 @@ public class FileResolver implements ModelNodeResolver<String> {
 
     private String resolve(final OperationContext context, final String relativeToPath, final String path) {
         // TODO it would be better if this came via the ExtensionContext
+        ServiceName pathMgrSvc = context.getCapabilityServiceName("org.wildfly.management.path-manager", PathManager.class);
         @SuppressWarnings("unchecked")
-        final ServiceController<PathManager> controller = (ServiceController<PathManager>) context.getServiceRegistry(false).getService(PathManagerService.SERVICE_NAME);
+        final ServiceController<PathManager> controller = (ServiceController<PathManager>) context.getServiceRegistry(false).getService(pathMgrSvc);
         if (controller == null) {
             return null;
         }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentHandlerUtil.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentHandlerUtil.java
@@ -47,7 +47,6 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.registry.Resource.ResourceEntry;
 import org.jboss.as.controller.services.path.PathManager;
-import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.repository.ContentReference;
 import org.jboss.as.repository.ContentRepository;
 import org.jboss.as.server.ServerEnvironment;
@@ -201,7 +200,7 @@ public class DeploymentHandlerUtil {
         else {
             final String path = contents[0].path;
             final String relativeTo = contents[0].relativeTo;
-            contentService = PathContentServitor.addService(serviceTarget, contentsServiceName, path, relativeTo);
+            contentService = PathContentServitor.addService(context, serviceTarget, contentsServiceName, path, relativeTo);
         }
         DeploymentOverlayIndex overlays = DeploymentOverlayIndex.createDeploymentOverlayIndex(context);
 
@@ -211,7 +210,7 @@ public class DeploymentHandlerUtil {
         final ServiceController<DeploymentUnit> deploymentUnitController = serviceTarget.addService(deploymentUnitServiceName, service)
                 .addDependency(Services.JBOSS_DEPLOYMENT_CHAINS, DeployerChains.class, service.getDeployerChainsInjector())
                 .addDependency(DeploymentMountProvider.SERVICE_NAME, DeploymentMountProvider.class, service.getServerDeploymentRepositoryInjector())
-                .addDependency(PathManagerService.SERVICE_NAME, PathManager.class, service.getPathManagerInjector())
+                .addDependency(context.getCapabilityServiceName("org.wildfly.management.path-manager", PathManager.class), PathManager.class, service.getPathManagerInjector())
                 .addDependency(contentsServiceName, VirtualFile.class, service.getContentsInjector())
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();

--- a/server/src/main/java/org/jboss/as/server/deployment/PathContentServitor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/PathContentServitor.java
@@ -21,8 +21,8 @@
  */
 package org.jboss.as.server.deployment;
 
+import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.services.path.PathManager;
-import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.msc.service.AbstractService;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -43,10 +43,11 @@ class PathContentServitor extends AbstractService<VirtualFile> {
     private final InjectedValue<PathManager> pathManagerValue = new InjectedValue<PathManager>();
     private volatile PathManager.Callback.Handle callbackHandle;
 
-    static ServiceController<VirtualFile> addService(final ServiceTarget serviceTarget, final ServiceName serviceName, final String path, final String relativeTo) {
+    static ServiceController<VirtualFile> addService(OperationContext context, final ServiceTarget serviceTarget, final ServiceName serviceName, final String path, final String relativeTo) {
         final PathContentServitor service = new PathContentServitor(path, relativeTo);
         return serviceTarget.addService(serviceName, service)
-                .addDependency(PathManagerService.SERVICE_NAME, PathManager.class, service.pathManagerValue)
+                .addDependency(context.getCapabilityServiceName("org.wildfly.management.path-manager", PathManager.class),
+                        PathManager.class, service.pathManagerValue)
                 .install();
     }
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractKernelServicesImpl.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractKernelServicesImpl.java
@@ -29,6 +29,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.ImmediateValue;
@@ -108,9 +109,10 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
 
         ModelTestModelControllerService svc = testModelControllerFactory.create(mainExtension, controllerInitializer, additionalInit, controllerExtensionRegistry, persister, validateOpsFilter, registerTransformers);
         ServiceBuilder<ModelController> builder = target.addService(Services.JBOSS_SERVER_CONTROLLER, svc);
-        builder.addDependency(PathManagerService.SERVICE_NAME); // ensure this is up before the ModelControllerService, as it would be in a real server
+        ServiceName pmSvcName = ServiceName.parse("org.wildfly.management.path-manager"); // we can't reference the capability directly as it's not present in legacy controllers
+        builder.addDependency(pmSvcName); // ensure this is up before the ModelControllerService, as it would be in a real server
         builder.install();
-        target.addService(PathManagerService.SERVICE_NAME, pathManager).install();
+        target.addService(pmSvcName, pathManager).addAliases(PathManagerService.SERVICE_NAME).install();
         if (legacyModelVersion == null) {
             ExecutorService mgmtExecutor = new ThreadPoolExecutor(1, Integer.MAX_VALUE, 20L, TimeUnit.SECONDS,
                     new SynchronousQueue<Runnable>());


### PR DESCRIPTION
…gister or its changes are lost

Add a deployment-scanner capability as a core consumer of the path-manager capability

https://issues.jboss.org/browse/WFCORE-2598

@pferraro FYI. Sorry about the hassle.  :(