### PR TITLE
[WFCORE-2929] Add description of default values in some Elytron ldap-key-store attributes

### DIFF
--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -974,9 +974,9 @@ elytron.ldap-key-store.search-path=The path in LDAP, where will be KeyStore item
 elytron.ldap-key-store.search-recursive=If the LDAP search should be recursive.
 elytron.ldap-key-store.search-time-limit=The time limit for obtaining keystore items from LDAP.
 
-elytron.ldap-key-store.filter-alias=The LDAP filter for obtaining item of the KeyStore by alias.
-elytron.ldap-key-store.filter-certificate=The LDAP filter for obtaining item of the KeyStore by certificate.
-elytron.ldap-key-store.filter-iterate=The LDAP filter for iterating over all items of the KeyStore.
+elytron.ldap-key-store.filter-alias=The LDAP filter for obtaining an item of the KeyStore by alias. If this is not specified then the default value will be (alias_attribute={0}). The string '{0}' will be replaced by the searched alias and the 'alias_attribute' value will be the value of the attribute 'alias-attribute'.
+elytron.ldap-key-store.filter-certificate=The LDAP filter for obtaining an item of the KeyStore by certificate. If this is not specified then the default value will be (certificate_attribute={0}). The string '{0}' will be replaced by searched encoded certificate and the 'certificate_attribute' will be the value of the attribute 'certificate-attribute'.
+elytron.ldap-key-store.filter-iterate=The LDAP filter for iterating over all items of the KeyStore. If this is not specified then the default value will be (alias_attribute=*). The 'alias_attribute' will be the value of the attribute 'alias-attribute'.
 
 elytron.ldap-key-store.new-item-template=Configuration for item creation. Define how will look LDAP entry of newly created keystore item.
 elytron.ldap-key-store.new-item-template.new-item-path=The path in LDAP, where will be newly created KeyStore items stored.

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -4464,26 +4464,27 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="filter-alias" type="xs:string" use="optional" default="(alias-attribute={0})">
+                    <xs:attribute name="filter-alias" type="xs:string" use="optional" default="(alias_attribute={0})">
                         <xs:annotation>
                             <xs:documentation>
                                 The LDAP filter, which will be used to obtain keystore item by alias.
-                                The string "{0}" will by replaced by searched alias.
+                                The string "{0}" will be replaced by the searched alias and the "alias_attribute" value will be the value of the attribute "alias-attribute".
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="filter-certificate" type="xs:string" use="optional" default="(certificate-attribute={0})">
+                    <xs:attribute name="filter-certificate" type="xs:string" use="optional" default="(certificate_attribute={0})">
                         <xs:annotation>
                             <xs:documentation>
                                 The LDAP filter, which will be used to obtain keystore item by certificate.
-                                The string "{0}" will by replaced by searched encoded certificate.
+                                The string "{0}" will be replaced by searched encoded certificate and the "certificate_attribute" will be the value of the attribute "certificate-attribute".
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
-                    <xs:attribute name="filter-iterate" type="xs:string" use="optional" default="(alias-attribute=*)">
+                    <xs:attribute name="filter-iterate" type="xs:string" use="optional" default="(alias_attribute=*)">
                         <xs:annotation>
                             <xs:documentation>
                                 The LDAP filter, which will be used to obtain keystore item by certificate.
+                                The "alias_attribute" will be the value of the attribute "alias-attribute".
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>


### PR DESCRIPTION
Some ldap-key-store default values get their defaults depending on the value of other attributes. Since we cannot represent them using set-default, this issue adds the information in the attribute descriptions.

Jira issues:
https://issues.jboss.org/browse/WFCORE-2929
https://issues.jboss.org/browse/JBEAP-7487
