### PR TITLE
WFCORE-2756: Added periodic-rotating and size-rotating audit logs for Elytron audit

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuditLoggingParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuditLoggingParser.java
@@ -33,9 +33,10 @@ import static org.wildfly.extension.elytron.ElytronDescriptionConstants.AGGREGAT
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.AUDIT_LOGGING;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.FILE_AUDIT_LOG;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.NAME;
-import static org.wildfly.extension.elytron.ElytronDescriptionConstants.ROTATING_FILE_AUDIT_LOG;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.PERIODIC_ROTATING_FILE_AUDIT_LOG;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SECURITY_EVENT_LISTENER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SECURITY_EVENT_LISTENERS;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SIZE_ROTATING_FILE_AUDIT_LOG;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SYSLOG_AUDIT_LOG;
 import static org.wildfly.extension.elytron.ElytronSubsystemParser.verifyNamespace;
 
@@ -62,9 +63,14 @@ class AuditLoggingParser {
             .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT)
             .build();
 
-    private final PersistentResourceXMLDescription rotatingFileAuditLogParser = builder(PathElement.pathElement(ROTATING_FILE_AUDIT_LOG), null)
+    private final PersistentResourceXMLDescription periodicRotatingFileAuditLogParser = builder(PathElement.pathElement(PERIODIC_ROTATING_FILE_AUDIT_LOG), null)
             .setUseElementsForGroups(false)
-            .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.MAX_BACKUP_INDEX, AuditResourceDefinitions.ROTATE_ON_BOOT, AuditResourceDefinitions.ROTATE_SIZE, AuditResourceDefinitions.SUFFIX)
+            .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.PERIODIC_SUFFIX)
+            .build();
+
+    private final PersistentResourceXMLDescription sizeRotatingFileAuditLogParser = builder(PathElement.pathElement(SIZE_ROTATING_FILE_AUDIT_LOG), null)
+            .setUseElementsForGroups(false)
+            .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.MAX_BACKUP_INDEX, AuditResourceDefinitions.ROTATE_ON_BOOT, AuditResourceDefinitions.ROTATE_SIZE, AuditResourceDefinitions.SIZE_SUFFIX)
             .build();
 
     private final PersistentResourceXMLDescription syslogAuditLogParser = builder(PathElement.pathElement(SYSLOG_AUDIT_LOG), null)
