### PR TITLE
[WFCORE-2770] Move org.jboss.as.test.integration.security.perimeter.*…

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/http/Authentication.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/http/Authentication.java
@@ -12,6 +12,7 @@ public class Authentication {
     public static final String PASSWORD = "testSuitePassword";
 
 
+    @Deprecated
     public static Authenticator getAuthenticator() {
         return new Authenticator() {
             @Override
@@ -21,6 +22,10 @@ public class Authentication {
         };
     }
 
+    /**
+     * @deprecated this could cause tests ran after this is set to fail, use the Apache HttpClient
+     */
+    @Deprecated
     public static void setupDefaultAuthenticator() {
         Authenticator.setDefault(getAuthenticator());
     }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpDeploymentUploadUnitTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/http/HttpDeploymentUploadUnitTestCase.java
@@ -46,6 +46,7 @@ import org.jboss.as.test.http.Authentication;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
@@ -58,6 +59,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  * @author Jonathan Pearlin
  */
 @RunWith(WildflyTestRunner.class)
+@Ignore("See WFCORE-2785 for details on why this test is being ignored")
 public class HttpDeploymentUploadUnitTestCase {
 
     private static final String BOUNDARY_PARAM = "NeAG1QNIHHOyB5joAS7Rox!!";

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/CLISecurityTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/CLISecurityTestCase.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.security.perimeter;
+
+import static org.junit.Assert.assertFalse;
+
+import java.io.File;
+
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.assume.AssumeTestGroupUtil;
+import org.jboss.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * This class contains a check that CLI access is secured.
+ *
+ * @author <a href="mailto:jlanik@redhat.com">Jan Lanik</a>.
+ */
+@RunWith(WildflyTestRunner.class)
+public class CLISecurityTestCase {
+
+    Logger logger = Logger.getLogger(CLISecurityTestCase.class);
+
+    private static final String JBOSS_INST = TestSuiteEnvironment.getJBossHome();
+
+    private static final File originalTokenDir = new File(JBOSS_INST, "/standalone/tmp/auth");
+    private static final File renamedTokenDir = new File(JBOSS_INST, "/standalone/tmp/auth.renamed");
+
+    /**
+     * Auxiliary class which extends CLIWrapper for specific purposes of this test case.
+     */
+    public static class UnauthentizedCLI extends CLIWrapper {
+
+        public UnauthentizedCLI() throws Exception {
+            super(false);
+        }
+
+        @Override
+        protected String getUsername() {
+            return null;
+        }
+
+        public synchronized void shutdown() {
+            this.quit();
+        }
+    }
+
+    @BeforeClass
+    @SuppressWarnings("deprecation")
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
+
+    /**
+     * Workaround to disable silent login on localhost.
+     */
+    @BeforeClass
+    public static void renameTokenDir() {
+        Assert.assertTrue(originalTokenDir.renameTo(renamedTokenDir));
+    }
+
+    /**
+     * Enables silent login after the test is completed.
+     */
+    @AfterClass
+    public static void cleanup() {
+        Assert.assertTrue(renamedTokenDir.renameTo(originalTokenDir));
+    }
+
+    /**
+     * This test checks that CLI access is secured.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConnect() throws Exception {
+
+        UnauthentizedCLI cli = new UnauthentizedCLI();
+
+        assertFalse(cli.isConnected());
+        cli.sendLine("connect " + TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getServerPort(), true);
+        final String line = cli.readOutput();
+        logger.tracef("cli response: ", line);
+        assertFalse("CLI should not be connected: " + line, cli.isConnected());
+
+        cli.shutdown();
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/DMRSecurityTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/DMRSecurityTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.security.perimeter;
+
+import java.io.File;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.assume.AssumeTestGroupUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * This class contains a check that the management api access is secured.
+ *
+ * @author <a href="mailto:jlanik@redhat.com">Jan Lanik</a>.
+ */
+@RunWith(WildflyTestRunner.class)
+public class DMRSecurityTestCase {
+
+    private static final String JBOSS_INST = TestSuiteEnvironment.getJBossHome();
+
+    private static final File originalTokenDir = new File(JBOSS_INST, "/standalone/tmp/auth");
+    private static final File renamedTokenDir = new File(JBOSS_INST, "/standalone/tmp/auth.renamed");
+
+    @BeforeClass
+    @SuppressWarnings("deprecation")
+    public static void beforeClass() {
+        AssumeTestGroupUtil.assumeElytronProfileTestsEnabled();
+    }
+
+    /**
+     * Workaround to disable silent login on localhost.
+     */
+    @BeforeClass
+    public static void renameTokenDir() {
+        Assert.assertTrue(originalTokenDir.renameTo(renamedTokenDir));
+    }
+
+    /**
+     * Enables silent login after the test is completed.
+     */
+    @AfterClass
+    public static void cleanup() {
+        Assert.assertTrue(renamedTokenDir.renameTo(originalTokenDir));
+    }
+
+    /**
+     * This test checks that CLI access is secured.
+     *
+     * @throws Exception We do not provide any credentials so the IOException is required to be thrown.
+     */
+    @Test(expected = java.io.IOException.class)
+    public void testConnect() throws Exception {
+        try (ModelControllerClient modelControllerClient = TestSuiteEnvironment.getModelControllerClient()) {
+
+            modelControllerClient.execute(Operations.createReadAttributeOperation(new ModelNode().setEmptyList(), "server-state"));
+            Assert.fail("Operation should have failed, but was successful");
+        }
+    }
+
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/WebConsoleSecurityTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/perimeter/WebConsoleSecurityTestCase.java
@@ -1,0 +1,118 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.security.perimeter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpTrace;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.logging.Logger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Test verifies that the web management console is secured
+ *
+ * @author jlanik@redhat.com
+ */
+
+@RunWith(WildflyTestRunner.class)
+public class WebConsoleSecurityTestCase {
+
+
+    private static final Logger log = Logger.getLogger(WebConsoleSecurityTestCase.class);
+
+    private HttpURLConnection getConnection() throws Exception {
+        final URL url = new URL("http://" + TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getServerPort() + "/management");
+        final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        assertNotNull(connection);
+        log.debug("connection opened");
+        connection.setDoInput(true);
+        connection.setRequestProperty("Cookie", "MODIFY ME IF NEEDED");
+        return connection;
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        final HttpURLConnection connection = getConnection();
+        connection.setRequestMethod(HttpGet.METHOD_NAME);
+        connection.connect();
+        assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, connection.getResponseCode());
+    }
+
+    @Test
+    public void testPost() throws Exception {
+        final HttpURLConnection connection = getConnection();
+        connection.setRequestMethod(HttpPost.METHOD_NAME);
+        connection.connect();
+        assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, connection.getResponseCode());
+    }
+
+    @Test
+    public void testHead() throws Exception {
+        final HttpURLConnection connection = getConnection();
+        connection.setRequestMethod(HttpHead.METHOD_NAME);
+        connection.connect();
+        assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, connection.getResponseCode());
+    }
+
+    @Test
+    public void testOptions() throws Exception {
+        final HttpURLConnection connection = getConnection();
+        connection.setRequestMethod(HttpOptions.METHOD_NAME);
+        connection.connect();
+        assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, connection.getResponseCode());
+    }
+
+    @Test
+    public void testPut() throws Exception {
+        final HttpURLConnection connection = getConnection();
+        connection.setRequestMethod(HttpPut.METHOD_NAME);
+        connection.connect();
+        assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, connection.getResponseCode());
+    }
+
+    @Test
+    public void testTrace() throws Exception {
+        final HttpURLConnection connection = getConnection();
+        connection.setRequestMethod(HttpTrace.METHOD_NAME);
+        connection.connect();
+        assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, connection.getResponseCode());
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        final HttpURLConnection connection = getConnection();
+        connection.setRequestMethod(HttpDelete.METHOD_NAME);
+        connection.connect();
+        assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, connection.getResponseCode());
+    }
+
+}


### PR DESCRIPTION
… from WildFly to WildFly Core.

Tests were copied from WildFly full, however I did make additional changes to clean the tests up a bit. There is also change to enable the `CLISecurityTestCase`. The assumption was changed from assuming some text exists to assuming the CLI client is not connected.

https://issues.jboss.org/browse/WFCORE-2770