### PR TITLE
WFCORE-2750 ModuleSpecProcessor + WFCORE-2738 SubDeploymentProcessor undeploy() leaks

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentProcessor.java
@@ -82,7 +82,7 @@ public class SubDeploymentProcessor implements DeploymentUnitProcessor {
     }
 
     @Override
-    public void undeploy(DeploymentUnit deploymentUnit) {
+    public void undeploy(final DeploymentUnit deploymentUnit) {
         final ServiceRegistry serviceRegistry = deploymentUnit.getServiceRegistry();
         final List<ResourceRoot> childRoots = deploymentUnit.getAttachmentList(Attachments.RESOURCE_ROOTS);
         for (final ResourceRoot childRoot : childRoots) {
@@ -95,5 +95,6 @@ public class SubDeploymentProcessor implements DeploymentUnitProcessor {
                 serviceController.setMode(ServiceController.Mode.REMOVE);
             }
         }
+        deploymentUnit.removeAttachment(Attachments.SUB_DEPLOYMENTS);
     }
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
@@ -89,6 +89,9 @@ public class ModuleSpecProcessor implements DeploymentUnitProcessor {
 
     @Override
     public void undeploy(final DeploymentUnit deploymentUnit) {
+        deploymentUnit.removeAttachment(Attachments.MODULE);
+        deploymentUnit.removeAttachment(Attachments.MODULE_PERMISSIONS);
+        deploymentUnit.removeAttachment(DelegatingClassFileTransformer.ATTACHMENT_KEY);
     }
 
     private void deployModuleSpec(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {


### PR DESCRIPTION
Jiras
https://issues.jboss.org/browse/WFCORE-2738
https://issues.jboss.org/browse/WFCORE-2750

blocks singleton deployments
https://issues.jboss.org/browse/JBEAP-10593