### PR TITLE
[WFCORE-3208]: Saving an attachement should create the specified path  if it doesn't exist.

### DIFF
--- a/cli/src/main/resources/help/attachment.txt
+++ b/cli/src/main/resources/help/attachment.txt
@@ -20,4 +20,7 @@ OPTIONS
  --file          - optional, the path of file used to save the attachments.
 
  --overwrite     - optional, used when saving to a file. Will make the received 
-                   file to overwrite existing file. 
+                   file to overwrite existing file.
+
+ --createDirs     - optional, used when saving to a file. Will create the intermediate path
+                    to the received file avoiding failure if those directories don't exist.

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -1313,8 +1313,8 @@ public class CliCompletionTestCase {
                 List<String> candidates = new ArrayList<>();
                 ctx.getDefaultCommandCompleter().complete(ctx, cmd,
                         cmd.length(), candidates);
-                assertTrue(candidates.toString(), candidates.size() == 3);
-                assertEquals(candidates.toString(), Arrays.asList("--file",
+                assertTrue(candidates.toString(), candidates.size() == 4);
+                assertEquals(candidates.toString(), Arrays.asList("--createDirs", "--file",
                         "--headers", "--overwrite"),
                         candidates);
             }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/AttachmentTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/AttachmentTestCase.java
@@ -24,8 +24,11 @@ package org.jboss.as.test.integration.management.cli;
 import java.io.File;
 import java.nio.file.Files;
 import org.jboss.as.test.integration.management.util.CLIWrapper;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Path;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.WildflyTestRunner;
@@ -104,6 +107,30 @@ public class AttachmentTestCase {
             assertFalse(f2.exists());
         } finally {
             f.delete();
+            cli.quit();
+        }
+    }
+
+    @Test
+    public void testCreateDirectories() throws Exception {
+        CLIWrapper cli = new CLIWrapper(true);
+        Path dir = new File(System.currentTimeMillis() + "attachment").toPath();
+        Path f = dir.resolve(System.currentTimeMillis() + "attachment.log");
+        assertFalse(Files.exists(dir));
+        assertFalse(Files.exists(f));
+        try {
+            assertFalse(cli.sendLine("attachment save --operation=/subsystem=logging/log-file=server.log:"
+                    + "read-attribute(name=stream) --file=" + f.toAbsolutePath(), true));
+            assertFalse(Files.exists(dir));
+            assertFalse(Files.exists(f));
+            cli.sendLine("attachment save --createDirs --operation=/subsystem=logging/log-file=server.log:"
+                    + "read-attribute(name=stream) --file=" + f.toAbsolutePath());
+            assertTrue(Files.exists(dir));
+            assertTrue(Files.exists(f));
+            assertTrue(Files.size(f) > 0L);
+        } finally {
+            Files.deleteIfExists(f);
+            Files.deleteIfExists(dir);
             cli.quit();
         }
     }


### PR DESCRIPTION
Creating the directories before saving the attachment to file.

Jira: https://issues.jboss.org/browse/WFCORE-3208