### PR TITLE
[WFCORE-2899]: not possible to remove deployment-overlay in mixed domain when slave host is EAP 6.3. or older

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DeploymentOverlayTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DeploymentOverlayTransformers.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.domain.controller.transformers;
+
+import java.util.Set;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import static org.jboss.as.controller.client.helpers.ClientConstants.STEPS;
+import org.jboss.as.controller.client.helpers.Operations;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import org.jboss.as.controller.transform.OperationResultTransformer;
+import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
+import org.jboss.as.controller.transform.TransformationContext;
+import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+import org.jboss.as.server.deploymentoverlay.DeploymentOverlayModel;
+import static org.jboss.as.server.deploymentoverlay.DeploymentOverlayModel.REMOVED_CONTENTS;
+import static org.jboss.as.server.deploymentoverlay.DeploymentOverlayModel.REMOVED_LINKS;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+class DeploymentOverlayTransformers {
+
+     public static ChainedTransformationDescriptionBuilder buildTransformerChain(ModelVersion currentVersion) {
+        ChainedTransformationDescriptionBuilder chainedBuilder =
+                TransformationDescriptionBuilder.Factory.createChainedInstance(DeploymentOverlayModel.DEPLOYMENT_OVERRIDE_PATH, currentVersion);
+
+        ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(currentVersion, DomainTransformers.VERSION_1_6);
+        builder.addOperationTransformationOverride(REMOVE)
+            .setCustomOperationTransformer((TransformationContext context, PathAddress address, ModelNode operation) -> {
+                Set<PathAddress> removedContents = context.getAttachment(REMOVED_CONTENTS);
+                    if (removedContents != null && !removedContents.isEmpty()) {
+                        ModelNode compositeOp = Operations.createCompositeOperation();
+                        for (PathAddress removed : removedContents) {
+                            if (address.equals(removed.subAddress(0, address.size()))) {
+                                compositeOp.get(STEPS).add(Operations.createRemoveOperation(removed.toModelNode()));
+                            }
+                        }
+                        compositeOp.get(STEPS).add(operation);
+                        return new TransformedOperation(compositeOp, OperationResultTransformer.ORIGINAL_RESULT);
+                    }
+                return new TransformedOperation(operation, OperationResultTransformer.ORIGINAL_RESULT);
+        }).end();
+        return chainedBuilder;
+    }
+
+     public static void registerServerGroupTransformers1_6_AndBelow(ResourceTransformationDescriptionBuilder parent) {
+        parent.addChildResource(DeploymentOverlayModel.DEPLOYMENT_OVERRIDE_PATH)
+                .addOperationTransformationOverride(REMOVE)
+                .setCustomOperationTransformer((TransformationContext context, PathAddress address, ModelNode operation) -> {
+                    Set<PathAddress> removedLinks = context.getAttachment(REMOVED_LINKS);
+                    if (removedLinks != null && !removedLinks.isEmpty()) {
+                        ModelNode compositeOp = Operations.createCompositeOperation();
+                        for (PathAddress removed : removedLinks) {
+                            if (address.equals(removed.subAddress(0, address.size()))) {
+                                compositeOp.get(STEPS).add(Operations.createRemoveOperation(removed.toModelNode()));
+                            }
+                        }
+                        compositeOp.get(STEPS).add(operation);
+                        return new TransformedOperation(compositeOp, OperationResultTransformer.ORIGINAL_RESULT);
+                    }
+                    return new TransformedOperation(operation, OperationResultTransformer.ORIGINAL_RESULT);
+                })
+                .end();
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -104,6 +104,7 @@ public class DomainTransformers {
         registerProfileTransformers(registry, CURRENT);
         registerSocketBindingGroupTransformers(registry, CURRENT);
         registerDeploymentTransformers(registry, CURRENT);
+        registerDeploymentOverlayTransformers(registry, CURRENT);
     }
 
     private static void registerRootTransformers(TransformerRegistry registry) {
@@ -177,6 +178,11 @@ public class DomainTransformers {
     private static void registerDeploymentTransformers(TransformerRegistry registry, ModelVersion CURRENT) {
         ChainedTransformationDescriptionBuilder builder = DeploymentTransformers.buildTransformerChain(CURRENT);
         registerChainedTransformer(registry, builder, VERSION_4_1, VERSION_4_0, VERSION_3_0, VERSION_2_1, VERSION_2_0, VERSION_1_8, VERSION_1_7, VERSION_1_6, VERSION_1_5);
+    }
+
+    private static void registerDeploymentOverlayTransformers(TransformerRegistry registry, ModelVersion CURRENT) {
+        ChainedTransformationDescriptionBuilder builder = DeploymentOverlayTransformers.buildTransformerChain(CURRENT);
+        registerChainedTransformer(registry, builder, VERSION_1_6, VERSION_1_5);
     }
 
     private static class ProfileCloneOperationTransformer implements OperationTransformer {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ServerGroupTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/ServerGroupTransformers.java
@@ -50,6 +50,7 @@ class ServerGroupTransformers {
                 .end();
         DomainServerLifecycleHandlers.registerServerLifeCycleOperationsTransformers(builder);
         JvmTransformers.registerTransformers2_1_AndBelow(builder);
+        DeploymentOverlayTransformers.registerServerGroupTransformers1_6_AndBelow(builder);
 
         return chainedBuilder;
     }

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayContentRemove.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayContentRemove.java
@@ -22,11 +22,15 @@ package org.jboss.as.server.deploymentoverlay;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.server.deploymentoverlay.DeploymentOverlayModel.REMOVED_CONTENTS;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.transform.TransformerOperationAttachment;
 import org.jboss.as.repository.ContentRepository;
 import org.jboss.as.server.deployment.ModelContentReference;
 import org.jboss.dmr.ModelNode;
@@ -46,6 +50,12 @@ public class DeploymentOverlayContentRemove implements OperationStepHandler {
 
     @Override
     public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+        Set<PathAddress> removed = TransformerOperationAttachment.getOrCreate(context).getAttachment(REMOVED_CONTENTS);
+        if (removed == null) {
+            removed = new HashSet<>();
+            TransformerOperationAttachment.getOrCreate(context).attach(REMOVED_CONTENTS, removed);
+        }
+        removed.add(context.getCurrentAddress());
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
         ModelNode model = context.readResourceFromRoot(address, false).getModel();
         final byte[] hash;

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayDeploymentRemoveHandler.java
@@ -23,8 +23,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RED
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REDEPLOY_LINKS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import static org.jboss.as.server.deploymentoverlay.DeploymentOverlayModel.REMOVED_LINKS;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
@@ -37,6 +39,7 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.transform.TransformerOperationAttachment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -61,6 +64,12 @@ public class DeploymentOverlayDeploymentRemoveHandler extends AbstractRemoveStep
     @Override
     protected void performRemove(OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
             final String runtimeName = context.getCurrentAddressValue();
+            Set<PathAddress> removed = TransformerOperationAttachment.getOrCreate(context).getAttachment(REMOVED_LINKS);
+            if (removed == null) {
+                removed = new HashSet<>();
+                TransformerOperationAttachment.getOrCreate(context).attach(REMOVED_LINKS, removed);
+            }
+            removed.add(context.getCurrentAddress());
             if (REDEPLOY_AFFECTED_DEFINITION.resolveModelAttribute(context, operation).asBoolean()) {
                 if (SERVER_GROUP.equals(context.getCurrentAddress().getElement(0).getKey())) {
                     PathAddress overlayAddress = context.getCurrentAddress().getParent();

--- a/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayModel.java
+++ b/server/src/main/java/org/jboss/as/server/deploymentoverlay/DeploymentOverlayModel.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.server.deploymentoverlay;
 
+import java.util.Set;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 
@@ -29,7 +32,10 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
  * @author Stuart Douglas
  */
 public class DeploymentOverlayModel {
-    protected static final PathElement CONTENT_PATH = PathElement.pathElement(ModelDescriptionConstants.CONTENT);
-    protected static final PathElement DEPLOYMENT_OVERRIDE_PATH = PathElement.pathElement(ModelDescriptionConstants.DEPLOYMENT_OVERLAY);
-    protected static final PathElement DEPLOYMENT_OVERRIDE_DEPLOYMENT_PATH = PathElement.pathElement(ModelDescriptionConstants.DEPLOYMENT);
+    public static final PathElement CONTENT_PATH = PathElement.pathElement(ModelDescriptionConstants.CONTENT);
+    public static final PathElement DEPLOYMENT_OVERRIDE_PATH = PathElement.pathElement(ModelDescriptionConstants.DEPLOYMENT_OVERLAY);
+    public static final PathElement DEPLOYMENT_OVERRIDE_DEPLOYMENT_PATH = PathElement.pathElement(ModelDescriptionConstants.DEPLOYMENT);
+
+    public static final OperationContext.AttachmentKey<Set<PathAddress>> REMOVED_LINKS = OperationContext.AttachmentKey.create(Set.class);
+    public static final OperationContext.AttachmentKey<Set<PathAddress>> REMOVED_CONTENTS = OperationContext.AttachmentKey.create(Set.class);
 }


### PR DESCRIPTION
Attaching the removed contents and links to deployments so that those are added to the operation to be executed on old slaves.

Jira: https://issues.jboss.org/browse/WFCORE-2899
JBEAP: https://issues.jboss.org/browse/JBEAP-10720

Please note that the test is in FULL (https://github.com/wildfly/wildfly/pull/10139)
Experimental build https://ci.wildfly.org/viewType.html?buildTypeId=WF_WildFlyCoreIntegrationExperiments&branch_WF=%2FWFCORE-2899%3B%2Fehsavoie