### PR TITLE
[WFCORE-2616]: Rename DomainOperationTransformer to avoid confusion with the mixed domain transformers.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/CompositeOperationAwareTransmuter.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/CompositeOperationAwareTransmuter.java
@@ -37,23 +37,23 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STE
 /**
  * @author Stuart Douglas
  */
-public class CompositeOperationAwareTransformer implements DomainOperationTransformer {
+public class CompositeOperationAwareTransmuter implements DomainOperationTransmuter {
 
     private final ModelNode newOperation;
 
-    public CompositeOperationAwareTransformer(final ModelNode newOperation) {
+    public CompositeOperationAwareTransmuter(final ModelNode newOperation) {
         this.newOperation = newOperation;
     }
 
     @Override
-    public ModelNode transform(final OperationContext context, final ModelNode operation) {
+    public ModelNode transmmute(final OperationContext context, final ModelNode operation) {
         if (operation.get(OP).asString().equals(COMPOSITE)) {
             ModelNode ret = operation.clone();
             final List<ModelNode> list = new ArrayList<ModelNode>();
             ListIterator<ModelNode> it = ret.get(STEPS).asList().listIterator();
             while (it.hasNext()) {
                 final ModelNode subOperation = it.next();
-                list.add(transform(context, subOperation));
+                list.add(transmmute(context, subOperation));
             }
             ret.get(STEPS).set(list);
             return ret;

--- a/controller/src/main/java/org/jboss/as/controller/operations/DomainOperationTransmuter.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/DomainOperationTransmuter.java
@@ -33,12 +33,12 @@ import org.jboss.dmr.ModelNode;
  *
  *
  * @author Stuart Douglas
- * @see OperationAttachments#SLAVE_SERVER_OPERATION_TRANSFORMERS
+ * @see OperationAttachments#SLAVE_SERVER_OPERATION_TRANSMUTERS
  * @see  CompositeOperationAwareTransformer
  *
  */
-public interface DomainOperationTransformer {
+public interface DomainOperationTransmuter {
 
-    ModelNode transform(final OperationContext context, final ModelNode operation);
+    ModelNode transmmute(final OperationContext context, final ModelNode operation);
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/OperationAttachments.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/OperationAttachments.java
@@ -32,7 +32,7 @@ import org.jboss.as.controller.OperationContext;
 public class OperationAttachments {
 
 
-    public static final OperationContext.AttachmentKey<List<DomainOperationTransformer>> SLAVE_SERVER_OPERATION_TRANSFORMERS = OperationContext.AttachmentKey.create(List.class);
+    public static final OperationContext.AttachmentKey<List<DomainOperationTransmuter>> SLAVE_SERVER_OPERATION_TRANSMUTERS = OperationContext.AttachmentKey.create(List.class);
 
 
     private OperationAttachments() {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/DomainSlaveHandler.java
@@ -47,13 +47,13 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.TransformingProxyController;
 import org.jboss.as.controller.client.OperationResponse;
-import org.jboss.as.controller.operations.DomainOperationTransformer;
 import org.jboss.as.controller.operations.OperationAttachments;
 import org.jboss.as.controller.remote.ResponseAttachmentInputStreamSupport;
 import org.jboss.as.controller.remote.TransactionalProtocolClient;
 import org.jboss.as.controller.transform.Transformers;
 import org.jboss.dmr.ModelNode;
 import org.jboss.threads.AsyncFuture;
+import org.jboss.as.controller.operations.DomainOperationTransmuter;
 
 /**
  * Executes the first phase of a two phase operation on one or more remote, slave host controllers.
@@ -86,15 +86,15 @@ public class DomainSlaveHandler implements OperationStepHandler {
         final Map<String, HostControllerUpdateTask.ExecutedHostRequest> finalResults = new HashMap<String, HostControllerUpdateTask.ExecutedHostRequest>();
         final HostControllerUpdateTask.ProxyOperationListener listener = new HostControllerUpdateTask.ProxyOperationListener();
         final Transformers.TransformationInputs transformationInputs = Transformers.TransformationInputs.getOrCreate(context);
-        final List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
+        final List<DomainOperationTransmuter> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS);
         for (Map.Entry<String, ProxyController> entry : hostProxies.entrySet()) {
             // Create the proxy task
             final String host = entry.getKey();
             final TransformingProxyController proxyController = (TransformingProxyController) entry.getValue();
             ModelNode clonedOp = operation.clone();
             if (transformers != null) {
-                for (final DomainOperationTransformer transformer : transformers) {
-                    clonedOp = transformer.transform(context, clonedOp);
+                for (final DomainOperationTransmuter transformer : transformers) {
+                    clonedOp = transformer.transmmute(context, clonedOp);
                 }
             }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationResolver.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationResolver.java
@@ -82,7 +82,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-import org.jboss.as.controller.operations.DomainOperationTransformer;
 import org.jboss.as.controller.operations.OperationAttachments;
 import org.jboss.as.controller.operations.common.ResolveExpressionHandler;
 import org.jboss.as.controller.operations.common.Util;
@@ -99,6 +98,7 @@ import org.jboss.as.server.operations.SystemPropertyAddHandler;
 import org.jboss.as.server.operations.SystemPropertyRemoveHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
+import org.jboss.as.controller.operations.DomainOperationTransmuter;
 
 /**
  * Logic for creating a server-level operation that realizes the effect
@@ -233,11 +233,11 @@ public class ServerOperationResolver {
         if (HOST_CONTROLLER_LOGGER.isTraceEnabled()) {
             HOST_CONTROLLER_LOGGER.tracef("Resolving %s", originalOperation);
         }
-        List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
+        List<DomainOperationTransmuter> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS);
         ModelNode operation = originalOperation;
         if(transformers != null) {
-            for(DomainOperationTransformer transformer : transformers) {
-                operation = transformer.transform(context, operation);
+            for(DomainOperationTransmuter transformer : transformers) {
+                operation = transformer.transmmute(context, operation);
             }
         }
         if (isDontPropagateToServers(context, operation)) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentUploadUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentUploadUtil.java
@@ -51,8 +51,7 @@ import java.util.List;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.operations.CompositeOperationAwareTransformer;
-import org.jboss.as.controller.operations.DomainOperationTransformer;
+import org.jboss.as.controller.operations.CompositeOperationAwareTransmuter;
 import org.jboss.as.controller.operations.OperationAttachments;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.logging.DomainControllerLogger;
@@ -67,6 +66,7 @@ import org.jboss.dmr.ModelNode;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.DEPLOYMENT_CONTENT_PATH;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.EMPTY;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.OVERWRITE;
+import org.jboss.as.controller.operations.DomainOperationTransmuter;
 
 /**
  * Utility method for storing deployment content.
@@ -103,11 +103,11 @@ class DeploymentUploadUtil {
         final ModelNode slave = operation.clone();
         slave.get(CONTENT).setEmptyList().add().get(HASH).set(hash);
         // Add the domain op transformer
-        List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
+        List<DomainOperationTransmuter> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS);
         if (transformers == null) {
-            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS, transformers = new ArrayList<>());
+            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS, transformers = new ArrayList<>());
         }
-        transformers.add(new CompositeOperationAwareTransformer(slave));
+        transformers.add(new CompositeOperationAwareTransmuter(slave));
         return hash;
     }
 
@@ -122,11 +122,11 @@ class DeploymentUploadUtil {
         contentItemNode.get(CONTENT_ARCHIVE.getName()).set(false);
         slave.get(CONTENT).setEmptyList().add(contentItemNode);
         // Add the domain op transformer
-        List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
+        List<DomainOperationTransmuter> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS);
         if (transformers == null) {
-            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS, transformers = new ArrayList<>());
+            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS, transformers = new ArrayList<>());
         }
-        transformers.add(new CompositeOperationAwareTransformer(slave));
+        transformers.add(new CompositeOperationAwareTransmuter(slave));
         return hash;
     }
 
@@ -159,11 +159,11 @@ class DeploymentUploadUtil {
         addedContent.get(TARGET_PATH.getName()).set("./");
         slave.get(CONTENT).setEmptyList().add(addedContent);
         // Add the domain op transformer
-        List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
+        List<DomainOperationTransmuter> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS);
         if (transformers == null) {
-            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS, transformers = new ArrayList<>());
+            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS, transformers = new ArrayList<>());
         }
-        transformers.add(new CompositeOperationAwareTransformer(slave));
+        transformers.add(new CompositeOperationAwareTransmuter(slave));
         return hash;
     }
 
@@ -206,11 +206,11 @@ class DeploymentUploadUtil {
         addedContent.get(TARGET_PATH.getName()).set(".");
         slave.get(CONTENT).setEmptyList().add(addedContent);
         // Add the domain op transformer
-        List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
+        List<DomainOperationTransmuter> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS);
         if (transformers == null) {
-            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS, transformers = new ArrayList<>());
+            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS, transformers = new ArrayList<>());
         }
-        transformers.add(new CompositeOperationAwareTransformer(slave));
+        transformers.add(new CompositeOperationAwareTransmuter(slave));
         return hash;
     }
 
@@ -236,11 +236,11 @@ class DeploymentUploadUtil {
         slave.get(CONTENT).setEmptyList().add().get(HASH).set(hash);
         slave.get(CONTENT).add().get(ARCHIVE).set(false);
         // Add the domain op transformer
-        List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
+        List<DomainOperationTransmuter> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS);
         if (transformers == null) {
-            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS, transformers = new ArrayList<>());
+            context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS, transformers = new ArrayList<>());
         }
-        transformers.add(new CompositeOperationAwareTransformer(slave));
+        transformers.add(new CompositeOperationAwareTransmuter(slave));
         return hash;
     }
 

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayContentAdd.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayContentAdd.java
@@ -44,8 +44,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.RunningMode;
-import org.jboss.as.controller.operations.CompositeOperationAwareTransformer;
-import org.jboss.as.controller.operations.DomainOperationTransformer;
+import org.jboss.as.controller.operations.CompositeOperationAwareTransmuter;
 import org.jboss.as.controller.operations.OperationAttachments;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.protocol.StreamUtils;
@@ -55,6 +54,7 @@ import org.jboss.as.repository.DeploymentFileRepository;
 import org.jboss.as.server.deployment.ModelContentReference;
 import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.dmr.ModelNode;
+import org.jboss.as.controller.operations.DomainOperationTransmuter;
 
 /**
  * @author Stuart Douglas
@@ -88,11 +88,11 @@ public class DeploymentOverlayContentAdd extends AbstractAddStepHandler {
             slave.get(CONTENT).clear();
             slave.get(CONTENT).get(HASH).set(hash);
 
-            List<DomainOperationTransformer> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS);
+            List<DomainOperationTransmuter> transformers = context.getAttachment(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS);
             if(transformers == null) {
-                context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSFORMERS, transformers = new ArrayList<DomainOperationTransformer>());
+                context.attach(OperationAttachments.SLAVE_SERVER_OPERATION_TRANSMUTERS, transformers = new ArrayList<DomainOperationTransmuter>());
             }
-            transformers.add(new CompositeOperationAwareTransformer(slave));
+            transformers.add(new CompositeOperationAwareTransmuter(slave));
         }
         contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, hash));
 


### PR DESCRIPTION
Renaming DomainOperationTransformer as DomainOperationTransmuter.

Jira: https://issues.jboss.org/browse/WFCORE-2616