### PR TITLE
[WFCORE-3050] Upgrade jboss-logmanager from 2.0.6.Final to 2.0.7.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <!--<version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>-->
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Alpha2</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.0.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
-        <version.org.jboss.logmanager.jboss-logmanager>2.0.6.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.0.7.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.3.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.0.CR1</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.6.0.CR1</version.org.jboss.modules.jboss-modules>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3050

This only contains two fixes. The fix for [LOGMGR-163](https://issues.jboss.org/browse/LOGMGR-163) may be needed as if weekly log rotation is used log messages will be lost.