### PR TITLE
[WFCORE-2747 & WFCORE-2769]

### DIFF
--- a/controller-client/pom.xml
+++ b/controller-client/pom.xml
@@ -71,6 +71,14 @@
             <groupId>org.jboss.threads</groupId>
             <artifactId>jboss-threads</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly.common</groupId>
+            <artifactId>wildfly-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.security</groupId>
+            <artifactId>wildfly-elytron</artifactId>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClientConfiguration.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClientConfiguration.java
@@ -30,6 +30,7 @@ import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
 import java.io.Closeable;
 import java.net.InetAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.security.PrivilegedAction;
 import java.util.Map;
@@ -111,6 +112,16 @@ public interface ModelControllerClientConfiguration extends Closeable {
      */
     String getClientBindAddress();
 
+    /**
+     * Specifies the URI for the authentication configuration.
+     *
+     * @return the location to the authentication configuration file or {@code null} to use auto
+     * discovery
+     */
+    default URI getAuthenticationConfigUri() {
+        return null;
+    }
+
     class Builder {
         private String hostName;
         private String clientBindAddress;
@@ -120,6 +131,7 @@ public interface ModelControllerClientConfiguration extends Closeable {
         private SSLContext sslContext;
         private String protocol;
         private int connectionTimeout = 0;
+        private URI authConfigUri;
 
         public Builder() {
         }
@@ -211,13 +223,24 @@ public interface ModelControllerClientConfiguration extends Closeable {
         }
 
         /**
+         * Set the location of the authentication configuration file.
+         * @param authConfigUri the location to the authentication configuration file or {@code null} to use auto
+         *                      discovery
+         * @return a builder to allow continued configuration
+         */
+        public Builder setAuthenticationConfigUri(final URI authConfigUri) {
+            this.authConfigUri = authConfigUri;
+            return this;
+        }
+
+        /**
          * Builds the configuration object based on this builder's settings.
          *
          * @return the configuration
          */
         public ModelControllerClientConfiguration build() {
            return new ClientConfigurationImpl(hostName, port, handler, saslOptions, sslContext,
-                   Factory.createDefaultExecutor(), true, connectionTimeout, protocol, clientBindAddress);
+                   Factory.createDefaultExecutor(), true, connectionTimeout, protocol, clientBindAddress, authConfigUri);
         }
 
     }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ContextualModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ContextualModelControllerClient.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.controller.client.helpers;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.client.OperationResponse;
+import org.jboss.dmr.ModelNode;
+import org.jboss.threads.AsyncFuture;
+import org.wildfly.common.Assert;
+import org.wildfly.common.context.Contextual;
+
+/**
+ * A {@linkplain ModelControllerClient client} which wraps invocations of the delegate client in the provided
+ * {@linkplain Contextual context}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public final class ContextualModelControllerClient implements ModelControllerClient {
+    private final ModelControllerClient delegate;
+    private final Contextual<?> context;
+
+    /**
+     * Creates a client which uses the supplied {@linkplain Contextual context}.
+     *
+     * @param delegate the delegate client
+     * @param context  the context used to execute operations
+     */
+    public ContextualModelControllerClient(final ModelControllerClient delegate, final Contextual<?> context) {
+        this.delegate = Assert.checkNotNullParam("delegate", delegate);
+        this.context = Assert.checkNotNullParam("context", context);
+    }
+
+    @Override
+    public OperationResponse executeOperation(final Operation operation, final OperationMessageHandler messageHandler) throws IOException {
+        return context.runExFunction(o -> delegate.executeOperation(operation, messageHandler), null);
+    }
+
+    @Override
+    public AsyncFuture<ModelNode> executeAsync(final Operation operation, final OperationMessageHandler messageHandler) {
+        return context.runExFunction(o -> delegate.executeAsync(operation, messageHandler), null);
+    }
+
+    @Override
+    public AsyncFuture<OperationResponse> executeOperationAsync(final Operation operation, final OperationMessageHandler messageHandler) {
+        return context.runExFunction(o -> delegate.executeOperationAsync(operation, messageHandler), null);
+    }
+
+    @Override
+    public void close() throws IOException {
+        delegate.close();
+    }
+}

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
@@ -26,6 +26,7 @@ import org.jboss.as.controller.client.ModelControllerClientConfiguration;
 
 import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
+import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
@@ -46,8 +47,9 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
     private final String protocol;
     private final boolean shutdownExecutor;
     private final int connectionTimeout;
