### PR TITLE
Don't remove directory hashing as David's expalination in WFCORE-2410.

### DIFF
--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -714,7 +714,7 @@ elytron.filesystem-realm.remove=The remove operation for the security realm.
 elytron.filesystem-realm.case-sensitive=Case sensitivity of the filesystem realm. If case insensitive only lower usernames are allowed.
 elytron.filesystem-realm.path=The path to the file containing the realm.
 elytron.filesystem-realm.relative-to=The pre-defined path the path is relative to.
-elytron.filesystem-realm.levels=The number of levels of directory to apply.
+elytron.filesystem-realm.levels=The number of levels of directory hashing to apply.
 elytron.filesystem-realm.encoded=Whether the identity names should be stored encoded (Base32) in file names.
 elytron.filesystem-realm.identity=An identity which can be managed by a security realm.
 

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -1481,7 +1481,7 @@
                 <xs:attribute name="levels" type="xs:int" default="2">
                     <xs:annotation>
                         <xs:documentation>
-                            The number of levels of directory to apply
+                            The number of levels of directory hashing to apply
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>


### PR DESCRIPTION
Revert back incorrect change part in previous PR https://github.com/wildfly/wildfly-core/pull/2542
As David's explanation in https://issues.jboss.org/browse/WFCORE-2410 and https://github.com/wildfly-security/wildfly-elytron/pull/879

> The practice of using initial characters for directory levels like we are is commonly known as hashing.