### PR TITLE
Fix for WFCORE-2832. CLI on IBM JRE connects with TLS v1.2

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.bat
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.bat
@@ -67,6 +67,9 @@ if "x%JBOSS_MODULEPATH%" == "x" (
 rem Add base package for L&F
 set "JAVA_OPTS=%JAVA_OPTS% -Djboss.modules.system.pkgs=com.sun.java.swing"
 
+rem Override ibm JRE behavior
+set "JAVA_OPTS=%JAVA_OPTS% -Dcom.ibm.jsse2.overrideDefaultTLS=true"
+
 set LOGGING_CONFIG=
 echo "%JAVA_OPTS%" | findstr /I "logging.configuration" > nul
 if errorlevel == 1 (

--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
@@ -9,6 +9,9 @@ $scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;
 
 $SERVER_OPTS = Process-Script-Parameters -Params $ARGS
 
+# Override ibm JRE behavior
+$SERVER_OPTS += "-Dcom.ibm.jsse2.overrideDefaultTLS=true"
+
 $PROG_ARGS = Get-Java-Arguments -entryModule "org.jboss.as.cli" -serverOpts $SERVER_OPTS -logFileProperties "$JBOSS_HOME/bin/jboss-cli-logging.properties"
 
 & $JAVA $PROG_ARGS

--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.sh
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.sh
@@ -67,6 +67,9 @@ else
     JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=com.sun.java.swing"
 fi
 
+# Override ibm JRE behavior
+JAVA_OPTS="$JAVA_OPTS -Dcom.ibm.jsse2.overrideDefaultTLS=true"
+
 # Sample JPDA settings for remote socket debugging
 #JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 


### PR DESCRIPTION
Updated scripts with ibm JRE system property. This will also be documented in release notes.