+    private final URI authConfigUri;
 
-    public ClientConfigurationImpl(String address, int port, CallbackHandler handler, Map<String, String> saslOptions, SSLContext sslContext, ExecutorService executorService, boolean shutdownExecutor, final int connectionTimeout, final String protocol, String clientBindAddress) {
+    public ClientConfigurationImpl(String address, int port, CallbackHandler handler, Map<String, String> saslOptions, SSLContext sslContext, ExecutorService executorService, boolean shutdownExecutor, final int connectionTimeout, final String protocol, String clientBindAddress, final URI authConfigUri) {
         this.address = address;
         this.port = port;
         this.handler = handler;
@@ -58,6 +60,7 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
         this.protocol = protocol;
         this.clientBindAddress = clientBindAddress;
         this.connectionTimeout = connectionTimeout > 0 ? connectionTimeout : DEFAULT_CONNECTION_TIMEOUT;
+        this.authConfigUri = authConfigUri;
     }
 
     @Override
@@ -111,5 +114,10 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
     @Override
     public String getClientBindAddress() {
         return clientBindAddress;
+    }
+
+    @Override
+    public URI getAuthenticationConfigUri() {
+        return authConfigUri;
     }
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/logging/ControllerClientLogger.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/logging/ControllerClientLogger.java
@@ -34,6 +34,7 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 
 /**
@@ -367,6 +368,9 @@ public interface ControllerClientLogger extends BasicLogger {
 
     @Message(id = 36, value = "Stream was closed")
     IOException streamWasClosed();
+
+    @Message(id = 37, value = "Failed to parse the configuration file: %s")
+    RuntimeException failedToParseAuthenticationConfig(@Cause Throwable cause, URI location);
 
     class LeakDescription extends Throwable {
         private static final long serialVersionUID = -7193498784746897578L;

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
@@ -34,6 +34,7 @@
 
     <dependencies>
         <module name="org.wildfly.common"/>
+        <module name="org.wildfly.security.elytron-private"/>
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.dmr"/>
         <module name="org.jboss.logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -47,6 +47,10 @@
         <module name="javax.security.jacc.api" optional="true"/>
         <module name="sun.jdk"/>
         <module name="org.wildfly.common"/>
-        <module name="org.wildfly.client.config"/>
+        <!--
+        This is only exported because some of the ElytronXmlParser methods throw an exception in this module. If other
+        modules use the parser, they need to have visibility to this module.
+        -->
+        <module name="org.wildfly.client.config" export="true"/>
     </dependencies>
 </module>

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/ElytronModelControllerClientTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/mgmt/elytron/ElytronModelControllerClientTestCase.java
@@ -1,0 +1,124 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.manualmode.mgmt.elytron;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.integration.management.util.CustomCLIExecutor;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Tests that the {@link ManagementClient} will connect to a server configured for an Elytron realm.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class ElytronModelControllerClientTestCase {
+
+    private static final URL WILDFLY_CONFIG = ElytronModelControllerClientTestCase.class.getClassLoader().getResource("test-wildfly-config.xml");
+
+    @Inject
+    private static ServerController CONTROLLER;
+
+    @After
+    public void tearDown() throws Exception {
+        if (CONTROLLER.isStarted()) {
+            CONTROLLER.stop();
+        }
+    }
+
+    @Test
+    public void testElytronAdminConfig() throws Exception {
+        Assert.assertNotNull("Could not find test-wildfly-config.xml", WILDFLY_CONFIG);
+        final Path copiedConfig = configureElytron();
+        // Start the server
+        CONTROLLER.start(copiedConfig.getFileName().toString(), WILDFLY_CONFIG.toURI());
+
+        testConnection();
+
+        // Stop the container, then remove the copied config
+        CONTROLLER.stop();
+        Files.deleteIfExists(copiedConfig);
+    }
+
+    @Test
+    public void testDefaultClient() throws Exception {
+        // Start the server
+        CONTROLLER.start();
+
+        testConnection();
+
+        // Stop the container
+        CONTROLLER.stop();
+    }
+
+    private void testConnection() throws IOException {
+
+        final ModelNode op = Operations.createReadAttributeOperation(new ModelNode().setEmptyList(), "server-state");
+        ModelNode result = CONTROLLER.getClient().getControllerClient().execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.fail(Operations.getFailureDescription(result).asString());
+        }
+    }
+
+    private Path configureElytron() throws Exception {
+        final String jbossHome = TestSuiteEnvironment.getJBossHome();
+        Assert.assertNotNull("Could not find the JBoss home directory", jbossHome);
+
+        final Path configPath = Paths.get(jbossHome, "standalone", "configuration");
+
+        // We copy the config here as we don't know what the default value of the http-upgrade.sasl-authentication-factory
+        // attribute on the /core-service=management/management-interface=http-interface resource is.
+        final String config = "test-standalone-elytron.xml";
+        final Path configFile = configPath.resolve(config);
+        Files.copy(configPath.resolve("standalone.xml"), configFile, StandardCopyOption.REPLACE_EXISTING);
+
+        final List<String> commands = new ArrayList<>();
+        commands.add("embed-server --server-config=" + config);
+        commands.add("/subsystem=elytron/filesystem-realm=testRealm:add(path=fs-realm-users,relative-to=jboss.server.config.dir)");
+        commands.add("/subsystem=elytron/filesystem-realm=testRealm/identity=test-admin:add()");
+        commands.add("/subsystem=elytron/filesystem-realm=testRealm/identity=test-admin:set-password(clear={password=\"admin.12345\"})");
+        commands.add("/subsystem=elytron/security-domain=testSecurityDomain:add(realms=[{realm=testRealm}],default-realm=testRealm,permission-mapper=default-permission-mapper)");
+        commands.add("/subsystem=elytron/sasl-authentication-factory=test-sasl-auth:add(sasl-server-factory=configured, security-domain=testSecurityDomain, mechanism-configurations=[{mechanism-name=DIGEST-MD5, mechanism-realm-configurations=[{realm-name=testRealm}]}])");
+        commands.add("/core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade.sasl-authentication-factory, value=test-sasl-auth)");
+        commands.add("stop-embedded-server");
+        CustomCLIExecutor.executeOffline(commands);
+        return configFile;
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/PreparedResponseTestCase.java
@@ -24,8 +24,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SHUTDOWN;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import javax.inject.Inject;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -145,13 +143,7 @@ public class PreparedResponseTestCase {
     }
 
     static ManagementClient getManagementClient() {
-        ModelControllerClient client = null;
-        try {
-            client = ModelControllerClient.Factory.create("remote+http", InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
-                    TestSuiteEnvironment.getServerPort(), new org.wildfly.core.testrunner.Authentication.CallbackHandler());
-        } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
-        }
+        final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         return new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
     }
 }

--- a/testsuite/manualmode/src/test/resources/test-wildfly-config.xml
+++ b/testsuite/manualmode/src/test/resources/test-wildfly-config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2017 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <authentication-client xmlns="urn:elytron:1.0">
+        <authentication-rules>
+            <rule use-configuration="test-login">
+            </rule>
+        </authentication-rules>
+        <authentication-configurations>
+            <configuration name="test-login">
+                <allow-sasl-mechanisms names="DIGEST-MD5" />
+                <use-service-loader-providers />
+                <set-user-name name="test-admin" />
+                <credentials>
+                    <clear-password password="admin.12345" />
+                </credentials>
+                <set-mechanism-realm name="testRealm" />
+            </configuration>
+        </authentication-configurations>
+    </authentication-client>
+</configuration>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
@@ -55,6 +55,26 @@ public class TestSuiteEnvironment {
         return "java";
     }
 
+    /**
+     * Returns the JBoss home directory or {@code null} if it could not be found.
+     * <p>
+     * The following is the order the directory is resolved:
+     * <ol>
+     *     <li>The {@code jboss.dist} system property is checked</li>
+     *     <li>The {@code jboss.home} system property is checked</li>
+     *     <li>The {@code JBOSS_HOME} environment variable is checked</li>
+     * </ol>
+     * </p>
+     * @return the JBoss home directory or {@code null} if it could not be resolved
+     */
+    public static String getJBossHome() {
+        String jbossHome = getSystemProperty("jboss.dist");
+        if (jbossHome == null) {
+            jbossHome = getSystemProperty("jboss.home");
+        }
+        return jbossHome == null ? System.getenv("JBOSS_HOME") : jbossHome;
+    }
+
     public static String getSystemProperty(String name, String def) {
         return System.getProperty(name, def);
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
@@ -1,13 +1,13 @@
 package org.jboss.as.test.shared;
 
-import java.net.InetAddress;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.ModelControllerClientConfiguration;
 import org.wildfly.test.api.Authentication;
 
 /**
@@ -20,15 +20,28 @@ import org.wildfly.test.api.Authentication;
 public class TestSuiteEnvironment {
 
     public static ModelControllerClient getModelControllerClient() {
-        try {
-            return ModelControllerClient.Factory.create(
-                    InetAddress.getByName(getServerAddress()),
-                    TestSuiteEnvironment.getServerPort(),
-                    Authentication.getCallbackHandler()
-                    );
-        } catch (UnknownHostException e) {
-            throw new RuntimeException(e);
+        return getModelControllerClient(null);
+    }
+
+    /**
+     * Creates a client based on the {@linkplain #getServerAddress() server address} and
+     * {@linkplain #getServerPort() port}. If the {@code authConfigUri} is not {@code null} the it will be used to
+     * authenticate the client.
+     *
+     * @param authConfigUri the path too the authentication configuration or {@code null}
+     *
+     * @return the client
+     */
+    public static ModelControllerClient getModelControllerClient(final URI authConfigUri) {
+        final ModelControllerClientConfiguration.Builder builder = new ModelControllerClientConfiguration.Builder()
+                .setHostName(getServerAddress())
+                .setPort(getServerPort());
+        if (authConfigUri == null) {
+            builder.setHandler(Authentication.getCallbackHandler());
+        } else {
+            builder.setAuthenticationConfigUri(authConfigUri);
         }
+        return ModelControllerClient.Factory.create(builder.build());
     }
 
     public static String getJavaPath() {

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ServerController.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ServerController.java
@@ -3,6 +3,7 @@ package org.wildfly.core.testrunner;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -27,13 +28,50 @@ public class ServerController {
         start(serverConfig, adminMode ? Server.StartMode.ADMIN_ONLY : Server.StartMode.NORMAL);
     }
 
+    /**
+     * Starts the server. If the {@code authConfigUri} is not {@code null} the resource will be used for
+     * authentication of the {@link org.jboss.as.controller.client.ModelControllerClient}.
+     *
+     * @param authConfigUri the path to the {@code wildfly-config.xml} or {@code null}
+     */
+    public void start(final URI authConfigUri) {
+        start(null, authConfigUri);
+    }
+
+    /**
+     * Starts the server. If the {@code authConfigUri} is not {@code null} the resource will be used for
+     * authentication of the {@link org.jboss.as.controller.client.ModelControllerClient}.
+     *
+     * @param serverConfig  the configuration file to use or {@code null} to use the default
+     * @param authConfigUri the path to the {@code wildfly-config.xml} or {@code null}
+     */
+    public void start(final String serverConfig, final URI authConfigUri) {
+        start(serverConfig, authConfigUri, Server.StartMode.NORMAL, System.out);
+    }
+
     public void start(final String serverConfig, Server.StartMode startMode) {
         start(serverConfig, startMode, System.out);
     }
 
     public void start(final String serverConfig, Server.StartMode startMode, PrintStream out) {
+        start(serverConfig, null, startMode, out);
+    }
+
+    /**
+     * Stats the server.
+     * <p>
+     * If the {@code authConfigUri} is not {@code null} the resource will be used for authentication of the
+     * {@link org.jboss.as.controller.client.ModelControllerClient}.
+     * </p>
+     *
+     * @param serverConfig  the configuration file to use or {@code null} to use the default
+     * @param authConfigUri the path to the {@code wildfly-config.xml} or {@code null}
+     * @param startMode     the mode to start the server in
+     * @param out           the print stream used to consume the {@code stdout} and {@code stderr} streams
+     */
+    public void start(final String serverConfig, final URI authConfigUri, Server.StartMode startMode, PrintStream out) {
         if (started.compareAndSet(false, true)) {
-            server = new Server();
+            server = new Server(authConfigUri);
             if (serverConfig != null) {
                 server.setServerConfig(serverConfig);
             }


### PR DESCRIPTION
The first commit adds a new `ContextualModelControllerClient` which allows a context to be used when executing operations. It also adds a dependency to `org.wildfly.common:wildfly-common` and `org.wildfly.elytron:wildfly-elytron`. Both of these were already transitive dependencies from the `org.wildfly.protocol:wildfly-protocol` dependency. It also adds an option to the client builder to allow a `wildfly-config.xml` to be defined for authentication.

The second commit enables the usage of authentication options for the `ModelControllerClient` so that an Elytron authentication configuration can be used to authentication the management client.

The next two could likely be squashed. I just left them separate for now.