### PR TITLE
WFCORE-2722: Add OTP support for identity set-password operation using filesystem-realm

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -182,6 +182,7 @@ interface ElytronDescriptionConstants {
     String HOST = "host";
     String HOST_NAME = "host-name";
     String HOST_NAME_VERIFICATION_POLICY = "host-name-verification-policy";
+    String HASH = "hash";
     String HASH_FROM = "hash-from";
     String HTTP = "http";
     String HTTP_AUTHENTICATION_FACTORY = "http-authentication-factory";
@@ -295,6 +296,7 @@ interface ElytronDescriptionConstants {
     String OBTAIN_KERBEROS_TICKET = "obtain-kerberos-ticket";
     String OID = "oid";
     String OTHER_PROVIDERS = "other-providers";
+    String OTP = "otp";
     String OTP_CREDENTIAL_MAPPER = "otp-credential-mapper";
     String OPTION = "option";
     String OPTIONS = "options";
@@ -409,6 +411,7 @@ interface ElytronDescriptionConstants {
     String SECURITY_REALMS = "security-realms";
     String SECRET_VALUE = "secret-value";
     String SELECTION_CRITERIA = "selection-criteria";
+    String SEED = "seed";
     String SEED_FROM = "seed-from";
     String SERVER_NAME = "server-name";
     String SERIAL_NUMBER = "serial-number";
@@ -424,6 +427,7 @@ interface ElytronDescriptionConstants {
     String SERVICE_LOADER_HTTP_SERVER_MECHANISM_FACTORY = "service-loader-http-server-mechanism-factory";
     String SERVICE_LOADER_SASL_SERVER_FACTORY = "service-loader-sasl-server-factory";
     String SERVICES = "services";
+    String SEQUENCE = "sequence";
     String SEQUENCE_FROM = "sequence-from";
     String SHA_1_DIGEST = "sha-1-digest";
     String SHA_256_DIGEST = "sha-256-digest";

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -800,6 +800,16 @@ elytron.modifiable-security-realm.digest.name=The credential name.
 elytron.modifiable-security-realm.digest.algorithm=The algorithm used to encrypt the password.
 elytron.modifiable-security-realm.digest.realm=The realm.
 elytron.modifiable-security-realm.digest.password=The actual password to set.
+elytron.modifiable-security-realm.otp=A one-time password, used by the OTP SASL mechanism.
+elytron.modifiable-security-realm.otp.algorithm=The algorithm used to encrypt the password.
+elytron.modifiable-security-realm.otp.hash=The hash represented by this password.
+elytron.modifiable-security-realm.otp.seed=The seed used to generate the hash.
+elytron.modifiable-security-realm.otp.sequence=The sequence number used to generate the hash.
+elytron.modifiable-security-realm.set-password.otp=A one-time password, used by the OTP SASL mechanism.
+elytron.modifiable-security-realm.set-password.algorithm=The algorithm used to encrypt the password.
+elytron.modifiable-security-realm.set-password.otp.hash=The hash represented by this password.
+elytron.modifiable-security-realm.set-password.otp.seed=The seed used to generate the hash.
+elytron.modifiable-security-realm.set-password.otp.sequence=The sequence number used to generate the hash.
 
 elytron.caching-realm=A realm definition that enables caching to another security realm. Caching strategy is LRU (Least Recently Used) where least accessed entries are discarded when maximum number of entries is reached.
 # Operations


### PR DESCRIPTION
Added the possibility to set OTP configurations for an identity using the file system realm

Jira Issues:
https://issues.jboss.org/browse/WFCORE-2722
https://issues.jboss.org/browse/JBEAP-10532
