### PR TITLE
[WFCORE-2595] Use core expression resolution in subsystem testsuite SchemaValidator; remove jboss-metadata-common dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,6 @@
         <version.org.jboss.logmanager.jboss-logmanager>2.0.6.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.3.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.0.Beta5</version.org.jboss.marshalling.jboss-marshalling>
-        <!-- this is test only dependancy -->
-        <version.org.jboss.metadata.jboss-metadata-common>10.0.0.Final</version.org.jboss.metadata.jboss-metadata-common>
         <version.org.jboss.modules.jboss-modules>1.6.0.Beta6</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.7.SP1</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.0.Beta19</version.org.jboss.remoting>
@@ -1224,12 +1222,6 @@
                 <groupId>org.jboss.marshalling</groupId>
                 <artifactId>jboss-marshalling-river</artifactId>
                 <version>${version.org.jboss.marshalling.jboss-marshalling}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.metadata</groupId>
-                <artifactId>jboss-metadata-common</artifactId>
-                <version>${version.org.jboss.metadata.jboss-metadata-common}</version>
             </dependency>
 
             <dependency>

--- a/subsystem-test/framework/pom.xml
+++ b/subsystem-test/framework/pom.xml
@@ -59,11 +59,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.metadata</groupId>
-            <artifactId>jboss-metadata-common</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.slf4j</groupId>
             <artifactId>slf4j-jboss-logmanager</artifactId>
         </dependency>


### PR DESCRIPTION

This avoids the need for EAP productization to upgrade core any time we want to update jboss-metadata in full.