### PR TITLE
WFCORE-2620 - Add ability to read computed runtime values of IO subsystem buffer-pool attributes

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/BufferPoolResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/BufferPoolResourceDefinition.java
@@ -85,15 +85,18 @@ class BufferPoolResourceDefinition extends PersistentResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .setValidator(new IntRangeValidator(1, true, true))
+            .setDefaultValue(new ModelNode(defaultBufferSize))
             .build();
     static final SimpleAttributeDefinition BUFFER_PER_SLICE = new SimpleAttributeDefinitionBuilder(Constants.BUFFER_PER_SLICE, ModelType.INT, true)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
             .setValidator(new IntRangeValidator(1, true, true))
+            .setDefaultValue(new ModelNode(defaultBuffersPerRegion))
             .build();
     static final SimpleAttributeDefinition DIRECT_BUFFERS = new SimpleAttributeDefinitionBuilder(Constants.DIRECT_BUFFERS, ModelType.BOOLEAN, true)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(defaultDirectBuffers))
             .build();
 
 


### PR DESCRIPTION
Issue: [JBEAP-6984](https://issues.jboss.org/browse/JBEAP-6984)
Upstream Issue: [WFCORE-2620](https://issues.jboss.org/browse/WFCORE-2620) 