### PR TITLE
[WFCORE-3179] Elytron - Kerberos SASL tests

### DIFF
--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -20,9 +20,22 @@
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}</jbossas.project.dir>
         <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
+        <version.javax.enterprise>1.2</version.javax.enterprise>
 
         <ts.elytron.cli>enable-elytron.cli</ts.elytron.cli>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-parent</artifactId>
+                <version>${version.org.apache.ds}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -74,6 +87,28 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-jmx</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.directory.api</groupId>
+            <artifactId>api-ldap-codec-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-interceptor-kerberos</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-server-annotations</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
@@ -1,0 +1,538 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.elytron.sasl.mgmt;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.jboss.as.test.integration.security.common.SecurityTestConstants.KEYSTORE_PASSWORD;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.PrivilegedAction;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import javax.security.auth.Subject;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import javax.security.sasl.SaslException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.directory.api.ldap.model.constants.SupportedSaslMechanisms;
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
+import org.apache.directory.server.annotations.CreateKdcServer;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.annotations.SaslMechanism;
+import org.apache.directory.server.core.annotations.AnnotationUtils;
+import org.apache.directory.server.core.annotations.CreateDS;
+import org.apache.directory.server.core.annotations.CreatePartition;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.factory.DSAnnotationProcessor;
+import org.apache.directory.server.core.kerberos.KeyDerivationInterceptor;
+import org.apache.directory.server.factory.ServerAnnotationProcessor;
+import org.apache.directory.server.kerberos.kdc.KdcServer;
+import org.apache.directory.server.ldap.LdapServer;
+import org.apache.directory.server.ldap.handlers.sasl.cramMD5.CramMd5MechanismHandler;
+import org.apache.directory.server.ldap.handlers.sasl.digestMD5.DigestMd5MechanismHandler;
+import org.apache.directory.server.ldap.handlers.sasl.gssapi.GssapiMechanismHandler;
+import org.apache.directory.server.ldap.handlers.sasl.ntlm.NtlmMechanismHandler;
+import org.apache.directory.server.ldap.handlers.sasl.plain.PlainMechanismHandler;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSManager;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.network.NetworkUtils;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.integration.security.common.SecurityTestConstants;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.wildfly.security.SecurityFactory;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.MatchRule;
+import org.wildfly.security.sasl.SaslMechanismSelector;
+import org.wildfly.security.ssl.SSLContextBuilder;
+import org.wildfly.test.security.common.kerberos.AbstractKrb5ConfServerSetupTask;
+import org.wildfly.test.security.common.kerberos.InMemoryDirectoryServiceFactory;
+import org.wildfly.test.security.common.kerberos.KDCServerAnnotationProcessor;
+import org.wildfly.test.security.common.kerberos.KerberosTestUtils;
+import org.wildfly.test.security.common.kerberos.Krb5LoginConfiguration;
+import org.wildfly.test.security.common.kerberos.ManagedCreateLdapServer;
+import org.wildfly.test.security.common.kerberos.ManagedCreateTransport;
+import org.xnio.http.RedirectException;
+
+/**
+ * Parent class for Elytron Kerberos remoting (GSSAPI and GS2-KRB5* SASL mechanism) testing.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractKerberosMgmtSaslTestBase {
+
+    protected static Logger LOGGER = Logger.getLogger(AbstractKerberosMgmtSaslTestBase.class);
+
+    protected static final int CONNECTION_TIMEOUT_IN_MS = TimeoutUtil.adjust(6 * 1000);
+
+    protected static final int PORT_NATIVE = 10567;
+
+    protected static final int LDAP_PORT = 10389;
+    protected static final String LDAP_URL = "ldap://" + NetworkUtils.formatPossibleIpv6Address(
+            CoreUtils.getCannonicalHost(TestSuiteEnvironment.getSecondaryTestAddress(false))) + ":" + LDAP_PORT;
+
+    protected static final File WORK_DIR_GSSAPI;
+    static {
+        try {
+            WORK_DIR_GSSAPI = Files.createTempDirectory("gssapi-").toFile();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to create temporary folder", e);
+        }
+    }
+
+    protected static final File SERVER_KEYSTORE_FILE = new File(WORK_DIR_GSSAPI, SecurityTestConstants.SERVER_KEYSTORE);
+    protected static final File SERVER_TRUSTSTORE_FILE = new File(WORK_DIR_GSSAPI, SecurityTestConstants.SERVER_TRUSTSTORE);
+    protected static final File CLIENT_TRUSTSTORE_FILE = new File(WORK_DIR_GSSAPI, SecurityTestConstants.CLIENT_TRUSTSTORE);
+
+    protected static Krb5LoginConfiguration KRB5_CONFIGURATION;
+
+    protected static SecurityFactory<SSLContext> sslFactory;
+
+    @BeforeClass
+    public static void beforeClass() {
+        KerberosTestUtils.assumeKerberosAuthenticationSupported();
+    }
+
+    /**
+     * Test GSSAPI SASL mechanism configured on the server-side for management interface without using SSL.
+     */
+    @Test
+    public void testGssapiWithoutSsl() throws Exception {
+        try (AutoCloseable ac = configureSaslMechanismOnServer("GSSAPI", false)) {
+            assertKerberosSaslMechPasses("GSSAPI", "hnelson", "secret", false);
+            assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", false);
+            assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", false);
+        }
+    }
+
+    /**
+     * Tests that Kerberos login correctly fails when a wrong username or a wrong password is used.
+     */
+    @Test
+    public void testKerberosWrongCredentials() throws Exception {
+        assertKerberosLoginFails("hnelson", "wrongpassword");
+        assertKerberosLoginFails("wronguser", "secret");
+    }
+
+    /**
+     * Test GSSAPI SASL mechanism configured on the server-side for management interface with using SSL.
+     */
+    @Test
+    public void testGssapiOverSsl() throws Exception {
+        try (AutoCloseable ac = configureSaslMechanismOnServer("GSSAPI", true)) {
+            assertKerberosSaslMechPasses("GSSAPI", "hnelson", "secret", true);
+            assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", false);
+            assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", true);
+            assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", true);
+        }
+    }
+
+    /**
+     * Test GS2-KRB5 SASL mechanism configured on the server-side for management interface without using SSL.
+     */
+    @Test
+    public void testGs2Krb5WithoutSsl() throws Exception {
+        try (AutoCloseable ac = configureSaslMechanismOnServer("GS2-KRB5", false)) {
+            assertKerberosSaslMechPasses("GS2-KRB5", "hnelson", "secret", false);
+            assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", false);
+            assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", false);
+        }
+    }
+
+    /**
+     * Test GS2-KRB5 SASL mechanism configured on the server-side for management interface with using SSL.
+     */
+    @Test
+    @Ignore("ELY-1330")
+    public void testGs2Krb5OverSsl() throws Exception {
+        try (AutoCloseable ac = configureSaslMechanismOnServer("GS2-KRB5", true)) {
+            assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", true);
+            assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", false);
+            assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", true);
+            assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", true);
+        }
+    }
+
+    /**
+     * Test GS2-KRB5-PLUS SASL mechanism configured on the server-side for management interface with using SSL.
+     */
+    @Test
+    public void testGs2Krb5PlusWithoutSsl() throws Exception {
+        try (AutoCloseable ac = configureSaslMechanismOnServer("GS2-KRB5-PLUS", false)) {
+            assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", false);
+            assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", false);
+            assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", false);
+        }
+    }
+
+    /**
+     * Test GS2-KRB5-PLUS SASL mechanism configured on the server-side for management interface with using SSL.
+     */
+    @Test
+    @Ignore("ELY-1328")
+    public void testGs2Krb5PlusOverSsl() throws Exception {
+        try (AutoCloseable ac = configureSaslMechanismOnServer("GS2-KRB5-PLUS", true)) {
+            assertKerberosSaslMechPasses("GS2-KRB5-PLUS", "hnelson", "secret", true);
+            assertKerberosSaslMechFails("GS2-KRB5-PLUS", "hnelson", "secret", false);
+            assertKerberosSaslMechFails("GS2-KRB5", "hnelson", "secret", true);
+            assertKerberosSaslMechFails("GSSAPI", "hnelson", "secret", true);
+        }
+    }
+
+    /**
+     * Configures given mechanism with (or without) SSL on the server side. The returned {@link AutoCloseable} instance (must
+     * not be {@code null}) wraps the tests in try-with-resource block and is used after the test to do a clean-up.
+     */
+    protected abstract AutoCloseable configureSaslMechanismOnServer(String mechanism, boolean withSsl) throws Exception;
+
+    /**
+     * Asserts that given user can authenticate with given Kerberos SASL mechanism.
+     */
+    protected void assertKerberosSaslMechPasses(String mech, String user, String password, boolean withSsl)
+            throws MalformedURLException, LoginException, Exception {
+        // 1. Authenticate to Kerberos.
+        final LoginContext lc = KerberosTestUtils.loginWithKerberos(KRB5_CONFIGURATION, user, password);
+        try {
+            AuthenticationConfiguration authCfg = AuthenticationConfiguration.empty()
+                    .setSaslMechanismSelector(SaslMechanismSelector.fromString(mech))
+                    .useGSSCredential(getGSSCredential(lc.getSubject()));
+
+            AuthenticationContext authnCtx = AuthenticationContext.empty().with(MatchRule.ALL, authCfg);
+            if (withSsl) {
+                authnCtx = authnCtx.withSsl(MatchRule.ALL, sslFactory);
+            }
+            authnCtx.run(() -> assertWhoAmI(user + "@JBOSS.ORG", withSsl));
+        } finally {
+            lc.logout();
+        }
+    }
+
+    protected void assertKerberosSaslMechFails(String mech, String user, String password, boolean withSsl)
+            throws MalformedURLException, LoginException, Exception {
+        // 1. Authenticate to Kerberos.
+        final LoginContext lc = KerberosTestUtils.loginWithKerberos(KRB5_CONFIGURATION, user, password);
+        try {
+            AuthenticationConfiguration authCfg = AuthenticationConfiguration.empty()
+                    .setSaslMechanismSelector(SaslMechanismSelector.fromString(mech))
+                    .useGSSCredential(getGSSCredential(lc.getSubject()));
+
+            AuthenticationContext authnCtx = AuthenticationContext.empty().with(MatchRule.ALL, authCfg);
+            if (withSsl) {
+                authnCtx = authnCtx.withSsl(MatchRule.ALL, sslFactory);
+            }
+            authnCtx.run(() -> assertAuthenticationFails(null, null, withSsl));
+        } finally {
+            lc.logout();
+        }
+    }
+
+    protected void assertKerberosLoginFails(String user, String password) {
+        LoginContext lc = null;
+        try {
+            lc = KerberosTestUtils.loginWithKerberos(KRB5_CONFIGURATION, user, password);
+            fail("Kerberos authentication failure was expected.");
+        } catch (LoginException e) {
+            LOGGER.debug("Kerberos authentication failed as expected.");
+        } finally {
+            if (lc != null) {
+                try {
+                    lc.logout();
+                } catch (LoginException e) {
+                    LOGGER.warn("Unsuccessful logout", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieves {@link GSSCredential} from given Subject
+     */
+    protected GSSCredential getGSSCredential(Subject subject) {
+        return Subject.doAs(subject, new PrivilegedAction<GSSCredential>() {
+            @Override
+            public GSSCredential run() {
+                try {
+                    GSSManager gssManager = GSSManager.getInstance();
+                    return gssManager.createCredential(GSSCredential.INITIATE_ONLY);
+                } catch (Exception e) {
+                    LOGGER.warn("Unable to retrieve GSSCredential from given Subject.", e);
+                }
+                return null;
+            }
+        });
+    }
+
+    /**
+     * Get the trust manager for {@link #CLIENT_TRUSTSTORE_FILE}.
+     *
+     * @return the trust manager
+     */
+    protected static X509TrustManager getTrustManager() throws Exception {
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory.init(loadKeyStore(CLIENT_TRUSTSTORE_FILE));
+
+        for (TrustManager current : trustManagerFactory.getTrustManagers()) {
+            if (current instanceof X509TrustManager) {
+                return (X509TrustManager) current;
+            }
+        }
+
+        throw new IllegalStateException("Unable to obtain X509TrustManager.");
+    }
+
+    protected static KeyStore loadKeyStore(final File ksFile) throws Exception {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        try (FileInputStream fis = new FileInputStream(ksFile)) {
+            ks.load(fis, KEYSTORE_PASSWORD.toCharArray());
+        }
+        return ks;
+    }
+
+    protected void assertAuthenticationFails(String message, Class<? extends Exception> secondCauseClass, boolean withTls) {
+        if (message == null) {
+            message = "The failure of :whoami operation execution was expected, but the call passed";
+        }
+        final long startTime = System.currentTimeMillis();
+        try {
+            executeWhoAmI(withTls);
+            fail(message);
+        } catch (IOException | GeneralSecurityException e) {
+            assertTrue("Connection reached its timeout (hang).",
+                    startTime + CONNECTION_TIMEOUT_IN_MS > System.currentTimeMillis());
+            Throwable cause = e.getCause();
+            assertThat("ConnectionException was expected as a cause when authentication fails", cause,
+                    is(instanceOf(ConnectException.class)));
+            assertThat("Unexpected type of inherited exception for authentication failure", cause.getCause(),
+                    anyOf(is(instanceOf(SSLException.class)), is(instanceOf(SaslException.class)),
+                            is(instanceOf(RedirectException.class))));
+        }
+    }
+
+    protected abstract ModelNode executeWhoAmI(boolean withTls) throws IOException, GeneralSecurityException;
+
+    protected void assertWhoAmI(String expected, boolean withTls) {
+        try {
+            ModelNode result = executeWhoAmI(withTls);
+            assertTrue("The whoami operation should finish with success", Operations.isSuccessfulOutcome(result));
+            assertEquals("The whoami operation returned unexpected value", expected,
+                    Operations.readResult(result).get("identity").get("username").asString());
+        } catch (Exception e) {
+            LOGGER.warn("Operation execution failed", e);
+            fail("The whoami operation failed - " + e.getMessage());
+        }
+    }
+
+    public static class KeyMaterialSetup implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient) throws Exception {
+            FileUtils.deleteQuietly(WORK_DIR_GSSAPI);
+            WORK_DIR_GSSAPI.mkdir();
+            CoreUtils.createKeyMaterial(WORK_DIR_GSSAPI);
+
+            sslFactory = new SSLContextBuilder().setClientMode(true).setTrustManager(getTrustManager()).build();
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient) throws Exception {
+            FileUtils.deleteQuietly(WORK_DIR_GSSAPI);
+        }
+
+    }
+
+    /**
+     * Task which generates krb5.conf and keytab file(s).
+     */
+    public static class Krb5ConfServerSetupTask extends AbstractKrb5ConfServerSetupTask {
+        public static final File HNELSON_KEYTAB_FILE = new File(WORK_DIR, "hnelson.keytab");
+        public static final File JDUKE_KEYTAB_FILE = new File(WORK_DIR, "jduke.keytab");
+        public static final String REMOTE_PRINCIPAL = "remote/"
+                + CoreUtils.getCannonicalHost(TestSuiteEnvironment.getSecondaryTestAddress(false)) + "@JBOSS.ORG";
+        public static final File REMOTE_KEYTAB_FILE = new File(WORK_DIR, "remote.keytab");
+
+        @Override
+        protected List<UserForKeyTab> kerberosUsers() {
+            List<UserForKeyTab> users = new ArrayList<UserForKeyTab>();
+            users.add(new UserForKeyTab("hnelson@JBOSS.ORG", "secret", HNELSON_KEYTAB_FILE));
+            users.add(new UserForKeyTab("jduke@JBOSS.ORG", "theduke", JDUKE_KEYTAB_FILE));
+            users.add(new UserForKeyTab(REMOTE_PRINCIPAL, "zelvicka", REMOTE_KEYTAB_FILE));
+            return users;
+        }
+
+    }
+
+    // @formatter:off
+    @CreateDS(name = "WildFlyDS", factory = InMemoryDirectoryServiceFactory.class, partitions = @CreatePartition(name = "wildfly", suffix = "dc=wildfly,dc=org"), additionalInterceptors = {
+            KeyDerivationInterceptor.class }, allowAnonAccess = true)
+    @CreateKdcServer(primaryRealm = "JBOSS.ORG", kdcPrincipal = "krbtgt/JBOSS.ORG@JBOSS.ORG", searchBaseDn = "dc=wildfly,dc=org", transports = {
+            @CreateTransport(protocol = "UDP", port = 6088) })
+    @CreateLdapServer(transports = {
+            @CreateTransport(protocol = "LDAP", port = LDAP_PORT) }, saslHost = "localhost", saslPrincipal = "ldap/localhost@JBOSS.ORG", saslMechanisms = {
+                    @SaslMechanism(name = SupportedSaslMechanisms.PLAIN, implClass = PlainMechanismHandler.class),
+                    @SaslMechanism(name = SupportedSaslMechanisms.CRAM_MD5, implClass = CramMd5MechanismHandler.class),
+                    @SaslMechanism(name = SupportedSaslMechanisms.DIGEST_MD5, implClass = DigestMd5MechanismHandler.class),
+                    @SaslMechanism(name = SupportedSaslMechanisms.GSSAPI, implClass = GssapiMechanismHandler.class),
+                    @SaslMechanism(name = SupportedSaslMechanisms.NTLM, implClass = NtlmMechanismHandler.class),
+                    @SaslMechanism(name = SupportedSaslMechanisms.GSS_SPNEGO, implClass = NtlmMechanismHandler.class) })
+    // @formatter:on
+    static class DirectoryServerSetupTask implements ServerSetupTask {
+
+        private DirectoryService directoryService;
+        private KdcServer kdcServer;
+        private LdapServer ldapServer;
+        private boolean removeBouncyCastle = false;
+
+        /**
+         * Creates directory services, starts LDAP server and KDCServer
+         *
+         * @param managementClient
+         * @param containerId
+         * @throws Exception
+         * @see org.jboss.as.arquillian.api.ServerSetupTask#setup(org.jboss.as.arquillian.container.ManagementClient,
+         *      java.lang.String)
+         */
+        @Override
+        public void setup(ManagementClient managementClient) throws Exception {
+            try {
+                if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+                    Security.addProvider(new BouncyCastleProvider());
+                    removeBouncyCastle = true;
+                }
+            } catch (SecurityException ex) {
+                LOGGER.warn("Cannot register BouncyCastleProvider", ex);
+            }
+            directoryService = DSAnnotationProcessor.getDirectoryService();
+            final String hostname = CoreUtils.getCannonicalHost(TestSuiteEnvironment.getHttpAddress());
+            final Map<String, String> map = new HashMap<String, String>();
+            map.put("hostname", NetworkUtils.formatPossibleIpv6Address(hostname));
+            final String secondaryTestAddress = NetworkUtils
+                    .canonize(CoreUtils.getCannonicalHost(TestSuiteEnvironment.getSecondaryTestAddress(false)));
+            map.put("ldaphost", secondaryTestAddress);
+            final String ldifContent = StrSubstitutor.replace(IOUtils.toString(
+                    AbstractKerberosMgmtSaslTestBase.class.getResourceAsStream("remoting-krb5-test.ldif"), "UTF-8"), map);
+            LOGGER.trace(ldifContent);
+            final SchemaManager schemaManager = directoryService.getSchemaManager();
+            try {
+                for (LdifEntry ldifEntry : new LdifReader(IOUtils.toInputStream(ldifContent, StandardCharsets.UTF_8))) {
+                    directoryService.getAdminSession().add(new DefaultEntry(schemaManager, ldifEntry.getEntry()));
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Importing LDIF to a directoryService failed.", e);
+                throw e;
+            }
+            kdcServer = KDCServerAnnotationProcessor.getKdcServer(directoryService, 1024, hostname);
+            final ManagedCreateLdapServer createLdapServer = new ManagedCreateLdapServer(
+                    (CreateLdapServer) AnnotationUtils.getInstance(CreateLdapServer.class));
+            createLdapServer.setSaslHost(secondaryTestAddress);
+            createLdapServer.setSaslPrincipal("ldap/" + secondaryTestAddress + "@JBOSS.ORG");
+            KerberosTestUtils.fixApacheDSTransportAddress(createLdapServer, secondaryTestAddress);
+            ldapServer = ServerAnnotationProcessor.instantiateLdapServer(createLdapServer, directoryService);
+            ldapServer.getSaslHost();
+            ldapServer.setSearchBaseDn("dc=wildfly,dc=org");
+            ldapServer.start();
+
+            KRB5_CONFIGURATION = new Krb5LoginConfiguration(CoreUtils.getLoginConfiguration());
+            // Use our custom configuration to avoid reliance on external config
+            Configuration.setConfiguration(KRB5_CONFIGURATION);
+
+        }
+
+        /**
+         * Stops LDAP server and KDCServer and shuts down the directory service.
+         *
+         * @param managementClient
+         * @param containerId
+         * @throws Exception
+         * @see org.jboss.as.arquillian.api.ServerSetupTask#tearDown(org.jboss.as.arquillian.container.ManagementClient,
+         *      java.lang.String)
+         */
+        @Override
+        public void tearDown(ManagementClient managementClient) throws Exception {
+            KRB5_CONFIGURATION.resetConfiguration();
+            ldapServer.stop();
+            kdcServer.stop();
+            directoryService.shutdown();
+            FileUtils.deleteDirectory(directoryService.getInstanceLayout().getInstanceDirectory());
+            if (removeBouncyCastle) {
+                try {
+                    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+                } catch (SecurityException ex) {
+                    LOGGER.warn("Cannot deregister BouncyCastleProvider", ex);
+                }
+            }
+
+        }
+
+        /**
+         * Fixes/replaces LDAP bind address in the CreateTransport annotation of ApacheDS.
+         *
+         * @param createLdapServer
+         * @param address
+         */
+        public static void fixApacheDSTransportAddress(ManagedCreateLdapServer createLdapServer, String address) {
+            final CreateTransport[] createTransports = createLdapServer.transports();
+            for (int i = 0; i < createTransports.length; i++) {
+                final ManagedCreateTransport mgCreateTransport = new ManagedCreateTransport(createTransports[i]);
+                // localhost is a default used in original CreateTransport annotation. We use it as a fallback.
+                mgCreateTransport.setAddress(address != null ? address : "localhost");
+                createTransports[i] = mgCreateTransport;
+            }
+        }
+    }
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosHttpMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosHttpMgmtSaslTestCase.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.elytron.sasl.mgmt;
+
+import static org.jboss.as.test.integration.security.common.SecurityTestConstants.KEYSTORE_PASSWORD;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.ModelControllerClientConfiguration;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
+import org.wildfly.test.security.common.elytron.CliPath;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.ConstantPermissionMapper;
+import org.wildfly.test.security.common.elytron.CredentialReference;
+import org.wildfly.test.security.common.elytron.DirContext;
+import org.wildfly.test.security.common.elytron.IdentityMapping;
+import org.wildfly.test.security.common.elytron.KerberosSecurityFactory;
+import org.wildfly.test.security.common.elytron.LdapRealm;
+import org.wildfly.test.security.common.elytron.MechanismConfiguration;
+import org.wildfly.test.security.common.elytron.MechanismRealmConfiguration;
+import org.wildfly.test.security.common.elytron.PermissionRef;
+import org.wildfly.test.security.common.elytron.SimpleConfigurableSaslServerFactory;
+import org.wildfly.test.security.common.elytron.SimpleKeyManager;
+import org.wildfly.test.security.common.elytron.SimpleKeyStore;
+import org.wildfly.test.security.common.elytron.SimpleSaslAuthenticationFactory;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain.SecurityDomainRealm;
+import org.wildfly.test.security.common.elytron.SimpleServerSslContext;
+import org.wildfly.test.security.common.elytron.SimpleTrustManager;
+import org.wildfly.test.security.common.kerberos.KerberosSystemPropertiesSetupTask;
+import org.wildfly.test.security.common.other.AccessIdentityConfigurator;
+import org.wildfly.test.security.common.other.HttpMgmtConfigurator;
+import org.wildfly.test.security.common.other.SimpleMgmtNativeInterface;
+import org.wildfly.test.security.common.other.SimpleSocketBinding;
+
+/**
+ * Tests Elytron Kerberos remoting (GSSAPI and GS2-KRB5* SASL mechanism) through HTTP management interface.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(WildflyTestRunner.class)
+@org.wildfly.core.testrunner.ServerSetup({ AbstractKerberosMgmtSaslTestBase.Krb5ConfServerSetupTask.class, //
+        KerberosSystemPropertiesSetupTask.class, //
+        AbstractKerberosMgmtSaslTestBase.DirectoryServerSetupTask.class, //
+        AbstractKerberosMgmtSaslTestBase.KeyMaterialSetup.class, //
+        KerberosHttpMgmtSaslTestCase.ServerSetup.class })
+public class KerberosHttpMgmtSaslTestCase extends AbstractKerberosMgmtSaslTestBase {
+
+    private static final String NAME = KerberosHttpMgmtSaslTestCase.class.getSimpleName();
+
+    private static final ModelControllerClient client = ModelControllerClient.Factory
+            .create(new ModelControllerClientConfiguration.Builder().setHostName(CoreUtils.getDefaultHost(false))
+                    .setPort(PORT_NATIVE).setProtocol("remote").setConnectionTimeout(CONNECTION_TIMEOUT_IN_MS).build());
+
+    /**
+     * Configures test sasl-server-factory to use given mechanism. It also enables/disables SSL based on provided flag.
+     */
+    @Override
+    protected AutoCloseable configureSaslMechanismOnServer(String mechanism, boolean withSsl) throws Exception {
+        HttpMgmtConfigurator.Builder httpMgmtConfigBuilder = HttpMgmtConfigurator.builder().withSaslAuthenticationFactory(NAME);
+        configurePatternFilter(mechanism);
+        if (withSsl) {
+            httpMgmtConfigBuilder.withSslContext(NAME).withSecureSocketBinding("management-https");
+        }
+        final HttpMgmtConfigurator httpMgmtConfig = httpMgmtConfigBuilder.build();
+        httpMgmtConfig.create(client, null);
+
+        ServerReload.executeReloadAndWaitForCompletion(client, 30 * 1000, false, "remote",
+                TestSuiteEnvironment.getServerAddress(), PORT_NATIVE);
+        return () -> {
+            httpMgmtConfig.remove(client, null);
+            ServerReload.executeReloadAndWaitForCompletion(client, 30 * 1000, false, "remote",
+                    TestSuiteEnvironment.getServerAddress(), PORT_NATIVE);
+        };
+    }
+
+    /**
+     * @param mechanism
+     * @throws Exception
+     */
+    private void configurePatternFilter(String mechanism) throws Exception {
+        ModelNode op = Util.createEmptyOperation("write-attribute",
+                PathAddress.pathAddress().append("subsystem", "elytron").append("configurable-sasl-server-factory", NAME));
+        op.get("name").set("filters");
+        ModelNode newValue = new ModelNode();
+        newValue.get("pattern-filter").set(mechanism);
+        op.get("value").add(newValue);
+        CoreUtils.applyUpdate(op, client);
+    }
+
+    @Override
+    protected ModelNode executeWhoAmI(boolean withTls) throws IOException, GeneralSecurityException {
+        ModelControllerClientConfiguration.Builder clientConfigBuilder = new ModelControllerClientConfiguration.Builder()
+                .setHostName(CoreUtils.getDefaultHost(false)).setPort(withTls ? 9993 : 9990)
+                .setProtocol(withTls ? "https-remoting" : "http-remoting").setConnectionTimeout(CONNECTION_TIMEOUT_IN_MS);
+        if (withTls) {
+            clientConfigBuilder.setSslContext(sslFactory.create());
+        }
+        ModelControllerClient client = ModelControllerClient.Factory.create(clientConfigBuilder.build());
+
+        ModelNode operation = new ModelNode();
+        operation.get("operation").set("whoami");
+        operation.get("verbose").set("true");
+
+        return client.execute(operation);
+    }
+
+
+    /**
+     * Setup task which configures Elytron security domains and remoting connectors for this test.
+     */
+    public static class ServerSetup extends TestRunnerConfigSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            List<ConfigurableElement> elements = new ArrayList<>();
+
+            elements.add(ConstantPermissionMapper.builder().withName(NAME)
+                    .withPermissions(PermissionRef.fromPermission(new LoginPermission())).build());
+
+            final CredentialReference credentialReference = CredentialReference.builder().withClearText(KEYSTORE_PASSWORD)
+                    .build();
+
+            // KeyStores
+            final SimpleKeyStore.Builder ksCommon = SimpleKeyStore.builder().withType("JKS")
+                    .withCredentialReference(credentialReference);
+            elements.add(ksCommon.withName("server-keystore")
+                    .withPath(CliPath.builder().withPath(SERVER_KEYSTORE_FILE.getAbsolutePath()).build()).build());
+            elements.add(ksCommon.withName("server-truststore")
+                    .withPath(CliPath.builder().withPath(SERVER_TRUSTSTORE_FILE.getAbsolutePath()).build()).build());
+
+            // Key and Trust Managers
+            elements.add(SimpleKeyManager.builder().withName("server-keymanager").withCredentialReference(credentialReference)
+                    .withKeyStore("server-keystore").build());
+            elements.add(
+                    SimpleTrustManager.builder().withName("server-trustmanager").withKeyStore("server-truststore").build());
+
+            // dir-context
+            elements.add(DirContext.builder().withName(NAME).withUrl(LDAP_URL).withPrincipal("uid=admin,ou=system")
+                    .withCredentialReference(CredentialReference.builder().withClearText("secret").build()).build());
+            // ldap-realm
+            elements.add(LdapRealm.builder()
+                    .withName(NAME).withDirContext(NAME).withIdentityMapping(IdentityMapping.builder()
+                            .withRdnIdentifier("krb5PrincipalName").withSearchBaseDn("ou=Users,dc=wildfly,dc=org").build())
+                    .build());
+            // security-domain
+            elements.add(SimpleSecurityDomain.builder().withName(NAME).withDefaultRealm(NAME).withPermissionMapper(NAME)
+                    .withRealms(SecurityDomainRealm.builder().withRealm(NAME).build()).build());
+            elements.add(AccessIdentityConfigurator.builder().build());
+
+            // kerberos-security-factory
+            elements.add(
+                    KerberosSecurityFactory.builder()
+                            .withName(NAME).withPrincipal(Krb5ConfServerSetupTask.REMOTE_PRINCIPAL).withCliPath(CliPath
+                                    .builder().withPath(Krb5ConfServerSetupTask.REMOTE_KEYTAB_FILE.getAbsolutePath()).build())
+                            .build());
+
+            // SASL Authentication
+            elements.add(SimpleConfigurableSaslServerFactory.builder().withName(NAME).withSaslServerFactory("elytron").build());
+            MechanismConfiguration.Builder mechConfigBuilder = MechanismConfiguration.builder()
+                    .addMechanismRealmConfiguration(MechanismRealmConfiguration.builder().withRealmName(NAME).build())
+                    .withCredentialSecurityFactory(NAME);
+            elements.add(SimpleSaslAuthenticationFactory.builder().withName(NAME).withSaslServerFactory(NAME)
+                    .withSecurityDomain(NAME).addMechanismConfiguration(mechConfigBuilder.withMechanismName("GSSAPI").build())
+                    .addMechanismConfiguration(mechConfigBuilder.withMechanismName("GS2-KRB5").build())
+                    .addMechanismConfiguration(mechConfigBuilder.withMechanismName("GS2-KRB5-PLUS").build())
+                    .addMechanismConfiguration(MechanismConfiguration.builder().build()).build());
+
+            // Socket binding and native management interface
+            elements.add(SimpleSocketBinding.builder().withName(NAME).withPort(PORT_NATIVE).build());
+            elements.add(SimpleMgmtNativeInterface.builder().withSocketBinding(NAME)
+                    .withSaslAuthenticationFactory("management-sasl-authentication").build());
+
+            // SSLContext
+            elements.add(SimpleServerSslContext.builder().withName(NAME).withKeyManagers("server-keymanager")
+                    .withTrustManagers("server-trustmanager").build());
+
+            // HTTP(s) management interface
+            // elements.add(HttpMgmtConfigurator.builder().withSaslAuthenticationFactory(NAME).build());
+
+            return elements.toArray(new ConfigurableElement[elements.size()]);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosNativeMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/KerberosNativeMgmtSaslTestCase.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.elytron.sasl.mgmt;
+
+import static org.jboss.as.test.integration.security.common.SecurityTestConstants.KEYSTORE_PASSWORD;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.ModelControllerClientConfiguration;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.security.auth.permission.LoginPermission;
+import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
+import org.wildfly.test.security.common.elytron.CliPath;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+import org.wildfly.test.security.common.elytron.ConstantPermissionMapper;
+import org.wildfly.test.security.common.elytron.CredentialReference;
+import org.wildfly.test.security.common.elytron.DirContext;
+import org.wildfly.test.security.common.elytron.IdentityMapping;
+import org.wildfly.test.security.common.elytron.KerberosSecurityFactory;
+import org.wildfly.test.security.common.elytron.LdapRealm;
+import org.wildfly.test.security.common.elytron.MechanismConfiguration;
+import org.wildfly.test.security.common.elytron.MechanismRealmConfiguration;
+import org.wildfly.test.security.common.elytron.PermissionRef;
+import org.wildfly.test.security.common.elytron.SimpleConfigurableSaslServerFactory;
+import org.wildfly.test.security.common.elytron.SimpleKeyManager;
+import org.wildfly.test.security.common.elytron.SimpleKeyStore;
+import org.wildfly.test.security.common.elytron.SimpleSaslAuthenticationFactory;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain;
+import org.wildfly.test.security.common.elytron.SimpleSecurityDomain.SecurityDomainRealm;
+import org.wildfly.test.security.common.elytron.SimpleServerSslContext;
+import org.wildfly.test.security.common.elytron.SimpleTrustManager;
+import org.wildfly.test.security.common.kerberos.KerberosSystemPropertiesSetupTask;
+import org.wildfly.test.security.common.other.AccessIdentityConfigurator;
+import org.wildfly.test.security.common.other.SimpleMgmtNativeInterface;
+import org.wildfly.test.security.common.other.SimpleSocketBinding;
+
+/**
+ * Tests Elytron Kerberos remoting (GSSAPI and GS2-KRB5* SASL mechanism) through management interface.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(WildflyTestRunner.class)
+@org.wildfly.core.testrunner.ServerSetup({ AbstractKerberosMgmtSaslTestBase.Krb5ConfServerSetupTask.class, //
+        KerberosSystemPropertiesSetupTask.class, //
+        AbstractKerberosMgmtSaslTestBase.DirectoryServerSetupTask.class, //
+        AbstractKerberosMgmtSaslTestBase.KeyMaterialSetup.class, //
+        KerberosNativeMgmtSaslTestCase.ServerSetup.class })
+public class KerberosNativeMgmtSaslTestCase extends AbstractKerberosMgmtSaslTestBase {
+
+
+    private static final String NAME = KerberosNativeMgmtSaslTestCase.class.getSimpleName();
+
+    /**
+     * Configures test sasl-server-factory to use given mechanism. It also enables/disables SSL based on provided flag.
+     */
+    @Override
+    protected AutoCloseable configureSaslMechanismOnServer(String mechanism, boolean withSsl) throws Exception {
+        try (CLIWrapper cli = new CLIWrapper(true)) {
+            cli.sendLine(String.format(
+                    "/subsystem=elytron/configurable-sasl-server-factory=%s:write-attribute(name=filters, value=[{pattern-filter=%s}])",
+                    NAME, mechanism));
+            String sslContextCli = withSsl ? String.format(
+                    "/core-service=management/management-interface=native-interface:write-attribute(name=ssl-context, value=%s)",
+                    NAME) : "/core-service=management/management-interface=native-interface:write-attribute(name=ssl-context)";
+            cli.sendLine(sslContextCli);
+        }
+        ServerReload.reloadIfRequired(TestSuiteEnvironment.getModelControllerClient());
+        return ()->LOGGER.debug("No cleanup needed after the test.");
+    }
+
+    @Override
+    protected ModelNode executeWhoAmI(boolean withTls) throws IOException, GeneralSecurityException {
+        ModelControllerClientConfiguration.Builder clientConfigBuilder = new ModelControllerClientConfiguration.Builder()
+                .setHostName(CoreUtils.getDefaultHost(false)).setPort(PORT_NATIVE)
+                .setProtocol("remote").setConnectionTimeout(CONNECTION_TIMEOUT_IN_MS);
+        if (withTls) {
+            clientConfigBuilder.setSslContext(sslFactory.create());
+        }
+        ModelControllerClient client = ModelControllerClient.Factory.create(clientConfigBuilder.build());
+
+        ModelNode operation = new ModelNode();
+        operation.get("operation").set("whoami");
+        operation.get("verbose").set("true");
+
+        return client.execute(operation);
+    }
+
+    /**
+     * Setup task which configures Elytron security domains and remoting connectors for this test.
+     */
+    public static class ServerSetup extends TestRunnerConfigSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            List<ConfigurableElement> elements = new ArrayList<>();
+
+            elements.add(ConstantPermissionMapper.builder().withName(NAME)
+                    .withPermissions(PermissionRef.fromPermission(new LoginPermission())).build());
+
+            final CredentialReference credentialReference = CredentialReference.builder().withClearText(KEYSTORE_PASSWORD)
+                    .build();
+
+            // KeyStores
+            final SimpleKeyStore.Builder ksCommon = SimpleKeyStore.builder().withType("JKS")
+                    .withCredentialReference(credentialReference);
+            elements.add(ksCommon.withName("server-keystore")
+                    .withPath(CliPath.builder().withPath(SERVER_KEYSTORE_FILE.getAbsolutePath()).build()).build());
+            elements.add(ksCommon.withName("server-truststore")
+                    .withPath(CliPath.builder().withPath(SERVER_TRUSTSTORE_FILE.getAbsolutePath()).build()).build());
+
+            // Key and Trust Managers
+            elements.add(SimpleKeyManager.builder().withName("server-keymanager").withCredentialReference(credentialReference)
+                    .withKeyStore("server-keystore").build());
+            elements.add(
+                    SimpleTrustManager.builder().withName("server-trustmanager").withKeyStore("server-truststore").build());
+
+            // dir-context
+            elements.add(DirContext.builder().withName(NAME).withUrl(LDAP_URL).withPrincipal("uid=admin,ou=system")
+                    .withCredentialReference(CredentialReference.builder().withClearText("secret").build()).build());
+            // ldap-realm
+            elements.add(LdapRealm
+                    .builder().withName(NAME).withDirContext(NAME).withIdentityMapping(IdentityMapping.builder()
+                            .withRdnIdentifier("krb5PrincipalName").withSearchBaseDn("ou=Users,dc=wildfly,dc=org").build())
+                    .build());
+            // security-domain
+            elements.add(SimpleSecurityDomain.builder().withName(NAME).withDefaultRealm(NAME).withPermissionMapper(NAME)
+                    .withRealms(SecurityDomainRealm.builder().withRealm(NAME).build()).build());
+            elements.add(AccessIdentityConfigurator.builder().build());
+
+            // kerberos-security-factory
+            elements.add(KerberosSecurityFactory.builder().withName(NAME)
+                    .withPrincipal(Krb5ConfServerSetupTask.REMOTE_PRINCIPAL)
+                    .withCliPath(
+                            CliPath.builder().withPath(Krb5ConfServerSetupTask.REMOTE_KEYTAB_FILE.getAbsolutePath()).build())
+                    .build());
+
+            // SASL Authentication
+            elements.add(SimpleConfigurableSaslServerFactory.builder().withName(NAME).withSaslServerFactory("elytron").build());
+            MechanismConfiguration.Builder mechConfigBuilder = MechanismConfiguration.builder()
+                    .addMechanismRealmConfiguration(MechanismRealmConfiguration.builder().withRealmName(NAME).build())
+                    .withCredentialSecurityFactory(NAME);
+            elements.add(SimpleSaslAuthenticationFactory.builder().withName(NAME).withSaslServerFactory(NAME)
+                    .withSecurityDomain(NAME).addMechanismConfiguration(mechConfigBuilder.withMechanismName("GSSAPI").build())
+                    .addMechanismConfiguration(mechConfigBuilder.withMechanismName("GS2-KRB5").build())
+                    .addMechanismConfiguration(mechConfigBuilder.withMechanismName("GS2-KRB5-PLUS").build()).build());
+
+            // SSLContext
+            elements.add(SimpleServerSslContext.builder().withName(NAME).withKeyManagers("server-keymanager")
+                    .withTrustManagers("server-trustmanager").build());
+
+            // Socket binding and native management interface
+            elements.add(SimpleSocketBinding.builder().withName(NAME).withPort(PORT_NATIVE).build());
+            elements.add(SimpleMgmtNativeInterface.builder().withSocketBinding(NAME).withSaslAuthenticationFactory(NAME)
+                    .withSslContext(NAME).build());
+
+            return elements.toArray(new ConfigurableElement[elements.size()]);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/AbstractSystemPropertiesServerSetupTask.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/AbstractSystemPropertiesServerSetupTask.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetupTask;
+
+/**
+ * {@link ServerSetupTask} instance for system properties setup.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractSystemPropertiesServerSetupTask implements ServerSetupTask {
+
+    private static final Logger LOGGER = Logger.getLogger(AbstractSystemPropertiesServerSetupTask.class);
+
+    private Map<String, String> systemProperties;
+
+    // Public methods --------------------------------------------------------
+
+    public final void setup(final ManagementClient managementClient) throws Exception {
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.trace("Adding system properties.");
+        }
+        systemProperties = getSystemProperties();
+        if (systemProperties == null || systemProperties.isEmpty()) {
+            LOGGER.warn("No system property configured in the ServerSetupTask");
+            return;
+        }
+
+        final List<ModelNode> updates = new ArrayList<ModelNode>();
+
+        for (Map.Entry<String, String> systemProperty : systemProperties.entrySet()) {
+            final String propertyName = systemProperty.getKey();
+            if (propertyName == null || propertyName.trim().length() == 0) {
+                LOGGER.warn("Empty property name provided.");
+                continue;
+            }
+            ModelNode op = new ModelNode();
+            op.get(OP).set(ADD);
+            op.get(OP_ADDR).add(SYSTEM_PROPERTY, propertyName);
+            op.get(ModelDescriptionConstants.VALUE).set(systemProperty.getValue());
+            updates.add(op);
+        }
+        CoreUtils.applyUpdates(updates, managementClient.getControllerClient());
+    }
+
+    /**
+     *
+     * @param managementClient
+     * @param containerId
+     * @see org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup#tearDown(org.jboss.as.arquillian.container.ManagementClient,
+     *      java.lang.String)
+     */
+    public final void tearDown(ManagementClient managementClient) throws Exception {
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.trace("Removing system properties.");
+        }
+        if (systemProperties == null || systemProperties.isEmpty()) {
+            return;
+        }
+
+        final List<ModelNode> updates = new ArrayList<ModelNode>();
+
+        for (Map.Entry<String, String> systemProperty : systemProperties.entrySet()) {
+            final String propertyName = systemProperty.getKey();
+            if (propertyName == null || propertyName.trim().length() == 0) {
+                continue;
+            }
+            ModelNode op = new ModelNode();
+            op.get(OP).set(REMOVE);
+            op.get(OP_ADDR).add(SYSTEM_PROPERTY, propertyName);
+            updates.add(op);
+        }
+        CoreUtils.applyUpdates(updates, managementClient.getControllerClient());
+
+    }
+
+
+    // Protected methods -----------------------------------------------------
+
+    /**
+     * Returns configuration of the login modules.
+     *
+     * @return
+     */
+    protected abstract Map<String, String> getSystemProperties();
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/ModelNodeUtil.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/ModelNodeUtil.java
@@ -16,7 +16,10 @@
 
 package org.wildfly.test.security.common;
 
+import java.util.Map;
+
 import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.elytron.ModelNodeConvertable;
 
 /**
  * Helper methods for {@link ModelNode} class.
@@ -64,4 +67,48 @@ public class ModelNodeUtil {
         }
     }
 
+    /**
+     * Set list attribute of given node if the value is not-<code>null</code>.
+     */
+    public static void setIfNotNull(ModelNode node, String attribute, Map<String, String> objectValue) {
+        if (objectValue != null) {
+            ModelNode objectNode = node.get(attribute);
+            for (Map.Entry<String, String> entry : objectValue.entrySet()) {
+                objectNode.get(entry.getKey()).set(entry.getValue());
+            }
+        }
+    }
+
+    /**
+     * Adds given items to list attribute.
+     */
+    public static void setIfNotNull(ModelNode node, String attribute, ModelNodeConvertable... items) {
+        if (items != null && items.length > 0) {
+            ModelNode listNode = node.get(attribute);
+            for (ModelNodeConvertable item : items) {
+                listNode.add(item.toModelNode());
+            }
+        }
+    }
+
+    /**
+     * Set attribute of given node if the value is not-<code>null</code>.
+     */
+    public static void setIfNotNull(ModelNode node, String attribute, Long value) {
+        if (value != null) {
+            node.get(attribute).set(value.longValue());
+        }
+    }
+
+    /**
+     * Set attribute of given node if the value is not-<code>null</code>.
+     */
+    public static void setIfNotNull(ModelNode node, String attribute, ModelNodeConvertable value) {
+        if (value != null) {
+            ModelNode modelNode = value.toModelNode();
+            if (modelNode != null) {
+                node.get(attribute).set(modelNode);
+            }
+        }
+    }
 }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/AttributeMapping.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/AttributeMapping.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represantation of an attribute-mapping configuration in ldap-realm/identity-mapping.
+ *
+ * @author Josef Cacek
+ */
+public class AttributeMapping implements ModelNodeConvertable {
+
+    private final String from;
+    private final String to;
+    private final String reference;
+    private final String filter;
+    private final String filterBaseDn;
+    private final Boolean searchRecursive;
+    private final Integer roleRecursion;
+    private final String roleRecursionName;
+    private final String extractRdn;
+
+
+    private AttributeMapping(Builder builder) {
+        this.from = builder.from;
+        this.to = builder.to;
+        this.reference = builder.reference;
+        this.filter = builder.filter;
+        this.filterBaseDn = builder.filterBaseDn;
+        this.searchRecursive = builder.searchRecursive;
+        this.roleRecursion = builder.roleRecursion;
+        this.roleRecursionName = builder.roleRecursionName;
+        this.extractRdn = builder.extractRdn;
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        ModelNode modelNode = new ModelNode();
+        setIfNotNull(modelNode, "from", from);
+        setIfNotNull(modelNode, "to", to);
+        setIfNotNull(modelNode, "reference", reference);
+        setIfNotNull(modelNode, "filter", filter);
+        setIfNotNull(modelNode, "filter-base-dn", filterBaseDn);
+        setIfNotNull(modelNode, "search-recursive", searchRecursive);
+        setIfNotNull(modelNode, "role-recursion", roleRecursion);
+        setIfNotNull(modelNode, "role-recursion-name", roleRecursionName);
+        setIfNotNull(modelNode, "extract-rdn", extractRdn);
+        return modelNode;
+    }
+
+    /**
+     * Creates builder to build {@link AttributeMapping}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+    /**
+     * Builder to build {@link AttributeMapping}.
+     */
+    public static final class Builder {
+        private String from;
+        private String to;
+        private String reference;
+        private String filter;
+        private String filterBaseDn;
+        private Boolean searchRecursive;
+        private Integer roleRecursion;
+        private String roleRecursionName;
+        private String extractRdn;
+
+        private Builder() {
+        }
+
+        public Builder withFrom(String from) {
+            this.from = from;
+            return this;
+        }
+
+        public Builder withTo(String to) {
+            this.to = to;
+            return this;
+        }
+
+        public Builder withReference(String reference) {
+            this.reference = reference;
+            return this;
+        }
+
+        public Builder withFilter(String filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder withFilterBaseDn(String filterBaseDn) {
+            this.filterBaseDn = filterBaseDn;
+            return this;
+        }
+
+        public Builder withSearchRecursive(Boolean searchRecursive) {
+            this.searchRecursive = searchRecursive;
+            return this;
+        }
+
+        public Builder withRoleRecursion(Integer roleRecursion) {
+            this.roleRecursion = roleRecursion;
+            return this;
+        }
+
+        public Builder withRoleRecursionName(String roleRecursionName) {
+            this.roleRecursionName = roleRecursionName;
+            return this;
+        }
+
+        public Builder withExtractRdn(String extractRdn) {
+            this.extractRdn = extractRdn;
+            return this;
+        }
+
+        public AttributeMapping build() {
+            return new AttributeMapping(this);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/ConstantRealmMapper.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/ConstantRealmMapper.java
@@ -45,7 +45,7 @@ public class ConstantRealmMapper extends AbstractConfigurableElement {
     @Override
     public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
         ModelNode op = Util.createAddOperation(PATH_ELYTRON.append(CONSTANT_REALM_MAPPER, name));
-        ModelNode rolesNode = op.get("realm").set(realm);
+        op.get("realm").set(realm);
         CoreUtils.applyUpdate(op, client);
     }
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/CredentialReference.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/CredentialReference.java
@@ -17,30 +17,35 @@
 package org.wildfly.test.security.common.elytron;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import org.jboss.dmr.ModelNode;
 
 /**
  * Helper class for adding "credential-reference" attributes into CLI commands.
  *
  * @author Josef Cacek
  */
-public class CredentialReference implements CliFragment {
+public class CredentialReference implements CliFragment, ModelNodeConvertable {
 
     public static final CredentialReference EMPTY = CredentialReference.builder().build();
 
     private final String store;
     private final String alias;
+    private final String type;
     private final String clearText;
 
     private CredentialReference(Builder builder) {
         this.store = builder.store;
         this.alias = builder.alias;
+        this.type = builder.type;
         this.clearText = builder.clearText;
     }
 
     @Override
     public String asString() {
         StringBuilder sb = new StringBuilder();
-        if (isNotBlank(alias) || isNotBlank(clearText) || isNotBlank(store)) {
+        if (isNotBlank(alias) || isNotBlank(clearText) || isNotBlank(store) || isNotBlank(type)) {
             sb.append("credential-reference={ ");
             if (isNotBlank(alias)) {
                 sb.append(String.format("alias=\"%s\", ", alias));
@@ -48,12 +53,28 @@ public class CredentialReference implements CliFragment {
             if (isNotBlank(store)) {
                 sb.append(String.format("store=\"%s\", ", store));
             }
+            if (isNotBlank(type)) {
+                sb.append(String.format("type=\"%s\", ", type));
+            }
             if (isNotBlank(clearText)) {
                 sb.append(String.format("clear-text=\"%s\"", clearText));
             }
             sb.append("}, ");
         }
         return sb.toString();
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        if (this == EMPTY) {
+            return null;
+        }
+        final ModelNode node= new ModelNode();
+        setIfNotNull(node, "store", store);
+        setIfNotNull(node, "alias", alias);
+        setIfNotNull(node, "type", type);
+        setIfNotNull(node, "clear-text", clearText);
+        return node;
     }
 
     /**
@@ -71,6 +92,7 @@ public class CredentialReference implements CliFragment {
     public static final class Builder {
         private String store;
         private String alias;
+        private String type;
         private String clearText;
 
         private Builder() {
@@ -86,6 +108,11 @@ public class CredentialReference implements CliFragment {
             return this;
         }
 
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
         public Builder withClearText(String clearText) {
             this.clearText = clearText;
             return this;
@@ -95,5 +122,4 @@ public class CredentialReference implements CliFragment {
             return new CredentialReference(this);
         }
     }
-
 }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/DirContext.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/DirContext.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Elytron 'dir-context' configuration.
+ *
+ * @author Josef Cacek
+ */
+public class DirContext extends AbstractConfigurableElement {
+
+    private final String url;
+    private final String authenticationContext;
+    private final String authenticationLevel;
+    private final Long connectionTimeout;
+    private final CredentialReference credentialReference;
+    private final Boolean enableConnectionPooling;
+    private final String module;
+    private final String principal;
+    private final Map<String, String> properties;
+    private final Long readTimeout;
+    private final String referralMode;
+    private final String sslContext;
+
+    private DirContext(Builder builder) {
+        super(builder);
+        this.url = Objects.requireNonNull(builder.url, "URL in Elytron dir-context configuration has to be provided.");
+        this.authenticationContext = builder.authenticationContext;
+        this.authenticationLevel = builder.authenticationLevel;
+        this.connectionTimeout = builder.connectionTimeout;
+        this.credentialReference = builder.credentialReference;
+        this.enableConnectionPooling = builder.enableConnectionPooling;
+        this.module = builder.module;
+        this.principal = builder.principal;
+        this.properties = new HashMap<>(builder.properties);
+        this.readTimeout = builder.readTimeout;
+        this.referralMode = builder.referralMode;
+        this.sslContext = builder.sslContext;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util
+                .createAddOperation(PathAddress.pathAddress().append("subsystem", "elytron").append("dir-context", name));
+        op.get("url").set(url);
+        setIfNotNull(op, "authentication-context", authenticationContext);
+        setIfNotNull(op, "authentication-level", authenticationLevel);
+        setIfNotNull(op, "connection-timeout", connectionTimeout);
+        setIfNotNull(op, "credential-reference", credentialReference);
+        setIfNotNull(op, "enable-connection-pooling", enableConnectionPooling);
+        setIfNotNull(op, "module", module);
+        setIfNotNull(op, "principal", principal);
+        setIfNotNull(op, "properties", properties);
+        setIfNotNull(op, "read-timeout", readTimeout);
+        setIfNotNull(op, "referral-mode", referralMode);
+        setIfNotNull(op, "ssl-context", sslContext);
+
+        CoreUtils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        CoreUtils.applyUpdate(Util.createRemoveOperation(
+                PathAddress.pathAddress().append("subsystem", "elytron").append("dir-context", name)), client);
+    }
+
+    /**
+     * Creates builder to build {@link DirContext}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link DirContext}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private String authenticationContext;
+        private String authenticationLevel;
+        private Long connectionTimeout;
+        private CredentialReference credentialReference;
+        private Boolean enableConnectionPooling;
+        private String module;
+        private String principal;
+        private Map<String, String> properties = new HashMap<String, String>();
+        private Long readTimeout;
+        private String referralMode;
+        private String sslContext;
+        private String url;
+
+        private Builder() {
+        }
+
+        public Builder withAuthenticationContext(String authenticationContext) {
+            this.authenticationContext = authenticationContext;
+            return self();
+        }
+
+        public Builder withAuthenticationLevel(String authenticationLevel) {
+            this.authenticationLevel = authenticationLevel;
+            return self();
+        }
+
+        public Builder withConnectionTimeout(Long connectionTimeout) {
+            this.connectionTimeout = connectionTimeout;
+            return self();
+        }
+
+        public Builder withCredentialReference(CredentialReference credentialReference) {
+            this.credentialReference = credentialReference;
+            return self();
+        }
+
+        public Builder withEnableConnectionPooling(Boolean enableConnectionPooling) {
+            this.enableConnectionPooling = enableConnectionPooling;
+            return self();
+        }
+
+        public Builder withModule(String module) {
+            this.module = module;
+            return self();
+        }
+
+        public Builder withPrincipal(String principal) {
+            this.principal = principal;
+            return self();
+        }
+
+        public Builder addProperty(String key, String value) {
+            this.properties.put(key, value);
+            return self();
+        }
+
+        public Builder withReadTimeout(Long readTimeout) {
+            this.readTimeout = readTimeout;
+            return self();
+        }
+
+        public Builder withReferralMode(String referralMode) {
+            this.referralMode = referralMode;
+            return self();
+        }
+
+        public Builder withSslContext(String sslContext) {
+            this.sslContext = sslContext;
+            return self();
+        }
+
+        public Builder withUrl(String url) {
+            this.url = url;
+            return self();
+        }
+
+        public DirContext build() {
+            return new DirContext(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/IdentityMapping.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/IdentityMapping.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represantation of identity-mapping configuration in ldap-realm.
+ *
+ * @author Josef Cacek
+ */
+public class IdentityMapping implements ModelNodeConvertable {
+
+    private final String rdnIdentifier;
+    private final Boolean useRecursiveSearch;
+    private final String searchBaseDn;
+    private final AttributeMapping[] attributeMapping;
+    private final String filterName;
+    private final String iteratorFilter;
+    private final String newIdentityParentDn;
+    private final NameValue[] newIdentityAttributes;
+    private final UserPasswordMapper userPasswordMapper;
+    private final OtpCredentialMapper otpCredentialMapper;
+    private final X509CredentialMapper x509CredentialMapper;
+
+
+    private IdentityMapping(Builder builder) {
+        this.rdnIdentifier = Objects.requireNonNull(builder.rdnIdentifier, "The rdn-identifier has to be provided in identity-mapping.");
+        this.useRecursiveSearch = builder.useRecursiveSearch;
+        this.searchBaseDn = builder.searchBaseDn;
+        this.attributeMapping = builder.attributeMapping.toArray(new AttributeMapping[builder.attributeMapping.size()]);
+        this.filterName = builder.filterName;
+        this.iteratorFilter = builder.iteratorFilter;
+        this.newIdentityParentDn = builder.newIdentityParentDn;
+        this.newIdentityAttributes = builder.newIdentityAttributes;
+        this.userPasswordMapper = builder.userPasswordMapper;
+        this.otpCredentialMapper = builder.otpCredentialMapper;
+        this.x509CredentialMapper = builder.x509CredentialMapper;
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        ModelNode modelNode = new ModelNode();
+        modelNode.get("rdn-identifier").set(rdnIdentifier);
+        setIfNotNull(modelNode, "use-recursive-search", useRecursiveSearch);
+        setIfNotNull(modelNode, "search-base-dn", searchBaseDn);
+        setIfNotNull(modelNode, "attribute-mapping", attributeMapping);
+        setIfNotNull(modelNode, "filter-name", filterName);
+        setIfNotNull(modelNode, "iterator-filter", iteratorFilter);
+        setIfNotNull(modelNode, "new-identity-parent-dn", newIdentityParentDn);
+        setIfNotNull(modelNode, "new-identity-attributes", newIdentityAttributes);
+        setIfNotNull(modelNode, "user-password-mapper", userPasswordMapper);
+        setIfNotNull(modelNode, "otp-credential-mapper", otpCredentialMapper);
+        setIfNotNull(modelNode, "x509-credential-mapper", x509CredentialMapper);
+        return modelNode;
+    }
+
+    /**
+     * Creates builder to build {@link IdentityMapping}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+    /**
+     * Builder to build {@link IdentityMapping}.
+     */
+    public static final class Builder {
+        private String rdnIdentifier;
+        private Boolean useRecursiveSearch;
+        private String searchBaseDn;
+        private List<AttributeMapping> attributeMapping = new ArrayList<>();
+        private String filterName;
+        private String iteratorFilter;
+        private String newIdentityParentDn;
+        private NameValue[] newIdentityAttributes;
+        private UserPasswordMapper userPasswordMapper;
+        private OtpCredentialMapper otpCredentialMapper;
+        private X509CredentialMapper x509CredentialMapper;
+
+        private Builder() {
+        }
+
+        public Builder withRdnIdentifier(String rdnIdentifier) {
+            this.rdnIdentifier = rdnIdentifier;
+            return this;
+        }
+
+        public Builder withUseRecursiveSearch(Boolean useRecursiveSearch) {
+            this.useRecursiveSearch = useRecursiveSearch;
+            return this;
+        }
+
+        public Builder withSearchBaseDn(String searchBaseDn) {
+            this.searchBaseDn = searchBaseDn;
+            return this;
+        }
+
+        public Builder addAttributeMapping(AttributeMapping attributeMapping) {
+            this.attributeMapping.add(attributeMapping);
+            return this;
+        }
+
+        public Builder withFilterName(String filterName) {
+            this.filterName = filterName;
+            return this;
+        }
+
+        public Builder withIteratorFilter(String iteratorFilter) {
+            this.iteratorFilter = iteratorFilter;
+            return this;
+        }
+
+        public Builder withNewIdentityParentDn(String newIdentityParentDn) {
+            this.newIdentityParentDn = newIdentityParentDn;
+            return this;
+        }
+
+        public Builder withNewIdentityAttributes(NameValue... newIdentityAttributes) {
+            this.newIdentityAttributes = newIdentityAttributes;
+            return this;
+        }
+
+        public Builder withUserPasswordMapper(UserPasswordMapper userPasswordMapper) {
+            this.userPasswordMapper = userPasswordMapper;
+            return this;
+        }
+
+        public Builder withOtpCredentialMapper(OtpCredentialMapper otpCredentialMapper) {
+            this.otpCredentialMapper = otpCredentialMapper;
+            return this;
+        }
+
+        public Builder withX509CredentialMapper(X509CredentialMapper x509CredentialMapper) {
+            this.x509CredentialMapper = x509CredentialMapper;
+            return this;
+        }
+
+        public IdentityMapping build() {
+            return new IdentityMapping(this);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/KerberosSecurityFactory.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/KerberosSecurityFactory.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.Map;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Elytron 'kerberos-security-factory' configuration helper.
+ *
+ * @author Josef Cacek
+ */
+public class KerberosSecurityFactory extends AbstractConfigurableElement {
+
+    private final Boolean debug;
+    private final String[] mechanismNames;
+    private final String[] mechanismOids;
+    private final Integer minimumRemainingLifetime;
+    private final Boolean obtainKerberosTicket;
+    private final Map<String, String> options;
+    private final String principal;
+    private final Integer requestLifetime;
+    private final Boolean server;
+    private final Boolean wrapGssCredential;
+    private final CliPath cliPath;
+
+    private KerberosSecurityFactory(Builder builder) {
+        super(builder);
+        this.debug = builder.debug;
+        this.mechanismNames = builder.mechanismNames;
+        this.mechanismOids = builder.mechanismOids;
+        this.minimumRemainingLifetime = builder.minimumRemainingLifetime;
+        this.obtainKerberosTicket = builder.obtainKerberosTicket;
+        this.options = builder.options;
+        this.principal = builder.principal;
+        this.requestLifetime = builder.requestLifetime;
+        this.server = builder.server;
+        this.wrapGssCredential = builder.wrapGssCredential;
+        this.cliPath = builder.cliPath;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util.createAddOperation(
+                PathAddress.pathAddress().append("subsystem", "elytron").append("kerberos-security-factory", name));
+        setIfNotNull(op, "debug", debug);
+        setIfNotNull(op, "mechanism-names", mechanismNames);
+        setIfNotNull(op, "mechanism-oids", mechanismOids);
+        setIfNotNull(op, "minimum-remaining-lifetime", minimumRemainingLifetime);
+        setIfNotNull(op, "obtain-kerberos-ticket", obtainKerberosTicket);
+        setIfNotNull(op, "obtain-kerberos-ticket", obtainKerberosTicket);
+        setIfNotNull(op, "options", options);
+        setIfNotNull(op, "principal", principal);
+        setIfNotNull(op, "request-lifetime", requestLifetime);
+        setIfNotNull(op, "server", server);
+        setIfNotNull(op, "wrap-gss-credential", wrapGssCredential);
+        setIfNotNull(op, "principal", principal);
+        setIfNotNull(op, "path", cliPath.getPath());
+        setIfNotNull(op, "relative-to", cliPath.getRelativeTo());
+
+        CoreUtils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        CoreUtils.applyUpdate(
+                Util.createRemoveOperation(
+                        PathAddress.pathAddress().append("subsystem", "elytron").append("kerberos-security-factory", name)),
+                client);
+    }
+
+    /**
+     * Creates builder to build {@link KerberosSecurityFactory}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link KerberosSecurityFactory}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private Boolean debug;
+        private String[] mechanismNames;
+        private String[] mechanismOids;
+        private Integer minimumRemainingLifetime;
+        private Boolean obtainKerberosTicket;
+        private Map<String, String> options;
+        private String principal;
+        private Integer requestLifetime;
+        private Boolean server;
+        private Boolean wrapGssCredential;
+        private CliPath cliPath;
+
+        private Builder() {
+        }
+
+        public Builder withDebug(Boolean debug) {
+            this.debug = debug;
+            return this;
+        }
+
+        public Builder withMechanismNames(String[] mechanismNames) {
+            this.mechanismNames = mechanismNames;
+            return this;
+        }
+
+        public Builder withMechanismOids(String[] mechanismOids) {
+            this.mechanismOids = mechanismOids;
+            return this;
+        }
+
+        public Builder withMinimumRemainingLifetime(Integer minimumRemainingLifetime) {
+            this.minimumRemainingLifetime = minimumRemainingLifetime;
+            return this;
+        }
+
+        public Builder withObtainKerberosTicket(Boolean obtainKerberosTicket) {
+            this.obtainKerberosTicket = obtainKerberosTicket;
+            return this;
+        }
+
+        public Builder withOptions(Map<String, String> options) {
+            this.options = options;
+            return this;
+        }
+
+        public Builder withPrincipal(String principal) {
+            this.principal = principal;
+            return this;
+        }
+
+        public Builder withRequestLifetime(Integer requestLifetime) {
+            this.requestLifetime = requestLifetime;
+            return this;
+        }
+
+        public Builder withServer(Boolean server) {
+            this.server = server;
+            return this;
+        }
+
+        public Builder withWrapGssCredential(Boolean wrapGssCredential) {
+            this.wrapGssCredential = wrapGssCredential;
+            return this;
+        }
+
+        public Builder withCliPath(CliPath cliPath) {
+            this.cliPath = cliPath;
+            return this;
+        }
+
+        public KerberosSecurityFactory build() {
+            return new KerberosSecurityFactory(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/LdapRealm.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/LdapRealm.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.Objects;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Elytron 'ldap-realm' configuration.
+ *
+ * @author Josef Cacek
+ */
+public class LdapRealm extends AbstractConfigurableElement {
+
+    private final Boolean allowBlankPassword;
+    private final String dirContext;
+    private final Boolean directVerification;
+    private final IdentityMapping identityMapping;
+
+    private LdapRealm(Builder builder) {
+        super(builder);
+        this.allowBlankPassword = builder.allowBlankPassword;
+        this.dirContext = Objects.requireNonNull(builder.dirContext, "The 'dir-context' has to be provided.");
+        this.directVerification = builder.directVerification;
+        this.identityMapping = Objects.requireNonNull(builder.identityMapping, "The 'identity-mapping' has to be provided.");
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode op = Util
+                .createAddOperation(PathAddress.pathAddress().append("subsystem", "elytron").append("ldap-realm", name));
+        op.get("dir-context").set(dirContext);
+        setIfNotNull(op, "allow-blank-password", allowBlankPassword);
+        setIfNotNull(op, "direct-verification", directVerification);
+        setIfNotNull(op, "identity-mapping", identityMapping);
+        CoreUtils.applyUpdate(op, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        CoreUtils.applyUpdate(
+                Util.createRemoveOperation(PathAddress.pathAddress().append("subsystem", "elytron").append("ldap-realm", name)),
+                client);
+    }
+
+    /**
+     * Creates builder to build {@link LdapRealm}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link LdapRealm}.
+     */
+    public static final class Builder extends AbstractConfigurableElement.Builder<Builder> {
+        private Boolean allowBlankPassword;
+        private String dirContext;
+        private Boolean directVerification;
+        private IdentityMapping identityMapping;
+
+        private Builder() {
+        }
+
+        public Builder withAllowBlankPassword(Boolean allowBlankPassword) {
+            this.allowBlankPassword = allowBlankPassword;
+            return this;
+        }
+
+        public Builder withDirContext(String dirContext) {
+            this.dirContext = dirContext;
+            return this;
+        }
+
+        public Builder withDirectVerification(Boolean directVerification) {
+            this.directVerification = directVerification;
+            return this;
+        }
+
+        public Builder withIdentityMapping(IdentityMapping identityMapping) {
+            this.identityMapping = identityMapping;
+            return this;
+        }
+
+        public LdapRealm build() {
+            return new LdapRealm(this);
+        }
+
+        @Override
+        protected Builder self() {
+            return this;
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/MechanismConfiguration.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/MechanismConfiguration.java
@@ -34,12 +34,14 @@ public class MechanismConfiguration extends AbstractMechanismConfiguration {
     private final String hostName;
     private final String protocol;
     private final List<MechanismRealmConfiguration> mechanismRealmConfigurations;
+    private final String credentialSecurityFactory;
 
     private MechanismConfiguration(Builder builder) {
         super(builder);
         this.mechanismName = builder.mechanismName;
         this.hostName = builder.hostName;
         this.protocol = builder.protocol;
+        this.credentialSecurityFactory = builder.credentialSecurityFactory;
         this.mechanismRealmConfigurations = new ArrayList<>(builder.mechanismRealmConfigurations);
     }
 
@@ -74,6 +76,7 @@ public class MechanismConfiguration extends AbstractMechanismConfiguration {
         setIfNotNull(node, "mechanism-name", mechanismName);
         setIfNotNull(node, "host-name", hostName);
         setIfNotNull(node, "protocol", protocol);
+        setIfNotNull(node, "credential-security-factory", credentialSecurityFactory);
         if (!mechanismRealmConfigurations.isEmpty()) {
             ModelNode confs = node.get("mechanism-realm-configurations");
             for (MechanismRealmConfiguration conf:mechanismRealmConfigurations) {
@@ -90,6 +93,7 @@ public class MechanismConfiguration extends AbstractMechanismConfiguration {
         private String mechanismName;
         private String hostName;
         private String protocol;
+        private String credentialSecurityFactory;
         private List<MechanismRealmConfiguration> mechanismRealmConfigurations = new ArrayList<>();
 
         private Builder() {
@@ -107,6 +111,11 @@ public class MechanismConfiguration extends AbstractMechanismConfiguration {
 
         public Builder withProtocol(String protocol) {
             this.protocol = protocol;
+            return this;
+        }
+
+        public Builder withCredentialSecurityFactory(String credentialSecurityFactory) {
+            this.credentialSecurityFactory = credentialSecurityFactory;
             return this;
         }
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/ModelNodeConvertable.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/ModelNodeConvertable.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represents objects which are convertable to ModelNode instances.
+ *
+ * @author Josef Cacek
+ */
+public interface ModelNodeConvertable {
+
+    ModelNode toModelNode();
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/NameValue.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/NameValue.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import java.util.Objects;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Representation of name and value attribute pair in domain model.
+ *
+ * @author Josef Cacek
+ */
+public class NameValue implements ModelNodeConvertable {
+
+    private final String name;
+    private final String value;
+
+    private NameValue(Builder builder) {
+        this.name = Objects.requireNonNull(builder.name, "Value of 'name' attribute has to be provided.");
+        this.value = Objects.requireNonNull(builder.value, "Value of 'value' attribute has to be provided.");
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        final ModelNode node = new ModelNode();
+        node.get("name").set(name);
+        node.get("value").set(value);
+        return null;
+    }
+
+    /**
+     * Creates builder to build {@link NameValue}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static NameValue from(String name, String value) {
+        return builder().withName(name).withValue(value).build();
+    }
+
+    /**
+     * Builder to build {@link NameValue}.
+     */
+    public static final class Builder {
+        private String name;
+        private String value;
+
+        private Builder() {
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withValue(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public NameValue build() {
+            return new NameValue(this);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/OtpCredentialMapper.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/OtpCredentialMapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.Objects;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represantation of an otp-credential-mapper configuration in ldap-realm/identity-mapping.
+ *
+ * @author Josef Cacek
+ */
+public class OtpCredentialMapper implements ModelNodeConvertable {
+
+    private final String algorithmFrom;
+    private final String hashFrom;
+    private final String seedFrom;
+    private final String sequenceFrom;
+
+    private OtpCredentialMapper(Builder builder) {
+        this.algorithmFrom = Objects.requireNonNull(builder.algorithmFrom);
+        this.hashFrom = Objects.requireNonNull(builder.hashFrom);
+        this.seedFrom = Objects.requireNonNull(builder.seedFrom);
+        this.sequenceFrom = Objects.requireNonNull(builder.sequenceFrom);
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        ModelNode modelNode = new ModelNode();
+        setIfNotNull(modelNode, "algorithm-from", algorithmFrom);
+        setIfNotNull(modelNode, "hash-from", hashFrom);
+        setIfNotNull(modelNode, "seed-from", seedFrom);
+        setIfNotNull(modelNode, "sequence-from", sequenceFrom);
+        return modelNode;
+    }
+
+    /**
+     * Creates builder to build {@link OtpCredentialMapper}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link OtpCredentialMapper}.
+     */
+    public static final class Builder {
+        private String algorithmFrom;
+        private String hashFrom;
+        private String seedFrom;
+        private String sequenceFrom;
+
+        private Builder() {
+        }
+
+        public Builder withAlgorithmFrom(String algorithmFrom) {
+            this.algorithmFrom = algorithmFrom;
+            return this;
+        }
+
+        public Builder withHashFrom(String hashFrom) {
+            this.hashFrom = hashFrom;
+            return this;
+        }
+
+        public Builder withSeedFrom(String seedFrom) {
+            this.seedFrom = seedFrom;
+            return this;
+        }
+
+        public Builder withSequenceFrom(String sequenceFrom) {
+            this.sequenceFrom = sequenceFrom;
+            return this;
+        }
+
+        public OtpCredentialMapper build() {
+            return new OtpCredentialMapper(this);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/UserPasswordMapper.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/UserPasswordMapper.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import java.util.Objects;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represantation of a user-password-mapper configuration in ldap-realm/identity-mapping.
+ *
+ * @author Josef Cacek
+ */
+public class UserPasswordMapper implements ModelNodeConvertable {
+
+    private final String from;
+    private final Boolean writable;
+    private final Boolean verifiable;
+
+    private UserPasswordMapper(Builder builder) {
+        this.from = Objects.requireNonNull(builder.from, "The 'from' attribute has to be provided.");
+        this.writable = builder.writable;
+        this.verifiable = builder.verifiable;
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        ModelNode modelNode = new ModelNode();
+        setIfNotNull(modelNode, "from", from);
+        setIfNotNull(modelNode, "writable", writable);
+        setIfNotNull(modelNode, "verifiable", verifiable);
+        return modelNode;
+    }
+
+    /**
+     * Creates builder to build {@link UserPasswordMapper}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link UserPasswordMapper}.
+     */
+    public static final class Builder {
+        private String from;
+        private Boolean writable;
+        private Boolean verifiable;
+
+        private Builder() {
+        }
+
+        public Builder withFrom(String from) {
+            this.from = from;
+            return this;
+        }
+
+        public Builder withWritable(Boolean writable) {
+            this.writable = writable;
+            return this;
+        }
+
+        public Builder withVerifiable(Boolean verifiable) {
+            this.verifiable = verifiable;
+            return this;
+        }
+
+        public UserPasswordMapper build() {
+            return new UserPasswordMapper(this);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/X509CredentialMapper.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/elytron/X509CredentialMapper.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.elytron;
+
+import static org.wildfly.test.security.common.ModelNodeUtil.setIfNotNull;
+
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Represantation of an x509-credential-mapper configuration in ldap-realm/identity-mapping.
+ *
+ * @author Josef Cacek
+ */
+public class X509CredentialMapper implements ModelNodeConvertable {
+
+    private final String digestFrom;
+    private final String digestAlgorithm;
+    private final String certificateFrom;
+    private final String serialNumberFrom;
+    private final String subjectDnFrom;
+
+    private X509CredentialMapper(Builder builder) {
+        this.digestFrom = builder.digestFrom;
+        this.digestAlgorithm = builder.digestAlgorithm;
+        this.certificateFrom = builder.certificateFrom;
+        this.serialNumberFrom = builder.serialNumberFrom;
+        this.subjectDnFrom = builder.subjectDnFrom;
+    }
+
+    @Override
+    public ModelNode toModelNode() {
+        ModelNode modelNode = new ModelNode();
+        setIfNotNull(modelNode, "digest-from", digestFrom);
+        setIfNotNull(modelNode, "digest-algorithm", digestAlgorithm);
+        setIfNotNull(modelNode, "certificate-from", certificateFrom);
+        setIfNotNull(modelNode, "serial-number-from", serialNumberFrom);
+        setIfNotNull(modelNode, "subject-dn-from", subjectDnFrom);
+        return modelNode;
+    }
+
+    /**
+     * Creates builder to build {@link X509CredentialMapper}.
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link X509CredentialMapper}.
+     */
+    public static final class Builder {
+        private String digestFrom;
+        private String digestAlgorithm;
+        private String certificateFrom;
+        private String serialNumberFrom;
+        private String subjectDnFrom;
+
+        private Builder() {
+        }
+
+        public Builder withDigestFrom(String digestFrom) {
+            this.digestFrom = digestFrom;
+            return this;
+        }
+
+        public Builder withDigestAlgorithm(String digestAlgorithm) {
+            this.digestAlgorithm = digestAlgorithm;
+            return this;
+        }
+
+        public Builder withCertificateFrom(String certificateFrom) {
+            this.certificateFrom = certificateFrom;
+            return this;
+        }
+
+        public Builder withSerialNumberFrom(String serialNumberFrom) {
+            this.serialNumberFrom = serialNumberFrom;
+            return this;
+        }
+
+        public Builder withSubjectDnFrom(String subjectDnFrom) {
+            this.subjectDnFrom = subjectDnFrom;
+            return this;
+        }
+
+        public X509CredentialMapper build() {
+            return new X509CredentialMapper(this);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/AbstractKrb5ConfServerSetupTask.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/AbstractKrb5ConfServerSetupTask.java
@@ -1,0 +1,286 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.kerberos;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.directory.server.kerberos.shared.crypto.encryption.KerberosKeyFactory;
+import org.apache.directory.server.kerberos.shared.keytab.Keytab;
+import org.apache.directory.shared.kerberos.KerberosTime;
+import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
+import org.apache.directory.shared.kerberos.components.EncryptionKey;
+import org.apache.log4j.Logger;
+import org.jboss.as.network.NetworkUtils;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetupTask;
+
+/**
+ * This server setup task creates a krb5.conf file and generates KeyTab files for the HTTP server and users hnelson and jduke.
+ * The task also sets system properties
+ * <ul>
+ * <li>"java.security.krb5.conf" - path to the newly created krb5.conf is set</li>
+ * <li>"sun.security.krb5.debug" - true is set (Kerberos debugging for Oracle Java)</li>
+ * </ul>
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractKrb5ConfServerSetupTask implements ServerSetupTask {
+
+    private static Logger LOGGER = Logger.getLogger(AbstractKrb5ConfServerSetupTask.class);
+
+    protected static final File WORK_DIR;
+    static {
+        try {
+            WORK_DIR = Files.createTempDirectory("krbconf-").toFile();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to create temporary folder", e);
+        }
+    }
+
+    private static final String KRB5_CONF = "krb5.conf";
+    private static final File KRB5_CONF_FILE = new File(WORK_DIR, KRB5_CONF);
+
+    public static final File HTTP_KEYTAB_FILE = new File(WORK_DIR, "http.keytab");
+
+    private String origKrb5Conf;
+    private String origKrbDebug;
+    private String origIbmJGSSDebug;
+    private String origIbmKrbDebug;
+
+    // Public methods --------------------------------------------------------
+
+    /**
+     *
+     * @param managementClient
+     * @param containerId
+     * @throws Exception
+     * @see org.jboss.as.arquillian.api.ServerSetupTask#setup(org.jboss.as.arquillian.container.ManagementClient,
+     *      java.lang.String)
+     */
+    public void setup(ManagementClient managementClient) throws Exception {
+        LOGGER.trace("(Re)Creating workdir: " + WORK_DIR.getAbsolutePath());
+        FileUtils.deleteDirectory(WORK_DIR);
+        WORK_DIR.mkdirs();
+        final String cannonicalHost = NetworkUtils.formatPossibleIpv6Address(CoreUtils.getCannonicalHost(TestSuiteEnvironment.getServerAddress()));
+        final Map<String, String> map = new HashMap<String, String>();
+        map.put("hostname", cannonicalHost);
+        final String supportedEncTypes = CoreUtils.IBM_JDK ? getSupportedEncTypes() : "des-cbc-md5,des3-cbc-sha1-kd";
+        map.put("enctypes", supportedEncTypes);
+        LOGGER.trace("Supported enctypes in krb5.conf: " + supportedEncTypes);
+        FileUtils.write(
+                KRB5_CONF_FILE,
+                StrSubstitutor.replace(
+                        IOUtils.toString(AbstractKrb5ConfServerSetupTask.class.getResourceAsStream(KRB5_CONF), "UTF-8"), map),
+                "UTF-8");
+        createServerKeytab(cannonicalHost);
+        final List<UserForKeyTab> kerberosUsers = kerberosUsers();
+        if (kerberosUsers != null) {
+            for (UserForKeyTab userForKeyTab : kerberosUsers) {
+                createKeytab(userForKeyTab.getUser(), userForKeyTab.getPassword(), userForKeyTab.getKeyTabFileName());
+            }
+        }
+        LOGGER.trace("Setting Kerberos configuration: " + KRB5_CONF_FILE);
+        origKrb5Conf = CoreUtils.setSystemProperty("java.security.krb5.conf", KRB5_CONF_FILE.getAbsolutePath());
+        origKrbDebug = CoreUtils.setSystemProperty("sun.security.krb5.debug", "true");
+        origIbmJGSSDebug = CoreUtils.setSystemProperty("com.ibm.security.jgss.debug", "all");
+        origIbmKrbDebug = CoreUtils.setSystemProperty("com.ibm.security.krb5.Krb5Debug", "all");
+    }
+
+    /**
+     * Removes working directory with Kerberos related generated files.
+     *
+     * @param managementClient
+     * @param containerId
+     * @throws Exception
+     * @see org.jboss.as.arquillian.api.ServerSetupTask#tearDown(org.jboss.as.arquillian.container.ManagementClient,
+     *      java.lang.String)
+     */
+    public void tearDown(ManagementClient managementClient) throws Exception {
+        FileUtils.deleteDirectory(WORK_DIR);
+        CoreUtils.setSystemProperty("java.security.krb5.conf", origKrb5Conf);
+        CoreUtils.setSystemProperty("sun.security.krb5.debug", origKrbDebug);
+        CoreUtils.setSystemProperty("com.ibm.security.jgss.debug", origIbmJGSSDebug);
+        CoreUtils.setSystemProperty("com.ibm.security.krb5.Krb5Debug", origIbmKrbDebug);
+    }
+
+    /**
+     * Returns an absolute path to krb5.conf file.
+     *
+     * @return
+     */
+    public static final String getKrb5ConfFullPath() {
+        return KRB5_CONF_FILE.getAbsolutePath();
+    }
+
+    /**
+     * Returns an absolute path to a keytab with JBoss AS credentials (HTTP/host@JBOSS.ORG).
+     *
+     * @return
+     */
+    public static final String getKeyTabFullPath() {
+        return HTTP_KEYTAB_FILE.getAbsolutePath();
+    }
+
+    /**
+     * Creates a default "HTTP/{host}@JBOSS.ORG" server keytab. it can be overridden if you want to use another SPN, password or
+     * keytab file location (or do more magic here).
+     *
+     * @param host
+     * @throws IOException
+     */
+    protected void createServerKeytab(String host) throws IOException {
+        createKeytab("HTTP/" + host + "@JBOSS.ORG", "httppwd", HTTP_KEYTAB_FILE);
+    }
+
+    /**
+     * Sets or removes (in case value==null) a system property. It's only a helper method, which avoids
+     * {@link NullPointerException} thrown from {@link System#setProperty(String, String)} method, when the value is
+     * <code>null</code>.
+     *
+     * @param key property name
+     * @param value property value
+     * @return the previous string value of the system property
+     */
+    public static String setSystemProperty(final String key, final String value) {
+        return value == null ? System.clearProperty(key) : System.setProperty(key, value);
+    }
+
+    // Private methods -------------------------------------------------------
+
+    /**
+     * Returns comma-separated list of JDK-supported encryption type names for use in krb5.conf.
+     *
+     * @return
+     */
+    private String getSupportedEncTypes() {
+        final List<String> enctypesList = new ArrayList<String>();
+        for (EncryptionType encType : KerberosKeyFactory.getKerberosKeys("dummy@JBOSS.ORG", "dummy").keySet()) {
+            enctypesList.add(encType.getName());
+        }
+        return StringUtils.join(enctypesList, ',');
+    }
+
+    /**
+     * Creates a keytab file for given principal.
+     *
+     * @param principalName
+     * @param passPhrase
+     * @param keytabFile
+     * @throws IOException
+     */
+    protected void createKeytab(final String principalName, final String passPhrase, final File keytabFile) throws IOException {
+        LOGGER.trace("Principal name: " + principalName);
+        final KerberosTime timeStamp = new KerberosTime();
+
+        DataOutputStream dos = null;
+        try {
+            dos = new DataOutputStream(new FileOutputStream(keytabFile));
+            dos.write(Keytab.VERSION_0X502_BYTES);
+
+            for (Map.Entry<EncryptionType, EncryptionKey> keyEntry : KerberosKeyFactory.getKerberosKeys(principalName,
+                    passPhrase).entrySet()) {
+                final EncryptionKey key = keyEntry.getValue();
+                final byte keyVersion = (byte) key.getKeyVersion();
+                // entries.add(new KeytabEntry(principalName, principalType, timeStamp, keyVersion, key));
+
+                final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream entryDos = new DataOutputStream(baos);
+                // handle principal name
+                String[] spnSplit = principalName.split("@");
+                String nameComponent = spnSplit[0];
+                String realm = spnSplit[1];
+
+                String[] nameComponents = nameComponent.split("/");
+                try {
+                    // increment for v1
+                    entryDos.writeShort((short) nameComponents.length);
+                    entryDos.writeUTF(realm);
+                    // write components
+                    for (String component : nameComponents) {
+                        entryDos.writeUTF(component);
+                    }
+
+                    entryDos.writeInt(1); // principal type: KRB5_NT_PRINCIPAL
+                    entryDos.writeInt((int) (timeStamp.getTime() / 1000));
+                    entryDos.write(keyVersion);
+
+                    entryDos.writeShort((short) key.getKeyType().getValue());
+
+                    byte[] data = key.getKeyValue();
+                    entryDos.writeShort((short) data.length);
+                    entryDos.write(data);
+                } finally {
+                    IOUtils.closeQuietly(entryDos);
+                }
+                final byte[] entryBytes = baos.toByteArray();
+                dos.writeInt(entryBytes.length);
+                dos.write(entryBytes);
+            }
+            // } catch (IOException ioe) {
+        } finally {
+            IOUtils.closeQuietly(dos);
+        }
+    }
+
+    protected abstract List<UserForKeyTab> kerberosUsers();
+
+    public static class UserForKeyTab {
+        private final String user;
+        private final String password;
+        private final File keyTabFileName;
+
+        public UserForKeyTab(String user, String password, File keyTabFileName) {
+            this.user = user;
+            this.password = password;
+            this.keyTabFileName = keyTabFileName;
+        }
+
+        public String getUser() {
+            return user;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public File getKeyTabFileName() {
+            return keyTabFileName;
+        }
+
+    }
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/AnnotationLiteral.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/AnnotationLiteral.java
@@ -1,0 +1,275 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.kerberos;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+
+/**
+ * <p>
+ * Supports inline instantiation of annotation type instances.
+ * </p>
+ *
+ * <p>
+ * An instance of an annotation type may be obtained by subclassing <tt>AnnotationLiteral</tt>.
+ * </p>
+ *
+ * <pre>
+ * public abstract class PayByQualifier extends AnnotationLiteral&lt;PayBy&gt; implements PayBy {
+ * }
+ * </pre>
+ *
+ * <pre>
+ * PayBy paybyCheque = new PayByQualifier() {
+ *     public PaymentMethod value() {
+ *         return CHEQUE;
+ *     }
+ * };
+ * </pre>
+ *
+ * @author Pete Muir
+ * @author Gavin King
+ */
+public abstract class AnnotationLiteral<T extends Annotation> implements Annotation, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient Class<T> annotationType;
+    private transient Method[] members;
+
+    protected AnnotationLiteral() {
+    }
+
+    private Method[] getMembers() {
+        if (members == null) {
+            members = annotationType().getDeclaredMethods();
+            if (members.length > 0 && !annotationType().isAssignableFrom(this.getClass())) {
+                throw new RuntimeException(getClass() + " does not implement the annotation type with members "
+                        + annotationType().getName());
+            }
+        }
+        return members;
+    }
+
+    private static Class<?> getAnnotationLiteralSubclass(Class<?> clazz) {
+        Class<?> superclass = clazz.getSuperclass();
+        if (superclass.equals(AnnotationLiteral.class)) {
+            return clazz;
+        } else if (superclass.equals(Object.class)) {
+            return null;
+        } else {
+            return (getAnnotationLiteralSubclass(superclass));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> Class<T> getTypeParameter(Class<?> annotationLiteralSuperclass) {
+        Type type = annotationLiteralSuperclass.getGenericSuperclass();
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            if (parameterizedType.getActualTypeArguments().length == 1) {
+                return (Class<T>) parameterizedType.getActualTypeArguments()[0];
+            }
+        }
+        return null;
+    }
+
+    public Class<? extends Annotation> annotationType() {
+        if (annotationType == null) {
+            Class<?> annotationLiteralSubclass = getAnnotationLiteralSubclass(this.getClass());
+            if (annotationLiteralSubclass == null) {
+                throw new RuntimeException(getClass() + "is not a subclass of AnnotationLiteral");
+            }
+            annotationType = getTypeParameter(annotationLiteralSubclass);
+            if (annotationType == null) {
+                throw new RuntimeException(getClass() + " does not specify the type parameter T of AnnotationLiteral<T>");
+            }
+        }
+        return annotationType;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder string = new StringBuilder();
+        string.append('@').append(annotationType().getName()).append('(');
+        for (int i = 0; i < getMembers().length; i++) {
+            string.append(getMembers()[i].getName()).append('=');
+            Object value = invoke(getMembers()[i], this);
+            assertMemberValueNotNull(getMembers()[i], this, value);
+            if (value instanceof boolean[]) {
+                appendInBraces(string, Arrays.toString((boolean[]) value));
+            } else if (value instanceof byte[]) {
+                appendInBraces(string, Arrays.toString((byte[]) value));
+            } else if (value instanceof short[]) {
+                appendInBraces(string, Arrays.toString((short[]) value));
+            } else if (value instanceof int[]) {
+                appendInBraces(string, Arrays.toString((int[]) value));
+            } else if (value instanceof long[]) {
+                appendInBraces(string, Arrays.toString((long[]) value));
+            } else if (value instanceof float[]) {
+                appendInBraces(string, Arrays.toString((float[]) value));
+            } else if (value instanceof double[]) {
+                appendInBraces(string, Arrays.toString((double[]) value));
+            } else if (value instanceof char[]) {
+                appendInBraces(string, Arrays.toString((char[]) value));
+            } else if (value instanceof String[]) {
+                String[] strings = (String[]) value;
+                String[] quoted = new String[strings.length];
+                for (int j = 0; j < strings.length; j++) {
+                    quoted[j] = "\"" + strings[j] + "\"";
+                }
+                appendInBraces(string, Arrays.toString(quoted));
+            } else if (value instanceof Class<?>[]) {
+                Class<?>[] classes = (Class<?>[]) value;
+                String[] names = new String[classes.length];
+                for (int j = 0; j < classes.length; j++) {
+                    names[j] = classes[j].getName() + ".class";
+                }
+                appendInBraces(string, Arrays.toString(names));
+            } else if (value instanceof Object[]) {
+                appendInBraces(string, Arrays.toString((Object[]) value));
+            } else if (value instanceof String) {
+                string.append('"').append(value).append('"');
+            } else if (value instanceof Class<?>) {
+                string.append(((Class<?>) value).getName()).append(".class");
+            } else {
+                string.append(value);
+            }
+            if (i < getMembers().length - 1) {
+                string.append(", ");
+            }
+        }
+        return string.append(')').toString();
+    }
+
+    private void appendInBraces(StringBuilder buf, String s) {
+        buf.append('{').append(s.substring(1, s.length() - 1)).append('}');
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof Annotation) {
+            Annotation that = (Annotation) other;
+            if (this.annotationType().equals(that.annotationType())) {
+                for (Method member : getMembers()) {
+                    Object thisValue = invoke(member, this);
+                    assertMemberValueNotNull(member, this, thisValue);
+                    Object thatValue = invoke(member, that);
+                    assertMemberValueNotNull(member, this, thatValue);
+                    if (thisValue instanceof byte[] && thatValue instanceof byte[]) {
+                        if (!Arrays.equals((byte[]) thisValue, (byte[]) thatValue))
+                            return false;
+                    } else if (thisValue instanceof short[] && thatValue instanceof short[]) {
+                        if (!Arrays.equals((short[]) thisValue, (short[]) thatValue))
+                            return false;
+                    } else if (thisValue instanceof int[] && thatValue instanceof int[]) {
+                        if (!Arrays.equals((int[]) thisValue, (int[]) thatValue))
+                            return false;
+                    } else if (thisValue instanceof long[] && thatValue instanceof long[]) {
+                        if (!Arrays.equals((long[]) thisValue, (long[]) thatValue))
+                            return false;
+                    } else if (thisValue instanceof float[] && thatValue instanceof float[]) {
+                        if (!Arrays.equals((float[]) thisValue, (float[]) thatValue))
+                            return false;
+                    } else if (thisValue instanceof double[] && thatValue instanceof double[]) {
+                        if (!Arrays.equals((double[]) thisValue, (double[]) thatValue))
+                            return false;
+                    } else if (thisValue instanceof char[] && thatValue instanceof char[]) {
+                        if (!Arrays.equals((char[]) thisValue, (char[]) thatValue))
+                            return false;
+                    } else if (thisValue instanceof boolean[] && thatValue instanceof boolean[]) {
+                        if (!Arrays.equals((boolean[]) thisValue, (boolean[]) thatValue))
+                            return false;
+                    } else if (thisValue instanceof Object[] && thatValue instanceof Object[]) {
+                        if (!Arrays.equals((Object[]) thisValue, (Object[]) thatValue))
+                            return false;
+                    } else {
+                        if (!thisValue.equals(thatValue))
+                            return false;
+                    }
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int hashCode = 0;
+        for (Method member : getMembers()) {
+            int memberNameHashCode = 127 * member.getName().hashCode();
+            Object value = invoke(member, this);
+            assertMemberValueNotNull(member, this, value);
+            int memberValueHashCode;
+            if (value instanceof boolean[]) {
+                memberValueHashCode = Arrays.hashCode((boolean[]) value);
+            } else if (value instanceof short[]) {
+                memberValueHashCode = Arrays.hashCode((short[]) value);
+            } else if (value instanceof int[]) {
+                memberValueHashCode = Arrays.hashCode((int[]) value);
+            } else if (value instanceof long[]) {
+                memberValueHashCode = Arrays.hashCode((long[]) value);
+            } else if (value instanceof float[]) {
+                memberValueHashCode = Arrays.hashCode((float[]) value);
+            } else if (value instanceof double[]) {
+                memberValueHashCode = Arrays.hashCode((double[]) value);
+            } else if (value instanceof byte[]) {
+                memberValueHashCode = Arrays.hashCode((byte[]) value);
+            } else if (value instanceof char[]) {
+                memberValueHashCode = Arrays.hashCode((char[]) value);
+            } else if (value instanceof Object[]) {
+                memberValueHashCode = Arrays.hashCode((Object[]) value);
+            } else {
+                memberValueHashCode = value.hashCode();
+            }
+            hashCode += memberNameHashCode ^ memberValueHashCode;
+        }
+        return hashCode;
+    }
+
+    private static Object invoke(Method method, Object instance) {
+        try {
+            if (!method.isAccessible())
+                method.setAccessible(true);
+            return method.invoke(instance);
+        } catch (IllegalArgumentException e) {
+            throw new RuntimeException("Error checking value of member method " + method.getName() + " on "
+                    + method.getDeclaringClass(), e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("Error checking value of member method " + method.getName() + " on "
+                    + method.getDeclaringClass(), e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException("Error checking value of member method " + method.getName() + " on "
+                    + method.getDeclaringClass(), e);
+        }
+    }
+
+    private static void assertMemberValueNotNull(Method member, Annotation instance, Object value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Annotation member " + instance.getClass().getName() + "." + member.getName()
+                    + " must not be null");
+        }
+    }
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/InMemoryDirectoryServiceFactory.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/InMemoryDirectoryServiceFactory.java
@@ -1,0 +1,608 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.kerberos;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import net.sf.ehcache.CacheManager;
+import net.sf.ehcache.config.CacheConfiguration;
+import net.sf.ehcache.config.Configuration;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.directory.api.ldap.codec.api.LdapApiService;
+import org.apache.directory.api.ldap.model.constants.SchemaConstants;
+import org.apache.directory.api.ldap.model.csn.Csn;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.ldif.LdifEntry;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.schema.LdapComparator;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
+import org.apache.directory.api.ldap.model.schema.comparators.NormalizingComparator;
+import org.apache.directory.api.ldap.model.schema.registries.ComparatorRegistry;
+import org.apache.directory.api.ldap.model.schema.registries.SchemaLoader;
+import org.apache.directory.api.ldap.schemaloader.JarLdifSchemaLoader;
+import org.apache.directory.api.ldap.schemamanager.impl.DefaultSchemaManager;
+import org.apache.directory.api.ldap.util.tree.DnNode;
+import org.apache.directory.api.util.exception.Exceptions;
+import org.apache.directory.server.constants.ServerDNConstants;
+import org.apache.directory.server.core.DefaultDirectoryService;
+import org.apache.directory.server.core.api.CacheService;
+import org.apache.directory.server.core.api.CoreSession;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.api.DnFactory;
+import org.apache.directory.server.core.api.InstanceLayout;
+import org.apache.directory.server.core.api.LdapPrincipal;
+import org.apache.directory.server.core.api.OperationEnum;
+import org.apache.directory.server.core.api.OperationManager;
+import org.apache.directory.server.core.api.ReferralManager;
+import org.apache.directory.server.core.api.administrative.AccessControlAdministrativePoint;
+import org.apache.directory.server.core.api.administrative.CollectiveAttributeAdministrativePoint;
+import org.apache.directory.server.core.api.administrative.SubschemaAdministrativePoint;
+import org.apache.directory.server.core.api.administrative.TriggerExecutionAdministrativePoint;
+import org.apache.directory.server.core.api.changelog.ChangeLog;
+import org.apache.directory.server.core.api.event.EventService;
+import org.apache.directory.server.core.api.interceptor.Interceptor;
+import org.apache.directory.server.core.api.journal.Journal;
+import org.apache.directory.server.core.api.partition.Partition;
+import org.apache.directory.server.core.api.partition.PartitionNexus;
+import org.apache.directory.server.core.api.schema.SchemaPartition;
+import org.apache.directory.server.core.api.subtree.SubentryCache;
+import org.apache.directory.server.core.api.subtree.SubtreeEvaluator;
+import org.apache.directory.server.core.factory.AvlPartitionFactory;
+import org.apache.directory.server.core.factory.DirectoryServiceFactory;
+import org.apache.directory.server.core.factory.PartitionFactory;
+import org.apache.directory.server.i18n.I18n;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Factory for a fast (mostly in-memory-only) ApacheDS DirectoryService. Use only for tests!!
+ *
+ * @author Josef Cacek
+ */
+public class InMemoryDirectoryServiceFactory implements DirectoryServiceFactory {
+
+    private static Logger LOG = LoggerFactory.getLogger(InMemoryDirectoryServiceFactory.class);
+
+    private final DirectoryService directoryService;
+    private final PartitionFactory partitionFactory;
+    private CacheManager cacheManager;
+
+    /**
+     * Default constructor which creates {@link DefaultDirectoryService} instance and configures {@link AvlPartitionFactory} as
+     * the {@link PartitionFactory} implementation.
+     */
+    public InMemoryDirectoryServiceFactory() {
+        try {
+            directoryService = new DefaultDirectoryService();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        directoryService.setShutdownHookEnabled(false);
+        partitionFactory = new AvlPartitionFactory();
+    }
+
+    /**
+     * Constructor which uses provided {@link DirectoryService} and {@link PartitionFactory} implementations.
+     *
+     * @param directoryService must be not-<code>null</code>
+     * @param partitionFactory must be not-<code>null</code>
+     */
+    public InMemoryDirectoryServiceFactory(DirectoryService directoryService, PartitionFactory partitionFactory) {
+        this.directoryService = directoryService;
+        this.partitionFactory = partitionFactory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(String name) throws Exception {
+        if ((directoryService != null) && directoryService.isStarted()) {
+            return;
+        }
+
+        directoryService.setInstanceId(name);
+
+        // instance layout
+        InstanceLayout instanceLayout = new InstanceLayout(System.getProperty("java.io.tmpdir") + "/server-work-" + name);
+        if (instanceLayout.getInstanceDirectory().exists()) {
+            try {
+                FileUtils.deleteDirectory(instanceLayout.getInstanceDirectory());
+            } catch (IOException e) {
+                LOG.warn("couldn't delete the instance directory before initializing the DirectoryService", e);
+            }
+        }
+        directoryService.setInstanceLayout(instanceLayout);
+
+        // EhCache in disabled-like-mode
+        Configuration ehCacheConfig = new Configuration();
+        CacheConfiguration defaultCache = new CacheConfiguration("ApacheDSTestCache", 1).eternal(false).timeToIdleSeconds(30)
+                .timeToLiveSeconds(30).overflowToDisk(false);
+        ehCacheConfig.addDefaultCache(defaultCache);
+        cacheManager = new CacheManager(ehCacheConfig);
+        CacheService cacheService = new CacheService(cacheManager);
+        directoryService.setCacheService(cacheService);
+
+        // Init the schema
+        // SchemaLoader loader = new SingleLdifSchemaLoader();
+        SchemaLoader loader = new JarLdifSchemaLoader();
+        SchemaManager schemaManager = new DefaultSchemaManager(loader);
+        schemaManager.loadAllEnabled();
+        ComparatorRegistry comparatorRegistry = schemaManager.getComparatorRegistry();
+        for (LdapComparator<?> comparator : comparatorRegistry) {
+            if (comparator instanceof NormalizingComparator) {
+                ((NormalizingComparator) comparator).setOnServer();
+            }
+        }
+        directoryService.setSchemaManager(schemaManager);
+        InMemorySchemaPartition inMemorySchemaPartition = new InMemorySchemaPartition(schemaManager);
+
+        SchemaPartition schemaPartition = new SchemaPartition(schemaManager);
+        schemaPartition.setWrappedPartition(inMemorySchemaPartition);
+        directoryService.setSchemaPartition(schemaPartition);
+        List<Throwable> errors = schemaManager.getErrors();
+        if (errors.size() != 0) {
+            throw new Exception(I18n.err(I18n.ERR_317, Exceptions.printErrors(errors)));
+        }
+
+        // Init system partition
+        Partition systemPartition = partitionFactory.createPartition(directoryService.getSchemaManager(), "system",
+                ServerDNConstants.SYSTEM_DN, 500, new File(directoryService.getInstanceLayout().getPartitionsDirectory(),
+                        "system"));
+        systemPartition.setSchemaManager(directoryService.getSchemaManager());
+        partitionFactory.addIndex(systemPartition, SchemaConstants.OBJECT_CLASS_AT, 100);
+        directoryService.setSystemPartition(systemPartition);
+
+        directoryService.startup();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DirectoryService getDirectoryService() throws Exception {
+        return cacheManager != null ? new WrapperDirectoryService(directoryService, cacheManager) : directoryService;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public PartitionFactory getPartitionFactory() throws Exception {
+        return partitionFactory;
+    }
+
+    private class WrapperDirectoryService implements DirectoryService {
+
+        private final DirectoryService wrapped;
+        private final CacheManager cacheManager;
+
+        private WrapperDirectoryService(DirectoryService wrapped, CacheManager cacheManager) {
+            this.wrapped = wrapped;
+            this.cacheManager = cacheManager;
+        }
+
+        @Override
+        public Entry newEntry(Dn dn) throws LdapException {
+            return wrapped.newEntry(dn);
+        }
+
+        @Override
+        public long revert(long revision) throws LdapException {
+            return wrapped.revert(revision);
+        }
+
+        @Override
+        public long revert() throws LdapException {
+            return wrapped.revert();
+        }
+
+        @Override
+        public PartitionNexus getPartitionNexus() {
+            return wrapped.getPartitionNexus();
+        }
+
+        @Override
+        public void addPartition(Partition partition) throws Exception {
+            wrapped.addPartition(partition);
+        }
+
+        @Override
+        public void removePartition(Partition partition) throws Exception {
+            wrapped.removePartition(partition);
+        }
+
+        @Override
+        public SchemaManager getSchemaManager() {
+            return wrapped.getSchemaManager();
+        }
+
+        @Override
+        public LdapApiService getLdapCodecService() {
+            return wrapped.getLdapCodecService();
+        }
+
+        @Override
+        public ReferralManager getReferralManager() {
+            return wrapped.getReferralManager();
+        }
+
+        @Override
+        public void setReferralManager(ReferralManager referralManager) {
+            wrapped.setReferralManager(referralManager);
+        }
+
+        @Override
+        public SchemaPartition getSchemaPartition() {
+            return wrapped.getSchemaPartition();
+        }
+
+        @Override
+        public void setSchemaPartition(SchemaPartition schemaPartition) {
+            wrapped.setSchemaPartition(schemaPartition);
+        }
+
+        @Override
+        public EventService getEventService() {
+            return wrapped.getEventService();
+        }
+
+        @Override
+        public void setEventService(EventService eventService) {
+            wrapped.setEventService(eventService);
+        }
+
+        @Override
+        public void startup() throws Exception {
+            wrapped.startup();
+        }
+
+        @Override
+        public void shutdown() throws Exception {
+            wrapped.shutdown();
+            cacheManager.shutdown();
+        }
+
+        @Override
+        public void sync() throws Exception {
+            wrapped.sync();
+        }
+
+        @Override
+        public boolean isStarted() {
+            return wrapped.isStarted();
+        }
+
+        @Override
+        public CoreSession getAdminSession() {
+            return wrapped.getAdminSession();
+        }
+
+        @Override
+        public SubentryCache getSubentryCache() {
+            return wrapped.getSubentryCache();
+        }
+
+        @Override
+        public SubtreeEvaluator getEvaluator() {
+            return wrapped.getEvaluator();
+        }
+
+        @Override
+        public CoreSession getSession() throws Exception {
+            return wrapped.getSession();
+        }
+
+        @Override
+        public CoreSession getSession(LdapPrincipal principal) throws Exception {
+            return wrapped.getSession(principal);
+        }
+
+        @Override
+        public CoreSession getSession(Dn principalDn, byte[] credentials) throws LdapException {
+            return wrapped.getSession(principalDn, credentials);
+        }
+
+        @Override
+        public CoreSession getSession(Dn principalDn, byte[] credentials, String saslMechanism, String saslAuthId) throws Exception {
+            return wrapped.getSession(principalDn, credentials, saslMechanism, saslAuthId);
+        }
+
+        @Override
+        public void setInstanceId(String instanceId) {
+            wrapped.setInstanceId(instanceId);
+        }
+
+        @Override
+        public String getInstanceId() {
+            return wrapped.getInstanceId();
+        }
+
+        @Override
+        public Set<? extends Partition> getPartitions() {
+            return wrapped.getPartitions();
+        }
+
+        @Override
+        public void setPartitions(Set<? extends Partition> partitions) {
+            wrapped.setPartitions(partitions);
+        }
+
+        @Override
+        public boolean isAccessControlEnabled() {
+            return wrapped.isAccessControlEnabled();
+        }
+
+        @Override
+        public void setAccessControlEnabled(boolean accessControlEnabled) {
+            wrapped.setAccessControlEnabled(accessControlEnabled);
+        }
+
+        @Override
+        public boolean isAllowAnonymousAccess() {
+            return wrapped.isAllowAnonymousAccess();
+        }
+
+        @Override
+        public boolean isPasswordHidden() {
+            return wrapped.isPasswordHidden();
+        }
+
+        @Override
+        public void setPasswordHidden(boolean passwordHidden) {
+            wrapped.setPasswordHidden(passwordHidden);
+        }
+
+        @Override
+        public void setAllowAnonymousAccess(boolean enableAnonymousAccess) {
+            wrapped.setAllowAnonymousAccess(enableAnonymousAccess);
+        }
+
+        @Override
+        public List<Interceptor> getInterceptors() {
+            return wrapped.getInterceptors();
+        }
+
+        @Override
+        public List<String> getInterceptors(OperationEnum operation) {
+            return wrapped.getInterceptors(operation);
+        }
+
+        @Override
+        public void setInterceptors(List<Interceptor> interceptors) {
+            wrapped.setInterceptors(interceptors);
+        }
+
+        @Override
+        public void addFirst(Interceptor interceptor) throws LdapException {
+            wrapped.addFirst(interceptor);
+        }
+
+        @Override
+        public void addLast(Interceptor interceptor) throws LdapException {
+            wrapped.addLast(interceptor);
+        }
+
+        @Override
+        public void addAfter(String interceptorName, Interceptor interceptor) {
+            wrapped.addAfter(interceptorName, interceptor);
+        }
+
+        @Override
+        public void remove(String interceptorName) {
+            wrapped.remove(interceptorName);
+        }
+
+        @Override
+        public void setJournal(Journal journal) {
+            wrapped.setJournal(journal);
+        }
+
+        @Override
+        public List<LdifEntry> getTestEntries() {
+            return wrapped.getTestEntries();
+        }
+
+        @Override
+        public void setTestEntries(List<? extends LdifEntry> testEntries) {
+            wrapped.setTestEntries(testEntries);
+        }
+
+        @Override
+        public InstanceLayout getInstanceLayout() {
+            return wrapped.getInstanceLayout();
+        }
+
+        @Override
+        public void setInstanceLayout(InstanceLayout instanceLayout) throws IOException {
+            wrapped.setInstanceLayout(instanceLayout);
+        }
+
+        @Override
+        public void setShutdownHookEnabled(boolean shutdownHookEnabled) {
+            wrapped.setShutdownHookEnabled(shutdownHookEnabled);
+        }
+
+        @Override
+        public boolean isShutdownHookEnabled() {
+            return wrapped.isShutdownHookEnabled();
+        }
+
+        @Override
+        public void setExitVmOnShutdown(boolean exitVmOnShutdown) {
+            wrapped.setExitVmOnShutdown(exitVmOnShutdown);
+        }
+
+        @Override
+        public boolean isExitVmOnShutdown() {
+            return wrapped.isExitVmOnShutdown();
+        }
+
+
+        @Override
+        public void setSystemPartition(Partition systemPartition) {
+            wrapped.setSystemPartition(systemPartition);
+        }
+
+        @Override
+        public Partition getSystemPartition() {
+            return wrapped.getSystemPartition();
+        }
+
+        @Override
+        public boolean isDenormalizeOpAttrsEnabled() {
+            return wrapped.isDenormalizeOpAttrsEnabled();
+        }
+
+        @Override
+        public void setDenormalizeOpAttrsEnabled(boolean denormalizeOpAttrsEnabled) {
+            wrapped.setDenormalizeOpAttrsEnabled(denormalizeOpAttrsEnabled);
+        }
+
+        @Override
+        public ChangeLog getChangeLog() {
+            return wrapped.getChangeLog();
+        }
+
+        @Override
+        public Journal getJournal() {
+            return wrapped.getJournal();
+        }
+
+        @Override
+        public void setChangeLog(ChangeLog changeLog) {
+            wrapped.setChangeLog(changeLog);
+        }
+
+        @Override
+        public Entry newEntry(String ldif, String dn) {
+            return wrapped.newEntry(ldif, dn);
+        }
+
+        @Override
+        public OperationManager getOperationManager() {
+            return wrapped.getOperationManager();
+        }
+
+        @Override
+        public int getMaxPDUSize() {
+            return wrapped.getMaxPDUSize();
+        }
+
+        @Override
+        public void setMaxPDUSize(int maxPDUSize) {
+            wrapped.setMaxPDUSize(maxPDUSize);
+        }
+
+        @Override
+        public Interceptor getInterceptor(String interceptorName) {
+            return wrapped.getInterceptor(interceptorName);
+        }
+
+        @Override
+        public Csn getCSN() {
+            return wrapped.getCSN();
+        }
+
+        @Override
+        public int getReplicaId() {
+            return wrapped.getReplicaId();
+        }
+
+        @Override
+        public void setReplicaId(int replicaId) {
+            wrapped.setReplicaId(replicaId);
+        }
+
+        @Override
+        public void setSchemaManager(SchemaManager schemaManager) {
+            wrapped.setSchemaManager(schemaManager);
+        }
+
+        @Override
+        public void setContextCsn(String lastCommittedCsnVal) {
+            wrapped.setContextCsn(lastCommittedCsnVal);
+        }
+
+        @Override
+        public String getContextCsn() {
+            return wrapped.getContextCsn();
+        }
+
+        @Override
+        public void setSyncPeriodMillis(long syncPeriodMillis) {
+            wrapped.setSyncPeriodMillis(syncPeriodMillis);
+        }
+
+        @Override
+        public long getSyncPeriodMillis() {
+            return wrapped.getSyncPeriodMillis();
+        }
+
+        @Override
+        public CacheService getCacheService() {
+            return wrapped.getCacheService();
+        }
+
+        @Override
+        public DnNode<AccessControlAdministrativePoint> getAccessControlAPCache() {
+            return wrapped.getAccessControlAPCache();
+        }
+
+        @Override
+        public DnNode<CollectiveAttributeAdministrativePoint> getCollectiveAttributeAPCache() {
+            return wrapped.getCollectiveAttributeAPCache();
+        }
+
+        @Override
+        public DnNode<SubschemaAdministrativePoint> getSubschemaAPCache() {
+            return wrapped.getSubschemaAPCache();
+        }
+
+        @Override
+        public DnNode<TriggerExecutionAdministrativePoint> getTriggerExecutionAPCache() {
+            return wrapped.getTriggerExecutionAPCache();
+        }
+
+        @Override
+        public boolean isPwdPolicyEnabled() {
+            return wrapped.isPwdPolicyEnabled();
+        }
+
+        @Override
+        public DnFactory getDnFactory() {
+            return wrapped.getDnFactory();
+        }
+
+        @Override
+        public void setCacheService(CacheService cacheService) {
+            wrapped.setCacheService(cacheService);
+        }
+
+    }
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/InMemorySchemaPartition.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/InMemorySchemaPartition.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.kerberos;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import org.apache.directory.api.ldap.model.constants.SchemaConstants;
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.ldif.LdifEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
+import org.apache.directory.api.ldap.schemaextractor.impl.DefaultSchemaLdifExtractor;
+import org.apache.directory.api.ldap.schemaextractor.impl.ResourceMap;
+import org.apache.directory.server.core.api.interceptor.context.AddOperationContext;
+import org.apache.directory.server.core.partition.ldif.AbstractLdifPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * In-memory schema-only partition which loads the data in the similar way as the
+ * {@link org.apache.directory.api.ldap.schemaloader.JarLdifSchemaLoader}.
+ *
+ * @author Josef Cacek
+ */
+public class InMemorySchemaPartition extends AbstractLdifPartition {
+
+    private static Logger LOG = LoggerFactory.getLogger(InMemorySchemaPartition.class);
+
+    /**
+     * Filesystem path separator pattern, either forward slash or backslash. java.util.regex.Pattern is immutable so only one
+     * instance is needed for all uses.
+     */
+
+    public InMemorySchemaPartition(SchemaManager schemaManager) {
+        super(schemaManager);
+    }
+
+    /**
+     * Partition initialization - loads schema entries from the files on classpath.
+     *
+     * @see org.apache.directory.server.core.partition.impl.avl.AvlPartition#doInit()
+     */
+    @Override
+    protected void doInit() throws Exception {
+        if (initialized)
+            return;
+
+        LOG.debug("Initializing schema partition " + getId());
+        suffixDn.apply(schemaManager);
+        super.doInit();
+
+        // load schema
+        final Map<String, Boolean> resMap = ResourceMap.getResources(Pattern.compile("schema[/\\Q\\\\E]ou=schema.*"));
+        for (String resourcePath : new TreeSet<String>(resMap.keySet())) {
+            if (resourcePath.endsWith(".ldif")) {
+                URL resource = DefaultSchemaLdifExtractor.getUniqueResource(resourcePath, "Schema LDIF file");
+                LdifReader reader = new LdifReader(resource.openStream());
+                LdifEntry ldifEntry = reader.next();
+                reader.close();
+
+                Entry entry = new DefaultEntry(schemaManager, ldifEntry.getEntry());
+                // add mandatory attributes
+                if (entry.get(SchemaConstants.ENTRY_CSN_AT) == null) {
+                    entry.add(SchemaConstants.ENTRY_CSN_AT, defaultCSNFactory.newInstance().toString());
+                }
+                if (entry.get(SchemaConstants.ENTRY_UUID_AT) == null) {
+                    entry.add(SchemaConstants.ENTRY_UUID_AT, UUID.randomUUID().toString());
+                }
+                AddOperationContext addContext = new AddOperationContext(null, entry);
+                super.add(addContext);
+            }
+        }
+    }
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/KDCServerAnnotationProcessor.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/KDCServerAnnotationProcessor.java
@@ -1,0 +1,254 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.kerberos;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import javax.security.auth.kerberos.KerberosPrincipal;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
+import org.apache.directory.server.annotations.CreateChngPwdServer;
+import org.apache.directory.server.annotations.CreateKdcServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.AnnotationUtils;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.i18n.I18n;
+import org.apache.directory.server.kerberos.ChangePasswordConfig;
+import org.apache.directory.server.kerberos.KerberosConfig;
+import org.apache.directory.server.kerberos.changepwd.ChangePasswordServer;
+import org.apache.directory.server.kerberos.kdc.KdcServer;
+import org.apache.directory.server.kerberos.shared.replay.ReplayCache;
+import org.apache.directory.server.protocol.shared.transport.TcpTransport;
+import org.apache.directory.server.protocol.shared.transport.Transport;
+import org.apache.directory.server.protocol.shared.transport.UdpTransport;
+import org.apache.directory.shared.kerberos.KerberosTime;
+import org.apache.mina.util.AvailablePortFinder;
+import org.jboss.logging.Logger;
+
+/**
+ * Annotation processor for creating Kerberos servers - based on original implementation in
+ * {@link org.apache.directory.server.factory.ServerAnnotationProcessor}. This implementation only adds a workaround for
+ * https://issues.apache.org/jira/browse/DIRKRB-85<br/>
+ * Use this class together with {@link ExtCreateKdcServer} annotation.
+ *
+ * @author Josef Cacek
+ * @see ExtCreateKdcServer
+ */
+public class KDCServerAnnotationProcessor {
+
+    // Public methods --------------------------------------------------------
+    /**
+     * Creates and starts KdcServer based on configuration from {@link ExtCreateKdcServer} annotation.
+     *
+     * @param directoryService
+     * @param startPort start port number used for searching free ports in case the transport has no port number preconfigured.
+     * @return
+     * @throws Exception
+     */
+    public static KdcServer getKdcServer(DirectoryService directoryService, int startPort, String address) throws Exception {
+        final CreateKdcServer createKdcServer = (CreateKdcServer) AnnotationUtils.getInstance(CreateKdcServer.class);
+        return createKdcServer(createKdcServer, directoryService, startPort, address);
+    }
+
+    // Private methods -------------------------------------------------------
+    /**
+     * Creates and starts {@link KdcServer} instance based on given configuration.
+     *
+     * @param createKdcServer
+     * @param directoryService
+     * @param startPort
+     * @return
+     */
+    private static KdcServer createKdcServer(CreateKdcServer createKdcServer, DirectoryService directoryService,
+            int startPort, String bindAddress) {
+        if (createKdcServer == null) {
+            return null;
+        }
+
+        KerberosConfig kdcConfig = new KerberosConfig();
+        kdcConfig.setServicePrincipal(createKdcServer.kdcPrincipal());
+        kdcConfig.setPrimaryRealm(createKdcServer.primaryRealm());
+        kdcConfig.setMaximumTicketLifetime(createKdcServer.maxTicketLifetime());
+        kdcConfig.setMaximumRenewableLifetime(createKdcServer.maxRenewableLifetime());
+        kdcConfig.setPaEncTimestampRequired(false);
+
+        KdcServer kdcServer = new NoReplayKdcServer(kdcConfig);
+
+        kdcServer.setSearchBaseDn(createKdcServer.searchBaseDn());
+
+        CreateTransport[] transportBuilders = createKdcServer.transports();
+
+        if (transportBuilders == null) {
+            // create only UDP transport if none specified
+            UdpTransport defaultTransport = new UdpTransport(bindAddress, AvailablePortFinder.getNextAvailable(startPort));
+            kdcServer.addTransports(defaultTransport);
+        } else if (transportBuilders.length > 0) {
+            for (CreateTransport transportBuilder : transportBuilders) {
+               String protocol = transportBuilder.protocol();
+                int port = transportBuilder.port();
+                int nbThreads = transportBuilder.nbThreads();
+                int backlog = transportBuilder.backlog();
+                final String address = bindAddress != null ? bindAddress : transportBuilder.address();
+
+                if (port == -1) {
+                    port = AvailablePortFinder.getNextAvailable(startPort);
+                    startPort = port + 1;
+                }
+
+                if (protocol.equalsIgnoreCase("TCP")) {
+                    Transport tcp = new TcpTransport(address, port, nbThreads, backlog);
+                    kdcServer.addTransports(tcp);
+                } else if (protocol.equalsIgnoreCase("UDP")) {
+                    UdpTransport udp = new UdpTransport(address, port);
+                    kdcServer.addTransports(udp);
+                } else {
+                    throw new IllegalArgumentException(I18n.err(I18n.ERR_689, protocol));
+                }
+            }
+        }
+
+        CreateChngPwdServer[] createChngPwdServers = createKdcServer.chngPwdServer();
+
+        if (createChngPwdServers.length > 0) {
+
+            CreateChngPwdServer createChngPwdServer = createChngPwdServers[0];
+            ChangePasswordConfig config = new ChangePasswordConfig(kdcConfig);
+            config.setServicePrincipal(createChngPwdServer.srvPrincipal());
+
+            ChangePasswordServer chngPwdServer = new ChangePasswordServer(config);
+
+            for (CreateTransport transportBuilder : createChngPwdServer.transports()) {
+                Transport t = createTransport(transportBuilder, startPort);
+                startPort = t.getPort() + 1;
+                chngPwdServer.addTransports(t);
+            }
+
+            chngPwdServer.setDirectoryService(directoryService);
+
+            kdcServer.setChangePwdServer(chngPwdServer);
+        }
+
+        kdcServer.setDirectoryService(directoryService);
+
+        // Launch the server
+        try {
+            kdcServer.start();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return kdcServer;
+
+    }
+
+    private static Transport createTransport( CreateTransport transportBuilder, int startPort )
+    {
+        String protocol = transportBuilder.protocol();
+        int port = transportBuilder.port();
+        int nbThreads = transportBuilder.nbThreads();
+        int backlog = transportBuilder.backlog();
+        String address = transportBuilder.address();
+
+        if ( port == -1 )
+        {
+            port = AvailablePortFinder.getNextAvailable( startPort );
+            startPort = port + 1;
+        }
+
+        if ( protocol.equalsIgnoreCase( "TCP" ) )
+        {
+            Transport tcp = new TcpTransport( address, port, nbThreads, backlog );
+            return tcp;
+        }
+        else if ( protocol.equalsIgnoreCase( "UDP" ) )
+        {
+            UdpTransport udp = new UdpTransport( address, port );
+            return udp;
+        }
+        else
+        {
+            throw new IllegalArgumentException( I18n.err( I18n.ERR_689, protocol ) );
+        }
+    }
+
+}
+
+
+/**
+ *
+ * Replacement of apacheDS KdcServer class with disabled ticket replay cache.
+ *
+ * @author Dominik Pospisil <dpospisi@redhat.com>
+ */
+class NoReplayKdcServer extends KdcServer {
+
+    NoReplayKdcServer(KerberosConfig kdcConfig) {
+        super(kdcConfig);
+    }
+
+    private static Logger LOGGER = Logger.getLogger(NoReplayKdcServer.class);
+
+    /**
+     *
+     * Dummy implementation of the ApacheDS kerberos replay cache. Essentially disables kerbores ticket replay checks.
+     * https://issues.jboss.org/browse/JBPAPP-10974
+     *
+     * @author Dominik Pospisil <dpospisi@redhat.com>
+     */
+    private class DummyReplayCache implements ReplayCache {
+
+        @Override
+        public boolean isReplay(KerberosPrincipal serverPrincipal, KerberosPrincipal clientPrincipal, KerberosTime clientTime,
+                int clientMicroSeconds) {
+            return false;
+        }
+
+        @Override
+        public void save(KerberosPrincipal serverPrincipal, KerberosPrincipal clientPrincipal, KerberosTime clientTime,
+                int clientMicroSeconds) {
+            return;
+        }
+
+        @Override
+        public void clear() {
+            return;
+        }
+
+    }
+
+    /**
+     * @throws IOException if we cannot bind to the sockets
+     */
+    public void start() throws IOException, LdapInvalidDnException {
+        super.start();
+
+        try {
+
+            // override initialized replay cache with a dummy implementation
+            Field replayCacheField = KdcServer.class.getDeclaredField("replayCache");
+            replayCacheField.setAccessible(true);
+            replayCacheField.set(this, new DummyReplayCache());
+        } catch (Exception e) {
+            LOGGER.warn("Unable to override replay cache.", e);
+        }
+
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/KerberosSystemPropertiesSetupTask.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/KerberosSystemPropertiesSetupTask.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.kerberos;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.wildfly.test.security.common.AbstractSystemPropertiesServerSetupTask;
+
+/**
+ * ServerSetup task which configures server system properties for Kerberos testing - path to {@code krb5.conf} file etc.
+ *
+ * @author Josef Cacek
+ */
+public class KerberosSystemPropertiesSetupTask extends AbstractSystemPropertiesServerSetupTask {
+
+    /**
+     * Returns "java.security.krb5.conf" and "sun.security.krb5.debug" properties.
+     *
+     * @return Kerberos properties
+     * @see org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask#getSystemProperties()
+     */
+    @Override
+    protected Map<String, String> getSystemProperties() {
+        final Map<String, String> map = new HashMap<String, String>();
+        map.put("java.security.krb5.conf", AbstractKrb5ConfServerSetupTask.getKrb5ConfFullPath());
+        map.put("sun.security.krb5.debug", "true");
+        return map;
+    }
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/KerberosTestUtils.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/KerberosTestUtils.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.test.security.common.kerberos;
+
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+
+import org.apache.directory.server.annotations.CreateTransport;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.security.auth.callback.UsernamePasswordHandler;
+import org.junit.AssumptionViolatedException;
+
+/**
+ * Helper methods for JGSSAPI &amp; SPNEGO &amp; Kerberos testcases. It mainly helps to skip tests on configurations which
+ * contains issues.
+ *
+ * @author Josef Cacek
+ */
+public final class KerberosTestUtils {
+
+    public static final String OID_KERBEROS_V5 = "1.2.840.113554.1.2.2";
+    public static final String OID_KERBEROS_V5_LEGACY = "1.2.840.48018.1.2.2";
+    public static final String OID_NTLM = "1.3.6.1.4.1.311.2.2.10";
+    public static final String OID_SPNEGO = "1.3.6.1.5.5.2";
+    public static final String OID_DUMMY = "1.1.2.5.6.7";
+
+    /**
+     * Just a private constructor.
+     */
+    private KerberosTestUtils() {
+        // It's OK to be empty - we don't instantiate this class.
+    }
+
+    /**
+     * This method throws an {@link AssumptionViolatedException} (i.e. it skips the test-case) if the configuration is
+     * unsupported for HTTP authentication with Kerberos. Configuration in this case means combination of [ hostname used | JDK
+     * vendor | Java version ].
+     *
+     * @throws AssumptionViolatedException
+     */
+    public static void assumeKerberosAuthenticationSupported() throws AssumptionViolatedException {
+        if (CoreUtils.IBM_JDK && isIPV6()) {
+            throw new AssumptionViolatedException(
+                    "Kerberos tests are not supported on IBM Java with IPv6. Find more info in https://bugzilla.redhat.com/show_bug.cgi?id=1188632");
+        }
+        if (isIPV6()) {
+            throw new AssumptionViolatedException(
+                    "Kerberos tests are not supported when hostname is not available for tested IPv6 address. Find more info in https://issues.jboss.org/browse/WFLY-5409");
+        }
+    }
+
+    /**
+     * Returns true if the server bind address is an IPv6 address without canonical hostname.
+     *
+     * @return
+     */
+    private static boolean isIPV6() {
+        return CoreUtils.getDefaultHost(true).indexOf(':')>=0;
+    }
+
+    /**
+     * Creates login context for given {@link Krb5LoginConfiguration} and credentials and calls the {@link LoginContext#login()}
+     * method on it. This method contains workaround for IBM JDK issue described in bugzilla <a
+     * href="https://bugzilla.redhat.com/show_bug.cgi?id=1206177">https://bugzilla.redhat.com/show_bug.cgi?id=1206177</a>.
+     *
+     * @param krb5Configuration
+     * @param user
+     * @param pass
+     * @return
+     * @throws LoginException
+     */
+    public static LoginContext loginWithKerberos(final Krb5LoginConfiguration krb5Configuration, final String user,
+            final String pass) throws LoginException {
+        LoginContext lc = new LoginContext(krb5Configuration.getName(), new UsernamePasswordHandler(user, pass));
+        if (CoreUtils.IBM_JDK) {
+            // workaround for IBM JDK on RHEL5 issue described in https://bugzilla.redhat.com/show_bug.cgi?id=1206177
+            // The first negotiation always fail, so let's do a dummy login/logout round.
+            lc.login();
+            lc.logout();
+            lc = new LoginContext(krb5Configuration.getName(), new UsernamePasswordHandler(user, pass));
+        }
+        lc.login();
+        return lc;
+    }
+
+    /**
+     * Fixes/replaces LDAP bind address in the CreateTransport annotation of ApacheDS.
+     *
+     * @param createLdapServer
+     * @param address
+     */
+    public static void fixApacheDSTransportAddress(ManagedCreateLdapServer createLdapServer, String address) {
+        final CreateTransport[] createTransports = createLdapServer.transports();
+        for (int i = 0; i < createTransports.length; i++) {
+            final ManagedCreateTransport mgCreateTransport = new ManagedCreateTransport(createTransports[i]);
+            // localhost is a default used in original CreateTransport annotation. We use it as a fallback.
+            mgCreateTransport.setAddress(address != null ? address : "localhost");
+            createTransports[i] = mgCreateTransport;
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/Krb5LoginConfiguration.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/Krb5LoginConfiguration.java
@@ -1,0 +1,175 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.kerberos;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+
+import org.jboss.as.test.integration.security.common.CoreUtils;
+
+
+/**
+ * Simple Krb5LoginModule configuration.
+ *
+ * @author Josef Cacek
+ */
+public class Krb5LoginConfiguration extends Configuration {
+
+    /** The list with configuration entries. */
+    private final AppConfigurationEntry[] configList = new AppConfigurationEntry[1];
+    private final String name;
+    private final Configuration wrapped;
+
+    /**
+     * Create a new Krb5LoginConfiguration. Neither principal nor keytab are not filled and JGSS credential type is initiator.
+     *
+     * @throws MalformedURLException
+     */
+    public Krb5LoginConfiguration(final Configuration wrapped) throws MalformedURLException {
+        this(null, null, false, wrapped);
+    }
+
+    /**
+     * Create a new Krb5LoginConfiguration with given principal name, keytab and credential type.
+     *
+     * @param principal principal name, may be <code>null</code>
+     * @param keyTab keytab file, may be <code>null</code>
+     * @param acceptor flag for setting credential type. Set to true, if the authenticated subject should be acceptor (i.e.
+     *        credsType=acceptor for IBM JDK, and storeKey=true for Oracle JDK)
+     * @param wrapped wrapped configuration (you can receive it for instance by calling Configuration#getConfiguration()
+     * @throws MalformedURLException
+     */
+    public Krb5LoginConfiguration(final String principal, final File keyTab, final boolean acceptor, final Configuration wrapped)
+            throws MalformedURLException {
+        final String loginModule = getLoginModule();
+        Map<String, String> options = getOptions(principal, keyTab, acceptor);
+        configList[0] = new AppConfigurationEntry(loginModule, AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, options);
+        name = UUID.randomUUID().toString();
+        this.wrapped = wrapped;
+    }
+
+    /**
+     * Returns Map with Krb5LoginModule options. The result depends on currently running JVM.
+     *
+     * @param principal principal name, may be <code>null</code>
+     * @param keyTab keytab file, may be <code>null</code>
+     * @param acceptor flag for setting credential type. Set to true, if the authenticated subject should be acceptor (i.e.
+     *        credsType=acceptor for IBM JDK, and storeKey=true for Oracle JDK)
+     * @return HashMap with Krb5LoginModule options.
+     */
+    public static Map<String, String> getOptions(final String principal, final File keyTab, final boolean acceptor) {
+        final Map<String, String> res = new HashMap<String, String>();
+
+        if (CoreUtils.IBM_JDK) {
+            if (keyTab != null) {
+                res.put("useKeytab", keyTab.toURI().toString());
+            }
+            if (acceptor) {
+                res.put("credsType", "acceptor");
+            } else {
+                res.put("noAddress", "true");
+            }
+        } else {
+            if (keyTab != null) {
+                res.put("keyTab", keyTab.getAbsolutePath());
+                res.put("doNotPrompt", "true");
+                res.put("useKeyTab", "true");
+            }
+            if (acceptor) {
+                res.put("storeKey", "true");
+            }
+        }
+
+        res.put("refreshKrb5Config", "true");
+        //res.put("debug", "true");
+
+        if (principal != null) {
+            res.put("principal", principal);
+        }
+
+        return res;
+    }
+
+    /**
+     * Returns Krb5LoginModule class name. The returned name depends on the currently running JVM.
+     *
+     * @return class name
+     */
+    public static String getLoginModule() {
+        if (CoreUtils.IBM_JDK) {
+            return "com.ibm.security.auth.module.Krb5LoginModule";
+        } else {
+            return "com.sun.security.auth.module.Krb5LoginModule";
+        }
+    }
+
+    /**
+     * Returns this login configuration name.
+     *
+     * @return
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the wrapped configuration.
+     *
+     * @return
+     */
+    protected Configuration getWrapped() {
+        return wrapped;
+    }
+
+    /**
+     * Interface method requiring us to return all the LoginModules we know about.
+     *
+     * @param applicationName the application name
+     * @return the configuration entry
+     */
+    @Override
+    public AppConfigurationEntry[] getAppConfigurationEntry(String applicationName) {
+        if (name.equals(applicationName)) {
+            // We will ignore the applicationName, since we want all apps to use Kerberos V5
+            return configList;
+        } else {
+            return wrapped == null ? null : wrapped.getAppConfigurationEntry(applicationName);
+        }
+    }
+
+    /**
+     * Resets configuration to the wrapped one and returns it.
+     *
+     * @return login configuration to which it was reseted
+     */
+    public Configuration resetConfiguration() {
+        Configuration.setConfiguration(wrapped);
+        return wrapped;
+    }
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/ManagedCreateLdapServer.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/ManagedCreateLdapServer.java
@@ -1,0 +1,334 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.kerberos;
+
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.annotations.SaslMechanism;
+
+/**
+ * A helper implementation of {@link CreateLdapServer} annotation which allows to configure values.
+ *
+ * @author Josef Cacek
+ */
+public class ManagedCreateLdapServer extends AnnotationLiteral<CreateLdapServer> implements CreateLdapServer {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The instance name */
+    private String name;
+    /** The transports to use, default to LDAP */
+    private CreateTransport[] transports;
+    /** The LdapServer factory */
+    private Class<?> factory;
+    /** The maximum size limit. */
+    private long maxSizeLimit;
+    /** The maximum time limit. */
+    private int maxTimeLimit;
+    /** Tells if anonymous access are allowed or not. */
+    private boolean allowAnonymousAccess;
+    /** The external keyStore file to use, default to the empty string */
+    private String keyStore;
+    /** The certificate password in base64, default to the empty string */
+    private String certificatePassword;
+    /** name of the classes implementing extended operations */
+    private Class<?>[] extendedOpHandlers;
+    /** supported set of SASL mechanisms */
+    private SaslMechanism[] saslMechanisms;
+    /** NTLM provider class, default value is an invalid class */
+    private Class<?> ntlmProvider;
+    /** The name of this host, validated during SASL negotiation. */
+    private String saslHost;
+    /** The service principal, used by GSSAPI. */
+    private String saslPrincipal;
+
+    /** The service principal, used by GSSAPI. */
+    private String[] saslRealms;
+
+    // Constructors ----------------------------------------------------------
+
+    /**
+     * Create a new ManagedCreateLdapServer.
+     *
+     * @param createLdapServer
+     */
+    public ManagedCreateLdapServer(CreateLdapServer createLdapServer) {
+        name = createLdapServer.name();
+        transports = createLdapServer.transports();
+        factory = createLdapServer.factory();
+        maxSizeLimit = createLdapServer.maxSizeLimit();
+        maxTimeLimit = createLdapServer.maxTimeLimit();
+        allowAnonymousAccess = createLdapServer.allowAnonymousAccess();
+        keyStore = createLdapServer.keyStore();
+        certificatePassword = createLdapServer.certificatePassword();
+        extendedOpHandlers = createLdapServer.extendedOpHandlers();
+        saslMechanisms = createLdapServer.saslMechanisms();
+        ntlmProvider = createLdapServer.ntlmProvider();
+        saslHost = createLdapServer.saslHost();
+        saslPrincipal = createLdapServer.saslPrincipal();
+        saslRealms = createLdapServer.saslRealms();
+    }
+
+    // Public methods --------------------------------------------------------
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#name()
+     */
+    public String name() {
+        return name;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#transports()
+     */
+    public CreateTransport[] transports() {
+        return transports;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#factory()
+     */
+    public Class<?> factory() {
+        return factory;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#maxSizeLimit()
+     */
+    public long maxSizeLimit() {
+        return maxSizeLimit;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#maxTimeLimit()
+     */
+    public int maxTimeLimit() {
+        return maxTimeLimit;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#allowAnonymousAccess()
+     */
+    public boolean allowAnonymousAccess() {
+        return allowAnonymousAccess;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#keyStore()
+     */
+    public String keyStore() {
+        return keyStore;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#certificatePassword()
+     */
+    public String certificatePassword() {
+        return certificatePassword;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#extendedOpHandlers()
+     */
+    public Class<?>[] extendedOpHandlers() {
+        return extendedOpHandlers;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#saslMechanisms()
+     */
+    public SaslMechanism[] saslMechanisms() {
+        return saslMechanisms;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#ntlmProvider()
+     */
+    public Class<?> ntlmProvider() {
+        return ntlmProvider;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#saslHost()
+     */
+    public String saslHost() {
+        return saslHost;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateLdapServer#saslPrincipal()
+     */
+    public String saslPrincipal() {
+        return saslPrincipal;
+    }
+
+    @Override
+    public String[] saslRealms() {
+        return saslRealms;
+    }
+
+    /**
+     * Set the name.
+     *
+     * @param name The name to set.
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * Set the transports.
+     *
+     * @param transports The transports to set.
+     */
+    public void setTransports(CreateTransport[] transports) {
+        this.transports = transports;
+    }
+
+    /**
+     * Set the factory.
+     *
+     * @param factory The factory to set.
+     */
+    public void setFactory(Class<?> factory) {
+        this.factory = factory;
+    }
+
+    /**
+     * Set the maxSizeLimit.
+     *
+     * @param maxSizeLimit The maxSizeLimit to set.
+     */
+    public void setMaxSizeLimit(long maxSizeLimit) {
+        this.maxSizeLimit = maxSizeLimit;
+    }
+
+    /**
+     * Set the maxTimeLimit.
+     *
+     * @param maxTimeLimit The maxTimeLimit to set.
+     */
+    public void setMaxTimeLimit(int maxTimeLimit) {
+        this.maxTimeLimit = maxTimeLimit;
+    }
+
+    /**
+     * Set the allowAnonymousAccess.
+     *
+     * @param allowAnonymousAccess The allowAnonymousAccess to set.
+     */
+    public void setAllowAnonymousAccess(boolean allowAnonymousAccess) {
+        this.allowAnonymousAccess = allowAnonymousAccess;
+    }
+
+    /**
+     * Set the keyStore.
+     *
+     * @param keyStore The keyStore to set.
+     */
+    public void setKeyStore(String keyStore) {
+        this.keyStore = keyStore;
+    }
+
+    /**
+     * Set the certificatePassword.
+     *
+     * @param certificatePassword The certificatePassword to set.
+     */
+    public void setCertificatePassword(String certificatePassword) {
+        this.certificatePassword = certificatePassword;
+    }
+
+    /**
+     * Set the extendedOpHandlers.
+     *
+     * @param extendedOpHandlers The extendedOpHandlers to set.
+     */
+    public void setExtendedOpHandlers(Class<?>[] extendedOpHandlers) {
+        this.extendedOpHandlers = extendedOpHandlers;
+    }
+
+    /**
+     * Set the saslMechanisms.
+     *
+     * @param saslMechanisms The saslMechanisms to set.
+     */
+    public void setSaslMechanisms(SaslMechanism[] saslMechanisms) {
+        this.saslMechanisms = saslMechanisms;
+    }
+
+    /**
+     * Set the ntlmProvider.
+     *
+     * @param ntlmProvider The ntlmProvider to set.
+     */
+    public void setNtlmProvider(Class<?> ntlmProvider) {
+        this.ntlmProvider = ntlmProvider;
+    }
+
+    /**
+     * Set the saslHost.
+     *
+     * @param saslHost The saslHost to set.
+     */
+    public void setSaslHost(String saslHost) {
+        this.saslHost = saslHost;
+    }
+
+    /**
+     * Set the saslPrincipal.
+     *
+     * @param saslPrincipal The saslPrincipal to set.
+     */
+    public void setSaslPrincipal(String saslPrincipal) {
+        this.saslPrincipal = saslPrincipal;
+    }
+
+
+
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/ManagedCreateTransport.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/kerberos/ManagedCreateTransport.java
@@ -1,0 +1,195 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.test.security.common.kerberos;
+
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.annotations.TransportType;
+
+/**
+ * A helper implementation of {@link CreateTransport} annotation which allows to configure values.
+ *
+ * @author Josef Cacek
+ */
+public class ManagedCreateTransport extends AnnotationLiteral<CreateTransport> implements CreateTransport {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The name for this protocol */
+    private String protocol;
+    /** The transport type (TCP or UDP) Default to TCP */
+    private TransportType type;
+    /** The port to use, default to a bad value so that we know we have to pick one random available port */
+    private int port;
+    /** The InetAddress for this transport. Default to localhost */
+    private String address;
+    /** The backlog. Default to 50 */
+    private int backlog;
+    /** A flag to tell if the transport is SSL based. Default to false */
+    private boolean ssl;
+    /** The number of threads to use. Default to 3 */
+    private int nbThreads;
+
+    // Constructors ----------------------------------------------------------
+
+    /**
+     * Create a new ManagedCreateTransport.
+     *
+     * @param createLdapServer
+     */
+    public ManagedCreateTransport(final CreateTransport original) {
+        protocol = original.protocol();
+        type = original.type();
+        port = original.port();
+        address = original.address();
+        backlog = original.backlog();
+        ssl = original.ssl();
+        nbThreads = original.nbThreads();
+    }
+
+    // Public methods --------------------------------------------------------
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateTransport#protocol()
+     */
+    public String protocol() {
+        return protocol;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateTransport#type()
+     */
+    public TransportType type() {
+        return type;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateTransport#port()
+     */
+    public int port() {
+        return port;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateTransport#address()
+     */
+    public String address() {
+        return address;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateTransport#backlog()
+     */
+    public int backlog() {
+        return backlog;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateTransport#ssl()
+     */
+    public boolean ssl() {
+        return ssl;
+    }
+
+    /**
+     *
+     * @return
+     * @see org.apache.directory.server.annotations.CreateTransport#nbThreads()
+     */
+    public int nbThreads() {
+        return nbThreads;
+    }
+
+    /**
+     * Set the protocol.
+     *
+     * @param protocol The protocol to set.
+     */
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    /**
+     * Set the type.
+     *
+     * @param type The type to set.
+     */
+    public void setType(TransportType type) {
+        this.type = type;
+    }
+
+    /**
+     * Set the port.
+     *
+     * @param port The port to set.
+     */
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    /**
+     * Set the address.
+     *
+     * @param address The address to set.
+     */
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    /**
+     * Set the backlog.
+     *
+     * @param backlog The backlog to set.
+     */
+    public void setBacklog(int backlog) {
+        this.backlog = backlog;
+    }
+
+    /**
+     * Set the ssl.
+     *
+     * @param ssl The ssl to set.
+     */
+    public void setSsl(boolean ssl) {
+        this.ssl = ssl;
+    }
+
+    /**
+     * Set the nbThreads.
+     *
+     * @param nbThreads The nbThreads to set.
+     */
+    public void setNbThreads(int nbThreads) {
+        this.nbThreads = nbThreads;
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/other/AccessIdentityConfigurator.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/other/AccessIdentityConfigurator.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.other;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+
+/**
+ * Configuration helper for '/core-service=management/access=identity'. It can set or remove the security-domain name.
+ *
+ * @author Josef Cacek
+ */
+public class AccessIdentityConfigurator implements ConfigurableElement {
+
+    private static final PathAddress IDENTITY_ADDR = PathAddress.pathAddress().append("core-service", "management")
+            .append("access", "identity");
+    private final String securityDomain;
+    private String originalDomain;
+
+    private AccessIdentityConfigurator(Builder builder) {
+        this.securityDomain = builder.securityDomain;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        originalDomain = setAccessIdentity(client, securityDomain);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        setAccessIdentity(client, originalDomain);
+        originalDomain = null;
+    }
+
+    @Override
+    public String getName() {
+        return "/core-service=management/access=identity";
+    }
+
+    private String setAccessIdentity(ModelControllerClient client, String domainToSet) throws Exception {
+        String origDomainValue = null;
+        ModelNode op = Util.createEmptyOperation("read-attribute", IDENTITY_ADDR);
+        op.get("name").set("security-domain");
+        ModelNode result = client.execute(op);
+        boolean identityExists = Operations.isSuccessfulOutcome(result);
+        op = null;
+        if (identityExists) {
+            result = Operations.readResult(result);
+            origDomainValue = result.isDefined() ? result.asString() : null;
+
+            if (domainToSet == null) {
+                op = Util.createRemoveOperation(IDENTITY_ADDR);
+            } else if (!domainToSet.equals(origDomainValue)) {
+                op = Util.createEmptyOperation("write-attribute", IDENTITY_ADDR);
+                op.get("name").set("security-domain");
+                op.get("value").set(domainToSet);
+            }
+        } else if (domainToSet != null) {
+            op = Util.createAddOperation(IDENTITY_ADDR);
+            op.get("security-domain").set(domainToSet);
+        }
+
+        if (op!=null) {
+            CoreUtils.applyUpdate(op, client);
+        }
+        return origDomainValue;
+    }
+    /**
+     * Creates builder to build {@link AccessIdentityConfigurator}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link AccessIdentityConfigurator}.
+     */
+    public static final class Builder {
+        private String securityDomain;
+
+        private Builder() {
+        }
+
+        public Builder withSecurityDomain(String securityDomain) {
+            this.securityDomain = securityDomain;
+            return this;
+        }
+
+        public AccessIdentityConfigurator build() {
+            return new AccessIdentityConfigurator(this);
+        }
+    }
+}

--- a/testsuite/elytron/src/test/java/org/wildfly/test/security/common/other/HttpMgmtConfigurator.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/security/common/other/HttpMgmtConfigurator.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.security.common.other;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.integration.security.common.CoreUtils;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+
+/**
+ * Configuration helper for https configuration in '/core-service=management/management-interface=http-interface'. It sets
+ * {@code ssl-context}, {@code secure-socket-binding} and {@code http-upgrade.sasl-authentication-factory} attributes.
+ *
+ * @author Josef Cacek
+ */
+public class HttpMgmtConfigurator implements ConfigurableElement {
+
+    private static final PathAddress HTTP_IFACE_ADDR = PathAddress.pathAddress().append("core-service", "management")
+            .append("management-interface", "http-interface");
+    private final String sslContext;
+    private final String secureSocketBinding;
+    private final String saslAuthenticationFactory;
+
+    private String originalSslContext;
+    private String originalSecureSocketBinding;
+    private String originalSaslAuthenticationFactory;
+
+    private HttpMgmtConfigurator(Builder builder) {
+        this.sslContext = builder.sslContext;
+        this.secureSocketBinding = builder.secureSocketBinding;
+        this.saslAuthenticationFactory = builder.saslAuthenticationFactory;
+    }
+
+    @Override
+    public void create(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        originalSslContext = readAttribute(client, "ssl-context");
+        originalSecureSocketBinding = readAttribute(client, "secure-socket-binding");
+        originalSaslAuthenticationFactory = readAttribute(client, "http-upgrade.sasl-authentication-factory");
+
+        ModelNode composite = Util.createEmptyOperation("composite", null);
+        composite.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        ModelNode steps = composite.get("steps");
+        steps.add(createWriteAttributeOp("ssl-context", sslContext));
+        steps.add(createWriteAttributeOp("secure-socket-binding", secureSocketBinding));
+        steps.add(createWriteAttributeOp("http-upgrade.sasl-authentication-factory", saslAuthenticationFactory));
+        CoreUtils.applyUpdate(composite, client);
+    }
+
+    @Override
+    public void remove(ModelControllerClient client, CLIWrapper cli) throws Exception {
+        ModelNode composite = Util.createEmptyOperation("composite", null);
+        composite.get(OPERATION_HEADERS, ROLLBACK_ON_RUNTIME_FAILURE).set(false);
+        ModelNode steps = composite.get("steps");
+        steps.add(createWriteAttributeOp("ssl-context", originalSslContext));
+        steps.add(createWriteAttributeOp("secure-socket-binding", originalSecureSocketBinding));
+        steps.add(createWriteAttributeOp("http-upgrade.sasl-authentication-factory", originalSaslAuthenticationFactory));
+        CoreUtils.applyUpdate(composite, client);
+
+        originalSslContext = null;
+        originalSecureSocketBinding = null;
+        originalSaslAuthenticationFactory = null;
+    }
+
+    @Override
+    public String getName() {
+        return "/core-service=management/management-interface=http-interface";
+    }
+
+    private String readAttribute(ModelControllerClient client, String name) throws Exception {
+        String originalVal;
+        ModelNode op = Util.createEmptyOperation("read-attribute", HTTP_IFACE_ADDR);
+        op.get("name").set(name);
+        ModelNode result = client.execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            result = Operations.readResult(result);
+            originalVal = result.isDefined() ? result.asString() : null;
+        } else {
+            throw new RuntimeException(
+                    "Reading existing value of attribute " + name + " failed: " + Operations.getFailureDescription(result));
+        }
+        return originalVal;
+    }
+
+    private ModelNode createWriteAttributeOp(String name, String value) throws Exception {
+        ModelNode op = Util.createEmptyOperation("write-attribute", HTTP_IFACE_ADDR);
+        op.get("name").set(name);
+        if (value != null) {
+            op.get("value").set(value);
+        }
+        return op;
+    }
+
+    /**
+     * Creates builder to build {@link HttpMgmtConfigurator}.
+     *
+     * @return created builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder to build {@link HttpMgmtConfigurator}.
+     */
+    public static final class Builder {
+        private String sslContext;
+        private String secureSocketBinding;
+        private String saslAuthenticationFactory;
+
+        private Builder() {
+        }
+
+        public Builder withSslContext(String sslContext) {
+            this.sslContext = sslContext;
+            return this;
+        }
+
+        public Builder withSecureSocketBinding(String secureSocketBinding) {
+            this.secureSocketBinding = secureSocketBinding;
+            return this;
+        }
+
+        public Builder withSaslAuthenticationFactory(String saslAuthenticationFactory) {
+            this.saslAuthenticationFactory = saslAuthenticationFactory;
+            return this;
+        }
+
+        public HttpMgmtConfigurator build() {
+            return new HttpMgmtConfigurator(this);
+        }
+    }
+
+}

--- a/testsuite/elytron/src/test/resources/org/wildfly/test/integration/elytron/sasl/mgmt/remoting-krb5-test.ldif
+++ b/testsuite/elytron/src/test/resources/org/wildfly/test/integration/elytron/sasl/mgmt/remoting-krb5-test.ldif
@@ -1,0 +1,77 @@
+version: 1
+
+dn: dc=wildfly,dc=org
+dc: wildfly
+objectClass: top
+objectClass: domain
+
+dn: ou=Users,dc=wildfly,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: Users
+
+dn: uid=krbtgt,ou=Users,dc=wildfly,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: KDC Service
+sn: Service
+uid: krbtgt
+userPassword: secret
+krb5PrincipalName: krbtgt/JBOSS.ORG@JBOSS.ORG
+krb5KeyVersionNumber: 0
+
+dn: uid=ldap,ou=Users,dc=wildfly,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: LDAP
+sn: Service
+uid: ldap
+userPassword: randall
+krb5PrincipalName: ldap/${ldaphost}@JBOSS.ORG
+krb5KeyVersionNumber: 0
+
+dn: uid=remote,ou=Users,dc=wildfly,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: JBoss Remoting
+sn: Service
+uid: remote
+userPassword: zelvicka
+krb5PrincipalName: remote/${hostname}@JBOSS.ORG
+krb5KeyVersionNumber: 0
+
+dn: uid=hnelson,ou=Users,dc=wildfly,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: Horatio Nelson
+sn: Nelson
+uid: hnelson
+userPassword: secret
+krb5PrincipalName: hnelson@JBOSS.ORG
+krb5KeyVersionNumber: 0
+
+dn: uid=jduke,ou=Users,dc=wildfly,dc=org
+objectClass: top
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: krb5principal
+objectClass: krb5kdcentry
+cn: Java Duke
+mail: jduke@JBOSS.ORG
+sn: duke
+uid: jduke
+userPassword: theduke
+krb5PrincipalName: jduke@JBOSS.ORG
+krb5KeyVersionNumber: 0

--- a/testsuite/elytron/src/test/resources/org/wildfly/test/security/common/kerberos/krb5.conf
+++ b/testsuite/elytron/src/test/resources/org/wildfly/test/security/common/kerberos/krb5.conf
@@ -1,0 +1,20 @@
+[libdefaults]
+	default_realm = JBOSS.ORG
+	default_tgs_enctypes = ${enctypes}
+	default_tkt_enctypes = ${enctypes}
+	kdc_timeout = 5000
+	dns_lookup_realm = false
+	dns_lookup_kdc = false
+	allow_weak_crypto = yes
+	forwardable = true
+
+[realms]
+	JBOSS.ORG = {
+		kdc = ${hostname}:6088
+	}
+	JBOSS.COM = {
+		kdc = ${hostname}:6188
+	}
+
+[domain_realm]
+#	${hostname} = JBOSS.ORG

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/CoreUtils.java
@@ -44,9 +44,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import javax.security.auth.login.Configuration;
+
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -68,6 +71,7 @@ import org.apache.http.util.EntityUtils;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.as.network.NetworkUtils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
@@ -86,6 +90,8 @@ public class CoreUtils {
     private static final Logger LOGGER = Logger.getLogger(CoreUtils.class);
 
     public static final String UTF_8 = "UTF-8";
+
+    public static final boolean IBM_JDK = StringUtils.startsWith(SystemUtils.JAVA_VENDOR, "IBM");
 
     /**
      * Return MD5 hash of the given string value, encoded with given {@link Coding}. If the value or coding is <code>null</code>
@@ -631,4 +637,32 @@ public class CoreUtils {
         }
         return response;
     }
+
+    /**
+     * Returns hostname - either read from the "node0" system property or the loopback address "127.0.0.1".
+     *
+     * @param canonical return hostname in canonical form
+     *
+     * @return
+     */
+    public static String getDefaultHost(boolean canonical) {
+        final String hostname = TestSuiteEnvironment.getHttpAddress();
+        return canonical ? getCannonicalHost(hostname) : hostname;
+    }
+
+    /**
+     * Returns installed login configuration.
+     *
+     * @return Configuration
+     */
+    public static Configuration getLoginConfiguration() {
+        Configuration configuration = null;
+        try {
+            configuration = Configuration.getConfiguration();
+        } catch (SecurityException e) {
+            LOGGER.debug("Unable to load default login configuration", e);
+        }
+        return configuration;
+    }
+
 }


### PR DESCRIPTION
Upstream: https://issues.jboss.org/browse/WFCORE-3179
Downstream: https://issues.jboss.org/browse/JBEAP-11775

Tests for Elytron Kerberos SASL mechanisms - `GSSAPI`, `GS2-KRB5`, `GS2-KRB5-PLUS`.

Replaces:
https://github.com/jbossas/jboss-eap7/pull/2058
https://github.com/wildfly/wildfly/pull/10243

