### PR TITLE
WFCORE-2933 add support for empty host.xml & domain.xml when starting…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -69,6 +69,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
     private static final String REMOVE_EXISTING_HOST_CONFIG = "--remove-existing-host-config";
     private static final String EMPTY_DOMAIN_CONFIG = "--empty-domain-config";
     private static final String REMOVE_EXISTING_DOMAIN_CONFIG = "--remove-existing-domain-config";
+    private static final String HOST_CONTROLLER_NAME = "--host-controller-name";
 
     private static final String JBOSS_DOMAIN_BASE_DIR = "jboss.domain.base.dir";
     private static final String JBOSS_DOMAIN_CONFIG_DIR = "jboss.domain.config.dir";
@@ -95,6 +96,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
     private ArgumentWithoutValue removeExistingDomainConfig;
     private ArgumentWithoutValue emptyHostConfig;
     private ArgumentWithoutValue removeExistingHostConfig;
+    private ArgumentWithValue hostControllerName;
 
     static EmbedHostControllerHandler create(final AtomicReference<EmbeddedProcessLaunch> hostControllerReference, final CommandContext ctx, final boolean modular) {
         EmbedHostControllerHandler result = new EmbedHostControllerHandler(hostControllerReference);
@@ -113,6 +115,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
         result.removeExistingDomainConfig = new ArgumentWithoutValue(result, REMOVE_EXISTING_DOMAIN_CONFIG);
         result.emptyHostConfig = new ArgumentWithoutValue(result, EMPTY_HOST_CONFIG);
         result.removeExistingHostConfig = new ArgumentWithoutValue(result, REMOVE_EXISTING_HOST_CONFIG);
+        result.hostControllerName = new ArgumentWithValue(result, HOST_CONTROLLER_NAME);
         return result;
     }
 
@@ -240,6 +243,14 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
             }
             if (removeHost) {
                 cmdsList.add(REMOVE_EXISTING_HOST_CONFIG);
+            }
+
+            // allow the user to provide --host-controller-name when starting to set the initial name.
+            // if this isn't specified, the name will be generated in HostControllerEnvironment based on the FQDN etc.
+            // in some specific cases, the user may want to set this specifically when starting with an empty config etc.
+            if (hostControllerName.isPresent(parsedCmd)) {
+                cmdsList.add(HOST_CONTROLLER_NAME);
+                cmdsList.add(hostControllerName.getValue(parsedCmd,true));
             }
 
             File hostXmlCfgFile = new File(controllerCfgDir + File.separator + (hostConfig.isPresent(parsedCmd) ? hostXml : "host.xml"));

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -69,7 +69,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
     private static final String REMOVE_EXISTING_HOST_CONFIG = "--remove-existing-host-config";
     private static final String EMPTY_DOMAIN_CONFIG = "--empty-domain-config";
     private static final String REMOVE_EXISTING_DOMAIN_CONFIG = "--remove-existing-domain-config";
-    private static final String HOST_CONTROLLER_NAME = "--host-controller-name";
+    private static final String HOST_CONTROLLER_NAME = "--temp-host-controller-name";
 
     private static final String JBOSS_DOMAIN_BASE_DIR = "jboss.domain.base.dir";
     private static final String JBOSS_DOMAIN_CONFIG_DIR = "jboss.domain.config.dir";
@@ -246,14 +246,14 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
                 cmdsList.add(REMOVE_EXISTING_HOST_CONFIG);
             }
 
