### PR TITLE
[WFCORE-2880] The remove-alias operation should fail when attempting to remove a non-existing alias from a credential store

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
@@ -417,6 +417,9 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
                         String alias = ALIAS.resolveModelAttribute(context, operation).asString();
                         CredentialStore credentialStore = credentialStoreService.getValue();
                         PasswordCredential retrieved = credentialStore.retrieve(alias, PasswordCredential.class);
+                        if (retrieved == null) {
+                            throw ROOT_LOGGER.credentialDoesNotExist(alias, PasswordCredential.class.getName());
+                        }
                         credentialStore.remove(alias, PasswordCredential.class);
                         try {
                             credentialStore.flush();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-2880
https://issues.jboss.org/browse/JBEAP-11189