### PR TITLE
[WFCORE-2855] CLIProcessWrapper - destroy the CLI process forcibly

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/cli/CliProcessWrapper.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/cli/CliProcessWrapper.java
@@ -176,7 +176,7 @@ public class CliProcessWrapper extends CliProcessBuilder {
      * @return process exit value
      */
     public void destroyProcess() {
-        cliProcess.destroy();
+        cliProcess.destroyForcibly();
     }
 
     /**
@@ -270,7 +270,7 @@ public class CliProcessWrapper extends CliProcessBuilder {
 
             // If the timeout is reached, destroy the process and return false
             if (waitingTime > resultTimeout) {
-                cliProcess.destroy();
+                cliProcess.destroyForcibly();
                 wait = false;
             }
         }


### PR DESCRIPTION
process.destroy() doesn't kill the CLI process completely on HP-UX and Solaris boxes

Jira:
https://issues.jboss.org/browse/WFCORE-2855 - CLIProcessWrapper - destroy the CLI process forcibly