### PR TITLE
[WFCORE-2894] Ensure that if the protocol is specified in the AuthenticationConfiguration that is resolved for a remote outbound connection, then this protocol is also used in the destination URI

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionAdd.java
@@ -62,13 +62,13 @@ class RemoteOutboundConnectionAdd extends AbstractAddStepHandler {
         final String connectionName = address.getLastElement().getValue();
 
         final String outboundSocketBindingRef = RemoteOutboundConnectionResourceDefinition.OUTBOUND_SOCKET_BINDING_REF.resolveModelAttribute(context, operation).asString();
-        final String protocol = RemoteOutboundConnectionResourceDefinition.PROTOCOL.resolveModelAttribute(context, operation).asString();
         final ServiceName outboundSocketBindingDependency = context.getCapabilityServiceName(OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME, outboundSocketBindingRef, OutboundSocketBinding.class);
         // fetch the connection creation options from the model
         final OptionMap connectionCreationOptions = ConnectorUtils.getOptions(context, fullModel.get(CommonAttributes.PROPERTY));
         final String username = RemoteOutboundConnectionResourceDefinition.USERNAME.resolveModelAttribute(context, fullModel).asStringOrNull();
         final String securityRealm = fullModel.hasDefined(CommonAttributes.SECURITY_REALM) ? fullModel.require(CommonAttributes.SECURITY_REALM).asString() : null;
         final String authenticationContext = fullModel.hasDefined(CommonAttributes.AUTHENTICATION_CONTEXT) ? fullModel.require(CommonAttributes.AUTHENTICATION_CONTEXT).asString() : null;
+        final String protocol = authenticationContext != null ? null : RemoteOutboundConnectionResourceDefinition.PROTOCOL.resolveModelAttribute(context, operation).asString();
 
         // create the service
         final RemoteOutboundConnectionService outboundConnectionService = new RemoteOutboundConnectionService(connectionCreationOptions, username, protocol);

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
@@ -97,7 +97,7 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
         final OutboundSocketBinding binding = destinationOutboundSocketBindingInjectedValue.getValue();
         final String hostName = NetworkUtils.formatPossibleIpv6Address(binding.getUnresolvedDestinationAddress());
         final int port = binding.getDestinationPort();
-        final URI uri;
+        URI uri;
         final String username = this.username;
         final SSLContext sslContext;
         try {
@@ -112,6 +112,13 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
                 sslContext = AUTH_CONFIGURATION_CLIENT.getSSLContext(uri, injectedContext);
             } catch (GeneralSecurityException e) {
                 throw RemotingLogger.ROOT_LOGGER.failedToObtainSSLContext(e);
+            }
+            // if the protocol is specified in the authentication configuration, use it in the destination URI
+            final String realProtocol = AUTH_CONFIGURATION_CLIENT.getRealProtocol(configuration);
+            try {
+                uri = new URI(realProtocol == null ? Protocol.HTTP_REMOTING.toString() : realProtocol, username, hostName, port, null, null, null);
+            } catch (URISyntaxException e) {
+                throw new StartException(e);
             }
         } else {
             final SecurityRealm securityRealm = securityRealmInjectedValue.getOptionalValue();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2894
https://issues.jboss.org/browse/JBEAP-11237