### PR TITLE
[WFCORE-2853] - Referral mode 'throw' for searching groups in legacy …

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapGroupSearcherFactory.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapGroupSearcherFactory.java
@@ -364,6 +364,8 @@ public class LdapGroupSearcherFactory {
                                 groupLoadHandler = groupLoadHandler.findForReferral(groupReferralAddress);
                                 if (groupLoadHandler == null) {
                                     SECURITY_LOGGER.tracef("Unable to follow referral to '%s'", fullUri);
+                                    //exception is propagated to avoid nullPointerException in next iteration
+                                    throw e;
                                 }
                                 retry = true;
                             } catch (URISyntaxException ue) {


### PR DESCRIPTION
…LDAP realm causes NPE

Issue: https://issues.jboss.org/browse/WFCORE-2853