### PR TITLE
WFCORE-2722: Remove hash attribute from OTP set-pasword for Elytron filesystem realm

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -177,7 +177,6 @@ interface ElytronDescriptionConstants {
     String HOST = "host";
     String HOST_NAME = "host-name";
     String HOST_NAME_VERIFICATION_POLICY = "host-name-verification-policy";
-    String HASH = "hash";
     String HASH_FROM = "hash-from";
     String HTTP = "http";
     String HTTP_AUTHENTICATION_FACTORY = "http-authentication-factory";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableRealmDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableRealmDecorator.java
@@ -59,11 +59,10 @@ import org.wildfly.security.password.spec.ClearPasswordSpec;
 import org.wildfly.security.password.spec.DigestPasswordAlgorithmSpec;
 import org.wildfly.security.password.spec.EncryptablePasswordSpec;
 import org.wildfly.security.password.spec.IteratedSaltedPasswordAlgorithmSpec;
-import org.wildfly.security.password.spec.OneTimePasswordSpec;
+import org.wildfly.security.password.spec.OneTimePasswordAlgorithmSpec;
 import org.wildfly.security.password.spec.PasswordSpec;
 import org.wildfly.security.password.spec.SaltedPasswordAlgorithmSpec;
 
-import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
@@ -327,14 +326,14 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
 
     static class SetPasswordHandler extends ElytronRuntimeOnlyHandler {
 
+        static final SimpleAttributeDefinition PASSWORD = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PASSWORD, ModelType.STRING, false)
+                .build();
+
         static class Bcrypt {
             static final SimpleAttributeDefinition ALGORITHM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALGORITHM, ModelType.STRING)
                     .setRequired(false)
                     .setDefaultValue(new ModelNode(BCryptPassword.ALGORITHM_BCRYPT))
                     .setValidator(new StringAllowedValuesValidator(BCryptPassword.ALGORITHM_BCRYPT))
-                    .build();
-
-            static final SimpleAttributeDefinition PASSWORD = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PASSWORD, ModelType.STRING, false)
                     .build();
 
             static final SimpleAttributeDefinition ITERATION_COUNT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ITERATION_COUNT, ModelType.INT, false)
@@ -356,10 +355,6 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
                     .setValidator(new StringAllowedValuesValidator(ClearPassword.ALGORITHM_CLEAR))
                     .build();
 
-            static final SimpleAttributeDefinition PASSWORD = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PASSWORD, ModelType.STRING, false)
-                    .build();
-
-
             static final ObjectTypeAttributeDefinition OBJECT_DEFINITION = new ObjectTypeAttributeDefinition.Builder(
                     ElytronDescriptionConstants.CLEAR, PASSWORD)
                     .setRequired(false)
@@ -379,10 +374,6 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
                             SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_512
                     ))
                     .build();
-
-            static final SimpleAttributeDefinition PASSWORD = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PASSWORD, ModelType.STRING, false)
-                    .build();
-
 
             static final ObjectTypeAttributeDefinition OBJECT_DEFINITION = new ObjectTypeAttributeDefinition.Builder(
                     ElytronDescriptionConstants.SIMPLE_DIGEST, ALGORITHM, PASSWORD)
@@ -408,9 +399,6 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
                     ))
                     .build();
 
-            static final SimpleAttributeDefinition PASSWORD = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PASSWORD, ModelType.STRING, false)
-                    .build();
-
             static final SimpleAttributeDefinition SALT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SALT, ModelType.BYTES, false)
                     .build();
 
@@ -430,9 +418,6 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
                             DigestPassword.ALGORITHM_DIGEST_SHA_256,
                             DigestPassword.ALGORITHM_DIGEST_SHA_512
                     ))
-                    .build();
-
-            static final SimpleAttributeDefinition PASSWORD = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PASSWORD, ModelType.STRING, false)
                     .build();
 
             static final SimpleAttributeDefinition REALM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.REALM, ModelType.STRING, false)
