### PR TITLE
[WFCORE-2792-fix]: Fix for WFCORE-2792 which reverted back the "disallowed-providers" attribute parsing

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -108,8 +108,8 @@ class ElytronDefinition extends SimpleResourceDefinition {
 
     static final StringListAttributeDefinition DISALLOWED_PROVIDERS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.DISALLOWED_PROVIDERS)
             .setRequired(false)
-            .setAttributeParser(AttributeParser.COMMA_DELIMITED_STRING_LIST)
-            .setAttributeMarshaller(AttributeMarshaller.COMMA_STRING_LIST)
+            .setAttributeParser(AttributeParser.STRING_LIST)
+            .setAttributeMarshaller(AttributeMarshaller.STRING_LIST)
             .setRestartJVM()
             .setElementValidator(new StringLengthValidator(1))
             .setAllowExpression(true)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser.java
@@ -118,7 +118,7 @@ class ElytronSubsystemParser implements XMLElementReader<List<ModelNode>>, XMLEl
                         ElytronDefinition.FINAL_PROVIDERS.parseAndSetParameter(value, subsystemAdd, reader);
                         break;
                     case DISALLOWED_PROVIDERS:
-                        ElytronDefinition.DISALLOWED_PROVIDERS.parseAndSetParameter(value, subsystemAdd, reader);
+                        ElytronDefinition.DISALLOWED_PROVIDERS.getParser().parseAndSetParameter(ElytronDefinition.DISALLOWED_PROVIDERS,value, subsystemAdd, reader);
                         break;
                     default:
                         throw unexpectedAttribute(reader, i);

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
@@ -20,9 +20,13 @@ package org.wildfly.extension.elytron;
 
 
 import java.io.IOException;
+import java.util.List;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
 import org.junit.Test;
 
 
@@ -69,6 +73,14 @@ public class SubsystemParsingTestCase extends AbstractSubsystemBaseTest {
     @Test
     public void testParseAndMarshalModel_ProviderLoader() throws Exception {
         standardSubsystemTest("providers.xml");
+    }
+
+    @Test
+    public void testDisallowedProviders() throws Exception {
+        KernelServices services = standardSubsystemTest("providers.xml", true);
+        List<ModelNode> disallowedProviders = services.readWholeModel().get("subsystem", "elytron", "disallowed-providers").asList();
+        Assert.assertNotNull(disallowedProviders);
+        Assert.assertEquals(3, disallowedProviders.size());
     }
 
     @Test


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-2792