### PR TITLE
Revert "WFCORE-2720 Adding keystore with generate-self-signed-certificate-hos…"

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/KeystoreAttributes.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/KeystoreAttributes.java
@@ -74,7 +74,6 @@ public class KeystoreAttributes {
     public static final SimpleAttributeDefinition GENERATE_SELF_SIGNED_CERTIFICATE_HOST = new SimpleAttributeDefinitionBuilder(org.jboss.as.controller.descriptions.ModelDescriptionConstants.GENERATE_SELF_SIGNED_CERTIFICATE_HOST, ModelType.STRING, true)
             .setAllowExpression(true)
             .setAllowNull(true)
-            .setRequires(ModelDescriptionConstants.KEY_PASSWORD)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
     /** Prevent instantiation */


### PR DESCRIPTION
Reverts wildfly/wildfly-core#2360

Need to revert because I messed up and did the 3.0.0.Beta17 release without pulling this one down first. So I'll reapply once I get the release commits into master.