### PR TITLE
Boot optimizations

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -401,19 +401,17 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
         if (!isFlagPresent(flag)) {
             return (BUILDER) this; //if not present no need to remove
         }
-        if (flags != null && flags.length > 0) {
-            final int length = flags.length;
-            final AttributeAccess.Flag[] newFlags = new AttributeAccess.Flag[length - 1];
-            int k = 0;
-            for (AttributeAccess.Flag flag1 : flags) {
-                if (flag1 != flag) {
-                    newFlags[k] = flag1;
-                    k++;
-                }
+        final int length = flags.length;
+        final AttributeAccess.Flag[] newFlags = new AttributeAccess.Flag[length - 1];
+        int k = 0;
+        for (AttributeAccess.Flag flag1 : flags) {
+            if (flag1 != flag) {
+                newFlags[k] = flag1;
+                k++;
             }
-            if (k != length - 1) {
-                flags = newFlags;
-            }
+        }
+        if (k != length - 1) {
+            flags = newFlags;
         }
         return (BUILDER) this;
     }

--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -227,16 +227,6 @@ public abstract class AttributeDefinition {
         }
     }
 
-    private static EnumSet<AttributeAccess.Flag> wrapFlags(AttributeAccess.Flag[] flags) {
-        if (flags == null || flags.length == 0) {
-            return EnumSet.noneOf(AttributeAccess.Flag.class);
-        } else if (flags.length == 1) {
-            return EnumSet.of(flags[0]);
-        } else {
-            return EnumSet.of(flags[0], flags);
-        }
-    }
-
     /**
      * The attribute's name in the management model.
      *

--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLParser.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLParser.java
@@ -34,11 +34,28 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
  */
 public abstract class PersistentResourceXMLParser implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
 
+    private volatile PersistentResourceXMLDescription cachedDescription;
+
     public abstract PersistentResourceXMLDescription getParserDescription();
+
+    /** @deprecated Experimental; for internal use only. May be removed at any time. */
+    @Deprecated
+    public final void cacheXMLDescription() {
+        if (cachedDescription == null) {
+            cachedDescription = getParserDescription();
+        }
+    }
 
     @Override
     public void readElement(XMLExtendedStreamReader xmlExtendedStreamReader, List<ModelNode> modelNodes) throws XMLStreamException {
-        getParserDescription().parse(xmlExtendedStreamReader, PathAddress.EMPTY_ADDRESS, modelNodes);
+        PersistentResourceXMLDescription xmlDescription = cachedDescription;
+        if (xmlDescription == null) {
+            xmlDescription = getParserDescription();
+        } else {
+            // To reduce memory footprint, we only cache for a single parsing run
+            cachedDescription = null;
+        }
+        xmlDescription.parse(xmlExtendedStreamReader, PathAddress.EMPTY_ADDRESS, modelNodes);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -48,6 +48,7 @@ import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceXMLParser;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ProxyController;
 import org.jboss.as.controller.ResourceDefinition;
@@ -440,6 +441,16 @@ public class ExtensionRegistry {
                 extension.getSubsystemInfo(subsystemName).addParsingNamespace(namespaceUri);
                 if (extension.xmlMapper != null) {
                     extension.xmlMapper.registerRootElement(new QName(namespaceUri, SUBSYSTEM), reader);
+                    if (reader instanceof PersistentResourceXMLParser) {
+                        // In a standard WildFly boot this method is being called as part of concurrent
+                        // work on multiple extensions. Generating the PersistentResourceXMLDescription
+                        // used by PersistentResourceXMLParser involves a lot of classloading and static
+                        // field initialization that can benefit by being done as part of this concurrent
+                        // work instead of being deferred to the single-threaded parsing phase. So, we ask
+                        // the parser to generate and cache that description for later use during parsing.
+                        //noinspection deprecation
+                        ((PersistentResourceXMLParser) reader).cacheXMLDescription();
+                    }
                 }
             }
         }

