### PR TITLE
[WFCORE-2966] WildFly Elytron tool script has to pass the command name from the script to the tool.

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/elytron-tool.bat
+++ b/core-feature-pack/src/main/resources/content/bin/elytron-tool.bat
@@ -58,6 +58,6 @@ if not "x%ELYTRON_TOOL_ADDONS%" == "x" (
 
 "%JAVA%" %JAVA_OPTS% ^
     -cp "%ELYTRON_TOOL_RUNJAR%%SEP%%ELYTRON_TOOL_ADDONS%" org.wildfly.security.tool.ElytronTool ^
-     %*
+     {%~nx0}%*
 
 :END

--- a/core-feature-pack/src/main/resources/content/bin/elytron-tool.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/elytron-tool.ps1
@@ -6,7 +6,11 @@
 $scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;
 . $scripts'\common.ps1'
 
+$SCRIPT_NAME = $MyInvocation.MyCommand | select -ExpandProperty Name
+$SCRIPT_NAME = "{" + $SCRIPT_NAME + "}"
+
 $ELYTRON_TOOL_OPTS = Process-Script-Parameters -Params $ARGS
+$ELYTRON_TOOL_OPTS = $SCRIPT_NAME + $ELYTRON_TOOL_OPTS 
 
 $JAVA_OPTS = @()
 

--- a/core-feature-pack/src/main/resources/content/bin/elytron-tool.sh
+++ b/core-feature-pack/src/main/resources/content/bin/elytron-tool.sh
@@ -79,4 +79,4 @@ fi
 
 eval \"$JAVA\" $JAVA_OPTS -cp \""$JBOSS_HOME"/bin/wildfly-elytron-tool.jar$SEP$ELYTRON_TOOL_ADDONS\" \
          org.wildfly.security.tool.ElytronTool \
-         '"$@"'
+         '{"$0"}"$@"'


### PR DESCRIPTION
wildfly-core: https://issues.jboss.org/browse/WFCORE-2966
JBEAP: https://issues.jboss.org/browse/JBEAP-11591