### PR TITLE
[WFCORE-2712] Elytron - predefined-filter must have flag required in configurable-sasl-server-factory

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
@@ -164,7 +164,7 @@ class SaslServerDefinitions {
         .setRestartAllServices()
         .build();
 
-    static final SimpleAttributeDefinition PREDEFINED_FILTER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PREDEFINED_FILTER, ModelType.STRING, true)
+    static final SimpleAttributeDefinition PREDEFINED_FILTER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PREDEFINED_FILTER, ModelType.STRING, false)
         .setAllowExpression(true)
         .setXmlName(VALUE)
         .setAllowedValues(NamePredicate.names())


### PR DESCRIPTION
Elytron Subsystem: https://issues.jboss.org/browse/WFCORE-2712
JBEAP: https://issues.jboss.org/browse/JBEAP-10481