### PR TITLE
Fix for WFCORE-2993. NPE in CapabilityRegitry when retrieving capability names

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityRegistry.java
@@ -730,6 +730,7 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
         if (!forServer) {
             target.knownContexts.addAll(source.knownContexts);
         }
+        target.resolutionContext.copy(source.resolutionContext);
     }
 
     /**
@@ -954,6 +955,12 @@ public final class CapabilityRegistry implements ImmutableCapabilityRegistry, Po
     private static class ResolutionContextImpl extends CapabilityResolutionContext {
         private boolean resolutionComplete;
         private Resource rootResource;
+
+        private void copy(ResolutionContextImpl source) {
+            super.copy(source);
+            rootResource = source.rootResource;
+            resolutionComplete = source.resolutionComplete;
+        }
 
         @Override
         public Resource getResourceRoot() {

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityResolutionContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/CapabilityResolutionContext.java
@@ -106,6 +106,16 @@ public abstract class CapabilityResolutionContext {
     }
 
     /**
+     * Update this context content with the source context.
+     *
+     * @param source The context to copy.
+     */
+    protected void copy(CapabilityResolutionContext source) {
+        reset();
+        contextAttachments.putAll(source.contextAttachments);
+    }
+
+    /**
      * An attachment key instance.
      *
      * @param <T> the attachment value type


### PR DESCRIPTION
ResolutionContext need to be copied onto the parent repository when copy of CapabilityRegistry occurs.
Test will come as a PR for Wildfly full.
