### PR TITLE
[WFCORE-2958] Add an addtional runtime step to remove formatters from…

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
@@ -646,7 +646,7 @@ final class HandlerOperations {
                 configuration.setFormatterName(resolvedValue);
                 // Check the current formatter name, if it's the same name as the handler, remove the old formatter
                 if (!formatterName.equals(resolvedValue) && logContextConfiguration.getFormatterNames().contains(formatterName)) {
-                    logContextConfiguration.removeFormatterConfiguration(formatterName);
+                    addAfterCommitRuntimeStep(context, (ctx, operation) -> logContextConfiguration.removeFormatterConfiguration(formatterName));
                 }
             } else {
                 // Use a formatter only if a named-formatter is not defined or the named-formatter was explicitly undefined
@@ -669,7 +669,7 @@ final class HandlerOperations {
                 configuration.setFormatterName(resolvedValue);
                 // Check the current formatter name, if it's the same name as the handler, remove the old formatter
                 if (!formatterName.equals(resolvedValue) && logContextConfiguration.getFormatterNames().contains(formatterName)) {
-                    logContextConfiguration.removeFormatterConfiguration(formatterName);
+                    addAfterCommitRuntimeStep(context, (ctx, operation) -> logContextConfiguration.removeFormatterConfiguration(formatterName));
                 }
             } else {
                 // If the current formatter name already equals the name defined in the configuration, there is no need to process
@@ -945,5 +945,17 @@ final class HandlerOperations {
                 }
             }, Stage.RUNTIME);
         }
+    }
+
+    private static void addAfterCommitRuntimeStep(final OperationContext context, final OperationStepHandler step) {
+        Collection<OperationStepHandler> steps = context.getAttachment(LoggingOperations.AFTER_COMMIT_STEPS);
+        if (steps == null) {
+            steps = new ArrayList<>();
+            final Collection<OperationStepHandler> appearing = context.attachIfAbsent(LoggingOperations.AFTER_COMMIT_STEPS, steps);
+            if (appearing != null) {
+                steps = appearing;
+            }
+        }
+        steps.add(step);
     }
 }


### PR DESCRIPTION
… a handler. In the case of a composite operation the formatter may be changed in a undefine-attribute operation followed by a removal of the formatter in a write-attribute handler for the named-formatter attribute. This causes the commit of the log managers configuration as the handler no longer exists after the write-attribute.

https://issues.jboss.org/browse/WFCORE-2958