### PR TITLE
[WFCORE-2906]:  Server-identity/secret has required "value" attribute…

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecretServerIdentityResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecretServerIdentityResourceDefinition.java
@@ -53,7 +53,7 @@ public class SecretServerIdentityResourceDefinition extends SimpleResourceDefini
             .setAlternatives(CredentialReference.CREDENTIAL_REFERENCE)
             .build();
 
-    public static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE = CredentialReference.getAttributeBuilder(true, false)
+    public static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE = CredentialReference.getAttributeBuilder(false, false)
             .setAlternatives(ModelDescriptionConstants.VALUE)
             .build();
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/UserResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/UserResourceDefinition.java
@@ -50,8 +50,8 @@ public class UserResourceDefinition extends SimpleResourceDefinition {
             .setAlternatives(CredentialReference.CREDENTIAL_REFERENCE)
             .build();
 
-    public static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE = CredentialReference.getAttributeBuilder(true, false)
-            .setAlternatives(org.jboss.as.domain.management.ModelDescriptionConstants.VALUE)
+    public static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE = CredentialReference.getAttributeBuilder(false, false)
+            .setAlternatives(ModelDescriptionConstants.PASSWORD)
             .build();
 
     public UserResourceDefinition() {


### PR DESCRIPTION
…, but there is now credential-reference too and there is no way how to update existing resource to use another option.

Fixing model metadata

Jira: https://issues.jboss.org/browse/WFCORE-2906
JBEAP: https://issues.jboss.org/browse/JBEAP-11294