### PR TITLE
[WFCORE-2368] Add description of Elytron ldap-realm.identity-mapping.filter-name default value

### DIFF
--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -685,7 +685,7 @@ elytron.ldap-realm.identity-mapping.search-recursive=Indicates if attribute LDAP
 elytron.ldap-realm.identity-mapping.role-recursion=Sets recursive roles assignment - value determine maximum depth of recursion. (0 for no recursion)
 elytron.ldap-realm.identity-mapping.role-recursion-name=Determine LDAP attribute of role entry which will be substitute for "{0}" in filter-name when searching roles of role.
 elytron.ldap-realm.identity-mapping.extract-rdn=The RDN key to use as the value for an attribute, in case the value in its raw form is in X.500 format.
-elytron.ldap-realm.identity-mapping.filter-name=The LDAP filter for getting identity by name.
+elytron.ldap-realm.identity-mapping.filter-name=The LDAP filter for getting identity by name. If this is not specified then the default value will be (rdn_identifier={0}). The string '{0}' will be replaced by searched identity name and the 'rdn_identifier' will be the value of the attribute 'rdn-identifier'.
 elytron.ldap-realm.identity-mapping.iterator-filter=The LDAP filter for iterating over identities of the realm.
 elytron.ldap-realm.identity-mapping.new-identity-parent-dn=The DN of parent of newly created identities. Required for modifiability of the realm.
 elytron.ldap-realm.identity-mapping.new-identity-attributes=The attributes of newly created identities. Required for modifiability of the realm.

--- a/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_1_0.xsd
@@ -1756,11 +1756,11 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="filter-name" type="xs:string" use="optional" default="(rdn-identifier={0})">
+        <xs:attribute name="filter-name" type="xs:string" use="optional" default="(rdn_identifier={0})">
             <xs:annotation>
                 <xs:documentation>
                     The LDAP filter for getting identity by name.
-                    The string "{0}" will by replaced by searched identity name.
+                    The string "{0}" will be replaced by searched identity name and the "rdn_identifier" will be the value of the attribute "rdn-identifier".
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>


### PR DESCRIPTION
Elytron ldap-realm.identity-mapping.filter-name default value gets its default depending on the value of "rdn-identifier" attribute. Since we cannot represent it using set-default, this issue adds the information in the attribute description.

Its default value is assigned in LdapSecurityRealmBuilder.IdentityMappingBuilder#build method.

Jira issues:
https://issues.jboss.org/browse/WFCORE-2368
https://issues.jboss.org/browse/JBEAP-7336