### PR TITLE
WFCORE-3097 add support for on-demand creation of xml writers

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/SubsystemRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/SubsystemRegistration.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.controller;
 
+import java.util.function.Supplier;
+
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.CombinedTransformer;
@@ -69,9 +71,20 @@ public interface SubsystemRegistration {
      * the subsystem's configuration to XML.
      *
      * @param writer the writer
+     * @deprecated use the {@link #registerXMLElementWriter(Supplier)} variant
      */
+    @Deprecated
     void registerXMLElementWriter(XMLElementWriter<SubsystemMarshallingContext> writer);
 
+    /**
+     * Registers the {@link XMLElementWriter} that can handle marshalling
+     * the subsystem's configuration to XML.
+     *
+     * @param writer the writer
+     */
+    default void registerXMLElementWriter(Supplier<XMLElementWriter<SubsystemMarshallingContext>> writer) {
+        registerXMLElementWriter(writer.get());
+    }
     /**
      * Register transformers for a specific model versions.
      *

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -718,6 +718,11 @@ public class ExtensionRegistry {
         }
 
         @Override
+        public void registerXMLElementWriter(Supplier<XMLElementWriter<SubsystemMarshallingContext>> writer) {
+            writerRegistry.registerSubsystemWriter(name, writer);
+        }
+
+        @Override
         public TransformersSubRegistration registerModelTransformers(final ModelVersionRange range, final ResourceTransformer subsystemTransformer) {
             modelsRegistered = true;
             checkHostCapable();

--- a/controller/src/main/java/org/jboss/as/controller/persistence/SubsystemXmlWriterRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/SubsystemXmlWriterRegistry.java
@@ -18,6 +18,8 @@
  */
 package org.jboss.as.controller.persistence;
 
+import java.util.function.Supplier;
+
 import org.jboss.staxmapper.XMLElementWriter;
 
 /**
@@ -34,8 +36,19 @@ public interface SubsystemXmlWriterRegistry {
      *
      * @param name the name of the subsystem
      * @param writer the XML writer
+     * @deprecated use {@link #registerSubsystemWriter(String, Supplier)} variant
      */
+    @Deprecated
     void registerSubsystemWriter(String name, XMLElementWriter<SubsystemMarshallingContext> writer);
+
+    /**
+     * Registers the writer that can marshal to XML the configuration of the
+     * named subsystem.
+     *
+     * @param name the name of the subsystem
+     * @param writer the XML writer
+     */
+    void registerSubsystemWriter(String name, Supplier<XMLElementWriter<SubsystemMarshallingContext>> writer);
 
     /**
      * Unregisters the XML configuration writer of the named subsystem.

--- a/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/CoreManagementExtension.java
+++ b/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/CoreManagementExtension.java
@@ -61,7 +61,7 @@ public class CoreManagementExtension implements Extension {
     @Override
     public void initialize(ExtensionContext context) {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_VERSION);
-        subsystem.registerXMLElementWriter(new CoreManagementSubsystemParser_1_0());
+        subsystem.registerXMLElementWriter(CoreManagementSubsystemParser_1_0::new);
         //This subsystem should be runnable on a host
         subsystem.setHostCapable();
         ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new CoreManagementRootResourceDefinition());

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerExtension.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerExtension.java
@@ -69,7 +69,7 @@ public class DeploymentScannerExtension implements Extension {
         }
 
         final SubsystemRegistration subsystem = context.registerSubsystem(CommonAttributes.DEPLOYMENT_SCANNER, CURRENT_VERSION);
-        subsystem.registerXMLElementWriter(new DeploymentScannerParser_2_0());
+        subsystem.registerXMLElementWriter(DeploymentScannerParser_2_0::new);
 
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new DeploymentScannerSubsystemDefinition());
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);

--- a/discovery/src/main/java/org/wildfly/extension/discovery/DiscoveryExtension.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/DiscoveryExtension.java
@@ -72,10 +72,6 @@ public final class DiscoveryExtension implements Extension {
 
     static final RuntimeCapability<?> DISCOVERY_PROVIDER_RUNTIME_CAPABILITY = RuntimeCapability.Builder.of(DISCOVERY_PROVIDER_CAPABILITY, true).setServiceType(DiscoveryProvider.class).build();
 
-    // fields
-
-    private final DiscoverySubsystemParser parser = new DiscoverySubsystemParser();
-
     /**
      * Construct a new instance.
      */
@@ -86,7 +82,7 @@ public final class DiscoveryExtension implements Extension {
     public void initialize(final ExtensionContext context) {
         final SubsystemRegistration subsystemRegistration = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1, 0));
         subsystemRegistration.setHostCapable();
-        subsystemRegistration.registerXMLElementWriter(parser);
+        subsystemRegistration.registerXMLElementWriter(DiscoverySubsystemParser::new);
 
         final ManagementResourceRegistration resourceRegistration = subsystemRegistration.registerSubsystemModel(DiscoverySubsystemDefinition.getInstance());
         resourceRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
@@ -94,7 +90,7 @@ public final class DiscoveryExtension implements Extension {
 
     @Override
     public void initializeParsers(final ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE, parser);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE, DiscoverySubsystemParser::new);
     }
 
     static StandardResourceDescriptionResolver getResourceDescriptionResolver(final String... keyPrefixes) {

--- a/discovery/src/main/java/org/wildfly/extension/discovery/DiscoverySubsystemParser.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/DiscoverySubsystemParser.java
@@ -39,22 +39,16 @@ import org.jboss.as.controller.PersistentResourceXMLParser;
  */
 final class DiscoverySubsystemParser extends PersistentResourceXMLParser {
 
-    private static final PersistentResourceXMLDescription xmlDescription;
-
-    static {
-        xmlDescription = builder(PathElement.pathElement(SUBSYSTEM, DISCOVERY), DiscoveryExtension.NAMESPACE)
-            .addChild(
-                builder(PathElement.pathElement(STATIC_PROVIDER))
-                    .addAttribute(StaticProviderDefinition.SERVICES, AttributeParser.UNWRAPPED_OBJECT_LIST_PARSER, AttributeMarshaller.UNWRAPPED_OBJECT_LIST_MARSHALLER)
-            )
-            .addChild(
-                builder(PathElement.pathElement(AGGREGATE_PROVIDER))
-                    .addAttribute(AggregateProviderDefinition.PROVIDER_NAMES)
-            )
-            .build();
-    }
-
     public PersistentResourceXMLDescription getParserDescription() {
-        return xmlDescription;
+        return builder(PathElement.pathElement(SUBSYSTEM, DISCOVERY), DiscoveryExtension.NAMESPACE)
+                .addChild(
+                        builder(PathElement.pathElement(STATIC_PROVIDER))
+                                .addAttribute(StaticProviderDefinition.SERVICES, AttributeParser.UNWRAPPED_OBJECT_LIST_PARSER, AttributeMarshaller.UNWRAPPED_OBJECT_LIST_MARSHALLER)
+                )
+                .addChild(
+                        builder(PathElement.pathElement(AGGREGATE_PROVIDER))
+                                .addAttribute(AggregateProviderDefinition.PROVIDER_NAMES)
+                )
+                .build();
     }
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
@@ -74,10 +74,6 @@ public class ElytronExtension implements Extension {
 
     static final String ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
-    /**
-     * The parser used for parsing our subsystem
-     */
-    private final ElytronSubsystemParser parser = new ElytronSubsystemParser();
 
     protected static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME);
     private static final String RESOURCE_NAME = ElytronExtension.class.getPackage().getName() + ".LocalDescriptions";
@@ -104,7 +100,7 @@ public class ElytronExtension implements Extension {
 
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE, parser);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE, ElytronSubsystemParser::new);
     }
 
     @Override
@@ -117,7 +113,7 @@ public class ElytronExtension implements Extension {
         final ManagementResourceRegistration registration = subsystemRegistration.registerSubsystemModel(ElytronDefinition.INSTANCE);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
-        subsystemRegistration.registerXMLElementWriter(parser);
+        subsystemRegistration.registerXMLElementWriter(ElytronSubsystemParser::new);
     }
 
     @SuppressWarnings("unchecked")

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
 
 import javax.xml.namespace.QName;
 
@@ -144,6 +145,12 @@ public class ConfigurationPersisterFactory {
         public void registerSubsystemWriter(String name, XMLElementWriter<SubsystemMarshallingContext> deparser) {
             bootWriter.registerSubsystemWriter(name, deparser);
             super.registerSubsystemWriter(name, deparser);
+        }
+
+        @Override
+        public void registerSubsystemWriter(String name, Supplier<XMLElementWriter<SubsystemMarshallingContext>> writer) {
+            bootWriter.registerSubsystemWriter(name, writer);
+            super.registerSubsystemWriter(name, writer);
         }
 
         @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerConfigurationPersister.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerConfigurationPersister.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.extension.ExtensionRegistry;
@@ -213,6 +214,11 @@ public class HostControllerConfigurationPersister implements ExtensibleConfigura
 
     @Override
     public void registerSubsystemWriter(String name, XMLElementWriter<SubsystemMarshallingContext> writer) {
+        domainPersister.registerSubsystemWriter(name, writer);
+    }
+
+    @Override
+    public void registerSubsystemWriter(String name, Supplier<XMLElementWriter<SubsystemMarshallingContext>> writer) {
         domainPersister.registerSubsystemWriter(name, writer);
     }
 

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/IOExtension.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/IOExtension.java
@@ -72,7 +72,7 @@ public class IOExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(3));
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(IORootDefinition.INSTANCE);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE, false);
-        subsystem.registerXMLElementWriter(new IOSubsystemParser_2_0());
+        subsystem.registerXMLElementWriter(IOSubsystemParser_2_0::new);
     }
 
 

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemParser_2_0.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemParser_2_0.java
@@ -32,10 +32,9 @@ import org.jboss.as.controller.PersistentResourceXMLParser;
  */
 class IOSubsystemParser_2_0 extends PersistentResourceXMLParser {
 
-    private static final PersistentResourceXMLDescription xmlDescription;
-
-    static {
-        xmlDescription = builder(IORootDefinition.INSTANCE.getPathElement(), Namespace.CURRENT.getUriString())
+    @Override
+    public PersistentResourceXMLDescription getParserDescription() {
+        return builder(IORootDefinition.INSTANCE.getPathElement(), Namespace.CURRENT.getUriString())
                 .addChild(
                         builder(WorkerResourceDefinition.INSTANCE.getPathElement())
                                 .addAttributes(
@@ -44,12 +43,12 @@ class IOSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                         WorkerResourceDefinition.WORKER_TASK_MAX_THREADS,
                                         WorkerResourceDefinition.STACK_SIZE)
                                 .addChild(
-                                    builder(OutboundBindAddressResourceDefinition.getInstance().getPathElement())
-                                        .addAttributes(
-                                            OutboundBindAddressResourceDefinition.MATCH,
-                                            OutboundBindAddressResourceDefinition.BIND_ADDRESS,
-                                            OutboundBindAddressResourceDefinition.BIND_PORT
-                                        )
+                                        builder(OutboundBindAddressResourceDefinition.getInstance().getPathElement())
+                                                .addAttributes(
+                                                        OutboundBindAddressResourceDefinition.MATCH,
+                                                        OutboundBindAddressResourceDefinition.BIND_ADDRESS,
+                                                        OutboundBindAddressResourceDefinition.BIND_PORT
+                                                )
                                 )
                 )
                 .addChild(
@@ -59,11 +58,6 @@ class IOSubsystemParser_2_0 extends PersistentResourceXMLParser {
                                         BufferPoolResourceDefinition.DIRECT_BUFFERS)
                 )
                 .build();
-    }
-
-    @Override
-    public PersistentResourceXMLDescription getParserDescription() {
-        return xmlDescription;
     }
 }
 

--- a/jmx/src/main/java/org/jboss/as/jmx/JMXExtension.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXExtension.java
@@ -81,7 +81,6 @@ public class JMXExtension implements Extension {
             new SensitivityClassification(SUBSYSTEM_NAME, "jmx", false, false, true);
 
     static final SensitiveTargetAccessConstraintDefinition JMX_SENSITIVITY_DEF = new SensitiveTargetAccessConstraintDefinition(JMX_SENSITIVITY);
-    static final JMXSubsystemWriter writer = new JMXSubsystemWriter();
 
     private static final int MANAGEMENT_API_MAJOR_VERSION = 1;
     private static final int MANAGEMENT_API_MINOR_VERSION = 2;
@@ -113,7 +112,7 @@ public class JMXExtension implements Extension {
         RuntimeHostControllerInfoAccessor hostInfoAccessor = ((ExtensionContextSupplement)context).getHostControllerInfoAccessor();
 
         registration.registerSubsystemModel(JMXSubsystemRootResource.create(auditLogger, authorizer, securityIdentitySupplier, hostInfoAccessor));
-        registration.registerXMLElementWriter(writer);
+        registration.registerXMLElementWriter(JMXSubsystemWriter::new);
     }
 
     /**

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -224,7 +224,7 @@ public class LoggingExtension implements Extension {
             configurationResource.registerSubModel(LoggingDeploymentResources.ERROR_MANAGER);
         }
 
-        subsystem.registerXMLElementWriter(LoggingSubsystemWriter.INSTANCE);
+        subsystem.registerXMLElementWriter(LoggingSubsystemWriter::new);
     }
 
 

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
@@ -85,8 +85,6 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
  */
 public class LoggingSubsystemWriter implements XMLStreamConstants, XMLElementWriter<SubsystemMarshallingContext> {
 
-    static final LoggingSubsystemWriter INSTANCE = new LoggingSubsystemWriter();
-
     @Override
     public void writeContent(final XMLExtendedStreamWriter writer, final SubsystemMarshallingContext context) throws XMLStreamException {
         context.startSubsystemElement(Namespace.CURRENT.getUriString(), false);

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -90,7 +90,7 @@ public class RemotingExtension implements Extension {
 
         // Register the remoting subsystem
         final SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_VERSION);
-        registration.registerXMLElementWriter(RemotingSubsystemXMLPersister.INSTANCE);
+        registration.registerXMLElementWriter(RemotingSubsystemXMLPersister::new);
 
         final ManagementResourceRegistration subsystem = registration.registerSubsystemModel(new RemotingSubsystemRootResource());
         subsystem.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, new DescribeHandler());

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemXMLPersister.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemXMLPersister.java
@@ -43,8 +43,6 @@ import static org.jboss.as.remoting.CommonAttributes.*;
  */
 class RemotingSubsystemXMLPersister implements XMLStreamConstants, XMLElementWriter<SubsystemMarshallingContext> {
 
-    static final RemotingSubsystemXMLPersister INSTANCE = new RemotingSubsystemXMLPersister();
-
     /**
      * {@inheritDoc}
      */

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerExtension.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerExtension.java
@@ -56,7 +56,7 @@ public class RequestControllerExtension implements Extension {
 
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REQUEST_CONTROLLER_1_0.getUriString(), RequestControllerSubsystemParser_1_0.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REQUEST_CONTROLLER_1_0.getUriString(), RequestControllerSubsystemParser_1_0::new);
     }
 
     @Override
@@ -64,7 +64,7 @@ public class RequestControllerExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, ModelVersion.create(1, 1));
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new RequestControllerRootDefinition(context.isRuntimeOnlyRegistrationValid()));
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE, false);
-        subsystem.registerXMLElementWriter(RequestControllerSubsystemParser_1_0.INSTANCE);
+        subsystem.registerXMLElementWriter(RequestControllerSubsystemParser_1_0::new);
     }
 
 

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerSubsystemParser_1_0.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerSubsystemParser_1_0.java
@@ -32,19 +32,12 @@ import org.jboss.as.controller.PersistentResourceXMLParser;
  */
 class RequestControllerSubsystemParser_1_0 extends PersistentResourceXMLParser {
 
-    static final RequestControllerSubsystemParser_1_0 INSTANCE = new RequestControllerSubsystemParser_1_0();
-
-    private final PersistentResourceXMLDescription xmlDescription;
-
-    private RequestControllerSubsystemParser_1_0() {
-        xmlDescription = builder(RequestControllerRootDefinition.INSTANCE, Namespace.CURRENT.getUriString())
-                .addAttributes(RequestControllerRootDefinition.MAX_REQUESTS, RequestControllerRootDefinition.TRACK_INDIVIDUAL_ENDPOINTS)
-                .build();
-    }
 
     @Override
     public PersistentResourceXMLDescription getParserDescription() {
-        return xmlDescription;
+        return builder(RequestControllerRootDefinition.INSTANCE, Namespace.CURRENT.getUriString())
+                .addAttributes(RequestControllerRootDefinition.MAX_REQUESTS, RequestControllerRootDefinition.TRACK_INDIVIDUAL_ENDPOINTS)
+                .build();
     }
 }
 

