### PR TITLE
Fix for WFCORE-2888. Upgrade CLI to jansi 1.16, aesh 0.66.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,9 +95,9 @@
         <version.org.codehaus.plexus.plexus-utils>3.0.24</version.org.codehaus.plexus.plexus-utils>
         <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
-        <version.org.fusesource.jansi>1.11</version.org.fusesource.jansi>
+        <version.org.fusesource.jansi>1.16</version.org.fusesource.jansi>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
-        <version.org.jboss.aesh>0.66.17</version.org.jboss.aesh>
+        <version.org.jboss.aesh>0.66.18</version.org.jboss.aesh>
         <version.org.jboss.byteman>3.0.6</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.1.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.0.Beta4</version.org.jboss.invocation>


### PR DESCRIPTION
Expected by build team, jansi built with source level > 1.5

