### PR TITLE
Fix for WFCORE-2637. Invalid completion for cd,ls,read-op/attr

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -1349,4 +1349,41 @@ public class CliCompletionTestCase {
             ctx.terminateSession();
         }
     }
+
+    @Test
+    public void testNoArgumentCompletion() throws Exception {
+        CommandContext ctx = CLITestUtil.getCommandContext(testSupport,
+                System.in, System.out);
+        ctx.connectController();
+        try {
+            {
+                String cmd = "cd --hel";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), Arrays.asList("--help"),
+                        candidates);
+            }
+
+            {
+                String cmd = "cd --no";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), Arrays.asList("--no-validation"),
+                        candidates);
+            }
+
+            {
+                String cmd = "ls --hel";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), Arrays.asList("--help"),
+                        candidates);
+            }
+        } finally {
+            ctx.terminateSession();
+        }
+    }
 }


### PR DESCRIPTION
Handle the special case of un-named option value completer completing option name.
Added unit test.
