### PR TITLE
[WFCORE-2828]: org.wildfly.core.test.standalone.mgmt.events.ProcessStateListenerTestCase from wf-core fails intermittently

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3492,4 +3492,8 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = 441, value = "Operation has resulted in failed or missing services %n")
     String serviceStatusReportFailureHeader();
+
+    @LogMessage(level = Level.WARN)
+    @Message(id = 442, value = "Error stopping server")
+    void errorStoppingServer(@Cause Exception cause);
 }

--- a/core-management/core-management-client/src/main/java/org/wildfly/extension/core/management/client/RunningStateChangeEvent.java
+++ b/core-management/core-management-client/src/main/java/org/wildfly/extension/core/management/client/RunningStateChangeEvent.java
@@ -42,4 +42,9 @@ public class RunningStateChangeEvent {
         return newState;
     }
 
+    @Override
+    public String toString() {
+        return "RunningStateChangeEvent{" + "oldState=" + oldState + ", newState=" + newState + '}';
+    }
+
 }

--- a/core-management/core-management-client/src/main/java/org/wildfly/extension/core/management/client/RuntimeConfigurationStateChangeEvent.java
+++ b/core-management/core-management-client/src/main/java/org/wildfly/extension/core/management/client/RuntimeConfigurationStateChangeEvent.java
@@ -40,4 +40,9 @@ public class RuntimeConfigurationStateChangeEvent {
         return oldState;
     }
 
+    @Override
+    public String toString() {
+        return "RuntimeConfigurationStateChangeEvent{" + "newState=" + newState + ", oldState=" + oldState + '}';
+    }
+
 }

