### PR TITLE
WFCORE-2426: Use correct restart-required attribute access flag in Elytron resources

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/FileSystemRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/FileSystemRealmDefinition.java
@@ -87,6 +87,7 @@ class FileSystemRealmDefinition extends SimpleResourceDefinition {
             new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ENCODED, ModelType.BOOLEAN, true)
                     .setDefaultValue(new ModelNode(true))
                     .setAllowExpression(true)
+                    .setRestartAllServices()
                     .build();
 
     static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{PATH, RELATIVE_TO, LEVELS, ENCODED, CASE_SENSITIVE};


### PR DESCRIPTION
This PR finishes the work done in JBEAP-10168, setting the correct restart-required attribute flags for some pending Elytron resources.

Jira issues:
https://issues.jboss.org/browse/WFCORE-2426
https://issues.jboss.org/browse/JBEAP-6922