### PR TITLE
[WFCORE-2675]: Simplify and fix ContentReference management

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentAddHandler.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.HashUtil;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationContext.ResultAction;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -153,12 +152,9 @@ public class DeploymentAddHandler implements OperationStepHandler {
 
         if (contentRepository != null && hash != null) {
             final byte[] contentHash = hash;
-            context.completeStep(new OperationContext.ResultHandler() {
-                public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
-                    if (resultAction == ResultAction.KEEP) {
-                        contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, contentHash));
-                    }
-                }
+            contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, contentHash));
+            context.completeStep((OperationContext context1, ModelNode operation1) -> {
+                contentRepository.removeContent(ModelContentReference.fromModelAddress(address, contentHash));
             });
         }
     }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentExplodeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentExplodeHandler.java
@@ -115,6 +115,7 @@ public class DeploymentExplodeHandler implements OperationStepHandler {
             newHash = DeploymentUploadUtil.synchronizeSlaveHostController(operation, address, fileRepository, contentRepository, backup, oldHash);
         }
         if (newHash != null) {
+            contentRepository.addContentReference(ModelContentReference.fromModelAddress(context.getCurrentAddress(), newHash));
             contentItem = new ModelNode();
             contentItem.get(HASH).set(newHash);
             contentItem.get(ARCHIVE).set(false);
@@ -129,11 +130,9 @@ public class DeploymentExplodeHandler implements OperationStepHandler {
                             if (oldHash != null && contentRepository.hasContent(oldHash)) {
                                 contentRepository.removeContent(ModelContentReference.fromModelAddress(address, oldHash));
                             }
-                            if (contentRepository.hasContent(newHash)) {
-                                contentRepository.addContentReference(ModelContentReference.fromModelAddress(context.getCurrentAddress(), newHash));
-                            }
-                        } // else the model update will be reverted and no ref content repo references changes will be made so
-                        // the newly exploded content will be eligible for content repo gc
+                        } else {
+                            contentRepository.removeContent(ModelContentReference.fromModelAddress(address, newHash));
+                        }
                     }
                 });
             }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentFullReplaceHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentFullReplaceHandler.java
@@ -148,6 +148,9 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
             newHash = null;
         }
 
+        if (newHash != null && contentRepository != null) {
+            contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, newHash));
+        }
         // Store state to the model
         deploymentModel.get(RUNTIME_NAME).set(runtimeName);
         deploymentModel.get(CONTENT).set(content);
@@ -180,9 +183,6 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
                         } else {
                             fileRepository.deleteDeployment(reference);
                         }
-                    }
-                    if (newHash != null && contentRepository != null) {
-                        contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, newHash));
                     }
                 } else if (newHash != null && (replacedHash == null || !Arrays.equals(replacedHash, newHash))) {
                     // Due to rollback, the new content isn't used; clean from repos

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ExplodedDeploymentAddContentHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ExplodedDeploymentAddContentHandler.java
@@ -100,6 +100,9 @@ public class ExplodedDeploymentAddContentHandler implements OperationStepHandler
             newHash = DeploymentUploadUtil.synchronizeSlaveHostController(operation, address, fileRepository, contentRepository, backup, oldHash);
         }
         if (newHash != null) {
+            contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, newHash));
+        }
+        if (newHash != null) {
             contentItem = new ModelNode();
             contentItem.get(HASH).set(newHash);
             contentItem.get(ARCHIVE).set(false);
@@ -114,9 +117,6 @@ public class ExplodedDeploymentAddContentHandler implements OperationStepHandler
                             if (oldHash != null && (newHash == null || !Arrays.equals(oldHash, newHash))) {
                                 // The old content is no longer used; clean from repos
                                 contentRepository.removeContent(ModelContentReference.fromModelAddress(address, oldHash));
-                            }
-                            if (newHash != null) {
-                                contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, newHash));
                             }
                         }
                     } else {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ExplodedDeploymentRemoveContentHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ExplodedDeploymentRemoveContentHandler.java
@@ -99,6 +99,9 @@ public class ExplodedDeploymentRemoveContentHandler implements OperationStepHand
         } else { //Slave HC
             newHash = DeploymentUploadUtil.synchronizeSlaveHostController(operation, address, fileRepository, contentRepository, backup, oldHash);
         }
