### PR TITLE
Fix for WFCORE-2975. CLI, NPE in Ctrl-S. Upgrade aesh to 0.66.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.fusesource.jansi>1.16</version.org.fusesource.jansi>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
-        <version.org.jboss.aesh>0.66.18</version.org.jboss.aesh>
+        <version.org.jboss.aesh>0.66.19</version.org.jboss.aesh>
         <version.org.jboss.byteman>3.0.6</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.1.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.0.Beta4</version.org.jboss.invocation>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2975