@@ -455,10 +440,6 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
                     .setAllowExpression(false)
                     .build();
 
-            static final SimpleAttributeDefinition HASH = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.HASH, ModelType.STRING, false)
-                    .setAllowExpression(true)
-                    .build();
-
             static final SimpleAttributeDefinition SEED = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SEED, ModelType.STRING, false)
                     .setAllowExpression(true)
                     .build();
@@ -468,7 +449,7 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
                     .build();
 
             static final ObjectTypeAttributeDefinition OBJECT_DEFINITION = new ObjectTypeAttributeDefinition.Builder(
-                    ElytronDescriptionConstants.OTP, ALGORITHM, HASH, SEED, SEQUENCE)
+                    ElytronDescriptionConstants.OTP, ALGORITHM, PASSWORD, SEED, SEQUENCE)
                     .setAllowNull(true)
                     .build();
         }
@@ -523,37 +504,32 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
             }
         }
 
-        private Password createPassword(final OperationContext parentContext, final String principalName, String passwordType, ModelNode passwordNode) throws OperationFailedException, NoSuchAlgorithmException, InvalidKeySpecException {
-            String password;
+        private Password createPassword(final OperationContext parentContext, final String principalName, String passwordType, ModelNode passwordNode) throws OperationFailedException, NoSuchAlgorithmException, InvalidKeySpecException  {
+            final String password = PASSWORD.resolveModelAttribute(parentContext, passwordNode).asString();
             final PasswordSpec passwordSpec;
             final String algorithm;
 
             if (passwordType.equals(ElytronDescriptionConstants.BCRYPT)) {
-                password = Bcrypt.PASSWORD.resolveModelAttribute(parentContext, passwordNode).asString();
                 byte[] salt = Bcrypt.SALT.resolveModelAttribute(parentContext, passwordNode).asBytes();
                 int iterationCount = Bcrypt.ITERATION_COUNT.resolveModelAttribute(parentContext, passwordNode).asInt();
                 passwordSpec = new EncryptablePasswordSpec(password.toCharArray(), new IteratedSaltedPasswordAlgorithmSpec(iterationCount, salt));
                 algorithm = Bcrypt.ALGORITHM.resolveModelAttribute(parentContext, passwordNode).asString();
 
             } else if (passwordType.equals(ElytronDescriptionConstants.CLEAR)) {
-                password = Clear.PASSWORD.resolveModelAttribute(parentContext, passwordNode).asString();
                 passwordSpec = new ClearPasswordSpec(password.toCharArray());
                 algorithm = Clear.ALGORITHM.resolveModelAttribute(parentContext, passwordNode).asString();
 
             } else if (passwordType.equals(ElytronDescriptionConstants.SIMPLE_DIGEST)) {
-                password = SimpleDigest.PASSWORD.resolveModelAttribute(parentContext, passwordNode).asString();
                 passwordSpec = new EncryptablePasswordSpec(password.toCharArray(), null);
                 algorithm = SimpleDigest.ALGORITHM.resolveModelAttribute(parentContext, passwordNode).asString();
 
             } else if (passwordType.equals(ElytronDescriptionConstants.SALTED_SIMPLE_DIGEST)) {
-                password = SaltedSimpleDigest.PASSWORD.resolveModelAttribute(parentContext, passwordNode).asString();
                 byte[] salt = SaltedSimpleDigest.SALT.resolveModelAttribute(parentContext, passwordNode).asBytes();
                 SaltedPasswordAlgorithmSpec spec = new SaltedPasswordAlgorithmSpec(salt);
                 passwordSpec = new EncryptablePasswordSpec(password.toCharArray(), spec);
                 algorithm = SaltedSimpleDigest.ALGORITHM.resolveModelAttribute(parentContext, passwordNode).asString();
 
             } else if (passwordType.equals(ElytronDescriptionConstants.DIGEST)) {
-                password = Digest.PASSWORD.resolveModelAttribute(parentContext, passwordNode).asString();
                 String realm = Digest.REALM.resolveModelAttribute(parentContext, passwordNode).asString();
                 algorithm = Digest.ALGORITHM.resolveModelAttribute(parentContext, passwordNode).asString();
                 DigestPasswordAlgorithmSpec dpas = new DigestPasswordAlgorithmSpec(principalName, realm);
@@ -561,10 +537,11 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
 
             } else if (passwordType.equals(ElytronDescriptionConstants.OTP)) {
                 algorithm = OTPassword.ALGORITHM.resolveModelAttribute(parentContext, passwordNode).asString();
-                byte[] hash = OTPassword.HASH.resolveModelAttribute(parentContext, passwordNode).asBytes();
-                byte[] seed = OTPassword.SEED.resolveModelAttribute(parentContext, passwordNode).asString().getBytes(StandardCharsets.US_ASCII);
                 int sequenceNumber = OTPassword.SEQUENCE.resolveModelAttribute(parentContext, passwordNode).asInt();
-                passwordSpec = new OneTimePasswordSpec(hash, seed, sequenceNumber);
+                String seed = OTPassword.SEED.resolveModelAttribute(parentContext, passwordNode).asString();
+
+                OneTimePasswordAlgorithmSpec otpSpec = new OneTimePasswordAlgorithmSpec(algorithm, seed, sequenceNumber);
+                passwordSpec = new EncryptablePasswordSpec(password.toCharArray(), otpSpec);
 
             } else {
                 throw ROOT_LOGGER.unexpectedPasswordType(passwordType);

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -801,12 +801,12 @@ elytron.modifiable-security-realm.digest.realm=The realm.
 elytron.modifiable-security-realm.digest.password=The actual password to set.
 elytron.modifiable-security-realm.otp=A one-time password, used by the OTP SASL mechanism.
 elytron.modifiable-security-realm.otp.algorithm=The algorithm used to encrypt the password.
-elytron.modifiable-security-realm.otp.hash=The hash represented by this password.
+elytron.modifiable-security-realm.otp.password=The actual password to set.
 elytron.modifiable-security-realm.otp.seed=The seed used to generate the hash.
 elytron.modifiable-security-realm.otp.sequence=The sequence number used to generate the hash.
 elytron.modifiable-security-realm.set-password.otp=A one-time password, used by the OTP SASL mechanism.
 elytron.modifiable-security-realm.set-password.algorithm=The algorithm used to encrypt the password.
-elytron.modifiable-security-realm.set-password.otp.hash=The hash represented by this password.
+elytron.modifiable-security-realm.set-password.otp.password=The actual password to set.
 elytron.modifiable-security-realm.set-password.otp.seed=The seed used to generate the hash.
 elytron.modifiable-security-realm.set-password.otp.sequence=The sequence number used to generate the hash.
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/IdentityOperationsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/IdentityOperationsTestCase.java
@@ -271,7 +271,7 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
         byte[] salt = PasswordUtil.generateRandomSalt(BCryptPassword.BCRYPT_SALT_SIZE);
 
         operation = createSetPasswordOperation("default", realmAddress, principalName,
-                ModifiableRealmDecorator.SetPasswordHandler.Bcrypt.OBJECT_DEFINITION, "bcryptPassword", salt, 10, null, null, null, null, null);
+                ModifiableRealmDecorator.SetPasswordHandler.Bcrypt.OBJECT_DEFINITION, "bcryptPassword", salt, 10, null, null, null, null);
         result = services.executeOperation(operation);
         assertSuccessful(result);
     }
@@ -288,7 +288,7 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
         assertSuccessful(result);
 
         operation = createSetPasswordOperation("default", realmAddress, principalName,
-                ModifiableRealmDecorator.SetPasswordHandler.Clear.OBJECT_DEFINITION, "clearPassword", null, null, null, null, null, null, null);
+                ModifiableRealmDecorator.SetPasswordHandler.Clear.OBJECT_DEFINITION, "clearPassword", null, null, null, null, null, null);
         result = services.executeOperation(operation);
         assertSuccessful(result);
     }
