### PR TITLE
[WFCORE-3063] Fix the delegate HttpServerAuthenticationMechanismFactory that gets passed to PropertiesServerMechanismFactory

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
@@ -166,7 +166,7 @@ class HttpServerDefinitions {
                     HttpServerAuthenticationMechanismFactory factory = factoryInjector.getValue();
                     factory = new SetMechanismInformationMechanismFactory(factory);
                     factory = finalFilter != null ? new FilterServerMechanismFactory(factory, finalFilter) : factory;
-                    factory = propertiesMap != null ? new PropertiesServerMechanismFactory(factoryInjector.getValue(), propertiesMap) : factory;
+                    factory = propertiesMap != null ? new PropertiesServerMechanismFactory(factory, propertiesMap) : factory;
 
                     return factory;
                 };


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3063
https://issues.jboss.org/browse/JBEAP-12068