### PR TITLE
[3.x] WFCORE-3258 ServiceRemoveStepHandler fails to remove services if any associated capabilities use a dynamic name mapper

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ServiceRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ServiceRemoveStepHandler.java
@@ -111,13 +111,7 @@ public class ServiceRemoveStepHandler extends AbstractRemoveStepHandler {
 
             for (RuntimeCapability<?> capability : capabilitySet) {
                 if (capability.getCapabilityServiceValueType() != null) {
-                    ServiceName sname;
-                    if (capability.isDynamicallyNamed()) {
-                        sname = capability.getCapabilityServiceName(name);
-                    } else {
-                        sname = capability.getCapabilityServiceName();
-                    }
-                    context.removeService(sname);
+                    context.removeService(capability.getCapabilityServiceName(address));
                 }
             }
         } else {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3258