--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/SecurityManagerExtension.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/SecurityManagerExtension.java
@@ -60,7 +60,7 @@ public class SecurityManagerExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(Constants.SUBSYSTEM_NAME, CURRENT_MODEL_VERSION);
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(SecurityManagerRootDefinition.INSTANCE);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE, false);
-        subsystem.registerXMLElementWriter(new SecurityManagerSubsystemParser_3_0());
+        subsystem.registerXMLElementWriter(SecurityManagerSubsystemParser_3_0::new);
     }
 
     @Override

--- a/threads/src/main/java/org/jboss/as/threads/ThreadsExtension.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadsExtension.java
@@ -66,7 +66,7 @@ public class ThreadsExtension extends AbstractLegacyExtension {
 
         // Register the threads subsystem
         final SubsystemRegistration registration = context.registerSubsystem(THREADS, CURRENT_VERSION);
-        registration.registerXMLElementWriter(ThreadsParser2_0.INSTANCE);
+        registration.registerXMLElementWriter(ThreadsParser2_0::new);
 
         // Remoting threads description and operation handlers
         @SuppressWarnings("deprecation")
@@ -77,8 +77,8 @@ public class ThreadsExtension extends AbstractLegacyExtension {
 
     @Override
     protected void initializeLegacyParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.CURRENT.getUriString(), ThreadsParser2_0.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.THREADS_1_1.getUriString(), ThreadsParser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.THREADS_1_0.getUriString(), ThreadsParser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.CURRENT.getUriString(), ThreadsParser2_0::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.THREADS_1_1.getUriString(), ThreadsParser::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.THREADS_1_0.getUriString(), ThreadsParser::new);
     }
 }

