### PR TITLE
Small fix so that the configuration files don't change

### DIFF
--- a/elytron/src/main/resources/subsystem-templates/elytron.xml
+++ b/elytron/src/main/resources/subsystem-templates/elytron.xml
@@ -21,13 +21,12 @@
     <extension-module>org.wildfly.extension.elytron</extension-module>
     <subsystem xmlns="urn:wildfly:elytron:1.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
         <providers>
-            <provider-loader name="elytron" module="org.wildfly.security.elytron" />
-            <provider-loader name="openssl" module="org.wildfly.openssl" />
-
             <aggregate-providers name="combined-providers">
                 <providers name="elytron" />
                 <providers name="openssl" />
             </aggregate-providers>
+            <provider-loader name="elytron" module="org.wildfly.security.elytron" />
+            <provider-loader name="openssl" module="org.wildfly.openssl" />
         </providers>
 
         <?AUDIT_DEFINITIONS?>
@@ -69,17 +68,17 @@
 
         <sasl>
             <?SASL_DEFINITIONS?>
-            <provider-sasl-server-factory name="global"/>
-            <mechanism-provider-filtering-sasl-server-factory name="elytron" sasl-server-factory="global">
-                <filters>
-                    <filter provider-name="WildFlyElytron" />
-                </filters>
-            </mechanism-provider-filtering-sasl-server-factory>
             <configurable-sasl-server-factory name="configured" sasl-server-factory="elytron">
                 <properties>
                     <property name="wildfly.sasl.local-user.default-user" value="$local" />
                 </properties>
             </configurable-sasl-server-factory>
+            <mechanism-provider-filtering-sasl-server-factory name="elytron" sasl-server-factory="global">
+                <filters>
+                    <filter provider-name="WildFlyElytron" />
+                </filters>
+            </mechanism-provider-filtering-sasl-server-factory>
+            <provider-sasl-server-factory name="global"/>
         </sasl>
     </subsystem>
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml_5.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml_5.java
@@ -162,25 +162,20 @@ class DomainXml_5 extends CommonXml implements ManagementXmlDelegate {
             DomainRootDefinition.ORGANIZATION_IDENTIFIER.marshallAsAttribute(modelNode, writer);
         }
 
-        WriteUtils.writeNewLine(writer);
         if (modelNode.hasDefined(EXTENSION)) {
             extensionXml.writeExtensions(writer, modelNode.get(EXTENSION));
-            WriteUtils.writeNewLine(writer);
         }
         if (modelNode.hasDefined(SYSTEM_PROPERTY)) {
             writeProperties(writer, modelNode.get(SYSTEM_PROPERTY), Element.SYSTEM_PROPERTIES, false);
-            WriteUtils.writeNewLine(writer);
         }
         if (modelNode.hasDefined(PATH)) {
             writePaths(writer, modelNode.get(PATH), true);
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(CORE_SERVICE) && modelNode.get(CORE_SERVICE).hasDefined(MANAGEMENT)) {
             // We use CURRENT here as we only support writing the most recent.
             ManagementXml managementXml = ManagementXml.newInstance(CURRENT, this);
             managementXml.writeManagement(writer, modelNode.get(CORE_SERVICE, MANAGEMENT), true);
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(PROFILE)) {
@@ -190,11 +185,9 @@ class DomainXml_5 extends CommonXml implements ManagementXmlDelegate {
                 writeProfile(writer, profile, profiles.get(profile), context);
             }
             writer.writeEndElement();
-            WriteUtils.writeNewLine(writer);
         }
         if (modelNode.hasDefined(INTERFACE)) {
             writeInterfaces(writer, modelNode.get(INTERFACE));
-            WriteUtils.writeNewLine(writer);
         }
         if (modelNode.hasDefined(SOCKET_BINDING_GROUP)) {
             writer.writeStartElement(Element.SOCKET_BINDING_GROUPS.getLocalName());
@@ -203,15 +196,12 @@ class DomainXml_5 extends CommonXml implements ManagementXmlDelegate {
                 writeSocketBindingGroup(writer, sbgs.get(sbg), sbg);
             }
             writer.writeEndElement();
-            WriteUtils.writeNewLine(writer);
         }
         if (modelNode.hasDefined(DEPLOYMENT)) {
             writeDomainDeployments(writer, modelNode.get(DEPLOYMENT));
-            WriteUtils.writeNewLine(writer);
         }
         if (modelNode.hasDefined(DEPLOYMENT_OVERLAY)) {
             writeDeploymentOverlays(writer, modelNode.get(DEPLOYMENT_OVERLAY));
-            WriteUtils.writeNewLine(writer);
         }
         if (modelNode.hasDefined(SERVER_GROUP)) {
             writer.writeStartElement(Element.SERVER_GROUPS.getLocalName());
@@ -220,19 +210,15 @@ class DomainXml_5 extends CommonXml implements ManagementXmlDelegate {
                 writeServerGroup(writer, sg, sgs.get(sg));
             }
             writer.writeEndElement();
-            WriteUtils.writeNewLine(writer);
         }
         if (modelNode.hasDefined(HOST_EXCLUDE)) {
             writeHostExcludes(writer, modelNode.get(HOST_EXCLUDE));
-            WriteUtils.writeNewLine(writer);
         }
         if (modelNode.hasDefined(MANAGEMENT_CLIENT_CONTENT)) {
             writeManagementClientContent(writer, modelNode.get(MANAGEMENT_CLIENT_CONTENT));
-            WriteUtils.writeNewLine(writer);
         }
 
         writer.writeEndElement();
