### PR TITLE
[WFCORE-3118]: Allow to override the validation of operation request in CommandContext.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -180,12 +180,12 @@ class CliConfigImpl implements CliConfig {
     private static CliConfigImpl overrideConfigWithArguments(CliConfigImpl cliConfig, CommandContextConfiguration configuration){
         // The configuration options from the command line should only override if they are not defaults.
         // This is to prevent a default Configuration option from overriding an Option defined in the config file.
-        cliConfig.connectionTimeout = configuration.getConnectionTimeout() != -1    ? configuration.getConnectionTimeout()  : cliConfig.getConnectionTimeout();
-        cliConfig.silent            = configuration.isSilent()                      ? configuration.isSilent()              : cliConfig.silent;
-        cliConfig.errorOnInteract   = configuration.isErrorOnInteract() != null     ? configuration.isErrorOnInteract()     : cliConfig.errorOnInteract;
-        cliConfig.echoCommand       = configuration.isEchoCommand()                 ? configuration.isEchoCommand()         : cliConfig.echoCommand;
-        cliConfig.commandTimeout    = configuration.getCommandTimeout() != null     ? configuration.getCommandTimeout()     : cliConfig.commandTimeout;
-
+        cliConfig.connectionTimeout         = configuration.getConnectionTimeout() != -1          ? configuration.getConnectionTimeout()        : cliConfig.getConnectionTimeout();
+        cliConfig.silent                    = configuration.isSilent()                            ? configuration.isSilent()                    : cliConfig.silent;
+        cliConfig.errorOnInteract           = configuration.isErrorOnInteract() != null           ? configuration.isErrorOnInteract()           : cliConfig.errorOnInteract;
+        cliConfig.echoCommand               = configuration.isEchoCommand()                       ? configuration.isEchoCommand()               : cliConfig.echoCommand;
+        cliConfig.commandTimeout            = configuration.getCommandTimeout() != null           ? configuration.getCommandTimeout()           : cliConfig.commandTimeout;
+        cliConfig.validateOperationRequests = configuration.isValidateOperationRequests() != null ? configuration.isValidateOperationRequests() : cliConfig.validateOperationRequests;
         return cliConfig;
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextConfiguration.java
@@ -39,6 +39,7 @@ public class CommandContextConfiguration {
     private final int connectionTimeout;
     private boolean silent;
     private Boolean errorOnInteract;
+    private Boolean validateOperationRequests;
     private final boolean echoCommand;
     private final Integer commandTimeout;
 
@@ -108,6 +109,10 @@ public class CommandContextConfiguration {
         return errorOnInteract;
     }
 
+    public Boolean isValidateOperationRequests() {
+        return validateOperationRequests;
+    }
+
     public boolean isEchoCommand() {
         return echoCommand;
     }
@@ -125,6 +130,7 @@ public class CommandContextConfiguration {
         private boolean disableLocalAuthUnset = true;
         private boolean silent;
         private Boolean errorOnInteract;
+        private Boolean validateOperationRequests;
         private boolean echoCommand;
         private Integer commandTimeout;
         public Builder() {
@@ -138,6 +144,7 @@ public class CommandContextConfiguration {
                     initConsole, connectionTimeout, consoleInput, consoleOutput, echoCommand, commandTimeout);
             config.silent = silent;
             config.errorOnInteract = errorOnInteract;
+            config.validateOperationRequests = validateOperationRequests;
             return config;
         }
 
@@ -208,6 +215,11 @@ public class CommandContextConfiguration {
 
         public Builder setErrorOnInteract(boolean errorOnInteract) {
             this.errorOnInteract = errorOnInteract;
+            return this;
+        }
+
+        public Builder setValidateOperationRequests(boolean validateOperationRequests) {
+            this.validateOperationRequests = validateOperationRequests;
             return this;
         }
     }


### PR DESCRIPTION
The CommandContextBuilder allows to redefine the validate-operation-requests configuration.

Jira: https://issues.jboss.org/browse/WFCORE-3118