### PR TITLE
WFCORE-2443: Fix wrong description in configurable-sasl-server-factory and configurable-http-server-mechanism-factory

### DIFF
--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -238,7 +238,7 @@ elytron.aggregate-http-server-mechanism-factory.http-server-mechanism-factories=
 # Runtime Attributes
 elytron.aggregate-http-server-mechanism-factory.available-mechanisms=The HTTP mechanisms available from this factory instance.
 
-elytron.configurable-http-server-mechanism-factory=A sasl server factory definition where the sasl server factory is an aggregation of other sasl server factories.
+elytron.configurable-http-server-mechanism-factory=A HTTP server factory definition that wraps another HTTP server factory and applies the specified configuration and filtering.
 # Operations
 elytron.configurable-http-server-mechanism-factory.add=The add operation for the http server factory.
 elytron.configurable-http-server-mechanism-factory.remove=The remove operation for the http server factory.
@@ -815,7 +815,7 @@ elytron.aggregate-sasl-server-factory.sasl-server-factories=The referenced sasl 
 # Runtime Attributes
 elytron.aggregate-sasl-server-factory.available-mechanisms=The SASL mechanisms available from this factory after all filtering has been applied.
 
-elytron.configurable-sasl-server-factory=A sasl server factory definition where the sasl server factory is an aggregation of other sasl server factories.
+elytron.configurable-sasl-server-factory=A SaslServerFactory definition that wraps another SaslServerFactory and applies the specified configuration and filtering.
 # Operations
 elytron.configurable-sasl-server-factory.add=The add operation for the sasl server factory.
 elytron.configurable-sasl-server-factory.remove=The remove operation for the sasl server factory.


### PR DESCRIPTION
The issue only describes an error on configurable-sasl-server-factory description, but configurable-http-server-mechanism-factory had the same problem. Single commit to fixing both.

Jira Issues:
https://issues.jboss.org/browse/WFCORE-2443
https://issues.jboss.org/browse/JBEAP-6798