-        WriteUtils.writeNewLine(writer);
         writer.writeEndDocument();
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_5.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml_5.java
@@ -194,32 +194,26 @@ class HostXml_5 extends CommonXml implements ManagementXmlDelegate {
         writeNamespaces(writer, modelNode);
         writeSchemaLocation(writer, modelNode);
 
-        WriteUtils.writeNewLine(writer);
-
         if (modelNode.hasDefined(EXTENSION)) {
             extensionXml.writeExtensions(writer, modelNode.get(EXTENSION));
         }
 
         if (modelNode.hasDefined(SYSTEM_PROPERTY)) {
             writeProperties(writer, modelNode.get(SYSTEM_PROPERTY), Element.SYSTEM_PROPERTIES, false);
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(PATH)) {
             writePaths(writer, modelNode.get(PATH), false);
-            WriteUtils.writeNewLine(writer);
         }
 
         boolean hasCoreServices = modelNode.hasDefined(CORE_SERVICE);
         if (hasCoreServices && modelNode.get(CORE_SERVICE).hasDefined(VAULT)) {
             writeVault(writer, modelNode.get(CORE_SERVICE, VAULT));
-            WriteUtils.writeNewLine(writer);
         }
 
         if (hasCoreServices) {
             ManagementXml managementXml = ManagementXml.newInstance(CURRENT, this);
             managementXml.writeManagement(writer, modelNode.get(CORE_SERVICE, MANAGEMENT), true);
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(DOMAIN_CONTROLLER)) {
@@ -235,12 +229,10 @@ class HostXml_5 extends CommonXml implements ManagementXmlDelegate {
                 discoveryOptions = modelNode.get(CORE_SERVICE, DISCOVERY_OPTIONS, ModelDescriptionConstants.OPTIONS);
             }
             writeDomainController(writer, modelNode.get(DOMAIN_CONTROLLER), ignoredResources, discoveryOptions);
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(INTERFACE)) {
             writeInterfaces(writer, modelNode.get(INTERFACE));
-            WriteUtils.writeNewLine(writer);
         }
         if (modelNode.hasDefined(JVM)) {
             writer.writeStartElement(Element.JVMS.getLocalName());
@@ -249,7 +241,6 @@ class HostXml_5 extends CommonXml implements ManagementXmlDelegate {
                 JvmXml.writeJVMElement(writer, jvm, jvms.get(jvm));
             }
             writer.writeEndElement();
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(SERVER_CONFIG)) {
@@ -257,7 +248,6 @@ class HostXml_5 extends CommonXml implements ManagementXmlDelegate {
             // Write the directory grouping
             HostResourceDefinition.DIRECTORY_GROUPING.marshallAsAttribute(modelNode, writer);
             writeServers(writer, modelNode.get(SERVER_CONFIG));
-            WriteUtils.writeNewLine(writer);
             writer.writeEndElement();
         } else if (modelNode.hasDefined(DIRECTORY_GROUPING)) {
             // In case there are no servers defined, write an empty element, preserving the directory grouping
@@ -275,12 +265,10 @@ class HostXml_5 extends CommonXml implements ManagementXmlDelegate {
             for (String group : groups) {
                 writeSocketBindingGroup(writer, modelNode.get(SOCKET_BINDING_GROUP, group), group);
             }
-            WriteUtils.writeNewLine(writer);
         }
 
 
         writer.writeEndElement();
-        WriteUtils.writeNewLine(writer);
         writer.writeEndDocument();
     }
 

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml_5.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml_5.java
@@ -674,40 +674,31 @@ class StandaloneXml_5 extends CommonXml implements ManagementXmlDelegate {
         writeNamespaces(writer, modelNode);
         writeSchemaLocation(writer, modelNode);
 
-        WriteUtils.writeNewLine(writer);
-
         if (modelNode.hasDefined(EXTENSION)) {
             extensionHandler.writeExtensions(writer, modelNode.get(EXTENSION));
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(SYSTEM_PROPERTY)) {
             writeProperties(writer, modelNode.get(SYSTEM_PROPERTY), Element.SYSTEM_PROPERTIES, true);
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(PATH)) {
             writePaths(writer, modelNode.get(PATH), false);
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(CORE_SERVICE) && modelNode.get(CORE_SERVICE).hasDefined(VAULT)) {
             writeVault(writer, modelNode.get(CORE_SERVICE, VAULT));
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(CORE_SERVICE)) {
             ManagementXml managementXml = ManagementXml.newInstance(CURRENT, this);
             managementXml.writeManagement(writer, modelNode.get(CORE_SERVICE, MANAGEMENT), true);
-            WriteUtils.writeNewLine(writer);
         }
 
         writeServerProfile(writer, context);
-        WriteUtils.writeNewLine(writer);
 
         if (modelNode.hasDefined(INTERFACE)) {
             writeInterfaces(writer, modelNode.get(INTERFACE));
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(SOCKET_BINDING_GROUP)) {
@@ -718,7 +709,6 @@ class StandaloneXml_5 extends CommonXml implements ManagementXmlDelegate {
             for (String group : groups) {
                 writeSocketBindingGroup(writer, modelNode.get(SOCKET_BINDING_GROUP, group), group);
             }
-            WriteUtils.writeNewLine(writer);
         }
 
         if (modelNode.hasDefined(DEPLOYMENT)) {
@@ -731,7 +721,6 @@ class StandaloneXml_5 extends CommonXml implements ManagementXmlDelegate {
             WriteUtils.writeNewLine(writer);
         }
         writer.writeEndElement();
-        WriteUtils.writeNewLine(writer);
         writer.writeEndDocument();
     }
 
@@ -843,26 +832,36 @@ class StandaloneXml_5 extends CommonXml implements ManagementXmlDelegate {
             }
 
             final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
-            if (attribute == Attribute.PROVIDER) {
-                ModelNode provider = AccessAuthorizationResourceDefinition.PROVIDER.parse(value, reader);
-                ModelNode op = Util.getWriteAttributeOperation(accAuthzAddr,
-                        AccessAuthorizationResourceDefinition.PROVIDER.getName(), provider);
-
-                operationsList.add(op);
-            } else if (attribute == Attribute.USE_IDENTITY_ROLES) {
-                ModelNode useIdentityRoles = AccessAuthorizationResourceDefinition.USE_IDENTITY_ROLES.parse(value, reader);
-                ModelNode op = Util.getWriteAttributeOperation(accAuthzAddr,
-                        AccessAuthorizationResourceDefinition.USE_IDENTITY_ROLES.getName(), useIdentityRoles);
-
-                operationsList.add(op);
-            } else if (attribute == Attribute.PERMISSION_COMBINATION_POLICY) {
-                ModelNode provider = AccessAuthorizationResourceDefinition.PERMISSION_COMBINATION_POLICY.parse(value, reader);
-                ModelNode op = Util.getWriteAttributeOperation(accAuthzAddr,
-                        AccessAuthorizationResourceDefinition.PERMISSION_COMBINATION_POLICY.getName(), provider);
-
-                operationsList.add(op);
-            } else {
+            if (null == attribute) {
                 throw unexpectedAttribute(reader, i);
+            }
+            switch (attribute) {
+                case PROVIDER:
+                    {
+                        ModelNode provider = AccessAuthorizationResourceDefinition.PROVIDER.getParser().parse(AccessAuthorizationResourceDefinition.PROVIDER, value, reader);
+                        ModelNode op = Util.getWriteAttributeOperation(accAuthzAddr,
+                                AccessAuthorizationResourceDefinition.PROVIDER.getName(), provider);
+                        operationsList.add(op);
+                        break;
+                    }
+                case USE_IDENTITY_ROLES:
+                    {
+                        ModelNode useIdentityRoles = AccessAuthorizationResourceDefinition.USE_IDENTITY_ROLES.getParser().parse(AccessAuthorizationResourceDefinition.USE_IDENTITY_ROLES, value, reader);
+                        ModelNode op = Util.getWriteAttributeOperation(accAuthzAddr,
+                                AccessAuthorizationResourceDefinition.USE_IDENTITY_ROLES.getName(), useIdentityRoles);
+                        operationsList.add(op);
+                        break;
+                    }
+                case PERMISSION_COMBINATION_POLICY:
+                    {
+                        ModelNode provider = AccessAuthorizationResourceDefinition.PERMISSION_COMBINATION_POLICY.getParser().parse(AccessAuthorizationResourceDefinition.PERMISSION_COMBINATION_POLICY, value, reader);
+                        ModelNode op = Util.getWriteAttributeOperation(accAuthzAddr,
+                                AccessAuthorizationResourceDefinition.PERMISSION_COMBINATION_POLICY.getName(), provider);
+                        operationsList.add(op);
+                        break;
+                    }
+                default:
+                    throw unexpectedAttribute(reader, i);
             }
         }
 


### PR DESCRIPTION
Reordering elements so that they appear in the same order after a marshaling
Removing the creation of empty lines so that configuration files are not updated with just new empty lines.