### PR TITLE
[WFCORE-13] Prevent end-user invocation of EntryType.PRIVATE operations

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CompositeOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/CompositeOperationHandler.java
@@ -22,7 +22,10 @@
 
 package org.jboss.as.controller;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CALLER_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.USER;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -95,7 +98,9 @@ public class CompositeOperationHandler implements OperationStepHandler {
         }
 
         boolean adjustStepAddresses = context.getCurrentAddress().size() > 0;
-        MultistepUtil.recordOperationSteps(context, operationMap, addedResponses, getOperationHandlerResolver(), adjustStepAddresses);
+        boolean rejectPrivateSteps = operation.hasDefined(OPERATION_HEADERS, CALLER_TYPE) && USER.equals(operation.get(OPERATION_HEADERS, CALLER_TYPE).asString());
+        MultistepUtil.recordOperationSteps(context, operationMap, addedResponses,
+                getOperationHandlerResolver(), adjustStepAddresses, rejectPrivateSteps);
 
         context.completeStep(new OperationContext.RollbackHandler() {
             @Override

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerClientFactory.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerClientFactory.java
@@ -53,6 +53,9 @@ public interface ModelControllerClientFactory {
      * against the returned client can only occur from a calling context with the
      * {@link org.jboss.as.controller.security.ControllerPermission#PERFORM_IN_VM_CALL PERFORM_IN_VM_CALL}
      * permission. Without this permission a {@link SecurityException} will be thrown.
+     * <p>
+     * Calling this method is equivalent to a call to
+     * {@link #createSuperUserClient(Executor, boolean) createSuperUserClient(executor, false)}.
      *
      * @param executor the executor to use for asynchronous operation execution. Cannot be {@code null}
      * @return the client. Will not return {@code null}
@@ -61,5 +64,32 @@ public interface ModelControllerClientFactory {
      *            {@link org.jboss.as.controller.security.ControllerPermission#CAN_ACCESS_MODEL_CONTROLLER CAN_ACCESS_MODEL_CONTROLLER}
      *            permission
      */
-    LocalModelControllerClient createSuperUserClient(Executor executor);
+    default LocalModelControllerClient createSuperUserClient(Executor executor) {
+        return createSuperUserClient(executor, false);
+    }
+
+    /**
+     * Create an in-VM client whose operations are executed as if they were invoked by a user in the
+     * RBAC {@code SuperUser} role, regardless of any security identity that is or isn't associated
+     * with the calling thread when the client is invoked. <strong>This client generally should not
+     * be used to handle requests from external callers, and if it is used great care should be
+     * taken to ensure such use is not suborning the intended access control scheme.</strong>
+     * <p>
+     * In a VM with a {@link java.lang.SecurityManager SecurityManager} installed, invocations
+     * against the returned client can only occur from a calling context with the
+     * {@link org.jboss.as.controller.security.ControllerPermission#PERFORM_IN_VM_CALL PERFORM_IN_VM_CALL}
+     * permission. Without this permission a {@link SecurityException} will be thrown.
+     *
+     * @param executor the executor to use for asynchronous operation execution. Cannot be {@code null}
+     * @param forUserCalls if {@code true} the operation executed by this client should be regarded as coming
+     *                     from an end user. For example, such operations cannot target
+     *                     {@link org.jboss.as.controller.registry.OperationEntry.EntryType#PRIVATE}
+     *                     operations
+     * @return the client. Will not return {@code null}
+     *
+     * @throws SecurityException if the caller does not have the
+     *            {@link org.jboss.as.controller.security.ControllerPermission#CAN_ACCESS_MODEL_CONTROLLER CAN_ACCESS_MODEL_CONTROLLER}
+     *            permission
+     */
+    LocalModelControllerClient createSuperUserClient(Executor executor, boolean forUserCalls);
 }

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -681,7 +681,7 @@ class ModelControllerImpl implements ModelController {
 
     @Override
     public ModelControllerClient createClient(final Executor executor) {
-        return getClientFactory().createSuperUserClient(executor);
+        return getClientFactory().createSuperUserClient(executor, false);
     }
 
     ConfigurationPersister.PersistenceResource writeModel(final ManagementModelImpl model, final Set<PathAddress> affectedAddresses,

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -1650,7 +1650,7 @@ final class OperationContextImpl extends AbstractOperationContext {
     private void rejectUserDomainServerUpdates() {
         if (isModelUpdateRejectionRequired()) {
             ModelNode op = activeStep.operation;
-            if (op.hasDefined(OPERATION_HEADERS) && op.get(OPERATION_HEADERS).hasDefined(CALLER_TYPE) && USER.equals(op.get(OPERATION_HEADERS, CALLER_TYPE).asString())) {
+            if (op.hasDefined(OPERATION_HEADERS, CALLER_TYPE) && USER.equals(op.get(OPERATION_HEADERS, CALLER_TYPE).asString())) {
                 throw ControllerLogger.ROOT_LOGGER.modelUpdateNotAuthorized(op.require(OP).asString(), activeStep.address);
             }
         }

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -143,7 +143,6 @@ final class OperationContextImpl extends AbstractOperationContext {
     private static final Set<Action.ActionEffect> ALL_READ_WRITE = EnumSet.of(Action.ActionEffect.READ_CONFIG, Action.ActionEffect.READ_RUNTIME, Action.ActionEffect.WRITE_CONFIG, Action.ActionEffect.WRITE_RUNTIME);
 
     private final ModelControllerImpl modelController;
-    private final OperationHeaders operationHeaders;
     private final OperationMessageHandler messageHandler;
     private final Map<ServiceName, ServiceController<?>> realRemovingControllers = new HashMap<>();
     // protected by "realRemovingControllers"
@@ -218,7 +217,7 @@ final class OperationContextImpl extends AbstractOperationContext {
                          final boolean partialModel,
                          final Supplier<SecurityIdentity> securityIdentitySupplier) {
         super(processType, runningMode, transactionControl, processState, booting, auditLogger, notificationSupport,
-                modelController, skipModelValidation, extraValidationStepHandler, securityIdentitySupplier);
+                modelController, skipModelValidation, extraValidationStepHandler, operationHeaders, securityIdentitySupplier);
         this.operationId = operationId;
         this.operationName = operationName;
         this.operationAddress = operationAddress.isDefined()
@@ -229,7 +228,6 @@ final class OperationContextImpl extends AbstractOperationContext {
         this.messageHandler = messageHandler;
         this.attachments = attachments;
         this.affectsModel = booting ? new ConcurrentHashMap<>(16 * 16) : new HashMap<>(1);
-        this.operationHeaders = operationHeaders;
         this.hostServerGroupTracker = hostServerGroupTracker;
         this.activeOperationResource = new ActiveOperationResource();
         this.accessAuditContext = accessAuditContext;

--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
@@ -68,7 +68,7 @@ class ParallelBootOperationContext extends AbstractOperationContext {
                                  final ModelControllerImpl controller, final int operationId, final AuditLogger auditLogger,
                                  final Resource model, final OperationStepHandler extraValidationStepHandler, final Supplier<SecurityIdentity> securityIdentitySupplier) {
         super(primaryContext.getProcessType(), primaryContext.getRunningMode(), transactionControl, processState, true, auditLogger,
-                controller.getNotificationSupport(), controller, true, extraValidationStepHandler, securityIdentitySupplier);
+                controller.getNotificationSupport(), controller, true, extraValidationStepHandler, null, securityIdentitySupplier);
         this.primaryContext = primaryContext;
         this.runtimeOps = runtimeOps;
         AbstractOperationContext.controllingThread.set(controllingThread);

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -72,7 +72,7 @@ class ReadOnlyContext extends AbstractOperationContext {
                     final AbstractOperationContext primaryContext, final ModelControllerImpl controller, final int operationId, final Supplier<SecurityIdentity> securityIdentitySupplier) {
         super(processType, runningMode, transactionControl, processState,
                 booting, controller.getAuditLogger(), controller.getNotificationSupport(),
-                controller, true, null, securityIdentitySupplier);
+                controller, true, null, null, securityIdentitySupplier);
         this.primaryContext = primaryContext;
         this.controller = controller;
         this.operationId = operationId;

--- a/controller/src/main/java/org/jboss/as/controller/SimpleOperationDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleOperationDefinition.java
@@ -125,7 +125,7 @@ public class SimpleOperationDefinition extends OperationDefinition {
 
     @Override
     public DescriptionProvider getDescriptionProvider() {
-        if (entryType == OperationEntry.EntryType.PRIVATE) {
+        if (entryType == OperationEntry.EntryType.PRIVATE || flags.contains(OperationEntry.Flag.HIDDEN)) {
             return PRIVATE_PROVIDER;
         }
         if (descriptionProvider !=null) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/GenericSubsystemDescribeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/GenericSubsystemDescribeHandler.java
@@ -49,6 +49,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -66,7 +67,7 @@ public class GenericSubsystemDescribeHandler implements OperationStepHandler, De
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.READ_WHOLE_CONFIG)
             .setReplyType(ModelType.LIST)
             .setReplyValueType(ModelType.OBJECT)
-            .setPrivateEntry()
+            .withFlag(OperationEntry.Flag.HIDDEN)
             .build();
 
     public static final Set<Action.ActionEffect> DESCRIBE_EFFECTS =

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ValidateOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ValidateOperationHandler.java
@@ -49,6 +49,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.operations.validation.OperationValidator;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -72,11 +73,11 @@ public class ValidateOperationHandler implements OperationStepHandler {
             .setRuntimeOnly()
             .build();
 
-    public static final OperationDefinition DEFINITION_PRIVATE = new SimpleOperationDefinitionBuilder(VALIDATE_OPERATION, ControllerResolver.getResolver("global"))
+    public static final OperationDefinition DEFINITION_HIDDEN = new SimpleOperationDefinitionBuilder(VALIDATE_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(VALUE)
             .setReadOnly()
             .setRuntimeOnly()
-            .setPrivateEntry()
+            .withFlags(OperationEntry.Flag.HIDDEN) // can't be private, because the proxyReg != null case in execute results in a caller-type=user op being executed for this
             .build();
 
 

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -48,6 +48,7 @@ import static org.jboss.as.controller.operations.global.GlobalOperationAttribute
 import static org.jboss.as.controller.operations.global.GlobalOperationAttributes.PROXIES;
 import static org.jboss.as.controller.operations.global.GlobalOperationAttributes.RECURSIVE;
 import static org.jboss.as.controller.operations.global.GlobalOperationAttributes.RECURSIVE_DEPTH;
+import static org.jboss.as.controller.operations.global.ReadOperationNamesHandler.isVisible;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -218,12 +219,10 @@ public class ReadResourceDescriptionHandler extends GlobalOperationHandlers.Abst
 
         if (ops) {
             for (final Map.Entry<String, OperationEntry> entry : registry.getOperationDescriptions(PathAddress.EMPTY_ADDRESS, inherited).entrySet()) {
-                if (entry.getValue().getType() == OperationEntry.EntryType.PUBLIC) {
-                    if (context.getProcessType() != ProcessType.DOMAIN_SERVER || entry.getValue().getFlags().contains(OperationEntry.Flag.RUNTIME_ONLY)
-                            || entry.getValue().getFlags().contains(OperationEntry.Flag.READ_ONLY)) {
-                        ReadOperationDescriptionHandler.DescribedOp describedOp = new ReadOperationDescriptionHandler.DescribedOp(entry.getValue(), locale);
-                        operations.put(entry.getKey(), describedOp.getDescription());
-                    }
+                OperationEntry operationEntry = entry.getValue();
+                if (isVisible(operationEntry, context)) {
+                    ReadOperationDescriptionHandler.DescribedOp describedOp = new ReadOperationDescriptionHandler.DescribedOp(operationEntry, locale);
+                    operations.put(entry.getKey(), describedOp.getDescription());
                 }
             }
         }

--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/OperationValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/OperationValidator.java
@@ -122,7 +122,7 @@ public class OperationValidator {
             throwOrWarnAboutDescriptorProblem(ControllerLogger.ROOT_LOGGER.noOperationEntry(name, address));
         }
         //noinspection ConstantConditions
-        if (entry.getType() == EntryType.PRIVATE) {
+        if (entry.getType() == EntryType.PRIVATE || entry.getFlags().contains(OperationEntry.Flag.HIDDEN)) {
             return;
         }
         if (entry.getOperationHandler() == null) {

--- a/controller/src/main/java/org/jboss/as/controller/registry/OperationEntry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/OperationEntry.java
@@ -66,7 +66,15 @@ public final class OperationEntry {
         MASTER_HOST_CONTROLLER_ONLY,
         /** Operations with this flag do not affect the mode or change the installed services. The main intention for
          * this is to only make RUNTIME_ONLY methods on domain mode servers visible to end users. */
-        RUNTIME_ONLY
+        RUNTIME_ONLY,
+        /** Operations with this flag do not appear in management API description output but still can be invoked
+         *  by external callers.  This is meant for operations that were not meant to be part of the supported external
+         *  management API but users may have learned of them. Such ops should be evaluated for inclusion as normally
+         *  described ops, or perhaps should be marked with {@link EntryType#PRIVATE} and external use thus disabled.
+         *  This can also be used for ops that are invoked internally on one domain process by another domain process
+         *  but where it's not possible for the caller to suppress the caller-type=user header from the op, making
+         *  use of {@link EntryType#PRIVATE} not workable. */
+        HIDDEN
     }
 
     private final OperationDefinition operationDefinition;

--- a/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
@@ -57,7 +57,7 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
 
     private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("proxy-step",
             NonResolvingResourceDescriptionResolver.INSTANCE)
-            .setPrivateEntry()
+            .withFlags(OperationEntry.Flag.HIDDEN)
             .setRuntimeOnly()
             .build();
 

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DefaultDeploymentOperations.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DefaultDeploymentOperations.java
@@ -64,8 +64,8 @@ final class DefaultDeploymentOperations implements DeploymentOperations {
     private final LocalModelControllerClient controllerClient;
 
     DefaultDeploymentOperations(final ModelControllerClientFactory clientFactory, final Executor executor) {
-        // We need to run with RBAC SuperUser rights
-        this.controllerClient = clientFactory.createSuperUserClient(executor);
+        // We need to run with RBAC SuperUser rights, but don't need to invoke private operations
+        this.controllerClient = clientFactory.createSuperUserClient(executor, false);
     }
 
     @Override

--- a/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentServiceUnitTestCase.java
+++ b/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentServiceUnitTestCase.java
@@ -2062,7 +2062,7 @@ public class FileSystemDeploymentServiceUnitTestCase {
         }
 
         @Override
-        public LocalModelControllerClient createSuperUserClient(Executor executor) {
+        public LocalModelControllerClient createSuperUserClient(Executor executor, boolean forUserCalls) {
             return  this;
         }
 

--- a/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/ShutdownFileSystemDeploymentServiceUnitTestCase.java
+++ b/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/ShutdownFileSystemDeploymentServiceUnitTestCase.java
@@ -230,7 +230,7 @@ public class ShutdownFileSystemDeploymentServiceUnitTestCase {
         }
 
         @Override
-        public LocalModelControllerClient createSuperUserClient(Executor executor) {
+        public LocalModelControllerClient createSuperUserClient(Executor executor, boolean forUserCalls) {
             return this;
         }
 

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
@@ -319,7 +319,7 @@ public class EmbeddedHostControllerFactory {
                     clientFactory = null;
                 }
                 if (clientFactory != null) {
-                    newClient = clientFactory.createSuperUserClient(executorService);
+                    newClient = clientFactory.createSuperUserClient(executorService, true);
                 }
             }
             modelControllerClient = newClient;

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
@@ -388,7 +388,7 @@ public class EmbeddedStandaloneServerFactory {
                     clientFactory = null;
                 }
                 if (clientFactory != null) {
-                    newClient = clientFactory.createSuperUserClient(executorService);
+                    newClient = clientFactory.createSuperUserClient(executorService, true);
                 }
             }
             modelControllerClient = newClient;

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerExecutionSupport.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerExecutionSupport.java
@@ -201,8 +201,8 @@ interface HostControllerExecutionSupport {
                 if (operation.hasDefined(STEPS)) {
                     List<HostControllerExecutionSupport> parsedSteps = new ArrayList<HostControllerExecutionSupport>();
                     for (ModelNode step : operation.get(STEPS).asList()) {
-                        //Remove the caller-type=user header
-                        if (operation.hasDefined(OPERATION_HEADERS) && operation.get(OPERATION_HEADERS).hasDefined(CALLER_TYPE) && operation.get(OPERATION_HEADERS, CALLER_TYPE).asString().equals(USER)) {
+                        // Propagate the caller-type=user header
+                        if (operation.hasDefined(OPERATION_HEADERS, CALLER_TYPE) && operation.get(OPERATION_HEADERS, CALLER_TYPE).asString().equals(USER)) {
                             step = step.clone();
                             step.get(OPERATION_HEADERS, CALLER_TYPE).set(USER);
                         }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationCoordinatorStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationCoordinatorStepHandler.java
@@ -94,12 +94,12 @@ public class OperationCoordinatorStepHandler {
             if (COMPOSITE.equals(operation.get(OP).asString()) && PathAddress.pathAddress(operation.get(OP_ADDR)).size() == 0) {
                 executeTwoPhaseOperation(context, operation, routing);
             } else {
-                executeDirect(context, operation);
+                executeDirect(context, operation, false); // don't need to check private as we are just going to forward this
             }
         }
         else if (!routing.isTwoStep()) {
             // It's a domain or host level op (probably a read) that does not require bringing in other hosts or servers
-            executeDirect(context, operation);
+            executeDirect(context, operation, true);
         }
         else {
             // Else we are responsible for coordinating a two-phase op
@@ -129,13 +129,14 @@ public class OperationCoordinatorStepHandler {
      * Directly handles the op in the standard way the default prepare step handler would
      * @param context the operation execution context
      * @param operation the operation
+     * @param checkPrivate {@code true} if a check should be made for a direct user call to a private operation
      * @throws OperationFailedException if there is no handler registered for the operation
      */
-    private void executeDirect(OperationContext context, ModelNode operation) throws OperationFailedException {
+    private void executeDirect(OperationContext context, ModelNode operation, boolean checkPrivate) throws OperationFailedException {
         if (HOST_CONTROLLER_LOGGER.isTraceEnabled()) {
             HOST_CONTROLLER_LOGGER.tracef("%s executing direct", getClass().getSimpleName());
         }
-        PrepareStepHandler.executeDirectOperation(context, operation);
+        PrepareStepHandler.executeDirectOperation(context, operation, checkPrivate);
     }
 
     private void executeTwoPhaseOperation(OperationContext context, ModelNode operation, OperationRouting routing) throws OperationFailedException {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
@@ -114,7 +114,7 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
                         for (Map.Entry<Set<ServerIdentity>, ModelNode> entry : ops.entrySet()) {
                             ModelNode op = entry.getValue();
                             //Remove the caller-type=user header
-                            if (op.hasDefined(OPERATION_HEADERS) && op.get(OPERATION_HEADERS).hasDefined(CALLER_TYPE) && op.get(OPERATION_HEADERS, CALLER_TYPE).asString().equals(USER)) {
+                            if (op.hasDefined(OPERATION_HEADERS, CALLER_TYPE) && op.get(OPERATION_HEADERS, CALLER_TYPE).asString().equals(USER)) {
                                 op.get(OPERATION_HEADERS).remove(CALLER_TYPE);
                             }
                         }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ProfileResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ProfileResourceDefinition.java
@@ -39,6 +39,7 @@ import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.domain.controller.operations.DomainIncludesValidationWriteAttributeHandler;
 import org.jboss.as.domain.controller.operations.GenericModelDescribeOperationHandler;
@@ -65,7 +66,7 @@ public class ProfileResourceDefinition extends SimpleResourceDefinition {
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.READ_WHOLE_CONFIG)
             .setReplyType(ModelType.LIST)
             .setReplyValueType(ModelType.OBJECT)
-            .setPrivateEntry()
+            .withFlag(OperationEntry.Flag.HIDDEN)
             .setReadOnly()
             .build();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -476,7 +476,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
 
         //server configurations
         hostRegistration.registerSubModel(new ServerConfigResourceDefinition(hostControllerInfo, serverInventory, pathManager, processState, environment.getDomainDataDir()));
-        hostRegistration.registerSubModel(new StoppedServerResource(serverInventory));
+        hostRegistration.registerSubModel(new StoppedServerResource());
 
         hostRegistration.registerSubModel(SocketBindingGroupResourceDefinition.INSTANCE);
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -373,7 +373,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
         DomainServerLifecycleHandlers.initializeServerInventory(serverInventory);
 
         ValidateOperationHandler validateOperationHandler = hostControllerInfo.isMasterDomainController() ? ValidateOperationHandler.INSTANCE : ValidateOperationHandler.SLAVE_HC_INSTANCE;
-        hostRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION_PRIVATE, validateOperationHandler);
+        hostRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION_HIDDEN, validateOperationHandler);
 
 
         SnapshotDeleteHandler snapshotDelete = new SnapshotDeleteHandler(configurationPersister.getHostPersister());

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/InstallationReportHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/InstallationReportHandler.java
@@ -51,9 +51,8 @@ public class InstallationReportHandler extends AbstractInstallationReporter {
             OPERATION_NAME, HostResolver.getResolver(HOST))
             .setRuntimeOnly()
             .setReadOnly()
-            .setPrivateEntry()
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.READ_WHOLE_CONFIG)
-            .withFlags(OperationEntry.Flag.DOMAIN_PUSH_TO_SERVERS)
+            .withFlags(OperationEntry.Flag.DOMAIN_PUSH_TO_SERVERS, OperationEntry.Flag.HIDDEN)  // can't be private because of how GlobalInstallationReportHandler calls it
             .setReplyType(ModelType.OBJECT)
             .setReplyParameters(SUMMARY_DEFINITION)
             .build();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/StoppedServerResource.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/StoppedServerResource.java
@@ -23,22 +23,15 @@
 package org.jboss.as.host.controller.resources;
 
 import org.jboss.as.controller.CompositeOperationHandler;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationDefinition;
-import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.host.controller.ServerInventory;
 import org.jboss.as.host.controller.descriptions.HostResolver;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.controller.resources.ServerRootResourceDefinition;
 import org.jboss.as.server.operations.LaunchTypeHandler;
-import org.jboss.dmr.ModelNode;
 
 /**
  * {@code ResourceDescription} describing a stopped server instance.
@@ -49,33 +42,20 @@ public class StoppedServerResource extends SimpleResourceDefinition {
 
     private static final PathElement SERVER = PathElement.pathElement(ModelDescriptionConstants.RUNNING_SERVER);
 
-    private static final OperationDefinition RELOAD = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.RELOAD, HostResolver.getResolver("host.server"))
-            .setPrivateEntry()
-            .build();
-
-    private final ServerInventory serverInventory;
-    public StoppedServerResource(final ServerInventory serverInventory) {
+    public StoppedServerResource() {
         super(SERVER, HostResolver.getResolver(ModelDescriptionConstants.RUNNING_SERVER, false));
-        this.serverInventory = serverInventory;
     }
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
 
         resourceRegistration.registerReadOnlyAttribute(ServerRootResourceDefinition.LAUNCH_TYPE, new LaunchTypeHandler(ServerEnvironment.LaunchType.DOMAIN));
-        resourceRegistration.registerReadOnlyAttribute(ServerRootResourceDefinition.SERVER_STATE, new OperationStepHandler() {
-            @Override
-            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                // note this is inconsistent with the other values, should be lower case, preserved for now.
-                context.getResult().set("STOPPED");
-            }
+        resourceRegistration.registerReadOnlyAttribute(ServerRootResourceDefinition.SERVER_STATE, (context, operation) -> {
+            // note this is inconsistent with the other values, should be lower case, preserved for now.
+            context.getResult().set("STOPPED");
         });
-        resourceRegistration.registerReadOnlyAttribute(ServerRootResourceDefinition.RUNTIME_CONFIGURATION_STATE, new OperationStepHandler() {
-            @Override
-            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                context.getResult().set(ClientConstants.CONTROLLER_PROCESS_STATE_STOPPED);
-            }
-        });
+        resourceRegistration.registerReadOnlyAttribute(ServerRootResourceDefinition.RUNTIME_CONFIGURATION_STATE,
+                (context, operation) -> context.getResult().set(ClientConstants.CONTROLLER_PROCESS_STATE_STOPPED));
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/deployment/ContentCleanerService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/ContentCleanerService.java
@@ -104,8 +104,9 @@ public class ContentCleanerService implements Service<Void> {
 
     @Override
     public synchronized void start(StartContext context) throws StartException {
-        this.deploymentContentCleaner = new ContentRepositoryCleaner(clientFactoryValue.getValue().createSuperUserClient(
-                executorServiceValue.getValue()), controlledProcessStateServiceValue.getValue(),
+        this.deploymentContentCleaner = new ContentRepositoryCleaner(
+                clientFactoryValue.getValue().createSuperUserClient(executorServiceValue.getValue(), false),
+                controlledProcessStateServiceValue.getValue(),
                 scheduledExecutorValue.getValue(), unit.toMillis(interval), server);
         deploymentContentCleaner.startScan();
     }

--- a/server/src/main/java/org/jboss/as/server/operations/InstallationReportHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/InstallationReportHandler.java
@@ -49,7 +49,7 @@ public class InstallationReportHandler extends AbstractInstallationReporter {
             OPERATION_NAME, ServerDescriptions.getResourceDescriptionResolver())
             .setRuntimeOnly()
             .setReadOnly()
-            .setPrivateEntry()
+            .withFlags(OperationEntry.Flag.HIDDEN) // can't be private because of how GlobalInstallationReportHandler calls it
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.READ_WHOLE_CONFIG)
             .setReplyType(ModelType.OBJECT)
             .setReplyParameters(SUMMARY_DEFINITION).build();

--- a/server/src/main/java/org/jboss/as/server/operations/ServerProcessStateHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerProcessStateHandler.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.server.controller.descriptions.ServerDescriptions;
 import org.jboss.dmr.ModelNode;
 
@@ -41,11 +42,11 @@ public class ServerProcessStateHandler implements OperationStepHandler {
     public static final String REQUIRE_RESTART_OPERATION = "server-set-restart-required";
 
     public static final SimpleOperationDefinition RELOAD_DEFINITION = new SimpleOperationDefinitionBuilder(REQUIRE_RELOAD_OPERATION, ServerDescriptions.getResourceDescriptionResolver())
-            .setPrivateEntry()
+            .withFlag(OperationEntry.Flag.HIDDEN)
             .build();
 
     public static final SimpleOperationDefinition RESTART_DEFINITION = new SimpleOperationDefinitionBuilder(REQUIRE_RESTART_OPERATION, ServerDescriptions.getResourceDescriptionResolver())
-            .setPrivateEntry()
+            .withFlag(OperationEntry.Flag.HIDDEN)
             .build();
 
     public static final OperationStepHandler SET_RELOAD_REQUIRED_HANDLER = new ServerProcessStateHandler(true);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -60,6 +60,7 @@ import org.junit.runners.Suite;
         OperationErrorTestCase.class,
         OperationTransformationTestCase.class,
         OperationWarningTestsCase.class,
+        PrivateHiddenOperationsTestCase.class,
         ResponseStreamTestCase.class,
         ServerRestartRequiredTestCase.class,
         ValidateAddressOperationTestCase.class,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/PrivateHiddenOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/PrivateHiddenOperationsTestCase.java
@@ -1,0 +1,167 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+import org.jboss.as.test.integration.management.extension.ExtensionUtils;
+import org.jboss.as.test.integration.management.extension.optypes.OpTypesExtension;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.core.testrunner.ManagementClient;
+
+/**
+ * Tests invocations of private and hidden operations.
+ *
+ * @author Brian Stansberry
+ */
+public class PrivateHiddenOperationsTestCase {
+
+    private static final PathAddress MASTER = PathAddress.pathAddress(ModelDescriptionConstants.HOST, "master");
+    private static final PathAddress SLAVE = PathAddress.pathAddress(ModelDescriptionConstants.HOST, "slave");
+
+    private static final PathAddress EXT = PathAddress.pathAddress("extension", OpTypesExtension.EXTENSION_NAME);
+    private static final PathAddress PROFILE = PathAddress.pathAddress("profile", "default");
+    private static final PathElement SUBSYSTEM = PathElement.pathElement("subsystem", OpTypesExtension.SUBSYSTEM_NAME);
+    private static final PathElement MAIN_ONE = PathElement.pathElement("server", "main-one");
+    private static final PathElement MAIN_THREE = PathElement.pathElement("server", "main-three");
+
+    private static DomainTestSupport testSupport;
+    private static ManagementClient managementClient;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(PrivateHiddenOperationsTestCase.class.getSimpleName());
+        DomainClient masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+        managementClient = new ManagementClient(masterClient, TestSuiteEnvironment.getServerAddress(), 9090, "remoting+http");
+
+
+        ExtensionUtils.createExtensionModule(OpTypesExtension.EXTENSION_NAME, OpTypesExtension.class,
+                EmptySubsystemParser.class.getPackage());
+
+        executeOp(Util.createAddOperation(EXT), SUCCESS);
+        executeOp(Util.createAddOperation(PROFILE.append(SUBSYSTEM)), SUCCESS);
+
+        executeOp(Util.createAddOperation(MASTER.append(EXT)), SUCCESS);
+        executeOp(Util.createAddOperation(MASTER.append(SUBSYSTEM)), SUCCESS);
+
+        executeOp(Util.createAddOperation(SLAVE.append(EXT)), SUCCESS);
+        executeOp(Util.createAddOperation(SLAVE.append(SUBSYSTEM)), SUCCESS);
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws IOException {
+        Throwable t = null;
+        List<ModelNode> ops = new ArrayList<>();
+        ops.add(Util.createRemoveOperation(MASTER.append(SUBSYSTEM)));
+        ops.add(Util.createRemoveOperation(MASTER.append(EXT)));
+        ops.add(Util.createRemoveOperation(SLAVE.append(SUBSYSTEM)));
+        ops.add(Util.createRemoveOperation(SLAVE.append(EXT)));
+        ops.add(Util.createRemoveOperation(PROFILE.append(SUBSYSTEM)));
+        ops.add(Util.createRemoveOperation(EXT));
+        for (ModelNode op : ops) {
+            try {
+                executeOp(op, SUCCESS);
+            } catch (IOException | AssertionError e) {
+                if (t == null) {
+                    t = e;
+                }
+            }
+        }
+
+        testSupport = null;
+        managementClient = null;
+        DomainTestSuite.stopSupport();
+
+        if (t instanceof IOException) {
+            throw (IOException) t;
+        } else if (t instanceof AssertionError) {
+            throw (Error) t;
+        }
+    }
+
+    @Test
+    public void testDomainLevel() throws IOException {
+        testPrivateHiddenOps(PROFILE, false);
+    }
+
+    @Test
+    public void testDomainCallsPrivateServer() throws IOException {
+        testPrivateOp(PROFILE, true, SUCCESS);
+    }
+
+    @Test
+    public void testMasterServer() throws IOException {
+        testPrivateHiddenOps(MASTER.append(MAIN_ONE), true);
+    }
+
+    @Test
+    public void testSlaveServer() throws IOException {
+        testPrivateHiddenOps(SLAVE.append(MAIN_THREE), true);
+    }
+
+    @Test
+    public void testMasterHC() throws IOException {
+        testPrivateHiddenOps(MASTER, false);
+    }
+
+    @Test
+    public void testSlaveHC() throws IOException {
+        testPrivateHiddenOps(SLAVE, false);
+    }
+
+    private void testPrivateHiddenOps(PathAddress base, boolean domain) throws IOException {
+        testHiddenOp(base, domain);
+        testPrivateOp(base, domain, FAILED);
+    }
+
+    private void testHiddenOp(PathAddress base, boolean domain) throws IOException {
+        PathAddress target = base.append(SUBSYSTEM);
+        String prefix = domain ? "domain-" : "";
+        executeOp(Util.createEmptyOperation(prefix + "hidden", target), SUCCESS);
+    }
+
+    private void testPrivateOp(PathAddress base, boolean domain, String outcome) throws IOException {
+        PathAddress target = base.append(SUBSYSTEM);
+        String prefix = domain ? "domain-" : "";
+        executeOp(Util.createEmptyOperation(prefix + "private", target), outcome);
+    }
+
+    private static void executeOp(ModelNode op, String outcome) throws IOException {
+        ModelNode response = managementClient.getControllerClient().execute(op);
+        assertTrue(response.toString(), response.hasDefined(OUTCOME));
+        assertEquals(response.toString(), outcome, response.get(OUTCOME).asString());
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/optypes/OpTypesExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/optypes/OpTypesExtension.java
@@ -1,0 +1,117 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.management.extension.optypes;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.NoopOperationStepHandler;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+
+/**
+ * Extension whose subsystem exposes different types of operations besides the typical ones.
+ * For testing of handling of such operations.
+ *
+ * @author Brian Stansberry
+ */
+@SuppressWarnings("deprecation")
+public class OpTypesExtension implements Extension {
+
+    public static final String EXTENSION_NAME = "org.wildfly.extension.operation-types-test";
+    public static final String SUBSYSTEM_NAME = "operation-types-test";
+
+    private static final EmptySubsystemParser PARSER = new EmptySubsystemParser("urn:wildfly:extension:operation-types-test:1.0");
+
+    private static final OperationDefinition PUBLIC = new SimpleOperationDefinitionBuilder("public", NonResolvingResourceDescriptionResolver.INSTANCE)
+            .build();
+
+    private static final OperationDefinition HIDDEN = new SimpleOperationDefinitionBuilder("hidden", NonResolvingResourceDescriptionResolver.INSTANCE)
+            .withFlags(OperationEntry.Flag.HIDDEN)
+            .build();
+    private static final OperationDefinition DOMAIN_HIDDEN  = new SimpleOperationDefinitionBuilder("domain-hidden", NonResolvingResourceDescriptionResolver.INSTANCE)
+            .withFlags(OperationEntry.Flag.HIDDEN)
+            .setRuntimeOnly()
+            .build();
+
+    private static final OperationDefinition PRIVATE = new SimpleOperationDefinitionBuilder("private", NonResolvingResourceDescriptionResolver.INSTANCE)
+            .setPrivateEntry()
+            .build();
+    private static final OperationDefinition DOMAIN_PRIVATE = new SimpleOperationDefinitionBuilder("domain-private", NonResolvingResourceDescriptionResolver.INSTANCE)
+            .setRuntimeOnly()
+            .build();
+    private static final OperationDefinition DOMAIN_SERVER_PRIVATE = new SimpleOperationDefinitionBuilder("domain-private", NonResolvingResourceDescriptionResolver.INSTANCE)
+            .setPrivateEntry()
+            .setRuntimeOnly()
+            .build();
+
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
+        subsystem.setHostCapable();
+        subsystem.registerSubsystemModel(new OperationTypesSubsystemResourceDefinition(context.getProcessType()));
+        subsystem.registerXMLElementWriter(PARSER);
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, PARSER.getNamespace(), PARSER);
+    }
+
+    private static class OperationTypesSubsystemResourceDefinition extends SimpleResourceDefinition {
+
+        private final ProcessType processType;
+
+        private OperationTypesSubsystemResourceDefinition(ProcessType processType) {
+            super(new Parameters(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver())
+                    .setAddHandler(new ModelOnlyAddStepHandler())
+                    .setRemoveHandler(new ModelOnlyRemoveStepHandler())
+            );
+            this.processType = processType;
+        }
+
+        @Override
+        public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+            super.registerOperations(resourceRegistration);
+
+            resourceRegistration.registerOperationHandler(PUBLIC, NoopOperationStepHandler.WITH_RESULT);
+            resourceRegistration.registerOperationHandler(HIDDEN, NoopOperationStepHandler.WITH_RESULT);
+            resourceRegistration.registerOperationHandler(PRIVATE, NoopOperationStepHandler.WITH_RESULT);
+
+            if (processType == ProcessType.DOMAIN_SERVER) {
+                resourceRegistration.registerOperationHandler(DOMAIN_HIDDEN, NoopOperationStepHandler.WITH_RESULT);
+                resourceRegistration.registerOperationHandler(DOMAIN_SERVER_PRIVATE, NoopOperationStepHandler.WITH_RESULT);
+            } else if (!processType.isServer()) {
+                resourceRegistration.registerOperationHandler(DOMAIN_PRIVATE, NoopOperationStepHandler.WITH_RESULT);
+            }
+        }
+    }
+}

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/optypes/module.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/optypes/module.xml
@@ -1,0 +1,16 @@
+<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.operation-types-test">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="test-extension.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.msc"/>
+    </dependencies>
+</module>

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/optypes/org.jboss.as.controller.Extension
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/optypes/org.jboss.as.controller.Extension
@@ -1,0 +1,1 @@
+org.jboss.as.test.integration.management.extension.optypes.OpTypesExtension

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/PrivateHiddenOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/PrivateHiddenOperationsTestCase.java
@@ -1,0 +1,92 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.wildfly.core.test.standalone.mgmt;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+import org.jboss.as.test.integration.management.extension.ExtensionUtils;
+import org.jboss.as.test.integration.management.extension.optypes.OpTypesExtension;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Tests invocations of private and hidden operations.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(WildflyTestRunner.class)
+public class PrivateHiddenOperationsTestCase {
+
+    private static final PathAddress EXT = PathAddress.pathAddress("extension", OpTypesExtension.EXTENSION_NAME);
+    private static final PathAddress SUBSYSTEM = PathAddress.pathAddress("subsystem", OpTypesExtension.SUBSYSTEM_NAME);
+
+    @Inject
+    private static ManagementClient managementClient;
+
+    @Before
+    public void installExtensionModule() throws IOException {
+        ExtensionUtils.createExtensionModule(OpTypesExtension.EXTENSION_NAME, OpTypesExtension.class,
+                EmptySubsystemParser.class.getPackage());
+
+        ModelNode addOp = Util.createAddOperation(EXT);
+        executeOp(addOp, SUCCESS);
+        addOp = Util.createAddOperation(SUBSYSTEM);
+        executeOp(addOp, SUCCESS);
+    }
+
+    @After
+    public void removeExtensionModule() throws IOException {
+
+        try {
+            executeOp(Util.createRemoveOperation(SUBSYSTEM), SUCCESS);
+        } finally {
+            try {
+                executeOp(Util.createRemoveOperation(EXT), SUCCESS);
+            } finally {
+                ExtensionUtils.deleteExtensionModule(OpTypesExtension.EXTENSION_NAME);
+            }
+        }
+    }
+
+    @Test
+    public void testPrivateHiddenOps() throws IOException {
+        executeOp(Util.createEmptyOperation("hidden", SUBSYSTEM), SUCCESS);
+        executeOp(Util.createEmptyOperation("private", SUBSYSTEM), FAILED);
+    }
+
+    private void executeOp(ModelNode op, String outcome) throws IOException {
+        ModelNode response = managementClient.getControllerClient().execute(op);
+        assertTrue(response.toString(), response.hasDefined(OUTCOME));
+        assertEquals(response.toString(), outcome, response.get(OUTCOME).asString());
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-13

If the caller-type=user operation header is set, prevent execution of OperationEntry.EntryType.PRIVATE operations.

Ensure that for in-vm clients created by ModelControllerClientFactory that this is set appropriately. This is particularly relevant to the offline CLI, where a user is using an in-VM client.

Some ops we don't want described in the API, but we still need them to be invocable when caller-type=user is set. This is either for compatibility reasons (users may have been told to invoke the ops and doing so isn't really harmful) or because of how some ops work internally in domain mode. For these cases we create a new OperationEntry.Flag, HIDDEN, and use it to prevent these ops being visible instead of using EntryType.PRIVATE.