### PR TITLE
update classfilewriter to 1.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <version.org.fusesource.jansi>1.11</version.org.fusesource.jansi>
         <version.org.jboss.aesh>0.66.15</version.org.jboss.aesh>
         <version.org.jboss.byteman>3.0.6</version.org.jboss.byteman>
-        <version.org.jboss.classfilewriter>1.1.2.Final</version.org.jboss.classfilewriter>
+        <version.org.jboss.classfilewriter>1.2.1.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.0.Beta4</version.org.jboss.invocation>
         <version.org.jboss.jandex>2.0.3.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.4.0.Final</version.org.jboss.jboss-dmr>


### PR DESCRIPTION
This fixes the following error, that occurs if you have default methods in resteasy interfaces:

java.lang.VerifyError: Expecting a stackmap frame at branch target 13