### PR TITLE
[WFCORE-3010] Deprecate the non-builder SimpleOperationDefinition constructors; eliminate their use

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/SimpleOperationDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleOperationDefinition.java
@@ -43,14 +43,16 @@ import org.jboss.dmr.ModelType;
  */
 public class SimpleOperationDefinition extends OperationDefinition {
 
-    final ResourceDescriptionResolver resolver;
-    final ResourceDescriptionResolver attributeResolver;
+    private final ResourceDescriptionResolver resolver;
+    private final ResourceDescriptionResolver attributeResolver;
 
+    /** @deprecated use {@link org.jboss.as.controller.SimpleOperationDefinitionBuilder} */
     @SuppressWarnings("deprecation")
     public SimpleOperationDefinition(final String name, final ResourceDescriptionResolver resolver) {
         this(name, resolver, EnumSet.noneOf(OperationEntry.Flag.class));
     }
 
+    /** @deprecated use {@link org.jboss.as.controller.SimpleOperationDefinitionBuilder} */
     @SuppressWarnings("deprecation")
     public SimpleOperationDefinition(final String name, final ResourceDescriptionResolver resolver, AttributeDefinition... parameters) {
         this(name, resolver, OperationEntry.EntryType.PUBLIC, EnumSet.noneOf(OperationEntry.Flag.class), parameters);

--- a/controller/src/main/java/org/jboss/as/controller/SimpleOperationDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleOperationDefinitionBuilder.java
@@ -40,7 +40,13 @@ import org.jboss.dmr.ModelType;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
  */
 public class SimpleOperationDefinitionBuilder {
+
     private static AttributeDefinition[] NO_ATTRIBUTES = new AttributeDefinition[0];
+
+    public static SimpleOperationDefinitionBuilder of(String name, ResourceDescriptionResolver resolver) {
+        return new SimpleOperationDefinitionBuilder(name, resolver);
+    }
+
     ResourceDescriptionResolver resolver;
     ResourceDescriptionResolver attributeResolver;
     protected String name;

--- a/controller/src/main/java/org/jboss/as/controller/StringListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/StringListAttributeDefinition.java
@@ -91,6 +91,10 @@ public final class StringListAttributeDefinition extends PrimitiveListAttributeD
 
     public static class Builder extends ListAttributeDefinition.Builder<Builder, StringListAttributeDefinition> {
 
+        public static final Builder of(final String name) {
+            return new Builder(name);
+        }
+
         public Builder(final String name) {
             super(name);
             parser = AttributeParser.STRING_LIST;

--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/IntRangeValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/IntRangeValidator.java
@@ -36,6 +36,10 @@ public class IntRangeValidator extends ModelTypeValidator implements MinMaxValid
         this(min, Integer.MAX_VALUE, false, false);
     }
 
+    public IntRangeValidator(final int min, final int max) {
+        this(min, max, false, false);
+    }
+
     public IntRangeValidator(final int min, final boolean nullable) {
         this(min, Integer.MAX_VALUE, nullable, false);
     }

--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/ListValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/ListValidator.java
@@ -33,7 +33,7 @@ import org.wildfly.common.Assert;
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  *
  */
-public class ListValidator extends ModelTypeValidator implements ParameterValidator {
+public class ListValidator extends ModelTypeValidator implements ParameterValidator, MinMaxValidator {
 
     private final int min;
     private final int max;
@@ -119,4 +119,13 @@ public class ListValidator extends ModelTypeValidator implements ParameterValida
         }
     }
 
+    @Override
+    public Long getMin() {
+        return (long) min;
+    }
+
+    @Override
+    public Long getMax() {
+        return (long) max;
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/LongRangeValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/LongRangeValidator.java
@@ -36,6 +36,10 @@ public class LongRangeValidator extends ModelTypeValidator implements MinMaxVali
         this(min, Long.MAX_VALUE, false, false);
     }
 
+    public LongRangeValidator(final long min, final Long max) {
+        this(min, max, false, false);
+    }
+
     public LongRangeValidator(final long min, final boolean nullable) {
         this(min, Integer.MAX_VALUE, nullable, false);
     }

--- a/controller/src/main/java/org/jboss/as/controller/operations/validation/StringLengthValidator.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/validation/StringLengthValidator.java
@@ -40,6 +40,10 @@ public class StringLengthValidator extends ModelTypeValidator implements MinMaxV
         this(min, Integer.MAX_VALUE, false, false);
     }
 
+    public StringLengthValidator(final int min, final int max) {
+        this(min, max, false, false);
+    }
+
     /**
      * Equivalent to {@code this(min, Integer.MAX_VALUE, nullable, false)}.
      * @param min the minimum length of the string

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
@@ -127,8 +127,8 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             .setRemoveOperation(new ReloadRequiredRemoveStepHandler(IO_POOL_RUNTIME_CAPABILITY, IO_WORKER_RUNTIME_CAPABILITY))
             .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
             .addReadWriteAttribute(other, null, new ReloadRequiredWriteAttributeHandler(other))
-            .addOperation(new SimpleOperationDefinition("add-cap",
-                            new NonResolvingResourceDescriptionResolver()),
+            .addOperation(SimpleOperationDefinitionBuilder.of("add-cap",
+                            new NonResolvingResourceDescriptionResolver()).build(),
                     (context, operation) -> {
                         ManagementResourceRegistration mrr = context.getResourceRegistrationForUpdate();
                         mrr.registerCapability(TEST_CAPABILITY1);
@@ -154,15 +154,15 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             .addReadWriteAttribute(ad, null, new ReloadRequiredWriteAttributeHandler(ad))
             .addReadWriteAttribute(other, null, new ReloadRequiredWriteAttributeHandler(other))
             .addCapability(TEST_CAPABILITY2)
-            .addOperation(new SimpleOperationDefinition("add-sub-resource",
-                            new NonResolvingResourceDescriptionResolver()),
+            .addOperation(SimpleOperationDefinitionBuilder.of("add-sub-resource",
+                            new NonResolvingResourceDescriptionResolver()).build(),
                     (context, operation) -> {
                         ManagementResourceRegistration mrr = context.getResourceRegistrationForUpdate();
                         mrr.registerSubModel(SUB_RESOURCE);
                     })
 
-            .addOperation(new SimpleOperationDefinition("remove-sub-resource",
-                            new NonResolvingResourceDescriptionResolver()),
+            .addOperation(SimpleOperationDefinitionBuilder.of("remove-sub-resource",
+                            new NonResolvingResourceDescriptionResolver()).build(),
                     (context, operation) -> {
                         ManagementResourceRegistration mrr = context.getResourceRegistrationForUpdate();
                         mrr.unregisterSubModel(SUB_RESOURCE.getPathElement());
@@ -198,7 +198,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             context.completeStep(OperationContext.RollbackHandler.REVERT_RELOAD_REQUIRED_ROLLBACK_HANDLER);
         }
     };
-    private static final OperationDefinition RELOAD_DEFINITION = new SimpleOperationDefinition("reload", NonResolvingResourceDescriptionResolver.INSTANCE);
+    private static final OperationDefinition RELOAD_DEFINITION = SimpleOperationDefinitionBuilder.of("reload", NonResolvingResourceDescriptionResolver.INSTANCE).build();
 
     private static final OperationStepHandler RUNTIME_MOD_HANDLER = new OperationStepHandler() {
         @Override
@@ -213,8 +213,8 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
         }
     };
 
-    private static final OperationDefinition RUNTIME_MOD_DEFINITION = new SimpleOperationDefinition("runtime-mod", NonResolvingResourceDescriptionResolver.INSTANCE);
-    private static final OperationDefinition RUNTIME_ONLY_DEFINITION = new SimpleOperationDefinitionBuilder("runtime-only", NonResolvingResourceDescriptionResolver.INSTANCE)
+    private static final OperationDefinition RUNTIME_MOD_DEFINITION = SimpleOperationDefinitionBuilder.of("runtime-mod", NonResolvingResourceDescriptionResolver.INSTANCE).build();
+    private static final OperationDefinition RUNTIME_ONLY_DEFINITION = SimpleOperationDefinitionBuilder.of("runtime-only", NonResolvingResourceDescriptionResolver.INSTANCE)
             .setRuntimeOnly()
             .build();
 
@@ -298,7 +298,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
                 }
             })
             .setRemoveOperation(new ReloadRequiredRemoveStepHandler(TEST_CAPABILITY3))
-            .addOperation(new SimpleOperationDefinition("read", NonResolvingResourceDescriptionResolver.INSTANCE),
+            .addOperation(SimpleOperationDefinitionBuilder.of("read", NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                     ((context, operation) -> context.getResult().set(true)))
             .build();
 
@@ -315,7 +315,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
         // register the global notifications so there is no warning that emitted notifications are not described by the resource.
         GlobalNotifications.registerGlobalNotifications(rootRegistration, processType);
         rootRegistration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
-        rootRegistration.registerOperationHandler(new SimpleOperationDefinition("clean", NonResolvingResourceDescriptionResolver.INSTANCE), (context, operation) -> {
+        rootRegistration.registerOperationHandler(SimpleOperationDefinitionBuilder.of("clean", NonResolvingResourceDescriptionResolver.INSTANCE).build(), (context, operation) -> {
             ManagementResourceRegistration mrr = context.getResourceRegistrationForUpdate();
             mrr.unregisterSubModel(TEST_RESOURCE1.getPathElement());
             mrr.unregisterSubModel(TEST_RESOURCE2.getPathElement());
@@ -328,7 +328,7 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             mrr.unregisterSubModel(DEP_CAP_RESOURCE.getPathElement());
         });
 
-        rootRegistration.registerOperationHandler(new SimpleOperationDefinition("create", NonResolvingResourceDescriptionResolver.INSTANCE), (context, operation) -> {
+        rootRegistration.registerOperationHandler(SimpleOperationDefinitionBuilder.of("create", NonResolvingResourceDescriptionResolver.INSTANCE).build(), (context, operation) -> {
             ManagementResourceRegistration mrr = context.getResourceRegistrationForUpdate();
             mrr.registerSubModel(TEST_RESOURCE1);
             mrr.registerSubModel(TEST_RESOURCE2);
@@ -340,14 +340,14 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
             mrr.registerSubModel(NO_CAP_RESOURCE);
             mrr.registerSubModel(DEP_CAP_RESOURCE);
         });
-        rootRegistration.registerOperationHandler(new SimpleOperationDefinition("root-cap", NonResolvingResourceDescriptionResolver.INSTANCE),
+        rootRegistration.registerOperationHandler(SimpleOperationDefinitionBuilder.of("root-cap", NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                 new OperationStepHandler() {
                     @Override
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                         context.registerCapability(ROOT_CAPABILITY);
                     }
                 });
-        rootRegistration.registerOperationHandler(new SimpleOperationDefinition("no-root-cap", NonResolvingResourceDescriptionResolver.INSTANCE),
+        rootRegistration.registerOperationHandler(SimpleOperationDefinitionBuilder.of("no-root-cap", NonResolvingResourceDescriptionResolver.INSTANCE).build(),
                 new OperationStepHandler() {
                     @Override
                     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {

--- a/controller/src/test/java/org/jboss/as/controller/test/WildcardReadResourceDescriptionUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WildcardReadResourceDescriptionUnitTestCase.java
@@ -34,7 +34,7 @@ import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.NoopOperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.OverrideDescriptionProvider;
@@ -392,8 +392,8 @@ public class WildcardReadResourceDescriptionUnitTestCase  extends AbstractContro
         GlobalOperationHandlers.registerGlobalOperations(root, processType);
         root.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
-        root.registerOperationHandler(new SimpleOperationDefinition("setup",
-                new NonResolvingResourceDescriptionResolver()), NoopOperationStepHandler.WITHOUT_RESULT);
+        root.registerOperationHandler(SimpleOperationDefinitionBuilder.of("setup",
+                new NonResolvingResourceDescriptionResolver()).build(), NoopOperationStepHandler.WITHOUT_RESULT);
 
         GlobalNotifications.registerGlobalNotifications(root, processType);
 

--- a/controller/src/test/java/org/jboss/as/controller/test/WildcardReadResourceUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/WildcardReadResourceUnitTestCase.java
@@ -42,7 +42,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.OverrideDescriptionProvider;
@@ -132,8 +132,8 @@ public class WildcardReadResourceUnitTestCase extends AbstractControllerTestBase
         GlobalOperationHandlers.registerGlobalOperations(root, processType);
         root.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
-        root.registerOperationHandler(new SimpleOperationDefinition("setup",
-                new NonResolvingResourceDescriptionResolver()), new OperationStepHandler() {
+        root.registerOperationHandler(SimpleOperationDefinitionBuilder.of("setup",
+                new NonResolvingResourceDescriptionResolver()).build(), new OperationStepHandler() {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/IdentityOperationsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/IdentityOperationsTestCase.java
@@ -33,7 +33,7 @@ import static org.wildfly.extension.elytron.ElytronDescriptionConstants.ROLES;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
@@ -509,7 +509,7 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
     }
 
     private ModelNode createReadSecurityDomainIdentityOperation(PathAddress parentAddress, String principalName) {
-        return SubsystemOperations.OperationBuilder.create(new SimpleOperationDefinition(ElytronDescriptionConstants.READ_IDENTITY, ElytronExtension.getResourceDescriptionResolver(ElytronDescriptionConstants.SECURITY_DOMAIN)),
+        return SubsystemOperations.OperationBuilder.create(SimpleOperationDefinitionBuilder.of(ElytronDescriptionConstants.READ_IDENTITY, ElytronExtension.getResourceDescriptionResolver(ElytronDescriptionConstants.SECURITY_DOMAIN)).build(),
                 parentAddress.toModelNode())
                 .addAttribute(DomainDefinition.ReadSecurityDomainIdentityHandler.NAME, principalName)
                 .build();

--- a/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentResourceDefinition.java
+++ b/management-client-content/src/main/java/org/jboss/as/management/client/content/ManagedDMRContentResourceDefinition.java
@@ -26,7 +26,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -77,7 +77,7 @@ public class ManagedDMRContentResourceDefinition extends SimpleResourceDefinitio
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
 
-        OperationDefinition addOD = new SimpleOperationDefinition("add", getResourceDescriptionResolver(),contentDefinition);
+        OperationDefinition addOD = SimpleOperationDefinitionBuilder.of("add", getResourceDescriptionResolver()).addParameter(contentDefinition).build();
         resourceRegistration.registerOperationHandler(addOD, new ManagedDMRContentAddHandler(contentDefinition));
 
         final ManagedDMRContentStoreHandler handler = new ManagedDMRContentStoreHandler(contentDefinition, getResourceDescriptionResolver());

--- a/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/DeploymentAttributes.java
@@ -52,7 +52,6 @@ import org.jboss.as.controller.ParameterCorrector;
 import org.jboss.as.controller.PrimitiveListAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
@@ -353,12 +352,13 @@ public class DeploymentAttributes {
     @SuppressWarnings("unchecked")
     public static final Map<String, AttributeDefinition> ALL_CONTENT_ATTRIBUTES = createAttributeMap(MANAGED_CONTENT_ATTRIBUTES, UNMANAGED_CONTENT_ATTRIBUTES);
 
-    public static final OperationDefinition DEPLOY_DEFINITION = new SimpleOperationDefinition(ModelDescriptionConstants.DEPLOY, DEPLOYMENT_RESOLVER);
-    public static final OperationDefinition UNDEPLOY_DEFINITION = new SimpleOperationDefinition(ModelDescriptionConstants.UNDEPLOY, DEPLOYMENT_RESOLVER);
-    public static final OperationDefinition REDEPLOY_DEFINITION = new SimpleOperationDefinition(ModelDescriptionConstants.REDEPLOY, DEPLOYMENT_RESOLVER);
-    public static final OperationDefinition EXPLODE_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.EXPLODE, DEPLOYMENT_RESOLVER)
+    public static final OperationDefinition DEPLOY_DEFINITION = SimpleOperationDefinitionBuilder.of(ModelDescriptionConstants.DEPLOY, DEPLOYMENT_RESOLVER).build();
+    public static final OperationDefinition UNDEPLOY_DEFINITION = SimpleOperationDefinitionBuilder.of(ModelDescriptionConstants.UNDEPLOY, DEPLOYMENT_RESOLVER).build();
+    public static final OperationDefinition REDEPLOY_DEFINITION = SimpleOperationDefinitionBuilder.of(ModelDescriptionConstants.REDEPLOY, DEPLOYMENT_RESOLVER).build();
+    public static final OperationDefinition EXPLODE_DEFINITION = SimpleOperationDefinitionBuilder.of(ModelDescriptionConstants.EXPLODE, DEPLOYMENT_RESOLVER)
             .addParameter(DEPLOYMENT_CONTENT_PATH)
-            .withFlag(Flag.DOMAIN_PUSH_TO_SERVERS).build();
+            .withFlag(Flag.DOMAIN_PUSH_TO_SERVERS)
+            .build();
 
     /** Server add deployment definition */
     public static final OperationDefinition SERVER_DEPLOYMENT_ADD_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.ADD, DEPLOYMENT_RESOLVER)


### PR DESCRIPTION

https://issues.jboss.org/browse/WFCORE-3010

Also includes the commit from #2637 for https://issues.jboss.org/browse/WFCORE-3091. It was the work on this PR (reworking ValidateOperationsTestCase) that revealed to me that we're not outputting the min/max-length metadata for lists. Without that commit the test won't pass.