### PR TITLE
[WFCORE-2633] Allow user to declare that undefined attributes with de…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -615,7 +615,8 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
      * the default value is whether the attribute {@link AttributeDefinition#isRequired()} () is not required} and
      * has a {@link AttributeDefinition#getDefaultValue() default value}.
      *
-     * @param nullSignificant {@code true} if an undefined value is significant
+     * @param nullSignificant {@code true} if an undefined value is significant; {@code false} if it is not significant,
+     *                                    even if a default value is configured
      * @return a builder that can be used to continue building the attribute definition
      */
     public BUILDER setNullSignificant(boolean nullSignificant) {

--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -317,7 +317,7 @@ public abstract class AttributeDefinition {
      *
      * @return {@code true} if an {@code undefined} value is significant
      */
-    public boolean isNullSignificant() {
+    public final boolean isNullSignificant() {
         if (nilSignificant != null) {
             return nilSignificant;
         }

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -2498,8 +2498,7 @@ final class OperationContextImpl extends AbstractOperationContext {
                 if (ad == null) {
                     return false;
                 }
-                if (ad.isRequired() || (ad.getDefaultValue() != null && ad.getDefaultValue().isDefined())
-                        || ad.isNullSignificant()) {
+                if (ad.isRequired() || ad.isNullSignificant()) {
                     // must be set, presence of a default means not setting is the same as setting,
                     // or the AD is specifically configured that null is significant
                     return true;

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ConstrainedResource.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/ConstrainedResource.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraint
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -55,15 +56,23 @@ public class ConstrainedResource extends SimpleResourceDefinition {
 
     static SimpleAttributeDefinition SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder("security-domain", ModelType.STRING)
             .setAllowExpression(true)
-            .setAllowNull(true)
+            .setRequired(false)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
+            .addAccessConstraint(DS_SECURITY_DEF)
+            .build();
+
+    static final SimpleAttributeDefinition AUTHENTICATION_INFLOW = new SimpleAttributeDefinitionBuilder("authentication-inflow", ModelType.BOOLEAN)
+            .setRequired(false)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(false))
+            .setNullSignificant(false)
             .addAccessConstraint(DS_SECURITY_DEF)
             .build();
 
 
     public ConstrainedResource(PathElement pathElement) {
         super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
-                .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN))
+                .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN, AUTHENTICATION_INFLOW))
                 .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("datasources", "datasource"))));
     }
@@ -73,5 +82,6 @@ public class ConstrainedResource extends SimpleResourceDefinition {
         super.registerAttributes(resourceRegistration);
         resourceRegistration.registerReadOnlyAttribute(PASSWORD, null);
         resourceRegistration.registerReadOnlyAttribute(SECURITY_DOMAIN, null);
+        resourceRegistration.registerReadOnlyAttribute(AUTHENTICATION_INFLOW, null);
     }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/WildcardReadsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/WildcardReadsTestCase.java
@@ -435,9 +435,10 @@ public class WildcardReadsTestCase extends AbstractRbacTestCase {
         assert accItem != null;
         assertEquals(accItem.toString(), reporter, PathAddress.pathAddress(accItem.get(RELATIVE_ADDRESS)));
         assertTrue(accItem.toString(), accItem.hasDefined(FILTERED_ATTRIBUTES));
-        assertEquals(accItem.toString(), 2, accItem.get(FILTERED_ATTRIBUTES).asInt());
+        assertEquals(accItem.toString(), 3, accItem.get(FILTERED_ATTRIBUTES).asInt());
         assertTrue(accItem.toString(), accItem.get(FILTERED_ATTRIBUTES).asString().contains("password"));
         assertTrue(accItem.toString(), accItem.get(FILTERED_ATTRIBUTES).asString().contains("security-domain"));
+        assertTrue(accItem.toString(), accItem.get(FILTERED_ATTRIBUTES).asString().contains("authentication-inflow"));
 
     }
 

--- a/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
+++ b/testsuite/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/extension/ConstrainedResource.java
@@ -62,10 +62,19 @@ public class ConstrainedResource extends SimpleResourceDefinition {
     static SimpleAttributeDefinition SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder("security-domain", ModelType.STRING)
             .setAllowExpression(true)
             .setAttributeGroup("security")
-            .setAllowNull(true)
+            .setRequired(false)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SECURITY_DOMAIN_REF)
             .addAccessConstraint(DS_SECURITY_DEF)
             .build();
+
+    static final SimpleAttributeDefinition AUTHENTICATION_INFLOW = new SimpleAttributeDefinitionBuilder("authentication-inflow", ModelType.BOOLEAN)
+            .setRequired(false)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(false))
+            .setNullSignificant(false)
+            .addAccessConstraint(DS_SECURITY_DEF)
+            .build();
+
 
     static SimpleAttributeDefinition NEW_CONNECTION_SQL = new SimpleAttributeDefinitionBuilder("new-connection-sql", ModelType.STRING, true)
             .setAllowExpression(true)
@@ -100,7 +109,7 @@ public class ConstrainedResource extends SimpleResourceDefinition {
 
     public ConstrainedResource(PathElement pathElement) {
         super(new Parameters(pathElement, new NonResolvingResourceDescriptionResolver())
-                .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN))
+                .setAddHandler(new AbstractAddStepHandler(PASSWORD, SECURITY_DOMAIN, AUTHENTICATION_INFLOW))
                 .setRemoveHandler(ModelOnlyRemoveStepHandler.INSTANCE)
                 .setAccessConstraints(new ApplicationTypeAccessConstraintDefinition(new ApplicationTypeConfig("rbac", "datasource"))));
     }
@@ -110,6 +119,7 @@ public class ConstrainedResource extends SimpleResourceDefinition {
         super.registerAttributes(resourceRegistration);
         resourceRegistration.registerReadWriteAttribute(PASSWORD, null, new BasicAttributeWriteHandler(PASSWORD));
         resourceRegistration.registerReadOnlyAttribute(SECURITY_DOMAIN, null);
+        resourceRegistration.registerReadWriteAttribute(AUTHENTICATION_INFLOW, null, new BasicAttributeWriteHandler(AUTHENTICATION_INFLOW));
         resourceRegistration.registerReadOnlyAttribute(JNDI_NAME, null);
         resourceRegistration.registerReadWriteAttribute(NEW_CONNECTION_SQL, null, new BasicAttributeWriteHandler(NEW_CONNECTION_SQL));
     }


### PR DESCRIPTION
…fault values are not considered sensitive in add operations

The original approach I outlined in the WFCORE-2633 description doesn't work. The read-resource-description access control data for an attribute with a "defined but non-sensitive" value can't be correctly determined as the answer depends on the values in a specific resource, while r-r-d is often used for the wildcard address. So, tools like HAL would not be able to get an accurate r-r-d answer for use in tailoring the UI.

Instead I went for a much simpler approach to the WildFly issue that WFCORE-2633 was trying to address. Now the kernel allows an attribute with a default value in its definition to be configured such that the existence of the default value is ignored during the add op, so long as the attribute is not specifically configured (i.e. it's value is undefined). This is simply a small change to existing behavior, utilizing the already present AttributeDefinition.isNullSignificant() setting.  Things work as before, so clients will see no differences, but now the existing behavior can be applied to more attributes. For attributes where AttributeDefinition.isNullSignificant() == false, the attribute can be set with an undefined value by a non-sensitive user in an add op, but can't be edited by such a user, regardless of new or current value, and can't be defined in the add op.