### PR TITLE
[WFCORE-2704] PersistentResourceXMLDescription should by default mars…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -492,7 +492,7 @@ public final class PersistentResourceXMLDescription {
         private final LinkedHashMap<String, AttributeMarshaller> attributeMarshallers = new LinkedHashMap<>();
         private boolean useElementsForGroups = true;
         private String forcedName;
-        private boolean marshallDefaultValues = false;
+        private boolean marshallDefaultValues = true;
         private String nameAttributeName = NAME;
 
         private PersistentResourceXMLBuilder(final PathElement pathElement) {


### PR DESCRIPTION
…hal configured attribute values that match the default

Reopening of #2352.

Requires https://github.com/wildfly/wildfly/pull/10219 and https://github.com/jbossas/jboss-eap7/pull/2035 to remove a no longer relevant test that explicitly requires the incorrect behavior WFCORE-2704 is fixing.