@@ -86,8 +92,11 @@ class AuditLoggingParser {
                 case FILE_AUDIT_LOG:
                     fileAuditLogParser.parse(reader, parentAddress, operations);
                     break;
-                case ROTATING_FILE_AUDIT_LOG:
-                    rotatingFileAuditLogParser.parse(reader, parentAddress, operations);
+                case PERIODIC_ROTATING_FILE_AUDIT_LOG:
+                    periodicRotatingFileAuditLogParser.parse(reader, parentAddress, operations);
+                    break;
+                case SIZE_ROTATING_FILE_AUDIT_LOG:
+                    sizeRotatingFileAuditLogParser.parse(reader, parentAddress, operations);
                     break;
                 case SYSLOG_AUDIT_LOG:
                     syslogAuditLogParser.parse(reader, parentAddress, operations);
@@ -176,7 +185,8 @@ class AuditLoggingParser {
 
         writeAggregateSecurityEventListener(subsystem, writer);
         fileAuditLogParser.persist(writer, subsystem);
-        rotatingFileAuditLogParser.persist(writer, subsystem);
+        periodicRotatingFileAuditLogParser.persist(writer, subsystem);
+        sizeRotatingFileAuditLogParser.persist(writer, subsystem);
         syslogAuditLogParser.persist(writer, subsystem);
 
         writer.writeEndElement();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -138,7 +138,8 @@ class ElytronDefinition extends SimpleResourceDefinition {
         // Audit
         resourceRegistration.registerSubModel(AuditResourceDefinitions.getAggregateSecurityEventListenerDefinition());
         resourceRegistration.registerSubModel(AuditResourceDefinitions.getFileAuditLogResourceDefinition());
-        resourceRegistration.registerSubModel(AuditResourceDefinitions.getRotatingFileAuditLogResourceDefinition());
+        resourceRegistration.registerSubModel(AuditResourceDefinitions.getPeriodicRotatingFileAuditLogResourceDefinition());
+        resourceRegistration.registerSubModel(AuditResourceDefinitions.getSizeRotatingFileAuditLogResourceDefinition());
         resourceRegistration.registerSubModel(AuditResourceDefinitions.getSyslogAuditLogResourceDefinition());
 
         // Security Domain SASL / HTTP Configurations

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -308,6 +308,7 @@ interface ElytronDescriptionConstants {
     String PEER_HOST = "peer-host";
     String PEER_PORT = "peer-port";
     String PEER_PRINCIPAL = "peer-principal";
+    String PERIODIC_ROTATING_FILE_AUDIT_LOG = "periodic-rotating-file-audit-log";
     String PERMISSION = "permission";
     String PERMISSIONS = "permissions";
     String PERMISSION_MAPPER = "permission-mapper";
@@ -379,7 +380,6 @@ interface ElytronDescriptionConstants {
     String ROLES = "roles";
     String ROTATE_SIZE = "rotate-size";
     String ROTATE_ON_BOOT = "rotate-on-boot";
-    String ROTATING_FILE_AUDIT_LOG = "rotating-file-audit-log";
 
     String SALT = "salt";
     String SALT_INDEX = "salt-index";
@@ -433,6 +433,7 @@ interface ElytronDescriptionConstants {
     String SIMPLE_REGEX_REALM_MAPPER = "simple-regex-realm-mapper";
     String SIMPLE_ROLE_DECODER = "simple-role-decoder";
     String SIZE = "size";
+    String SIZE_ROTATING_FILE_AUDIT_LOG = "size-rotating-file-audit-log";
     String SQL = "sql";
     String SSL_CONTEXT = "ssl-context";
     String SSL_SESSION = "ssl-session";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -405,4 +405,13 @@ public interface ElytronSubsystemMessages extends BasicLogger {
 
     @Message(id = 1017, value = "Invalid value for cipher-suite-filter. %s")
     OperationFailedException invalidCipherSuiteFilter(@Cause Throwable cause, String causeMessage);
+
+    @Message(id = 1018, value = "Invalid size %s")
+    OperationFailedException invalidSize(String size);
+
+    @Message(id = 1019, value = "The suffix (%s) can not contain seconds or milliseconds.")
+    OperationFailedException suffixContainsMillis(String suffix);
+
+    @Message(id = 1020, value = "The suffix (%s) is invalid. A suffix must be a valid date format.")
+    OperationFailedException invalidSuffix(String suffix);
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/validators/SizeValidator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/validators/SizeValidator.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.elytron.validators;
+
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.wildfly.extension.elytron._private.ElytronSubsystemMessages;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SizeValidator extends ModelTypeValidator {
+    private static final Pattern SIZE_PATTERN = Pattern.compile("(\\d+)([kKmMgGbBtT])?");
+
+    public SizeValidator() {
+        this(false);
+    }
+
+    public SizeValidator(final boolean nullable) {
+        super(ModelType.STRING, nullable);
+    }
+
+    @Override
+    public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+        super.validateParameter(parameterName, value);
+        if (value.isDefined()) {
+            parseSize(value);
+        }
+    }
+
+    public static long parseSize(final ModelNode value) throws OperationFailedException {
+        final Matcher matcher = SIZE_PATTERN.matcher(value.asString());
+        if (!matcher.matches()) {
+            throw ElytronSubsystemMessages.ROOT_LOGGER.invalidSize(value.asString());
+        }
+        long qty = Long.parseLong(matcher.group(1), 10);
+        final String chr = matcher.group(2);
+        if (chr != null) {
+            switch (chr.charAt(0)) {
+                case 'b':
+                case 'B':
+                    break;
+                case 'k':
+                case 'K':
+                    qty <<= 10L;
+                    break;
+                case 'm':
+                case 'M':
+                    qty <<= 20L;
+                    break;
+                case 'g':
+                case 'G':
+                    qty <<= 30L;
+                    break;
+                case 't':
+                case 'T':
+                    qty <<= 40L;
+                    break;
+                default:
+                    throw ElytronSubsystemMessages.ROOT_LOGGER.invalidSize(value.asString());
+            }
+        }
+        return qty;
+    }
+}

--- a/elytron/src/main/java/org/wildfly/extension/elytron/validators/SuffixValidator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/validators/SuffixValidator.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.extension.elytron.validators;
+
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.operations.validation.ModelTypeValidator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.wildfly.extension.elytron._private.ElytronSubsystemMessages;
+
+import java.time.format.DateTimeFormatter;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SuffixValidator extends ModelTypeValidator {
+    private final boolean denySeconds;
+
+    public SuffixValidator() {
+        this(false, true);
+    }
+
+    public SuffixValidator(final boolean nullable, final boolean denySeconds) {
+        super(ModelType.STRING, nullable);
+        this.denySeconds = denySeconds;
+    }
+
+    @Override
+    public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+        super.validateParameter(parameterName, value);
+        if (value.isDefined()) {
+            final String suffix = value.asString();
+            try {
+                if (denySeconds && (suffix.contains("s") || suffix.contains("S"))) {
+                    throw ElytronSubsystemMessages.ROOT_LOGGER.suffixContainsMillis(suffix);
+                }
+                DateTimeFormatter.ofPattern(suffix);
+            } catch (IllegalArgumentException e) {
+                throw ElytronSubsystemMessages.ROOT_LOGGER.invalidSuffix(suffix);
+            }
+        }
+    }
+}

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -118,22 +118,34 @@ elytron.file-audit-log.remove=Remove the audit logger resource.
 #Attributes
 elytron.file-audit-log.path=Path of the file to be written.
 elytron.file-audit-log.relative-to=The relative path to the audit log.
-elytron.file-audit-log.synchronized=Should every event be immediately synchronised to disk.
+elytron.file-audit-log.synchronized=Whether every event should be immediately synchronised to disk.
 elytron.file-audit-log.format=The format to use to record the audit event.
 
-elytron.rotating-file-audit-log=An audit logger that logs to a local file with log rotation.
+elytron.periodic-rotating-file-audit-log=An audit log definition for persisting an audit log to a local files rotating the log after a time period derived from the given suffix string, which should be in a format understood by java.time.format.DateTimeFormatter.
 # Operations
-elytron.rotating-file-audit-log.add=Add the audit logger resource.
-elytron.rotating-file-audit-log.remove=Remove the audit logger resource.
+elytron.periodic-rotating-file-audit-log.add=Add the audit logger resource.
+elytron.periodic-rotating-file-audit-log.remove=Remove the audit logger resource.
 #Attributes
-elytron.rotating-file-audit-log.path=Path of the file to be written.
-elytron.rotating-file-audit-log.relative-to=The relative path to the audit log.
-elytron.rotating-file-audit-log.synchronized=Should every event be immediately synchronised to disk.
-elytron.rotating-file-audit-log.format=The format to use to record the audit event.
-elytron.rotating-file-audit-log.max-backup-index=The maximum number of files to backup when rotating.
-elytron.rotating-file-audit-log.rotate-size=The log file size the file should rotate at.
-elytron.rotating-file-audit-log.rotate-on-boot=Whether the file should be rotated before the a new file is set.
-elytron.rotating-file-audit-log.suffix=Format of date used as suffix of log file names in java.text.SimpleDateFormat format.
+elytron.periodic-rotating-file-audit-log.path=Path of the file to be written.
+elytron.periodic-rotating-file-audit-log.relative-to=The relative path to the audit log.
+elytron.periodic-rotating-file-audit-log.synchronized=Whether every event should be immediately synchronised to disk.
+elytron.periodic-rotating-file-audit-log.format=The format to use to record the audit event.
+elytron.periodic-rotating-file-audit-log.suffix=The suffix string in a format which can be understood by java.time.format.DateTimeFormatter. The period of the rotation is automatically calculated based on the suffix.
+
+elytron.size-rotating-file-audit-log=An audit log definition for persisting an audit log to a local files rotating the log after the size of the file grows beyond a certain point and keeping a fixed number of backups.
+# Operations
+elytron.size-rotating-file-audit-log.add=Add the audit logger resource.
+elytron.size-rotating-file-audit-log.remove=Remove the audit logger resource.
+#Attributes
+elytron.size-rotating-file-audit-log.path=Path of the file to be written.
+elytron.size-rotating-file-audit-log.relative-to=The relative path to the audit log.
+elytron.size-rotating-file-audit-log.synchronized=Whether every event should be immediately synchronised to disk.
+elytron.size-rotating-file-audit-log.format=The format to use to record the audit event.
+elytron.size-rotating-file-audit-log.max-backup-index=The maximum number of files to backup when rotating.
+elytron.size-rotating-file-audit-log.rotate-size=The log file size the file should rotate at.
+elytron.size-rotating-file-audit-log.rotate-on-boot=Whether the file should be rotated before the a new file is set.
+elytron.size-rotating-file-audit-log.suffix=Format of date used as suffix of log file names in java.time.format.DateTimeFormatter. The suffix does not play a role in determining when the file should be rotated.
+
 
 elytron.syslog-audit-log=An audit logger that sends audit events to a remote syslog server.
 # Operations

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -483,7 +483,8 @@
         <xs:sequence>
             <xs:element name="aggregate-security-event-listener" type="aggregateSecurityEventListener" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="file-audit-log" type="fileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
-            <xs:element name="rotating-file-audit-log" type="rotatingFileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="periodic-rotating-file-audit-log" type="periodicRotatingFileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="size-rotating-file-audit-log" type="sizeRotatingFileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="syslog-audit-log" type="syslogAuditLogType" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
     </xs:complexType>
@@ -578,7 +579,7 @@
                 <xs:attribute name="synchronized" type="xs:boolean" default="true">
                     <xs:annotation>
                         <xs:documentation>
-                            Should all audit events be immediately synchronised to disk?
+                            Whether every event should be immediately synchronised to disk.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -593,68 +594,62 @@
         </xs:complexContent>
     </xs:complexType>
 
-    <xs:complexType name="rotatingFileAuditLogType">
+    <xs:complexType name="periodicRotatingFileAuditLogType">
         <xs:annotation>
             <xs:documentation>
-                An audit log definition for persisting an audit log to a local files with log rotation.
+                An audit log definition for persisting an audit log to a local file rotating the log after a time period
+                derived from the given suffix string, which should be in a format understood by java.time.format.DateTimeFormatter.
             </xs:documentation>
         </xs:annotation>
         <xs:complexContent>
-            <xs:extension base="auditLogType">
-                <xs:attribute name="path" type="xs:string" use="required">
+            <xs:extension base="fileAuditLogType">
+                <xs:attribute name="suffix" type="xs:string" use="required">
                     <xs:annotation>
                         <xs:documentation>
-                            The path to write the audit log to.
+                            The suffix string in a format which can be understood by java.time.format.DateTimeFormatter.
+                            The period of the rotation is automatically calculated based on the suffix.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="relative-to" type="xs:string">
-                    <xs:annotation>
-                        <xs:documentation>
-                            A reference to a previously defined path that the path of the audit log is
-                            relative to.
-                        </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-                <xs:attribute name="synchronized" type="xs:boolean" default="true">
-                    <xs:annotation>
-                        <xs:documentation>
-                            Should all audit events be immediately synchronised to disk?
-                        </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-                <xs:attribute name="format" default="SIMPLE" type="formatType">
-                    <xs:annotation>
-                        <xs:documentation>
-                            The format to use to log the event.
-                        </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-                <xs:attribute name="max-backup-index" default="0" type="xs:long">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sizeRotatingFileAuditLogType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit log definition for persisting an audit log to a local file rotating the log after the
+                size of the file grows beyond a certain point and keeping a fixed number of backups.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fileAuditLogType">
+                <xs:attribute name="max-backup-index" default="1" type="xs:long" use="optional">
                     <xs:annotation>
                         <xs:documentation>
                             The maximum number of files to backup when rotating.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="rotate-on-boot" type="xs:boolean" default="false">
+                <xs:attribute name="rotate-on-boot" type="xs:boolean" default="false" use="optional">
                     <xs:annotation>
                         <xs:documentation>
                             Whether the file should be rotated before the a new file is set.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="rotate-size" default="0" type="xs:long">
+                <xs:attribute name="rotate-size" default="10m" type="xs:string" use="optional">
                     <xs:annotation>
                         <xs:documentation>
                             The log file size the file should rotate at.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="suffix" type="xs:string">
+                <xs:attribute name="suffix" type="xs:string" use="optional">
                     <xs:annotation>
                         <xs:documentation>
-                            Format of date used as suffix of log file names in java.text.SimpleDateFormat format.
+                            Format of date used as suffix of log file names in java.time.format.DateTimeFormatter.
+                            The suffix does not play a role in determining when the file should be rotated.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
@@ -8,7 +8,8 @@
             <security-event-listener name="remote-syslog"/>
         </aggregate-security-event-listener>
         <file-audit-log name="local-file" path="audit.log" relative-to="jboss.home.dir" synchronized="false" format="JSON" />
-        <rotating-file-audit-log name="rotating" path="audit.log" relative-to="jboss.server.log.dir" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d"/>
+        <periodic-rotating-file-audit-log name="periodic-rotating" path="audit.log" relative-to="jboss.server.log.dir" format="JSON" suffix="y-M-d"/>
+        <size-rotating-file-audit-log name="size-rotating" path="audit.log" relative-to="jboss.server.log.dir" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d"/>
         <syslog-audit-log name="remote-syslog" server-address="remote-server" port="9898" transport="UDP" format="JSON" host-name="Elytron" />
         <syslog-audit-log name="remote-syslog-ssl" server-address="remote-server" port="9898" transport="SSL_TCP" host-name="Elytron" ssl-context="audit-ssl" />
     </audit-logging>


### PR DESCRIPTION
Now there are two different rotating file logs in Elytron:

- periodic-rotating-file-audit-log: Which rotates based on a suffix in DateTimeFormatter format. Similar behaviour than /core-service=management/access=audit/periodic-rotating-file-handler. The suffix is mandatory here.
- size-rotating-file-audit-log: which rotates in size and can use a suffix in DateTimeFormatter format appended to each file rotation. Similar behaviour than /subsystem=logging/size-rotating-file-handler. The suffix is optional here.

Jira issues:
https://issues.jboss.org/browse/WFCORE-2756
https://issues.jboss.org/browse/JBEAP-10700

Depends on: https://github.com/wildfly-security/wildfly-elytron/pull/845
