### PR TITLE
[WFCORE-3138] Upgrade VDX from 1.1.5 to 1.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <version.org.jmockit>1.33</version.org.jmockit>
         <version.org.mockito>2.8.47</version.org.mockito>
         <version.org.picketbox>5.0.2.Final</version.org.picketbox>
-        <version.org.projectodd.vdx>1.1.5</version.org.projectodd.vdx>
+        <version.org.projectodd.vdx>1.1.6</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.22</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.eclipse.aether>1.1.0</version.org.eclipse.aether>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3138

The changes mainly include the license updates and internationalized messages.

https://github.com/projectodd/vdx/compare/1.1.5...1.1.6