### PR TITLE
Revert "[WFCORE-1802] Ensure the providers are registered first so they have priority."

### DIFF
--- a/elytron/src/main/resources/subsystem-templates/elytron.xml
+++ b/elytron/src/main/resources/subsystem-templates/elytron.xml
@@ -19,7 +19,7 @@
 
 <config default-supplement="standalone" >
     <extension-module>org.wildfly.extension.elytron</extension-module>
-    <subsystem xmlns="urn:wildfly:elytron:1.0" initial-providers="combined-providers" disallowed-providers="OracleUcrypto">
+    <subsystem xmlns="urn:wildfly:elytron:1.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
         <providers>
             <provider-loader name="elytron" module="org.wildfly.security.elytron" />
             <provider-loader name="openssl" module="org.wildfly.openssl" />


### PR DESCRIPTION
This reverts commit c7fa07b6fe767137afa1a51545f15234c9ed8094.

This is causing failures in 'org.jboss.as.test.integration.web.security.tg.TransportGuaranteeTestCase' - we suspect that the test case is passing on CI as OpenJDK may be failing to load for some reason (Possibly 32Bit JVM with 64Bit OpenSSL) and so is falling back to JDK Providers.
