### PR TITLE
WFCORE-2483 Extend HTTPSManagementInterfaceTestCase tests with usage of CR

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Constants.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Constants.java
@@ -33,6 +33,7 @@ public interface Constants {
     String ACL_MODULES = "acl-modules";
     String ADDITIONAL_PROPERTIES = "additional-properties";
     String ALGORITHM = "algorithm";
+    String ALIAS = "alias";
     String AUDIT = "audit";
     String AUDIT_MANAGER_CLASS_NAME = "audit-manager-class-name";
     String AUTH_MODULE = "auth-module";
@@ -45,6 +46,7 @@ public interface Constants {
     String CACHE_TYPE = "cache-type";
     String CIPHER_SUITES = "cipher-suites";
     String CLASSIC = "classic";
+    String CLEAR_TEXT = "clear-text";
     String CLIENT_ALIAS = "client-alias";
     String CLIENT_AUTH = "client-auth";
     String CODE = "code";
@@ -59,8 +61,11 @@ public interface Constants {
     String KEY_MANAGER = "key-manager";
     String KEY_MANAGER_FACTORY_ALGORITHM = "key-manager-factory-algorithm";
     String KEY_MANAGER_FACTORY_PROVIDER = "key-manager-factory-provider";
+    String KEY_PASSWORD = "key-password";
+    String KEY_PASSWORD_CREDENTIAL_REFERENCE = "key-password-credential-reference";
     String KEYSTORE = "keystore";
     String KEYSTORE_PASSWORD = "keystore-password";
+    String KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE = "keystore-password-credential-reference";
     String KEYSTORE_PROVIDER = "keystore-provider";
     String KEYSTORE_PROVIDER_ARGUMENT = "keystore-provider-argument";
     String KEYSTORE_TYPE = "keystore-type";
@@ -93,6 +98,7 @@ public interface Constants {
     String SECURITY_PROPERTIES = "security-properties";
     String SERVER_ALIAS = "server-alias";
     String SERVICE_AUTH_TOKEN = "service-auth-token";
+    String STORE = "store";
     String SUBJECT_FACTORY = "subject-factory";
     String SUBJECT_FACTORY_CLASS_NAME = "subject-factory-class-name";
     String SUFFICIENT = "sufficient";

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/config/realm/CredentialReference.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/config/realm/CredentialReference.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.integration.security.common.config.realm;
+
+
+/**
+ * A helper class to provide settings for credential reference.
+ *
+ * @author Martin Choma
+ */
+public class CredentialReference {
+
+    private final String store;
+    private final String alias;
+    private final String type;
+    private final String clearText;
+
+    private CredentialReference(Builder builder) {
+        this.store = builder.store;
+        this.alias = builder.alias;
+        this.type = builder.type;
+        this.clearText = builder.clearText;
+    }
+
+    /**
+     * Get the store
+     *
+     * @return the store
+     */
+    public String getStore() {
+        return store;
+    }
+
+    /**
+     * Get the alias
+     *
+     * @return alias
+     */
+    public String getAlias() {
+        return alias;
+    }
+
+    /**
+     * Get the type
+     *
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Get the clearText
+     *
+     * @return the clearText
+     */
+    public String getClearText() {
+        return clearText;
+    }
+
+    @Override
+    public String toString() {
+        return "CredentialReference [store=" + store + ", alias=" + alias + ", type=" + type + ", clearText=" + clearText + "]";
+    }
+
+    public static class Builder {
+
+        private String store;
+        private String alias;
+        private String type;
+        private String clearText;
+
+
+        public Builder store(String store) {
+            this.store = store;
+            return this;
+        }
+
+        public Builder alias(String alias) {
+            this.alias = alias;
+            return this;
+        }
+
+        public Builder type(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder clearText(String clearText) {
+            this.clearText = clearText;
+            return this;
+        }
+
+        public CredentialReference build() {
+            return new CredentialReference(this);
+        }
+    }
+
+}
+

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/config/realm/RealmKeystore.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/config/realm/RealmKeystore.java
@@ -34,6 +34,9 @@ public class RealmKeystore {
 
     private final String keystorePath;
     private final String keystorePassword;
+    private final String keyPassword;
+    private final CredentialReference keystorePasswordCredentialReference;
+    private final CredentialReference keyPasswordCredentialReference;
 
     // Constructors ----------------------------------------------------------
 
@@ -45,6 +48,9 @@ public class RealmKeystore {
     private RealmKeystore(Builder builder) {
         this.keystorePath = builder.keystorePath;
         this.keystorePassword = builder.keystorePassword;
+        this.keyPassword = builder.keyPassword;
+        this.keystorePasswordCredentialReference = builder.keystorePasswordCredentialReference;
+        this.keyPasswordCredentialReference = builder.keyPasswordCredentialReference;
     }
 
     // Public methods --------------------------------------------------------
@@ -67,9 +73,36 @@ public class RealmKeystore {
         return keystorePassword;
     }
 
+    /**
+     * Get the keystorePasswordCredentialReference.
+     *
+     * @return the keystorePasswordCredentialReference
+     */
+    public CredentialReference getKeystorePasswordCredentialReference() {
+        return keystorePasswordCredentialReference;
+    }
+
+    /**
+     * Get the keyPassword.
+     *
+     * @return the keyPassword.
+     */
+    public String getKeyPassword() {
+        return keyPassword;
+    }
+
+    /**
+     * Get the keyPasswordCredentialReference.
+     *
+     * @return the keyPasswordCredentialReference
+     */
+    public CredentialReference getKeyPasswordCredentialReference() {
+        return keyPasswordCredentialReference;
+    }
+
     @Override
     public String toString() {
-        return "RealmKeystore [keystorePath=" + keystorePath + ", keystorePassword=" + keystorePassword + "]";
+        return "RealmKeystore [keystorePath=" + keystorePath + ", keystorePassword=" + keystorePassword + ", keystorePasswordCredentialReference=" + keystorePasswordCredentialReference + ", keyPassword=" + keyPassword + ", keyPasswordCredentialReference=" + keyPasswordCredentialReference + "]";
     }
 
     // Embedded classes ------------------------------------------------------
@@ -77,6 +110,9 @@ public class RealmKeystore {
     public static class Builder {
         private String keystorePath;
         private String keystorePassword;
+        private String keyPassword;
+        private CredentialReference keystorePasswordCredentialReference;
+        private CredentialReference keyPasswordCredentialReference;
 
         public Builder keystorePath(String keystorePath) {
             this.keystorePath = keystorePath;
@@ -85,6 +121,21 @@ public class RealmKeystore {
 
         public Builder keystorePassword(String keystorePassword) {
             this.keystorePassword = keystorePassword;
+            return this;
+        }
+
+        public Builder keystorePasswordCredentialReference(CredentialReference keystorePasswordCredentialReference) {
+            this.keystorePasswordCredentialReference = keystorePasswordCredentialReference;
+            return this;
+        }
+
+        public Builder keyPassword(String keyPassword) {
+            this.keyPassword = keyPassword;
+            return this;
+        }
+
+        public Builder keyPasswordCredentialReference(CredentialReference keyPasswordCredentialReference) {
+            this.keyPasswordCredentialReference = keyPasswordCredentialReference;
             return this;
         }
 


### PR DESCRIPTION
Controversy of this PR is reload is needed during each test method. This is because reload is needed to change security realm on management interface.

Reload optimalization can be performed, if it would be possible to define order of test methods. But as this is not possible I have to ensure correct security realm is configured before each test method.

Locally this test takes 1.5 sec