### PR TITLE
[WFCORE-3218] Upgrade jboss-logmanager from 2.0.7.Final to 2.1.0.Alpha4.

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
@@ -30,5 +30,6 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="org.jboss.modules"/>
+        <module name="org.wildfly.common"/>
     </dependencies>
 </module>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -55,17 +55,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <useManifestOnlyJar>false</useManifestOnlyJar>
-                    <!-- the log manager needs to be setup before the agent this is only needed on windows!-->
-                    <argLine>-Xbootclasspath/a:"${org.jboss.logmanager:jboss-logmanager:jar}"
-                        -javaagent:"${org.jboss.byteman:byteman:jar}"=port:${byteman.port},address:${byteman.host},boot:"${org.jboss.byteman:byteman:jar}" ${surefire.system.args}
-                    </argLine>
                     <systemPropertyVariables>
                         <jboss.server.log.dir>${project.build.directory}${file.separator}logs</jboss.server.log.dir>
                         <jboss.server.config.dir>${project.build.directory}${file.separator}config</jboss.server.config.dir>
-                        <org.jboss.byteman.debug>true</org.jboss.byteman.debug>
-                        <org.jboss.byteman.contrib.bmunit.agent.host>${byteman.host}</org.jboss.byteman.contrib.bmunit.agent.host>
-                        <org.jboss.byteman.contrib.bmunit.agent.port>${byteman.port}</org.jboss.byteman.contrib.bmunit.agent.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.2.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
-        <version.org.jboss.logmanager.jboss-logmanager>2.0.7.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.1.0.Alpha4</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.4.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.0.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.6.0.Final</version.org.jboss.modules.jboss-modules>

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractLoggingTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/AbstractLoggingTestCase.java
@@ -38,7 +38,6 @@ import java.nio.file.Paths;
 import java.security.Permission;
 import java.util.Collections;
 import java.util.Map;
-import java.util.logging.LoggingPermission;
 import javax.inject.Inject;
 
 import org.jboss.as.controller.PathAddress;
@@ -120,9 +119,6 @@ public abstract class AbstractLoggingTestCase {
         }
         archive.addAsResource(new StringAsset(manifest.toString()), "META-INF/MANIFEST.MF");
         return addPermissions(archive,
-                // TODO (jrp) remove this once LOGMGR-149 is resolved
-                // Add the logging permissions as a workaround for LOGMGR-149
-                new LoggingPermission("control", null),
                 new SocketPermission(TestSuiteEnvironment.getHttpAddress()+ ":0", "listen,resolve"));
     }
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/ReconnectSyslogServerTestCase.java
@@ -23,7 +23,6 @@ package org.jboss.as.test.manualmode.logging;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LoggingPermission;
 
 import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
@@ -55,10 +54,7 @@ public class ReconnectSyslogServerTestCase extends AbstractSyslogReconnectionTes
     public void setupContainer() throws Exception {
         container.start();
         host = CoreUtils.stripSquareBrackets(TestSuiteEnvironment.getServerAddress());
-        // TODO (jrp) remove this once LOGMGR-149 is resolved
         final JavaArchive deployment = createDeployment();
-        // Add the logging permissions as a workaround for LOGMGR-149
-        addPermissions(deployment, new LoggingPermission("control", null));
         deploy(deployment);
         SyslogServer.shutdown();
         BlockedAllProtocolsSyslogServerEventHandler.initializeForProtocol(SyslogConstants.UDP);

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SyslogIsNotAvailableDuringServerBootTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/logging/SyslogIsNotAvailableDuringServerBootTestCase.java
@@ -23,7 +23,6 @@ package org.jboss.as.test.manualmode.logging;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LoggingPermission;
 
 import org.jboss.as.test.integration.security.common.CoreUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
@@ -56,10 +55,7 @@ public class SyslogIsNotAvailableDuringServerBootTestCase extends AbstractSyslog
     public void setupContainer() throws Exception {
         container.start();
         host = CoreUtils.stripSquareBrackets(TestSuiteEnvironment.getServerAddress());
-        // TODO (jrp) remove this once LOGMGR-149 is resolved
         final JavaArchive deployment = createDeployment();
-        // Add the logging permissions as a workaround for LOGMGR-149
-        addPermissions(deployment, new LoggingPermission("control", null));
         deploy(deployment);
         SyslogServer.shutdown();
         BlockedAllProtocolsSyslogServerEventHandler.initializeForProtocol(SyslogConstants.UDP);

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.LoggingPermission;
 
 import org.apache.http.HttpStatus;
 import org.jboss.as.controller.client.helpers.Operations;
@@ -90,10 +89,7 @@ public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
 
     @BeforeClass
     public static void deploy() throws Exception {
-        // TODO (jrp) remove this once LOGMGR-149 is resolved
         final JavaArchive deployment = createDeployment(Collections.singletonMap("Logging-Profile", "syslog-profile"));
-        // Add the logging permissions as a workaround for LOGMGR-149
-        addPermissions(deployment, new LoggingPermission("control", null));
         deploy(deployment, DEPLOYMENT_NAME);
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3218

I don't think the custom byteman settings are required any longer. They passed for me locally without them.  This was done to fix some kind of issue with running on IPv6. Locally this seemed to work so it may not be required any longer.