### PR TITLE
[WFCORE-2665]: RemotingModelControllerClient should be able to be used with security manager

### DIFF
--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClientPermission.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClientPermission.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.controller.client;
+
+import java.security.BasicPermission;
+
+/**
+ * Permission to execute remote management calls on a server.
+ * <p>
+ * A permission contains a name (also referred to as a "target name") but
+ * no actions list; you either have the named permission or you don't.
+ * </p>
+ *
+ * <p>
+ * The target name is the name of the permission. The following table lists all the possible {@link org.jboss.as.controller.client.ModelControllerClientPermission} target names,
+ * and for each provides a description of what the permission allows.
+ * <ul>
+ * <li>performRemoteCall: permission to perform a remote call on the server model controller</li>
+ * </ul>
+ * </p>
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class ModelControllerClientPermission extends BasicPermission {
+
+    public static final String CONNECT_NAME = "connect";
+    public static final String PERFORM_REMOTE_CALL_NAME = "performRemoteCall";
+    public static final String PERFORM_IN_VM_CALL_NAME = "performInVmCall";
+    private static final String WILDCARD_NAME = "*";
+
+    public static final ModelControllerClientPermission CONNECT = new ModelControllerClientPermission(CONNECT_NAME);
+    public static final ModelControllerClientPermission PERFORM_REMOTE_CALL = new ModelControllerClientPermission(PERFORM_REMOTE_CALL_NAME);
+    public static final ModelControllerClientPermission PERFORM_IN_VM_CALL = new ModelControllerClientPermission(PERFORM_IN_VM_CALL_NAME);
+
+    private static final long serialVersionUID = 1L;
+
+    public ModelControllerClientPermission(String name) {
+        super(name);
+    }
+
+    public ModelControllerClientPermission(String name, String actions) {
+        super(validatePermissionName(name));
+        assert actions == null;
+    }
+
+    private static String validatePermissionName(String name) throws IllegalArgumentException {
+        switch (name) {
+            case CONNECT_NAME:
+            case PERFORM_REMOTE_CALL_NAME:
+            case PERFORM_IN_VM_CALL_NAME:
+            case WILDCARD_NAME:
+                return name;
+            default:
+                throw new IllegalArgumentException(name);
+        }
+    }
+}

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/AbstractModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/AbstractModelControllerClient.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import org.jboss.as.controller.client.MessageSeverity;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.ModelControllerClientPermission;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.as.controller.client.OperationMessageHandler;
@@ -165,6 +166,10 @@ public abstract class AbstractModelControllerClient implements ModelControllerCl
      * @throws IOException
      */
     private AsyncFuture<OperationResponse> execute(final OperationExecutionContext executionContext) throws IOException {
+        final SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(ModelControllerClientPermission.PERFORM_REMOTE_CALL);
+        }
         return executeRequest(new AbstractManagementRequest<OperationResponse, OperationExecutionContext>() {
 
             @Override
@@ -259,12 +264,12 @@ public abstract class AbstractModelControllerClient implements ModelControllerCl
 
     }
 
-    protected AsyncFuture<OperationResponse> executeRequest(final ManagementRequest<OperationResponse, OperationExecutionContext> request, final OperationExecutionContext attachment) throws IOException {
+    private AsyncFuture<OperationResponse> executeRequest(final ManagementRequest<OperationResponse, OperationExecutionContext> request, final OperationExecutionContext attachment) throws IOException {
         final ActiveOperation<OperationResponse, OperationExecutionContext> support = getChannelAssociation().executeRequest(request, attachment, attachment);
         return new DelegatingCancellableAsyncFuture(support.getResult(), support.getOperationId());
     }
 
-    static class OperationExecutionContext implements ActiveOperation.CompletedCallback<OperationResponse> {
+    private static class OperationExecutionContext implements ActiveOperation.CompletedCallback<OperationResponse> {
 
         private final Operation operation;
         private final OperationMessageHandler handler;

--- a/controller/src/main/java/org/jboss/as/controller/access/InVmAccess.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/InVmAccess.java
@@ -18,8 +18,8 @@
 
 package org.jboss.as.controller.access;
 
+import static org.jboss.as.controller.client.ModelControllerClientPermission.PERFORM_IN_VM_CALL;
 import static org.jboss.as.controller.security.ControllerPermission.GET_IN_VM_CALL_STATE;
-import static org.jboss.as.controller.security.ControllerPermission.PERFORM_IN_VM_CALL;
 
 import java.security.Permission;
 import java.security.PrivilegedAction;

--- a/controller/src/main/java/org/jboss/as/controller/security/ControllerPermission.java
+++ b/controller/src/main/java/org/jboss/as/controller/security/ControllerPermission.java
@@ -128,11 +128,6 @@ public class ControllerPermission extends BasicPermission {
      * The Controller Permission named inflowSecurityIdentity, which is required where a SecurityIdentity is inflowed as-is bypassing local security.
      */
     public static final ControllerPermission INFLOW_SECURITY_IDENTITY = new ControllerPermission(INFLOW_SECURITY_IDENTITY_NAME);
-    /**
-     * The Controller Permission named performInVmCall, which should be used to perform an in-vm call.
-     */
-    public static final ControllerPermission PERFORM_IN_VM_CALL = new ControllerPermission(PERFORM_IN_VM_CALL_NAME);
-
 
     private static String validatePermissionName(String name) throws IllegalArgumentException {
         switch (name) {
@@ -144,7 +139,6 @@ public class ControllerPermission extends BasicPermission {
             case GET_CALLER_SECURITY_IDENTITY_NAME:
             case GET_IN_VM_CALL_STATE_NAME:
             case INFLOW_SECURITY_IDENTITY_NAME:
-            case PERFORM_IN_VM_CALL_NAME:
             case WILDCARD_NAME:
                 return name;
             default:


### PR DESCRIPTION
Adding privileged blocks to allow arquillian tests to call model operations.
Protecting those privileged blocks in RemotingModelControllerClient with a specific permission.

Jira: https://issues.jboss.org/browse/WFCORE-2665