### PR TITLE
[WFCORE-3004] read-alias, read-aliases and read-identity are read-only operations.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
@@ -190,6 +190,7 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
 
     static final SimpleOperationDefinition READ_ALIASES = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.READ_ALIASES, RESOURCE_RESOLVER)
             .setRuntimeOnly()
+            .setReadOnly()
             .build();
 
     static final SimpleOperationDefinition ADD_ALIAS = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.ADD_ALIAS, RESOURCE_RESOLVER)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
@@ -571,6 +571,7 @@ class DomainDefinition extends SimpleResourceDefinition {
                     new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.READ_IDENTITY, descriptionResolver)
                             .setParameters(NAME)
                             .setRuntimeOnly()
+                            .setReadOnly()
                             .build(),
                     new ReadSecurityDomainIdentityHandler());
         }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableKeyStoreDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableKeyStoreDecorator.java
@@ -26,6 +26,7 @@ import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -85,7 +86,10 @@ public class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
     static class ReadAliasesHandler extends ElytronRuntimeOnlyHandler {
 
         static void register(ManagementResourceRegistration resourceRegistration, ResourceDescriptionResolver descriptionResolver) {
-            resourceRegistration.registerOperationHandler(new SimpleOperationDefinition(ElytronDescriptionConstants.READ_ALIASES, descriptionResolver), new ReadAliasesHandler());
+            SimpleOperationDefinition READ_ALIASES = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.READ_ALIASES, descriptionResolver)
+                    .setReadOnly()
+                    .build();
+            resourceRegistration.registerOperationHandler(READ_ALIASES, new ReadAliasesHandler());
         }
 
         @Override
@@ -111,7 +115,11 @@ public class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
                 .build();
 
         static void register(ManagementResourceRegistration resourceRegistration, ResourceDescriptionResolver descriptionResolver) {
-            resourceRegistration.registerOperationHandler(new SimpleOperationDefinition(ElytronDescriptionConstants.READ_ALIAS, descriptionResolver, ALIAS), new ReadAliasHandler());
+            SimpleOperationDefinition READ_ALIAS = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.READ_ALIAS, descriptionResolver)
+                    .setParameters(ALIAS)
+                    .setReadOnly()
+                    .build();
+            resourceRegistration.registerOperationHandler(READ_ALIAS, new ReadAliasHandler());
         }
 
         @Override

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableRealmDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableRealmDecorator.java
@@ -189,6 +189,7 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
                     new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.READ_IDENTITY, descriptionResolver)
                             .setParameters(IDENTITY)
                             .setRuntimeOnly()
+                            .setReadOnly()
                             .build(),
                     new ReadIdentityHandler());
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3004
read-alias, read-aliases and read-identity are read-only operations.

Operations:
/subsystem=elytron/key-store=test:read-operation-description(name=read-alias)
/subsystem=elytron/credential-store=test:read-operation-description(name=read-aliases)
/subsystem=elytron/security-domain=ApplicationDomain:read-operation-description(name=read-identity)
