### PR TITLE
[WFCORE-2851] Stabilise CLIExecutor

### DIFF
--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
@@ -22,8 +22,18 @@
 
 package org.wildfly.core.test.standalone.mgmt;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.HTTPS_CONTROLLER;
+import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.MANAGEMENT_NATIVE_PORT;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import static org.junit.Assert.assertThat;
+
 import java.io.File;
 import java.io.IOException;
+
 import javax.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
@@ -46,7 +56,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ManagementClient;
@@ -54,15 +63,6 @@ import org.wildfly.core.testrunner.ServerControl;
 import org.wildfly.core.testrunner.ServerController;
 import org.wildfly.core.testrunner.ServerSetupTask;
 import org.wildfly.core.testrunner.WildflyTestRunner;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
-import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.HTTPS_CONTROLLER;
-import static org.jboss.as.test.integration.management.util.CustomCLIExecutor.MANAGEMENT_NATIVE_PORT;
-import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
-import static org.junit.Assert.assertThat;
 
 /**
  * Testing https connection to the http management interface with cli console
@@ -75,7 +75,6 @@ import static org.junit.Assert.assertThat;
 
 @RunWith(WildflyTestRunner.class)
 @ServerControl(manual = true)
-@Ignore("[WFCORE-2068] Test failure during clean up.")
 public class HTTPSConnectionWithCLITestCase {
 
     private static Logger LOGGER = Logger.getLogger(HTTPSConnectionWithCLITestCase.class);
@@ -123,7 +122,7 @@ public class HTTPSConnectionWithCLITestCase {
      */
     @Test
     public void testDefaultCLIConfiguration() throws InterruptedException, IOException {
-        String cliOutput = CustomCLIExecutor.execute(null, TESTING_OPERATION, HTTPS_CONTROLLER, true, "N");
+        String cliOutput = CustomCLIExecutor.execute(null, TESTING_OPERATION, HTTPS_CONTROLLER, true);
         assertThat("Untrusted client should not be authenticated.", cliOutput, not(containsString("\"outcome\" => \"success\"")));
 
     }


### PR DESCRIPTION
1. Use standard Process.waitFor() instead of custom polling mechanism
2. Use standard CLI option --error-on-interact instead of custom
answering "Accept Certificate?" prompt
3. Always log CLI output