### PR TITLE
WFCORE-2929: Added missing default values in management model for Elytron ldap-key-store

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/LdapKeyStoreDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/LdapKeyStoreDefinition.java
@@ -95,6 +95,7 @@ final class LdapKeyStoreDefinition extends SimpleResourceDefinition {
             .setXmlName("recursive")
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setDefaultValue(new ModelNode(true))
             .build();
 
     static final SimpleAttributeDefinition SEARCH_TIME_LIMIT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SEARCH_TIME_LIMIT, ModelType.INT, true)
@@ -102,6 +103,7 @@ final class LdapKeyStoreDefinition extends SimpleResourceDefinition {
             .setXmlName("time-limit")
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setDefaultValue(new ModelNode(10000))
             .build();
 
     static final SimpleAttributeDefinition FILTER_ALIAS = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.FILTER_ALIAS, ModelType.STRING, true)
@@ -156,42 +158,49 @@ final class LdapKeyStoreDefinition extends SimpleResourceDefinition {
             .setAttributeGroup(ElytronDescriptionConstants.ATTRIBUTE_MAPPING)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setDefaultValue(new ModelNode("cn"))
             .build();
 
     static final SimpleAttributeDefinition CERTIFICATE_ATTRIBUTE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CERTIFICATE_ATTRIBUTE, ModelType.STRING, true)
             .setAttributeGroup(ElytronDescriptionConstants.ATTRIBUTE_MAPPING)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setDefaultValue(new ModelNode("usercertificate"))
             .build();
 
     static final SimpleAttributeDefinition CERTIFICATE_TYPE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CERTIFICATE_TYPE, ModelType.STRING, true)
             .setAttributeGroup(ElytronDescriptionConstants.ATTRIBUTE_MAPPING)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setDefaultValue(new ModelNode("X.509"))
             .build();
 
     static final SimpleAttributeDefinition CERTIFICATE_CHAIN_ATTRIBUTE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CERTIFICATE_CHAIN_ATTRIBUTE, ModelType.STRING, true)
             .setAttributeGroup(ElytronDescriptionConstants.ATTRIBUTE_MAPPING)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setDefaultValue(new ModelNode("userSMIMECertificate"))
             .build();
 
     static final SimpleAttributeDefinition CERTIFICATE_CHAIN_ENCODING = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CERTIFICATE_CHAIN_ENCODING, ModelType.STRING, true)
             .setAttributeGroup(ElytronDescriptionConstants.ATTRIBUTE_MAPPING)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setDefaultValue(new ModelNode("PKCS7"))
             .build();
 
     static final SimpleAttributeDefinition KEY_ATTRIBUTE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.KEY_ATTRIBUTE, ModelType.STRING, true)
             .setAttributeGroup(ElytronDescriptionConstants.ATTRIBUTE_MAPPING)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setDefaultValue(new ModelNode("userPKCS12"))
             .build();
 
     static final SimpleAttributeDefinition KEY_TYPE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.KEY_TYPE, ModelType.STRING, true)
             .setAttributeGroup(ElytronDescriptionConstants.ATTRIBUTE_MAPPING)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setDefaultValue(new ModelNode("PKCS12"))
             .build();
 
     static final StandardResourceDescriptionResolver RESOURCE_RESOLVER = ElytronExtension.getResourceDescriptionResolver(ElytronDescriptionConstants.LDAP_KEY_STORE);
@@ -276,6 +285,10 @@ final class LdapKeyStoreDefinition extends SimpleResourceDefinition {
             LdapName createPathLdapName = null;
             String createRdn = null;
             Attributes createAttributes = null;
+
+            if (filterAlias == null) filterAlias = "(" + aliasAttribute + "={0})";
+            if (filterCertificate == null) filterCertificate = "(" + certificateAttribute + "={0})";
+            if (filterIterate == null) filterIterate = "(" + aliasAttribute + "=*)";
 
             ModelNode newNode = NewItemTemplateObjectDefinition.OBJECT_DEFINITION.resolveModelAttribute(context, model);
             if (newNode.isDefined()) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TlsParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TlsParser.java
@@ -94,7 +94,7 @@ class TlsParser {
             .addAttribute(LdapKeyStoreDefinition.CERTIFICATE_CHAIN_ENCODING)
             .addAttribute(LdapKeyStoreDefinition.KEY_ATTRIBUTE)
             .addAttribute(LdapKeyStoreDefinition.KEY_TYPE)
-
+            .setMarshallDefaultValues(true)
             .build();
 
     private PersistentResourceXMLDescription trustManagerParser = PersistentResourceXMLDescription.builder(PathElement.pathElement(TRUST_MANAGER))

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -1733,14 +1733,14 @@
         <xs:attribute name="connection-timeout" type="xs:integer" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The timeout for connecting to the LDAP server in miliseconds.
+                    The timeout for connecting to the LDAP server in milliseconds.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="read-timeout" type="xs:integer" use="optional">
             <xs:annotation>
                 <xs:documentation>
-                    The read timeout for an LDAP operation in miliseconds.
+                    The read timeout for an LDAP operation in milliseconds.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -4514,7 +4514,7 @@
                     <xs:attribute name="time-limit" type="xs:integer" use="optional" default="10000">
                         <xs:annotation>
                             <xs:documentation>
-                                The time limit for LDAP search in miliseconds.
+                                The time limit for LDAP search in milliseconds.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>


### PR DESCRIPTION
Default values were already being correctly used in LdapKeyStore. The only advantage I can see setting default values on LdapKeyStoreDefinition is LdapKeyStoreService will end up with those defaults instead of nulls, and any class using the service will get the "real" defaults, so I created this PR instead of solving the issue directly. 

Jira issues:
https://issues.jboss.org/browse/WFCORE-2929
https://issues.jboss.org/browse/JBEAP-7487