### PR TITLE
Fix for WFCORE-2798. CLI, cd command --no-validation handling

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/LsHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/LsHandler.java
@@ -527,7 +527,7 @@ public class LsHandler extends BaseOperationCommand {
         return address;
     }
 
-    protected String getNodePath(String nodePathString) {
+    protected static String getNodePath(String nodePathString) {
         int i = 0;
         while(i < nodePathString.length()) {
             i = nodePathString.indexOf('-', i);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/PrefixHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/PrefixHandler.java
@@ -65,7 +65,10 @@ public class PrefixHandler extends CommandHandlerWithHelp {
         }
 
         final OperationRequestAddress tmp = new DefaultOperationRequestAddress(prefix);
-        ctx.getCommandLineParser().parse(ctx.getArgumentsString(), new DefaultCallbackHandler(tmp));
+
+        // We need to remove any option
+        String np = LsHandler.getNodePath(ctx.getArgumentsString());
+        ctx.getCommandLineParser().parse(np, new DefaultCallbackHandler(tmp));
         if(!noValidation.isPresent(ctx.getParsedCommandLine())) {
             assertValid(ctx, tmp);
         }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CdTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CdTestCase.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.integration.management.cli;
 
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestAddress;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.junit.Assert;
 import org.junit.Test;
@@ -56,6 +57,29 @@ public class CdTestCase {
             Assert.fail("Can't cd into a non-existing nodepath.");
         } catch(CommandLineException e) {
             // expected
+        } finally {
+            ctx.terminateSession();
+        }
+    }
+
+    @Test
+    public void testNoValidation() throws Exception {
+        final CommandContext ctx = CLITestUtil.getCommandContext();
+        try {
+            ctx.connectController();
+            ctx.handle("cd /subsystem=subsystem --no-validation");
+            DefaultOperationRequestAddress address = new DefaultOperationRequestAddress();
+            address.toNode("subsystem", "subsystem");
+            Assert.assertEquals("Invalid address " + ctx.getCurrentNodePath().getNodeName(),
+                    address.getNodeName(), ctx.getCurrentNodePath().getNodeName());
+            Assert.assertEquals("Invalid address " + ctx.getCurrentNodePath().getNodeType(),
+                    address.getNodeType(), ctx.getCurrentNodePath().getNodeType());
+
+            ctx.handle("cd --no-validation /subsystem=subsystem");
+            Assert.assertEquals("Invalid address " + ctx.getCurrentNodePath().getNodeName(),
+                    address.getNodeName(), ctx.getCurrentNodePath().getNodeName());
+            Assert.assertEquals("Invalid address " + ctx.getCurrentNodePath().getNodeType(),
+                    address.getNodeType(), ctx.getCurrentNodePath().getNodeType());
         } finally {
             ctx.terminateSession();
         }


### PR DESCRIPTION
Filter out options present in arguments. Added unit test.