### PR TITLE
Work around the WFCORE-2235 problem to avoid intermittent failures fo…

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/InterdependentDeploymentTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/InterdependentDeploymentTestCase.java
@@ -281,9 +281,10 @@ public class InterdependentDeploymentTestCase {
         for (String dep : dependencies) {
             sb.append(
                     "      <module name=\"deployment.").append(dep).append("\"");
-            if (dep.equals("interrelated-c.jar")) {
-                sb.append(" optional=\"true\"");
-            }
+            // FIXME WFCORE-2235 this should work, but it fails intermittently
+            //if (dep.equals("interrelated-c.jar")) {
+            //    sb.append(" optional=\"true\"");
+            //}
             sb.append("/>\n");
         }
         sb.append(


### PR DESCRIPTION
…r the known issue

Related to but not a fix for https://issues.jboss.org/browse/WFCORE-2235

Example failure I'm trying to avoid: https://ci.wildfly.org/viewLog.html?buildId=72854&buildTypeId=WildFlyCore_PullRequestWindows&tab=buildResultsDiv