### PR TITLE
Allow ReloadRequiredWriteAttributeHandler subclasses overriding revertUpdateToRuntime(...) to throw OperationFailedException

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ReloadRequiredWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReloadRequiredWriteAttributeHandler.java
@@ -109,7 +109,7 @@ public class ReloadRequiredWriteAttributeHandler extends AbstractWriteAttributeH
     }
 
     @Override
-    protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode valueToRestore, ModelNode resolvedValue, Void handback) {
+    protected void revertUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode valueToRestore, ModelNode resolvedValue, Void handback) throws OperationFailedException {
         // no-op
     }
 }


### PR DESCRIPTION
This exception is thrown by the AbstractWriteAttributeHandler.revertUpdateToRuntime(...), but not the overriden implementation.