### PR TITLE
[WFCORE-2608]: /deployment-overlay=test:redeploy-links doesn't work in mixed domain.

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/AffectedDeploymentOverlay.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/AffectedDeploymentOverlay.java
@@ -157,7 +157,6 @@ public class AffectedDeploymentOverlay {
         }
         if (deploymentPerServerGroup.isEmpty()) {
             runtimeNames.forEach(s -> ServerLogger.ROOT_LOGGER.debugf("We haven't found any server-group for %s", s));
-            return;
         }
         Operations.CompositeOperationBuilder opBuilder = Operations.CompositeOperationBuilder.create();
         if(removeOperation != null) {
@@ -190,11 +189,10 @@ public class AffectedDeploymentOverlay {
      */
      public static void redeployLinksAndTransformOperation(OperationContext context, ModelNode removeOperation, PathAddress deploymentsRootAddress, Set<String> runtimeNames) throws OperationFailedException {
         Set<String> deploymentNames = listDeployments(context.readResourceFromRoot(deploymentsRootAddress), runtimeNames);
+        Operations.CompositeOperationBuilder opBuilder = Operations.CompositeOperationBuilder.create();
         if (deploymentNames.isEmpty()) {
             runtimeNames.forEach(s -> ServerLogger.ROOT_LOGGER.debugf("We haven't found any deployment for %s in server-group %s", s, deploymentsRootAddress.getLastElement().getValue()));
-            return;
         }
-        Operations.CompositeOperationBuilder opBuilder = Operations.CompositeOperationBuilder.create();
         if(removeOperation != null) {
              opBuilder.addStep(removeOperation);
         }
@@ -299,7 +297,7 @@ public class AffectedDeploymentOverlay {
         }
 
         private boolean validOverlay(PathAddress operationAddress) {
-            if (operationAddress.size() > 1 && operationAddress.size() >= overlayAddress.size()) {
+            if (operationAddress.size() >= 1 && operationAddress.size() >= overlayAddress.size()) {
                 ServerLogger.AS_ROOT_LOGGER.debugf("Comparing address %s with %s", operationAddress.subAddress(0, overlayAddress.size()).toCLIStyleString(), overlayAddress.toCLIStyleString());
                 return operationAddress.subAddress(0, overlayAddress.size()).equals(overlayAddress);
             }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
@@ -119,7 +119,7 @@ public class DomainTestSupport {
     public static WildFlyManagedConfiguration getMasterConfiguration(String domainConfigPath, String hostConfigPath,
                 String testName, WildFlyManagedConfiguration baseConfig,
                 boolean readOnlyDomain, boolean readOnlyHost) {
-        return getMasterConfiguration(domainConfigPath, hostConfigPath, testName, baseConfig, readOnlyDomain, readOnlyHost, false);
+        return getMasterConfiguration(domainConfigPath, hostConfigPath, testName, baseConfig, readOnlyDomain, readOnlyHost, Boolean.getBoolean("wildfly.master.debug"));
     }
 
     public static WildFlyManagedConfiguration getMasterConfiguration(String domainConfigPath, String hostConfigPath,
@@ -146,7 +146,7 @@ public class DomainTestSupport {
     public static WildFlyManagedConfiguration getSlaveConfiguration(String hostName, String hostConfigPath, String testName,
                                                                     WildFlyManagedConfiguration baseConfig,
                                                                     boolean readOnlyHost) {
-        return getSlaveConfiguration(hostName, hostConfigPath, testName, baseConfig, readOnlyHost, false);
+        return getSlaveConfiguration(hostName, hostConfigPath, testName, baseConfig, readOnlyHost, Boolean.getBoolean("wildfly.slave.debug"));
     }
 
     public static WildFlyManagedConfiguration getSlaveConfiguration(String hostName, String hostConfigPath, String testName,


### PR DESCRIPTION
* The transformation should happen to avoid being redistributed to slaves.
* Fixing the root case which was missing for operation transformation.

Jira: https://issues.jboss.org/browse/WFCORE-2608
JBEAP: https://issues.jboss.org/browse/JBEAP-10035

Once this has been merged and released, please consider https://github.com/wildfly/wildfly/pull/9880