### PR TITLE
Fix for WFCORE-2782. CLI, advertise character encoding issues

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.CharacterCodingException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -207,6 +208,8 @@ public class Util {
     public static final String DESCRIPTION_RESPONSE = "DESCRIPTION_RESPONSE";
 
     public static final String NOT_OPERATOR = "!";
+
+    private static final String ENCODING_EXCEPTION_MESSAGE = "Encoding exception.";
 
     private static Logger LOG = Logger.getLogger(Util.class);
 
@@ -1215,7 +1218,7 @@ public class Util {
         return request;
     }
 
-    public static String getMessagesFromThrowable(Throwable t){
+    public static String getMessagesFromThrowable(Throwable t) {
         final StringBuilder buf = new StringBuilder();
 
         if (t.getLocalizedMessage() != null) {
@@ -1224,12 +1227,22 @@ public class Util {
             buf.append(t.getClass().getName());
         }
 
+        boolean encodingSeen = false;
+        if (t instanceof CharacterCodingException) {
+            encodingSeen = true;
+            buf.append(": " + ENCODING_EXCEPTION_MESSAGE);
+        }
+
         Throwable t1 = t.getCause();
         while (t1 != null) {
             if (t1.getLocalizedMessage() != null) {
                 buf.append(": ").append(t1.getLocalizedMessage());
             } else {
                 buf.append(": ").append(t1.getClass().getName());
+            }
+            if (!encodingSeen && t1 instanceof CharacterCodingException) {
+                encodingSeen = true;
+                buf.append(": " + ENCODING_EXCEPTION_MESSAGE);
             }
             t1 = t1.getCause();
         }

--- a/cli/src/main/java/org/jboss/as/cli/gui/metacommand/ScriptAction.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/metacommand/ScriptAction.java
@@ -19,12 +19,12 @@
 package org.jboss.as.cli.gui.metacommand;
 
 import java.awt.event.ActionEvent;
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
+import java.io.FileReader;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.List;
 import javax.swing.AbstractAction;
 import javax.swing.JOptionPane;
@@ -84,11 +84,17 @@ public abstract class ScriptAction extends AbstractAction {
 
     // read the file as a list of text lines
     private List<String> getCommandLines(File file) {
-        try {
-            return Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
-        } catch (IOException e) {
+        List<String> lines = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String line = reader.readLine();
+            while (line != null) {
+                lines.add(line);
+                line = reader.readLine();
+            }
+        } catch (Throwable e) {
             throw new IllegalStateException("Failed to process file " + file.getAbsolutePath(), e);
         }
+        return lines;
     }
 
     // We need this class because we have to pass on whether or not a

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ArchiveHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ArchiveHandler.java
@@ -26,10 +26,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.Enumeration;
 import java.util.Random;
 import java.util.jar.JarEntry;
@@ -105,7 +104,7 @@ public class ArchiveHandler extends BatchModeCommandHandler {
             }
             ctx.printLine("Processing script '" + script + "'.");
 
-            try (BufferedReader reader = Files.newBufferedReader(scriptFile.toPath(), StandardCharsets.UTF_8)){
+            try (BufferedReader reader = new BufferedReader(new FileReader(scriptFile))) {
                 String line = reader.readLine();
                 while (!ctx.isTerminated() && line != null) {
                     ctx.handle(line);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
@@ -25,11 +25,10 @@ package org.jboss.as.cli.handlers;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -657,9 +656,7 @@ public class DeployHandler extends DeploymentHandler {
                     throw new CommandFormatException("ERROR: script '" + script + "' not found.");
                 }
 
-                BufferedReader reader = null;
-                try {
-                    reader = Files.newBufferedReader(scriptFile.toPath(), StandardCharsets.UTF_8);
+                try (BufferedReader reader = new BufferedReader(new FileReader(scriptFile))) {
                     String line = reader.readLine();
                     while (!ctx.isTerminated() && line != null) {
                         ctx.handle(line);
@@ -671,13 +668,6 @@ public class DeployHandler extends DeploymentHandler {
                     throw new CommandFormatException("Failed to read the next command from " + scriptFile.getName() + ": " + e.getMessage(), e);
                 } catch (CommandLineException e) {
                     throw new CommandFormatException(e.getMessage(), e);
-                } finally {
-                    if(reader != null) {
-                        try {
-                            reader.close();
-                        } catch (IOException e) {
-                        }
-                    }
                 }
 
                 return ctx.getBatchManager().getActiveBatch().toRequest();

--- a/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
@@ -25,9 +25,8 @@ package org.jboss.as.cli.handlers;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -350,9 +349,7 @@ public class UndeployHandler extends DeploymentHandler {
                     throw new CommandFormatException("ERROR: script '" + script + "' not found in archive '" + f.getAbsolutePath() + "'.");
                 }
 
-                BufferedReader reader = null;
-                try {
-                    reader = Files.newBufferedReader(scriptFile.toPath(), StandardCharsets.UTF_8);
+                try (BufferedReader reader = new BufferedReader(new FileReader(scriptFile))) {
                     String line = reader.readLine();
                     while (!ctx.isTerminated() && line != null) {
                         ctx.handle(line);
@@ -364,13 +361,6 @@ public class UndeployHandler extends DeploymentHandler {
                     throw new CommandFormatException("Failed to read the next command from " + scriptFile.getName() + ": " + e.getMessage(), e);
                 } catch (CommandLineException e) {
                     throw new CommandFormatException(e.getMessage(), e);
-                } finally {
-                    if(reader != null) {
-                        try {
-                            reader.close();
-                        } catch (IOException e) {
-                        }
-                    }
                 }
 
                 return ctx.getBatchManager().getActiveBatch().toRequest();

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchHandler.java
@@ -23,9 +23,8 @@ package org.jboss.as.cli.handlers.batch;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -146,9 +145,7 @@ public class BatchHandler extends CommandHandlerWithHelp {
                 ctx.setCurrentDir(baseDir);
             }
 
-            BufferedReader reader = null;
-            try {
-                reader = Files.newBufferedReader(f.toPath(), StandardCharsets.UTF_8);
+            try (BufferedReader reader = new BufferedReader(new FileReader(f))) {
                 String line = reader.readLine();
                 batchManager.activateNewBatch();
                 final Batch batch = batchManager.getActiveBatch();
@@ -166,13 +163,8 @@ public class BatchHandler extends CommandHandlerWithHelp {
                 batchManager.discardActiveBatch();
                 throw new CommandLineException("Failed to create batch from " + f.getAbsolutePath(), e);
             } finally {
-                if(baseDir != null) {
+                if (baseDir != null) {
                     ctx.setCurrentDir(currentDir);
-                }
-                if(reader != null) {
-                    try {
-                        reader.close();
-                    } catch (IOException e) {}
                 }
             }
             return;

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
@@ -24,9 +24,8 @@ package org.jboss.as.cli.handlers.batch;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.List;
 import org.jboss.aesh.console.Config;
 import org.jboss.as.cli.Attachments;
@@ -220,9 +219,7 @@ public class BatchRunHandler extends BaseOperationCommand {
                 ctx.setCurrentDir(baseDir);
             }
 
-            BufferedReader reader = null;
-            try {
-                reader = Files.newBufferedReader(f.toPath(), StandardCharsets.UTF_8);
+            try (BufferedReader reader = new BufferedReader(new FileReader(f))) {
                 String line = reader.readLine();
                 batchManager.activateNewBatch();
                 while(line != null) {
@@ -241,11 +238,6 @@ public class BatchRunHandler extends BaseOperationCommand {
             } finally {
                 if(baseDir != null) {
                     ctx.setCurrentDir(currentDir);
-                }
-                if(reader != null) {
-                    try {
-                        reader.close();
-                    } catch (IOException e) {}
                 }
             }
         }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -25,8 +25,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
+import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -335,7 +334,7 @@ public class CliLauncher {
 
         BufferedReader reader = null;
         try {
-            reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8);
+            reader = new BufferedReader(new FileReader(file));
             String line = reader.readLine();
             while (cmdCtx.getExitCode() == 0 && !cmdCtx.isTerminated() && line != null) {
                 cmdCtx.handleSafe(line.trim());

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -25,14 +25,12 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
@@ -1612,11 +1610,14 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
             this.outputTarget = null;
             return;
         }
+        FileWriter writer;
         try {
-            this.outputTarget = Files.newBufferedWriter(Paths.get(filePath), StandardCharsets.UTF_8);
+            writer = new FileWriter(filePath, false);
         } catch (IOException e) {
             error(e.getLocalizedMessage());
+            return;
         }
+        this.outputTarget = new BufferedWriter(writer);
     }
 
     protected void notifyListeners(CliEvent event) {


### PR DESCRIPTION
Revert UTF-8 constraints added when reading files from CLI. Redirected output is also not constrained by UTF-8 encoding. Encoding exception message is now clearer.
