### PR TITLE
[WFCORE-2807] removed server-side attributes from client-ssl-context

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -763,7 +763,7 @@ class SSLDefinitions {
                 .build();
 
         AttributeDefinition[] attributes = new AttributeDefinition[] { CIPHER_SUITE_FILTER, PROTOCOLS,
-                USE_CIPHER_SUITES_ORDER, MAXIMUM_SESSION_CACHE_SIZE, SESSION_TIMEOUT, KEY_MANAGERS, TRUST_MANAGERS, providersDefinition, PROVIDER_NAME };
+                KEY_MANAGERS, TRUST_MANAGERS, providersDefinition, PROVIDER_NAME };
 
         return new SSLContextDefinition(ElytronDescriptionConstants.CLIENT_SSL_CONTEXT, false, new TrivialAddHandler<SSLContext>(SSLContext.class, attributes, SSL_CONTEXT_RUNTIME_CAPABILITY) {
             @Override
@@ -776,9 +776,6 @@ class SSLDefinitions {
                 final String providerName = asStringIfDefined(context, PROVIDER_NAME, model);
                 final List<String> protocols = PROTOCOLS.unwrap(context, model);
                 final String cipherSuiteFilter = asStringIfDefined(context, CIPHER_SUITE_FILTER, model);
-                final boolean useCipherSuitesOrder = USE_CIPHER_SUITES_ORDER.resolveModelAttribute(context, model).asBoolean();
-                final int maximumSessionCacheSize = MAXIMUM_SESSION_CACHE_SIZE.resolveModelAttribute(context, model).asInt();
-                final int sessionTimeout = SESSION_TIMEOUT.resolveModelAttribute(context, model).asInt();
 
                 return () -> {
                     X509ExtendedKeyManager keyManager = getX509KeyManager(keyManagersInjector.getOptionalValue());
@@ -793,17 +790,14 @@ class SSLDefinitions {
                     if ( ! protocols.isEmpty()) builder.setProtocolSelector(ProtocolSelector.empty().add(
                             EnumSet.copyOf(protocols.stream().map(Protocol::forName).collect(Collectors.toList()))
                     ));
-                    builder.setClientMode(true)
-                           .setUseCipherSuitesOrder(useCipherSuitesOrder)
-                           .setSessionCacheSize(maximumSessionCacheSize)
-                           .setSessionTimeout(sessionTimeout);
+                    builder.setClientMode(true);
 
                     if (ROOT_LOGGER.isTraceEnabled()) {
                         ROOT_LOGGER.tracef(
                                 "ClientSSLContext supplying:  keyManager = %s  trustManager = %s  providers = %s  " +
-                                "cipherSuiteFilter = %s  protocols = %s  maximumSessionCacheSize = %s  sessionTimeout = %s",
+                                "cipherSuiteFilter = %s  protocols = %s",
                                 keyManager, trustManager, Arrays.toString(providers), cipherSuiteFilter,
-                                Arrays.toString(protocols.toArray()), maximumSessionCacheSize, sessionTimeout
+                                Arrays.toString(protocols.toArray())
                         );
                     }
 

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -4317,27 +4317,6 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="use-cipher-suites-order" type="xs:boolean" default="true">
-            <xs:annotation>
-                <xs:documentation>
-                    Configure the SSLContext to honor local cipher suites preference.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="maximum-session-cache-size" type="xs:int" default="-1">
-            <xs:annotation>
-                <xs:documentation>
-                    The maximum number of SSL sessions in the cache. The default value -1 means use the JVM default value. Value zero means there is no limit.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="session-timeout" type="xs:int" default="-1">
-            <xs:annotation>
-                <xs:documentation>
-                    The timeout for SSL sessions, in seconds. The default value -1 means use the JVM default value. Value zero means there is no limit.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="key-managers" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-test.xml
@@ -66,11 +66,12 @@
         <server-ssl-contexts>
             <server-ssl-context name="ServerSslContextNoAuth" key-managers="ServerKeyManager" trust-managers="CaTrustManager"/>
             <server-ssl-context name="ServerSslContextAuth" protocols="TLSv1.3 TLSv1.2 TLSv1.1" key-managers="ServerKeyManager" trust-managers="CaTrustManager"
-                                want-client-auth="true" need-client-auth="true" authentication-optional="false" use-cipher-suites-order="false" providers="ManagerProviderLoader" provider-name="SunJSSE"/>
+                                want-client-auth="true" need-client-auth="true" authentication-optional="false" use-cipher-suites-order="false"
+                                providers="ManagerProviderLoader" provider-name="SunJSSE" session-timeout="321" maximum-session-cache-size="123"/>
         </server-ssl-contexts>
         <client-ssl-contexts>
             <client-ssl-context name="ClientSslContextNoAuth" trust-managers="CaTrustManager" />
-            <client-ssl-context name="ClientSslContextAuth" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2" key-managers="ClientKeyManager" trust-managers="CaTrustManager" use-cipher-suites-order="false" providers="ManagerProviderLoader"/>
+            <client-ssl-context name="ClientSslContextAuth" protocols="SSLv2 SSLv3 TLSv1 TLSv1.3 TLSv1.2" key-managers="ClientKeyManager" trust-managers="CaTrustManager" providers="ManagerProviderLoader"/>
         </client-ssl-contexts>
     </tls>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
@@ -46,7 +46,7 @@
                 session-timeout="120" wrap="false" key-managers="serverKey" trust-managers="serverTrust" providers="custom-loader" provider-name="first" />
         </server-ssl-contexts>
         <client-ssl-contexts>
-            <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" use-cipher-suites-order="true" key-managers="clientKey" trust-managers="serverTrust" providers="custom-loader" provider-name="first" />
+            <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" key-managers="clientKey" trust-managers="serverTrust" providers="custom-loader" provider-name="first" />
         </client-ssl-contexts>
     </tls>
     <credential-stores>


### PR DESCRIPTION
use-cipher-suites-order, maximum-session-cache-size, session-timeout attributes are relevant only for server side, so removing from client-ssl-context

https://issues.jboss.org/browse/WFCORE-2807
(no PR deps)