### PR TITLE
[WFCORE-2934] Remove 'purpose' from call to getAuthenticationConfiguration()

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
@@ -108,7 +108,7 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
         }
         final AuthenticationContext injectedContext = this.authenticationContext.getOptionalValue();
         if (injectedContext != null) {
-            configuration = AUTH_CONFIGURATION_CLIENT.getAuthenticationConfiguration(uri, injectedContext, -1, null, null, "connect");
+            configuration = AUTH_CONFIGURATION_CLIENT.getAuthenticationConfiguration(uri, injectedContext, -1, null, null);
             try {
                 sslContext = AUTH_CONFIGURATION_CLIENT.getSSLContext(uri, injectedContext);
             } catch (GeneralSecurityException e) {


### PR DESCRIPTION
This is a clean up PR following Elytron API changes, ideally we need to get this removed soon so we can upgrade to an Elytron version without the compatibility stubs.

https://issues.jboss.org/browse/WFCORE-2934
