### PR TITLE
[WFCORE-389[WFCORE-2858] Support runtime-only ops on profile resources

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ListOperations.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ListOperations.java
@@ -46,7 +46,6 @@ public class ListOperations {
 
     public static final OperationDefinition LIST_ADD_DEFINITION = new SimpleOperationDefinitionBuilder("list-add", ControllerResolver.getResolver("global"))
             .setParameters(AbstractCollectionHandler.NAME, AbstractCollectionHandler.VALUE, AbstractListHandler.INDEX)
-            .setRuntimeOnly()
             .build();
     public static final OperationDefinition LIST_GET_DEFINITION = new SimpleOperationDefinitionBuilder("list-get", ControllerResolver.getResolver("global"))
             .setParameters(AbstractCollectionHandler.NAME, AbstractListHandler.INDEX)
@@ -55,11 +54,9 @@ public class ListOperations {
             .build();
     public static final OperationDefinition LIST_REMOVE_DEFINITION = new SimpleOperationDefinitionBuilder("list-remove", ControllerResolver.getResolver("global"))
             .setParameters(AbstractCollectionHandler.NAME, AbstractCollectionHandler.VALUE, AbstractListHandler.INDEX)
-            .setRuntimeOnly()
             .build();
     public static final OperationDefinition LIST_CLEAR_DEFINITION = new SimpleOperationDefinitionBuilder("list-clear", ControllerResolver.getResolver("global"))
             .setParameters(AbstractCollectionHandler.NAME)
-            .setRuntimeOnly()
             .build();
     public static final OperationStepHandler LIST_ADD_HANDLER = new ListAddHandler();
     public static final OperationStepHandler LIST_REMOVE_HANDLER = new ListRemoveHandler();

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ListOperations.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ListOperations.java
@@ -49,7 +49,6 @@ public class ListOperations {
             .build();
     public static final OperationDefinition LIST_GET_DEFINITION = new SimpleOperationDefinitionBuilder("list-get", ControllerResolver.getResolver("global"))
             .setParameters(AbstractCollectionHandler.NAME, AbstractListHandler.INDEX)
-            .setRuntimeOnly()
             .setReadOnly()
             .build();
     public static final OperationDefinition LIST_REMOVE_DEFINITION = new SimpleOperationDefinitionBuilder("list-remove", ControllerResolver.getResolver("global"))

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/MapOperations.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/MapOperations.java
@@ -39,11 +39,9 @@ import org.jboss.dmr.ModelType;
 public class MapOperations {
     public static final OperationDefinition MAP_CLEAR_DEFINITION = new SimpleOperationDefinitionBuilder("map-clear", ControllerResolver.getResolver("global"))
             .setParameters(AbstractMapHandler.NAME)
-            .setRuntimeOnly()
             .build();
     public static final OperationDefinition MAP_REMOVE_DEFINITION = new SimpleOperationDefinitionBuilder("map-remove", ControllerResolver.getResolver("global"))
             .setParameters(AbstractMapHandler.NAME, AbstractMapHandler.KEY)
-            .setRuntimeOnly()
             .build();
     public static final OperationDefinition MAP_GET_DEFINITION = new SimpleOperationDefinitionBuilder("map-get", ControllerResolver.getResolver("global"))
             .setParameters(AbstractMapHandler.NAME, AbstractMapHandler.KEY)
@@ -52,7 +50,6 @@ public class MapOperations {
             .build();
     public static final OperationDefinition MAP_PUT_DEFINITION = new SimpleOperationDefinitionBuilder("map-put", ControllerResolver.getResolver("global"))
             .setParameters(AbstractMapHandler.NAME, AbstractMapHandler.KEY, AbstractMapHandler.VALUE)
-            .setRuntimeOnly()
             .build();
 
     public static final OperationStepHandler MAP_CLEAR_HANDLER = new MapClearHandler();

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/MapOperations.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/MapOperations.java
@@ -45,7 +45,6 @@ public class MapOperations {
             .build();
     public static final OperationDefinition MAP_GET_DEFINITION = new SimpleOperationDefinitionBuilder("map-get", ControllerResolver.getResolver("global"))
             .setParameters(AbstractMapHandler.NAME, AbstractMapHandler.KEY)
-            .setRuntimeOnly()
             .setReadOnly()
             .build();
     public static final OperationDefinition MAP_PUT_DEFINITION = new SimpleOperationDefinitionBuilder("map-put", ControllerResolver.getResolver("global"))

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeGroupHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeGroupHandler.java
@@ -66,7 +66,6 @@ public class ReadAttributeGroupHandler extends AbstractMultiTargetHandler {
     static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(READ_ATTRIBUTE_GROUP_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(NAME, INCLUDE_RUNTIME, INCLUDE_DEFAULTS, INCLUDE_ALIASES)
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.LIST)
             .setReplyValueType(ModelType.PROPERTY)
             .build();
@@ -79,7 +78,6 @@ public class ReadAttributeGroupHandler extends AbstractMultiTargetHandler {
     public static final OperationDefinition RESOLVE_DEFINITION = new SimpleOperationDefinitionBuilder(READ_ATTRIBUTE_GROUP_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(NAME, RESOLVE, INCLUDE_RUNTIME, INCLUDE_DEFAULTS, INCLUDE_ALIASES)
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.LIST)
             .setReplyValueType(ModelType.PROPERTY)
             .build();

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeGroupNamesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeGroupNamesHandler.java
@@ -47,7 +47,6 @@ public class ReadAttributeGroupNamesHandler implements OperationStepHandler {
 
     static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(READ_ATTRIBUTE_GROUP_NAMES_OPERATION, ControllerResolver.getResolver("global"))
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.LIST)
             .setReplyValueType(ModelType.STRING)
             .build();

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeHandler.java
@@ -64,7 +64,6 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
     public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(READ_ATTRIBUTE_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(GlobalOperationAttributes.NAME, GlobalOperationAttributes.INCLUDE_DEFAULTS)
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.OBJECT)
             .build();
 
@@ -78,7 +77,6 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
     public static final OperationDefinition RESOLVE_DEFINITION = new SimpleOperationDefinitionBuilder(READ_ATTRIBUTE_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(RESOLVE, GlobalOperationAttributes.NAME, GlobalOperationAttributes.INCLUDE_DEFAULTS)
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.OBJECT)
             .build();
 

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenNamesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenNamesHandler.java
@@ -62,7 +62,6 @@ public class ReadChildrenNamesHandler implements OperationStepHandler {
     static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(READ_CHILDREN_NAMES_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(CHILD_TYPE, INCLUDE_SINGLETONS)
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.LIST)
             .setReplyValueType(ModelType.STRING)
             .build();

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenResourcesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenResourcesHandler.java
@@ -66,7 +66,6 @@ public class ReadChildrenResourcesHandler implements OperationStepHandler {
     static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(READ_CHILDREN_RESOURCES_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(CHILD_TYPE, RECURSIVE, RECURSIVE_DEPTH, PROXIES, INCLUDE_RUNTIME, INCLUDE_DEFAULTS)
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.LIST)
             .setReplyValueType(ModelType.OBJECT)
             .build();

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenTypesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadChildrenTypesHandler.java
@@ -55,7 +55,6 @@ public class ReadChildrenTypesHandler implements OperationStepHandler {
     static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(READ_CHILDREN_TYPES_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(INCLUDE_ALIASES, INCLUDE_SINGLETONS)
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.LIST)
             .setReplyValueType(ModelType.STRING)
             .build();

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadOperationDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadOperationDescriptionHandler.java
@@ -76,7 +76,6 @@ public class ReadOperationDescriptionHandler implements OperationStepHandler {
             .setParameters(NAME, LOCALE, ACCESS_CONTROL)
             .setReplyType(ModelType.OBJECT)
             .setReadOnly()
-            .setRuntimeOnly()
             .build();
 
     static final OperationStepHandler INSTANCE = new ReadOperationDescriptionHandler();

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadOperationNamesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadOperationNamesHandler.java
@@ -63,7 +63,6 @@ public class ReadOperationNamesHandler implements OperationStepHandler {
 
     static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(READ_OPERATION_NAMES_OPERATION, ControllerResolver.getResolver("global"))
             .setReadOnly()
-            .setRuntimeOnly()
             .setParameters(ACCESS_CONTROL)
             .setReplyType(ModelType.LIST)
             .setReplyValueType(ModelType.STRING)

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -125,7 +125,6 @@ public class ReadResourceDescriptionHandler extends GlobalOperationHandlers.Abst
     static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(READ_RESOURCE_DESCRIPTION_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(OPERATIONS, NOTIFICATIONS, INHERITED, RECURSIVE, RECURSIVE_DEPTH, PROXIES, INCLUDE_ALIASES, ACCESS_CONTROL, LOCALE)
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.OBJECT)
             .build();
 

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -94,7 +94,6 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
     public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(READ_RESOURCE_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(RECURSIVE, RECURSIVE_DEPTH, PROXIES, INCLUDE_RUNTIME, INCLUDE_DEFAULTS, ATTRIBUTES_ONLY, INCLUDE_ALIASES)
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.OBJECT)
             .build();
 
@@ -108,7 +107,6 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
     public static final OperationDefinition RESOLVE_DEFINITION = new SimpleOperationDefinitionBuilder(READ_RESOURCE_OPERATION, ControllerResolver.getResolver("global"))
             .setParameters(RESOLVE, RECURSIVE, RECURSIVE_DEPTH, PROXIES, INCLUDE_RUNTIME, INCLUDE_DEFAULTS, ATTRIBUTES_ONLY, INCLUDE_ALIASES)
             .setReadOnly()
-            .setRuntimeOnly()
             .setReplyType(ModelType.OBJECT)
             .build();
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -23,6 +23,7 @@
 package org.jboss.as.controller.registry;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NOTIFICATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -474,7 +475,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
     public void registerMetric(AttributeDefinition definition, OperationStepHandler metricHandler) {
         assert assertMetricValues(definition); //The real message will be in an assertion thrown by assertMetricValues
         checkPermission();
-        if (isAttributeRegistrationAllowed(definition)) {
+        if (isAttributeRegistrationAllowed(definition) && !isProfileResource()) {
             AttributeAccess aa = new AttributeAccess(AccessType.METRIC, AttributeAccess.Storage.RUNTIME, metricHandler, null, definition, definition.getFlags());
             storeAttribute(definition, aa);
         }
@@ -495,6 +496,10 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
             return true;
         }
         return getProcessType().isServer();
+    }
+
+    private boolean isProfileResource() {
+        return !getProcessType().isServer() && getPathAddress().size() > 1 && PROFILE.equals(getPathAddress().getElement(0).getKey());
     }
 
     private void storeAttribute(AttributeDefinition definition, AttributeAccess aa) {

--- a/controller/src/main/java/org/jboss/as/controller/services/path/PathInfoHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/PathInfoHandler.java
@@ -110,6 +110,11 @@ public class PathInfoHandler extends AbstractRuntimeOnlyHandler {
         this.pathManager = pathManager;
     }
 
+    @Override
+    protected boolean requiresRuntime(OperationContext context) {
+        return true;
+    }
+
     /**
      * Compute the file usage metric which contains the total size of a folder and the usable space (as in Java nio).
      * @throws org.jboss.as.controller.OperationFailedException

--- a/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
@@ -289,7 +289,8 @@ abstract class AbstractCapabilityResolutionTestCase {
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                         context.getResult().set(context.hasOptionalCapability(reqName, capName, null));
                     }
-                }, OperationContext.Stage.RUNTIME);
+                //}, OperationContext.Stage.RUNTIME);
+                }, OperationContext.Stage.VERIFY); // use VERIFY to work around the fact we don't allow RUNTIME in /profile=* any more
             }  else {
                 context.getResult().set(true);
             }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
@@ -527,8 +527,10 @@ public class BasicRbacTestCase extends AbstractRbacTestBase {
 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            context.getServiceRegistry(modify); // causes read-runtime/write-runtime auth, otherwise ignored
-            context.getResult().set(new Random().nextInt());
+            context.addStep((ctx, op) -> {
+                ctx.getServiceRegistry(modify); // causes read-runtime/write-runtime auth, otherwise ignored
+                ctx.getResult().set(new Random().nextInt());
+            }, OperationContext.Stage.RUNTIME);
         }
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
@@ -679,10 +679,15 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
                     context.getResourceRegistrationForUpdate(); // causes read-config+write-config auth
                 }
                 if (actionEffect == Action.ActionEffect.READ_RUNTIME) {
-                    context.getServiceRegistry(false); // causes read-runtime auth
+                    context.addStep((ctx, op) -> {
+                        ctx.getServiceRegistry(false); // causes read-runtime auth
+                    }, OperationContext.Stage.RUNTIME);
+
                 }
                 if (actionEffect == Action.ActionEffect.WRITE_RUNTIME) {
-                    context.getServiceRegistry(true); // causes read-runtime+write-runtime auth
+                    context.addStep((ctx, op) -> {
+                        ctx.getServiceRegistry(true);  // causes read-runtime+write-runtime auth
+                    }, OperationContext.Stage.RUNTIME);
                 }
             }
 

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractGlobalOperationsTestCase.java
@@ -40,6 +40,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_GROUP_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_GROUP_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
@@ -353,19 +355,11 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
         if (operations) {
             assertTrue(result.require(OPERATIONS).isDefined());
             Set<String> ops = result.require(OPERATIONS).keys();
-            assertEquals(processType == ProcessType.DOMAIN_SERVER ? 19 : 23, ops.size());
+            assertEquals(processType == ProcessType.DOMAIN_SERVER ? 13 : 23, ops.size());
             boolean runtimeOnly = processType != ProcessType.DOMAIN_SERVER;
             assertEquals(runtimeOnly, ops.contains("testA1-1"));
             assertEquals(runtimeOnly, ops.contains("testA1-2"));
-            assertTrue(ops.contains(READ_RESOURCE_OPERATION));
-            assertTrue(ops.contains(READ_ATTRIBUTE_OPERATION));
-            assertTrue(ops.contains(READ_RESOURCE_DESCRIPTION_OPERATION));
-            assertTrue(ops.contains(READ_CHILDREN_NAMES_OPERATION));
-            assertTrue(ops.contains(READ_CHILDREN_TYPES_OPERATION));
-            assertTrue(ops.contains(READ_CHILDREN_RESOURCES_OPERATION));
-            assertTrue(ops.contains(READ_OPERATION_NAMES_OPERATION));
-            assertTrue(ops.contains(READ_OPERATION_DESCRIPTION_OPERATION));
-            assertEquals(runtimeOnly, ops.contains(WRITE_ATTRIBUTE_OPERATION));
+            assertGlobalOperations(ops);
 
         } else {
             assertFalse(result.get(OPERATIONS).isDefined());
@@ -393,6 +387,38 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
         checkType2Description(result.require(CHILDREN).require("type2").require(MODEL_DESCRIPTION).require("other"));
     }
 
+    private void assertGlobalOperations(Set<String> ops) {
+        assertTrue(ops.contains(READ_RESOURCE_OPERATION));
+        assertTrue(ops.contains(READ_ATTRIBUTE_OPERATION));
+        assertTrue(ops.contains(READ_ATTRIBUTE_GROUP_OPERATION));
+        assertTrue(ops.contains(READ_ATTRIBUTE_GROUP_NAMES_OPERATION));
+        assertTrue(ops.contains(READ_RESOURCE_DESCRIPTION_OPERATION));
+        assertTrue(ops.contains(READ_CHILDREN_NAMES_OPERATION));
+        assertTrue(ops.contains(READ_CHILDREN_TYPES_OPERATION));
+        assertTrue(ops.contains(READ_CHILDREN_RESOURCES_OPERATION));
+        assertTrue(ops.contains(READ_OPERATION_NAMES_OPERATION));
+        assertTrue(ops.contains(READ_OPERATION_DESCRIPTION_OPERATION));
+        assertTrue(ops.contains("list-get"));
+        assertTrue(ops.contains("map-get"));
+        if (processType == ProcessType.DOMAIN_SERVER) {
+            assertFalse(ops.contains(WRITE_ATTRIBUTE_OPERATION));
+            assertFalse(ops.contains("list-add"));
+            assertFalse(ops.contains("list-remove"));
+            assertFalse(ops.contains("list-clear"));
+            assertFalse(ops.contains("map-put"));
+            assertFalse(ops.contains("map-remove"));
+            assertFalse(ops.contains("map-clear"));
+        } else {
+            assertTrue(ops.contains(WRITE_ATTRIBUTE_OPERATION));
+            assertTrue(ops.contains("list-add"));
+            assertTrue(ops.contains("list-remove"));
+            assertTrue(ops.contains("list-clear"));
+            assertTrue(ops.contains("map-put"));
+            assertTrue(ops.contains("map-remove"));
+            assertTrue(ops.contains("map-clear"));
+        }
+    }
+
     protected void checkType1Description(ModelNode result) {
         assertNotNull(result);
         assertEquals(ModelType.STRING, result.require(ATTRIBUTES).require("name").require(TYPE).asType());
@@ -405,17 +431,8 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
         if (result.hasDefined(OPERATIONS)) {
             assertTrue(result.require(OPERATIONS).isDefined());
             Set<String> ops = result.require(OPERATIONS).keys();
-            assertEquals(processType == ProcessType.DOMAIN_SERVER ? 19 : 21, ops.size());
-            assertTrue(ops.contains(READ_RESOURCE_OPERATION));
-            assertTrue(ops.contains(READ_ATTRIBUTE_OPERATION));
-            assertTrue(ops.contains(READ_RESOURCE_DESCRIPTION_OPERATION));
-            assertTrue(ops.contains(READ_CHILDREN_NAMES_OPERATION));
-            assertTrue(ops.contains(READ_CHILDREN_TYPES_OPERATION));
-            assertTrue(ops.contains(READ_CHILDREN_RESOURCES_OPERATION));
-            assertTrue(ops.contains(READ_OPERATION_NAMES_OPERATION));
-            assertTrue(ops.contains(READ_OPERATION_DESCRIPTION_OPERATION));
-            assertEquals(processType != ProcessType.DOMAIN_SERVER, ops.contains(WRITE_ATTRIBUTE_OPERATION));
-
+            assertEquals(processType == ProcessType.DOMAIN_SERVER ? 13 : 21, ops.size());
+            assertGlobalOperations(ops);
         }
 
         if (result.hasDefined(NOTIFICATIONS)) {
@@ -440,16 +457,8 @@ public abstract class AbstractGlobalOperationsTestCase extends AbstractControlle
         if (result.hasDefined(OPERATIONS)) {
             assertTrue(result.require(OPERATIONS).isDefined());
             Set<String> ops = result.require(OPERATIONS).keys();
-            assertEquals(processType == ProcessType.DOMAIN_SERVER ? 19 : 21, ops.size());
-            assertTrue(ops.contains(READ_RESOURCE_OPERATION));
-            assertTrue(ops.contains(READ_ATTRIBUTE_OPERATION));
-            assertTrue(ops.contains(READ_RESOURCE_DESCRIPTION_OPERATION));
-            assertTrue(ops.contains(READ_CHILDREN_NAMES_OPERATION));
-            assertTrue(ops.contains(READ_CHILDREN_TYPES_OPERATION));
-            assertTrue(ops.contains(READ_CHILDREN_RESOURCES_OPERATION));
-            assertTrue(ops.contains(READ_OPERATION_NAMES_OPERATION));
-            assertTrue(ops.contains(READ_OPERATION_DESCRIPTION_OPERATION));
-            assertEquals(processType != ProcessType.DOMAIN_SERVER, ops.contains(WRITE_ATTRIBUTE_OPERATION));
+            assertEquals(processType == ProcessType.DOMAIN_SERVER ? 13 : 21, ops.size());
+            assertGlobalOperations(ops);
         }
 
         if (result.hasDefined(NOTIFICATIONS)) {

--- a/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/ConfigurationChangeResourceDefinition.java
+++ b/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/ConfigurationChangeResourceDefinition.java
@@ -182,6 +182,11 @@ public class ConfigurationChangeResourceDefinition extends PersistentResourceDef
         }
 
         @Override
+        protected boolean requiresRuntime(OperationContext context) {
+            return true;
+        }
+
+        @Override
         protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
             if (collector != null) {
                 ModelNode result = context.getResult().setEmptyList();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/LegacyConfigurationChangeResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/LegacyConfigurationChangeResourceDefinition.java
@@ -201,6 +201,11 @@ public class LegacyConfigurationChangeResourceDefinition extends SimpleResourceD
         }
 
         @Override
+        protected boolean requiresRuntime(OperationContext context) {
+            return true;
+        }
+
+        @Override
         protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
             if (collector != null) {
                 ModelNode result = context.getResult().setEmptyList();

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/AuditLogHandlerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/AuditLogHandlerResourceDefinition.java
@@ -120,8 +120,13 @@ public class AuditLogHandlerResourceDefinition extends SimpleResourceDefinition 
     private static class HandlerRuntimeAttributeHandler extends AbstractRuntimeOnlyHandler {
         private final ManagedAuditLogger auditLogger;
 
-        public HandlerRuntimeAttributeHandler(ManagedAuditLogger auditLogger) {
+        HandlerRuntimeAttributeHandler(ManagedAuditLogger auditLogger) {
             this.auditLogger = auditLogger;
+        }
+
+        @Override
+        protected boolean requiresRuntime(OperationContext context) {
+            return true;
         }
 
         @Override
@@ -139,8 +144,13 @@ public class AuditLogHandlerResourceDefinition extends SimpleResourceDefinition 
     private static class HandlerRecycleHandler extends AbstractRuntimeOnlyHandler {
         private final ManagedAuditLogger auditLogger;
 
-        public HandlerRecycleHandler(ManagedAuditLogger auditLogger) {
+        HandlerRecycleHandler(ManagedAuditLogger auditLogger) {
             this.auditLogger = auditLogger;
+        }
+
+        @Override
+        protected boolean requiresRuntime(OperationContext context) {
+            return true;
         }
 
         @Override
@@ -152,7 +162,7 @@ public class AuditLogHandlerResourceDefinition extends SimpleResourceDefinition 
     static class HandlerRemoveHandler extends AbstractRemoveStepHandler {
         private final ManagedAuditLogger auditLogger;
 
-        public HandlerRemoveHandler(ManagedAuditLogger auditLogger) {
+        HandlerRemoveHandler(ManagedAuditLogger auditLogger) {
             this.auditLogger = auditLogger;
         }
 
@@ -176,7 +186,7 @@ public class AuditLogHandlerResourceDefinition extends SimpleResourceDefinition 
         final ManagedAuditLogger auditLogger;
         final PathManagerService pathManager;
 
-        public HandlerWriteAttributeHandler(ManagedAuditLogger auditLogger, PathManagerService pathManager, AttributeDefinition... attributeDefinitions) {
+        HandlerWriteAttributeHandler(ManagedAuditLogger auditLogger, PathManagerService pathManager, AttributeDefinition... attributeDefinitions) {
             super(attributeDefinitions);
             this.auditLogger = auditLogger;
             this.pathManager = pathManager;

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/InMemoryAuditLogHandlerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/InMemoryAuditLogHandlerResourceDefinition.java
@@ -124,8 +124,13 @@ public class InMemoryAuditLogHandlerResourceDefinition extends AuditLogHandlerRe
     protected static class ShowInMemoryLogsHandler extends AbstractRuntimeOnlyHandler {
         private final ManagedAuditLogger auditLogger;
 
-        public ShowInMemoryLogsHandler(ManagedAuditLogger auditLogger) {
+        ShowInMemoryLogsHandler(ManagedAuditLogger auditLogger) {
             this.auditLogger = auditLogger;
+        }
+
+        @Override
+        protected boolean requiresRuntime(OperationContext context) {
+            return true;
         }
 
         @Override

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronRuntimeOnlyHandler.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronRuntimeOnlyHandler.java
@@ -20,20 +20,17 @@ package org.wildfly.extension.elytron;
 
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationFailedException;
-import org.jboss.dmr.ModelNode;
 
 /**
- * Extends the {@link AbstractRuntimeOnlyHandler} only {@linkplain #execute(OperationContext, ModelNode) executing} the
- * if the {@link #isServerOrHostController(OperationContext)} returns {@code true}.
+ * Extends the {@link AbstractRuntimeOnlyHandler} only {@linkplain #requiresRuntime(OperationContext) requring the runtime step }
+ * if {@link #isServerOrHostController(OperationContext)} returns {@code true}.
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 abstract class ElytronRuntimeOnlyHandler extends AbstractRuntimeOnlyHandler implements ElytronOperationStepHandler {
+
     @Override
-    public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-        if (isServerOrHostController(context)) {
-            super.execute(context, operation);
-        }
+    protected boolean requiresRuntime(OperationContext context) {
+        return isServerOrHostController(context);
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationCoordinatorStepHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationCoordinatorStepHandler.java
@@ -97,7 +97,7 @@ public class OperationCoordinatorStepHandler {
                 executeDirect(context, operation, false); // don't need to check private as we are just going to forward this
             }
         }
-        else if (!routing.isTwoStep()) {
+        else if (!routing.isMultiphase()) {
             // It's a domain or host level op (probably a read) that does not require bringing in other hosts or servers
             executeDirect(context, operation, true);
         }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationRouting.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationRouting.java
@@ -168,7 +168,7 @@ class OperationRouting {
                 boolean twoStep = false;
                 for (ModelNode step : operation.get(STEPS).asList()) {
                     OperationRouting stepRouting = determineRouting(step, localHostControllerInfo, rootRegistration, hostNames);
-                    if (stepRouting.isTwoStep()) {
+                    if (stepRouting.isMultiphase()) {
                         twoStep = true;
                         // Make sure we don't loose the information that we have to execute the operation on all hosts
                         fwdToAllHosts = fwdToAllHosts || stepRouting.getHosts().isEmpty();
@@ -220,56 +220,56 @@ class OperationRouting {
     }
 
     private final Set<String> hosts = new HashSet<String>();
-    private final boolean twoStep;
+    private final boolean multiphase;
 
     /** Constructor for domain-level requests where we are not master */
     private OperationRouting() {
-        twoStep = false;
+        multiphase = false;
     }
 
-    /** Constructor for multi-host ops */
-    private OperationRouting(final boolean twoStep) {
-        this.twoStep = twoStep;
+    /** Constructor for multi-process ops */
+    private OperationRouting(final boolean multiphase) {
+        this.multiphase = multiphase;
     }
 
     /**
-     * Constructor for a non-two-step request routed to this host
+     * Constructor for a non-multiphase request routed to this host
      *
      * @param localHostControllerInfo information describing this host
      */
     private OperationRouting(LocalHostControllerInfo localHostControllerInfo) {
         this.hosts.add(localHostControllerInfo.getLocalHostName());
-        this.twoStep = false;
+        this.multiphase = false;
     }
 
     /**
      * Constructor for a request routed to a single host
      *
      * @param hosts the name of the hosts
-     * @param twoStep true if a two-step execution is needed
+     * @param multiphase true if a multiphase execution is needed
      */
-    private OperationRouting(Set<String> hosts, boolean twoStep) {
+    private OperationRouting(Set<String> hosts, boolean multiphase) {
         this.hosts.addAll(hosts);
-        this.twoStep = twoStep;
+        this.multiphase = multiphase;
     }
 
-    public Set<String> getHosts() {
+    Set<String> getHosts() {
         return hosts;
     }
 
-    public String getSingleHost() {
+    String getSingleHost() {
         return hosts.size() == 1 ? hosts.iterator().next() : null;
     }
 
-    public boolean isTwoStep() {
-        return twoStep;
+    boolean isMultiphase() {
+        return multiphase;
     }
 
-    public boolean isLocalOnly(final String localHostName) {
+    boolean isLocalOnly(final String localHostName) {
         return hosts.size() == 1 && hosts.contains(localHostName);
     }
 
-    public boolean isLocalCallNeeded(final String localHostName) {
+    boolean isLocalCallNeeded(final String localHostName) {
         return hosts.size() == 0 || hosts.contains(localHostName);
     }
 
@@ -277,7 +277,7 @@ class OperationRouting {
     public String toString() {
         return "OperationRouting{" +
                 "hosts=" + hosts +
-                ", twoStep=" + twoStep +
+                ", multiphase=" + multiphase +
                 '}';
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
@@ -162,7 +162,9 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
         final PathAddress relativeAddress = domainOpAddress.subAddress(originalAddress.size());
         if(! pushToServers) {
             Set<OperationEntry.Flag> flags = originalRegistration.getOperationFlags(relativeAddress, domainOp.require(OP).asString());
-            if (flags.contains(OperationEntry.Flag.READ_ONLY) && !flags.contains(OperationEntry.Flag.DOMAIN_PUSH_TO_SERVERS)) {
+            if (flags.contains(OperationEntry.Flag.READ_ONLY)
+                    && !flags.contains(OperationEntry.Flag.DOMAIN_PUSH_TO_SERVERS)
+                    && !flags.contains(OperationEntry.Flag.RUNTIME_ONLY)) {
                 result = Collections.emptyMap();
             }
         }

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
@@ -24,6 +24,8 @@
 
 package org.wildfly.extension.io;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -201,14 +203,17 @@ class WorkerResourceDefinition extends PersistentResourceDefinition {
 
         public void execute(OperationContext outContext, ModelNode operation) throws OperationFailedException {
             populateValueFromModel(outContext, operation);
-            outContext.addStep((context, op) -> {
-                XnioWorker worker = getXnioWorker(context);
-                if (worker != null) {
-                    executeWithWorker(context, op, worker);
-                }
-            }, OperationContext.Stage.RUNTIME);
+            if (!PROFILE.equals(outContext.getCurrentAddress().getElement(0).getKey())) {
+                outContext.addStep((context, op) -> {
+                    XnioWorker worker = getXnioWorker(context);
+                    if (worker != null) {
+                        executeWithWorker(context, op, worker);
+                    }
+                }, OperationContext.Stage.RUNTIME);
+            }
         }
-         abstract void executeWithWorker(OperationContext context, ModelNode operation, XnioWorker worker) throws OperationFailedException;
+
+        abstract void executeWithWorker(OperationContext context, ModelNode operation, XnioWorker worker) throws OperationFailedException;
     }
 
     private abstract static class WorkerWriteAttributeHandler extends AbstractWriteAttributeHandler {

--- a/patching/src/main/java/org/jboss/as/patching/management/LocalPatchOperationStepHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/LocalPatchOperationStepHandler.java
@@ -47,7 +47,14 @@ public final class LocalPatchOperationStepHandler implements OperationStepHandle
 
     @Override
     public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+        if (context.getCurrentStage() == OperationContext.Stage.MODEL) {
+            context.addStep(this::executeRuntime, OperationContext.Stage.RUNTIME);
+        } else {
+            executeRuntime(context, operation);
+        }
+    }
 
+    private void executeRuntime(final OperationContext context, final ModelNode operation) throws OperationFailedException {
         // Acquire the lock and check the write permissions for this operation
         final ServiceRegistry registry = context.getServiceRegistry(true);
         final InstallationManager installationManager = (InstallationManager) registry.getRequiredService(InstallationManagerService.NAME).getValue();

--- a/patching/src/main/java/org/jboss/as/patching/management/PatchInfoHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/PatchInfoHandler.java
@@ -22,8 +22,13 @@
 
 package org.jboss.as.patching.management;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.OperationContext.Stage;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
@@ -48,39 +53,48 @@ public class PatchInfoHandler extends PatchStreamResourceOperationStepHandler {
     public static final PatchInfoHandler INSTANCE = new PatchInfoHandler();
 
     @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        String patchId = PatchResourceDefinition.PATCH_ID_OPTIONAL.resolveModelAttribute(context, operation).asStringOrNull();
+
+        if (patchId != null) {
+            super.execute(context, operation);
+        } else {
+            final ModelNode readResource = new ModelNode();
+            readResource.get(OP_ADDR).set(operation.get(OP_ADDR));
+            readResource.get(OP).set(READ_RESOURCE_OPERATION);
+            readResource.get(RECURSIVE).set(true);
+            readResource.get(INCLUDE_RUNTIME).set(true);
+            final OperationStepHandler readResHandler = context.getRootResourceRegistration().getOperationHandler(PathAddress.EMPTY_ADDRESS, READ_RESOURCE_OPERATION);
+            context.addStep(readResource, readResHandler, OperationContext.Stage.MODEL);
+        }
+    }
+
+    @Override
     protected void execute(final OperationContext context, final ModelNode operation, final InstalledIdentity installedIdentity) throws OperationFailedException {
 
-        final ModelNode patchIdNode = PatchResourceDefinition.PATCH_ID_OPTIONAL.resolveModelAttribute(context, operation);
-        final String patchId = patchIdNode.isDefined() ? patchIdNode.asString() : null;
+        String patchId = PatchResourceDefinition.PATCH_ID_OPTIONAL.resolveModelAttribute(context, operation).asStringOrNull();
+        assert patchId != null;  // the overridden execute(OperationContext context, ModelNode operation) ensures not
 
-        if(patchId == null) {
-            final ModelNode readResource = new ModelNode();
-            readResource.get("address").set(operation.get("address"));
-            readResource.get("operation").set("read-resource");
-            readResource.get("recursive").set(true);
-            readResource.get("include-runtime").set(true);
-            final OperationStepHandler readResHandler = context.getRootResourceRegistration().getOperationHandler(PathAddress.EMPTY_ADDRESS, "read-resource");
-            context.addStep(readResource, readResHandler, Stage.MODEL);
+        final boolean verbose = PatchResourceDefinition.VERBOSE.resolveModelAttribute(context, operation).asBoolean();
+        final PatchableTarget.TargetInfo info;
+        try {
+            info = installedIdentity.getIdentity().loadTargetInfo();
+        } catch (Exception e) {
+            throw new OperationFailedException(PatchLogger.ROOT_LOGGER.failedToLoadInfo(installedIdentity.getIdentity().getName()), e);
+        }
+
+        final PatchingHistory.Iterator i = PatchingHistory.Factory.iterator(installedIdentity, info);
+        final ModelNode result = patchIdInfo(context, patchId, verbose, i);
+        if (result == null) {
+            context.getFailureDescription().set(PatchLogger.ROOT_LOGGER.patchNotFoundInHistory(patchId).getLocalizedMessage());
         } else {
-            final boolean verbose = PatchResourceDefinition.VERBOSE.resolveModelAttribute(context, operation).asBoolean();
-            final PatchableTarget.TargetInfo info;
-            try {
-                info = installedIdentity.getIdentity().loadTargetInfo();
-            } catch (Exception e) {
-                throw new OperationFailedException(PatchLogger.ROOT_LOGGER.failedToLoadInfo(installedIdentity.getIdentity().getName()), e);
-            }
-
-            final PatchingHistory.Iterator i = PatchingHistory.Factory.iterator(installedIdentity, info);
-            final ModelNode result = patchIdInfo(context, patchId, verbose, i);
-            if (result == null) {
-                context.getFailureDescription().set(PatchLogger.ROOT_LOGGER.patchNotFoundInHistory(patchId).getLocalizedMessage());
-            }
             context.getResult().set(result);
         }
+
         context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
     }
 
-    protected ModelNode patchIdInfo(final OperationContext context, final String patchId, final boolean verbose, final PatchingHistory.Iterator i) {
+    private ModelNode patchIdInfo(final OperationContext context, final String patchId, final boolean verbose, final PatchingHistory.Iterator i) {
         while(i.hasNext()) {
             final Entry entry = i.next();
             if(patchId.equals(entry.getPatchId())) {

--- a/patching/src/main/java/org/jboss/as/patching/management/PatchStreamResourceOperationStepHandler.java
+++ b/patching/src/main/java/org/jboss/as/patching/management/PatchStreamResourceOperationStepHandler.java
@@ -43,6 +43,14 @@ abstract class PatchStreamResourceOperationStepHandler implements OperationStepH
 
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        if (context.getCurrentStage() == OperationContext.Stage.MODEL) {
+            context.addStep(this::executeRuntime, OperationContext.Stage.RUNTIME);
+        } else {
+            executeRuntime(context, operation);
+        }
+    }
+
+    private void executeRuntime(OperationContext context, ModelNode operation) throws OperationFailedException {
         context.acquireControllerLock();
         execute(context, operation, getInstallationManager(context), getPatchStreamName(context));
     }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/AbstractPlatformMBeanAttributeHandler.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/AbstractPlatformMBeanAttributeHandler.java
@@ -42,8 +42,8 @@ import org.jboss.dmr.ModelNode;
  */
 abstract class AbstractPlatformMBeanAttributeHandler implements OperationStepHandler {
 
-    protected final ParametersValidator readAttributeValidator = new ParametersValidator();
-    protected final ParametersValidator writeAttributeValidator = new ParametersValidator();
+    private final ParametersValidator readAttributeValidator = new ParametersValidator();
+    final ParametersValidator writeAttributeValidator = new ParametersValidator();
 
     protected AbstractPlatformMBeanAttributeHandler() {
         readAttributeValidator.registerValidator(NAME, new StringLengthValidator(1));
@@ -55,10 +55,10 @@ abstract class AbstractPlatformMBeanAttributeHandler implements OperationStepHan
         String op = operation.require(OP).asString();
         if (READ_ATTRIBUTE_OPERATION.equals(op)) {
             readAttributeValidator.validate(operation);
-            executeReadAttribute(context, operation);
+            context.addStep(this::executeReadAttribute, OperationContext.Stage.RUNTIME);
         } else if (WRITE_ATTRIBUTE_OPERATION.equals(op)) {
             writeAttributeValidator.validate(operation);
-            executeWriteAttribute(context, operation);
+            context.addStep(this::executeWriteAttribute, OperationContext.Stage.RUNTIME);
         }
 
         context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/ActiveRequestsReadHandler.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/ActiveRequestsReadHandler.java
@@ -36,6 +36,11 @@ import org.jboss.msc.service.ServiceController;
 class ActiveRequestsReadHandler extends AbstractRuntimeOnlyHandler {
 
     @Override
+    protected boolean requiresRuntime(OperationContext context) {
+        return true; // in WildFly 10 this worked in admin-only and there's no particular reason it shouldn't now
+    }
+
+    @Override
     protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
         ServiceController<?> service = context.getServiceRegistry(false).getService(RequestController.SERVICE_NAME);
         if(service != null) {

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ModuleLoadingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ModuleLoadingResourceDefinition.java
@@ -115,6 +115,11 @@ public class ModuleLoadingResourceDefinition extends SimpleResourceDefinition {
     private static class ListModuleRootsHandler extends AbstractRuntimeOnlyHandler {
 
         @Override
+        protected boolean requiresRuntime(OperationContext context) {
+            return true;
+        }
+
+        @Override
         protected boolean resourceMustExist(OperationContext context, ModelNode operation) {
             return false;
         }

--- a/server/src/main/java/org/jboss/as/server/operations/ServerProcessStateHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerProcessStateHandler.java
@@ -59,6 +59,10 @@ public class ServerProcessStateHandler implements OperationStepHandler {
 
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        context.addStep(this::doExecute, OperationContext.Stage.RUNTIME);
+    }
+
+    private void doExecute(OperationContext context, ModelNode operation) throws OperationFailedException {
         // Acquire the lock and check the write permissions for this operation
         context.getServiceRegistry(true);
         if (reload) {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OperationTimeoutTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OperationTimeoutTestCase.java
@@ -219,7 +219,7 @@ public class OperationTimeoutTestCase {
     @Test
     public void testPrePrepareHangOnSlaveHC() throws Exception {
         long start = System.currentTimeMillis();
-        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.RUNTIME);
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.MODEL);
         String id = findActiveOperation(masterClient, "slave", null, "block", null, start);
         ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
         assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -62,6 +62,7 @@ import org.junit.runners.Suite;
         OperationWarningTestsCase.class,
         PrivateHiddenOperationsTestCase.class,
         ResponseStreamTestCase.class,
+        RuntimeOnlyOperationsTestCase.class,
         ServerRestartRequiredTestCase.class,
         ValidateAddressOperationTestCase.class,
         ValidateOperationOperationTestCase.class,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/PrivateHiddenOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/PrivateHiddenOperationsTestCase.java
@@ -101,6 +101,8 @@ public class PrivateHiddenOperationsTestCase {
             }
         }
 
+        ExtensionUtils.deleteExtensionModule(OpTypesExtension.EXTENSION_NAME);
+
         testSupport = null;
         managementClient = null;
         DomainTestSuite.stopSupport();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/RuntimeOnlyOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/RuntimeOnlyOperationsTestCase.java
@@ -137,11 +137,18 @@ public class RuntimeOnlyOperationsTestCase {
         runtimeOnlyTest("domain-runtime-private", false);
     }
 
+    @Test
+    public void testRuntimeReadOnlyOp() throws IOException {
+        runtimeOnlyTest("runtime-read-only", true);
+    }
+
     private void runtimeOnlyTest(String opName, boolean directServerSuccess) throws IOException {
         ModelNode op = Util.createEmptyOperation(opName, PROFILE.append(SUBSYSTEM));
         ModelNode response = executeOp(op, SUCCESS);
         assertFalse(response.toString(), response.hasDefined(RESULT)); // handler doesn't set a result on profile
+        assertTrue(response.toString(), response.hasDefined(SERVER_GROUPS, "main-server-group", "host", "master", "main-one", "response", "result"));
         assertTrue(response.toString(), response.get(SERVER_GROUPS, "main-server-group", "host", "master", "main-one", "response", "result").asBoolean());
+        assertTrue(response.toString(), response.hasDefined(SERVER_GROUPS, "main-server-group", "host", "slave", "main-three", "response", "result"));
         assertTrue(response.toString(), response.get(SERVER_GROUPS, "main-server-group", "host", "slave", "main-three", "response", "result").asBoolean());
 
         // Now check direct invocation on servers

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/RuntimeOnlyOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/RuntimeOnlyOperationsTestCase.java
@@ -1,0 +1,217 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST_FAILURE_DESCRIPTIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+import org.jboss.as.test.integration.management.extension.ExtensionUtils;
+import org.jboss.as.test.integration.management.extension.optypes.OpTypesExtension;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.core.testrunner.ManagementClient;
+
+/**
+ * Tests behavior of runtime-only operations registered against domain profile resources.
+ *
+ * @author Brian Stansberry
+ */
+public class RuntimeOnlyOperationsTestCase {
+
+    private static final PathAddress MASTER = PathAddress.pathAddress(ModelDescriptionConstants.HOST, "master");
+    private static final PathAddress SLAVE = PathAddress.pathAddress(ModelDescriptionConstants.HOST, "slave");
+
+    private static final PathAddress EXT = PathAddress.pathAddress("extension", OpTypesExtension.EXTENSION_NAME);
+    private static final PathAddress PROFILE = PathAddress.pathAddress("profile", "default");
+    private static final PathElement SUBSYSTEM = PathElement.pathElement("subsystem", OpTypesExtension.SUBSYSTEM_NAME);
+    private static final PathElement MAIN_ONE = PathElement.pathElement("server", "main-one");
+    private static final PathElement MAIN_THREE = PathElement.pathElement("server", "main-three");
+
+    private static DomainTestSupport testSupport;
+    private static ManagementClient managementClient;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(RuntimeOnlyOperationsTestCase.class.getSimpleName());
+        DomainClient masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+        managementClient = new ManagementClient(masterClient, TestSuiteEnvironment.getServerAddress(), 9090, "remoting+http");
+
+
+        ExtensionUtils.createExtensionModule(OpTypesExtension.EXTENSION_NAME, OpTypesExtension.class,
+                EmptySubsystemParser.class.getPackage());
+
+        executeOp(Util.createAddOperation(EXT), SUCCESS);
+        executeOp(Util.createAddOperation(PROFILE.append(SUBSYSTEM)), SUCCESS);
+
+        executeOp(Util.createAddOperation(MASTER.append(EXT)), SUCCESS);
+        executeOp(Util.createAddOperation(MASTER.append(SUBSYSTEM)), SUCCESS);
+
+        executeOp(Util.createAddOperation(SLAVE.append(EXT)), SUCCESS);
+        executeOp(Util.createAddOperation(SLAVE.append(SUBSYSTEM)), SUCCESS);
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws IOException {
+        Throwable t = null;
+        List<ModelNode> ops = new ArrayList<>();
+        ops.add(Util.createRemoveOperation(MASTER.append(SUBSYSTEM)));
+        ops.add(Util.createRemoveOperation(MASTER.append(EXT)));
+        ops.add(Util.createRemoveOperation(SLAVE.append(SUBSYSTEM)));
+        ops.add(Util.createRemoveOperation(SLAVE.append(EXT)));
+        ops.add(Util.createRemoveOperation(PROFILE.append(SUBSYSTEM)));
+        ops.add(Util.createRemoveOperation(EXT));
+        for (ModelNode op : ops) {
+            try {
+                executeOp(op, SUCCESS);
+            } catch (IOException | AssertionError e) {
+                if (t == null) {
+                    t = e;
+                }
+            }
+        }
+
+        ExtensionUtils.deleteExtensionModule(OpTypesExtension.EXTENSION_NAME);
+
+        testSupport = null;
+        managementClient = null;
+        DomainTestSuite.stopSupport();
+
+        if (t instanceof IOException) {
+            throw (IOException) t;
+        } else if (t != null) {
+            throw (Error) t;
+        }
+    }
+
+    @Test
+    public void testStandardOp() throws IOException {
+        // Invoke the op on the profile resource and on the servers indivdually
+        // Expect all to succeed
+        runtimeOnlyTest("runtime-only", true);
+    }
+
+    @Test
+    public void testPrivateOnServerOp() throws IOException {
+        // Invoke the op on the profile resource and on the servers indivdually
+        // Expect the server ops to fail as they are private (see WFCORE-13)
+        runtimeOnlyTest("domain-runtime-private", false);
+    }
+
+    private void runtimeOnlyTest(String opName, boolean directServerSuccess) throws IOException {
+        ModelNode op = Util.createEmptyOperation(opName, PROFILE.append(SUBSYSTEM));
+        ModelNode response = executeOp(op, SUCCESS);
+        assertFalse(response.toString(), response.hasDefined(RESULT)); // handler doesn't set a result on profile
+        assertTrue(response.toString(), response.get(SERVER_GROUPS, "main-server-group", "host", "master", "main-one", "response", "result").asBoolean());
+        assertTrue(response.toString(), response.get(SERVER_GROUPS, "main-server-group", "host", "slave", "main-three", "response", "result").asBoolean());
+
+        // Now check direct invocation on servers
+        op = Util.createEmptyOperation(opName, MASTER.append(MAIN_ONE).append(SUBSYSTEM));
+        response = executeOp(op, directServerSuccess ? SUCCESS : FAILED);
+        if (directServerSuccess) {
+            assertTrue(response.toString(), response.get(RESULT).asBoolean());
+        }
+        op = Util.createEmptyOperation(opName, SLAVE.append(MAIN_THREE).append(SUBSYSTEM));
+        response = executeOp(op, directServerSuccess ? SUCCESS : FAILED);
+        if (directServerSuccess) {
+            assertTrue(response.toString(), response.get(RESULT).asBoolean());
+        }
+    }
+
+    @Test
+    public void testRuntimeOnlyAttribute() throws IOException {
+        attributeTest("runtime-only-attr", "read-only");
+    }
+
+    @Test
+    public void testMetric() throws IOException {
+        attributeTest("metric", "metric");
+    }
+
+    private void attributeTest(String attribute, String accessType) throws IOException {
+        ModelNode op = Util.getReadResourceDescriptionOperation(PROFILE.append(SUBSYSTEM));
+        ModelNode resp = executeOp(op, SUCCESS);
+        assertTrue(resp.toString(), resp.hasDefined(RESULT, ATTRIBUTES));
+        // non storage=configuration attributes should not get registered even though the ResourceDefinition tries
+        assertFalse(resp.toString(), resp.has(RESULT, ATTRIBUTES, attribute));
+
+        op = Util.getReadAttributeOperation(PROFILE.append(SUBSYSTEM), attribute);
+        executeOp(op, FAILED);
+
+        op = Util.getReadResourceDescriptionOperation(SLAVE.append(MAIN_THREE).append(SUBSYSTEM));
+        resp = executeOp(op, SUCCESS);
+        assertEquals(resp.toString(), accessType, resp.get(RESULT, ATTRIBUTES, attribute, ACCESS_TYPE).asString());
+
+        op = Util.getReadAttributeOperation(SLAVE.append(MAIN_THREE).append(SUBSYSTEM), attribute);
+        resp = executeOp(op, SUCCESS);
+        assertTrue(resp.toString(), resp.get(RESULT).asBoolean());
+    }
+
+    @Test
+    public void testRuntimeStepOnMaster() throws IOException {
+        illegalRuntimeStepTest("master");
+    }
+
+    @Test
+    public void testRuntimeStepOnSlave() throws IOException {
+        illegalRuntimeStepTest("slave");
+    }
+
+    private void illegalRuntimeStepTest(String host) throws IOException {
+        ModelNode op = Util.createEmptyOperation("runtime-only", PROFILE.append(SUBSYSTEM));
+        op.get(HOST).set(host);
+        ModelNode response = executeOp(op, FAILED);
+        if ("master".equals(host)) {
+            assertTrue(response.toString(), response.hasDefined(FAILURE_DESCRIPTION, DOMAIN_FAILURE_DESCRIPTION));
+        } else {
+            assertFalse(response.toString(), response.hasDefined(FAILURE_DESCRIPTION, DOMAIN_FAILURE_DESCRIPTION));
+            assertTrue(response.toString(), response.hasDefined(FAILURE_DESCRIPTION, HOST_FAILURE_DESCRIPTIONS, "slave"));
+        }
+    }
+
+    private static ModelNode executeOp(ModelNode op, String outcome) throws IOException {
+        ModelNode response = managementClient.getControllerClient().execute(op);
+        assertTrue(response.toString(), response.hasDefined(OUTCOME));
+        assertEquals(response.toString(), outcome, response.get(OUTCOME).asString());
+        return response;
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/ExtensionUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/ExtensionUtils.java
@@ -71,11 +71,11 @@ public class ExtensionUtils {
     public static void createExtensionModule(File extensionModuleRoot, Class<? extends Extension> extension, Package... additionalPackages) throws IOException {
         deleteRecursively(extensionModuleRoot.toPath());
 
-        if (extensionModuleRoot.exists()) {
-            throw new IllegalArgumentException(extensionModuleRoot + " already exists");
+        if (extensionModuleRoot.exists() && !extensionModuleRoot.isDirectory()) {
+            throw new IllegalArgumentException(extensionModuleRoot + " already exists and is not a directory");
         }
         File file = new File(extensionModuleRoot, "main");
-        if (!file.mkdirs()) {
+        if (!file.mkdirs() && !file.exists()) {
             throw new IllegalArgumentException("Could not create " + file);
         }
         final InputStream is = createResourceRoot(extension, additionalPackages).exportAsInputStream();

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -94,6 +94,7 @@ public class BlockerExtension implements Extension {
     @Override
     public void initialize(ExtensionContext context) {
         SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
+        subsystem.setHostCapable();
         subsystem.registerSubsystemModel(new BlockerSubsystemResourceDefinition(context.getProcessType() == ProcessType.HOST_CONTROLLER));
         subsystem.registerXMLElementWriter(PARSER);
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/error/ErrorExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/error/ErrorExtension.java
@@ -94,6 +94,7 @@ public class ErrorExtension implements Extension {
     @Override
     public void initialize(ExtensionContext context) {
         SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1));
+        subsystem.setHostCapable();
         subsystem.registerSubsystemModel(new BlockerSubsystemResourceDefinition(context.getProcessType() == ProcessType.HOST_CONTROLLER));
         subsystem.registerXMLElementWriter(PARSER);
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/optypes/OpTypesExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/optypes/OpTypesExtension.java
@@ -96,6 +96,10 @@ public class OpTypesExtension implements Extension {
             .setPrivateEntry()
             .setRuntimeOnly()
             .build();
+    private static final OperationDefinition RUNTIME_READ_ONLY = new SimpleOperationDefinitionBuilder("runtime-read-only", NonResolvingResourceDescriptionResolver.INSTANCE)
+            .setReadOnly()
+            .setRuntimeOnly()
+            .build();
 
     private static final AttributeDefinition RUNTIME_ONLY_ATTR = SimpleAttributeDefinitionBuilder.create("runtime-only-attr", ModelType.BOOLEAN)
             .setRequired(false)
@@ -138,6 +142,7 @@ public class OpTypesExtension implements Extension {
             resourceRegistration.registerOperationHandler(HIDDEN, NoopOperationStepHandler.WITH_RESULT);
             resourceRegistration.registerOperationHandler(PRIVATE, NoopOperationStepHandler.WITH_RESULT);
             resourceRegistration.registerOperationHandler(RUNTIME_ONLY, RuntimeOnlyHandler.INSTANCE);
+            resourceRegistration.registerOperationHandler(RUNTIME_READ_ONLY, RuntimeOnlyHandler.INSTANCE);
 
             if (processType == ProcessType.DOMAIN_SERVER) {
                 resourceRegistration.registerOperationHandler(DOMAIN_HIDDEN, NoopOperationStepHandler.WITH_RESULT);


### PR DESCRIPTION
Previously we didn't support runtime-only ops on profile resources, although at least for ops not marked as read-only, they actually work fine, and a couple have gotten in undetected. This PR is about formalizing support for them, mostly by cleaning up some ease of use things and adding some safeguards, plus it adds support for read-only behavior (WFCORE-2858).

https://issues.jboss.org/browse/WFCORE-389
https://issues.jboss.org/browse/WFCORE-2858
https://issues.jboss.org/browse/WFCORE-2815
https://issues.jboss.org/browse/WFCORE-2816
https://issues.jboss.org/browse/WFCORE-2823
https://issues.jboss.org/browse/WFCORE-2849
https://issues.jboss.org/browse/WFCORE-2870
https://issues.jboss.org/browse/WFCORE-2873

This DOES NOT resolve WFCORE-2850; it has a commit that is part one of a two phase change, with the 2nd phase following related changes in full.