### PR TITLE
WFCORE-2147 & WFCORE-1295 - A proposal to add expression expansion support for deployment descriptors without using JBoss Metadata project constructs

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
@@ -40,6 +40,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>
+        <module name="org.wildfly.common"/>
         <module name="org.wildfly.security.manager"/>
     </dependencies>
 </module>

--- a/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
@@ -26,6 +26,7 @@ import java.security.PermissionCollection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.jar.Manifest;
 
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
@@ -49,6 +50,7 @@ import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.vfs.VirtualFile;
+import org.wildfly.common.expression.ResolveContext;
 
 /**
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -102,6 +104,16 @@ public final class Attachments {
      * A builder used to install a deployment phase
      */
     public static final AttachmentKey<DeploymentUnitPhaseBuilder> DEPLOYMENT_UNIT_PHASE_BUILDER = AttachmentKey.create(DeploymentUnitPhaseBuilder.class);
+
+    /**
+     * A function which will be used to expand expressions within spec descriptors
+     */
+    public static final AttachmentKey<BiConsumer<ResolveContext<RuntimeException>, StringBuilder>> SPEC_DESCRIPTOR_EXPR_EXPAND_FUNCTION = AttachmentKey.create(BiConsumer.class);
+
+    /**
+     * A function which will be used to expand expressions within JBoss/WildFly (vendor specific) descriptors
+     */
+    public static final AttachmentKey<BiConsumer<ResolveContext<RuntimeException>, StringBuilder>> WFLY_DESCRIPTOR_EXPR_EXPAND_FUNCTION = AttachmentKey.create(BiConsumer.class);
 
     //
     // STRUCTURE


### PR DESCRIPTION
**Related JIRAs:**

https://issues.jboss.org/browse/WFCORE-2147
https://issues.jboss.org/browse/WFCORE-1295

**Background:**

WildFly (not WildFly Core), through its EE subsystem supports system property expansion (a.k.a expression expansion) in spec descriptors as well as JBoss/WildFly specific descriptors. For example, the content of the form `${foobar:blah}` is processed to look for the `foobar` system property to be set and in the absence of it, the value is computed as `blah`. In the presence of the system property, the value is computed to be whatever the system property value is.

The way this support is implemented by the EE subsystem involves 2 things:

- A toggle/switch, controlled through a EE subsystem resource attribute to decide whether the spec descriptors need to be processed with this support. A separate resource attribute to decide whether the JBoss/WildFly descriptors need to be processed with this support.

- If the spec or JBoss descriptors are enabled for expression expansion support, a `PropertyResolver`/`PropertyReplacer` is setup accordingly by the EE subsystem and this construct is passed around to various parsers that handle the spec/JBoss descriptors' parsing. The whole interface, implementation of the `PropertyResolver`/`PropertyReplacer` resides in the JBoss Metadata project. Many parsers (not all) resides in that project too

**The problem:**

With the split of WildFly Core and WildFly projects, there's now a case where certain WildFly specific descriptors and in fact even (EE) spec descriptor in one specific case (`permissions.xml`) can no longer make use of this support, since the support, which involves the toggle/switch management resource attribtue plus the JBoss metadata interfaces/implementation lies within the EE subsystem which is outside of WildFly core.

As noted in this JIRA https://issues.jboss.org/browse/WFCORE-1295 by Brian, the other aspect here is that if this support needs to be brought into WildFly core, then it can't be backed by JBoss Metadata project constructs (for reasons discussed elsewhere).

**Potential solution:**

Brian, in https://issues.jboss.org/browse/WFCORE-1295, notes that one way to solve this is to provide a hook in WildFly core which allows WildFly (and other consumers of WildFly Core) to somehow enable/disable the expression expansion in such descriptors. This PR, introduces such a hook, through the introduction of a couple of `org.jboss.as.server.deployment.Attachments` - specifically:

```
    /**
     * A function which will be used to expand expressions within spec descriptors
     */
    public static final AttachmentKey<BiConsumer<ResolveContext<RuntimeException>, StringBuilder>> SPEC_DESCRIPTOR_EXPR_EXPAND_FUNCTION = AttachmentKey.create(BiConsumer.class);

    /**
     * A function which will be used to expand expressions within JBoss/WildFly (vendor specific) descriptors
     */
    public static final AttachmentKey<BiConsumer<ResolveContext<RuntimeException>, StringBuilder>> WFLY_DESCRIPTOR_EXPR_EXPAND_FUNCTION = AttachmentKey.create(BiConsumer.class);

```
The 2 important aspects here are:

- Well-known attachment keys, which can be used to set an expression expansion function. One for spec descriptors and one for JBoss/WildFly descriptors. The absence of the respective attachment keys implies no expression expansion support in the corresponding descriptors.

- Using the `Expression` API from `wildfly-common` project as a formal contract, instead of JBoss Metadata project, for such expression expansion

With this change, one part of the problem would be solved - i.e. allowing a hook in WildFly Core, which doesn't rely on JBoss Metadata, to enable/disable expression expansion. This PR (intentionally) doesn't try to solve the other part of the problem, which is, who controls the toggle/switch to enable/disable the support. For now, it's the EE subsystem which does that and for the scope of the JIRAs noted above, IMO, it makes sense to leave that control to the EE subsystem for now until we decide whether that needs to be moved out to a more "core" level.

If the change proposed in this PR gets accepted, then all we need to do in WildFly is a small addition to an existing deployment unit processor, so that it constructs this expression expansion function that is backed by the currently integrated JBoss Metadata property resolvers/replacers. That change will look like this https://github.com/jaikiran/wildfly/commit/c6f5a2f06c886b163db33597664c1089431d4fdf

This PR also uses this proposed support in supporting property expansion in `permissions.xml`/`jboss-permissions.xml` files and as such should resolve https://issues.jboss.org/browse/WFCORE-2147. If this is accepted, subsequent PRs can be issued to add support for some other WildFly specific descriptor parsers like the one for `jboss-deployment-structure.xml`.
