### PR TITLE
Fix tests that rely on English messages.

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SlaveSynchronizationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SlaveSynchronizationTestCase.java
@@ -22,7 +22,6 @@
 package org.jboss.as.test.integration.domain;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST_FAILURE_DESCRIPTIONS;
@@ -187,7 +186,7 @@ public class SlaveSynchronizationTestCase {
        Assert.assertTrue(DomainTestUtils.checkState(masterClient, mainOneAddress, "STARTED"));
        ModelNode result = masterClient.execute(Util.createRemoveOperation(mainOneAddress));
        ModelNode failure = DomainTestSupport.validateFailedResponse(result);
-       Assert.assertThat("Failure " + failure.toString(), failure.get(HOST_FAILURE_DESCRIPTIONS).get("hc2").asString(), is(HostControllerLogger.ROOT_LOGGER.serverStillRunning("server-one")));
+       Assert.assertTrue("Failure " + failure.toString(), failure.get(HOST_FAILURE_DESCRIPTIONS).get("hc2").asString().matches("WFLYHC0078.+server-one.*"));
     }
 
     private ModelNode removeServer(final ModelControllerClient client, final PathAddress address) throws IOException, MgmtOperationException {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ValidateAddressOperationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ValidateAddressOperationTestCase.java
@@ -29,9 +29,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
-import org.jboss.as.controller.logging.ControllerLogger;
-import org.jboss.as.controller.PathElement;
-
 import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
@@ -98,7 +95,7 @@ public class ValidateAddressOperationTestCase  {
         assertFalse(value.asBoolean());
         assertTrue(result.hasDefined(PROBLEM));
         final ModelNode problem = result.get(PROBLEM);
-        assertTrue(problem.asString().contains(ControllerLogger.ROOT_LOGGER.childResourceNotFound(PathElement.pathElement("wrong", "illegal"))));
+        assertTrue(problem.asString().matches("WFLYCTL0217.+\"wrong\".+\"illegal\".*"));
     }
 
     @Test

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BasicOpsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/BasicOpsTestCase.java
@@ -72,26 +72,24 @@ public class BasicOpsTestCase {
     public void testReadAttribute() throws Exception {
         CLIWrapper cli = new CLIWrapper(true);
         {
-            cli.sendLine("read-attribute namespaces");
-            String output = cli.readOutput();
-            assertFalse(output.contains("Unknown attribute 'namespaces'"));
+            assertTrue("Failed to read attribute: " + cli.readOutput(),
+                    cli.sendLine("read-attribute namespaces", true));
         }
         {
-            cli.sendLine("read-attribute --node=subsystem=request-controller namespaces", true);
+            assertFalse("Expected command to fail on invalid node",
+                    cli.sendLine("read-attribute --node=subsystem=request-controller namespaces", true));
             String output = cli.readOutput();
-            assertTrue(output.contains("Unknown attribute 'namespaces'"));
-        }
-
-        {
-            cli.sendLine("read-attribute active-requests --node=subsystem=request-controller");
-            String output = cli.readOutput();
-            assertFalse(output.contains("Unknown attribute 'active-requests'"));
+            assertTrue(output.matches("WFLYCTL0201.*namespaces.*"));
         }
 
         {
-            cli.sendLine("read-attribute --node=subsystem=request-controller active-requests");
-            String output = cli.readOutput();
-            assertFalse(output.contains("Unknown attribute 'active-requests'"));
+            assertTrue("Failed to read attribute: " + cli.readOutput(),
+                    cli.sendLine("read-attribute active-requests --node=subsystem=request-controller", true));
+        }
+
+        {
+            assertTrue("Failed to read attribute: " + cli.readOutput(),
+                    cli.sendLine("read-attribute --node=subsystem=request-controller active-requests", true));
         }
         cli.quit();
     }

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ValidateAddressOperationTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/ValidateAddressOperationTestCase.java
@@ -23,8 +23,6 @@ package org.wildfly.core.test.standalone.mgmt.api;
 
 import java.io.IOException;
 
-import org.jboss.as.controller.logging.ControllerLogger;
-import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.as.test.integration.management.util.ModelUtil;
@@ -84,6 +82,6 @@ public class ValidateAddressOperationTestCase extends ContainerResourceMgmtTestB
         assertFalse(value.asBoolean());
         assertTrue(result.hasDefined(PROBLEM));
         final ModelNode problem = result.get(PROBLEM);
-        assertTrue(problem.asString().contains(ControllerLogger.ROOT_LOGGER.childResourceNotFound(PathElement.pathElement("wrong", "illegal"))));
+        assertTrue(problem.asString().matches("WFLYCTL0217.+\"wrong\".+\"illegal\".*"));
     }
 }


### PR DESCRIPTION
The changes where the message bundle interface was used may not be needed if the same locale is used for tests and the server boot. However testing with `-Djvm.args.other=-Duser.language=de` only boots the server with the locale and the test itself will still run under the users default locale.

This is a test run with translated messages added https://ci.wildfly.org/viewLog.html?buildId=63595&.