### PR TITLE
[I18n] Prepare for internationalization

### DIFF
--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2015 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <!-- Ignore files pulled down from zanata -->
+    <suppress files="LocalDescriptions_.+\.properties|.*\.i18n_.+\.properties" checks=".*"/>
+</suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,7 @@
                  <includes>**/*.i18n.properties,**/LocalDescriptions.properties</includes>
                  <!-- In previous versions, 3.8.0 and lower, this defaulted to true -->
                  <copyTrans>true</copyTrans>
+                 <deleteObsoleteModules>true</deleteObsoleteModules>
               </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,7 @@
                         <configLocation>wildfly-checkstyle/checkstyle.xml</configLocation>
                         <consoleOutput>true</consoleOutput>
                         <failsOnError>true</failsOnError>
+                        <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
                         <excludes>**/*$logger.java,**/*$bundle.java</excludes>
                         <useFile/>

--- a/zanata.xml
+++ b/zanata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <config xmlns="http://zanata.org/namespace/config/">
-    <url>https://translate.jboss.org/</url>
-    <project>jboss-eap-core</project>
+    <url>https://vendors.zanata.redhat.com/</url>
+    <project>eap-core</project>
     <project-version>3.0</project-version>
     <project-type>properties</project-type>
 


### PR DESCRIPTION
## First Commit (8303ab8)
This changes the zanata configuration to point to the new server.

## Second Commit (d6106a6)
This allows properties files downloaded from zanata to not be processed by the checkstyle plugin.

## Third Commit (d016690)
This allows entries that are no longer required to be deleted when the base properties files are uploaded.