--- a/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/logging/CoreManagementLogger.java
+++ b/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/logging/CoreManagementLogger.java
@@ -31,7 +31,6 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
-import org.jboss.modules.ModuleIdentifier;
 
 /**
  *
@@ -64,11 +63,11 @@ public interface CoreManagementLogger extends BasicLogger {
     void processStateCleanupError(@Cause Throwable t, final String name);
 
     @Message(id = 6, value = "Error to load module %s")
-    OperationFailedException errorToLoadModule(ModuleIdentifier moduleID);
+    OperationFailedException errorToLoadModule(String moduleID);
 
     @Message(id = 7, value = "Error to load class %s from module %s")
-    OperationFailedException errorToLoadModuleClass(String className, ModuleIdentifier moduleID);
+    OperationFailedException errorToLoadModuleClass(String className, String moduleID);
 
     @Message(id = 8, value = "Error to instantiate instance of class %s from module %s")
-    OperationFailedException errorToInstantiateClassInstanceFromModule(String className, ModuleIdentifier moduleID);
+    OperationFailedException errorToInstantiateClassInstanceFromModule(String className, String moduleID);
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/NativeManagementServices.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/NativeManagementServices.java
@@ -56,7 +56,7 @@ public class NativeManagementServices {
             ManagementRemotingServices.installManagementChannelServices(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
                     new ModelControllerClientOperationHandlerFactoryService(),
                     DomainModelControllerService.SERVICE_NAME, ManagementRemotingServices.MANAGEMENT_CHANNEL,
-                    HostControllerService.HC_EXECUTOR_SERVICE_NAME, HostControllerService.HC_SCHEDULED_EXECUTOR_SERVICE_NAME);
+                    DomainModelControllerService.EXECUTOR_CAPABILITY.getCapabilityServiceName(), HostControllerService.HC_SCHEDULED_EXECUTOR_SERVICE_NAME);
         }
     }
 }

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementServices.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementServices.java
@@ -1,5 +1,6 @@
 package org.jboss.as.server.operations;
 
+
 import org.jboss.as.controller.remote.ModelControllerClientOperationHandlerFactoryService;
 import org.jboss.as.remoting.EndpointService;
 import org.jboss.as.remoting.management.ManagementChannelRegistryService;
@@ -45,7 +46,7 @@ class NativeManagementServices {
                     new ModelControllerClientOperationHandlerFactoryService(),
                     Services.JBOSS_SERVER_CONTROLLER,
                     ManagementRemotingServices.MANAGEMENT_CHANNEL,
-                    Services.JBOSS_SERVER_EXECUTOR,
+                    ServerService.EXECUTOR_CAPABILITY.getCapabilityServiceName(),
                     ServerService.JBOSS_SERVER_SCHEDULED_EXECUTOR);
 
         }

--- a/server/src/main/java/org/jboss/as/server/operations/NativeRemotingManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeRemotingManagementAddHandler.java
@@ -73,7 +73,7 @@ public class NativeRemotingManagementAddHandler extends ManagementInterfaceAddSt
                 new ModelControllerClientOperationHandlerFactoryService(),
                 Services.JBOSS_SERVER_CONTROLLER,
                 ManagementRemotingServices.MANAGEMENT_CHANNEL,
-                Services.JBOSS_SERVER_EXECUTOR,
+                ServerService.EXECUTOR_CAPABILITY.getCapabilityServiceName(),
                 ServerService.JBOSS_SERVER_SCHEDULED_EXECUTOR);
         List<ServiceName> requiredServices = Collections.singletonList(RemotingServices.channelServiceName(endpointName, ManagementRemotingServices.MANAGEMENT_CHANNEL));
         addVerifyInstallationStep(context, requiredServices);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/ProcessStateListenerTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/events/ProcessStateListenerTestCase.java
@@ -302,8 +302,8 @@ public class ProcessStateListenerTestCase {
         public void verify() throws IOException {
             List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
             //MatcherAssert.assertThat(lines, Is.is(changes));
-            for (int i = 0; i < lines.size(); i++) {
-                Assert.assertThat("Incorrect match at line " + i, lines.get(i), is(changes.get(i)));
+            for(int i = 0; i <lines.size(); i++) {
+                Assert.assertThat("Incorrect match at line " + i + " " + lines.get(i), lines.get(i), is(changes.get(i)));
             }
         }
     }

--- a/testsuite/shared/src/main/java/org/wildfly/test/events/provider/ListenerFailureException.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/events/provider/ListenerFailureException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wildfly.test.events.provider;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class ListenerFailureException extends RuntimeException{
+
+    public ListenerFailureException() {
+    }
+
+    public ListenerFailureException(String message) {
+        super(message);
+    }
+
+    public ListenerFailureException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ListenerFailureException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/events/provider/TestListener.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/events/provider/TestListener.java
@@ -104,14 +104,18 @@ public class TestListener implements ProcessStateListener {
     @Override
     public void runtimeConfigurationStateChanged(RuntimeConfigurationStateChangeEvent evt) {
         if (parameters.getInitProperties().containsKey(FAIL_RUNTIME_CONFIGURATION_STATE_CHANGED)) {
-            throw new NullPointerException(FAIL_RUNTIME_CONFIGURATION_STATE_CHANGED);
+            throw new ListenerFailureException(FAIL_RUNTIME_CONFIGURATION_STATE_CHANGED);
         }
         try {
             if (parameters.getInitProperties().containsKey(TIMEOUT)) {
                 long timeout = Long.parseLong(parameters.getInitProperties().get(TIMEOUT));
                 Thread.sleep(timeout);
             }
-            fileRuntimeWriter.write(String.format("%s %s %s %s\n", parameters.getProcessType(), parameters.getRunningMode(), evt.getOldState(), evt.getNewState()));
+            fileRuntimeWriter.write(String.format("%s %s %s %s\n",
+                    parameters.getProcessType(),
+                    parameters.getRunningMode(),
+                    evt.getOldState(),
+                    evt.getNewState()));
             fileRuntimeWriter.flush();
         } catch (IOException | InterruptedException e) {
             e.printStackTrace();
@@ -121,10 +125,14 @@ public class TestListener implements ProcessStateListener {
     @Override
     public void runningStateChanged(RunningStateChangeEvent evt) {
         if (parameters.getInitProperties().containsKey(FAIL_RUNNING_STATE_CHANGED)) {
-            throw new NullPointerException(FAIL_RUNNING_STATE_CHANGED);
+            throw new ListenerFailureException(FAIL_RUNNING_STATE_CHANGED);
         }
         try {
-            fileRunningWriter.write(String.format("%s %s %s %s\n", parameters.getProcessType(), parameters.getRunningMode(), evt.getOldState(), evt.getNewState()));
+            fileRunningWriter.write(String.format("%s %s %s %s\n",
+                    parameters.getProcessType(),
+                    parameters.getRunningMode(),
+                    evt.getOldState(),
+                    evt.getNewState()));
             fileRunningWriter.flush();
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Executing stopping of the server out of the management-thread for a reload.
Preventing the ProcessStateListenerService from stopping while it is notifying its listener.

Cleaning the code :
 * making the test code more usable
 * using capability name for dependencies

Jira: https://issues.jboss.org/browse/WFCORE-2828
JBEAP: https://issues.jboss.org/browse/JBEAP-10998