### PR TITLE
WFCORE-2795: Added a custom validator for Cipher Suites filter in Elytron

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -160,6 +160,7 @@ class SSLDefinitions {
             .setAllowExpression(true)
             .setMinSize(1)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .setValidator(new CipherSuiteFilterValidator())
             .build();
 
     static final String[] ALLOWED_PROTOCOLS = { "SSLv2", "SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" };
@@ -287,6 +288,24 @@ class SSLDefinitions {
         }
     }
 
+    static class CipherSuiteFilterValidator extends ModelTypeValidator{
+
+        public CipherSuiteFilterValidator() {
+            super(ModelType.STRING, true, true, false);
+        }
+
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            super.validateParameter(parameterName,value);
+            if (value.isDefined()) {
+                try {
+                    CipherSuiteSelector.fromString(value.asString());
+                }catch (IllegalArgumentException e){
+                    throw ROOT_LOGGER.invalidCipherSuiteFilter(e, e.getLocalizedMessage());
+                }
+            }
+        }
+    }
 
     static ResourceDefinition getKeyManagerDefinition() {
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -388,4 +388,6 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 1016, value = "Server '%s' not known")
     OperationFailedException serverNotKnown(final String serverAddedd, @Cause UnknownHostException e);
 
+    @Message(id = 1017, value = "Invalid value for cipher-suite-filter. %s")
+    OperationFailedException invalidCipherSuiteFilter(@Cause Throwable cause, String causeMessage);
 }


### PR DESCRIPTION
Added a custom validator for cipher-suite-filters attribute in ssl-context definitions.
Although the EAP issue recommends implementing a cache to avoid the same value validation at Stage.RUNTIME, I couldn't find a simple way to do it without hackering over WriteAttributeHandler. 

Jira issues:
https://issues.jboss.org/browse/WFCORE-2795
https://issues.jboss.org/browse/JBEAP-7422