### PR TITLE
WFCORE-2478: Reverted allow creation of empty credential stores. The fix is implemented in wildfly-elytron

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreService.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreService.java
@@ -114,9 +114,6 @@ class CredentialStoreService implements Service<CredentialStore> {
             credentialStoreAttributes.put(CS_LOCATION_ATTRIBUTE, loc.toAbsolutePath().toString());
             credentialStore = getCredentialStoreInstance();
             credentialStore.initialize(credentialStoreAttributes, resolveCredentialStoreProtectionParameter(), otherProviders.getOptionalValue());
-            if ( credentialStoreAttributes.get(ElytronDescriptionConstants.CREATE).equals("true") && !loc.toFile().exists() ){
-                credentialStore.flush();
-            }
         } catch (Exception e) {
             throw ElytronSubsystemMessages.ROOT_LOGGER.unableToStartService(e);
         }


### PR DESCRIPTION
This issue removes some minor changes already in the master branch because it was decided to move the behaviour to wildfly-elytron. 

Jira Issues
https://issues.jboss.org/browse/WFCORE-2478
https://issues.jboss.org/browse/JBEAP-9211

depends on: https://github.com/wildfly-security/wildfly-elytron/pull/837