### PR TITLE
[WFCORE-2876]: Runtime-failure-causes-rollback does not seem to have effect when configured in model

### DIFF
--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerAdd.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerAdd.java
@@ -112,6 +112,7 @@ class DeploymentScannerAdd implements OperationStepHandler {
             final boolean autoDeployXml = AUTO_DEPLOY_XML.resolveModelAttribute(context, operation).asBoolean();
             final long deploymentTimeout = DEPLOYMENT_TIMEOUT.resolveModelAttribute(context, operation).asLong();
             final int scanInterval = SCAN_INTERVAL.resolveModelAttribute(context, operation).asInt();
+            final boolean rollback = RUNTIME_FAILURE_CAUSES_ROLLBACK.resolveModelAttribute(context, operation).asBoolean();
 
             final ScheduledExecutorService scheduledExecutorService = createScannerExecutorService();
 
@@ -130,6 +131,7 @@ class DeploymentScannerAdd implements OperationStepHandler {
                 bootTimeScanner.setAutoDeployXMLContent(autoDeployXml);
                 bootTimeScanner.setDeploymentTimeout(deploymentTimeout);
                 bootTimeScanner.setScanInterval(scanInterval);
+                bootTimeScanner.setRuntimeFailureCausesRollback(rollback);
             } else {
                 bootTimeScanner = null;
             }

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/FileSystemDeploymentService.java
@@ -767,7 +767,9 @@ class FileSystemDeploymentService implements DeploymentScanner, NotificationHand
 
         @Override
         public void run() {
-            forcedUndeployScan();
+            if(rollbackOnRuntimeFailure) {
+                forcedUndeployScan();
+            }
             processStateService.removePropertyChangeListener(propertyChangeListener);
         }
     }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/JmxAuditLogFieldsOfLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/JmxAuditLogFieldsOfLogTestCase.java
@@ -88,10 +88,10 @@ public class JmxAuditLogFieldsOfLogTestCase extends AbstractLogFieldsOfLogTestCa
     public void beforeTest() throws Exception {
         Files.deleteIfExists(FILE);
         // Start the server
-        container.start();
+        container.startInAdminMode();
         final ModelControllerClient client = container.getClient().getControllerClient();
 
-        final CompositeOperationBuilder compositeOp = CompositeOperationBuilder.create();
+        CompositeOperationBuilder compositeOp = CompositeOperationBuilder.create();
 
         configureUser(client, compositeOp);
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/AbstractDeploymentUnitTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/AbstractDeploymentUnitTestCase.java
@@ -56,7 +56,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
  */
 public abstract class AbstractDeploymentUnitTestCase {
 
-    protected void addDeploymentScanner(int scanInterval) throws Exception {
+    protected void addDeploymentScanner(int scanInterval, boolean rollback) throws Exception {
         ModelNode addOp = Util.createAddOperation(PathAddress.pathAddress(PathElement.pathElement(EXTENSION, "org.jboss.as.deployment-scanner")));
         ModelNode result = executeOperation(addOp);
         assertEquals("Unexpected outcome of adding the test deployment scanner extension: " + addOp, ModelDescriptionConstants.SUCCESS, result.get(OUTCOME).asString());
@@ -64,7 +64,7 @@ public abstract class AbstractDeploymentUnitTestCase {
         result = executeOperation(addOp);
         assertEquals("Unexpected outcome of adding the test deployment scanner subsystem: " + addOp, ModelDescriptionConstants.SUCCESS, result.get(OUTCOME).asString());
         // add deployment scanner
-        final ModelNode op = getAddDeploymentScannerOp(scanInterval);
+        final ModelNode op = getAddDeploymentScannerOp(scanInterval, rollback);
         result = executeOperation(op);
         assertEquals("Unexpected outcome of adding the test deployment scanner: " + op, ModelDescriptionConstants.SUCCESS, result.get(OUTCOME).asString());
     }
@@ -101,9 +101,10 @@ public abstract class AbstractDeploymentUnitTestCase {
 
     protected abstract File getDeployDir();
 
-    protected ModelNode getAddDeploymentScannerOp(int scanInterval) {
+    protected ModelNode getAddDeploymentScannerOp(int scanInterval, boolean rollback) {
         final ModelNode op = Util.createAddOperation(getTestDeploymentScannerResourcePath());
         op.get("scan-interval").set(scanInterval);
+        op.get("runtime-failure-causes-rollback").set(rollback);
         op.get("path").set(getDeployDir().getAbsolutePath());
         return op;
     }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerNotificationUnitTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/DeploymentScannerNotificationUnitTestCase.java
@@ -93,7 +93,7 @@ public class DeploymentScannerNotificationUnitTestCase extends AbstractDeploymen
                 createDeployment(deploymentOne, "org.jboss.modules");
 
                 // Add a new de
-                addDeploymentScanner(1000);
+                addDeploymentScanner(1000, false);
                 try {
                     // Wait until deployed ...
                     long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(30000);


### PR DESCRIPTION
The runtime-failure-causes-rollback wasn't properly propagated to the boot scanner.
If runtime-failure-causes-rollback is set to 'false' then failed deployments added at boot shouldn't be undeployed.

Jira: https://issues.jboss.org/browse/WFCORE-2876