### PR TITLE
[WFCORE-3070] syncing FIPS mode KeyStore loads on EmptyProvider as the same issue exists Elytron module

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/ProviderKeyManagerService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/ProviderKeyManagerService.java
@@ -31,6 +31,7 @@ import org.jboss.as.domain.management.logging.DomainManagementLogger;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
+import org.wildfly.security.EmptyProvider;
 
 /**
  * Extension of {@link AbstractKeyManagerService} to load the KeyStore using a specified provider.
@@ -55,7 +56,7 @@ class ProviderKeyManagerService extends AbstractKeyManagerService {
 
         try {
             KeyStore theKeyStore = KeyStore.getInstance(provider);
-            synchronized (SecurityRealmAddHandler.INSTANCE) {
+            synchronized (EmptyProvider.getInstance()) {
                 theKeyStore.load(null, storePassword);
             }
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/ProviderTrustManagerService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/ProviderTrustManagerService.java
@@ -32,6 +32,7 @@ import org.jboss.as.domain.management.logging.DomainManagementLogger;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
+import org.wildfly.security.EmptyProvider;
 
 /**
  * Extension of {@link AbstractTrustManagerService} to load the KeyStore using a specified provider.
@@ -54,7 +55,7 @@ public class ProviderTrustManagerService extends AbstractTrustManagerService {
 
         try {
             KeyStore theKeyStore = KeyStore.getInstance(provider);
-            synchronized (SecurityRealmAddHandler.INSTANCE) {
+            synchronized (EmptyProvider.getInstance()) {
                 theKeyStore.load(null, resolvePassword());
             }
             this.theKeyStore = theKeyStore;

--- a/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreService.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreService.java
@@ -47,6 +47,7 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.common.function.ExceptionSupplier;
 import org.wildfly.extension.elytron.FileAttributeDefinitions.PathResolver;
+import org.wildfly.security.EmptyProvider;
 import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.source.CredentialSource;
 import org.wildfly.security.keystore.AliasFilter;
@@ -134,7 +135,13 @@ class KeyStoreService implements ModifiableKeyStoreService {
                         type, provider, path, resolvedPath, password != null, aliasFilter
                 );
 
-                keyStore.load(is, password);
+                if (is != null) {
+                    keyStore.load(is, password);
+                } else {
+                    synchronized (EmptyProvider.getInstance()) {
+                        keyStore.load(null, password);
+                    }
+                }
                 checkCertificatesValidity(keyStore);
             }
 


### PR DESCRIPTION
KeyStoreSevice is affected as well and load can happen in Elytron's CredentialStore so need to sync on different instance.

https://issues.jboss.org/browse/WFCORE-3070
https://issues.jboss.org/browse/JBEAP-11693