### PR TITLE
[WFCORE-3228] Don't do the server-only runtime stuff on a profile res…

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerAdd.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerAdd.java
@@ -25,6 +25,7 @@
 package org.wildfly.extension.io;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.wildfly.extension.io.WorkerResourceDefinition.ATTRIBUTES;
 import static org.wildfly.extension.io.WorkerResourceDefinition.IO_WORKER_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.io.WorkerResourceDefinition.WORKER_IO_THREADS;
@@ -147,6 +148,10 @@ class WorkerAdd extends AbstractAddStepHandler {
 
     @Override
     protected Resource createResource(OperationContext context) {
+        if (PROFILE.equals(context.getCurrentAddress().getElement(0).getKey())) {
+            // Just do the standard thing
+            return super.createResource(context);
+        }
         Resource r = new WorkerResourceDefinition.WorkerResource(context);
         context.addResource(PathAddress.EMPTY_ADDRESS, r);
         return r;

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
@@ -194,8 +194,14 @@ class WorkerResourceDefinition extends PersistentResourceDefinition {
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         super.registerChildren(resourceRegistration);
-        resourceRegistration.registerSubModel(new WorkerServerDefinition());
         resourceRegistration.registerSubModel(OutboundBindAddressResourceDefinition.getInstance());
+        // Don't register on a domain profile, as there are no services to back the resource
+        // We could check if (resourceRegistration.getProcessType().isServer()) instead but
+        // if we ever support this extension as an HC subsystem (which seems reasonably possible)
+        // by doing it this way it will still behave correctly.
+        if (!PROFILE.equals(resourceRegistration.getPathAddress().getElement(0).getKey())) {
+            resourceRegistration.registerSubModel(new WorkerServerDefinition());
+        }
     }
 
     private abstract static class AbstractWorkerAttributeHandler implements OperationStepHandler {


### PR DESCRIPTION
…ource

Removing this isn't an incompatible change because these are runtime-only synthetic resources where WorkerResourceDefinition.WorkerResource will never produce a child resource against which an operation can be targeted. So no one could ever have run an operation against these.

https://issues.jboss.org/browse/WFCORE-3228