### PR TITLE
[WFCORE-2938] Ensure the SSLContext from an injected legacy security realm is used for a remote outbound connection regardless of whether or not a username is specified

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
@@ -123,14 +123,17 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
             }
         } else {
             final SecurityRealm securityRealm = securityRealmInjectedValue.getOptionalValue();
-            if (securityRealm != null && username != null) {
+            if (securityRealm != null) {
                 // legacy remote-outbound-connection configuration
-                configuration = AuthenticationConfiguration.empty()
-                    .useName(username)
-                    .setSaslMechanismSelector(SaslMechanismSelector.DEFAULT.forbidMechanism(JBOSS_LOCAL_USER));
-                final CallbackHandlerFactory callbackHandlerFactory = securityRealm.getSecretCallbackHandlerFactory();
-                if (callbackHandlerFactory != null) {
-                    configuration = configuration.useCallbackHandler(callbackHandlerFactory.getCallbackHandler(username));
+                configuration = AuthenticationConfiguration.empty();
+                if (username != null) {
+                    configuration = configuration
+                            .useName(username)
+                            .setSaslMechanismSelector(SaslMechanismSelector.DEFAULT.forbidMechanism(JBOSS_LOCAL_USER));
+                    final CallbackHandlerFactory callbackHandlerFactory = securityRealm.getSecretCallbackHandlerFactory();
+                    if (callbackHandlerFactory != null) {
+                        configuration = configuration.useCallbackHandler(callbackHandlerFactory.getCallbackHandler(username));
+                    }
                 }
                 sslContext = securityRealm.getSSLContext();
             } else {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2938
https://issues.jboss.org/browse/JBEAP-10860