### PR TITLE
[WFCORE-3151] TrustManager - non-lazy CRL reload

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -493,6 +493,10 @@ class SSLDefinitions {
 
     }
 
+    private abstract static class ReloadableX509ExtendedTrustManager extends X509ExtendedTrustManager {
+        abstract void reload();
+    }
+
     static ResourceDefinition getTrustManagerDefinition() {
 
         final SimpleAttributeDefinition providersDefinition = new SimpleAttributeDefinitionBuilder(PROVIDERS)
@@ -508,8 +512,6 @@ class SSLDefinitions {
                 .build();
 
         AttributeDefinition[] attributes = new AttributeDefinition[] { ALGORITHM, providersDefinition, PROVIDER_NAME, keystoreDefinition, ALIAS_FILTER, CERTIFICATE_REVOCATION_LIST};
-
-        AtomicBoolean reloadCrl = new AtomicBoolean(false);
 
         AbstractAddStepHandler add = new TrivialAddHandler<TrustManager>(TrustManager.class, attributes, TRUST_MANAGER_RUNTIME_CAPABILITY) {
 
@@ -540,7 +542,7 @@ class SSLDefinitions {
                 ModelNode crlNode = CERTIFICATE_REVOCATION_LIST.resolveModelAttribute(context, model);
 
                 if (crlNode.isDefined()) {
-                    return createX509CRLExtendedTrustManager(serviceBuilder, context, algorithm, providerName, providersInjector, keyStoreInjector, crlNode, reloadCrl);
+                    return createX509CRLExtendedTrustManager(serviceBuilder, context, algorithm, providerName, providersInjector, keyStoreInjector, crlNode);
                 }
 
                 return () -> {
@@ -576,7 +578,7 @@ class SSLDefinitions {
                 };
             }
 
-            private ValueSupplier<TrustManager> createX509CRLExtendedTrustManager(ServiceBuilder<TrustManager> serviceBuilder, OperationContext context, String algorithm, String providerName, InjectedValue<Provider[]> providersInjector, InjectedValue<KeyStore> keyStoreInjector, ModelNode crlNode, AtomicBoolean reloadCrl) throws OperationFailedException {
+            private ValueSupplier<TrustManager> createX509CRLExtendedTrustManager(ServiceBuilder<TrustManager> serviceBuilder, OperationContext context, String algorithm, String providerName, InjectedValue<Provider[]> providersInjector, InjectedValue<KeyStore> keyStoreInjector, ModelNode crlNode) throws OperationFailedException {
                 String crlPath = asStringIfDefined(context, PATH, crlNode);
                 String crlRelativeTo = asStringIfDefined(context, RELATIVE_TO, crlNode);
                 int certPath = asIntIfDefined(context, MAXIMUM_CERT_PATH, crlNode);
@@ -596,7 +598,7 @@ class SSLDefinitions {
                     if (crlPath != null) {
                         try {
                             X509CRLExtendedTrustManager trustManager = new X509CRLExtendedTrustManager(keyStore, trustManagerFactory, new FileInputStream(resolveFileLocation(crlPath, crlRelativeTo, pathManagerInjector)), certPath, null);
-                            return createReloadableX509CRLTrustManager(reloadCrl, crlPath, crlRelativeTo, certPath, pathManagerInjector, trustManagerFactory, keyStore, trustManager);
+                            return createReloadableX509CRLTrustManager(crlPath, crlRelativeTo, certPath, pathManagerInjector, trustManagerFactory, keyStore, trustManager);
                         } catch (FileNotFoundException e) {
                             throw ElytronSubsystemMessages.ROOT_LOGGER.unableToAccessCRL(e);
                         }
@@ -606,63 +608,58 @@ class SSLDefinitions {
                 };
             }
 
-            private TrustManager createReloadableX509CRLTrustManager(final AtomicBoolean reloadCrl, final String crlPath, final String crlRelativeTo, final int certPath, final InjectedValue<PathManager> pathManagerInjector, final TrustManagerFactory trustManagerFactory, final KeyStore keyStore, final X509CRLExtendedTrustManager trustManager) {
-                return new X509ExtendedTrustManager() {
+            private TrustManager createReloadableX509CRLTrustManager(final String crlPath, final String crlRelativeTo, final int certPath, final InjectedValue<PathManager> pathManagerInjector, final TrustManagerFactory trustManagerFactory, final KeyStore keyStore, final X509CRLExtendedTrustManager trustManager) {
+                return new ReloadableX509ExtendedTrustManager() {
 
                     private volatile X509ExtendedTrustManager delegate = trustManager;
                     private AtomicBoolean reloading = new AtomicBoolean();
 
-                    private X509ExtendedTrustManager getDelegate() {
-                        if (reloadCrl.get() && reloading.compareAndSet(false, true)) {
-                            X509ExtendedTrustManager reloaded = null;
+                    @Override
+                    void reload() {
+                        if (reloading.compareAndSet(false, true)) {
                             try {
-                                reloaded = new X509CRLExtendedTrustManager(keyStore, trustManagerFactory, new FileInputStream(resolveFileLocation(crlPath, crlRelativeTo, pathManagerInjector)), certPath, null);
+                                delegate = new X509CRLExtendedTrustManager(keyStore, trustManagerFactory, new FileInputStream(resolveFileLocation(crlPath, crlRelativeTo, pathManagerInjector)), certPath, null);
                             } catch (FileNotFoundException cause) {
                                 throw ElytronSubsystemMessages.ROOT_LOGGER.unableToReloadCRL(cause);
                             } finally {
-                                if (reloaded != null) {
-                                    delegate = reloaded;
-                                }
-                                reloadCrl.lazySet(false);
                                 reloading.lazySet(false);
                             }
                         }
-                        return delegate;
                     }
 
                     @Override
                     public void checkClientTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
-                        getDelegate().checkClientTrusted(x509Certificates, s, socket);
+                        delegate.checkClientTrusted(x509Certificates, s, socket);
                     }
 
                     @Override
                     public void checkServerTrusted(X509Certificate[] x509Certificates, String s, Socket socket) throws CertificateException {
-                        getDelegate().checkServerTrusted(x509Certificates, s, socket);
+                        delegate.checkServerTrusted(x509Certificates, s, socket);
                     }
 
                     @Override
                     public void checkClientTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
-                        getDelegate().checkClientTrusted(x509Certificates, s, sslEngine);
+                        delegate.checkClientTrusted(x509Certificates, s, sslEngine);
                     }
 
                     @Override
                     public void checkServerTrusted(X509Certificate[] x509Certificates, String s, SSLEngine sslEngine) throws CertificateException {
-                        getDelegate().checkServerTrusted(x509Certificates, s, sslEngine);
+                        delegate.checkServerTrusted(x509Certificates, s, sslEngine);
                     }
 
                     @Override
                     public void checkClientTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-                        getDelegate().checkClientTrusted(x509Certificates, s);
+                        delegate.checkClientTrusted(x509Certificates, s);
                     }
 
                     @Override
                     public void checkServerTrusted(X509Certificate[] x509Certificates, String s) throws CertificateException {
-                        getDelegate().checkServerTrusted(x509Certificates, s);
+                        delegate.checkServerTrusted(x509Certificates, s);
                     }
 
                     @Override
                     public X509Certificate[] getAcceptedIssuers() {
-                        return getDelegate().getAcceptedIssuers();
+                        return delegate.getAcceptedIssuers();
                     }
                 };
             }
@@ -710,18 +707,22 @@ class SSLDefinitions {
                 resourceRegistration.registerOperationHandler(new SimpleOperationDefinitionBuilder(ElytronDescriptionConstants.RELOAD_CERTIFICATE_REVOCATION_LIST, getResourceDescriptionResolver())
                             .setRuntimeOnly()
                             .build()
-                        , new ReloadCertificateRevocationList());
-            }
-
-            class ReloadCertificateRevocationList extends ElytronRuntimeOnlyHandler {
-
-                private ReloadCertificateRevocationList() {
-                }
-
-                @Override
-                protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
-                    reloadCrl.compareAndSet(false, true);
-                }
+                        , new ElytronRuntimeOnlyHandler() {
+                            @Override
+                            protected void executeRuntimeStep(OperationContext context, ModelNode operation) throws OperationFailedException {
+                                ServiceName serviceName = TRUST_MANAGER_RUNTIME_CAPABILITY.fromBaseCapability(context.getCurrentAddressValue()).getCapabilityServiceName();
+                                ServiceController<TrustManager> serviceContainer = getRequiredService(context.getServiceRegistry(true), serviceName, TrustManager.class);
+                                State serviceState;
+                                if ((serviceState = serviceContainer.getState()) != State.UP) {
+                                    throw ROOT_LOGGER.requiredServiceNotUp(serviceName, serviceState);
+                                }
+                                TrustManager trustManager = serviceContainer.getValue();
+                                if (! (trustManager instanceof ReloadableX509ExtendedTrustManager)) {
+                                    throw ROOT_LOGGER.unableToReloadCRLNotReloadable();
+                                }
+                                ((ReloadableX509ExtendedTrustManager) trustManager).reload();
+                            }
+                        });
             }
         };
     }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -318,6 +318,9 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 38, value = "Could not load permission class \"%s\"")
     void invalidPermissionClass(String className);
 
+    @Message(id = 39, value = "Unable to reload CRL file - TrustManager is not reloadable")
+    OperationFailedException unableToReloadCRLNotReloadable();
+
     // CREDENTIAL_STORE section
     @Message(id = 909, value = "Credential store '%s' does not support given credential store entry type '%s'")
     OperationFailedException credentialStoreEntryTypeNotSupported(String credentialStoreName, String entryType);

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
@@ -46,6 +46,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.wildfly.security.WildFlyElytronProvider;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
 /**
  * @author <a href="mailto:jkalina@redhat.com">Jan Kalina</a>
  */
@@ -118,6 +122,11 @@ public class TlsTestCase extends AbstractSubsystemTest {
         ServiceName serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-crl");
         TrustManager trustManager = (TrustManager) services.getContainer().getService(serviceName).getValue();
         Assert.assertNotNull(trustManager);
+
+        ModelNode operation = new ModelNode();
+        operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add(ElytronDescriptionConstants.TRUST_MANAGER, "trust-with-crl");
+        operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.RELOAD_CERTIFICATE_REVOCATION_LIST);
+        Assert.assertTrue(services.executeOperation(operation).get(OUTCOME).asString().equals(SUCCESS));
     }
 
     @Test
@@ -125,6 +134,11 @@ public class TlsTestCase extends AbstractSubsystemTest {
         ServiceName serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName("trust-with-crl-dp");
         TrustManager trustManager = (TrustManager) services.getContainer().getService(serviceName).getValue();
         Assert.assertNotNull(trustManager);
+
+        ModelNode operation = new ModelNode();
+        operation.get(ClientConstants.OP_ADDR).add("subsystem", "elytron").add(ElytronDescriptionConstants.TRUST_MANAGER, "trust-with-crl-dp");
+        operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.RELOAD_CERTIFICATE_REVOCATION_LIST);
+        Assert.assertTrue(services.executeOperation(operation).get(OUTCOME).asString().equals(FAILED)); // not realoadable
     }
 
     private SSLContext getSslContext(String contextName) {


### PR DESCRIPTION
Fixes of:
- errors occurred during reload not visible as operation result
- reload flag is shared across individual TrustManagers (first used TrustManager is reloaded instead of the chosen one)

https://issues.jboss.org/browse/WFCORE-3151
https://issues.jboss.org/browse/JBEAP-11225