### PR TITLE
[WFCORE-2900] Limit storage and allocations related to AttributeDefin…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -23,6 +23,7 @@
 package org.jboss.as.controller;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -145,8 +146,7 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
         }
         this.attributeGroup = basis.getAttributeGroup();
         if(!basis.getArbitraryDescriptors().isEmpty()) {
-            this.arbitraryDescriptors = new HashMap<>(basis.getArbitraryDescriptors().size());
-            this.arbitraryDescriptors.putAll(basis.getArbitraryDescriptors());
+            this.arbitraryDescriptors = new HashMap<>(basis.getArbitraryDescriptors());
         }
         this.referenceRecorder = basis.getReferenceRecorder();
     }
@@ -341,9 +341,13 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
      */
     public BUILDER addArbitraryDescriptor(String arbitraryDescriptor, ModelNode value) {
         if (this.arbitraryDescriptors == null) {
-            this.arbitraryDescriptors = new HashMap<>();
+            this.arbitraryDescriptors = Collections.singletonMap(arbitraryDescriptor, value);
+        } else {
+            if (this.arbitraryDescriptors.size() == 1) {
+                this.arbitraryDescriptors = new HashMap<>(this.arbitraryDescriptors);
+            }
+            arbitraryDescriptors.put(arbitraryDescriptor, value);
         }
-        arbitraryDescriptors.put(arbitraryDescriptor, value);
         return (BUILDER) this;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -90,7 +90,7 @@ public abstract class AttributeDefinition {
     private final String attributeGroup;
     private final ModelNode undefinedMetricValue;
     protected final CapabilityReferenceRecorder referenceRecorder;
-    private final Map<String, ModelNode> arbitraryDescriptors = new HashMap<>();
+    private final Map<String, ModelNode> arbitraryDescriptors;
 
     // NOTE: Standards for creating a constructor variant are:
     // 1) Don't.
@@ -153,11 +153,7 @@ public abstract class AttributeDefinition {
         this.valueCorrector = valueCorrector;
         this.validator = validator;
         this.flags = flags;
-        if (attributeMarshaller != null) {
-            this.attributeMarshaller = attributeMarshaller;
-        } else {
-            this.attributeMarshaller = new DefaultAttributeMarshaller();
-        }
+        this.attributeMarshaller = attributeMarshaller != null ? attributeMarshaller : AttributeMarshaller.SIMPLE;
         this.resourceOnly = resourceOnly;
         this.accessConstraints = accessConstraints;
         this.deprecationData = deprecationData;
@@ -172,7 +168,14 @@ public abstract class AttributeDefinition {
         }
         this.referenceRecorder = referenceRecorder;
         if (arbitraryDescriptors != null && !arbitraryDescriptors.isEmpty()) {
-            this.arbitraryDescriptors.putAll(arbitraryDescriptors);
+            if (arbitraryDescriptors.size() == 1) {
+                Map.Entry<String, ModelNode> entry = arbitraryDescriptors.entrySet().iterator().next();
+                this.arbitraryDescriptors = Collections.singletonMap(entry.getKey(), entry.getValue());
+            } else {
+                this.arbitraryDescriptors = Collections.unmodifiableMap(new HashMap<>(arbitraryDescriptors));
+            }
+        } else {
+            this.arbitraryDescriptors = Collections.emptyMap();
         }
     }
 
@@ -448,7 +451,7 @@ public abstract class AttributeDefinition {
     }
 
     public Map<String, ModelNode> getArbitraryDescriptors() {
-        return Collections.unmodifiableMap(arbitraryDescriptors);
+        return arbitraryDescriptors;
     }
 
     /**


### PR DESCRIPTION
…ition.arbitraryDescriptors

Also, don't create a new DefaultAttributeMarshaller per AD, since it's a stateless object.

https://issues.jboss.org/browse/WFCORE-2900