### PR TITLE
[WFCORE-2946]:  Errors publishing a large deployment to a remote server.

### DIFF
--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DeploymentPlanBuilderImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DeploymentPlanBuilderImpl.java
@@ -22,17 +22,12 @@
 
 package org.jboss.as.controller.client.helpers.domain.impl;
 
-import java.io.BufferedInputStream;
-import java.io.DataOutput;
 import java.io.File;
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 import org.jboss.as.controller.client.logging.ControllerClientLogger;
 import org.jboss.as.controller.client.helpers.domain.AddDeploymentPlanBuilder;
@@ -44,8 +39,7 @@ import org.jboss.as.controller.client.helpers.domain.ReplaceDeploymentPlanBuilde
 import org.jboss.as.controller.client.helpers.domain.ServerGroupDeploymentPlan;
 import org.jboss.as.controller.client.helpers.domain.ServerGroupDeploymentPlanBuilder;
 import org.jboss.as.controller.client.helpers.domain.UndeployDeploymentPlanBuilder;
-import org.jboss.as.controller.client.impl.InputStreamEntry;
-import org.jboss.as.protocol.StreamUtils;
+import org.jboss.as.controller.client.impl.InputStreamEntry.FileStreamEntry;
 import org.wildfly.common.Assert;
 
 /**
@@ -278,33 +272,5 @@ class DeploymentPlanBuilderImpl extends AbstractDeploymentPlanBuilder implements
         }
 
         return path.substring(idx + 1);
-    }
-
-    // Wrap the FIS in a streamEntry so that the controller-client has access to the underlying File
-    private static class FileStreamEntry extends FilterInputStream implements InputStreamEntry {
-
-        private final Path file;
-
-        private FileStreamEntry(final File file) throws IOException {
-            this(file.toPath());
-        }
-
-        private FileStreamEntry(final Path file) throws IOException {
-            super(Files.newInputStream(file)); // This stream will get closed regardless of autoClose
-            this.file = file;
-        }
-
-        @Override
-        public int initialize() throws IOException {
-            return (int) Files.size(file);
-        }
-
-        @Override
-        public void copyStream(final DataOutput output) throws IOException {
-            try (InputStream in = new BufferedInputStream(Files.newInputStream(file))) {
-                StreamUtils.copyStream(in, output);
-            }
-        }
-
     }
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DeploymentPlanBuilderImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/domain/impl/DeploymentPlanBuilderImpl.java
@@ -22,15 +22,17 @@
 
 package org.jboss.as.controller.client.helpers.domain.impl;
 
+import java.io.BufferedInputStream;
 import java.io.DataOutput;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import org.jboss.as.controller.client.logging.ControllerClientLogger;
 import org.jboss.as.controller.client.helpers.domain.AddDeploymentPlanBuilder;
@@ -85,11 +87,8 @@ class DeploymentPlanBuilderImpl extends AbstractDeploymentPlanBuilder implements
 
     @Override
     public AddDeploymentPlanBuilder add(String name, File file) throws IOException, DuplicateDeploymentNameException {
-        final InputStream is = new FileStreamEntry(file);
-        try {
+        try (final InputStream is = new FileStreamEntry(file)) {
             return add(name, name, is);
-        } finally {
-            try { is.close(); } catch (Exception ignored) {}
         }
     }
 
@@ -181,11 +180,8 @@ class DeploymentPlanBuilderImpl extends AbstractDeploymentPlanBuilder implements
 
     @Override
     public RemoveDeploymentPlanBuilder replace(String name, File file) throws IOException {
-        final InputStream is = new FileStreamEntry(file);
-        try {
+        try (final InputStream is = new FileStreamEntry(file)) {
             return replace(name, name, is);
-        } finally {
-            try { is.close(); } catch (Exception ignored) {}
         }
     }
 
@@ -287,25 +283,26 @@ class DeploymentPlanBuilderImpl extends AbstractDeploymentPlanBuilder implements
     // Wrap the FIS in a streamEntry so that the controller-client has access to the underlying File
     private static class FileStreamEntry extends FilterInputStream implements InputStreamEntry {
 
-        private final File file;
+        private final Path file;
+
         private FileStreamEntry(final File file) throws IOException {
-            super(new FileInputStream(file)); // This stream will get closed regardless of autoClose
+            this(file.toPath());
+        }
+
+        private FileStreamEntry(final Path file) throws IOException {
+            super(Files.newInputStream(file)); // This stream will get closed regardless of autoClose
             this.file = file;
         }
 
         @Override
         public int initialize() throws IOException {
-            return (int) file.length();
+            return (int) Files.size(file);
         }
 
         @Override
         public void copyStream(final DataOutput output) throws IOException {
-            final FileInputStream is = new FileInputStream(file);
-            try {
-                StreamUtils.copyStream(is, output);
-                is.close();
-            } finally {
-                StreamUtils.safeClose(is);
+            try (InputStream in = new BufferedInputStream(Files.newInputStream(file))) {
+                StreamUtils.copyStream(in, output);
             }
         }
 

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/DeploymentPlanBuilder.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/DeploymentPlanBuilder.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
@@ -249,12 +250,27 @@ public interface DeploymentPlanBuilder {
      * be deployed into the runtime. See {@link AddDeploymentPlanBuilder#andDeploy()}.
      *
      * @param deploymentName name by which the deployment is known in the model.
-     * @param contents tyhe content relative path and bytes.
+     * @param contents a map consisting of the content relative target path as key and the bytes as value.
      *
      * @return a builder that can continue building the overall deployment plan
      * @throws java.io.IOException
      */
     DeploymentPlanBuilder addContentToDeployment(String deploymentName, Map<String, InputStream> contents) throws IOException;
