### PR TITLE
WFCORE-1374 Update build for jdk9 b175+

### DIFF
--- a/host-controller/src/test/java/org/jboss/as/host/controller/model/jvm/JvmOptionsBuilderUnitTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/host/controller/model/jvm/JvmOptionsBuilderUnitTestCase.java
@@ -152,14 +152,13 @@ public class JvmOptionsBuilderUnitTestCase {
         element.getJvmOptions().addOption("--add-exports=java.base/sun.nio.ch=ALL-UNNAMED");
         element.getJvmOptions().addOption("--add-opens=java.base/sun.nio.ch=ALL-UNNAMED");
         element.getJvmOptions().addOption("--add-reads=java.base/sun.nio.ch=ALL-UNNAMED");
-        element.getJvmOptions().addOption("--permit-illegal-access"); //this one is going away
-        element.getJvmOptions().addOption("--illegal-access");
+        element.getJvmOptions().addOption("--illegal-access=warn");
         List<String> command = new ArrayList<String>();
         JvmOptionsBuilderFactory.getInstance().addOptions(element, command);
         if (JvmElement.getJVMMajorVersion() < 9) {
             Assert.assertEquals(0, command.size());
         } else {
-            Assert.assertEquals(5, command.size());
+            Assert.assertEquals(4, command.size());
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-parent</artifactId>
-      <version>23</version>
+      <version>24</version>
     </parent>
 
     <groupId>org.wildfly.core</groupId>
@@ -1697,10 +1697,10 @@
             <properties>
                 <modular.jdk.args>
                     --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
-                    --permit-illegal-access
+                    --illegal-access=permit
                 </modular.jdk.args>
                 <!-- [WFCORE-1494] remove JUL workaround -->
-                <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true -Dsun.reflect.debugModuleAccessChecks=true -Djdk.attach.allowAttachSelf=true</modular.jdk.props>
+                <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true -Djdk.attach.allowAttachSelf=true</modular.jdk.props>
                 <version.org.jboss.byteman>4.0.0-BETA5</version.org.jboss.byteman>
                 <version.org.jboss.logging.jboss-logging-tools>2.1.0.Alpha2</version.org.jboss.logging.jboss-logging-tools>
             </properties>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
@@ -79,7 +79,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
@@ -79,7 +79,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-master.xml
@@ -74,7 +74,6 @@
            <jvm-options>
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--permit-illegal-access"/>
            </jvm-options>
            <environment-variables>
                <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-auto-ignore-slave.xml
@@ -95,7 +95,6 @@
            <jvm-options>
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--permit-illegal-access"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-default-interface.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-default-interface.xml
@@ -76,7 +76,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover1.xml
@@ -74,7 +74,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -80,7 +80,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -97,7 +97,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-auto-start.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-auto-start.xml
@@ -90,7 +90,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-cacheddc.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-cacheddc.xml
@@ -96,7 +96,6 @@
            <jvm-options>
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--permit-illegal-access"/>
            </jvm-options>
            <environment-variables>
                <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-config-changes.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-config-changes.xml
@@ -97,7 +97,6 @@
            <jvm-options>
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--permit-illegal-access"/>
            </jvm-options>
            <environment-variables>
               <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-elytron.xml
@@ -78,7 +78,6 @@
                 <option value="-XX:MetaspaceSize=96m"/>
                 <option value="-XX:MaxMetaspaceSize=256m"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-kerberos.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-kerberos.xml
@@ -89,7 +89,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-no-local.xml
@@ -67,7 +67,6 @@
             <heap size="64m" max-size="128m"/>
             <jvm-options>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac-properties.xml
@@ -96,7 +96,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-rbac.xml
@@ -93,7 +93,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master-ssl.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master-ssl.xml
@@ -89,7 +89,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
             <environment-variables>
                 <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -96,7 +96,6 @@
            <jvm-options>
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--permit-illegal-access"/>
            </jvm-options>
           <environment-variables>
               <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-minimal.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-minimal.xml
@@ -79,7 +79,6 @@
            <jvm-options>
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--permit-illegal-access"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-outbound-ldap-connection.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-outbound-ldap-connection.xml
@@ -107,7 +107,6 @@
            <jvm-options>
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--permit-illegal-access"/>
            </jvm-options>
           <environment-variables>
               <variable name="DOMAIN_TEST_JVM" value="jvm"/>

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -69,7 +69,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-auto-start.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-auto-start.xml
@@ -113,7 +113,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
 	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-cacheddc.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-cacheddc.xml
@@ -79,7 +79,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-config-changes.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-config-changes.xml
@@ -121,7 +121,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -101,7 +101,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-elytron.xml
@@ -80,7 +80,6 @@
                 <option value="-server"/>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-failure.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-failure.xml
@@ -100,7 +100,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-kerberos.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-kerberos.xml
@@ -123,7 +123,6 @@
 			<jvm-options>
 				<option value="-ea"/>
 				<option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-				<option value="--permit-illegal-access"/>
 			</jvm-options>
 		</jvm>
 	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -117,7 +117,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -114,7 +114,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-1way.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-1way.xml
@@ -118,7 +118,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-2way.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-ssl-2way.xml
@@ -120,7 +120,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -119,7 +119,6 @@
            <jvm-options>
                <option value="-ea"/>
                <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-               <option value="--permit-illegal-access"/>
            </jvm-options>
        </jvm>
  	</jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc1.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc1.xml
@@ -71,7 +71,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-synchronization-hc2.xml
@@ -71,7 +71,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/host-synchronization-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-synchronization-master.xml
@@ -88,7 +88,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master-http.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master-http.xml
@@ -65,7 +65,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>

--- a/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/respawn-master.xml
@@ -68,7 +68,6 @@
             <jvm-options>
                 <option value="-ea"/>
                 <option value="--add-exports=java.base/sun.nio.ch=ALL-UNNAMED"/>
-                <option value="--permit-illegal-access"/>
             </jvm-options>
         </jvm>
     </jvms>


### PR DESCRIPTION
This is probably one of the last "big" changes as b175 has all the changes agreed by EC after the vote 
as well as new defaults for illegal accessing reflection which is now by default allowed.
see http://mail.openjdk.java.net/pipermail/jigsaw-dev/2017-May/012673.html for more details.

with this changes we get whole testsuite passing.