### PR TITLE
[WFCORE-3182] Remove audit logging from default security domain definitions.

### DIFF
--- a/elytron/src/main/resources/subsystem-templates/elytron.xml
+++ b/elytron/src/main/resources/subsystem-templates/elytron.xml
@@ -90,7 +90,7 @@
             </audit-logging>
         </replacement>
         <replacement placeholder="DOMAIN_DEFINITIONS">
-            <security-domain name="ApplicationDomain" default-realm="ApplicationRealm" permission-mapper="default-permission-mapper" security-event-listener="local-audit">
+            <security-domain name="ApplicationDomain" default-realm="ApplicationRealm" permission-mapper="default-permission-mapper">
                 <realm name="ApplicationRealm" role-decoder="groups-to-roles" />
             </security-domain>
         </replacement>
@@ -137,7 +137,7 @@
             </audit-logging>
         </replacement>
         <replacement placeholder="DOMAIN_DEFINITIONS">
-            <security-domain name="ManagementDomain" default-realm="ManagementRealm" permission-mapper="default-permission-mapper" security-event-listener="local-audit">
+            <security-domain name="ManagementDomain" default-realm="ManagementRealm" permission-mapper="default-permission-mapper">
                 <realm name="ManagementRealm" role-decoder="groups-to-roles" />
                 <realm name="local" role-mapper="super-user-mapper"/>
             </security-domain>
@@ -176,12 +176,12 @@
             </audit-logging>
         </replacement>
         <replacement placeholder="DOMAIN_DEFINITIONS">
-            <security-domain name="ApplicationDomain" default-realm="ApplicationRealm" permission-mapper="default-permission-mapper" security-event-listener="local-audit">
+            <security-domain name="ApplicationDomain" default-realm="ApplicationRealm" permission-mapper="default-permission-mapper">
                 <realm name="ApplicationRealm" role-decoder="groups-to-roles" />
                 <realm name="local"/>
             </security-domain>
 
-            <security-domain name="ManagementDomain" default-realm="ManagementRealm" permission-mapper="default-permission-mapper" security-event-listener="local-audit">
+            <security-domain name="ManagementDomain" default-realm="ManagementRealm" permission-mapper="default-permission-mapper">
                 <realm name="ManagementRealm" role-decoder="groups-to-roles" />
                 <realm name="local" role-mapper="super-user-mapper"/>
             </security-domain>

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogToTLSElytronSyslogSetup.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogToTLSElytronSyslogSetup.java
@@ -21,8 +21,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.KEY
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROTOCOL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TLS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TRUSTSTORE;
-import static org.jboss.as.test.integration.auditlog.AuditLogToTLSSyslogSetup.CLIENT_KEYSTORE_FILE;
-import static org.jboss.as.test.integration.auditlog.AuditLogToTLSSyslogSetup.CLIENT_TRUSTSTORE_FILE;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Also adjust the AuditLogBootingSyslogTest to take into account the reduced size of the composite operation to boot the server.

https://issues.jboss.org/browse/WFCORE-3182

This is the main fix for https://issues.jboss.org/browse/JBEAP-12631 - however a minor optimisation is still going to be applied to Elytron to minimise the steps within the synchronized block.