+        if (newHash != null) {
+            contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, newHash));
+        }
         contentItem.get(CONTENT_HASH.getName()).set(newHash);
         if (newHash != null) {
             contentItem = new ModelNode();
@@ -115,9 +118,6 @@ public class ExplodedDeploymentRemoveContentHandler implements OperationStepHand
                             if (oldHash != null && (newHash == null || !Arrays.equals(oldHash, newHash))) {
                                 // The old content is no longer used; clean from repos
                                 contentRepository.removeContent(ModelContentReference.fromModelAddress(address, oldHash));
-                            }
-                            if (newHash != null) {
-                                contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, newHash));
                             }
                         }
                     } else {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentAddHandler.java
@@ -78,6 +78,12 @@ public class ServerGroupDeploymentAddHandler implements OperationStepHandler {
                 fileRepository.getDeploymentFiles(reference);
                 if (contentRepository != null) {
                     contentRepository.addContentReference(reference);
+                    context.completeStep(new OperationContext.RollbackHandler() {
+                        @Override
+                        public void handleRollback(OperationContext context, ModelNode operation) {
+                            contentRepository.removeContent(reference);
+                        }
+                    });
                 }
             }
         }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentReplaceHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentReplaceHandler.java
@@ -122,18 +122,17 @@ public class ServerGroupDeploymentReplaceHandler implements OperationStepHandler
             }
             deploymentResource.getModel().get(ENABLED).set(true);
         }
-        //
+        if (contentRepository != null && shouldCreateResource) {
+            for (ContentReference reference : locallyAddedReferences) {
+                contentRepository.addContentReference(reference);
+            }
+        }
         replaceResource.getModel().get(ENABLED).set(false);
-        context.completeStep(new OperationContext.ResultHandler() {
-            @Override
-            public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
-                if (resultAction == OperationContext.ResultAction.KEEP) {
-                    //check that if this is a server group level op the referenced deployment overlay exists
-                    if (contentRepository != null && shouldCreateResource) {
-                        for(ContentReference reference : locallyAddedReferences) {
-                            contentRepository.addContentReference(reference);
-                        }
-                    }
+        context.completeStep((OperationContext context1, ModelNode operation1) -> {
+            //check that if this is a server group level op the referenced deployment overlay exists
+            if (contentRepository != null && shouldCreateResource) {
+                for(ContentReference reference : locallyAddedReferences) {
+                    contentRepository.removeContent(reference);
                 }
             }
         });

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
@@ -41,7 +41,6 @@ import java.io.InputStream;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationContext.ResultAction;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -150,13 +149,9 @@ public class DeploymentAddHandler implements OperationStepHandler {
 
         if (contentItem.getHash() != null) {
             final byte[] contentHash = contentItem.getHash();
-            context.completeStep(new OperationContext.ResultHandler() {
-                @Override
-                public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
-                    if (resultAction == ResultAction.KEEP) {
-                        contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, contentHash));
-                    }
-                }
+            contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, contentHash));
+            context.completeStep((OperationContext context1, ModelNode operation1) -> {
+                contentRepository.removeContent(ModelContentReference.fromModelAddress(address, contentHash));
             });
         }
     }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentExplodeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentExplodeHandler.java
@@ -90,6 +90,7 @@ public class DeploymentExplodeHandler implements OperationStepHandler {
         }
         contentItem.get(CONTENT_HASH.getName()).set(newHash);
         contentItem.get(CONTENT_ARCHIVE.getName()).set(false);
+        contentRepository.addContentReference(ModelContentReference.fromModelAddress(context.getCurrentAddress(), newHash));
 
         context.completeStep(new OperationContext.ResultHandler() {
             @Override
@@ -97,9 +98,9 @@ public class DeploymentExplodeHandler implements OperationStepHandler {
                 if (resultAction == OperationContext.ResultAction.KEEP) {
                     PathAddress address = context.getCurrentAddress();
                     contentRepository.removeContent(ModelContentReference.fromModelAddress(address, oldHash));
-                    contentRepository.addContentReference(ModelContentReference.fromModelAddress(context.getCurrentAddress(), newHash));
-                } // else the model update will be reverted and no ref content repo references changes will be made so
-                  // the newly exploded content will be eligible for content repo gc
+                } else {
+                    contentRepository.removeContent(ModelContentReference.fromModelAddress(context.getCurrentAddress(), newHash));
+                }
             }
         });
     }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
@@ -166,6 +166,9 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
         final Resource resource = Resource.Factory.create(!persistent);
         resource.writeModel(deploymentModel);
         context.addResource(PathAddress.pathAddress(deploymentPath), resource);