--- a/threads/src/main/java/org/jboss/as/threads/ThreadsParser.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadsParser.java
@@ -72,12 +72,11 @@ import org.wildfly.common.cpu.ProcessorInfo;
  */
 public final class ThreadsParser implements XMLStreamConstants, XMLElementReader<List<ModelNode>>,XMLElementWriter<SubsystemMarshallingContext> {
 
-    static final ThreadsParser INSTANCE = new ThreadsParser();
-
     private static final String SUBSYSTEM_NAME = "threads";
 
+    @Deprecated
     public static ThreadsParser getInstance() {
-        return INSTANCE;
+        return new ThreadsParser();
     }
 
     @Override

--- a/threads/src/main/java/org/jboss/as/threads/ThreadsParser2_0.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadsParser2_0.java
@@ -28,13 +28,12 @@ import org.jboss.as.controller.PersistentResourceXMLParser;
  * @author Tomaz Cerar (c) 2015 Red Hat Inc.
  */
 public class ThreadsParser2_0 extends PersistentResourceXMLParser {
-    static final ThreadsParser2_0 INSTANCE = new ThreadsParser2_0();
 
     public static final PersistentResourceXMLBuilder THREAD_FACTORY_PARSER = getThreadFactoryParser(ThreadFactoryResourceDefinition.DEFAULT_INSTANCE);
 
 
     @SuppressWarnings("deprecation")
-    private static final PersistentResourceXMLDescription xmlDescription = builder(new ThreadSubsystemResourceDefinition(false), Namespace.CURRENT.getUriString())
+    private final PersistentResourceXMLDescription xmlDescription = builder(new ThreadSubsystemResourceDefinition(false), Namespace.CURRENT.getUriString())
             .addChild(THREAD_FACTORY_PARSER)
             .addChild(getUnboundedQueueThreadPoolParser(UnboundedQueueThreadPoolResourceDefinition.create(false)))
             .addChild(getBoundedQueueThreadPoolParser(BoundedQueueThreadPoolResourceDefinition.create(false, false)))


### PR DESCRIPTION
add option to register xml writers on-demand, this reduces creation of xml writers during boot.
In common scenarios when user runs application server in production for longer period also allows that xml writers are never created or after creation (usage) they are able to be GC-ed.

With this change also registration of writer suppliers is now more concurrency friendly and does no longer block in synchronized block.