### PR TITLE
Fix NullPointerException in ModelControllerMBeanServerPlugin::accepts

### DIFF
--- a/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanServerPlugin.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanServerPlugin.java
@@ -115,7 +115,16 @@ public class ModelControllerMBeanServerPlugin extends BaseMBeanServerPlugin {
         }
 
         Pattern p = Pattern.compile(objectName.getDomain().replace("*", ".*"));
-        return p.matcher(configuredDomains.getLegacyDomain()).matches() || p.matcher(configuredDomains.getExprDomain()).matches();
+        
+        String legacyDomain = configuredDomains.getLegacyDomain();
+        if (legacyDomain != null && p.matcher(legacyDomain).matches()) {
+            return true;
+        }
+        String exprDomain = configuredDomains.getExprDomain();
+        if (exprDomain != null && p.matcher(exprDomain).matches()) {
+            return true;
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Accepts throws a NPE if getLegacyDomain returns null.
    java.lang.NullPointerException
        at java.util.regex.Matcher.getTextLength(Unknown Source)
        at java.util.regex.Matcher.reset(Unknown Source)
        at java.util.regex.Matcher.<init>(Unknown Source)
        at java.util.regex.Pattern.matcher(Unknown Source)
        at org.jboss.as.jmx.model.ModelControllerMBeanServerPlugin.accepts(ModelControllerMBeanServerPlugin.java:111)
        at org.jboss.as.jmx.PluggableMBeanServerImpl.queryMBeans(PluggableMBeanServerImpl.java:821)