-            // allow the user to provide --host-controller-name when starting to set the initial name.
+            // allow the user to provide --temp-host-controller-name when starting to set the initial name.
             // if this isn't specified, the name will be generated in HostControllerEnvironment based on the FQDN etc.
             // in some specific cases, the user may want to set this specifically when starting with an empty config etc.
             // this is only permitted when starting with --empty-host-config, booting with a non-empty config has the normal
             // methods of setting the hostcontroller name.
             if (hostControllerName.isPresent(parsedCmd)) {
                 if (!emptyHost) {
-                    throw new CommandFormatException("--host-controller-name must be used with --empty-host-config");
+                    throw new CommandFormatException("--temp-host-controller-name may only be used with --empty-host-config");
                 }
                 cmdsList.add(HOST_CONTROLLER_NAME);
                 cmdsList.add(hostControllerName.getValue(parsedCmd,true));

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -241,6 +241,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
             if (emptyHost) {
                 cmdsList.add(EMPTY_HOST_CONFIG);
             }
+
             if (removeHost) {
                 cmdsList.add(REMOVE_EXISTING_HOST_CONFIG);
             }
@@ -248,7 +249,12 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
             // allow the user to provide --host-controller-name when starting to set the initial name.
             // if this isn't specified, the name will be generated in HostControllerEnvironment based on the FQDN etc.
             // in some specific cases, the user may want to set this specifically when starting with an empty config etc.
+            // this is only permitted when starting with --empty-host-config, booting with a non-empty config has the normal
+            // methods of setting the hostcontroller name.
             if (hostControllerName.isPresent(parsedCmd)) {
+                if (!emptyHost) {
+                    throw new CommandFormatException("--host-controller-name must be used with --empty-host-config");
+                }
                 cmdsList.add(HOST_CONTROLLER_NAME);
                 cmdsList.add(hostControllerName.getValue(parsedCmd,true));
             }

--- a/cli/src/main/resources/help/embed-host-controller.txt
+++ b/cli/src/main/resources/help/embed-host-controller.txt
@@ -10,50 +10,72 @@ DESCRIPTION
 
 ARGUMENTS
 
- -c                - Name of the domain configuration file to use
-                     (default is "domain.xml")
+ -c                - Name of the domain configuration file to use (default is
+                     "domain.xml")
                      (Same as --domain-config)
 
- --jboss-home      - Filesystem path pointing to the root directory
-                     of the installation from which the embedded host controller
-                     should run. Only available if the CLI itself
-                     is not running in a modular classloading environment.
-                     In a non-modular classloading environment, if this
-                     option is not specified, the value of the
-                     environment variable JBOSS_HOME will be used.
-                     Must be specified if the environment variable
-                     JBOSS_HOME is not set. In a modular classloading
-                     environment it is assumed the CLI is running from
-                     the host controller installation itself and the JBOSS_HOME
-                     environment variable must be set.
+ --jboss-home      - Filesystem path pointing to the root directory of the
+                     installation from which the embedded host controller
+                     should run. Only available if the CLI itself is not
+                     running in a modular classloading environment. In a
+                     non-modular classloading environment, if this option is
+                     not specified, the value of the environment variable
+                     JBOSS_HOME will be used. Must be specified if the
+                     environment variable JBOSS_HOME is not set. In a modular
+                     classloading environment it is assumed the CLI is running
+                     from the host controller installation itself and the
+                     JBOSS_HOME environment variable must be set.
 
- --domain-config   - Name of the domain configuration file to use
-                     (default is "domain.xml")
+ --domain-config   - Name of the domain configuration file to use (default is
+                     "domain.xml")
                      (Same as -c)
 
- --host-config     - Name of the host configuration file to use
-                     (default is "host.xml")
+ --host-config     - Name of the host configuration file to use (default is
+                     "host.xml")
 
- --std-out         - How to handle output to System.out from the
-                     embedded host controller. Legal values are
-                     "discard" and "echo". The "discard" value indicates
-                     that writes to System.out from the server
-                     should be discarded. The "echo" value means
-                     writes should be handled and appear as part
-                     of the CLI's own output to System.out. The
-                     default value is "discard". If "echo" is
-                     chosen and the CLI is running an interactive
-                     session, the user should recognize that
-                     asynchronous output from the server may
-                     interfere with the normal appearance of
-                     the CLI prompt.
+ --std-out         - How to handle output to System.out from the embedded host
+                     controller. Legal values are "discard" and "echo". The
+                     "discard" value indicates that writes to System.out from
+                     the server should be discarded. The "echo" value means
+                     writes should be handled and appear as part of the CLI's
+                     own output to System.out. The default value is "discard".
+                     If "echo" is chosen and the CLI is running an interactive
+                     session, the user should recognize that asynchronous
+                     output from the server may interfere with the normal
+                     appearance of the CLI prompt.
 
- --timeout         - Maximum time, in seconds, to wait for the
-                     host controller to reach a running (i.e.
-                     fully started) state once the embedded server
-                     is created. If unspecified, the command will
-                     block for as long as necessary, with no upper
-                     limit. If the value is less than 1, the command
-                     will return as soon as the embedded server has
-                     reached the point in its boot where it is
-                     manageable by the CLI.
+ --timeout         - Maximum time, in seconds, to wait for the host controller
+                     to reach a running (i.e. fully started) state once the
+                     embedded server is created. If unspecified, the command
+                     will block for as long as necessary, with no upper limit.
+                     If the value is less than 1, the command will return as
+                     soon as the embedded server has reached the point in its
+                     boot where it is manageable by the CLI.
+
+ --empty-host-config  - Start the embedded host controller with an empty host
+                        configuration (host.xml). The hostname will be
+                     automatically derived from the current hostname.
+                     Configuration will be persisted when configuration changes
+                     are made. [See --temp-host-controller-name below for
+                     details on how to start an embedded host controller with a
+                     temporary name.]
+
+ --empty-domain-config  - Start the embedded host controller with an empty
+                          domain configuration (domain.xml). Configuration
+                     changes made will be persisted.
+
+ --temp-host-controller-name  - Start the host controller with the provided
+                                name. [May only be used in conjunction with
+                     --empty-host-config]
+
+ --remove-existing-host-config  - When --empty-host-config is used, and the
+                                  host configuration file already exists, allow
+                     the existing file to be removed and replaced with an empty
+                     one. [May only be used in conjunction with
+                     --empty-host-config.]
+
+ --remove-existing-domain-config  - When --empty-domain-config is used, and the
+                                    domain configuration file already exists,
+                     allow the existing domain configuration file to be removed
+                     and replace with an empty one. [May only be used in
+                     conjunction with --empty-domain-config.]

--- a/controller/src/main/java/org/jboss/as/controller/persistence/BackupXmlConfigurationPersister.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/BackupXmlConfigurationPersister.java
@@ -58,6 +58,19 @@ public class BackupXmlConfigurationPersister extends XmlConfigurationPersister {
 
     /**
      * Construct a new instance.
+     *
+     * @param file the configuration base file
+     * @param rootElement the root element of the configuration file
+     * @param rootParser the root model parser
+     * @param rootDeparser the root model deparser
+     */
+    public BackupXmlConfigurationPersister(final ConfigurationFile file, final QName rootElement, final XMLElementReader<List<ModelNode>> rootParser, final XMLElementWriter<ModelMarshallingContext> rootDeparser, final boolean supressLoad) {
+        super(file.getBootFile(), rootElement, rootParser, rootDeparser, supressLoad);
+        this.configurationFile = file;
+    }
+
+    /**
+     * Construct a new instance.
      *  @param file the configuration base file
      * @param rootElement the root element of the configuration file
      * @param rootParser the root model parser

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -648,41 +648,18 @@ public class DomainModelControllerService extends AbstractControllerService impl
             ConfigurationFile.InteractionPolicy configPolicy = environment.getHostConfigurationFile().getInteractionPolicy();
             if (!environment.getRunningModeControl().isReloaded() && (configPolicy == ConfigurationFile.InteractionPolicy.NEW || configPolicy == ConfigurationFile.InteractionPolicy.DISCARD)) {
 
+                String hostControllerName = environment.getHostControllerName();
                 // minimum needed to boot an embedded HC from an empty host.xml
-                ModelNode baseOp;
-
-                baseOp = new ModelNode();
+                ModelNode baseOp = new ModelNode();
                 baseOp.get("operation").set("register-host-model");
-                baseOp.get("name").set("master");
+                baseOp.get("name").set(hostControllerName);
                 baseOp.get("address").addEmptyList();
-                hostBootOps.add(baseOp);
-
-                baseOp = new ModelNode();
-                baseOp.get("operation").set("write-attribute");
-                baseOp.get("name").set("name");
-                baseOp.get("value").set("master");
-                baseOp.get("address").set(PathAddress.pathAddress("host", "master").toModelNode());
-                hostBootOps.add(baseOp);
-
-                // mgmt extension
-                baseOp = new ModelNode();
-                baseOp.get("operation").set("add");
-                baseOp.get("extension").set("name");
-                baseOp.get("address").set(PathAddress.pathAddress("host", "master").append(
-                        PathAddress.pathAddress("extension", "org.wildfly.extension.core-management")).toModelNode());
-                hostBootOps.add(baseOp);
-
-                // mgmt subsystem
-                baseOp = new ModelNode();
-                baseOp.get("operation").set("add");
-                baseOp.get("address").set(PathAddress.pathAddress("host", "master").
-                        append(PathAddress.pathAddress("subsystem", "core-management")).toModelNode());
                 hostBootOps.add(baseOp);
 
                 // flag as DC initially - without this, the CLI seems to hang in waiting for a "connection"
                 baseOp = new ModelNode();
                 baseOp.get("operation").set("write-local-domain-controller");
-                baseOp.get("address").set(PathAddress.pathAddress("host", "master").toModelNode());
+                baseOp.get("address").set(PathAddress.pathAddress("host", hostControllerName).toModelNode());
                 hostBootOps.add(baseOp);
             }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -41,6 +41,7 @@ import java.util.Properties;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.interfaces.InetAddressUtil;
+import org.jboss.as.controller.persistence.ConfigurationFile;
 import org.jboss.as.host.controller.logging.HostControllerLogger;
 import org.jboss.as.process.CommandLineArgumentUsageImpl;
 import org.jboss.as.process.CommandLineConstants;
@@ -212,6 +213,8 @@ public final class Main {
         RunningMode initialRunningMode = RunningMode.NORMAL;
         Map<String, String> hostSystemProperties = getHostSystemProperties();
         ProductConfig productConfig;
+        ConfigurationFile.InteractionPolicy hostConfigInteractionPolicy = ConfigurationFile.InteractionPolicy.STANDARD;
+        ConfigurationFile.InteractionPolicy domainConfigInteractionPolicy = ConfigurationFile.InteractionPolicy.STANDARD;
         String modulePath = null;
 
         // Note the java.security.manager shouldn't be set, but we'll check to ensure the security manager gets enabled
@@ -322,6 +325,23 @@ public final class Main {
                         return new HostControllerEnvironmentWrapper(HostControllerEnvironmentWrapper.HostControllerEnvironmentStatus.ERROR);
                     }
                     domainConfig = val;
+                } else if (arg.startsWith("--empty-host-config")) {
+                    assert processType == ProcessType.EMBEDDED_HOST_CONTROLLER;
+                    // don't reset to NEW if its already DISCARD
+                    if (hostConfigInteractionPolicy != ConfigurationFile.InteractionPolicy.DISCARD) {
+                        hostConfigInteractionPolicy = ConfigurationFile.InteractionPolicy.NEW;
+                    }
+                } else if (arg.startsWith("--remove-existing-host-config")) {
+                    assert processType == ProcessType.EMBEDDED_HOST_CONTROLLER;
+                    hostConfigInteractionPolicy = ConfigurationFile.InteractionPolicy.DISCARD;
+                } else if (arg.startsWith("--empty-domain-config")) {
+                    assert processType == ProcessType.EMBEDDED_HOST_CONTROLLER;
+                    if (domainConfigInteractionPolicy != ConfigurationFile.InteractionPolicy.DISCARD) {
+                        domainConfigInteractionPolicy = ConfigurationFile.InteractionPolicy.NEW;
+                    }
+                } else if (arg.startsWith("--remove-existing-domain-config")) {
+                    assert processType == ProcessType.EMBEDDED_HOST_CONTROLLER;
+                    domainConfigInteractionPolicy = ConfigurationFile.InteractionPolicy.DISCARD;
                 } else if (arg.startsWith(CommandLineConstants.READ_ONLY_DOMAIN_CONFIG)) {
                     initialDomainConfig = parseValue(arg, CommandLineConstants.READ_ONLY_DOMAIN_CONFIG);
                     if (initialDomainConfig == null) {
@@ -458,7 +478,7 @@ public final class Main {
         return new HostControllerEnvironmentWrapper(new HostControllerEnvironment(hostSystemProperties, isRestart, modulePath,
                 pmAddress, pmPort, pcSocketConfig.getBindAddress(), pcSocketConfig.getBindPort(), defaultJVM, domainConfig,
                 initialDomainConfig, hostConfig, initialHostConfig, initialRunningMode, backupDomainFiles, cachedDc,
-                productConfig, securityManagerEnabled, startTime, processType));
+                productConfig, securityManagerEnabled, startTime, processType, hostConfigInteractionPolicy, domainConfigInteractionPolicy));
     }
 
     private static String parseValue(final String arg, final String key) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.host.controller;
 
+import static org.jboss.as.host.controller.HostControllerEnvironment.HOST_NAME;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -342,6 +343,11 @@ public final class Main {
                 } else if (arg.startsWith("--remove-existing-domain-config")) {
                     assert processType == ProcessType.EMBEDDED_HOST_CONTROLLER;
                     domainConfigInteractionPolicy = ConfigurationFile.InteractionPolicy.DISCARD;
+                } else if (arg.startsWith("--host-controller-name")) {
+                    String val = checkValueIsNotAnArg(arg, args[++i]);
+                    if (val !=null && !val.isEmpty()) {
+                        hostSystemProperties.put(HOST_NAME, val);
+                    }
                 } else if (arg.startsWith(CommandLineConstants.READ_ONLY_DOMAIN_CONFIG)) {
                     initialDomainConfig = parseValue(arg, CommandLineConstants.READ_ONLY_DOMAIN_CONFIG);
                     if (initialDomainConfig == null) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -343,7 +343,7 @@ public final class Main {
                 } else if (arg.startsWith("--remove-existing-domain-config")) {
                     assert processType == ProcessType.EMBEDDED_HOST_CONTROLLER;
                     domainConfigInteractionPolicy = ConfigurationFile.InteractionPolicy.DISCARD;
-                } else if (arg.startsWith("--host-controller-name")) {
+                } else if (arg.startsWith("--temp-host-controller-name")) {
                     String val = checkValueIsNotAnArg(arg, args[++i]);
                     if (val !=null && !val.isEmpty()) {
                         hostSystemProperties.put(HOST_NAME, val);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1400,4 +1400,10 @@ public interface HostControllerLogger extends BasicLogger {
     @Message(id = 205, value = "An error occurred setting the -Dlogging.configuration property for server %s. Configuration path %s")
     void failedToSetLoggingConfiguration(@Cause Throwable cause, String serverName, File path);
 
+    @Message(id = 206, value = "File %s already exists, you must use --remove-existing-domain-config to overwrite existing files.")
+    IllegalStateException cannotOverwriteDomainXmlWithEmpty(String filename);
+
+    @Message(id = 207, value = "File %s already exists, you must use --remove-existing-host-config to overwrite existing files.")
+    IllegalStateException cannotOverwritHostXmlWithEmpty(String filename);
+
 }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedHostControllerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedHostControllerTestCase.java
@@ -508,7 +508,7 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
 
     @Test
     public void testEmptyHostConfigConfigureWithReload() throws Exception {
-        final String line = "embed-host-controller --std-out=echo --host-config=host-empty-cli.xml --domain-config=domain-cli.xml --empty-host-config --remove-existing-host-config" + JBOSS_HOME;
+        final String line = "embed-host-controller --std-out=echo --host-config=host-empty-cli.xml --domain-config=domain-cli.xml --empty-host-config --remove-existing-host-config --host-controller-name=master" + JBOSS_HOME;
         cli.sendLine(line);
         assertTrue(cli.isConnected());
         cli.sendLine("/host=master/core-service=management/security-realm=test-realm:add()");
@@ -543,7 +543,7 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
 
     @Test
     public void testEmptyDomainConfigAndHostConfigConfigureWithReload() throws Exception {
-        final String line = "embed-host-controller --std-out=echo --domain-config=domain-empty-cli.xml --empty-domain-config --remove-existing-domain-config --host-config=host-empty-cli.xml --empty-host-config --remove-existing-host-config " + JBOSS_HOME;
+        final String line = "embed-host-controller --std-out=echo --domain-config=domain-empty-cli.xml --empty-domain-config --remove-existing-domain-config --host-config=host-empty-cli.xml --empty-host-config --remove-existing-host-config --host-controller-name=master" + JBOSS_HOME;
         cli.sendLine(line);
         assertTrue(cli.isConnected());
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedHostControllerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedHostControllerTestCase.java
@@ -523,6 +523,15 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
     }
 
     @Test
+    public void testHostControllerNameOnlyAllowedWithEmptyHostConfig() throws Exception {
+        final String line = "embed-host-controller --std-out=echo --host-config=host-empty-cli.xml --domain-config=domain-cli.xml --remove-existing-host-config --host-controller-name=master" + JBOSS_HOME;
+        cli.sendLine(line, true);
+        String result = cli.readOutput();
+        // should fail, --empty-host-config is not present
+        assertTrue(result.contains("--host-controller-name must be used with --empty-host-config"));
+    }
+
+    @Test
     public void testEmptyDomainConfigConfigureWithReload() throws Exception {
         final String line = "embed-host-controller --std-out=echo --domain-config=domain-empty-cli.xml --empty-domain-config --remove-existing-domain-config" + JBOSS_HOME;
         cli.sendLine(line);

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedHostControllerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedHostControllerTestCase.java
@@ -508,7 +508,7 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
 
     @Test
     public void testEmptyHostConfigConfigureWithReload() throws Exception {
-        final String line = "embed-host-controller --std-out=echo --host-config=host-empty-cli.xml --domain-config=domain-cli.xml --empty-host-config --remove-existing-host-config --host-controller-name=master" + JBOSS_HOME;
+        final String line = "embed-host-controller --std-out=echo --host-config=host-empty-cli.xml --domain-config=domain-cli.xml --empty-host-config --remove-existing-host-config --temp-host-controller-name=master" + JBOSS_HOME;
         cli.sendLine(line);
         assertTrue(cli.isConnected());
         cli.sendLine("/host=master/core-service=management/security-realm=test-realm:add()");
@@ -524,11 +524,11 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
 
     @Test
     public void testHostControllerNameOnlyAllowedWithEmptyHostConfig() throws Exception {
-        final String line = "embed-host-controller --std-out=echo --host-config=host-empty-cli.xml --domain-config=domain-cli.xml --remove-existing-host-config --host-controller-name=master" + JBOSS_HOME;
+        final String line = "embed-host-controller --std-out=echo --host-config=host-empty-cli.xml --domain-config=domain-cli.xml --remove-existing-host-config --temp-host-controller-name=master" + JBOSS_HOME;
         cli.sendLine(line, true);
         String result = cli.readOutput();
         // should fail, --empty-host-config is not present
-        assertTrue(result.contains("--host-controller-name must be used with --empty-host-config"));
+        assertTrue(result.contains("--temp-host-controller-name may only be used with --empty-host-config"));
     }
 
     @Test
@@ -552,7 +552,7 @@ public class CLIEmbedHostControllerTestCase extends AbstractCliTestBase {
 
     @Test
     public void testEmptyDomainConfigAndHostConfigConfigureWithReload() throws Exception {
-        final String line = "embed-host-controller --std-out=echo --domain-config=domain-empty-cli.xml --empty-domain-config --remove-existing-domain-config --host-config=host-empty-cli.xml --empty-host-config --remove-existing-host-config --host-controller-name=master" + JBOSS_HOME;
+        final String line = "embed-host-controller --std-out=echo --domain-config=domain-empty-cli.xml --empty-domain-config --remove-existing-domain-config --host-config=host-empty-cli.xml --empty-host-config --remove-existing-host-config --temp-host-controller-name=master" + JBOSS_HOME;
         cli.sendLine(line);
         assertTrue(cli.isConnected());
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedUtil.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedUtil.java
@@ -32,6 +32,12 @@ public class CLIEmbedUtil {
                 StandardCopyOption.COPY_ATTRIBUTES);
     }
 
+    static void delConfigFile(final File root, String baseDirName, String base) throws IOException {
+        File configDir = new File(root, baseDirName + File.separatorChar + "configuration");
+        File baseFile = new File(configDir, base);
+        baseFile.delete();
+    }
+
     static void copyServerBaseDir(final File root, final String baseDirName, final String newbaseDirName, boolean force) throws IOException {
         // copy the base server directory (standalone etc to a new name to test changing jboss.server.base.dir etc)
         final File baseDir = new File(root + File.separator + baseDirName);


### PR DESCRIPTION
… an embedded-HC

(This should probably have a 4.0 label attached.)

(--empty-domain-config, --remove-existing-domain-config, --empty-host-config,
--remove-existing-host-config)

@aloubyansky FYI, this still has an issue I'll push an update for with using reload after configuring, the persisted changes still aren't loading for some reason. (Doing stop-embedded-host-controller and a start loads correctly, however).