### PR TITLE
WFCORE-2620 - Add ability to read computed runtime values of IO subsystem buffer-pool attributes

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/BufferPoolAdd.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/BufferPoolAdd.java
@@ -1,0 +1,83 @@
+package org.wildfly.extension.io;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import io.undertow.connector.ByteBufferPool;
+import io.undertow.server.XnioByteBufferPool;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.xnio.Pool;
+
+class BufferPoolAdd extends AbstractAddStepHandler {
+
+    static final BufferPoolAdd INSTANCE = new BufferPoolAdd();
+
+    BufferPoolAdd() {
+        super(BufferPoolResourceDefinition.ATTRIBUTES);
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)
+            throws OperationFailedException {
+        final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+
+        final String name = address.getLastElement().getValue();
+        final ModelNode bufferSizeModel = BufferPoolResourceDefinition.BUFFER_SIZE.resolveModelAttribute(context, model);
+
+        final ModelNode bufferPerSliceModel = BufferPoolResourceDefinition.BUFFER_PER_SLICE.resolveModelAttribute(context,
+                model);
+        final ModelNode directModel = BufferPoolResourceDefinition.DIRECT_BUFFERS.resolveModelAttribute(context, model);
+
+        final int bufferSize = bufferSizeModel.isDefined() ? bufferSizeModel.asInt()
+                : BufferPoolResourceDefinition.defaultBufferSize;
+        final int bufferPerSlice = bufferPerSliceModel.isDefined() ? bufferPerSliceModel.asInt()
+                : BufferPoolResourceDefinition.defaultBuffersPerRegion;
+        final boolean direct = directModel.isDefined() ? directModel.asBoolean()
+                : BufferPoolResourceDefinition.defaultDirectBuffers;
+
+        final BufferPoolService service = new BufferPoolService(bufferSize, bufferPerSlice, direct);
+        context.getCapabilityServiceTarget().addCapability(BufferPoolResourceDefinition.IO_POOL_RUNTIME_CAPABILITY, service)
+                .setInitialMode(ServiceController.Mode.ON_DEMAND)
+                .install();
+
+        ByteBufferPoolService poolService = new ByteBufferPoolService();
+
+        context.getCapabilityServiceTarget().addCapability(BufferPoolResourceDefinition.IO_BYTE_BUFFER_POOL_RUNTIME_CAPABILITY, poolService)
+                .addCapabilityRequirement(BufferPoolResourceDefinition.IO_POOL_RUNTIME_CAPABILITY.getDynamicName(address), Pool.class, poolService.bufferPool)
+                .setInitialMode(ServiceController.Mode.ON_DEMAND)
+                .install();
+
+    }
+
+    private static final class ByteBufferPoolService implements Service<ByteBufferPool> {
+
+        final InjectedValue<Pool> bufferPool = new InjectedValue<>();
+        private volatile ByteBufferPool byteBufferPool;
+
+        @Override
+        public void start(StartContext startContext) throws StartException {
+            byteBufferPool = new XnioByteBufferPool(bufferPool.getValue());
+        }
+
+        @Override
+        public void stop(StopContext stopContext) {
+            byteBufferPool.close();
+            byteBufferPool = null;
+        }
+
+        @Override
+        public ByteBufferPool getValue() throws IllegalStateException, IllegalArgumentException {
+            return byteBufferPool;
+        }
+    }
+
+}

--- a/io/tests/src/test/resources/org/wildfly/extension/io/io-2.0-transformer.xml
+++ b/io/tests/src/test/resources/org/wildfly/extension/io/io-2.0-transformer.xml
@@ -21,5 +21,5 @@
     <worker name="second-worker" io-threads="5" stack-size="300" task-keepalive="100" task-max-threads="200"/>
     <worker name="third-worker" task-max-threads="50"/>
     <worker name="fourth-worker"/>
-    <buffer-pool name="default" buffer-size="2048" buffers-per-slice="2048"/>
+    <buffer-pool name="default" buffer-size="16384" buffers-per-slice="20" direct-buffers="true"/>
 </subsystem>

--- a/io/tests/src/test/resources/org/wildfly/extension/io/io-3.0-transformer.xml
+++ b/io/tests/src/test/resources/org/wildfly/extension/io/io-3.0-transformer.xml
@@ -20,5 +20,5 @@
     <worker name="default" task-keepalive="100" stack-size="5000" />
     <worker name="second-worker" io-threads="${some.property:5}" stack-size="${property.stack:300}" task-keepalive="${property.keepalive:100}" task-max-threads="${prop.max-threads:200}"/>
     <worker name="third-worker" task-max-threads="50"/>
-    <buffer-pool name="default" buffer-size="2048" buffers-per-slice="2048"/>
+    <buffer-pool name="default" buffer-size="16384" buffers-per-slice="20" direct-buffers="true"/>
 </subsystem>


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/JBEAP-6984
Upstream Issue: https://issues.jboss.org/browse/WFCORE-2620
No upstream PR required

This changes is (hopefully) a better proposal than my previous changes. It is however just a draft - I don't expect it to be perfect, I'm sharing it to get feedback on what is wrong (and hopefully how to fix it). So please don't merge without thorough code review, thanks !