@@ -305,7 +305,7 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
         assertSuccessful(result);
 
         operation = createSetPasswordOperation("default", realmAddress, principalName,
-                ModifiableRealmDecorator.SetPasswordHandler.SimpleDigest.OBJECT_DEFINITION, "simpleDigest", null, null, null, SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_1, null, null, null);
+                ModifiableRealmDecorator.SetPasswordHandler.SimpleDigest.OBJECT_DEFINITION, "simpleDigest", null, null, null, SimpleDigestPassword.ALGORITHM_SIMPLE_DIGEST_SHA_1, null, null);
         result = services.executeOperation(operation);
         assertSuccessful(result);
     }
@@ -322,7 +322,7 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
         assertSuccessful(result);
 
         operation = createSetPasswordOperation("default", realmAddress, principalName,
-                ModifiableRealmDecorator.SetPasswordHandler.SaltedSimpleDigest.OBJECT_DEFINITION, "saltedSimpleDigest", PasswordUtil.generateRandomSalt(16), null, null, SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256, null, null, null);
+                ModifiableRealmDecorator.SetPasswordHandler.SaltedSimpleDigest.OBJECT_DEFINITION, "saltedSimpleDigest", PasswordUtil.generateRandomSalt(16), null, null, SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256, null, null);
         result = services.executeOperation(operation);
         assertSuccessful(result);
     }