+        if (newHash != null) {
+            contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, newHash));
+        }
 
         if (ENABLED.resolveModelAttribute(context, deploymentModel).asBoolean()) {
             DeploymentHandlerUtil.replace(context, originalDeployment, runtimeName, name, replacedRuntimeName, vaultReader, contentItem);
@@ -180,9 +183,6 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
                     if (replacedHash != null  && (newHash == null || !Arrays.equals(replacedHash, newHash))) {
                         // The old content is no longer used; clean from repos
                         contentRepository.removeContent(ModelContentReference.fromModelAddress(address, replacedHash));
-                    }
-                    if (newHash != null) {
-                        contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, newHash));
                     }
                 } else if (newHash != null && (replacedHash == null || !Arrays.equals(replacedHash, newHash))) {
                     // Due to rollback, the new content isn't used; clean from repos

--- a/server/src/main/java/org/jboss/as/server/deployment/ExplodedDeploymentAddContentHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/ExplodedDeploymentAddContentHandler.java
@@ -118,6 +118,9 @@ public class ExplodedDeploymentAddContentHandler implements OperationStepHandler
         final List<String> relativePaths = addedFiles.stream().map(ExplodedContent::getRelativePath).collect(Collectors.toList());
         contentItemNode.get(CONTENT_HASH.getName()).set(newHash);
         contentItemNode.get(CONTENT_ARCHIVE.getName()).set(false);
+        if (newHash != null) {
+            contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, newHash));
+        }
         if (!addedFiles.isEmpty() && ENABLED.resolveModelAttribute(context, deploymentResource.getModel()).asBoolean()) {
             context.addStep(new OperationStepHandler() {
                 @Override
@@ -141,21 +144,15 @@ public class ExplodedDeploymentAddContentHandler implements OperationStepHandler
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep(new OperationContext.ResultHandler() {
-            @Override
-            public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
-                if (resultAction == ResultAction.KEEP) {
-                    if (oldHash != null  && (newHash == null || !Arrays.equals(oldHash, newHash))) {
-                        // The old content is no longer used; clean from repos
-                        contentRepository.removeContent(ModelContentReference.fromModelAddress(address, oldHash));
-                    }
-                    if (newHash != null) {
-                        contentRepository.addContentReference(ModelContentReference.fromModelAddress(address, newHash));
-                    }
-                } else if (newHash != null && (oldHash == null || !Arrays.equals(oldHash, newHash))) {
-                    // Due to rollback, the new content isn't used; clean from repos
-                    contentRepository.removeContent(ModelContentReference.fromModelAddress(address, newHash));
+        context.completeStep((ResultAction resultAction, OperationContext context1, ModelNode operation1) -> {
+            if (resultAction == ResultAction.KEEP) {
+                if (oldHash != null  && (newHash == null || !Arrays.equals(oldHash, newHash))) {
+                    // The old content is no longer used; clean from repos
+                    contentRepository.removeContent(ModelContentReference.fromModelAddress(address, oldHash));
                 }
+            } else if (newHash != null && (oldHash == null || !Arrays.equals(oldHash, newHash))) {
+                // Due to rollback, the new content isn't used; clean from repos
+                contentRepository.removeContent(ModelContentReference.fromModelAddress(address, newHash));
             }
         });
     }

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayContentAdd.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayContentAdd.java
@@ -105,6 +105,12 @@ public class DeploymentOverlayContentAdd extends AbstractAddStepHandler {
         if (!contentRepository.syncContent(ModelContentReference.fromModelAddress(address, hash))) {
             throw ServerLogger.ROOT_LOGGER.noSuchDeploymentContent(Arrays.toString(hash));
         }
+        context.completeStep((OperationContext context1, ModelNode operation1) -> {
+            if (hash != null) {
+                // Due to rollback, the new content isn't used; clean from repos
+                contentRepository.removeContent(ModelContentReference.fromModelAddress(address, hash));
+            }
+        });
     }
 
     @Override
@@ -113,8 +119,9 @@ public class DeploymentOverlayContentAdd extends AbstractAddStepHandler {
     }
 
     protected static void validateOnePieceOfContent(final ModelNode content) throws OperationFailedException {
-        if (content.asList().size() != 1)
+        if (content.asList().size() != 1) {
             throw ServerLogger.ROOT_LOGGER.multipleContentItemsNotSupported();
+        }
     }
 
     byte[] addFromHash(byte[] hash, String deploymentOverlayName, final String contentName, final PathAddress address, final OperationContext context) throws OperationFailedException {


### PR DESCRIPTION
Using RollBackHandler to manage rollback and put adding the ContentReference in the execution step.
Fixing some rollback missing issues.

Jira: https://issues.jboss.org/browse/WFCORE-2675