### PR TITLE
[WFCORE-3191] / [WFCORE-3170] Upgrade WildFly Elytron to 1.1.0.CR6 and Elytron Web to 1.0.0.CR2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <version.org.wildfly.legacy.test>2.0.3.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.security.elytron>1.1.0.CR6</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron.tool>1.0.0.CR4</version.org.wildfly.security.elytron.tool>
-        <version.org.wildfly.security.elytron-web.undertow-server>1.0.0.CR1</version.org.wildfly.security.elytron-web.undertow-server>
+        <version.org.wildfly.security.elytron-web.undertow-server>1.0.0.CR2</version.org.wildfly.security.elytron-web.undertow-server>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
         <!-- Non-default maven plugin versions and configuration -->
         <version.org.zanata.plugin>3.9.1</version.org.zanata.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <version.org.wildfly.discovery>1.0.0.Final</version.org.wildfly.discovery>
         <version.org.wildfly.openssl>1.0.0.CR5</version.org.wildfly.openssl>
         <version.org.wildfly.legacy.test>2.0.3.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.security.elytron>1.1.0.CR5</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.1.0.CR6</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron.tool>1.0.0.CR4</version.org.wildfly.security.elytron.tool>
         <version.org.wildfly.security.elytron-web.undertow-server>1.0.0.CR1</version.org.wildfly.security.elytron-web.undertow-server>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3191
https://issues.jboss.org/browse/WFCORE-3170

https://issues.jboss.org/browse/JBEAP-12750
https://issues.jboss.org/browse/JBEAP-12618