### PR TITLE
[WFCORE-3065] Add regression tests for ELY-982 and ELY-1186

### DIFF
--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractMgmtSaslTestBase.java
@@ -64,6 +64,7 @@ import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
 import org.wildfly.test.security.common.elytron.SimpleSecurityDomain.SecurityDomainRealm;
 import org.wildfly.test.security.common.other.SimpleMgmtNativeInterface;
 import org.wildfly.test.security.common.other.SimpleSocketBinding;
+import org.wildfly.test.security.common.other.TrustedDomainsConfigurator;
 
 /**
  * Parent class for management interface SASL tests.
@@ -306,6 +307,8 @@ public abstract class AbstractMgmtSaslTestBase {
                 .withRealms(SecurityDomainRealm.builder().withRealm(NAME).build(),
                         SecurityDomainRealm.builder().withRealm("JWT").build())
                 .withRoleMapper(NAME).build());
+        elements.add(
+                TrustedDomainsConfigurator.builder().withName("ManagementDomain").withTrustedSecurityDomains(NAME).build());
 
         elements.add(new ConfigurableElement() {
 
@@ -319,10 +322,6 @@ public abstract class AbstractMgmtSaslTestBase {
 
             @Override
             public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
-                cli.sendLine(String.format(
-                        "/subsystem=elytron/security-domain=ManagementDomain:write-attribute(name=trusted-security-domains, value=[%s])",
-                        NAME));
-
                 // identities with digested PWD
                 addUserWithDigestPass(cli, DIGEST_ALGORITHM_MD5);
                 addUserWithDigestPass(cli, DIGEST_ALGORITHM_SHA);
@@ -332,14 +331,12 @@ public abstract class AbstractMgmtSaslTestBase {
 
             @Override
             public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
-                cli.sendLine(
-                        "/subsystem=elytron/security-domain=ManagementDomain:undefine-attribute(name=trusted-security-domains)");
                 // no need to remove identities, they'll be resolved with removing the FS realm
             }
 
             @Override
             public String getName() {
-                return "domain-trust-and-identities";
+                return "identities-with-digest-passwords";
             }
         });
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DefaultRealmDigestMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DefaultRealmDigestMgmtSaslTestCase.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.elytron.sasl.mgmt;
+
+import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.NAME;
+import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.PASSWORD_SFX;
+import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.PORT_NATIVE;
+import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.USERNAME;
+import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.assertAuthenticationFails;
+import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.assertWhoAmI;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.security.sasl.SaslMechanismSelector;
+import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.ConstantPermissionMapper;
+import org.wildfly.test.security.common.elytron.FileSystemRealm;
+import org.wildfly.test.security.common.elytron.PermissionRef;
+import org.wildfly.test.security.common.elytron.SimpleSaslAuthenticationFactory;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain.SecurityDomainRealm;
+import org.wildfly.test.security.common.other.SimpleMgmtNativeInterface;
+import org.wildfly.test.security.common.other.SimpleSocketBinding;
+import org.wildfly.test.security.common.other.TrustedDomainsConfigurator;
+
+/**
+ * Tests that the Elytron DIGEST-* SASL mechanisms work also with a default realm name (usually hostname is used).
+ *
+ * @see <a href="https://issues.jboss.org/browse/ELY-1186">ELY-1186</a>
+ * @author Josef Cacek
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerSetup({ DefaultRealmDigestMgmtSaslTestCase.ServerSetup.class })
+public class DefaultRealmDigestMgmtSaslTestCase {
+
+    @Test
+    public void testDigestMd5() throws Exception {
+        assertDefaultRealmWorks("DIGEST-MD5");
+    }
+
+    @Test
+    public void testDigestSha() throws Exception {
+        assertDefaultRealmWorks("DIGEST-SHA");
+    }
+
+    @Test
+    public void testDigestSha256() throws Exception {
+        assertDefaultRealmWorks("DIGEST-SHA-256");
+    }
+
+    @Test
+    public void testDigestSha512() throws Exception {
+        assertDefaultRealmWorks("DIGEST-SHA-512");
+    }
+
+    /**
+     * Tests if DIGEST-* mechanism with default realm used works correctly for both valid and invalid username/password
+     * combinations.
+     *
+     * @param mechanism DIGEST mechanism name
+     */
+    private void assertDefaultRealmWorks(String mechanism) throws Exception {
+        try (CLIWrapper cli = new CLIWrapper(true)) {
+            cli.sendLine(String.format(
+                    "/subsystem=elytron/sasl-authentication-factory=%s:write-attribute(name=mechanism-configurations, value=[{mechanism-name=%s}])",
+                    NAME, mechanism));
+        }
+        ServerReload.reloadIfRequired(TestSuiteEnvironment.getModelControllerClient());
+
+        AuthenticationConfiguration authnCfg = AuthenticationConfiguration.empty()
+                .setSaslMechanismSelector(SaslMechanismSelector.fromString(mechanism)).useName(USERNAME)
+                .usePassword(USERNAME + PASSWORD_SFX);
+        AuthenticationContext.empty().with(MatchRule.ALL, authnCfg).run(() -> assertWhoAmI(USERNAME));
+
+        authnCfg = AuthenticationConfiguration.empty().setSaslMechanismSelector(SaslMechanismSelector.fromString(mechanism))
+                .useName("noSuchUser").usePassword("aPassword");
+        AuthenticationContext.empty().with(MatchRule.ALL, authnCfg).run(() -> assertAuthenticationFails(
+                "Authentication should fail when the user doesn't exist in the security-realm"));
+    }
+
+    /**
+     * Setup task which configures Elytron security domains and remoting connectors for this test.
+     */
+    public static class ServerSetup extends TestRunnerConfigSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            List<ConfigurableElement> elements = new ArrayList<>();
+
+            elements.add(ConstantPermissionMapper.builder().withName(NAME)
+                    .withPermissions(PermissionRef.fromPermission(new LoginPermission())).build());
+            elements.add(FileSystemRealm.builder().withName(NAME).withUser(USERNAME, USERNAME + PASSWORD_SFX).build());
+            elements.add(SimpleSecurityDomain.builder().withName(NAME).withDefaultRealm(NAME).withPermissionMapper(NAME)
+                    .withRealms(SecurityDomainRealm.builder().withRealm(NAME).build()).build());
+            elements.add(
+                    TrustedDomainsConfigurator.builder().withName("ManagementDomain").withTrustedSecurityDomains(NAME).build());
+
+            elements.add(SimpleSaslAuthenticationFactory.builder().withName(NAME).withSaslServerFactory("elytron")
+                    .withSecurityDomain(NAME).build());
+
+            elements.add(SimpleSocketBinding.builder().withName(NAME).withPort(PORT_NATIVE).build());
+            elements.add(
+                    SimpleMgmtNativeInterface.builder().withSocketBinding(NAME).withSaslAuthenticationFactory(NAME).build());
+            return elements.toArray(new ConfigurableElement[elements.size()]);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ExternalMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/ExternalMgmtSaslTestCase.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.CONNECTION_TIMEOUT_IN_MS;
 import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.PORT_NATIVE;
