### PR TITLE
Fix for WFCORE-2956. CLI deploy archive stuck when command timeout set

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandExecutor.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandExecutor.java
@@ -633,7 +633,7 @@ public class CommandExecutor {
     }
 
     private final CommandContext ctx;
-    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
 
     private Future<?> handlerTask;
 


### PR DESCRIPTION
Make executor to use a cachedThreadPool. Added unit tests.