### PR TITLE
WFCORE-2446: Use required attribute for Elytron key-store element in xsd file

### DIFF
--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -3996,7 +3996,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="key-store" type="xs:string" use="optional">
+        <xs:attribute name="key-store" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>
                     Reference to the KeyStore to use with the KeyManager.
@@ -4069,7 +4069,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="key-store" type="xs:string" use="optional">
+        <xs:attribute name="key-store" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>
                     Reference to the KeyStore to use with the TrustManager.


### PR DESCRIPTION
There is an inconsistency between the xsd file and model definition for key-store element in key-manager and trust-manager 

Jira issues:
https://issues.jboss.org/browse/WFCORE-2446
https://issues.jboss.org/browse/JBEAP-7401