### PR TITLE
WFCORE-2761 Attachments#DEPLOYMENT_COMPLETE_SERVICES never get's clea…

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentCompleteServiceProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentCompleteServiceProcessor.java
@@ -32,7 +32,7 @@ public class DeploymentCompleteServiceProcessor implements DeploymentUnitProcess
 
     public static final ServiceName SERVICE_NAME = ServiceName.of("deploymentCompleteService");
 
-    public static final ServiceName serviceName(final ServiceName deploymentUnitServiceName) {
+    public static ServiceName serviceName(final ServiceName deploymentUnitServiceName) {
         return deploymentUnitServiceName.append(SERVICE_NAME);
     }
 
@@ -51,7 +51,7 @@ public class DeploymentCompleteServiceProcessor implements DeploymentUnitProcess
     }
 
     @Override
-    public void undeploy(final DeploymentUnit context) {
-
+    public void undeploy(final DeploymentUnit deploymentUnit) {
+        deploymentUnit.removeAttachment(Attachments.DEPLOYMENT_COMPLETE_SERVICES);
     }
 }


### PR DESCRIPTION
…red on undeploy()

https://issues.jboss.org/browse/WFCORE-2761

Since all other DUPs are contributing to org.jboss.as.server.deployment.Attachments#DEPLOYMENT_COMPLETE_SERVICES nothing actually clears the list on org.jboss.as.server.deployment.DeploymentUnitProcessor#undeploy (or cleanup phase).
This seems to be the responsibility of org.jboss.as.server.deployment.DeploymentCompleteServiceProcessor.
