### PR TITLE
WFCORE-1374 JDK9u166+ updates

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -201,31 +201,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <log4j.defaultInitOverride>true</log4j.defaultInitOverride>
-                        <test.level>${test.level}</test.level>
-                    </systemPropertyVariables>
-                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                    <enableAssertions>true</enableAssertions>
-                    <argLine>-Xmx512m</argLine>
-                    <systemProperties>
-                        <property>
-                            <name>jboss.home</name>
-                            <value>${jboss.home}</value>
-                        </property>
-                    </systemProperties>
-                    <includes>
-                        <include>**/*TestCase.java</include>
-                    </includes>
-                    <forkMode>once</forkMode>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>xml-maven-plugin</artifactId>
                 <version>1.0.1</version>

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
@@ -22,7 +22,7 @@ package org.wildfly.extension.elytron;
 import java.io.IOException;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
-import org.junit.Before;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.junit.Test;
 
 
@@ -40,10 +40,6 @@ public class SubsystemParsingTestCase extends AbstractSubsystemBaseTest {
         super(ElytronExtension.SUBSYSTEM_NAME, new ElytronExtension());
     }
 
-    @Before
-    public void init() throws Exception {
-        TestEnvironment.forceRequireRuntimeFalse();
-    }
 
     @Override
     protected String getSubsystemXml() throws IOException {
@@ -123,5 +119,10 @@ public class SubsystemParsingTestCase extends AbstractSubsystemBaseTest {
     @Test
     public void testParseAndMarshalModel_CredentialStores() throws Exception {
         standardSubsystemTest("credential-stores.xml");
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return AdditionalInitialization.MANAGEMENT;
     }
 }

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TestEnvironment.java
@@ -19,7 +19,6 @@ package org.wildfly.extension.elytron;
 
 import mockit.Mock;
 import mockit.MockUp;
-import org.jboss.as.controller.OperationContext;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
 
@@ -109,23 +108,4 @@ class TestEnvironment extends AdditionalInitialization {
         new ClassLoadingAttributeDefinitionsMock();
     }
 
-    // base add handler mock to prevent services starting for parsing testcase
-    private static class BaseAddHandlerMock extends MockUp<BaseAddHandler> {
-        @Mock
-        protected boolean requiresRuntime(OperationContext context) {
-            return false;
-        }
-    }
-
-    static void forceRequireRuntimeFalse() throws Exception {
-        new BaseAddHandlerMock();
-
-        Class<?> innerClass = Class.forName(SecurityPropertyResourceDefinition.class.getName() + "$PropertyRemoveHandler");
-        new MockUp<Object>(innerClass) {
-            @Mock
-            protected boolean requiresRuntime(OperationContext context) {
-                return false;
-            }
-        };
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-parent</artifactId>
-      <version>22</version>
+      <version>23</version>
     </parent>
 
     <groupId>org.wildfly.core</groupId>
@@ -124,7 +124,7 @@
         <version.org.jboss.xnio>3.5.0.Beta6</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
-        <version.org.jmockit>1.10</version.org.jmockit>
+        <version.org.jmockit>1.31</version.org.jmockit>
         <version.org.mockito>2.5.5</version.org.mockito>
         <version.org.picketbox>5.0.1.Final</version.org.picketbox>
         <version.org.projectodd.vdx>1.1.5</version.org.projectodd.vdx>
@@ -1692,25 +1692,8 @@
                 <!-- [WFCORE-1494] remove JUL workaround -->
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true -Dsun.reflect.debugModuleAccessChecks=true</modular.jdk.props>
                 <version.org.jboss.byteman>4.0.0-BETA5</version.org.jboss.byteman>
+                <version.org.jboss.logging.jboss-logging-tools>2.1.0.Alpha2</version.org.jboss.logging.jboss-logging-tools>
             </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${version.compiler.plugin}</version>
-                        <configuration>
-                            <release>8</release>
-                            <!-- fork is needed so compiler args can be used -->
-                            <fork>true</fork>
-                            <compilerArgs>
-                                <arg>-J--add-modules=java.xml.ws.annotation</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-
-                </plugins>
-            </build>
         </profile>
         <!--
           Name: jpda

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -170,9 +170,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <failIfNoTests>false</failIfNoTests>
-                    <!-- parallel>none</parallel -->
-                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
-
+                    
                     <!-- System properties to forked surefire JVM which runs clients. -->
                     <argLine>${jvm.args.ip.client} ${jvm.args.timeouts} ${surefire.system.args}</argLine>
 

--- a/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/vault/module/CustomVaultInModuleTestCase-module.xml
+++ b/testsuite/manualmode/src/test/resources/org/jboss/as/test/manualmode/vault/module/CustomVaultInModuleTestCase-module.xml
@@ -24,5 +24,6 @@
     <module name="org.jboss.staxmapper"/>
     <module name="org.picketbox"/>
     <module name="javax.xml.stream.api"/>
+    <module name="sun.jdk"/>
   </dependencies>
 </module>


### PR DESCRIPTION
- fix elytron integration module to have same surefire settings as others
- fix elytron test to properly bootstrap to management only
- update jboss-parent to 23
- update jboss-logging-tools to latest version that works with all "versions" of @Generated annotation
- update maven compiler config after logging-tools updated as we don't need to fork anymore
- update jmockit test dependency (only used by elytron) to one that works also with jdk9


