### PR TITLE
[WFCORE-2359]: Failure message when an op requires a non-existent capability doesn't list registration points for dynamic caps

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/AbstractCapabilityResolutionTestCase.java
@@ -265,7 +265,7 @@ abstract class AbstractCapabilityResolutionTestCase {
     }
 
     private static RuntimeCapabilityRegistration getCapabilityRegistration(PathElement pe) {
-        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(pe.getKey() + "." + pe.getValue()).build();
+        RuntimeCapability<Void> capability = RuntimeCapability.Builder.of(pe.getKey() + "." + pe.getValue(), SOCKET_BINDING_GROUP.equals(pe.getKey())).build();
         PathAddress pa = PathAddress.pathAddress(pe);
         CapabilityScope scope = CapabilityScope.Factory.create(ProcessType.EMBEDDED_HOST_CONTROLLER, pa);
         RegistrationPoint rp = new RegistrationPoint(pa, null);

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityResolutionErrorTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityResolutionErrorTestCase.java
@@ -39,17 +39,27 @@ public class CapabilityResolutionErrorTestCase extends AbstractCapabilityResolut
     public void testMissingGlobalRef() {
         ModelNode op = getCompositeOperation(getCapabilityOperation(SOCKET_A_1, "cap_b"), getCapabilityOperation(GLOBAL_A, "dep_a", "subsystem.only-registered"));
         ModelNode response = controller.execute(op, null, null, null);
-        validateMissingFailureDesc(response, "step-2", "cap_a", "global", true);
+        validateMissingFailureDesc(response, "step-2", "cap_a", "global","/subsystem=only-registered");
+    }
+
+    @Test
+    public void testMissingGlobalSimpleRef() {
+        ModelNode op = getCompositeOperation(getCapabilityOperation(SOCKET_A_1, "cap_b"), getCapabilityOperation(GLOBAL_A, "dep_a", "socket-binding-group.a.subsystem.only-registered"));
+        ModelNode response = controller.execute(op, null, null, null);
+        validateMissingFailureDesc(response, "step-2", "cap_a", "global", "/socket-binding-group=a");
+        op = getCompositeOperation(getCapabilityOperation(SOCKET_A_1, "cap_b"), getCapabilityOperation(GLOBAL_A, "dep_b", "socket-binding-group.x.subsystem.only-registered"));
+        response = controller.execute(op, null, null, null);
+        validateMissingFailureDesc(response, "step-2", "cap_a", "global", null);
     }
 
     @Test
     public void testMissingProfileRef() {
         ModelNode op = getCompositeOperation(getCapabilityOperation(SOCKET_A_1, "cap_b"), getCapabilityOperation(SUBSYSTEM_A_1, "dep_a", "cap_a"));
         ModelNode response = controller.execute(op, null, null, null);
-        validateMissingFailureDesc(response, "step-2", "cap_a", "profile=a", false);
+        validateMissingFailureDesc(response, "step-2", "cap_a", "profile=a", null);
     }
 
-    protected static void validateMissingFailureDesc(ModelNode response, String step, String cap, String context, boolean expectedPossible) {
+    protected static void validateMissingFailureDesc(ModelNode response, String step, String cap, String context, String possibleRegistrationPoint) {
         assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
         assertTrue(response.toString(), response.hasDefined(FAILURE_DESCRIPTION));
         String failDesc = response.get(FAILURE_DESCRIPTION).asString();
@@ -61,10 +71,11 @@ public class CapabilityResolutionErrorTestCase extends AbstractCapabilityResolut
         int lastLoc = loc;
         loc = failDesc.indexOf("WFLYCTL0369");
         assertTrue(response.toString(), loc > lastLoc);
-        if (expectedPossible) {
-            assertTrue(failDesc.contains("Possible registration points for this"));
+        if (possibleRegistrationPoint != null) {
+            assertTrue(failDesc, failDesc.contains("Possible registration points for this"));
+            assertTrue(failDesc, failDesc.contains(possibleRegistrationPoint));
         } else {
-            assertTrue(failDesc.contains("There are no known registration points"));
+            assertTrue(failDesc, failDesc.contains("There are no known registration points"));
         }
 
     }


### PR DESCRIPTION
if no possible registration point exists, looks for dynamic capabilities that might be a candidate and returns those registration points.

Jira: https://issues.jboss.org/browse/WFCORE-2359