### PR TITLE
[WFCORE-2656] Operations that didn't modify the capability registry or the resource registration tree should not roll back the capability registry

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -548,11 +548,6 @@ abstract class AbstractOperationContext implements OperationContext {
     abstract ConfigurationPersister.PersistenceResource createPersistenceResource() throws ConfigurationPersistenceException;
 
     /**
-     * publish any changes to capability registery
-     */
-    abstract void publishCapabilityRegistry();
-
-    /**
      * Notification that the operation is not going to proceed to normal completion.
      */
     abstract void operationRollingBack();
@@ -792,7 +787,7 @@ abstract class AbstractOperationContext implements OperationContext {
         try {
             // Prepare persistence of any configuration changes
             ConfigurationPersister.PersistenceResource persistenceResource = null;
-            if (isModelAffected() && resultAction != ResultAction.ROLLBACK) {
+            if (resultAction != ResultAction.ROLLBACK) {
                 try {
                     persistenceResource = createPersistenceResource();
                 } catch (ConfigurationPersistenceException e) {
@@ -831,9 +826,6 @@ abstract class AbstractOperationContext implements OperationContext {
                 } else {
                     persistenceResource.commit();
                 }
-            }
-            if (resultAction != ResultAction.ROLLBACK) {
-                publishCapabilityRegistry();
             }
         } catch (Throwable t) {
             toThrow = t;

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -519,21 +519,16 @@ final class OperationContextImpl extends AbstractOperationContext {
 
     @Override
     ConfigurationPersister.PersistenceResource createPersistenceResource() throws ConfigurationPersistenceException {
-        return modelController.writeModel(managementModel, affectsModel.keySet());
+        return
+            (affectsResourceTree || affectsCapabilityRegistry || affectsResourceRegistration)
+                ? modelController.writeModel(managementModel, affectsModel.keySet(), affectsResourceTree,
+                    affectsCapabilityRegistry, affectsResourceRegistration)
+                : null;
     }
 
     @Override
     void operationRollingBack() {
-        modelController.discardModel(managementModel);
-    }
-
-    void publishCapabilityRegistry() {
-        // WFCORE-1886 Only publish the capability registry if we ourselves modified it,
-        // or if we modified the MRR tree (which may have modified it without our awareness)
-        // Either one is done under the exclusive lock so we won't publish someone else's modifications
-        if (affectsCapabilityRegistry || affectsResourceRegistration) {
-            modelController.publishCapabilityRegistry(managementModel);
-        }
+        modelController.discardModel(managementModel, affectsResourceTree, affectsCapabilityRegistry, affectsResourceRegistration);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
@@ -330,11 +330,6 @@ class ParallelBootOperationContext extends AbstractOperationContext {
     }
 
     @Override
-    void publishCapabilityRegistry() {
-        //we don't publish anything
-    }
-
-    @Override
     void operationRollingBack() {
         // BES 2015/06/30 hmm. telling the primary context to discarding the management model
         // here will screw up other parallel contexts that are still running. but if we don't,

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -102,12 +102,8 @@ class ReadOnlyContext extends AbstractOperationContext {
 
     @Override
     ConfigurationPersister.PersistenceResource createPersistenceResource() throws ConfigurationPersistenceException {
-        throw readOnlyContext();
-    }
-
-    @Override
-    void publishCapabilityRegistry() {
-        //do noting
+        // We don't persist
+        return null;
     }
 
     @Override

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
@@ -794,6 +794,42 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
         }
     }
 
+
+    @Test
+    public void testAddRemoveAdd() throws OperationFailedException {
+        executeCheckNoFailure(Util.createEmptyOperation("root-cap", PathAddress.EMPTY_ADDRESS));
+        try {
+            for (int i = 0; i < 100; i++) {
+                addRemoveAddTest();
+            }
+        } finally {
+            //noinspection ThrowFromFinallyBlock
+            executeCheckNoFailure(Util.createEmptyOperation("no-root-cap", PathAddress.EMPTY_ADDRESS));
+        }
+    }
+
+    private void addRemoveAddTest() throws OperationFailedException {
+        ManagementResourceRegistration registration = managementModel.getRootResourceRegistration().getSubModel(PathAddress.pathAddress(DEP_CAP_ELEMENT));
+        Assert.assertEquals(1, registration.getCapabilities().size());
+        Assert.assertEquals(reloadCaps(3), capabilityRegistry.getPossibleCapabilities().size());  //resource1 has 2 + 1 from resource 2
+        Assert.assertEquals(expectedCaps(1), capabilityRegistry.getCapabilities().size());
+
+        add(DEP_CAP_ELEMENT);
+        Assert.assertEquals(expectedCaps(2), capabilityRegistry.getCapabilities().size());
+
+        remove(DEP_CAP_ELEMENT);
+        Assert.assertEquals(expectedCaps(1), capabilityRegistry.getCapabilities().size());
+
+        add(DEP_CAP_ELEMENT);
+
+        Assert.assertEquals(expectedCaps(2), capabilityRegistry.getCapabilities().size());
+        Assert.assertEquals(reloadCaps(3), capabilityRegistry.getPossibleCapabilities().size());
+
+        //remove resource so capabilites are moved
+        remove(DEP_CAP_ELEMENT);
+        Assert.assertEquals(expectedCaps(1), capabilityRegistry.getCapabilities().size());
+    }
+
     private void add(PathElement... address) throws OperationFailedException {
         executeCheckNoFailure(Util.createEmptyOperation("add", PathAddress.pathAddress(address)));
     }


### PR DESCRIPTION
Also, tighten up in general the logic around publishing / rolling back the capability registry

https://issues.jboss.org/browse/WFCORE-2656