### PR TITLE
[WFCORE-3082] Upgrade commons-logging-jboss-logmanager from 1.0.0.Fin…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
         <!--<version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>-->
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Alpha2</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.0.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
+        <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.1.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
         <version.org.jboss.logmanager.jboss-logmanager>2.0.7.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.3.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.0.CR1</version.org.jboss.marshalling.jboss-marshalling>


### PR DESCRIPTION
…al to 1.0.1.Final

https://issues.jboss.org/browse/WFCORE-3082

Very minor change in the release to make the log implementation serializable. https://github.com/jboss-logging/commons-logging-jboss-logmanager/compare/1.0.0.Final...1.0.1.Final