### PR TITLE
[WFCORE-2771] Console should log bound ports

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
@@ -26,6 +26,7 @@ import static org.xnio.Options.SSL_CLIENT_AUTH_MODE;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
@@ -654,6 +655,22 @@ public class ManagementHttpServer {
 
             next.handleRequest(exchange);
         }
+    }
+
+    public SocketAddress getLocalAddress() {
+        return normalServer.getLocalAddress();
+    }
+
+    public <A extends SocketAddress> A getLocalAddress(Class<A> type) {
+        return normalServer.getLocalAddress(type);
+    }
+
+    public SocketAddress getSecureLocalAddress() {
+        return secureServer.getLocalAddress();
+    }
+
+    public <A extends SocketAddress> A getSecureLocalAddress(Class<A> type) {
+        return secureServer.getLocalAddress(type);
     }
 
 }

--- a/server/src/main/java/org/jboss/as/server/BootstrapListener.java
+++ b/server/src/main/java/org/jboss/as/server/BootstrapListener.java
@@ -146,8 +146,8 @@ public final class BootstrapListener {
         if (controller != null) {
             HttpManagement mgmt = (HttpManagement)controller.getValue();
 
-            boolean hasHttp = mgmt.getHttpNetworkInterfaceBinding() != null && mgmt.getHttpPort() > 0;
-            boolean hasHttps = mgmt.getHttpsNetworkInterfaceBinding() != null && mgmt.getHttpsPort() > 0;
+            boolean hasHttp = mgmt.getHttpNetworkInterfaceBinding() != null;
+            boolean hasHttps = mgmt.getHttpsNetworkInterfaceBinding() != null;
             if (hasHttp && hasHttps) {
                 ServerLogger.AS_ROOT_LOGGER.logHttpAndHttpsManagement(NetworkUtils.formatIPAddressForURI(mgmt.getHttpNetworkInterfaceBinding().getAddress()), mgmt.getHttpPort(), NetworkUtils.formatIPAddressForURI(mgmt.getHttpsNetworkInterfaceBinding().getAddress()), mgmt.getHttpsPort());
                 if (mgmt.hasConsole()) {

--- a/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
@@ -306,21 +306,25 @@ public class UndertowHttpManagementService implements Service<HttpManagement> {
                 if (useUnmanagedBindings) {
                     SocketBindingManager.UnnamedBindingRegistry registry = socketBindingManager.getUnnamedRegistry();
                     if (bindAddress != null) {
-                        basicManagedBinding = ManagedBinding.Factory.createSimpleManagedBinding("management-http", bindAddress, null);
+                        final InetSocketAddress boundAddress = serverManagement.getLocalAddress(InetSocketAddress.class);
+                        basicManagedBinding = ManagedBinding.Factory.createSimpleManagedBinding("management-http", boundAddress, null);
                         registry.registerBinding(basicManagedBinding);
                     }
                     if (secureBindAddress != null) {
-                        secureManagedBinding = ManagedBinding.Factory.createSimpleManagedBinding("management-https", secureBindAddress, null);
+                        final InetSocketAddress boundAddress = serverManagement.getSecureLocalAddress(InetSocketAddress.class);
+                        secureManagedBinding = ManagedBinding.Factory.createSimpleManagedBinding("management-https", boundAddress, null);
                         registry.registerBinding(secureManagedBinding);
                     }
                 } else {
                     SocketBindingManager.NamedManagedBindingRegistry registry = socketBindingManager.getNamedRegistry();
                     if (basicBinding != null) {
-                        basicManagedBinding = ManagedBinding.Factory.createSimpleManagedBinding(basicBinding);
+                        final InetSocketAddress boundAddress = serverManagement.getLocalAddress(InetSocketAddress.class);
+                        basicManagedBinding = ManagedBinding.Factory.createSimpleManagedBinding(basicBinding.getName(), boundAddress, null);
                         registry.registerBinding(basicManagedBinding);
                     }
                     if (secureBinding != null) {
-                        secureManagedBinding = ManagedBinding.Factory.createSimpleManagedBinding(secureBinding);
+                        final InetSocketAddress boundAddress = serverManagement.getSecureLocalAddress(InetSocketAddress.class);
+                        secureManagedBinding = ManagedBinding.Factory.createSimpleManagedBinding(secureBinding.getName(), boundAddress, null);
                         registry.registerBinding(secureManagedBinding);
                     }
                 }


### PR DESCRIPTION
When specifying that Wildfly should bind the management console to an ephemeral port (by specifying the port number as 0), Wildfly logs that the management console is not enabled. In fact, this is not correct as can be verified with lsof (or any other tool that enables seeing the sockets that Wildfly has bound). The networking layer determined an actual port number when binding the socket. Instead, Wildfly should log the actual port that it is bound to. This commit causes this to be the case.

Relates https://issues.jboss.org/browse/WFCORE-2771