### PR TITLE
[WFCORE-3007] Add missing setRuntimeOnly() to runtime-only elytron operations

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/CachingRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CachingRealmDefinition.java
@@ -33,7 +33,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -59,7 +59,7 @@ import org.wildfly.security.cache.LRURealmIdentityCache;
 import org.wildfly.security.cache.RealmIdentityCache;
 
 /**
- * A {@link ResourceDefinition} for a {@link SecruityRealm} which enables caching to another realm.
+ * A {@link ResourceDefinition} for a {@link SecurityRealm} which enables caching to another realm.
  *
  * @author <a href="mailto:psilva@redhat.com">Pedro Igor</a>
  */
@@ -169,7 +169,10 @@ class CachingRealmDefinition extends SimpleResourceDefinition {
     private static class ClearCacheHandler extends ElytronRuntimeOnlyHandler {
 
         static void register(ManagementResourceRegistration resourceRegistration, ResourceDescriptionResolver descriptionResolver) {
-            resourceRegistration.registerOperationHandler(new SimpleOperationDefinition(ElytronDescriptionConstants.CLEAR_CACHE, descriptionResolver), new CachingRealmDefinition.ClearCacheHandler());
+            resourceRegistration.registerOperationHandler(new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.CLEAR_CACHE, descriptionResolver)
+                        .setRuntimeOnly()
+                        .build()
+                    , new CachingRealmDefinition.ClearCacheHandler());
         }
 
         private ClearCacheHandler() {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreDefinition.java
@@ -139,10 +139,12 @@ final class KeyStoreDefinition extends SimpleResourceDefinition {
 
     // Operations
 
-    static final SimpleOperationDefinition LOAD = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.LOAD, RESOURCE_RESOLVER)
+    private static final SimpleOperationDefinition LOAD = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.LOAD, RESOURCE_RESOLVER)
+        .setRuntimeOnly()
         .build();
 
-    static final SimpleOperationDefinition STORE = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.STORE, RESOURCE_RESOLVER)
+    private static final SimpleOperationDefinition STORE = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.STORE, RESOURCE_RESOLVER)
+        .setRuntimeOnly()
         .build();
 
     private static final AttributeDefinition[] CONFIG_ATTRIBUTES = new AttributeDefinition[] { TYPE, PROVIDER_NAME, PROVIDERS, CREDENTIAL_REFERENCE, PATH, RELATIVE_TO, REQUIRED, ALIAS_FILTER };

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableKeyStoreDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableKeyStoreDecorator.java
@@ -88,6 +88,7 @@ public class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
         static void register(ManagementResourceRegistration resourceRegistration, ResourceDescriptionResolver descriptionResolver) {
             SimpleOperationDefinition READ_ALIASES = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.READ_ALIASES, descriptionResolver)
                     .setReadOnly()
+                    .setRuntimeOnly()
                     .build();
             resourceRegistration.registerOperationHandler(READ_ALIASES, new ReadAliasesHandler());
         }
@@ -118,6 +119,7 @@ public class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
             SimpleOperationDefinition READ_ALIAS = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.READ_ALIAS, descriptionResolver)
                     .setParameters(ALIAS)
                     .setReadOnly()
+                    .setRuntimeOnly()
                     .build();
             resourceRegistration.registerOperationHandler(READ_ALIAS, new ReadAliasHandler());
         }
@@ -179,7 +181,11 @@ public class ModifiableKeyStoreDecorator extends DelegatingResourceDefinition {
                 .build();
 
         static void register(ManagementResourceRegistration resourceRegistration, ResourceDescriptionResolver descriptionResolver) {
-            resourceRegistration.registerOperationHandler(new SimpleOperationDefinition(ElytronDescriptionConstants.REMOVE_ALIAS, descriptionResolver, ALIAS), new RemoveAliasHandler());
+            resourceRegistration.registerOperationHandler(new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.REMOVE_ALIAS, descriptionResolver)
+                        .setParameters(ALIAS)
+                        .setRuntimeOnly()
+                        .build()
+                    , new RemoveAliasHandler());
         }
 
         @Override

--- a/elytron/src/main/java/org/wildfly/extension/elytron/PropertiesRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PropertiesRealmDefinition.java
@@ -125,7 +125,8 @@ class PropertiesRealmDefinition extends TrivialResourceDefinition {
 
     // Operations
 
-    static final SimpleOperationDefinition LOAD = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.LOAD, RESOURCE_RESOLVER)
+    private static final SimpleOperationDefinition LOAD = new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.LOAD, RESOURCE_RESOLVER)
+            .setRuntimeOnly()
             .build();
 
     private static final AbstractAddStepHandler ADD = new TrivialAddHandler<SecurityRealm>(SecurityRealm.class, ATTRIBUTES, SECURITY_REALM_RUNTIME_CAPABILITY) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -83,7 +83,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
@@ -484,7 +483,10 @@ class SSLDefinitions {
             @Override
             public void registerOperations(ManagementResourceRegistration registration) {
                 super.registerOperations(registration);
-                registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.INIT, RESOURCE_RESOLVER).build(), init);
+                registration.registerOperationHandler(new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.INIT, RESOURCE_RESOLVER)
+                            .setRuntimeOnly()
+                            .build()
+                        , init);
             }
         };
 
@@ -704,7 +706,10 @@ class SSLDefinitions {
             @Override
             public void registerOperations(ManagementResourceRegistration resourceRegistration) {
                 super.registerOperations(resourceRegistration);
-                resourceRegistration.registerOperationHandler(new SimpleOperationDefinition(ElytronDescriptionConstants.RELOAD_CERTIFICATE_REVOCATION_LIST, getResourceDescriptionResolver()), new ReloadCertificateRevocationList());
+                resourceRegistration.registerOperationHandler(new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.RELOAD_CERTIFICATE_REVOCATION_LIST, getResourceDescriptionResolver())
+                            .setRuntimeOnly()
+                            .build()
+                        , new ReloadCertificateRevocationList());
             }
 
             class ReloadCertificateRevocationList implements OperationStepHandler {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -712,16 +712,14 @@ class SSLDefinitions {
                         , new ReloadCertificateRevocationList());
             }
 
-            class ReloadCertificateRevocationList implements OperationStepHandler {
+            class ReloadCertificateRevocationList extends ElytronRuntimeOnlyHandler {
 
                 private ReloadCertificateRevocationList() {
                 }
 
                 @Override
-                public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                    context.addStep(operation, (parentContext, parentOperation) -> {
-                        reloadCrl.compareAndSet(false, true);
-                    }, OperationContext.Stage.RUNTIME);
+                protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+                    reloadCrl.compareAndSet(false, true);
                 }
             }
         };


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3007

Also https://issues.jboss.org/browse/WFCORE-3012

Corrects:

cache-manager:clear-cache
key-store:load
key-store:store
key-store:read-aliases
key-store:read-alias
key-store:remove-alias
ldap-key-store:read-aliases
ldap-key-store:read-alias
ldap-key-store:remove-alias
filtering-key-store:read-aliases
filtering-key-store:read-alias
filtering-key-store:remove-alias
properties-realm:load
key-manager:init
trust-manager:reload-certificate-revocation-list
