### PR TITLE
[WFCORE-3078]: Intermittent failure in AuditLogBootingSyslogTest shows that WFCORE-2923 doesn't cover every case

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/audit/ManagedAuditLoggerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/audit/ManagedAuditLoggerImpl.java
@@ -226,6 +226,7 @@ public class ManagedAuditLoggerImpl implements ManagedAuditLogger, ManagedAuditL
                     } catch (Exception e) {
                         handleLoggingException(e);
                     }
+                    queuedItems.clear();
                 }
             } else if (newStatus == Status.DISABLED){
                 queuedItems.clear();

--- a/controller/src/main/java/org/jboss/as/controller/audit/SyslogAuditLogHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/audit/SyslogAuditLogHandler.java
@@ -196,6 +196,7 @@ public class SyslogAuditLogHandler extends AuditLogHandler {
                 }
             }
         } catch (Exception ex) {
+            ControllerLogger.ROOT_LOGGER.errorObtainingPassword(ex, ex.getMessage());
             return pwd == null ? EMPTY_PASSWORD : pwd.toCharArray();
         }
         return pwd == null ? EMPTY_PASSWORD : pwd.toCharArray();

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3496,4 +3496,8 @@ public interface ControllerLogger extends BasicLogger {
     @LogMessage(level = Level.WARN)
     @Message(id = 442, value = "Error stopping server")
     void errorStoppingServer(@Cause Exception cause);
+
+    @LogMessage(level = Level.WARN)
+    @Message(id = 443, value = "Error getting the password from the supplier %s")
+    void errorObtainingPassword(@Cause Exception cause, String message);
 }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTest.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTest.java
@@ -115,8 +115,7 @@ public class AuditLogBootingSyslogTest {
         final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();
         queue.clear();
         container.start();
-        long endTime = System.currentTimeMillis() + TimeoutUtil.adjust(5000);
-        waitForExpectedQueueSize(18, queue);
+        waitForExpectedQueueSize(1, queue);
         queue.clear();
         makeOneLog();
         waitForExpectedQueueSize(1, queue);


### PR DESCRIPTION
Changing the AuditLogger in the ResultHandler of AuditLogLoggerAddHandler instead of as a RUNTIME step.
Clearing the queue when writting log entries after the ManagedAuditLogger change status to LOGGING.

Jira: https://issues.jboss.org/browse/WFCORE-3078
JBEAP: https://issues.jboss.org/browse/JBEAP-11387