### PR TITLE
[WFCORE-1762][WFCORE-2351] Improve handling of ops that result in broken services

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -1439,7 +1439,12 @@ abstract class AbstractOperationContext implements OperationContext {
                     response.get(OUTCOME).set(cancelled ? CANCELLED : FAILED);
                     response.get(ROLLED_BACK).set(true);
                 } else {
-                    response.get(OUTCOME).set(hasFailed() ? FAILED : SUCCESS);
+                    boolean failed = hasFailed();
+                    response.get(OUTCOME).set(failed ? FAILED : SUCCESS);
+                    if (failed) {
+                        // We didn't roll back despite failure. Report this
+                        response.get(ROLLED_BACK).set(false);
+                    }
                 }
                 if (ControllerLogger.MGMT_OP_LOGGER.isTraceEnabled()
                         && (forStage == Stage.MODEL || forStage == Stage.DOMAIN)) {

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -169,6 +169,8 @@ abstract class AbstractOperationContext implements OperationContext {
     private boolean executing;
     /** First response node provided to addStep  */
     ModelNode initialResponse;
+    /** Operation provided to addStep along with initialResponse */
+    ModelNode initialOperation;
 
     /** Operations that were added by the controller, before execution started */
     private final List<ModelNode> controllerOperations = new ArrayList<ModelNode>(2);
@@ -350,6 +352,7 @@ abstract class AbstractOperationContext implements OperationContext {
             recordControllerOperation(operation);
             if (initialResponse == null) {
                 initialResponse = response;
+                initialOperation = operation;
             }
         }
     }

--- a/controller/src/main/java/org/jboss/as/controller/ContainerStateVerificationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ContainerStateVerificationHandler.java
@@ -1,0 +1,50 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.controller;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Reports a failure due to a flawed container state, if and only if it appears no failure has already been
+ * reported. Serves as a last line of defense for cases where an op introduces service container problems
+ * but our standard mechanisms like ServiceVerificationHelper or OperationContextImpl.ServiceRemovalVerificationHandler
+ * were unable to detect the problem and associate it with a particular operation step.
+ *
+ * @author Brian Stansberry
+ */
+final class ContainerStateVerificationHandler implements OperationStepHandler {
+    static final OperationContext.AttachmentKey<Boolean> FAILURE_REPORTED_ATTACHMENT = OperationContext.AttachmentKey.create(Boolean.class);
+
+    private final ContainerStateMonitor.ContainerStateChangeReport changeReport;
+
+    ContainerStateVerificationHandler(ContainerStateMonitor.ContainerStateChangeReport changeReport) {
+        assert changeReport != null;
+        assert changeReport.hasNewProblems();
+        this.changeReport = changeReport;
+    }
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        // We only need to report if our response has no failure description already
+        // and if no other verification handler has reported a failure (which they may have done
+        // against a different response object that is invisible to us at this point,
+        // hence the use of the FAILURE_REPORTED_ATTACHMENT)
+        if (!context.hasFailureDescription() && context.getAttachment(FAILURE_REPORTED_ATTACHMENT) == null) {
+            throw new OperationFailedException(ContainerStateMonitor.createChangeReportLogMessage(changeReport, true));
+        }
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/ServiceVerificationHelper.java
+++ b/controller/src/main/java/org/jboss/as/controller/ServiceVerificationHelper.java
@@ -53,6 +53,7 @@ import org.jboss.msc.service.StartException;
  */
 @SuppressWarnings("deprecation")
 class ServiceVerificationHelper extends AbstractServiceListener<Object> implements ServiceListener<Object>, OperationStepHandler {
+
     private final StabilityMonitor monitor = new StabilityMonitor();
 
     @Override
@@ -159,6 +160,10 @@ class ServiceVerificationHelper extends AbstractServiceListener<Object> implemen
             if (context.isRollbackOnRuntimeFailure()) {
                 context.setRollbackOnly();
             }
+
+            // Notify ContainerStateVerificationHandler that we've reported an issue so it
+            // doesn't need to
+            context.attach(ContainerStateVerificationHandler.FAILURE_REPORTED_ATTACHMENT, Boolean.TRUE);
         }
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3489,4 +3489,7 @@ public interface ControllerLogger extends BasicLogger {
     @LogMessage(level = Level.WARN)
     @Message(id = 440, value = "Cannot delete file or directory %s")
     void cannotDeleteFileOrDirectory(File file);
+
+    @Message(id = 441, value = "Operation has resulted in failed or missing services %n")
+    String serviceStatusReportFailureHeader();
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1762 -- fail ops that break services even if Service
VerificationHelper and ServiceRemovalVerificationHandler don't detect the problem

https://issues.jboss.org/browse/WFCORE-2351 --correct the timing and content of messages about MSC status. Reporting is at op completion and this fix ensures that it reports the state as of op completion, not what the state was midway through. This plus WFCORE-1762 should result in such messages being rare, as only rollback-on-runtime=failure=true, a rollback problem or a later op correcting one of the above will result in these messages. Most other cases are corrected because of rollback.

Also fixes minor issue https://issues.jboss.org/browse/WFCORE-2558 by specifically reporting that rollback didn't occur in cases where the user has disabled it.