### PR TITLE
Fix for WFCORE-2684.IO extension doesn't initialise outbound bind add…

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/OutboundBindAddressRemoveHandler.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/OutboundBindAddressRemoveHandler.java
@@ -43,8 +43,8 @@ final class OutboundBindAddressRemoveHandler extends AbstractRemoveStepHandler {
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
         final CidrAddressTable<InetSocketAddress> bindingsTable = getWorkerService(context).getBindingsTable();
         if (bindingsTable != null) {
-            final CidrAddress cidrAddress = getCidrAddress(operation, context);
-            final InetSocketAddress bindAddress = getBindAddress(operation, context);
+            final CidrAddress cidrAddress = getCidrAddress(model, context);
+            final InetSocketAddress bindAddress = getBindAddress(model, context);
             bindingsTable.removeExact(cidrAddress, bindAddress);
         }
     }

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerService.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerService.java
@@ -40,7 +40,6 @@ import org.xnio.XnioWorker;
  */
 public class WorkerService implements Service<XnioWorker> {
     private final XnioWorker.Builder builder;
-    private CidrAddressTable<InetSocketAddress> bindingsTable;
     private XnioWorker worker;
     private volatile StopContext stopContext;
 
@@ -58,7 +57,6 @@ public class WorkerService implements Service<XnioWorker> {
     @Override
     public void start(StartContext startContext) throws StartException {
         builder.setTerminationTask(this::stopDone);
-        bindingsTable = builder.getBindAddressConfigurations();
         worker = builder.build();
     }
 
@@ -78,7 +76,7 @@ public class WorkerService implements Service<XnioWorker> {
     }
 
     CidrAddressTable<InetSocketAddress> getBindingsTable() {
-        return bindingsTable;
+        return builder.getBindAddressConfigurations();
     }
 
     @Override


### PR DESCRIPTION
WorkerService is started after the add handler is processed. The table was null so outbound address were not passed down to the Worker.
The worker builder table is now used by the service.
Found an issue when removing the outbound address, the match attribute was not found due to the usage of the operation instead of the model.
