### PR TITLE
Fix for WFCORE-2926. Disable error-on-interract for CLI.connect.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
+++ b/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
@@ -80,7 +80,10 @@ public class CLI {
      */
     public void connect() {
         doConnect(() -> {
-            return CommandContextFactory.getInstance().newCommandContext();
+            return CommandContextFactory.getInstance().
+                    newCommandContext(new CommandContextConfiguration.Builder()
+                    .setErrorOnInteract(false)
+                    .build());
         });
     }
 
@@ -93,7 +96,11 @@ public class CLI {
     public void connect(String username, char[] password) {
         doConnect(() -> {
             return CommandContextFactory.getInstance().
-                    newCommandContext(username, password);
+                    newCommandContext(new CommandContextConfiguration.Builder()
+                    .setUsername(username)
+                    .setPassword(password)
+                    .setErrorOnInteract(false)
+                    .build());
         });
     }
 
@@ -125,6 +132,7 @@ public class CLI {
                             .setController(controller)
                     .setUsername(username)
                     .setPassword(password)
+                    .setErrorOnInteract(false)
                     .setClientBindAddress(clientBindAddress)
                     .build());
         });
@@ -190,6 +198,7 @@ public class CLI {
                             controllerPort))
                     .setUsername(username)
                     .setPassword(password)
+                    .setErrorOnInteract(false)
                     .setClientBindAddress(clientBindAddress)
                     .build());
         });


### PR DESCRIPTION
CLI class connect method should set ignoreOnInteract to false.
In addition I added a connect method to allow to provide a CommandContextConfiguration. This class is in an impl package but has already been exposed as a public API in the CommandContextFactory. I wanted to move it to public API, but being already exposed we can't change its location.

