### PR TITLE
[WFCORE-3149] Use "remote+http" as the default protocol in the destination URI for an Elytron remote outbound connection if no protocol is specified in the resolved AuthenticationConfiguration

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
@@ -118,7 +118,7 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
             // if the protocol is specified in the authentication configuration, use it in the destination URI
             final String realProtocol = AUTH_CONFIGURATION_CLIENT.getRealProtocol(configuration);
             try {
-                uri = new URI(realProtocol == null ? Protocol.HTTP_REMOTING.toString() : realProtocol, username, hostName, port, null, null, null);
+                uri = new URI(realProtocol == null ? Protocol.REMOTE_HTTP.toString() : realProtocol, username, hostName, port, null, null, null);
             } catch (URISyntaxException e) {
                 throw new StartException(e);
             }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3149

Related to https://issues.jboss.org/browse/JBEAP-12561 (and also https://issues.jboss.org/browse/JBEAP-12290)