### PR TITLE
[WFCORE-1632] Interrupt Xnio worker tasks when the worker is stopped

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerAdd.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerAdd.java
@@ -33,6 +33,7 @@ import static org.wildfly.extension.io.WorkerResourceDefinition.WORKER_TASK_CORE
 import static org.wildfly.extension.io.WorkerResourceDefinition.WORKER_TASK_MAX_THREADS;
 
 import java.lang.management.ManagementFactory;
+import java.util.concurrent.ExecutorService;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
@@ -217,6 +218,8 @@ class WorkerAdd extends AbstractAddStepHandler {
 
         final WorkerService workerService = new WorkerService(builder);
         context.getCapabilityServiceTarget().addCapability(IO_WORKER_RUNTIME_CAPABILITY, workerService)
+                .addCapabilityRequirement("org.wildfly.management.executor",
+                        ExecutorService.class, workerService.injectedExecutor)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
                 .install();
     }

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerService.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerService.java
@@ -25,12 +25,17 @@
 package org.wildfly.extension.io;
 
 import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
 import org.wildfly.common.net.CidrAddressTable;
+import org.wildfly.extension.io.logging.IOLogger;
 import org.xnio.OptionMap;
 import org.xnio.Xnio;
 import org.xnio.XnioWorker;
@@ -39,7 +44,10 @@ import org.xnio.XnioWorker;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public class WorkerService implements Service<XnioWorker> {
+
     private final XnioWorker.Builder builder;
+    final InjectedValue<ExecutorService> injectedExecutor = new InjectedValue<>();
+    private final Object stopLock = new Object();
     private XnioWorker worker;
     private volatile StopContext stopContext;
 
@@ -61,18 +69,71 @@ public class WorkerService implements Service<XnioWorker> {
     }
 
     @Override
-    public void stop(StopContext context) {
+    public void stop(final StopContext context) {
         this.stopContext = context;
-        context.asynchronous();
-        worker.shutdown();
-        worker = null;
+        final ExecutorService executorService = injectedExecutor.getValue();
+        Runnable asyncStop = () -> {
+            XnioWorker localWorker = worker;
+            worker = null;
+            localWorker.shutdown();
+            boolean interrupted = false;
+            try {
+                synchronized (stopLock) {
+                    if (stopContext != null) {
+                        // stopDone has not been called by the worker yet
+                        try {
+                            // Hack. Give in progress tasks a chance to complete before we interrupt.
+                            // If we are shutting down gracefully this is redundant as the
+                            // graceful shutdown timeout gives tasks a chance, but if we aren't
+                            // graceful this helps a bit
+                            stopLock.wait(100);
+                        } catch (InterruptedException e) {
+                            interrupted = true;
+                        }
+                    }
+                }
+                if (stopContext != null) {
+                    // Tasks are still running. Interrupt those and submit
+                    // any unstarted ones to the management executor
+                    List<Runnable> tasks = localWorker.shutdownNow();
+                    for (Runnable task : tasks) {
+                        IOLogger.ROOT_LOGGER.debugf("Worker was shut down forcibly. Submitting task %s to the management executor", task);
+                        executorService.submit(task);
+                    }
+                }
+            } finally {
+                // TODO xnio doesn't seem to invoke its terminateTask
+                // following a shutdownNow() so we'll do it to ensure
+                // context.complete() is called
+                stopDone();
+
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        };
+
+        try {
+            try {
+                executorService.execute(asyncStop);
+            } catch (RejectedExecutionException e) {
+                asyncStop.run();
+            }
+        } finally {
+            context.asynchronous();
+        }
     }
 
+    // Callback from the worker when it terminates
     private void stopDone() {
-        final StopContext stopContext = this.stopContext;
-        this.stopContext = null;
-        assert stopContext != null;
-        stopContext.complete();
+        synchronized (stopLock) {
+            final StopContext stopContext = this.stopContext;
+            this.stopContext = null;
+            if (stopContext != null) {
+                stopContext.complete();
+            }
+            stopLock.notifyAll();
+        }
     }
 
     CidrAddressTable<InetSocketAddress> getBindingsTable() {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-1632

@gaol @dmlloyd @stuartwdouglas 

This is a continuation of the discussion of #1654, converting my experimental branch that was being looked at there into a PR.

This implements the approach discussed in the other PR of doing a shutdownNow on the xnio worker. It addresses, at least somewhat, the concern that tasks already assigned to the worker should be run by passing them off to the management executor to run.

In the end though the management executor needs to ensure tasks are finished too, so the stop logic for it also eventually does a shutdownNow, and it just discards any returned tasks. So, it's possible some tasks won't run.

The shutdown stuff is a bit kludgy in that a simple shutdown() is performed, and then a wait up to magic number 100ms will happen before the stop impl moves on the shutdownNow. So in flight requests are given a bit of a grace period to complete before their thread is interrupted. If no requests are in flight, e.g. if a graceful shutdown has happened and all active requests completed, then the wait is basically instantaneous. Perhaps the magic number could be a bit less.

I added a second commit today to what was in my previous experiment @gaol looked at in the comments on the other PR. I added a 0ms timeout suspend to the server reload handling. This is the right thing to do regardless IMHO. (In core 4.0 we intend to make the timeout configurable.) I wanted to add it here because triggering a suspend and then immediately stopping will at least result in new requests that come in perhaps getting the suspend response rather than getting into the normal logic and then getting a 500 when the thread is interrupted.