### PR TITLE
Fix for WFCORE-3199 - Make sure the security permissions.xml DUPs are registered before the deployment chain is frozen

### DIFF
--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/SecurityManagerSubsystemAdd.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/SecurityManagerSubsystemAdd.java
@@ -42,7 +42,6 @@ import java.util.List;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.server.AbstractDeploymentChainStep;
@@ -81,30 +80,8 @@ class SecurityManagerSubsystemAdd extends AbstractBoottimeAddStepHandler {
     protected void performBoottime(final OperationContext context, final ModelNode operation, final ModelNode model)
             throws OperationFailedException {
 
-        // This needs to run after all child resources so that they can detect a fresh state
-        context.addStep(new OperationStepHandler() {
-            @Override
-            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
-                ModelNode node = Resource.Tools.readModel(resource);
-                installProcessors(context, node);
-                // Rollback handled by the parent step
-                context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
-            }
-        }, OperationContext.Stage.RUNTIME);
-    }
-
-    /**
-     * Retrieves the permissions configured in the security manager subsystem and installs the DUPs that parse and validate
-     * the deployment permissions.
-     *
-     * @param context a reference to the {@link OperationContext}.
-     * @param node the {@link ModelNode} that contains all the configured permissions be added.
-     * @throws OperationFailedException if an error occurs while processing the permissions specified in the subsystem.
-     */
-    protected void installProcessors(final OperationContext context, final ModelNode node)
-            throws OperationFailedException {
-
+        final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
+        final ModelNode node = Resource.Tools.readModel(resource);
         // get the minimum set of deployment permissions.
         final ModelNode deploymentPermissionsModel = node.get(DEPLOYMENT_PERMISSIONS_PATH.getKeyValuePair());
         final ModelNode minimumPermissionsNode = MINIMUM_PERMISSIONS.resolveModelAttribute(context, deploymentPermissionsModel);
@@ -148,7 +125,7 @@ class SecurityManagerSubsystemAdd extends AbstractBoottimeAddStepHandler {
      * @return a {@link List} containing the retrieved permissions. They are wrapped as {@link PermissionFactory} instances.
      * @throws OperationFailedException if an error occurs while retrieving the security permissions.
      */
-    protected List<PermissionFactory> retrievePermissionSet(final OperationContext context, final ModelNode node) throws OperationFailedException {
+    private List<PermissionFactory> retrievePermissionSet(final OperationContext context, final ModelNode node) throws OperationFailedException {
 
         final List<PermissionFactory> permissions = new ArrayList<>();
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/secman/PermissionsDeploymentTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/secman/PermissionsDeploymentTestCase.java
@@ -1,0 +1,179 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.as.test.manualmode.secman;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.manualmode.deployment.AbstractDeploymentUnitTestCase;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Tests the processing of {@code permissions.xml} in deployments
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class PermissionsDeploymentTestCase extends AbstractDeploymentUnitTestCase {
+
+    private static final String SYS_PROP_SERVER_BOOTSTRAP_MAX_THREADS = "-Dorg.jboss.server.bootstrap.maxThreads=1";
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Inject
+    private ServerController container;
+
+    private ModelControllerClient modelControllerClient;
+
+    @Before
+    public void before() throws Exception {
+        modelControllerClient = TestSuiteEnvironment.getModelControllerClient();
+    }
+
+    @After
+    public void after() throws Exception {
+        modelControllerClient.close();
+    }
+
+
+    @Override
+    protected ModelNode executeOperation(final ModelNode op) throws IOException {
+        return this.modelControllerClient.execute(op);
+    }
+
+    @Override
+    protected File getDeployDir() {
+        return this.tempDir.getRoot();
+    }
+
+    /**
+     * Tests that when the server is booted with {@code org.jboss.server.bootstrap.maxThreads} system property
+     * set (to whatever value), the deployment unit processors relevant for dealing with processing of {@code permissions.xml},
+     * in deployments, do run and process the deployment
+     * <p>
+     * NOTE: This test just tests that the deployment unit processor(s) process the deployment unit for the {@code permissions.xml}
+     * and it's not in the scope of this test to verify that the permissions configured in that file are indeed applied correctly
+     * to the deployment unit
+     *
+     * @throws Exception
+     * @see <a href="https://issues.jboss.org/browse/WFLY-6657">WFLY-6657</a>
+     */
+    @Test
+    public void testWithConfiguredMaxBootThreads() throws Exception {
+        // Test-runner's ServerController/Server uses prop jvm.args to control what args are passed
+        // to the server process VM. So, we add the system property controlling the max boot threads,
+        // here
+        final String existingJvmArgs = System.getProperty("jvm.args");
+        if (existingJvmArgs == null) {
+            System.setProperty("jvm.args", SYS_PROP_SERVER_BOOTSTRAP_MAX_THREADS);
+        } else {
+            System.setProperty("jvm.args", existingJvmArgs + " " + SYS_PROP_SERVER_BOOTSTRAP_MAX_THREADS);
+        }
+        // start the container
+        container.start();
+        try {
+            addDeploymentScanner(1000, false);
+            this.testInvalidPermissionsXmlDeployment("test-permissions-xml-with-configured-max-boot-threads.jar");
+        } finally {
+            removeDeploymentScanner();
+            container.stop();
+            if (existingJvmArgs == null) {
+                System.clearProperty("jvm.args");
+            } else {
+                System.setProperty("jvm.args", existingJvmArgs);
+            }
+        }
+    }
+
+
+    /**
+     * Tests that when the server is booted *without* the {@code org.jboss.server.bootstrap.maxThreads} system property
+     * set, the deployment unit processors relevant for dealing with processing of {@code permissions.xml},
+     * in deployments, do run and process the deployment
+     * <p>
+     * NOTE: This test just tests that the deployment unit processor(s) process the deployment unit for the {@code permissions.xml}
+     * and it's not in the scope of this test to verify that the permissions configured in that file are indeed applied correctly
+     * to the deployment unit
+     *
+     * @throws Exception
+     * @see <a href="https://issues.jboss.org/browse/WFLY-6657">WFLY-6657</a>
+     */
+    @Test
+    public void testWithoutConfiguredMaxBootThreads() throws Exception {
+        container.start();
+        try {
+            addDeploymentScanner(1000, false);
+            this.testInvalidPermissionsXmlDeployment("test-permissions-xml-without-max-boot-threads.jar");
+        } finally {
+            removeDeploymentScanner();
+            container.stop();
+        }
+
+    }
+
+    private void testInvalidPermissionsXmlDeployment(final String deploymentName) throws Exception {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class);
+        // add an empty (a.k.a invalid content) in permissions.xml
+        jar.addAsManifestResource(new StringAsset(""), "permissions.xml");
+        // "deploy" it by placing it in the deployment directory
+        jar.as(ZipExporter.class).exportTo(new File(getDeployDir(), deploymentName));
+        final PathAddress deploymentPathAddr = PathAddress.pathAddress(ModelDescriptionConstants.DEPLOYMENT, deploymentName);
+        // wait for the deployment to be picked up and completed (either with success or failure)
+        waitForDeploymentToFinish(deploymentPathAddr);
+        // the deployment is expected to fail due to a parsing error in the permissions.xml
+        Assert.assertEquals("Deployment was expected to fail", "FAILED", deploymentState(deploymentPathAddr));
+    }
+
+    private void waitForDeploymentToFinish(final PathAddress deploymentPathAddr) throws Exception {
+        // Wait until deployed ...
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(30000);
+        while (!exists(deploymentPathAddr) && System.currentTimeMillis() < timeout) {
+            Thread.sleep(100);
+        }
+        Assert.assertTrue(exists(deploymentPathAddr));
+    }
+
+}


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-6657

The issue is a bit involved (which I explain below) but the gist of the issue is that the processing of `permissions.xml` and its associated security semantics, within a deployment, are completed skipped and ignored, because the deployment unit processor(s) responsible for setting up these security constraints never get triggered. That's because they get added by the `SecurityManagerSubsystemAdd` too late in the game after the `RUNTIME` step of `DeployerChainAddHandler` has already formalized deployment unit processors that are enrolled with it and has created a "final view" of those processors. 

The reason why this shows up only when the `org.jboss.server.bootstrap.maxThreads` system property is set, is the involved part. The way the boot process is setup, in the absence of this system property, a `parallel boot step handler` gets involved which in its implementation organizes the boot operations such that the subsystem specific operations are parallely executed _first_ and  then the non-subsystem related operations, like the `add-deployers-chain` (which is the one which deals with forming the deployment unit processors chain) are executed in the _end_. So, it just so happens that due to this implementation, the `SecurityManagerSubsystemAdd` (through its subsystem specific management operation steps) does indeed add the DUPs before the deployers chain is formed.

Now, when the `org.jboss.server.bootstrap.maxThreads` system property is set, this `parallel boot` for subsystems is skipped. Even then, the boot operations are arranged such that the `add-deployers-chain` ends up being at the end of the list of `RUNTIME` steps that run. In fact, the `DeployerChainAddHandler` does its best to make sure it ends up being the last `RUNTIME` step as it notes in its comment[1]:

>>> // Our real work needs to run after all RUNTIME steps that add DUPs have run. ServerService adds
            // this operation at the end of the boot op list, so our MODEL stage step is last, and
            // this RUNTIME step we are about to add should therefore be last as well *at the time
            // we register it*. However, other RUNTIME steps can themselves add new RUNTIME steps that
            // will then come after this one. So we do the same -- add a RUNTIME step that adds another
            // RUNTIME step that does the real work.
            // Theoretically this kind of "predecessor runtime step adds another runtime step, so we have to
            // add one to come later" business could go on forever. *But any operation that does that with
            // a DUP-add step is just broken and should just find another way.*

but as noted in the last sentence of that comment, if there are operations that create a RUNTIME step which then creates another RUNTIME step to add a DUP, then this whole finely balanced logic,  goes for a toss. The `SecurityManagerSubsystemAdd` is such a operation which, IMO, is faulty since it creates a `RUNTIME` step in its `performBoottime` and then that `RUNTIME` step goes ahead and creates another `RUNTIME` step which finally adds the DUPs.

The commit in this PR, removes the creation of the first `RUNTIME` step in this `SecurityManagerSubsystemAdd`, because from what I see, there's no need for it since all it does is read the complete model, relative to the subsystem, which should already be available in this `performBoottime` `RUNTIME` step. Of course, it's been a while since I have fiddled with the WildFly management operations, so I might have misunderstood or missed certain details of why this additional `RUNTIME` step was being created/needed.

The commit also contains a test case which reproduces the issue and verifies the proposed fix.

[1] https://github.com/wildfly/wildfly-core/blob/master/server/src/main/java/org/jboss/as/server/DeployerChainAddHandler.java#L96

P.S: On an unrelated note, shouldn't these `permissions.xml` related DUPs be part of the WildFly itself instead of wildfly-core, since that `permissions.xml` file within a deployment, is a EE functionality.