### PR TITLE
[WFCORE-3062] As a convenience, ObjectTypeAttributeDefinition should …

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ObjectListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ObjectListAttributeDefinition.java
@@ -22,11 +22,17 @@
 
 package org.jboss.as.controller;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
+import java.util.Set;
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -246,6 +252,16 @@ public class ObjectListAttributeDefinition extends ListAttributeDefinition {
         }
 
         public ObjectListAttributeDefinition build() {
+            List<AccessConstraintDefinition> valueConstraints = valueType.getAccessConstraints();
+            if (!valueConstraints.isEmpty()) {
+                Set<AccessConstraintDefinition> acdSet = new LinkedHashSet<>();
+                AccessConstraintDefinition[] curAcds = getAccessConstraints();
+                if (curAcds != null && curAcds.length > 0) {
+                    Collections.addAll(acdSet, curAcds);
+                }
+                acdSet.addAll(valueConstraints);
+                setAccessConstraints(acdSet.toArray(new AccessConstraintDefinition[acdSet.size()]));
+            }
             return new ObjectListAttributeDefinition(this);
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/ObjectMapAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ObjectMapAttributeDefinition.java
@@ -18,9 +18,14 @@
 
 package org.jboss.as.controller;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
+import java.util.Set;
 
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -163,6 +168,16 @@ public class ObjectMapAttributeDefinition extends MapAttributeDefinition {
         }
 
         public ObjectMapAttributeDefinition build() {
+            List<AccessConstraintDefinition> valueConstraints = valueType.getAccessConstraints();
+            if (!valueConstraints.isEmpty()) {
+                Set<AccessConstraintDefinition> acdSet = new LinkedHashSet<>();
+                AccessConstraintDefinition[] curAcds = getAccessConstraints();
+                if (curAcds != null && curAcds.length > 0) {
+                    Collections.addAll(acdSet, curAcds);
+                }
+                acdSet.addAll(valueConstraints);
+                setAccessConstraints(acdSet.toArray(new AccessConstraintDefinition[acdSet.size()]));
+            }
             return new ObjectMapAttributeDefinition(this);
         }
     }

--- a/controller/src/main/java/org/jboss/as/controller/management/BaseHttpInterfaceResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/management/BaseHttpInterfaceResourceDefinition.java
@@ -110,12 +110,12 @@ public abstract class BaseHttpInterfaceResourceDefinition extends SimpleResource
     public static final SimpleAttributeDefinition SASL_AUTHENTICATION_FACTORY = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SASL_AUTHENTICATION_FACTORY, ModelType.STRING, true)
         .setMinSize(1)
         .setCapabilityReference(SASL_AUTHENTICATION_FACTORY_CAPABILITY, HTTP_MANAGEMENT_RUNTIME_CAPABILITY)
-        .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.AUTHENTICATION_FACTORY_REF)
         .setRestartAllServices()
         .build();
 
     public static final ObjectTypeAttributeDefinition HTTP_UPGRADE = new ObjectTypeAttributeDefinition.Builder(ModelDescriptionConstants.HTTP_UPGRADE, ENABLED, SASL_AUTHENTICATION_FACTORY)
         .setRestartAllServices()
+        .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.AUTHENTICATION_FACTORY_REF)
         .build();
 
     public static final SimpleAttributeDefinition SERVER_NAME = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SERVER_NAME, ModelType.STRING, true)


### PR DESCRIPTION
…apply constraint definitions from its fields to itself, as should collection AD impls that use OTAD

Also, move the one instance of this pattern in core from so the constraint is initially registered on the top level attribute

https://issues.jboss.org/browse/WFCORE-3062