### PR TITLE
[WFCORE-2565] Incorrect permission class-name should throw exception at runtime

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
@@ -263,6 +263,7 @@ class PermissionMapperDefinitions {
             return PermissionUtil.createPermission(classLoader, permission.getClassName(), permission.getTargetName(), permission.getAction());
         } catch (InvalidPermissionClassException e) {
             // If we cannot load it, it can never be checked.
+            ElytronSubsystemMessages.ROOT_LOGGER.invalidPermissionClass(permission.getClassName());
             return null;
         } catch (Throwable e) {
             throw ElytronSubsystemMessages.ROOT_LOGGER.exceptionWhileCreatingPermission(permission.getClassName(), e);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -310,6 +310,9 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 37, value = "Injected value is not of '%s' type.")
     StartException invalidTypeInjected(final String type);
 
+    @LogMessage(level = WARN)
+    @Message(id = 38, value = "Could not load permission class \"%s\"")
+    void invalidPermissionClass(String className);
 
     // CREDENTIAL_STORE section
     @Message(id = 909, value = "Credential store '%s' does not support given credential store entry type '%s'")


### PR DESCRIPTION
wildfly-elytron-integration: https://issues.jboss.org/browse/WFCORE-2565
JBEAP: https://issues.jboss.org/browse/JBEAP-9726