### PR TITLE
[WFCORE-2958] Only remove default named handlers (those created via t…

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
@@ -425,21 +425,6 @@ final class HandlerOperations {
                 // Undefine the filter-spec
                 model.getModel().get(CommonAttributes.FILTER_SPEC.getName()).set(filterSpecValue);
             }
-
-            // Undefine formatter attribute if writing a named-formatter
-            if (AbstractHandlerDefinition.NAMED_FORMATTER.getName().equals(attributeName)) {
-                // If the formatter is defined in the model, remove it
-                final ModelNode m = model.getModel();
-                if (m.hasDefined(AbstractHandlerDefinition.FORMATTER.getName())) {
-                    m.get(AbstractHandlerDefinition.FORMATTER.getName()).clear();
-                }
-            } else if (AbstractHandlerDefinition.FORMATTER.getName().equals(attributeName)) {
-                // If the named-formatter is defined in the model, remove it
-                final ModelNode m = model.getModel();
-                if (m.hasDefined(AbstractHandlerDefinition.NAMED_FORMATTER.getName())) {
-                    m.get(AbstractHandlerDefinition.NAMED_FORMATTER.getName()).clear();
-                }
-            }
         }
     }
 
@@ -498,7 +483,7 @@ final class HandlerOperations {
             // Remove the handler
             logContextConfiguration.removeHandlerConfiguration(name);
             // Remove the formatter if there is one
-            if (logContextConfiguration.getFormatterNames().contains(name)) {
+            if (logContextConfiguration.getFormatterNames().contains(name) && !model.hasDefined(NAMED_FORMATTER.getName())) {
                 logContextConfiguration.removeFormatterConfiguration(name);
             }
             // Remove the POJO if it exists
@@ -637,53 +622,53 @@ final class HandlerOperations {
             final String resolvedValue = (resolveValue ? ENCODING.resolvePropertyValue(context, model) : model.isDefined() ? model.asString() : null);
             configuration.setEncoding(resolvedValue);
         } else if (attribute.getName().equals(FORMATTER.getName())) {
-            final String formatterName = configuration.getName();
-            // Use a formatter only if a named-formatter is not defined, note too that if explicitly undefining the named-formatter
-            // the formatter pattern will be used
-            if (model.hasDefined(NAMED_FORMATTER.getName())) {
-                final ModelNode valueNode = (resolveValue ? NAMED_FORMATTER.resolveModelAttribute(context, model) : model);
-                final String resolvedValue = (valueNode.isDefined() ? valueNode.asString() : null);
-                configuration.setFormatterName(resolvedValue);
-                // Check the current formatter name, if it's the same name as the handler, remove the old formatter
-                if (!formatterName.equals(resolvedValue) && logContextConfiguration.getFormatterNames().contains(formatterName)) {
-                    logContextConfiguration.removeFormatterConfiguration(formatterName);
+            // The handler name will be used for the name of a formatter for the formatter attribute
+            final String handlerName = configuration.getName();
+            // Get the current model and check for a defined named-formatter attribute
+            final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
+            final ModelNode m = resource.getModel();
+            if (m.hasDefined(NAMED_FORMATTER.getName())) {
+                // If a named-formatter exists in the model and a formatter already exists with the name of the handler
+                // remove the formatter
+                if (logContextConfiguration.getFormatterNames().contains(handlerName)) {
+                    logContextConfiguration.removeFormatterConfiguration(handlerName);
                 }
             } else {
-                // Use a formatter only if a named-formatter is not defined or the named-formatter was explicitly undefined
+                // Create a formatter based on the handlers name
                 final FormatterConfiguration fmtConfig;
-                if (logContextConfiguration.getFormatterNames().contains(formatterName)) {
-                    fmtConfig = logContextConfiguration.getFormatterConfiguration(formatterName);
+                if (logContextConfiguration.getFormatterNames().contains(handlerName)) {
+                    fmtConfig = logContextConfiguration.getFormatterConfiguration(handlerName);
                 } else {
-                    fmtConfig = logContextConfiguration.addFormatterConfiguration(null, PatternFormatter.class.getName(), formatterName, PATTERN.getPropertyName());
+                    fmtConfig = logContextConfiguration.addFormatterConfiguration(null, PatternFormatter.class.getName(), handlerName, PATTERN.getPropertyName());
                 }
                 final String resolvedValue = (resolveValue ? FORMATTER.resolvePropertyValue(context, model) : model.asString());
                 fmtConfig.setPropertyValueString(PATTERN.getPropertyName(), resolvedValue);
-                configuration.setFormatterName(formatterName);
+                configuration.setFormatterName(handlerName);
             }
         } else if (attribute.getName().equals(NAMED_FORMATTER.getName())) {
-            final String formatterName = configuration.getName();
+            // The name of the handler will be used for a "formatter" if the named-formatter is not defined
+            final String handlerName = configuration.getName();
             final ModelNode valueNode = (resolveValue ? NAMED_FORMATTER.resolveModelAttribute(context, model) : model);
-            // If the value not is undefined, this may have come from an undefine-attribute operation
+            // Set the formatter if the value is defined
             if (valueNode.isDefined()) {
                 final String resolvedValue = valueNode.asString();
                 configuration.setFormatterName(resolvedValue);
-                // Check the current formatter name, if it's the same name as the handler, remove the old formatter
-                if (!formatterName.equals(resolvedValue) && logContextConfiguration.getFormatterNames().contains(formatterName)) {
-                    logContextConfiguration.removeFormatterConfiguration(formatterName);
+                // If the formatter was previously defined by the formatter attribute, remove the formatter
+                if (logContextConfiguration.getFormatterNames().contains(handlerName)) {
+                    logContextConfiguration.removeFormatterConfiguration(handlerName);
                 }
             } else {
-                // If the current formatter name already equals the name defined in the configuration, there is no need to process
-                if (!formatterName.equals(configuration.getFormatterName())) {
-                    // Use a formatter only if a named-formatter is not defined or the named-formatter was explicitly undefined
-                    final FormatterConfiguration fmtConfig;
-                    if (logContextConfiguration.getFormatterNames().contains(formatterName)) {
-                        fmtConfig = logContextConfiguration.getFormatterConfiguration(formatterName);
-                    } else {
-                        fmtConfig = logContextConfiguration.addFormatterConfiguration(null, PatternFormatter.class.getName(), formatterName, PATTERN.getPropertyName());
-                    }
-                    fmtConfig.setPropertyValueString(PATTERN.getPropertyName(), FORMATTER.resolvePropertyValue(context, model));
-                    configuration.setFormatterName(formatterName);
+                // If the named-formatter was undefined we need to create a formatter based on the formatter attribute
+                final FormatterConfiguration fmtConfig;
+                if (logContextConfiguration.getFormatterNames().contains(handlerName)) {
+                    fmtConfig = logContextConfiguration.getFormatterConfiguration(handlerName);
+                } else {
+                    fmtConfig = logContextConfiguration.addFormatterConfiguration(null, PatternFormatter.class.getName(), handlerName, PATTERN.getPropertyName());
                 }
+                // Get the current model and set the value of the formatter based on the formatter attribute
+                final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
+                fmtConfig.setPropertyValueString(PATTERN.getPropertyName(), FORMATTER.resolvePropertyValue(context, resource.getModel()));
+                configuration.setFormatterName(handlerName);
             }
         } else if (attribute.getName().equals(FILTER_SPEC.getName())) {
             final ModelNode valueNode = (resolveValue ? FILTER_SPEC.resolveModelAttribute(context, model) : model);


### PR DESCRIPTION
…he formatter attribute) if a named-formatter attribute is defined. Also ensure that only a formatter or named-formatter attribute can be defined.

https://issues.jboss.org/browse/WFCORE-2958

Note the removal of allowing a `formatter` or `named-formatter` to overwrite each other on an undefine/write operation. Other subsystems fail the operation if alternatives are both defined. There is a fix in here which will now fail operations that have both attributes defined.

It's possible this should be in a separate commit, but with the changes to how the attributes are handled it seemed okay. to include it.

Note too I'm also using the `ContollerLogger` only to get the same messages as an `add` op would or other ops if multiple attributes are defined that are alternatives for each other.