### PR TITLE
WFCORE-2741: Add missing vault module attribute to the model boot updates sent by a HC

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerOperationsFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ManagedServerOperationsFactory.java
@@ -393,6 +393,10 @@ public final class ManagedServerOperationsFactory {
             if (codeNode.isDefined()) {
                 vault.get(Attribute.CODE.getLocalName()).set(codeNode.asString());
             }
+            ModelNode moduleNode = vaultNode.get(Attribute.MODULE.getLocalName());
+            if (moduleNode.isDefined()) {
+                vault.get(Attribute.MODULE.getLocalName()).set(moduleNode.asString());
+            }
             ModelNode vaultAddress = new ModelNode();
             vaultAddress.add(CORE_SERVICE, VAULT);
             addAddNameAndAddress(vault, vaultAddress);


### PR DESCRIPTION
In a managed domain a custom vault implementation doesn't work because the module name is not sent to the managed servers by the HC. This issue resolve it.

Jira issues:
https://issues.jboss.org/browse/WFCORE-2741
https://issues.jboss.org/browse/JBEAP-10646