### PR TITLE
[WFCORE-3070] Found multiple secret keys sharing same CKA_LABEL

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/ProviderKeyManagerService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/ProviderKeyManagerService.java
@@ -55,7 +55,9 @@ class ProviderKeyManagerService extends AbstractKeyManagerService {
 
         try {
             KeyStore theKeyStore = KeyStore.getInstance(provider);
-            theKeyStore.load(null, storePassword);
+            synchronized (SecurityRealmAddHandler.INSTANCE) {
+                theKeyStore.load(null, storePassword);
+            }
 
             this.theKeyStore = theKeyStore;
         } catch (KeyStoreException e) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/ProviderTrustManagerService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/ProviderTrustManagerService.java
@@ -54,7 +54,9 @@ public class ProviderTrustManagerService extends AbstractTrustManagerService {
 
         try {
             KeyStore theKeyStore = KeyStore.getInstance(provider);
-            theKeyStore.load(null, resolvePassword());
+            synchronized (SecurityRealmAddHandler.INSTANCE) {
+                theKeyStore.load(null, resolvePassword());
+            }
             this.theKeyStore = theKeyStore;
         } catch (KeyStoreException e) {
             throw DomainManagementLogger.ROOT_LOGGER.unableToStart(e);

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
@@ -34,7 +34,6 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -43,7 +42,6 @@ import java.util.function.Supplier;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
 
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ControlledProcessStateService;
@@ -206,23 +204,15 @@ public class HostControllerConnectionService implements Service<HostControllerCl
          * to be established.
          */
         try {
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance("SunX509");
+            KeyStore keyStore = KeyStore.getInstance("JKS");
+            keyStore.load( null, null);
+            trustManagerFactory.init(keyStore);
             SSLContext sslContext = SSLContext.getInstance("TLS");
-            TrustManager[] trustManagers = new TrustManager[] { new X509TrustManager() {
-                public void checkClientTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
-                }
-
-                public void checkServerTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
-                }
-
-                public X509Certificate[] getAcceptedIssuers() {
-                    return null;
-                }
-            } };
-
+            TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
             sslContext.init(null, trustManagers, null);
-
             return sslContext;
-        } catch (GeneralSecurityException e) {
+        } catch (IOException | GeneralSecurityException e) {
             throw ServerLogger.ROOT_LOGGER.unableToInitialiseSSLContext(e.getMessage());
         }
     }


### PR DESCRIPTION
Synchronization issue when using FIPS enabled NSS DB as PKCS11 keystore.
https://issues.jboss.org/browse/WFCORE-3070
https://issues.jboss.org/browse/JBEAP-11693