### PR TITLE
WFCORE-2968 - Servers in a domain won't boot if local auth is disabled on the host controller

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/DomainManagedServerCallbackHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/DomainManagedServerCallbackHandler.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.domain.management.security;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Principal;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.InvalidKeySpecException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.domain.management.AuthMechanism;
+import org.jboss.as.domain.management.SecurityRealm;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedSetValue;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.common.Assert;
+import org.wildfly.common.function.ExceptionSupplier;
+import org.wildfly.security.auth.SupportLevel;
+import org.wildfly.security.auth.server.RealmIdentity;
+import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.credential.Credential;
+import org.wildfly.security.credential.PasswordCredential;
+import org.wildfly.security.credential.source.CredentialSource;
+import org.wildfly.security.evidence.Evidence;
+import org.wildfly.security.evidence.PasswordGuessEvidence;
+import org.wildfly.security.password.Password;
+import org.wildfly.security.password.PasswordFactory;
+import org.wildfly.security.password.spec.ClearPasswordSpec;
+import org.wildfly.security.password.spec.PasswordSpec;
+
+import static org.jboss.as.domain.management.RealmConfigurationConstants.DIGEST_PLAIN_TEXT;
+import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
+import static org.wildfly.security.password.interfaces.DigestPassword.ALGORITHM_DIGEST_MD5;
+
+/**
+ * A callback handler for servers connecting back to the local host-controller
+ * When a server is started, the process is given a generated authKey from the initiating host-controller, that it
+ * uses to connect back to the host-controller after start {@see HostControllerConnection}.
+ *
+ * @author <a href="mailto:kwills@jboss.com">Ken Wills</a>
+ */
+public class DomainManagedServerCallbackHandler implements Service<CallbackHandlerService>, CallbackHandlerService, CallbackHandler {
+
+    private static final String SERVICE_SUFFIX = "servers";
+    private volatile CallbackHandler serverCallbackHandler;
+    // this realm is only used internally for server to host controller communication
+    public static final String REALM_NAME = "internal-domain-servers-security-realm";
+    private final InjectedValue<Map<String, ExceptionSupplier<CredentialSource, Exception>>> credentialSourceSupplier = new InjectedValue<>();
+
+    // the callback handler passed through from ServerInventory, containing the server authkeys.
+    // we don't have the ManagedServer etc classes here, so this seems to be the cleanest method of doing it.
+    public void setServerCallbackHandler(final CallbackHandler serverCallbackHandler) {
+        this.serverCallbackHandler = serverCallbackHandler;
+    }
+
+    Injector<Map<String, ExceptionSupplier<CredentialSource, Exception>>> getCredentialSourceSupplierInjector() {
+        return credentialSourceSupplier;
+    }
+
+    /*
+     * CallbackHandlerService Methods
+     */
+    public AuthMechanism getPreferredMechanism() {
+        return AuthMechanism.PLAIN;
+    }
+
+    public Set<AuthMechanism> getSupplementaryMechanisms() {
+        return Collections.EMPTY_SET;
+    }
+
+    public Map<String, String> getConfigurationOptions() {
+        return Collections.singletonMap(DIGEST_PLAIN_TEXT, Boolean.TRUE.toString());
+    }
+
+    @Override
+    public boolean isReadyForHttpChallenge() {
+        return false;
+    }
+
+    public CallbackHandler getCallbackHandler(Map<String, Object> sharedState) {
+        return this;
+    }
+
+    @Override
+    public org.wildfly.security.auth.server.SecurityRealm getElytronSecurityRealm() {
+        return new DomainServerSecurityRealmImpl();
+    }
+
+    /*
+     *  Service Methods
+     */
+
+    public void start(StartContext context) throws StartException {
+    }
+
+    public void stop(StopContext context) {
+    }
+
+    public DomainManagedServerCallbackHandler getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+    public void installServerSecurityRealm(final OperationContext context, final SecurityRealmService securityRealmService, final ServiceTarget serviceTarget,
+                                           final ServiceBuilder<?> realmBuilder, final Injector<CallbackHandlerService> injector) throws OperationFailedException {
+        ServiceName domainServersServiceName = DomainManagedServerCallbackHandler.ServiceUtil.createServiceName();
+        ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
+        // this realm is only created once.
+        if (serviceRegistry.getService(domainServersServiceName) != null) {
+            return;
+        }
+
+        InjectedSetValue<CallbackHandlerService> injectorSet = securityRealmService.getCallbackHandlerService();
+        ServiceBuilder<CallbackHandlerService> serviceBuilder = serviceTarget.addService(domainServersServiceName, this)
+                .setInitialMode(ServiceController.Mode.ON_DEMAND);
+        serviceBuilder.install();
+        CallbackHandlerService.ServiceUtil.addDependency(realmBuilder, injectorSet.injector(), domainServersServiceName);
+    }
+
+    /*
+     *  CallbackHandler Method
+     */
+
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        serverCallbackHandler.handle((callbacks));
+    }
+
+    private class DomainServerSecurityRealmImpl implements org.wildfly.security.auth.server.SecurityRealm {
+
+        @Override
+        public RealmIdentity getRealmIdentity(Principal principal) throws RealmUnavailableException {
+            String name = principal.getName();
+            return new RealmIdentityImpl(principal, name);
+        }
+
+        public SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName, AlgorithmParameterSpec parameterSpec) throws RealmUnavailableException {
+            Assert.checkNotNullParam("credentialType", credentialType);
+            return PasswordCredential.class.isAssignableFrom(credentialType) && (algorithmName == null || algorithmName.equals(ALGORITHM_CLEAR) ||
+                    algorithmName.equals(ALGORITHM_DIGEST_MD5)) ? SupportLevel.SUPPORTED : SupportLevel.UNSUPPORTED;
+        }
+
+        @Override
+        public SupportLevel getEvidenceVerifySupport(Class<? extends Evidence> evidenceType, String algorithmName)
+                throws RealmUnavailableException {
+            return SupportLevel.UNSUPPORTED;
+        }
+
+        private class RealmIdentityImpl implements RealmIdentity {
+
+            private final Principal principal;
+            private final String serverName;
+
+            private RealmIdentityImpl(final Principal principal, final String serverName) {
+                this.principal = principal;
+                this.serverName = serverName;
+            }
+
+            @Override
+            public Principal getRealmIdentityPrincipal() {
+                return principal;
+            }
+
+            public SupportLevel getCredentialAcquireSupport(Class<? extends Credential> credentialType, String algorithmName, AlgorithmParameterSpec parameterSpec) throws RealmUnavailableException {
+                return DomainManagedServerCallbackHandler.DomainServerSecurityRealmImpl.this.getCredentialAcquireSupport(credentialType, algorithmName, parameterSpec);
+            }
+
+            @Override
+            public <C extends Credential> C getCredential(Class<C> credentialType) throws RealmUnavailableException {
+                return getCredential(credentialType, null);
+            }
+
+            public <C extends Credential> C getCredential(Class<C> credentialType, final String algorithmName) throws RealmUnavailableException {
+                return getCredential(credentialType, algorithmName, null);
+            }
+
+            public <C extends Credential> C getCredential(Class<C> credentialType, final String algorithmName, final AlgorithmParameterSpec parameterSpec) throws RealmUnavailableException {
+
+                if (serverName == null || (PasswordCredential.class.isAssignableFrom(credentialType) == false)) {
+                    return null;
+                }
+
+                final PasswordFactory passwordFactory;
+                final PasswordSpec passwordSpec;
+
+                char[] password;
+                try {
+                    password = fetchCredential(serverName);
+                } catch (Exception e) {
+                    throw new RealmUnavailableException(e);
+                }
+
+                passwordFactory = getPasswordFactory(ALGORITHM_CLEAR);
+                passwordSpec = new ClearPasswordSpec(password);
+
+                try {
+                    return credentialType.cast(new PasswordCredential(passwordFactory.generatePassword(passwordSpec)));
+                } catch (InvalidKeySpecException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            @Override
+            public SupportLevel getEvidenceVerifySupport(Class<? extends Evidence> evidenceType, String algorithmName) throws RealmUnavailableException {
+                return DomainManagedServerCallbackHandler.DomainServerSecurityRealmImpl.this.getEvidenceVerifySupport(evidenceType, algorithmName);
+            }
+
+            @Override
+            public boolean verifyEvidence(Evidence evidence) throws RealmUnavailableException {
+
+                /*
+                // only support the internal server realm REALM_NAME
+                RealmUser realmUser;
+                if (principal instanceof RealmUser) {
+                    realmUser = (RealmUser)principal;
+                    if (!REALM_NAME.equals(realmUser.getRealm())) {
+                        throw DomainManagementLogger.ROOT_LOGGER.invalidRealm(realmUser.getRealm(), REALM_NAME);
+                    }
+                } else {
+                    throw new RealmUnavailableException(DomainManagementLogger.ROOT_LOGGER.realmMustBeSpecified());
+                }
+                */
+
+                if (serverName == null || evidence instanceof PasswordGuessEvidence == false) {
+                    return false;
+                }
+
+                char[] password;
+                final char[] guess = ((PasswordGuessEvidence) evidence).getGuess();
+                try {
+                    password = fetchCredential(serverName);
+                } catch (Exception e) {
+                    throw new RealmUnavailableException(e);
+                }
+
+                final PasswordFactory passwordFactory = getPasswordFactory(ALGORITHM_CLEAR);
+                final PasswordSpec passwordSpec = new ClearPasswordSpec(password);
+                final Password actualPassword;
+
+                try {
+                    actualPassword = passwordFactory.generatePassword(passwordSpec);
+                    return passwordFactory.verify(actualPassword, guess);
+                } catch (InvalidKeySpecException | InvalidKeyException | IllegalStateException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+
+            @Override
+            public boolean exists() throws RealmUnavailableException {
+                return serverName != null;
+            }
+        }
+    }
+
+    private char[] fetchCredential(final String serverName) throws UnsupportedCallbackException, IOException {
+        final List<Callback> callbacks = new ArrayList<>();
+        final NameCallback nc = new NameCallback("None", serverName);
+        callbacks.add(nc);
+        final PasswordCallback pc = new PasswordCallback("Password: ", false);
+        callbacks.add(pc);
+        serverCallbackHandler.handle(callbacks.toArray(new Callback[callbacks.size()]));
+        return pc.getPassword();
+    }
+
+    private static PasswordFactory getPasswordFactory(final String algorithm) {
+        try {
+            return PasswordFactory.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static final class ServiceUtil {
+
+        private ServiceUtil() {
+        }
+
+        public static ServiceName createServiceName() {
+            return SecurityRealm.ServiceUtil.createServiceName(REALM_NAME).append(SERVICE_SUFFIX);
+        }
+
+    }
+
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -160,6 +160,11 @@ public class SecurityRealmAddHandler extends AbstractAddStepHandler {
             addPlugInLoaderService(realmName, plugIns, serviceTarget);
         }
         InjectedSetValue<CallbackHandlerService> injectorSet = securityRealmService.getCallbackHandlerService();
+
+        // install the managed server realm callback handle for domain server authkeys
+        DomainManagedServerCallbackHandler dmc = new DomainManagedServerCallbackHandler();
+        dmc.installServerSecurityRealm(context, securityRealmService, serviceTarget, realmBuilder, injectorSet.injector());
+
         if (authentication != null) {
             // Authentication can have a truststore defined at the same time as a username/password based mechanism.
             //

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryImpl.java
@@ -70,6 +70,7 @@ import org.jboss.as.controller.transform.TransformationTarget;
 import org.jboss.as.controller.transform.TransformationTargetImpl;
 import org.jboss.as.controller.transform.TransformerRegistry;
 import org.jboss.as.domain.controller.DomainController;
+import org.jboss.as.domain.management.security.DomainManagedServerCallbackHandler;
 import org.jboss.as.host.controller.logging.HostControllerLogger;
 import org.jboss.as.process.ProcessController;
 import org.jboss.as.process.ProcessControllerClient;
@@ -802,6 +803,9 @@ public class ServerInventoryImpl implements ServerInventory {
                         toRespondTo.add(current);
                     } else if (current instanceof RealmCallback) {
                         realm = ((RealmCallback)current).getDefaultText();
+                        if (!DomainManagedServerCallbackHandler.REALM_NAME.equals(realm)) {
+                            throw new UnsupportedCallbackException(current);
+                        }
                     } else {
                         throw new UnsupportedCallbackException(current);
                     }

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnection.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnection.java
@@ -42,6 +42,7 @@ import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.remote.ResponseAttachmentInputStreamSupport;
 import org.jboss.as.controller.remote.TransactionalProtocolClient;
 import org.jboss.as.controller.remote.TransactionalProtocolOperationHandler;
+import org.jboss.as.domain.management.security.DomainManagedServerCallbackHandler;
 import org.jboss.as.protocol.ProtocolConnectionConfiguration;
 import org.jboss.as.protocol.ProtocolConnectionManager;
 import org.jboss.as.protocol.ProtocolConnectionUtils;
@@ -394,12 +395,13 @@ class HostControllerConnection extends FutureManagementChannel {
             this.authKey = authKey;
         }
 
+        @Override
         public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
             for (Callback current : callbacks) {
                 if (current instanceof RealmCallback) {
                     RealmCallback rcb = (RealmCallback) current;
-                    String defaultText = rcb.getDefaultText();
-                    rcb.setText(defaultText); // For now just use the realm suggested.
+                    // use the internal server-only auth realm
+                    rcb.setText(DomainManagedServerCallbackHandler.REALM_NAME);
                 } else if (current instanceof RealmChoiceCallback) {
                     throw new UnsupportedCallbackException(current, "Realm choice not currently supported.");
                 } else if (current instanceof NameCallback) {

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
@@ -58,6 +58,8 @@ import org.jboss.msc.value.InjectedValue;
 import org.jboss.remoting3.Endpoint;
 import org.xnio.IoUtils;
 import org.xnio.OptionMap;
+import org.xnio.Options;
+import org.xnio.Sequence;
 
 /**
  * Service setting up the connection to the local host controller.
@@ -110,11 +112,11 @@ public class HostControllerConnectionService implements Service<HostControllerCl
     public synchronized void start(final StartContext context) throws StartException {
         final Endpoint endpoint = endpointInjector.getValue();
         try {
-            // TODO Elytron - Don't disable local authentication for now.
-            //final OptionMap options = OptionMap.create(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of(JBOSS_LOCAL_USER));
+            // for servers, local auth is always disabled.
+            final OptionMap options = OptionMap.create(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of(JBOSS_LOCAL_USER));
             // Create the connection configuration
-            final ProtocolConnectionConfiguration configuration = ProtocolConnectionConfiguration.create(endpoint, connectionURI, OptionMap.EMPTY);
-            //configuration.setCallbackHandler(HostControllerConnection.createClientCallbackHandler(userName, initialAuthKey));
+            final ProtocolConnectionConfiguration configuration = ProtocolConnectionConfiguration.create(endpoint, connectionURI, options);
+            configuration.setCallbackHandler(HostControllerConnection.createClientCallbackHandler(userName, initialAuthKey));
             configuration.setConnectionTimeout(SERVER_CONNECTION_TIMEOUT);
             configuration.setSslContext(sslContextSupplier.get());
             this.responseAttachmentSupport = new ResponseAttachmentInputStreamSupport(scheduledExecutorInjector.getValue());


### PR DESCRIPTION
This adds a new internal realm for servers to auth to the HC using the authKey generated when they are started. Local auth is also disabled on the client for the connection back to the HC.

@darranl @bstansberry 

This got a bit involved and a bit hacky, but it is working for authenticating servers with local auth removed. It still needs a little more testing, but I'm sure that people will have feedback on some of the more "adventurous* bits.

In particular, it would be great if anyone had suggestions on anyu of the following:

- The DMCS linking of the serverinventory callback to the new DomainManagedServerCallbackHandler is super hacky and using a service name lookup etc, but I don't see a common way of doing this in the code. Most of the existing realms are static or being loaded from either property files that already have a fixed location, or something in the domain model. I thought about exposing the server keys in the domain model, but that seemed excessive for this use case.

 - Installing DomainManagedServerCallbackHandler
(https://github.com/wildfly/wildfly-core/compare/master...luck3y:WFCORE-2968?expand=1#diff-73aeedc480f0fb4506e791c2aeff6a00R144) 
Is there a better spot to install this realmcallbackhandler from? It only needs to be installed once, so its checking to see if it's already there in a hacky way.

- RealmName restrictions.
 I need to verify if this was an existing problem or not, but with DomainManagedServerCallbackHandler installed I can auth to the management console using the server credentials. This should be restricted to the internal realm name (https://github.com/wildfly/wildfly-core/compare/master...luck3y:WFCORE-2968?expand=1#diff-73aeedc480f0fb4506e791c2aeff6a00R83), but I always seem to get ManagementRealm.

