### PR TITLE
[WFCORE-2927] Share the AttributeAccess.Flag, OperationEntry.Flag and…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -138,7 +138,7 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
         List<AccessConstraintDefinition> acl = basis.getAccessConstraints();
         this.accessConstraints = acl.toArray(new AccessConstraintDefinition[acl.size()]);
         this.parser = basis.getParser();
-        Set<AttributeAccess.Flag> basisFlags = basis.getFlags();
+        Set<AttributeAccess.Flag> basisFlags = basis.getImmutableFlags();
         this.flags = basisFlags.toArray(new AttributeAccess.Flag[basisFlags.size()]);
         if (basis.getAllowedValues().size() > 0) {
             List<ModelNode> basisAllowedValues = basis.getAllowedValues();

--- a/controller/src/main/java/org/jboss/as/controller/AbstractWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractWriteAttributeHandler.java
@@ -103,7 +103,7 @@ public abstract class AbstractWriteAttributeHandler<T> implements OperationStepH
                     final HandbackHolder<T> handback = new HandbackHolder<T>();
                     final boolean reloadRequired = applyUpdateToRuntime(context, operation, attributeName, resolvedValue, currentValue, handback);
                     if (reloadRequired) {
-                        if (attributeDefinition != null && attributeDefinition.getFlags().contains(AttributeAccess.Flag.RESTART_JVM)){
+                        if (attributeDefinition != null && attributeDefinition.getImmutableFlags().contains(AttributeAccess.Flag.RESTART_JVM)){
                             context.restartRequired();
                         }else{
                             context.reloadRequired();
@@ -125,7 +125,7 @@ public abstract class AbstractWriteAttributeHandler<T> implements OperationStepH
                                         context.getCurrentAddress());
                             }
                             if (reloadRequired) {
-                                if (attributeDefinition != null && attributeDefinition.getFlags().contains(AttributeAccess.Flag.RESTART_JVM)) {
+                                if (attributeDefinition != null && attributeDefinition.getImmutableFlags().contains(AttributeAccess.Flag.RESTART_JVM)) {
                                     context.revertRestartRequired();
                                 } else {
                                     context.revertReloadRequired();

--- a/controller/src/main/java/org/jboss/as/controller/OperationDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationDefinition.java
@@ -24,10 +24,13 @@
 
 package org.jboss.as.controller;
 
+import static org.jboss.as.controller.registry.OperationEntry.Flag.immutableSetOf;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
@@ -46,7 +49,7 @@ public abstract class OperationDefinition {
 
     protected final String name;
     protected final OperationEntry.EntryType entryType;
-    protected final EnumSet<OperationEntry.Flag> flags;
+    protected final Set<OperationEntry.Flag> flags;
     protected final AttributeDefinition[] parameters;
     protected final ModelType replyType;
     protected final ModelType replyValueType;
@@ -59,7 +62,7 @@ public abstract class OperationDefinition {
     protected OperationDefinition(SimpleOperationDefinitionBuilder builder) {
         this.name = builder.name;
         this.entryType = builder.entryType;
-        this.flags = builder.flags;
+        this.flags = immutableSetOf(builder.flags);
         this.parameters = builder.parameters;
         this.replyType = builder.replyType;
         this.replyValueType = builder.replyValueType;
@@ -90,7 +93,7 @@ public abstract class OperationDefinition {
     ) {
         this.name = name;
         this.entryType = entryType;
-        this.flags = flags;
+        this.flags = immutableSetOf(flags);
         this.parameters = parameters;
         this.replyType = replyType;
         this.replyValueType = replyValueType;
@@ -113,7 +116,11 @@ public abstract class OperationDefinition {
         return entryType;
     }
 
-    public EnumSet<OperationEntry.Flag> getFlags() {
+    /**
+     * Gets an immutable set of any {@link OperationEntry.Flag flags} associated with the operation.
+     * @return the flags. Will not return {@code null} be may be empty
+     */
+    public Set<OperationEntry.Flag> getFlags() {
         return flags;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceDefinition.java
@@ -74,7 +74,7 @@ public abstract class PersistentResourceDefinition extends SimpleResourceDefinit
         super.registerAttributes(resourceRegistration);
         ReloadRequiredWriteAttributeHandler handler = new ReloadRequiredWriteAttributeHandler(getAttributes());
         for (AttributeDefinition attr : getAttributes()) {
-            if(!attr.getFlags().contains(AttributeAccess.Flag.RESTART_ALL_SERVICES)) {
+            if(!attr.getImmutableFlags().contains(AttributeAccess.Flag.RESTART_ALL_SERVICES)) {
                 throw ControllerLogger.ROOT_LOGGER.attributeWasNotMarkedAsReloadRequired(attr.getName(), resourceRegistration.getPathAddress());
             }
             resourceRegistration.registerReadWriteAttribute(attr, null, handler);

--- a/controller/src/main/java/org/jboss/as/controller/access/Action.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/Action.java
@@ -38,7 +38,7 @@ import org.jboss.dmr.ModelNode;
  */
 public final class Action {
 
-    public static enum ActionEffect {
+    public enum ActionEffect {
         /** "Address" a resource, thus confirming the address is valid. All operations have this effect. */
         ADDRESS("address"),
         /** Read the persistent configuration */
@@ -52,7 +52,7 @@ public final class Action {
 
         private final String name;
 
-        private ActionEffect(String name) {
+        ActionEffect(String name) {
             this.name = name;
         }
 
@@ -85,7 +85,7 @@ public final class Action {
             return Collections.emptySet();
         }
         final EnumSet<ActionEffect> result;
-        final EnumSet<OperationEntry.Flag> flags = operationEntry.getFlags();
+        final Set<OperationEntry.Flag> flags = operationEntry.getFlags();
         if (flags.contains(OperationEntry.Flag.RUNTIME_ONLY)) {
             result = EnumSet.of(ActionEffect.ADDRESS, ActionEffect.READ_RUNTIME);
             if (!flags.contains(OperationEntry.Flag.READ_ONLY)) {
@@ -107,7 +107,7 @@ public final class Action {
         return actionEffects;
     }
 
-    public EnumSet<OperationEntry.Flag> getFlags() {
+    public Set<OperationEntry.Flag> getFlags() {
         return operationEntry != null ? operationEntry.getFlags() : EnumSet.noneOf(OperationEntry.Flag.class);
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadOperationNamesHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadOperationNamesHandler.java
@@ -26,8 +26,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FIL
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_OPERATION_NAMES_OPERATION;
 
-import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -109,7 +109,7 @@ public class ReadOperationNamesHandler implements OperationStepHandler {
     }
 
     static boolean isVisible(OperationEntry operationEntry, OperationContext context) {
-        EnumSet<OperationEntry.Flag> flags = operationEntry.getFlags();
+        Set<OperationEntry.Flag> flags = operationEntry.getFlags();
         return operationEntry.getType() == OperationEntry.EntryType.PUBLIC
                 && !flags.contains(OperationEntry.Flag.HIDDEN)
                 && (context.getProcessType() != ProcessType.DOMAIN_SERVER || flags.contains(OperationEntry.Flag.RUNTIME_ONLY)

--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/ModelTypeValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/ModelTypeValidator.java
@@ -20,10 +20,14 @@ package org.jboss.as.controller.operations.validation;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -57,7 +61,22 @@ public class ModelTypeValidator implements ParameterValidator {
     protected static final BigInteger BIGINTEGER_MAX = BigInteger.valueOf(Integer.MAX_VALUE);
     protected static final BigInteger BIGINTEGER_MIN = BigInteger.valueOf(Integer.MIN_VALUE);
 
-    protected final EnumSet<ModelType> validTypes;
+    private static final Map<EnumSet<ModelType>, Set<ModelType>> flagSets = new ConcurrentHashMap<>(16);
+    private static Set<ModelType> sharedSetOf(boolean allowExpressions, ModelType firstValidType, ModelType... otherValidTypes) {
+        EnumSet<ModelType> baseSet = EnumSet.of(firstValidType, otherValidTypes);
+        if (allowExpressions) {
+            baseSet.add(ModelType.EXPRESSION);
+        }
+        Set<ModelType> result = flagSets.get(baseSet);
+        if (result == null) {
+            Set<ModelType> immutable = Collections.unmodifiableSet(baseSet);
+            Set<ModelType> existing = flagSets.putIfAbsent(baseSet, immutable);
+            result = existing == null ? immutable : existing;
+        }
+        return result;
+    }
+
+    protected final Set<ModelType> validTypes;
     protected final boolean nullable;
     protected final boolean strictType;
 
@@ -115,11 +134,8 @@ public class ModelTypeValidator implements ParameterValidator {
      * @param otherValidTypes additional valid types. May be {@code null}
      */
     public ModelTypeValidator(final boolean nullable, final boolean allowExpressions, final boolean strictType, ModelType firstValidType, ModelType... otherValidTypes) {
-        this.validTypes = EnumSet.of(firstValidType, otherValidTypes);
+        this.validTypes = sharedSetOf(allowExpressions, firstValidType, otherValidTypes);
         this.nullable = nullable;
-        if (allowExpressions) {
-            this.validTypes.add(ModelType.EXPRESSION);
-        }
         this.strictType = strictType;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
@@ -21,13 +21,14 @@
  */
 package org.jboss.as.controller.registry;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.OperationStepHandler;
 import org.wildfly.common.Assert;
 
@@ -41,7 +42,7 @@ public final class AttributeAccess {
     /**
      * Indicates how an attributed is accessed.
      */
-    public static enum AccessType {
+    public enum AccessType {
         /** A read-only attribute, which can be either {@code Storage.CONFIGURATION} or {@code Storage.RUNTIME} */
         READ_ONLY("read-only", false),
         /** A read-write attribute, which can be either {@code Storage.CONFIGURATION} or {@code Storage.RUNTIME} */
@@ -52,7 +53,7 @@ public final class AttributeAccess {
         private final String label;
         private final boolean writable;
 
-        private AccessType(final String label, final boolean writable) {
+        AccessType(final String label, final boolean writable) {
             this.label = label;
             this.writable = writable;
         }
@@ -89,7 +90,7 @@ public final class AttributeAccess {
     /**
      * Indicates whether an attribute is derived from the persistent configuration or is a purely runtime attribute.
      */
-    public static enum Storage {
+    public enum Storage {
         /**
          * An attribute whose value is stored in the persistent configuration.
          * The value may also be stored in runtime services.
@@ -103,7 +104,7 @@ public final class AttributeAccess {
 
         private final String label;
 
-        private Storage(final String label) {
+        Storage(final String label) {
             this.label = label;
         }
 
@@ -145,18 +146,38 @@ public final class AttributeAccess {
          * This flag can be used in conjunction with STORAGE_RUNTIME to specify that a runtime
          * attribute can work in the absence of runtime services.
          */
-         RUNTIME_SERVICE_NOT_REQUIRED
+         RUNTIME_SERVICE_NOT_REQUIRED;
+
+        private static final EnumSet<AttributeAccess.Flag> NONE = EnumSet.noneOf(AttributeAccess.Flag.class);
+        private static final Map<EnumSet<AttributeAccess.Flag>, Set<AttributeAccess.Flag>> flagSets = new ConcurrentHashMap<>(16);
+        public static Set<AttributeAccess.Flag> immutableSetOf(AttributeAccess.Flag... flags) {
+            EnumSet<AttributeAccess.Flag> baseSet;
+            if (flags == null || flags.length == 0) {
+                baseSet = NONE;
+            } else if (flags.length == 1) {
+                baseSet = EnumSet.of(flags[0]);
+            } else {
+                baseSet = EnumSet.of(flags[0], flags);
+            }
+            Set<AttributeAccess.Flag> result = flagSets.get(baseSet);
+            if (result == null) {
+                Set<AttributeAccess.Flag> immutable = Collections.unmodifiableSet(baseSet);
+                Set<AttributeAccess.Flag> existing = flagSets.putIfAbsent(baseSet, immutable);
+                result = existing == null ? immutable : existing;
+            }
+
+            return result;
+        }
     }
 
     private final AccessType access;
     private final Storage storage;
     private final OperationStepHandler readHandler;
     private final OperationStepHandler writeHandler;
-    private final EnumSet<Flag> flags;
     private final AttributeDefinition definition;
 
     AttributeAccess(final AccessType access, final Storage storage, final OperationStepHandler readHandler,
-                    final OperationStepHandler writeHandler, AttributeDefinition definition, final EnumSet<Flag> flags) {
+                    final OperationStepHandler writeHandler, AttributeDefinition definition) {
         Assert.assertNotNull(access);
         Assert.assertNotNull(storage);
         this.access = access;
@@ -164,24 +185,11 @@ public final class AttributeAccess {
         this.writeHandler = writeHandler;
         this.storage = storage;
         this.definition = definition;
-        if (flags != null && flags.contains(Flag.ALIAS)) {
+        if (definition.getImmutableFlags().contains(Flag.ALIAS)) {
             Assert.checkNotNullParam("readHandler", readHandler);
         }
         if (access == AccessType.READ_WRITE) {
             Assert.checkNotNullParam("writeHandler", writeHandler);
-        }
-        this.flags = flags == null ? EnumSet.noneOf(Flag.class) : EnumSet.copyOf(flags);
-        switch (storage) {
-            case CONFIGURATION:
-                this.flags.add(Flag.STORAGE_CONFIGURATION);
-                this.flags.remove(Flag.STORAGE_RUNTIME);
-                break;
-            case RUNTIME:
-                this.flags.add(Flag.STORAGE_RUNTIME);
-                this.flags.remove(Flag.STORAGE_CONFIGURATION);
-                break;
-            default:
-                throw ControllerLogger.ROOT_LOGGER.unexpectedStorage(storage);
         }
     }
 
@@ -230,7 +238,7 @@ public final class AttributeAccess {
      * @return the flags. Will not return {@code null}
      */
     public Set<Flag> getFlags() {
-        return EnumSet.copyOf(flags);
+        return definition.getImmutableFlags();
     }
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ConcreteResourceRegistration.java
@@ -27,7 +27,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRO
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -399,9 +398,8 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         if (!isAttributeRegistrationAllowed(definition)) {
             return;
         }
-        final EnumSet<AttributeAccess.Flag> flags = definition.getFlags();
-        AttributeAccess.Storage storage = (flags != null && flags.contains(AttributeAccess.Flag.STORAGE_RUNTIME)) ? Storage.RUNTIME : Storage.CONFIGURATION;
-        AttributeAccess aa = new AttributeAccess(AccessType.READ_WRITE, storage, readHandler, writeHandler, definition, flags);
+        AttributeAccess.Storage storage = definition.getImmutableFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME) ? Storage.RUNTIME : Storage.CONFIGURATION;
+        AttributeAccess aa = new AttributeAccess(AccessType.READ_WRITE, storage, readHandler, writeHandler, definition);
         storeAttribute(definition, aa);
     }
 
@@ -412,9 +410,8 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         if (!isAttributeRegistrationAllowed(definition)) {
             return;
         }
-        final EnumSet<AttributeAccess.Flag> flags = definition.getFlags();
-        AttributeAccess.Storage storage = (flags != null && flags.contains(AttributeAccess.Flag.STORAGE_RUNTIME)) ? Storage.RUNTIME : Storage.CONFIGURATION;
-        AttributeAccess aa = new AttributeAccess(AccessType.READ_ONLY, storage, readHandler, null, definition, flags);
+        AttributeAccess.Storage storage = definition.getImmutableFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME) ? Storage.RUNTIME : Storage.CONFIGURATION;
+        AttributeAccess aa = new AttributeAccess(AccessType.READ_ONLY, storage, readHandler, null, definition);
         storeAttribute(definition, aa);
     }
 
@@ -476,7 +473,7 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
         assert assertMetricValues(definition); //The real message will be in an assertion thrown by assertMetricValues
         checkPermission();
         if (isAttributeRegistrationAllowed(definition) && !isProfileResource()) {
-            AttributeAccess aa = new AttributeAccess(AccessType.METRIC, AttributeAccess.Storage.RUNTIME, metricHandler, null, definition, definition.getFlags());
+            AttributeAccess aa = new AttributeAccess(AccessType.METRIC, AttributeAccess.Storage.RUNTIME, metricHandler, null, definition);
             storeAttribute(definition, aa);
         }
     }
@@ -487,11 +484,11 @@ final class ConcreteResourceRegistration extends AbstractResourceRegistration {
      * {@link AttributeAccess.Flag#RUNTIME_SERVICE_NOT_REQUIRED}, they are registered regardless of the process type.
      */
     private boolean isAttributeRegistrationAllowed(AttributeDefinition definition) {
-        boolean runtime = definition.getFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME);
+        boolean runtime = definition.getImmutableFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME);
         if (!runtime) {
             return true;
         }
-        boolean runtimeServiceNotRequired = definition.getFlags().contains(AttributeAccess.Flag.RUNTIME_SERVICE_NOT_REQUIRED);
+        boolean runtimeServiceNotRequired = definition.getImmutableFlags().contains(AttributeAccess.Flag.RUNTIME_SERVICE_NOT_REQUIRED);
         if (runtimeServiceNotRequired) {
             return true;
         }

--- a/controller/src/main/java/org/jboss/as/controller/registry/LegacyResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/LegacyResourceDefinition.java
@@ -60,7 +60,7 @@ public class LegacyResourceDefinition implements ResourceDefinition {
                 String name = property.getName();
                 SimpleAttributeDefinition def = SimpleAttributeDefinitionBuilder.create(name, property.getValue()).build();
                 this.attributes.put(name, new AttributeAccess(
-                        AttributeAccess.AccessType.READ_ONLY, AttributeAccess.Storage.CONFIGURATION, null, null, def, null)
+                        AttributeAccess.AccessType.READ_ONLY, AttributeAccess.Storage.CONFIGURATION, null, null, def)
                 );
             }
         }

--- a/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ProxyControllerRegistration.java
@@ -23,7 +23,6 @@
 package org.jboss.as.controller.registry;
 
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Locale;
@@ -179,10 +178,9 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
 
     @Override
     public void registerReadWriteAttribute(final AttributeDefinition definition, final OperationStepHandler readHandler, final OperationStepHandler writeHandler) {
-        final EnumSet<AttributeAccess.Flag> flags = definition.getFlags();
         final String attributeName = definition.getName();
-        AttributeAccess.Storage storage = (flags != null && flags.contains(AttributeAccess.Flag.STORAGE_RUNTIME)) ? AttributeAccess.Storage.RUNTIME : AttributeAccess.Storage.CONFIGURATION;
-        AttributeAccess aa = new AttributeAccess(AttributeAccess.AccessType.READ_WRITE, storage, readHandler, writeHandler, definition, flags);
+        AttributeAccess.Storage storage = definition.getImmutableFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME) ? AttributeAccess.Storage.RUNTIME : AttributeAccess.Storage.CONFIGURATION;
+        AttributeAccess aa = new AttributeAccess(AttributeAccess.AccessType.READ_WRITE, storage, readHandler, writeHandler, definition);
         if (attributesUpdater.putIfAbsent(this, attributeName, aa) != null) {
             throw alreadyRegistered("attribute", attributeName);
         }
@@ -190,10 +188,9 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
 
     @Override
     public void registerReadOnlyAttribute(final AttributeDefinition definition, final OperationStepHandler readHandler) {
-        final EnumSet<AttributeAccess.Flag> flags = definition.getFlags();
         final String attributeName = definition.getName();
-        AttributeAccess.Storage storage = (flags != null && flags.contains(AttributeAccess.Flag.STORAGE_RUNTIME)) ? AttributeAccess.Storage.RUNTIME : AttributeAccess.Storage.CONFIGURATION;
-        AttributeAccess aa = new AttributeAccess(AttributeAccess.AccessType.READ_ONLY, storage, readHandler, null, definition, flags);
+        AttributeAccess.Storage storage = definition.getImmutableFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME) ? AttributeAccess.Storage.RUNTIME : AttributeAccess.Storage.CONFIGURATION;
+        AttributeAccess aa = new AttributeAccess(AttributeAccess.AccessType.READ_ONLY, storage, readHandler, null, definition);
         if (attributesUpdater.putIfAbsent(this, attributeName, aa) != null) {
             throw alreadyRegistered("attribute", attributeName);
         }
@@ -206,7 +203,7 @@ final class ProxyControllerRegistration extends AbstractResourceRegistration imp
 
     @Override
     public void registerMetric(AttributeDefinition definition, OperationStepHandler metricHandler) {
-        AttributeAccess aa = new AttributeAccess(AttributeAccess.AccessType.METRIC, AttributeAccess.Storage.RUNTIME, metricHandler, null, definition, definition.getFlags());
+        AttributeAccess aa = new AttributeAccess(AttributeAccess.AccessType.METRIC, AttributeAccess.Storage.RUNTIME, metricHandler, null, definition);
         if (attributesUpdater.putIfAbsent(this, definition.getName(), aa) != null) {
             throw alreadyRegistered("attribute", definition.getName());
         }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncServerStateOperationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncServerStateOperationHandler.java
@@ -21,7 +21,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRI
 import static org.jboss.as.domain.management.ModelDescriptionConstants.NAME;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -197,8 +196,7 @@ class SyncServerStateOperationHandler implements OperationStepHandler {
             // look up the attribute name we're writing, and check the flags to see if we need restart.
             final String attributeName = operation.get(NAME).asString();
             // look up if the attribute requires restart / reload
-            final EnumSet<AttributeAccess.Flag> flags = registration.getAttributeAccess(address, attributeName).getAttributeDefinition().getFlags();
-            if (flags.contains(AttributeAccess.Flag.RESTART_JVM)) {
+            if (registration.getAttributeAccess(address, attributeName).getFlags().contains(AttributeAccess.Flag.RESTART_JVM)) {
                 restart = true;
             }
         } else { // all other ops

--- a/host-controller/src/main/java/org/jboss/as/host/controller/discovery/StaticDiscoveryResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/discovery/StaticDiscoveryResourceDefinition.java
@@ -29,7 +29,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.host.controller.descriptions.HostResolver;
@@ -52,13 +51,8 @@ public class StaticDiscoveryResourceDefinition extends SimpleResourceDefinition 
     public static final SimpleAttributeDefinition PROTOCOL = DomainControllerWriteAttributeHandler.PROTOCOL; // protocol should allow null it appears
 
     private static SimpleAttributeDefinition getRequiredCopy(SimpleAttributeDefinition attr) {
-        return new SimpleAttributeDefinitionBuilder(attr.getName(), attr.getType())
+        return new SimpleAttributeDefinitionBuilder(attr)
         .setRequired(true)
-        .setAllowExpression(attr.isAllowExpression())
-        .setValidator(attr.getValidator())
-        .setFlags(attr.getFlags().toArray(new AttributeAccess.Flag[0]))
-        .setRequires(attr.getRequires())
-        .setDefaultValue(attr.getDefaultValue())
         .build();
     }
 


### PR DESCRIPTION
… ModelTypeValidator.validTypes sets

https://issues.jboss.org/browse/WFCORE-2927

Use immutable sets internally; intern the sets.

For AttributeDefinition.getFlags() I added a transitional API to make it possible to use immutable sets, and then in core 4 I'll change the return type in the signature of the current method from EnumSet to Set and drop the transitional API. I don't think any of that is strictly necessary as callers outside core are unlikely to be requiring EnumSet, but since we're fairly close to a .Final release I decided to be conservative about it.

I didn't bother with such compatibility stuff with OperationDefinition.flags as really no one outside core should be messing with those.