+import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.assertAuthenticationFails;
 import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.assertWhoAmI;
 import static org.wildfly.test.integration.elytron.sasl.mgmt.AbstractMgmtSaslTestBase.executeWhoAmI;
 
@@ -34,7 +35,9 @@ import java.net.ConnectException;
 import java.nio.file.Files;
 import java.security.KeyStore;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -44,6 +47,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.net.ssl.X509TrustManager;
+import javax.security.sasl.Sasl;
 
 import org.apache.commons.io.FileUtils;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -130,6 +134,57 @@ public class ExternalMgmtSaslTestCase {
                 .setKeyManager(getKeyManager(CLIENT_KEYSTORE_FILE)).setTrustManager(getTrustManager()).build();
         AuthenticationContext.empty().with(MatchRule.ALL, authCfg).withSsl(MatchRule.ALL, ssl)
                 .run(() -> assertWhoAmI("client"));
+    }
+
+    /**
+     * Tests SASL mechanism filtering through policy properties which are matched by EXTERNAL mechanism.
+     *
+     * @see <a href="https://issues.jboss.org/browse/ELY-982">ELY-982</a>
+     */
+    @Test
+    public void testMatchingFilteringProperties() throws Exception {
+        Map<String, String> mechanismProperties = new HashMap<>();
+        mechanismProperties.put(Sasl.POLICY_NOPLAINTEXT, "true");
+        mechanismProperties.put(Sasl.POLICY_NOACTIVE, "true");
+        mechanismProperties.put(Sasl.POLICY_NODICTIONARY, "true");
+        AuthenticationConfiguration authCfg = AuthenticationConfiguration.empty()
+                .setSaslMechanismSelector(SaslMechanismSelector.fromString(MECHANISM))
+                .useMechanismProperties(mechanismProperties);
+
+        SecurityFactory<SSLContext> ssl = new SSLContextBuilder().setClientMode(true)
+                .setKeyManager(getKeyManager(CLIENT_KEYSTORE_FILE)).setTrustManager(getTrustManager()).build();
+        AuthenticationContext.empty().with(MatchRule.ALL, authCfg).withSsl(MatchRule.ALL, ssl)
+                .run(() -> assertWhoAmI("client"));
+    }
+
+    /**
+     * Tests SASL mechanism filtering through policy properties which are not matched by EXTERNAL mechanism.
+     *
+     * @see <a href="https://issues.jboss.org/browse/ELY-982">ELY-982</a>
+     */
+    @Test
+    public void testUnmatchingFilteringProperties() throws Exception {
+        assertUnmatchingFilteringPropertyFails(Sasl.POLICY_FORWARD_SECRECY);
+        assertUnmatchingFilteringPropertyFails(Sasl.POLICY_PASS_CREDENTIALS);
+        assertUnmatchingFilteringPropertyFails(Sasl.POLICY_NOANONYMOUS);
+    }
+
+    /**
+     * @param policyProperty
+     * @throws Exception
+     */
+    private void assertUnmatchingFilteringPropertyFails(String policyProperty) throws Exception {
+        Map<String, String> mechanismProperties = new HashMap<>();
+        mechanismProperties.put(policyProperty, "true");
+        AuthenticationConfiguration authCfg = AuthenticationConfiguration.empty()
+                .setSaslMechanismSelector(SaslMechanismSelector.fromString(MECHANISM))
+                .useMechanismProperties(mechanismProperties);
+
+        SecurityFactory<SSLContext> ssl = new SSLContextBuilder().setClientMode(true)
+                .setKeyManager(getKeyManager(CLIENT_KEYSTORE_FILE)).setTrustManager(getTrustManager()).build();
+        AuthenticationContext.empty().with(MatchRule.ALL, authCfg).withSsl(MatchRule.ALL, ssl)
+                .run(() -> assertAuthenticationFails(
+                        String.format("The EXTERNAL SASL mechanism should not be selected, when property %s is true.", policyProperty)));
     }
 
     /**
@@ -223,7 +278,8 @@ public class ExternalMgmtSaslTestCase {
                     .withPermissions(PermissionRef.fromPermission(new LoginPermission())).build());
 
             // KeyStores
-            final SimpleKeyStore.Builder ksCommon = SimpleKeyStore.builder().withType("JKS").withCredentialReference(credentialReference);
+            final SimpleKeyStore.Builder ksCommon = SimpleKeyStore.builder().withType("JKS")
+                    .withCredentialReference(credentialReference);
             elements.add(ksCommon.withName("server-keystore")
                     .withPath(CliPath.builder().withPath(SERVER_KEYSTORE_FILE.getAbsolutePath()).build()).build());
             elements.add(ksCommon.withName("server-truststore")

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/other/TrustedDomainsConfigurator.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/other/TrustedDomainsConfigurator.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.other;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.elytron.AbstractConfigurableElement;
+
+/**
+ * Elytron configurator for trusted-domains attribute in a security-domain.
+ *
+ * @author Josef Cacek
+ */
+public class TrustedDomainsConfigurator extends AbstractConfigurableElement {
+
+    private final String[] trustedSecurityDomains;
+
+    private ModelNode originalDomains;
+
+    private TrustedDomainsConfigurator(Builder builder) {
+        super(builder);
+        this.trustedSecurityDomains = builder.trustedSecurityDomains;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        final PathAddress domainAddress = PathAddress.pathAddress().append("subsystem", "elytron").append("security-domain",
+                name);
+        ModelNode op = Util.createEmptyOperation("read-attribute", domainAddress);
+        op.get("name").set("trusted-security-domains");
+        ModelNode result = client.execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            result = Operations.readResult(result);
+            originalDomains = result.isDefined() ? result : null;
+        } else {
+            throw new RuntimeException("Reading existing value of trusted-security-domains attribute failed: "
+                    + Operations.getFailureDescription(result));
+        }
+
+        op = Util.createEmptyOperation("write-attribute", domainAddress);
+        op.get("name").set("trusted-security-domains");
+        for (String domain : trustedSecurityDomains) {
+            op.get("value").add(domain);
+        }
+        CoreUtils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        final PathAddress domainAddress = PathAddress.pathAddress().append("subsystem", "elytron").append("security-domain",
+                name);
+        ModelNode op = Util.createEmptyOperation("write-attribute", domainAddress);
+        op.get("name").set("trusted-security-domains");
+        if (originalDomains != null) {
+            op.get("value").set(originalDomains);
+        }
+        CoreUtils.applyUpdate(op, client);
+        originalDomains = null;
+    }
+
+    /**
+     * Creates builder to build {@link TrustedDomainsConfigurator}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link TrustedDomainsConfigurator}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private String[] trustedSecurityDomains;
+
+        private Builder() {
+        }
+
+        public Builder withTrustedSecurityDomains(String... trustedSecurityDomains) {
+            this.trustedSecurityDomains = trustedSecurityDomains;
+            return this;
+        }
+
+        public TrustedDomainsConfigurator build() {
+            return new TrustedDomainsConfigurator(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This commit adds regression tests for Elytron SASL mechanism improvements.

JIRAs
* upstream: https://issues.jboss.org/browse/WFCORE-3065
* downstream: https://issues.jboss.org/browse/JBEAP-12125

The original issues (already fixed):
* https://issues.jboss.org/browse/ELY-982
* https://issues.jboss.org/browse/ELY-1186
