### PR TITLE
[WFCORE-2626] Execute interface criteria in configured order, but put…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/interfaces/AbstractInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/AbstractInterfaceCriteria.java
@@ -87,4 +87,12 @@ public abstract class AbstractInterfaceCriteria implements InterfaceCriteria {
         }
         return clone;
     }
+
+    @Override
+    public int compareTo(InterfaceCriteria o) {
+        if (this.equals(o)) {
+            return 0;
+        }
+        return o instanceof InetAddressMatchInterfaceCriteria ? -1 : 1;
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/interfaces/AnyInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/AnyInterfaceCriteria.java
@@ -30,6 +30,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,7 +46,7 @@ public class AnyInterfaceCriteria implements InterfaceCriteria {
 
     private static final long serialVersionUID = 3384500068401101329L;
 
-    private final Set<InterfaceCriteria> criteria = new HashSet<InterfaceCriteria>();
+    private final Set<InterfaceCriteria> criteria = new LinkedHashSet<InterfaceCriteria>();
 
     /**
      * Creates a new AnyInterfaceCriteria
@@ -83,6 +84,14 @@ public class AnyInterfaceCriteria implements InterfaceCriteria {
             return false;
         }
         return criteria.equals(((AnyInterfaceCriteria)o).criteria);
+    }
+
+    @Override
+    public int compareTo(InterfaceCriteria o) {
+        if (this.equals(o)) {
+            return 0;
+        }
+        return o instanceof InetAddressMatchInterfaceCriteria ? -1 : 1;
     }
 
     private void addAccepted(Map<NetworkInterface, Set<InetAddress>> accepted, Map<NetworkInterface, Set<InetAddress>> result) {

--- a/controller/src/main/java/org/jboss/as/controller/interfaces/InetAddressMatchInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/InetAddressMatchInterfaceCriteria.java
@@ -98,6 +98,14 @@ public class InetAddressMatchInterfaceCriteria extends AbstractInterfaceCriteria
         return result;
     }
 
+    @Override
+    public int compareTo(InterfaceCriteria o) {
+        if (this.equals(o)) {
+            return 0;
+        }
+        return 1;
+    }
+
     /**
      * {@inheritDoc}
      *

--- a/controller/src/main/java/org/jboss/as/controller/interfaces/InterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/InterfaceCriteria.java
@@ -37,7 +37,7 @@ import java.util.Set;
  *
  * @author Brian Stansberry
  */
-public interface InterfaceCriteria extends Serializable {
+public interface InterfaceCriteria extends Serializable, Comparable<InterfaceCriteria> {
 
     /**
      * Gets which of the available network interfaces and addresses are acceptable for

--- a/controller/src/main/java/org/jboss/as/controller/interfaces/NotInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/NotInterfaceCriteria.java
@@ -30,6 +30,7 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -45,7 +46,7 @@ public class NotInterfaceCriteria implements InterfaceCriteria {
 
     private static final long serialVersionUID = -2037624198837453203L;
 
-    private final Set<InterfaceCriteria> criteria = new HashSet<InterfaceCriteria>();
+    private final Set<InterfaceCriteria> criteria = new LinkedHashSet<InterfaceCriteria>();
 
     /**
      * Creates a new NotInterfaceCriteria
@@ -87,6 +88,14 @@ public class NotInterfaceCriteria implements InterfaceCriteria {
             return false;
         }
         return criteria.equals(((NotInterfaceCriteria)o).criteria);
+    }
+
+    @Override
+    public int compareTo(InterfaceCriteria o) {
+        if (this.equals(o)) {
+            return 0;
+        }
+        return o instanceof InetAddressMatchInterfaceCriteria ? -1 : 1;
     }
 
     private Map<NetworkInterface, Set<InetAddress>> removeMatches(Map<NetworkInterface, Set<InetAddress>> candidates,

--- a/controller/src/main/java/org/jboss/as/controller/interfaces/OverallInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/OverallInterfaceCriteria.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.wildfly.security.manager.WildFlySecurityManager;
@@ -61,7 +62,8 @@ public final class OverallInterfaceCriteria implements InterfaceCriteria {
     public Map<NetworkInterface, Set<InetAddress>> getAcceptableAddresses(Map<NetworkInterface, Set<InetAddress>> candidates) throws SocketException {
 
         Map<NetworkInterface, Set<InetAddress>> result = AbstractInterfaceCriteria.cloneCandidates(candidates);
-        for (InterfaceCriteria criteria : interfaceCriteria) {
+        Set<InterfaceCriteria> sorted = new TreeSet<>(interfaceCriteria);
+        for (InterfaceCriteria criteria : sorted) {
             result = criteria.getAcceptableAddresses(result);
             if (result.size() == 0) {
                 break;
@@ -103,6 +105,14 @@ public final class OverallInterfaceCriteria implements InterfaceCriteria {
         sb.setLength(sb.length() - 1);
         sb.append(")");
         return sb.toString();
+    }
+
+    @Override
+    public int compareTo(InterfaceCriteria o) {
+        if (this.equals(o)) {
+            return 0;
+        }
+        return 1;
     }
 
     private Map<NetworkInterface, Set<InetAddress>> pruneIPTypes(Map<NetworkInterface, Set<InetAddress>> candidates) {

--- a/controller/src/main/java/org/jboss/as/controller/interfaces/ParsedInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/ParsedInterfaceCriteria.java
@@ -28,7 +28,7 @@ import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -56,7 +56,7 @@ public final class ParsedInterfaceCriteria {
 
     private final String failureMessage;
     private final boolean anyLocal;
-    private final Set<InterfaceCriteria> criteria = new HashSet<InterfaceCriteria>();
+    private final Set<InterfaceCriteria> criteria = new LinkedHashSet<InterfaceCriteria>();
 
     private ParsedInterfaceCriteria(final String failureMessage) {
         this.failureMessage = failureMessage;
@@ -101,7 +101,7 @@ public final class ParsedInterfaceCriteria {
         } else {
             try {
                 final List<Property> nodes = subModel.asPropertyList();
-                final Set<InterfaceCriteria> criteriaSet = new HashSet<InterfaceCriteria>();
+                final Set<InterfaceCriteria> criteriaSet = new LinkedHashSet<InterfaceCriteria>();
                 for (final Property property : nodes) {
                     final InterfaceCriteria criterion = parseCriteria(property, false, expressionResolver);
                     if (criterion instanceof WildcardInetAddressInterfaceCriteria) {
@@ -189,7 +189,7 @@ public final class ParsedInterfaceCriteria {
         if(!subModel.isDefined() || subModel.asInt() == 0) {
             return null;
         }
-        final Set<InterfaceCriteria> criteriaSet = new HashSet<InterfaceCriteria>();
+        final Set<InterfaceCriteria> criteriaSet = new LinkedHashSet<InterfaceCriteria>();
         for(final Property nestedProperty :  subModel.asPropertyList()) {
             final Element element = Element.forName(nestedProperty.getName());
             switch (element) {

--- a/controller/src/main/java/org/jboss/as/controller/interfaces/WildcardInetAddressInterfaceCriteria.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/WildcardInetAddressInterfaceCriteria.java
@@ -75,4 +75,12 @@ public class WildcardInetAddressInterfaceCriteria implements InterfaceCriteria {
         return (o instanceof WildcardInetAddressInterfaceCriteria)
                 && version == ((WildcardInetAddressInterfaceCriteria)o).version;
     }
+
+    @Override
+    public int compareTo(InterfaceCriteria o) {
+        if (this.equals(o)) {
+            return 0;
+        }
+        return o instanceof InetAddressMatchInterfaceCriteria ? -1 : 1;
+    }
 }


### PR DESCRIPTION
… InetAddressMatchInterfaceCriteria last so the AS7-4509 solution doesn't fail due to duplicates that other criteria would discard.

https://issues.jboss.org/browse/WFCORE-2626

This PR is a bit of overkill, but probably worth it:

1) It preserves the order of interface match criteria the user specifies, so the user gets some control. Probably not necessary given 2), but seems like a good idea.
2) Overrides 1) by sorting InetAddressMatchInterfaceCriteria last, giving other criteria a chance to eliminate dups before it checks for them.

Note this ordering thing has nothing to do with xml persistence; it's just about use of the configured data in the runtime. We always persisted in order.

Just 1) would be sufficient so long as users put ```<inet-address>``` after other things. Just 2) would be sufficient but 1) seemed like a good idea anyway.