### PR TITLE
Fix for WFCORE-2878, CLI complete empty complex object

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/ValueTypeCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ValueTypeCompleter.java
@@ -498,6 +498,13 @@ public class ValueTypeCompleter implements CommandLineCompleter {
                 case ']':
                 case '=':
                 case ',':
+                    // If the instance is complete, buffer will be returned as is
+                    // starting at 0;
+                    if (currentInstance != null
+                            && currentInstance.parent == null
+                            && currentInstance.isComplete()) {
+                        return 0;
+                    }
                     return lastStateIndex + (valLength == 0 ? 1 : valLength);
             }
             // Some value completer compute an offset between the lastStateIndex

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/ValueTypeCompletionTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/ValueTypeCompletionTestCase.java
@@ -705,6 +705,12 @@ public class ValueTypeCompletionTestCase {
                 + "replace={pattern=cdsc},accept=true", 0, candidates);
         assertEquals(Arrays.asList("}"), candidates);
         assertEquals(109, i);
+
+        candidates.clear();
+        String str = "{}";
+        i = new ValueTypeCompleter(propDescr).complete(null, str, str.length(), candidates);
+        assertEquals(Arrays.asList(str), candidates);
+        assertEquals(0, i);
     }
 
     @Test
@@ -1527,8 +1533,13 @@ public class ValueTypeCompletionTestCase {
                 + "prop1_2={}},prop2={}}";
         i = new ValueTypeCompleter(propDescr).complete(null, cmd, 0, candidates);
         assertEquals(Arrays.asList(cmd), candidates);
-        // Is one, due to logic when lastStateChar is '}'
-        assertEquals(i, 1);
+        assertEquals(i, 0);
+
+        candidates.clear();
+        String str = "{}";
+        i = new ValueTypeCompleter(propDescr).complete(null, str, str.length(), candidates);
+        assertEquals(Arrays.asList(str), candidates);
+        assertEquals(0, i);
     }
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
@@ -66,6 +66,25 @@ public class CliCompletionTestCase {
                 assertEquals(candidates.toString(), Arrays.asList("admin-only",
                         "normal", "suspend"), candidates);
             }
+
+            {
+                String cmd = "/subsystem=elytron/token-realm=JwtRealm:add(jwt={}";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), Arrays.asList(","), candidates);
+            }
+
+            {
+                String cmd = "/subsystem=logging/logger=cdsc:add(category=cdsc,"
+                        + "filter={accept=true,all={},change-level=ALL,not={},"
+                        + "level-range={min-level=ALL,max-level=ALL,"
+                        + "max-inclusive=true,min-inclusive=false}";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), Arrays.asList(","), candidates);
+            }
         } finally {
             ctx.terminateSession();
         }


### PR DESCRIPTION
Handle special case of object being complete and lastStateChar being a separator.
Added unit tests.