### PR TITLE
Fix for WFCORE-3074, replaced Path matching

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PathAddress.java
+++ b/controller/src/main/java/org/jboss/as/controller/PathAddress.java
@@ -451,6 +451,49 @@ public class PathAddress implements Iterable<PathElement> {
         return toString('/');
     }
 
+    /**
+     * Check if this path matches the address path.
+     * An address matches this address if its path elements match or are valid
+     * multi targets for this path elements. Addresses that are equal are matching.
+     *
+     * @param address The path to check against this path. If null, this method
+     * returns false.
+     * @return true if the provided path matches, false otherwise.
+     */
+    public boolean matches(PathAddress address) {
+        if (address == null) {
+            return false;
+        }
+        if (equals(address)) {
+            return true;
+        }
+        if (size() != address.size()) {
+            return false;
+        }
+        for (int i = 0; i < size(); i++) {
+            PathElement pe = getElement(i);
+            PathElement other = address.getElement(i);
+            if (!pe.matches(other)) {
+                // Could be a multiTarget with segments
+                if (pe.isMultiTarget() && !pe.isWildcard()) {
+                    boolean matched = false;
+                    for (String segment : pe.getSegments()) {
+                        if (segment.equals(other.getValue())) {
+                            matched = true;
+                            break;
+                        }
+                    }
+                    if (!matched) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     private String toString(char keyValSeparator) {
         if (pathAddressList.size() == 0) {
             return "/";

--- a/controller/src/main/java/org/jboss/as/controller/PathElement.java
+++ b/controller/src/main/java/org/jboss/as/controller/PathElement.java
@@ -169,11 +169,24 @@ public class PathElement {
 
     /**
      * Determine whether the given property matches this element.
+     * A property matches this element when property name and this key are equal,
+     * values are equal or this element value is a wildcard.
      * @param property the property to check
      * @return {@code true} if the property matches
      */
     public boolean matches(Property property) {
         return property.getName().equals(key) && (value == WILDCARD_VALUE || property.getValue().asString().equals(value));
+    }
+
+    /**
+     * Determine whether the given element matches this element.
+     * An element matches this element when keys are equal, values are equal
+     * or this element value is a wildcard.
+     * @param pe the element to check
+     * @return {@code true} if the element matches
+     */
+    public boolean matches(PathElement pe) {
+        return pe.key.equals(key) && (isWildcard() || pe.value.equals(value));
     }
 
     /**

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityRegistryTestCase.java
@@ -37,6 +37,8 @@ import org.jboss.as.controller.capability.Capability;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.capability.registry.CapabilityId;
 import org.jboss.as.controller.capability.registry.CapabilityScope;
+import org.jboss.as.controller.capability.registry.RegistrationPoint;
+import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
@@ -923,6 +925,24 @@ public class CapabilityRegistryTestCase extends AbstractControllerTestBase {
 
 
         executeCheckNoFailure(Util.createEmptyOperation("no-root-cap", PathAddress.EMPTY_ADDRESS));
+    }
+
+    @Test
+    public void testGetCapabilities() throws OperationFailedException {
+        CapabilityRegistry reg = new CapabilityRegistry(false);
+        reg.registerPossibleCapability(RuntimeCapability.Builder.of("org.wildfly.obj",
+                true, Object.class).build(),
+                PathAddress.pathAddress(new PathElement("subsystem", "java:jboss"),
+                        new PathElement("foo", "*")));
+        RegistrationPoint rp
+                = new RegistrationPoint(PathAddress.pathAddress(new PathElement("subsystem", "java:jboss"),
+                        new PathElement("foo", "bar")), "bar");
+        RuntimeCapabilityRegistration registration = new RuntimeCapabilityRegistration(RuntimeCapability.Builder.of("org.wildfly.obj.dyn",
+                true, Object.class).build(), CapabilityScope.GLOBAL, rp);
+        reg.registerCapability(registration);
+        Set<String> result = reg.getDynamicCapabilityNames("org.wildfly.obj", CapabilityScope.GLOBAL);
+        Assert.assertEquals(1, result.size());
+        Assert.assertTrue(result.contains("dyn"));
     }
 
     private void addRemoveAddTest() throws OperationFailedException {

--- a/controller/src/test/java/org/jboss/as/controller/PathAddressTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/PathAddressTestCase.java
@@ -182,4 +182,35 @@ public class PathAddressTestCase {
             assertThat(ex.getMessage(), containsString(wrongAddress));
         }
     }
+
+    @Test
+    public void testMatchingPaths() throws OperationFailedException {
+        Assert.assertTrue(PathAddress.parseCLIStyleAddress("/subsystem=*").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto")));
+        Assert.assertTrue(PathAddress.parseCLIStyleAddress("/subsystem=*/ext=*").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto/ext=foo")));
+        Assert.assertTrue(PathAddress.parseCLIStyleAddress("/subsystem=toto/ext=foo").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto/ext=foo")));
+        Assert.assertTrue(PathAddress.parseCLIStyleAddress("/subsystem=*/ext=foo").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto/ext=foo")));
+        Assert.assertTrue(PathAddress.parseCLIStyleAddress("/subsystem=[toto1,toto2]/ext=foo").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto1/ext=foo")));
+        Assert.assertTrue(PathAddress.parseCLIStyleAddress("/subsystem=[toto1,toto2]/ext=foo").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto2/ext=foo")));
+        Assert.assertTrue(PathAddress.parseCLIStyleAddress("/subsystem=[toto1,toto2]/ext=[foo1,foo2]").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto2/ext=foo2")));
+
+        Assert.assertFalse(PathAddress.parseCLIStyleAddress("/subsys=*").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto")));
+        Assert.assertFalse(PathAddress.parseCLIStyleAddress("/subsystem=*").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto/ext=foo")));
+        Assert.assertFalse(PathAddress.parseCLIStyleAddress("/subsystem=*/ext=*").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto")));
+        Assert.assertFalse(PathAddress.parseCLIStyleAddress("/subsystem=*/ext=*").matches(
+                null));
+        Assert.assertFalse(PathAddress.parseCLIStyleAddress("/subsystem=[toto1,toto2]/ext=foo").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto3/ext=foo")));
+        Assert.assertFalse(PathAddress.parseCLIStyleAddress("/subsystem=[toto1,toto2]/ext=[foo1,foo2]").matches(
+                PathAddress.parseCLIStyleAddress("/subsystem=toto2/ext=foo3")));
+    }
 }


### PR DESCRIPTION
Replaced Filesystem based matching with PathAddress/PathElement based matching.
Added unit test for path matching. Added unit test to cover the case that was failing with Filesystem based matching (with a possible provider address's value containing a ":" character).