### PR TITLE
[WFCORE-3209] Adding doAs blocks into KerberosHttpMgmtSaslTestCase for JDK9

### DIFF
--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractKerberosMgmtSaslTestBase.java
@@ -253,7 +253,11 @@ public abstract class AbstractKerberosMgmtSaslTestBase {
             if (withSsl) {
                 authnCtx = authnCtx.withSsl(MatchRule.ALL, sslFactory);
             }
-            authnCtx.run(() -> assertWhoAmI(user + "@JBOSS.ORG", withSsl));
+            final AuthenticationContext authnCtxFinal = authnCtx;
+            Subject.doAs(lc.getSubject(), (PrivilegedAction<Void>) () -> {
+                authnCtxFinal.run(() -> assertWhoAmI(user + "@JBOSS.ORG", withSsl));
+                return null;
+            });
         } finally {
             lc.logout();
         }
@@ -272,7 +276,11 @@ public abstract class AbstractKerberosMgmtSaslTestBase {
             if (withSsl) {
                 authnCtx = authnCtx.withSsl(MatchRule.ALL, sslFactory);
             }
-            authnCtx.run(() -> assertAuthenticationFails(null, null, withSsl));
+            final AuthenticationContext authnCtxFinal = authnCtx;
+            Subject.doAs(lc.getSubject(), (PrivilegedAction<Void>) () -> {
+                authnCtxFinal.run(() -> assertAuthenticationFails(null, null, withSsl));
+                return null;
+            });
         } finally {
             lc.logout();
         }


### PR DESCRIPTION
@ctomc fix of your failure for JDK9
For IBM there is also second failure, but it is already reported and tracked JDK bug - see jira:
https://issues.jboss.org/browse/WFCORE-3209