### PR TITLE
[WFCORE-2997] Remove the occasional extra jmx entries that happen whe…

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AbstractLogFieldsOfLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AbstractLogFieldsOfLogTestCase.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -117,7 +118,7 @@ abstract class AbstractLogFieldsOfLogTestCase {
         }
     }
 
-    List<ModelNode> readFile(int expectedRecords) throws IOException {
+    List<ModelNode> readFile(int expectedRecords, boolean trimModulesLoaderUnregister) throws IOException {
         List<ModelNode> list = new ArrayList<ModelNode>();
         final BufferedReader reader = Files.newBufferedReader(FILE, StandardCharsets.UTF_8);
         try {
@@ -141,8 +142,28 @@ abstract class AbstractLogFieldsOfLogTestCase {
         } finally {
             IoUtils.safeClose(reader);
         }
+        if (trimModulesLoaderUnregister) {
+            for (Iterator<ModelNode> it = list.iterator() ; it.hasNext() ; ) {
+                ModelNode log = it.next();
+                if (isJmxAuditLogRecord(log)) {
+                    //See https://issues.jboss.org/browse/WFCORE-2997 for why we remove this
+                     it.remove();
+                }
+            }
+        }
         Assert.assertEquals(list.toString(), expectedRecords, list.size());
         return list;
+    }
+
+    boolean isJmxAuditLogRecord(ModelNode record) {
+        final String type = record.get("type").asString();
+        if (type.equals("jmx") && record.get("method").asString().equals("unregisterMBean")) {
+            List<ModelNode> params = record.get("params").asList();
+            if (params.size() == 1 && params.get(0).asString().startsWith("\"jboss.modules:type=ModuleLoader,name=ServiceModuleLoader-")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static ModelNode executeForSuccess(final ModelControllerClient client, final Operation op) throws IOException {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTest.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTest.java
@@ -20,6 +20,8 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TRU
 import static org.jboss.as.test.manualmode.auditlog.AbstractLogFieldsOfLogTestCase.executeForSuccess;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import javax.inject.Inject;
 import org.jboss.as.controller.PathAddress;
@@ -117,7 +119,18 @@ public class AuditLogBootingSyslogTest {
         Assert.assertEquals(18, queue.size());
         queue.clear();
         makeOneLog();
-        Assert.assertEquals(1, queue.size());
+        //Temp code to get more information
+        //Assert.assertEquals(queue.size(), 1, queue.size());
+        int size = queue.size();
+        Assert.assertNotEquals(0, size); //If this is the cause of the errors, perhaps we need to loop and wait
+        if (queue.size() > 1) {
+            List<String> list = new ArrayList<>();
+            for (int i = 0 ; i < size ; i++) {
+                SyslogServerEventIF event = queue.take();
+                list.add(event.getMessage());
+            }
+            Assert.assertEquals(list.toString(), 1, size);
+        }
         queue.clear();
     }
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogFieldsOfLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogFieldsOfLogTestCase.java
@@ -140,7 +140,8 @@ public class AuditLogFieldsOfLogTestCase extends AbstractLogFieldsOfLogTestCase 
         message = DATE_STAMP_PATTERN.matcher(message).replaceFirst("{");
         ModelNode syslogNode = ModelNode.fromJSONString(message);
         checkLog("Syslog", syslogNode);
-        List<ModelNode> logs = readFile(1);
+        //Since JMX audit logging is not enabled for this test, we should not need to trim the records for WFCORE-2997
+        List<ModelNode> logs = readFile(1, false);
         ModelNode log = logs.get(0);
         checkLog("File", log);
     }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/JmxAuditLogFieldsOfLogTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/JmxAuditLogFieldsOfLogTestCase.java
@@ -57,7 +57,7 @@ public class JmxAuditLogFieldsOfLogTestCase extends AbstractLogFieldsOfLogTestCa
         connection = setupAndGetConnection();
         makeOneLog();
         Assert.assertTrue(Files.exists(FILE));
-        List<ModelNode> logs = readFile(1);
+        List<ModelNode> logs = readFile(1, true);
         ModelNode log = logs.get(0);
         Assert.assertEquals("jmx", log.get("type").asString());
         Assert.assertEquals("true", log.get("r/o").asString());


### PR DESCRIPTION
…n the ServiceLoader WeakReference is cleared resulting in audit-logged calls to unregisterMBean

Also improve error output for AuditLogBootingSyslogTest

https://issues.jboss.org/issues/?jql=text%20~%20%22JmxAuditLogFieldsOfTestCase%22
