### PR TITLE
[WFCORE-3126] export and env assignment must be on separate lines

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/domain.sh
+++ b/core-feature-pack/src/main/resources/content/bin/domain.sh
@@ -26,7 +26,8 @@ do
 done
 
 # tell linux glibc how many memory pools can be created that are used by malloc
-export MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-1}"
+MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-1}"
+export MALLOC_ARENA_MAX
 
 # OS specific support (must be 'true' or 'false').
 cygwin=false;

--- a/core-feature-pack/src/main/resources/content/bin/standalone.sh
+++ b/core-feature-pack/src/main/resources/content/bin/standalone.sh
@@ -44,7 +44,8 @@ GREP="grep"
 MAX_FD="maximum"
 
 # tell linux glibc how many memory pools can be created that are used by malloc
-export MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-1}"
+MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-1}"
+export MALLOC_ARENA_MAX
 
 # OS specific support (must be 'true' or 'false').
 cygwin=false;


### PR DESCRIPTION
Solaris 10 requires export and env assignment on separate lines.
Fixes https://issues.jboss.org/browse/WFCORE-3126