### PR TITLE
WFCORE-2968 re-enable local auth for domain servers

### DIFF
--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnectionService.java
@@ -61,8 +61,6 @@ import org.jboss.msc.value.InjectedValue;
 import org.jboss.remoting3.Endpoint;
 import org.xnio.IoUtils;
 import org.xnio.OptionMap;
-import org.xnio.Options;
-import org.xnio.Sequence;
 
 /**
  * Service setting up the connection to the local host controller.
@@ -116,9 +114,9 @@ public class HostControllerConnectionService implements Service<HostControllerCl
         final Endpoint endpoint = endpointInjector.getValue();
         try {
             // local auth is always disabled for domain servers
-            final OptionMap options = OptionMap.create(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of(JBOSS_LOCAL_USER));
+            //final OptionMap options = OptionMap.create(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of(JBOSS_LOCAL_USER));
             // Create the connection configuration
-            final ProtocolConnectionConfiguration configuration = ProtocolConnectionConfiguration.create(endpoint, connectionURI, options);
+            final ProtocolConnectionConfiguration configuration = ProtocolConnectionConfiguration.create(endpoint, connectionURI, OptionMap.EMPTY);
             configuration.setCallbackHandler(HostControllerConnection.createClientCallbackHandler(userName, initialAuthKey));
             configuration.setConnectionTimeout(SERVER_CONNECTION_TIMEOUT);
             configuration.setSslContext(sslContextSupplier.get());


### PR DESCRIPTION
This was mistakenly disabled, and should be allowed if available.