@@ -339,7 +339,7 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
         assertSuccessful(result);
 
         operation = createSetPasswordOperation("default", realmAddress, principalName,
-                ModifiableRealmDecorator.SetPasswordHandler.Digest.OBJECT_DEFINITION, "digestPassword", null, null, "Elytron Realm", DigestPassword.ALGORITHM_DIGEST_MD5, null, null, null);
+                ModifiableRealmDecorator.SetPasswordHandler.Digest.OBJECT_DEFINITION, "digestPassword", null, null, "Elytron Realm", DigestPassword.ALGORITHM_DIGEST_MD5, null, null);
 
         result = services.executeOperation(operation);
         assertSuccessful(result);
@@ -357,7 +357,7 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
         assertSuccessful(result);
 
         operation = createSetPasswordOperation("default", realmAddress, principalName,
-                ModifiableRealmDecorator.SetPasswordHandler.OTPassword.OBJECT_DEFINITION, null, null, null, "Elytron Realm", OneTimePassword.ALGORITHM_OTP_MD5, "abcde", "fghi", 123);
+                ModifiableRealmDecorator.SetPasswordHandler.OTPassword.OBJECT_DEFINITION, "pass123", null, null, "Elytron Realm", OneTimePassword.ALGORITHM_OTP_MD5, "fghi", 123);
 
         result = services.executeOperation(operation);
         assertSuccessful(result);
@@ -375,13 +375,13 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
         assertSuccessful(result);
 
         operation = createSetPasswordOperation("default", realmAddress, principalName,
-                ModifiableRealmDecorator.SetPasswordHandler.Digest.OBJECT_DEFINITION, "digestPassword", null, null, "Elytron Realm", DigestPassword.ALGORITHM_DIGEST_MD5, null, null, null);
+                ModifiableRealmDecorator.SetPasswordHandler.Digest.OBJECT_DEFINITION, "digestPassword", null, null, "Elytron Realm", DigestPassword.ALGORITHM_DIGEST_MD5, null, null);
 
         result = services.executeOperation(operation);
         assertSuccessful(result);
 
         operation = createSetPasswordOperation("default", realmAddress, principalName,
-                ModifiableRealmDecorator.SetPasswordHandler.Clear.OBJECT_DEFINITION, "clearPassword", null, null, null, null, null, null, null);
+                ModifiableRealmDecorator.SetPasswordHandler.Clear.OBJECT_DEFINITION, "clearPassword", null, null, null, null, null, null);
         result = services.executeOperation(operation);
         assertSuccessful(result);
     }
