### PR TITLE
[WFCORE-3035] x509-credential-mapper in ldap-realm tries to verify Subject DN even if it is not configured

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
@@ -283,7 +283,9 @@ class LdapRealmDefinition extends SimpleResourceDefinition {
             if (serialNumberFrom.isDefined()) b.addSerialNumberCertificateVerifier(serialNumberFrom.asString());
 
             ModelNode subjectDnFrom = SUBJECT_DN_FROM.resolveModelAttribute(context, model);
-            b.addSubjectDnCertificateVerifier(subjectDnFrom.asString());
+            if (subjectDnFrom.isDefined()) {
+                b.addSubjectDnCertificateVerifier(subjectDnFrom.asString());
+            }
 
             b.build();
         }


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-3035
EAP 7.1 Jira: https://issues.jboss.org/browse/JBEAP-11901