### PR TITLE
Fix for WFCORE-2936. Handle empty string in complex object

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/parsing/arguments/ArgumentValueCallbackHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/arguments/ArgumentValueCallbackHandler.java
@@ -125,6 +125,7 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
             }
         } else if(QuotesState.ID.equals(stateId)) {
             flag ^= QUOTES;
+            currentState.quoted();
         } else if(EscapeCharacterState.ID.equals(stateId)) {
             flag ^= ESCAPE;
         }
@@ -169,6 +170,9 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
         boolean isOnSeparator();
 
         void enteredValue();
+
+        default void quoted() {
+        }
     }
 
     class BytesState implements ValueState {
@@ -259,6 +263,7 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
         protected boolean onSeparator;
 
         protected ModelNode child;
+        private boolean quoted;
 
         @Override
         public boolean isOnSeparator() {
@@ -348,6 +353,9 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
             final ModelNode value = new ModelNode();
             if(buf != null) {
                 value.set(getTrimmedString());
+            } else if (quoted) {
+                // An empty String, just composed of 2 quotes.
+                value.set("");
             }
             return value;
         }
@@ -363,6 +371,11 @@ public class ArgumentValueCallbackHandler implements ParsingStateCallbackHandler
                 trimToSize = -1;
             }
             return buf.toString();
+        }
+
+        @Override
+        public void quoted() {
+            quoted = true;
         }
     }
 

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/ArgumentValueConverterTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/ArgumentValueConverterTestCase.java
@@ -256,6 +256,16 @@ public class ArgumentValueConverterTestCase {
         assertEquals("text", value.asString());
     }
 
+    @Test
+    public void testObject_TextEmptyValue() throws Exception {
+        final ModelNode obj = parseObject("{x=\"\"}");
+        assertNotNull(obj);
+        assertEquals(ModelType.OBJECT, obj.getType());
+        ModelNode val = obj.get("x");
+        assertEquals(ModelType.STRING, val.getType());
+        assertEquals("", val.asString());
+    }
+
     protected ModelNode parseObject(String value) throws CommandFormatException {
         return ArgumentValueConverter.DEFAULT.fromString(ctx, value);
     }


### PR DESCRIPTION
Handle "" in complex objects expressed with non DMR syntax. Added unit test.

