### PR TITLE
[WFCORE-2632][JBEAP-10169] remove service "org.wildfly.security.secur…

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
@@ -508,6 +508,13 @@ class DomainDefinition extends SimpleResourceDefinition {
         }
 
         @Override
+        protected void removeServices(final OperationContext context, final ServiceName parentService, final ModelNode parentModel) throws OperationFailedException {
+            // WFCORE-2632, just for security-domain, remove also service with initial suffix.
+            context.removeService(parentService.append(INITIAL));
+            super.removeServices(context, parentService, parentModel);
+        }
+
+        @Override
         protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel)
                 throws OperationFailedException {
             installService(context, getParentServiceName(parentAddress), parentModel);


### PR DESCRIPTION
…ity-domain.ManagementDomain.initial" before its service recreation.

https://issues.jboss.org/browse/WFCORE-2632

Override applyUpdateToRuntime method to remove both services org.wildfly.security.security-domain.ManagementDomain and org.wildfly.security.security-domain.ManagementDomain.initial before recreating both of them.

more notes on https://issues.jboss.org/browse/JBEAP-10169