+
+    /**
+     * Indicates the content readable from the specified <code>Path</code>
+     * should be added to the content repository.
+     * <p>
+     * Note that this operation does not indicate the content should
+     * be deployed into the runtime. See {@link AddDeploymentPlanBuilder#andDeploy()}.
+     *
+     * @param deploymentName name by which the deployment is known in the model.
+     * @param files a map consisting of the content relative target path as key and the file as value.
+     *
+     * @return a builder that can continue building the overall deployment plan
+     * @throws java.io.IOException
+     */
+    DeploymentPlanBuilder addContentFileToDeployment(String deploymentName, Map<String, Path> files) throws IOException;
 
     /**
      * Indicates the content readable from the specified targetPath should be removed from the deployment with the

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/AbstractServerDeploymentManager.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/AbstractServerDeploymentManager.java
@@ -50,6 +50,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.TARGET_PATH
 import static org.jboss.as.controller.client.helpers.ClientConstants.TO_REPLACE;
 
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Map.Entry;
 import java.util.concurrent.Future;
 
@@ -110,15 +111,23 @@ public abstract class AbstractServerDeploymentManager implements ServerDeploymen
             switch (action.getType()) {
                 case ADD: {
                     configureDeploymentOperation(step, ADD, uniqueName);
-                    if(action.getNewContentFileName() != null && action.getContentStream() != null) {
+                    if (action.getNewContentFileName() != null && action.getContentStream() != null) {
                         step.get(RUNTIME_NAME).set(action.getNewContentFileName());
                         builder.addInputStream(action.getContentStream());
                         step.get(CONTENT).get(0).get(INPUT_STREAM_INDEX).set(stream++);
-                    } else if(action.getContents() != null && !action.getContents().isEmpty()) {
+                    } else if (action.getContents() != null && !action.getContents().isEmpty()) {
                         int index = 0;
-                        for(Entry<String, InputStream> content : action.getContents().entrySet()) {
+                        for (Entry<String, InputStream> content : action.getContents().entrySet()) {
                             step.get(RUNTIME_NAME).set(content.getKey());
                             builder.addInputStream(content.getValue());
+                            step.get(CONTENT).get(index).get(INPUT_STREAM_INDEX).set(stream++);
+                            index++;
+                        }
+                    } else if (action.getFiles() != null && !action.getFiles().isEmpty()) {
+                        int index = 0;
+                        for (Entry<String, Path> fileEntry : action.getFiles().entrySet()) {
+                            step.get(RUNTIME_NAME).set(fileEntry.getKey());
+                            builder.addFileAsAttachment(fileEntry.getValue());
                             step.get(CONTENT).get(index).get(INPUT_STREAM_INDEX).set(stream++);
                             index++;
                         }
@@ -166,6 +175,12 @@ public abstract class AbstractServerDeploymentManager implements ServerDeploymen
                         builder.addInputStream(content.getValue());
                         step.get(CONTENT).get(i).get(INPUT_STREAM_INDEX).set(stream++);
                         step.get(CONTENT).get(i).get(TARGET_PATH).set(content.getKey());
+                        i++;
+                    }
+                    for (Entry<String, Path> fileEntry : action.getFiles().entrySet()) {
+                        builder.addFileAsAttachment(fileEntry.getValue());
+                        step.get(CONTENT).get(i).get(INPUT_STREAM_INDEX).set(stream++);
+                        step.get(CONTENT).get(i).get(TARGET_PATH).set(fileEntry.getKey());
                         i++;
                     }
                     break;

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/DeploymentActionImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/DeploymentActionImpl.java
@@ -23,6 +23,8 @@
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -51,36 +53,48 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
         return new DeploymentActionImpl(Type.ADD, deploymentName, fileName, in, internalStream, null);
     }
 
+    public static DeploymentActionImpl getAddAction(String deploymentName, String fileName, Path in) {
+        return new DeploymentActionImpl(Type.ADD, deploymentName, fileName, in, null);
+    }
+
     public static DeploymentActionImpl getAddContentAction(String deploymentName, Map<String, InputStream> contents) {
         return new DeploymentActionImpl(Type.ADD_CONTENT, deploymentName, contents, true, null);
     }
 
+    public static DeploymentActionImpl getAddContentFileAction(String deploymentName, Map<String, Path> files) {
+        return new DeploymentActionImpl(Type.ADD_CONTENT, deploymentName, files, null);
+    }
+
     public static DeploymentActionImpl getDeployAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.DEPLOY, deploymentName, null, null, false, null);
+        return new DeploymentActionImpl(Type.DEPLOY, deploymentName, null, (InputStream)null, false, null);
     }
 
     public static DeploymentActionImpl getExplodeAction(String deploymentName, String path) {
-        return new DeploymentActionImpl(Type.EXPLODE, deploymentName, path, null, false, null);
+        return new DeploymentActionImpl(Type.EXPLODE, deploymentName, path, (InputStream)null, false, null);
     }
 
     public static DeploymentActionImpl getRedeployAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.REDEPLOY, deploymentName, null, null, false, null);
+        return new DeploymentActionImpl(Type.REDEPLOY, deploymentName, null, (InputStream)null, false, null);
     }
 
     public static DeploymentActionImpl getUndeployAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.UNDEPLOY, deploymentName, null, null, false, null);
+        return new DeploymentActionImpl(Type.UNDEPLOY, deploymentName, null, (InputStream)null, false, null);
     }
 
     public static DeploymentActionImpl getReplaceAction(String deploymentName, String replacedName) {
-        return new DeploymentActionImpl(Type.REPLACE, deploymentName, null, null, false, replacedName);
+        return new DeploymentActionImpl(Type.REPLACE, deploymentName, null, (InputStream)null, false, replacedName);
     }
 
     public static DeploymentActionImpl getFullReplaceAction(String deploymentName, String fileName, InputStream in, boolean internalStream) {
         return new DeploymentActionImpl(Type.FULL_REPLACE, deploymentName, fileName, in, internalStream, null);
     }
 
+        public static DeploymentActionImpl getFullReplaceAction(String deploymentName, String fileName, Path in, boolean internalStream) {
+        return new DeploymentActionImpl(Type.FULL_REPLACE, deploymentName, fileName, in, null);
+    }
+
     public static DeploymentActionImpl getRemoveAction(String deploymentName) {
-        return new DeploymentActionImpl(Type.REMOVE, deploymentName, null, null, false, null);
+        return new DeploymentActionImpl(Type.REMOVE, deploymentName, null, (InputStream)null, false, null);
     }
 
     public static DeploymentActionImpl getRemoveContentAction(String deploymentName, List<String> fileNames) {
@@ -98,6 +112,7 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
     private final String newContentFileName;
     private final InputStream contentStream;
     private final Map<String, InputStream> contents;
+    private final Map<String, Path> files;
     private final boolean internalStream;
 
     private DeploymentActionImpl(Type type, String deploymentUnitName, String newContentFileName, InputStream contents, boolean internalStream, String replacedDeploymentUnitName) {
@@ -106,8 +121,10 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
         this.newContentFileName = newContentFileName;
         if(newContentFileName != null && contents != null) {
             this.contents = Collections.singletonMap(newContentFileName, contents);
+            this.files = Collections.emptyMap();
         } else {
             this.contents = Collections.emptyMap();
+            this.files = Collections.emptyMap();
         }
         if(contents != null) {
             this.contentStream = contents;
@@ -118,14 +135,51 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
         this.internalStream = internalStream;
     }
 
+    private DeploymentActionImpl(Type type, String deploymentUnitName, String newContentFileName, Path file,String replacedDeploymentUnitName) {
+        this.type = type;
+        this.deploymentUnitName = deploymentUnitName;
+        this.newContentFileName = newContentFileName;
+        boolean useableFile = file != null && Files.exists(file) && Files.isRegularFile(file);
+        if (newContentFileName != null && useableFile) {
+            this.files = Collections.singletonMap(newContentFileName, file);
+            this.contents = Collections.emptyMap();
+        } else {
+            this.files = Collections.emptyMap();
+            this.contents = Collections.emptyMap();
+        }
+        if (useableFile) {
+            try {
+                this.contentStream = Files.newInputStream(file);
+            } catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        } else {
+            this.contentStream = null;
+        }
+        this.oldDeploymentUnitName = replacedDeploymentUnitName;
+        this.internalStream = true;
+    }
+
     private DeploymentActionImpl(Type type, String deploymentUnitName, Map<String, InputStream> contents, boolean internalStream, String replacedDeploymentUnitName) {
         this.type = type;
         this.deploymentUnitName = deploymentUnitName;
         this.newContentFileName = null;
         this.contentStream = null;
         this.contents = contents;
+        this.files = Collections.emptyMap();
         this.oldDeploymentUnitName = replacedDeploymentUnitName;
         this.internalStream = internalStream;
+    }
+
+        private DeploymentActionImpl(Type type, String deploymentUnitName, Map<String, Path> files,String replacedDeploymentUnitName) {
+        this.type = type;
+        this.deploymentUnitName = deploymentUnitName;
+        this.newContentFileName = null;
+        this.contentStream = null;
+        this.files = files;
+        this.contents = Collections.emptyMap();
+        this.oldDeploymentUnitName = replacedDeploymentUnitName;
+        this.internalStream = true;
     }
 
     @Override
@@ -158,6 +212,10 @@ public class DeploymentActionImpl implements DeploymentAction, Serializable {
 
     public Map<String, InputStream> getContents() {
         return contents;
+    }
+
+    public Map<String, Path> getFiles() {
+        return files;
     }
 
     public boolean isInternalStream() {

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/DeploymentPlanBuilderImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/standalone/impl/DeploymentPlanBuilderImpl.java
@@ -22,16 +22,12 @@
 
 package org.jboss.as.controller.client.helpers.standalone.impl;
 
-import java.io.BufferedInputStream;
-import java.io.DataOutput;
 import java.io.File;
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,7 +44,7 @@ import org.jboss.as.controller.client.helpers.standalone.InitialDeploymentPlanBu
 import org.jboss.as.controller.client.helpers.standalone.ReplaceDeploymentPlanBuilder;
 import org.jboss.as.controller.client.helpers.standalone.UndeployDeploymentPlanBuilder;
 import org.jboss.as.controller.client.helpers.standalone.DeploymentAction.Type;
-import org.jboss.as.controller.client.impl.InputStreamEntry;
+import org.jboss.as.controller.client.impl.InputStreamEntry.FileStreamEntry;
 import org.jboss.as.protocol.StreamUtils;
 
 /**
@@ -448,34 +444,6 @@ class DeploymentPlanBuilderImpl
     public DeploymentPlanBuilder removeContenFromDeployment(String deploymentName, List<String> paths) throws IOException {
          DeploymentActionImpl mod = DeploymentActionImpl.getRemoveContentAction(deploymentName, paths);
         return new DeploymentPlanBuilderImpl(this, mod);
-    }
-
-    // Wrap the FIS in a streamEntry so that the controller-client has access to the underlying File
-    private static class FileStreamEntry extends FilterInputStream implements InputStreamEntry {
-
-        private final Path file;
-
-        private FileStreamEntry(final File file) throws IOException {
-            this(file.toPath());
-        }
-
-        private FileStreamEntry(final Path file) throws IOException {
-            super(Files.newInputStream(file)); // This stream will get closed regardless of autoClose
-            this.file = file;
-        }
-
-        @Override
-        public int initialize() throws IOException {
-            return (int) Files.size(file);
-        }
-
-        @Override
-        public void copyStream(final DataOutput output) throws IOException {
-            try (InputStream in = new BufferedInputStream(Files.newInputStream(file))) {
-                StreamUtils.copyStream(in, output);
-            }
-        }
-
     }
 
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/InputStreamEntry.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/InputStreamEntry.java
@@ -30,9 +30,9 @@ import java.io.Closeable;
 import java.io.DataOutput;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 
 /**
  * @author Emanuel Muckenhuber
@@ -113,16 +113,13 @@ public interface InputStreamEntry extends Closeable {
             this.autoClose = autoClose;
         }
 
+        @Override
         public synchronized int initialize() throws IOException {
             if(temp == null) {
                 temp = File.createTempFile("client", "stream");
-                final FileOutputStream os = new FileOutputStream(temp);
                 try {
-                    StreamUtils.copyStream(original, os);
-                    os.flush();
-                    os.close();
+                    return (int) Files.copy(original, temp.toPath());
                 } finally {
-                    StreamUtils.safeClose(os);
                     if(autoClose) {
                         StreamUtils.safeClose(original);
                     }


### PR DESCRIPTION
Modifying the API so that we may use a java.nio.file.Path instead of a InputStream thus removing the need to read the full input to get its length.

Jira: https://issues.jboss.org/browse/WFCORE-2946
JBEAP: https://issues.jboss.org/browse/JBEAP-11513