### PR TITLE
[WFCORE-2964] Use the default-server-logging.properties file on initi…

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -33,7 +33,6 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-
 import javax.security.sasl.SaslException;
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
@@ -1379,5 +1378,27 @@ public interface HostControllerLogger extends BasicLogger {
     @LogMessage(level = Level.WARN)
     @Message(id = 203, value = "The domain configuration was successfully applied, but restart is required before changes become active.")
     void domainModelAppliedButRestartIsRequired();
+
+    /**
+     * Logs a warning message indicating no logging configuration file could be found. Logging may not be configured
+     * until the logging subsystem is activated on the server.
+     *
+     * @param serverName the name of the server the configuration file could not be found for
+     */
+    @LogMessage(level = Level.WARN)
+    @Message(id = 204, value = "No logging configuration file could be found for the servers initial boot. Logging will " +
+            "not be configured until the logging subsystem is activated for the server %s")
+    void serverLoggingConfigurationFileNotFound(String serverName);
+
+    /**
+     * Logs an error message indicating the {@code -Dlogging.configuration} system property could not be set.
+     *
+     * @param cause      the cause of the error
+     * @param serverName the name of the server setting the property failed on
+     * @param path       the path to the configuration file
+     */
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 205, value = "An error occurred setting the -Dlogging.configuration property for server %s. Configuration path %s")
+    void failedToSetLoggingConfiguration(@Cause Throwable cause, String serverName, File path);
 
 }

--- a/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/ManagedServerBootCmdFactoryTestCase.java
@@ -121,7 +121,7 @@ public class ManagedServerBootCmdFactoryTestCase {
         ManagedServerBootCmdFactory instance = new ManagedServerBootCmdFactory("test-server", getDomainModel(), getHostModel(), getTestHostEnvironment(), ExpressionResolver.TEST_RESOLVER, false);
         List<String> result = instance.getServerLaunchCommand();
         Assert.assertThat(result.size(), is(notNullValue()));
-        Assert.assertThat(result.size(), is(16));
+        Assert.assertThat(result.size(), is(15));
         for (String arg : result) {
             if (arg.startsWith("-Djboss.server.log.dir")) {
                 Assert.assertThat(arg, is(not("-Djboss.server.log.dir=/tmp/")));


### PR DESCRIPTION
…al boot of domain servers. Ignore the logging.configuration system property which should always be set to the incorrect file by the domain startup scripts.

This could be considered a slight change in behavior if a user has modified the startup scripts, e.g. `domain\.(sh|bat|ps1)`. However on Windows there is an issue when comparing the system property, `logging.configuration`, and the resolved `%JBOSS_CONFIG_DIR%\logging.properties`. The system property is always set to `/logging.properties` and the one created internally uses `\logging.propeties`, with the correct file separator.

It seems okay to ignore the system property as it would be a very special use case and ONLY used on the initial boot assuming the logging subsystem is present.