### PR TITLE
WFCORE-2968 Domain server auth service cleanup

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/DomainManagedServerCallbackHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/DomainManagedServerCallbackHandler.java
@@ -40,7 +40,9 @@ import org.jboss.as.domain.management.SecurityRealm;
 import org.jboss.as.domain.management.logging.DomainManagementLogger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
@@ -62,6 +64,7 @@ import org.wildfly.security.password.spec.EncryptablePasswordSpec;
 import org.wildfly.security.password.spec.PasswordSpec;
 
 import static org.jboss.as.domain.management.RealmConfigurationConstants.VERIFY_PASSWORD_CALLBACK_SUPPORTED;
+import static org.jboss.msc.service.ServiceController.Mode.ON_DEMAND;
 import static org.wildfly.security.password.interfaces.ClearPassword.ALGORITHM_CLEAR;
 import static org.wildfly.security.password.interfaces.DigestPassword.ALGORITHM_DIGEST_MD5;
 
@@ -83,6 +86,14 @@ public class DomainManagedServerCallbackHandler implements Service<CallbackHandl
     private final InjectedValue<CallbackHandler> serverCallbackHandler = new InjectedValue<>();
 
     public DomainManagedServerCallbackHandler() {
+    }
+
+    public static void install(final ServiceTarget serviceTarget) {
+        DomainManagedServerCallbackHandler domainServersCallBackHandler = new DomainManagedServerCallbackHandler();
+        ServiceBuilder<CallbackHandlerService> builder = serviceTarget.addService(DomainManagedServerCallbackHandler.SERVICE_NAME, domainServersCallBackHandler)
+                .setInitialMode(ON_DEMAND);
+        builder.install();
+
     }
 
     // the callback handler passed through from ServerInventory, containing the server authkeys.

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -385,15 +385,11 @@ public class SecurityRealmAddHandler extends AbstractAddStepHandler {
 
     private void addDomainManagedServersService(OperationContext context, String realmName, ServiceTarget serviceTarget,
                                  ServiceBuilder<?> realmBuilder, Injector<CallbackHandlerService> injector) throws OperationFailedException {
-        // only installed once.
         final ServiceRegistry registry = context.getServiceRegistry(false);
-        if (registry.getService(DomainManagedServerCallbackHandler.SERVICE_NAME) == null) {
-            DomainManagedServerCallbackHandler domainServersCallBackHandler = new DomainManagedServerCallbackHandler();
-            ServiceBuilder<CallbackHandlerService> builder = serviceTarget.addService(DomainManagedServerCallbackHandler.SERVICE_NAME, domainServersCallBackHandler)
-                    .setInitialMode(ON_DEMAND);
-            builder.install();
+        ServiceController serviceController = registry.getService(DomainManagedServerCallbackHandler.SERVICE_NAME);
+        if (serviceController != null) {
+            CallbackHandlerService.ServiceUtil.addDependency(realmBuilder, injector, DomainManagedServerCallbackHandler.SERVICE_NAME);
         }
-        CallbackHandlerService.ServiceUtil.addDependency(realmBuilder, injector, DomainManagedServerCallbackHandler.SERVICE_NAME);
     }
 
     private void addPlugInAuthenticationService(OperationContext context, ModelNode model, String realmName,

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -145,6 +145,7 @@ import org.jboss.as.domain.controller.operations.DomainModelIncludesValidator;
 import org.jboss.as.domain.controller.operations.coordination.PrepareStepHandler;
 import org.jboss.as.domain.controller.resources.DomainRootDefinition;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
+import org.jboss.as.domain.management.security.DomainManagedServerCallbackHandler;
 import org.jboss.as.host.controller.RemoteDomainConnectionService.RemoteFileRepository;
 import org.jboss.as.host.controller.discovery.DiscoveryOption;
 import org.jboss.as.host.controller.discovery.DomainControllerManagementInterface;
@@ -637,6 +638,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
             // Install server inventory callback
             ServerInventoryCallbackService.install(serviceTarget);
 
+            // handler for domain server auth.
+            DomainManagedServerCallbackHandler.install(serviceTarget);
             // Parse the host.xml and invoke all the ops. The ops should rollback on any Stage.RUNTIME failure
             List<ModelNode> hostBootOps = hostControllerConfigurationPersister.load();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ServerInventoryService.java
@@ -110,7 +110,9 @@ class ServerInventoryService implements Service<ServerInventory> {
             serverInventory = new ServerInventoryImpl(domainController, environment, managementURI, processControllerConnectionService.getClient(), extensionRegistry);
             processControllerConnectionService.setServerInventory(serverInventory);
             serverCallback.getValue().setCallbackHandler(serverInventory.getServerCallbackHandler());
-            domainServerCallback.getValue().getServerCallbackHandlerInjector().inject(serverInventory.getServerCallbackHandler());
+            if (domainServerCallback != null && domainServerCallback.getValue() != null) {
+                domainServerCallback.getValue().getServerCallbackHandlerInjector().inject(serverInventory.getServerCallbackHandler());
+            }
             futureInventory.setInventory(serverInventory);
         } catch (Exception e) {
             futureInventory.setFailure(e);

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnection.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnection.java
@@ -154,7 +154,7 @@ class HostControllerConnection extends FutureManagementChannel {
         }
         // Update the configuration with the new credentials
         final ProtocolConnectionConfiguration config = ProtocolConnectionConfiguration.copy(configuration);
-        //config.setCallbackHandler(createClientCallbackHandler(userName, authKey));
+        config.setCallbackHandler(createClientCallbackHandler(userName, authKey));
         config.setUri(reconnectUri);
         this.configuration = config;
 

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
@@ -61,8 +61,6 @@ import org.jboss.msc.value.InjectedValue;
 import org.jboss.remoting3.Endpoint;
 import org.xnio.IoUtils;
 import org.xnio.OptionMap;
-import org.xnio.Options;
-import org.xnio.Sequence;
 
 /**
  * Service setting up the connection to the local host controller.
@@ -115,10 +113,11 @@ public class HostControllerConnectionService implements Service<HostControllerCl
     public synchronized void start(final StartContext context) throws StartException {
         final Endpoint endpoint = endpointInjector.getValue();
         try {
-            // local auth is always disabled for domain servers
-            final OptionMap options = OptionMap.create(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of(JBOSS_LOCAL_USER));
+            // we leave local auth enabled as an option for domain servers to use if available. elytron only configuration
+            // will require this to be enabled and available on the server side for servers to connect successfully.
+            // final OptionMap options = OptionMap.create(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of(JBOSS_LOCAL_USER));
             // Create the connection configuration
-            final ProtocolConnectionConfiguration configuration = ProtocolConnectionConfiguration.create(endpoint, connectionURI, options);
+            final ProtocolConnectionConfiguration configuration = ProtocolConnectionConfiguration.create(endpoint, connectionURI, OptionMap.EMPTY);
             configuration.setCallbackHandler(HostControllerConnection.createClientCallbackHandler(userName, initialAuthKey));
             configuration.setConnectionTimeout(SERVER_CONNECTION_TIMEOUT);
             configuration.setSslContext(sslContextSupplier.get());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ServerAuthenticationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ServerAuthenticationTestCase.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2017 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.LOCAL;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART_SERVERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_CONFIGURATION_STATE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SECURITY_REALM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.domain.management.ModelDescriptionConstants.AUTHENTICATION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.sasl.RealmCallback;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.extension.ExtensionSetup;
+import org.jboss.as.test.integration.domain.management.util.Authentication;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
+
+/**
+ * @author Ken Wills <kwills@redhat.com>
+ *
+ * Basic tests for domain server auth when local realm authentication is removed.
+ */
+public class ServerAuthenticationTestCase {
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil master;
+    private static DomainLifecycleUtil slave;
+
+    private static final String USERNAME = "testSuite";
+    private static final String PASSWORD = "testSuitePassword";
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        DomainTestSupport.Configuration config =  DomainTestSupport.Configuration.create(ServerAuthenticationTestCase.class.getSimpleName(),
+                "domain-configs/domain-minimal.xml", "host-configs/host-master.xml", "host-configs/host-minimal.xml");
+        testSupport = DomainTestSupport.createAndStartSupport(config);
+        ExtensionSetup.initialiseProfileIncludesExtension(testSupport);
+        master = testSupport.getDomainMasterLifecycleUtil();
+        slave = testSupport.getDomainSlaveLifecycleUtil();
+        // Initialize the extension
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        // TODO this seems a little racy adding back on shutdown, and gets rolled back sometimes. This should be fixed before adding
+        // to DomainTestSuite suiteClasses.
+        // ServerAuthenticationTestCase.addLocalAuth(master.getDomainClient(), "slave");
+        testSupport.stop();
+        testSupport = null;
+        master = null;
+        slave = null;
+    }
+
+    @Test
+    public void testDisableLocalAuthAndStartServers() throws Exception {
+        // add a user we can re-auth with
+        final String testName = ServerAuthenticationTestCase.class.getSimpleName();
+        final File domains = new File("target" + File.separator + "domains" + File.separator + testName);
+        final File masterDir = new File(domains, "slave");
+        final File domainConfigDir = new File(masterDir, "configuration");
+        addUser(domainConfigDir, "ManagementRealm", USERNAME, PASSWORD);
+
+        removeLocalAuth(master.getDomainClient(), "slave");
+
+        // don't reset the configs.
+        slave.getConfiguration().setRewriteConfigFiles(false);
+        slave.stop();
+        // update the slave config with the username / password since local auth is disabled
+        slave.getConfiguration().setCallbackHandler(Authentication.getCallbackHandler(USERNAME, PASSWORD, "ManagementRealm"));
+        slave.start();
+        // verify local-auth is off on the slave
+        ModelNode localSlaveAuth = getLocalAuthValue(master.getDomainClient(), "slave");
+        assertEquals(localSlaveAuth.toJSONString(true), FAILED, localSlaveAuth.get(OUTCOME).asString());
+        assertTrue(localSlaveAuth.get(FAILURE_DESCRIPTION).asString().startsWith("WFLYCTL0216:")); // resource not found
+        // verify server connected and running
+        verifyServerStarted(master.getDomainClient(), "slave", "main-three");
+        // now restart the slave HC, but don't restart the servers and verify they've reconnected afterwards
+        reloadHostController(master.getDomainClient(), "slave", false);
+        slave.awaitHostController(System.currentTimeMillis());
+        verifyServerStarted(master.getDomainClient(), "slave", "main-three");
+    }
+
+    private void addUser(final File domainConfigDir, final String realm, final String username, final String password) throws Exception {
+        File usersFile = new File(domainConfigDir, "mgmt-users.properties");
+        Files.write(usersFile.toPath(),
+                (username + "=" + new UsernamePasswordHashUtil().generateHashedHexURP(username, realm, password.toCharArray()) + "\n")
+                        .getBytes(StandardCharsets.UTF_8));
+    }
+
+    private CallbackHandler createCallbackHandler(final String username, final String password) {
+        return new CallbackHandler() {
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (Callback current : callbacks) {
+                    if (current instanceof NameCallback) {
+                        NameCallback ncb = (NameCallback) current;
+                        ncb.setName(username);
+                    } else if (current instanceof PasswordCallback) {
+                        PasswordCallback pcb = (PasswordCallback) current;
+                        pcb.setPassword(password.toCharArray());
+                    } else if (current instanceof RealmCallback) {
+                        RealmCallback rcb = (RealmCallback) current;
+                        rcb.setText(rcb.getDefaultText());
+                    } else {
+                        throw new UnsupportedCallbackException(current);
+                    }
+                }
+            }
+        };
+    }
+
+    private static ModelNode getLocalAuthPath(final String host) {
+        PathAddress path = PathAddress.pathAddress(HOST, host)
+                .append(CORE_SERVICE, MANAGEMENT)
+                .append(SECURITY_REALM, "ManagementRealm")
+                .append(AUTHENTICATION, LOCAL);
+        return path.toModelNode();
+    }
+
+    private static void removeLocalAuth(final DomainClient client, final String host) throws Exception {
+        // remove local auth, requires restart
+        final ModelNode op = new ModelNode();
+        op.get(OP).set(REMOVE);
+        op.get(OP_ADDR).set(getLocalAuthPath(host));
+        final ModelNode result = client.execute(op);
+        assertEquals(result.toJSONString(true), SUCCESS, result.get(OUTCOME).asString());
+    }
+
+    private static void reloadHostController(final DomainClient client, final String host, final boolean restartServers) throws Exception {
+        ModelNode op = Util.createEmptyOperation("reload", PathAddress.pathAddress(HOST, host));
+        op.get(OP).set(RELOAD);
+        op.get(OP_ADDR).set(HOST, host);
+        op.get(RESTART_SERVERS).set(restartServers);
+        final ModelNode result = client.execute(op);
+        assertEquals(result.toJSONString(true), SUCCESS, result.get(OUTCOME).asString());
+    }
+
+    private static void addLocalAuth(final DomainClient client, final String host) throws Exception {
+        // remove local auth, requires restart
+        final ModelNode op = new ModelNode();
+        op.get(OP).set(ADD);
+        op.get(OP_ADDR).set(getLocalAuthPath(host));
+        op.get("default-user").set("$local");
+        op.get("skip-group-loading").set("true");
+        final ModelNode result = client.execute(op);
+        assertEquals(result.toJSONString(true), SUCCESS, result.get(OUTCOME).asString());
+    }
+
+    private static ModelNode getLocalAuthValue(final ModelControllerClient client, final String host) throws Exception {
+        final ModelNode op = new ModelNode();
+        op.get(OP).set(READ_RESOURCE_OPERATION);
+        op.get(OP_ADDR).set(getLocalAuthPath(host));
+        return client.execute(op);
+    }
+
+    private void verifyServerStarted(final ModelControllerClient client, final String host, final String serverName) throws Exception {
+        // verify server connected and running
+        final ModelNode servers = new ModelNode();
+        servers.get(OP).set(READ_ATTRIBUTE_OPERATION);
+        final PathAddress serverPath = PathAddress.pathAddress(HOST, host)
+                .append(SERVER, serverName);
+        servers.get(OP_ADDR).set(serverPath.toModelNode());
+        servers.get(NAME).set(RUNTIME_CONFIGURATION_STATE);
+        final ModelNode serverResult = client.execute(servers);
+        assertEquals(SUCCESS, serverResult.get(OUTCOME).asString());
+        assertEquals("ok", serverResult.get(RESULT).asString());
+    }
+}


### PR DESCRIPTION
This uncouples the domain server auth service from the realm add handler, and insteads starts it from DomainModelControllerService. This will allow the service to start if no realms are present.