### PR TITLE
[WFCORE-3176] Upgrade jboss-logging-tools to version 2.1.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,7 @@
         <version.org.jboss.jboss-dmr>1.4.1.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.12.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
-        <!--<version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>-->
-        <version.org.jboss.logging.jboss-logging-tools>2.1.0.Alpha2</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.2.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
         <version.org.jboss.logmanager.jboss-logmanager>2.0.7.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.3.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
@@ -1712,7 +1711,6 @@
                 <!-- [WFCORE-1494] remove JUL workaround -->
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true -Djdk.attach.allowAttachSelf=true</modular.jdk.props>
                 <version.org.jboss.byteman>4.0.0-BETA5</version.org.jboss.byteman>
-                <version.org.jboss.logging.jboss-logging-tools>2.1.0.Alpha2</version.org.jboss.logging.jboss-logging-tools>
             </properties>
         </profile>
         <!--


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3176