@@ -398,7 +398,7 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
         assertSuccessful(result);
 
         operation = createSetPasswordOperation("default", realmAddress, principalName,
-                ModifiableRealmDecorator.SetPasswordHandler.Clear.OBJECT_DEFINITION, "clearPassword", null, null, null, null, null, null, null);
+                ModifiableRealmDecorator.SetPasswordHandler.Clear.OBJECT_DEFINITION, "clearPassword", null, null, null, null, null, null);
         result = services.executeOperation(operation);
         assertSuccessful(result);
     }
@@ -472,10 +472,11 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
                 .build();
     }
 
-    private ModelNode createSetPasswordOperation(String credentialName, PathAddress parentAddress, String principalName, ObjectTypeAttributeDefinition passwordDefinition, String password, byte[] salt, Integer iterationCount, String realm, String algorithm, String hash, String seed, Integer sequence) {
+    private ModelNode createSetPasswordOperation(String credentialName, PathAddress parentAddress, String principalName, ObjectTypeAttributeDefinition passwordDefinition, String password, byte[] salt, Integer iterationCount, String realm, String algorithm, String seed, Integer sequence) {
         ModelNode passwordNode = new ModelNode();
 
         passwordNode.get(ElytronDescriptionConstants.NAME).set(credentialName);
+        passwordNode.get(ElytronDescriptionConstants.PASSWORD).set(password);
 
         if (salt != null) {
             passwordNode.get(ElytronDescriptionConstants.SALT).set(salt);
@@ -491,14 +492,6 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
 
         if (realm != null) {
             passwordNode.get(REALM).set(realm);
-        }
-
-        if (password != null) {
-            passwordNode.get(ElytronDescriptionConstants.PASSWORD).set(password);
-        }
-
-        if (hash != null) {
-            passwordNode.get(ElytronDescriptionConstants.HASH).set(hash);
         }
 
         if (seed != null) {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/RealmsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/RealmsTestCase.java
@@ -164,7 +164,7 @@ public class RealmsTestCase extends AbstractSubsystemBaseTest {
         credentials.add(new PasswordCredential(factory.generatePassword(spec)));
 
         PasswordFactory factoryOtp = PasswordFactory.getInstance(OneTimePassword.ALGORITHM_OTP_SHA1);
-        KeySpec specOtp = new OneTimePasswordSpec(new byte[]{0x12}, new byte[]{0x34}, 56789);
+        KeySpec specOtp = new OneTimePasswordSpec(new byte[]{0x12}, "4", 56789);
         credentials.add(new PasswordCredential(factoryOtp.generatePassword(specOtp)));
 
         identity1.setCredentials(credentials);
@@ -180,7 +180,7 @@ public class RealmsTestCase extends AbstractSubsystemBaseTest {
         // obtain OTP
         OneTimePassword otp = identity2.getCredential(PasswordCredential.class, OneTimePassword.ALGORITHM_OTP_SHA1).getPassword(OneTimePassword.class);
         Assert.assertArrayEquals(new byte[]{0x12}, otp.getHash());
-        Assert.assertArrayEquals(new byte[]{0x34}, otp.getSeed());
+        Assert.assertEquals("4", otp.getSeed());
         Assert.assertEquals(56789, otp.getSequenceNumber());
         identity2.dispose();
 


### PR DESCRIPTION
Enable the use of a pass phrase for OTP file system realm set-password operation instead of using hash directly on this operation.

Jira issues:
https://issues.jboss.org/browse/WFCORE-2722
https://issues.jboss.org/browse/JBEAP-10532

It depends on https://github.com/wildfly-security/wildfly-elytron/pull/895