### PR TITLE
[WFCORE-2923]:  Credential reference integration with client-certificate-store does not work.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/security/CredentialReference.java
+++ b/controller/src/main/java/org/jboss/as/controller/security/CredentialReference.java
@@ -319,7 +319,9 @@ public final class CredentialReference {
             // use credential store service
             String credentialStoreCapabilityName = RuntimeCapability.buildDynamicCapabilityName(CREDENTIAL_STORE_CAPABILITY, credentialStoreName);
             credentialStoreServiceName = context.getCapabilityServiceName(credentialStoreCapabilityName, CredentialStore.class);
-            serviceBuilder.addDependency(ServiceBuilder.DependencyType.REQUIRED, credentialStoreServiceName);
+            if(serviceBuilder != null) {
+                serviceBuilder.addDependency(ServiceBuilder.DependencyType.REQUIRED, credentialStoreServiceName);
+            }
             serviceRegistry = context.getServiceRegistry(false);
         } else {
             credentialStoreServiceName = null;

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogHandlerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogHandlerResourceDefinition.java
@@ -55,8 +55,10 @@ import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.registry.Resource.ResourceEntry;
+import org.jboss.as.controller.security.CredentialReference;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.domain.management._private.DomainManagementResolver;
+import org.jboss.as.domain.management.audit.SyslogAuditLogProtocolResourceDefinition.TlsKeyStore;
 import org.jboss.as.domain.management.logging.DomainManagementLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -240,6 +242,8 @@ public class SyslogAuditLogHandlerResourceDefinition extends AuditLogHandlerReso
                     handler.setTlsClientCertStoreKeyPassword(
                             resolveUndefinableAttribute(context,
                                     SyslogAuditLogProtocolResourceDefinition.TlsKeyStore.KEY_PASSWORD, storeModel));
+                     handler.setTlsClientCertStoreSupplier(CredentialReference.getCredentialSourceSupplier(context, TlsKeyStore.KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE, storeModel, null));
+                     handler.setTlsClientCertStoreKeySupplier(CredentialReference.getCredentialSourceSupplier(context, TlsKeyStore.KEY_PASSWORD_CREDENTIAL_REFERENCE, storeModel, null));
                 } else if (type.equals(TRUSTSTORE)) {
                     handler.setTlsTruststorePassword(
                             resolveUndefinableAttribute(context,
@@ -249,6 +253,7 @@ public class SyslogAuditLogHandlerResourceDefinition extends AuditLogHandlerReso
                     handler.setTlsTrustStoreRelativeTo(
                             resolveUndefinableAttribute(context,
                                     SyslogAuditLogProtocolResourceDefinition.TlsKeyStore.KEYSTORE_RELATIVE_TO, storeModel));
+                     handler.setTlsTrustStoreSupplier(CredentialReference.getCredentialSourceSupplier(context, TlsKeyStore.KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE, storeModel, null));
                 }
             }
         }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogProtocolResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogProtocolResourceDefinition.java
@@ -35,6 +35,7 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -213,11 +214,11 @@ public abstract class SyslogAuditLogProtocolResourceDefinition extends SimpleRes
         public static final PathElement CLIENT_CERT_ELEMENT = PathElement.pathElement(AUTHENTICATION, CLIENT_CERT_STORE);
 
         public static final SimpleAttributeDefinition KEYSTORE_PASSWORD = KeystoreAttributes.KEYSTORE_PASSWORD;
-        public static final SimpleAttributeDefinition KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE = KeystoreAttributes.KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE;
+        public static final ObjectTypeAttributeDefinition KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE = KeystoreAttributes.KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE;
         public static final SimpleAttributeDefinition KEYSTORE_PATH = KeystoreAttributes.KEYSTORE_PATH;
         public static final SimpleAttributeDefinition KEYSTORE_RELATIVE_TO = KeystoreAttributes.KEYSTORE_RELATIVE_TO;
         public static final SimpleAttributeDefinition KEY_PASSWORD = KeystoreAttributes.KEY_PASSWORD;
-        public static final SimpleAttributeDefinition KEY_PASSWORD_CREDENTIAL_REFERENCE = KeystoreAttributes.KEY_PASSWORD_CREDENTIAL_REFERENCE;
+        public static final ObjectTypeAttributeDefinition KEY_PASSWORD_CREDENTIAL_REFERENCE = KeystoreAttributes.KEY_PASSWORD_CREDENTIAL_REFERENCE;
 
         private static final AttributeDefinition[] CLIENT_CERT_ATTRIBUTES = new AttributeDefinition[]{
                 KEYSTORE_PASSWORD, KEYSTORE_PASSWORD_CREDENTIAL_REFERENCE, KEYSTORE_PATH, KEYSTORE_RELATIVE_TO, KEY_PASSWORD, KEY_PASSWORD_CREDENTIAL_REFERENCE};

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogHandlerBootEnabledTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogHandlerBootEnabledTestCase.java
@@ -279,6 +279,17 @@ public class AuditLogHandlerBootEnabledTestCase extends AbstractAuditLogHandlerT
     }
 
 
+    @Test
+    public void testSyslogTlsNonTransparentFramingClientAuthCredentialReference() throws Exception {
+        File serverCertStore = new File(getClass().getResource("server-cert-store.jks").toURI());
+        File clientTrustStore = new File(getClass().getResource("client-trust-store.jks").toURI());
+        File clientCertStore = new File(getClass().getResource("client-cert-store.jks").toURI());
+        File serverTrustStore = new File(getClass().getResource("server-trust-store.jks").toURI());
+        SimpleSyslogServer server = SimpleSyslogServer.createTls(6666, false, serverCertStore, "changeit", serverTrustStore, "changeit");
+        runSyslogTest(server, 6666, createAddSyslogHandlerCredentialReferenceTlsOperation("syslog-test", "test-formatter", InetAddress.getByName("localhost"), 6666,
+                null, MessageTransfer.NON_TRANSPARENT_FRAMING, clientTrustStore, "changeit", clientCertStore, "changeit"));
+    }
+
     private void runSyslogTest(SimpleSyslogServer server, int port, ModelNode handlerAddOperation) throws Exception {
         try {
             File file = new File(logDir, "test-file.log");


### PR DESCRIPTION
Adding support for CredentialReferenceSupplier in SyslogAuditLogHandler.

Jira: https://issues.jboss.org/browse/WFCORE-2923
JBEAP: https://issues.jboss.org/browse/JBEAP-11363