### PR TITLE
[WFCORE-3068] OTP seed without base64 encoding

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableRealmDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableRealmDecorator.java
@@ -63,7 +63,6 @@ import org.wildfly.security.password.spec.OneTimePasswordSpec;
 import org.wildfly.security.password.spec.PasswordSpec;
 import org.wildfly.security.password.spec.SaltedPasswordAlgorithmSpec;
 
-import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
@@ -562,7 +561,7 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
             } else if (passwordType.equals(ElytronDescriptionConstants.OTP)) {
                 algorithm = OTPassword.ALGORITHM.resolveModelAttribute(parentContext, passwordNode).asString();
                 byte[] hash = OTPassword.HASH.resolveModelAttribute(parentContext, passwordNode).asBytes();
-                byte[] seed = OTPassword.SEED.resolveModelAttribute(parentContext, passwordNode).asString().getBytes(StandardCharsets.US_ASCII);
+                String seed = OTPassword.SEED.resolveModelAttribute(parentContext, passwordNode).asString();
                 int sequenceNumber = OTPassword.SEQUENCE.resolveModelAttribute(parentContext, passwordNode).asInt();
                 passwordSpec = new OneTimePasswordSpec(hash, seed, sequenceNumber);
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/RealmsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/RealmsTestCase.java
@@ -164,7 +164,7 @@ public class RealmsTestCase extends AbstractSubsystemBaseTest {
         credentials.add(new PasswordCredential(factory.generatePassword(spec)));
 
         PasswordFactory factoryOtp = PasswordFactory.getInstance(OneTimePassword.ALGORITHM_OTP_SHA1);
-        KeySpec specOtp = new OneTimePasswordSpec(new byte[]{0x12}, new byte[]{0x34}, 56789);
+        KeySpec specOtp = new OneTimePasswordSpec(new byte[]{0x12}, "34", 56789);
         credentials.add(new PasswordCredential(factoryOtp.generatePassword(specOtp)));
 
         identity1.setCredentials(credentials);
@@ -180,7 +180,7 @@ public class RealmsTestCase extends AbstractSubsystemBaseTest {
         // obtain OTP
         OneTimePassword otp = identity2.getCredential(PasswordCredential.class, OneTimePassword.ALGORITHM_OTP_SHA1).getPassword(OneTimePassword.class);
         Assert.assertArrayEquals(new byte[]{0x12}, otp.getHash());
-        Assert.assertArrayEquals(new byte[]{0x34}, otp.getSeed());
+        Assert.assertEquals("34", otp.getSeed());
         Assert.assertEquals(56789, otp.getSequenceNumber());
         identity2.dispose();
 


### PR DESCRIPTION
Related to https://github.com/wildfly-security/wildfly-elytron/pull/913
Need to be merged in coordination with ^^

https://issues.jboss.org/browse/JBEAP-12140
https://issues.jboss.org/browse/WFCORE-3068