--- a/controller/src/main/java/org/jboss/as/controller/parsing/ExtensionParsingContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/ExtensionParsingContext.java
@@ -63,9 +63,7 @@ public interface ExtensionParsingContext {
      *
      * @throws IllegalStateException if another {@link org.jboss.as.controller.Extension} has already registered a subsystem with the given
      *                               {@code subsystemName}
-     * @deprecated Use {@link ExtensionParsingContext#setSubsystemXmlMapping(java.lang.String, java.lang.String, java.util.function.Supplier)} instead.
      */
-    @Deprecated
     void setSubsystemXmlMapping(String subsystemName, String namespaceUri, XMLElementReader<List<ModelNode>> reader);
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
@@ -148,13 +148,13 @@ public final class AttributeAccess {
          */
          RUNTIME_SERVICE_NOT_REQUIRED;
 
-        private static final EnumSet<AttributeAccess.Flag> NONE = EnumSet.noneOf(AttributeAccess.Flag.class);
         private static final Map<EnumSet<AttributeAccess.Flag>, Set<AttributeAccess.Flag>> flagSets = new ConcurrentHashMap<>(16);
         public static Set<AttributeAccess.Flag> immutableSetOf(AttributeAccess.Flag... flags) {
-            EnumSet<AttributeAccess.Flag> baseSet;
             if (flags == null || flags.length == 0) {
-                baseSet = NONE;
-            } else if (flags.length == 1) {
+                return Collections.emptySet();
+            }
+            EnumSet<AttributeAccess.Flag> baseSet;
+            if (flags.length == 1) {
                 baseSet = EnumSet.of(flags[0]);
             } else {
                 baseSet = EnumSet.of(flags[0], flags);

--- a/controller/src/main/java/org/jboss/as/controller/registry/OperationEntry.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/OperationEntry.java
@@ -79,19 +79,15 @@ public final class OperationEntry {
          *  use of {@link EntryType#PRIVATE} not workable. */
         HIDDEN;
 
-        private static final EnumSet<Flag> NONE = EnumSet.noneOf(Flag.class);
         private static final Map<EnumSet<Flag>, Set<Flag>> flagSets = new ConcurrentHashMap<>(16);
         public static Set<OperationEntry.Flag> immutableSetOf(EnumSet<OperationEntry.Flag> flags) {
-            EnumSet<Flag> baseSet;
-            if (flags == null) {
-                baseSet = NONE;
-            } else {
-                baseSet = flags;
+            if (flags == null || flags.isEmpty()) {
+                return Collections.emptySet();
             }
-            Set<Flag> result = flagSets.get(baseSet);
+            Set<Flag> result = flagSets.get(flags);
             if (result == null) {
-                Set<Flag> immutable = Collections.unmodifiableSet(baseSet);
-                Set<Flag> existing = flagSets.putIfAbsent(baseSet, immutable);
+                Set<Flag> immutable = Collections.unmodifiableSet(flags);
+                Set<Flag> existing = flagSets.putIfAbsent(flags, immutable);
                 result = existing == null ? immutable : existing;
             }
 

--- a/controller/src/main/java/org/jboss/as/controller/services/path/PathInfoHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/PathInfoHandler.java
@@ -44,13 +44,13 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
@@ -109,7 +109,7 @@ public class PathInfoHandler extends AbstractRuntimeOnlyHandler {
 
     private static ZoneId getZoneId() {
         if (ZONE_ID == null) {
-            ZONE_ID = ZoneId.of(Calendar.getInstance().getTimeZone().getID());
+            ZONE_ID = ZoneId.systemDefault();
         }
         return ZONE_ID;
     }

--- a/controller/src/main/java/org/jboss/as/controller/services/path/PathInfoHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/PathInfoHandler.java
@@ -82,8 +82,8 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  */
 public class PathInfoHandler extends AbstractRuntimeOnlyHandler {
 
-    private static final DateTimeFormatter DATE_FORMAT = new DateTimeFormatterBuilder().appendInstant().appendZoneId().toFormatter(Locale.ENGLISH);
-    private static final ZoneId ZONE_ID = ZoneId.of(Calendar.getInstance().getTimeZone().getID());
+    private static volatile DateTimeFormatter DATE_FORMAT;
+    private static volatile ZoneId ZONE_ID ;
     private static final String USED_SPACE = "used-space";
     private static final String AVAILABLE_SPACE = "available-space";
     private static final String RESOLVED_PATH = "resolved-path";
@@ -99,6 +99,20 @@ public class PathInfoHandler extends AbstractRuntimeOnlyHandler {
                                 MEGABITS.getName(), GIGABITS.getName(), TERABITS.getName(), PETABITS.getName())
                         .setDefaultValue(new ModelNode(MeasurementUnit.BYTES.getName()))
                         .build();
+
+    private static DateTimeFormatter getDateFormat() {
+        if (DATE_FORMAT == null) {
+            DATE_FORMAT = new DateTimeFormatterBuilder().appendInstant().appendZoneId().toFormatter(Locale.ENGLISH);
+        }
+        return DATE_FORMAT;
+    }
+
+    private static ZoneId getZoneId() {
+        if (ZONE_ID == null) {
+            ZONE_ID = ZoneId.of(Calendar.getInstance().getTimeZone().getID());
+        }
+        return ZONE_ID;
+    }
 
     private final List<RelativePathSizeAttribute> relativePathAttributes;
     private final PathManager pathManager;
@@ -179,8 +193,10 @@ public class PathInfoHandler extends AbstractRuntimeOnlyHandler {
                 if (Files.exists(folder)) {
                     BasicFileAttributes attributes = Files.getFileAttributeView(folder, BasicFileAttributeView.class).readAttributes();
                     replyParameterNode.get(RESOLVED_PATH).set(folder.toAbsolutePath().toString());
-                    replyParameterNode.get(CREATION_TIME).set(DATE_FORMAT.format(attributes.creationTime().toInstant().atZone(ZONE_ID)));
-                    replyParameterNode.get(LAST_MODIFIED).set(DATE_FORMAT.format(attributes.lastModifiedTime().toInstant().atZone(ZONE_ID)));
+                    DateTimeFormatter formatter = getDateFormat();
+                    ZoneId zoneId = getZoneId();
+                    replyParameterNode.get(CREATION_TIME).set(formatter.format(attributes.creationTime().toInstant().atZone(zoneId)));
+                    replyParameterNode.get(LAST_MODIFIED).set(formatter.format(attributes.lastModifiedTime().toInstant().atZone(zoneId)));
                     replyParameterNode.get(AVAILABLE_SPACE).set(new ModelNode(offset * Files.getFileStore(folder).getUsableSpace()));
                 }
             } catch (IOException ex) {

--- a/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/CoreManagementExtension.java
+++ b/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/CoreManagementExtension.java
@@ -70,6 +70,8 @@ public class CoreManagementExtension implements Extension {
 
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, CoreManagementSubsystemParser_1_0.NAMESPACE, CoreManagementSubsystemParser_1_0::new);
+        // For the current version we don't use a Supplier as we want its description initialized
+        // TODO if any new xsd versions are added, use a Supplier for the old version
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, CoreManagementSubsystemParser_1_0.NAMESPACE, new CoreManagementSubsystemParser_1_0());
     }
 }

--- a/discovery/src/main/java/org/wildfly/extension/discovery/DiscoveryExtension.java
+++ b/discovery/src/main/java/org/wildfly/extension/discovery/DiscoveryExtension.java
@@ -90,7 +90,9 @@ public final class DiscoveryExtension implements Extension {
 
     @Override
     public void initializeParsers(final ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE, DiscoverySubsystemParser::new);
+        // For the current version we don't use a Supplier as we want its description initialized
+        // TODO if any new xsd versions are added, use a Supplier for the old version
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE, new DiscoverySubsystemParser());
     }
 
     static StandardResourceDescriptionResolver getResourceDescriptionResolver(final String... keyPrefixes) {

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -238,6 +238,13 @@ public class LoggingExtension implements Extension {
         setParser(context, Namespace.LOGGING_2_0, new LoggingSubsystemParser_2_0());
         setParser(context, Namespace.LOGGING_3_0, new LoggingSubsystemParser_3_0());
         setParser(context, Namespace.LOGGING_4_0, new LoggingSubsystemParser_4_0());
+
+        // Hack to ensure the Element and Attribute enums are loaded during this call which
+        // is part of concurrent boot. These enums trigger a lot of classloading and static
+        // initialization that we don't want deferred until the single-threaded parsing phase
+        if (Element.forName("").equals(Attribute.forName(""))) { // never true
+            throw new IllegalStateException();
+        }
     }
 
     private void registerLoggingProfileSubModels(final ManagementResourceRegistration registration, final PathManager pathManager) {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -128,7 +128,9 @@ public class RemotingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_1_2.getUriString(), RemotingSubsystem12Parser::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_2_0.getUriString(), RemotingSubsystem20Parser::new);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_3_0.getUriString(), RemotingSubsystem30Parser::new);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_4_0.getUriString(), RemotingSubsystem40Parser::new);
+        // For the current version we don't use a Supplier as we want its description initialized
+        // TODO if any new xsd versions are added, use a Supplier for the old version
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REMOTING_4_0.getUriString(), new RemotingSubsystem40Parser());
 
         // For servers only as a migration aid we'll install io if it is missing.
         // It is invalid to do this on an HC as the HC needs to support profiles running legacy

--- a/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerExtension.java
+++ b/request-controller/src/main/java/org/wildfly/extension/requestcontroller/RequestControllerExtension.java
@@ -56,7 +56,9 @@ public class RequestControllerExtension implements Extension {
 
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REQUEST_CONTROLLER_1_0.getUriString(), RequestControllerSubsystemParser_1_0::new);
+        // For the current version we don't use a Supplier as we want its description initialized
+        // TODO if any new xsd versions are added, use a Supplier for the old version
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.REQUEST_CONTROLLER_1_0.getUriString(), new RequestControllerSubsystemParser_1_0());
     }
 
     @Override

--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/SecurityManagerExtension.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/SecurityManagerExtension.java
@@ -65,7 +65,9 @@ public class SecurityManagerExtension implements Extension {
 
     @Override
     public void initializeParsers(final ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(Constants.SUBSYSTEM_NAME, Namespace.SECURITY_MANAGER_1_0.getUriString(), SecurityManagerSubsystemParser_1_0::new);
+        // For the current version we don't use a Supplier as we want its description initialized
+        // TODO if any new xsd versions are added, use a Supplier for the old version
+        context.setSubsystemXmlMapping(Constants.SUBSYSTEM_NAME, Namespace.SECURITY_MANAGER_1_0.getUriString(), new SecurityManagerSubsystemParser_1_0());
     }
 
 


### PR DESCRIPTION
This PR includes a couple different types of optimizations related to boot perf:

1) Small improvements to some object interning logic that I'd added to cut down on the WF memory footprint. (2nd and 3rd commits.)

2) A lot of management code (classloading and initialization of constants like AttributeDefinition FOO or XXXResourceDefinition.INSTANCE) is happening when xml parsers are invoked, which is a single-threaded part of boot meaning it all happens in series on one CPU core. All but one of the other commits here aim at pushing this work into the calls to Extension.initializeParsers, which happen concurrently for each extension.

There's also a trivial cleanup commit.