### PR TITLE
Restore otherwise useless controller module InterfaceRemoveHandler be…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/common/InterfaceRemoveHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/InterfaceRemoveHandler.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+package org.jboss.as.controller.operations.common;
+
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.capability.RuntimeCapability;
+
+/**
+ * @deprecated only retained becaused used by legacy controllers in mixed-domain testing.
+ *
+ * @author Brian Stansberry (c) 2011 Red Hat Inc.
+ */
+@Deprecated
+public class InterfaceRemoveHandler extends AbstractRemoveStepHandler {
+
+    public static final String OPERATION_NAME = REMOVE;
+
+    protected InterfaceRemoveHandler(RuntimeCapability... capabilities) {
+        super(capabilities);
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/resource/InterfaceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/InterfaceDefinition.java
@@ -51,6 +51,7 @@ import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.common.InterfaceAddHandler;
 import org.jboss.as.controller.operations.common.InterfaceCriteriaWriteHandler;
+import org.jboss.as.controller.operations.common.InterfaceRemoveHandler;
 import org.jboss.as.controller.operations.validation.ModelTypeValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
 import org.jboss.as.controller.operations.validation.SubnetValidator;
@@ -176,7 +177,13 @@ public class InterfaceDefinition extends SimpleResourceDefinition {
     private final boolean updateRuntime;
     private final boolean resolvable;
 
-    public InterfaceDefinition(InterfaceAddHandler addHandler, OperationStepHandler removeHandler, boolean updateRuntime, boolean resolvable) {
+    /** @deprecated only for use in mixed domain testing */
+    @Deprecated
+    public InterfaceDefinition(InterfaceAddHandler addHandler, InterfaceRemoveHandler removeHandler, boolean updateRuntime, boolean resolvable) {
+        this(addHandler, (OperationStepHandler) removeHandler, updateRuntime, resolvable);
+    }
+
+    protected InterfaceDefinition(InterfaceAddHandler addHandler, OperationStepHandler removeHandler, boolean updateRuntime, boolean resolvable) {
         super(new Parameters(PathElement.pathElement(INTERFACE), ControllerResolver.getResolver(INTERFACE))
                 .setAddHandler(addHandler)
                 .setRemoveHandler(removeHandler)

--- a/server/src/main/java/org/jboss/as/server/services/net/InterfaceRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/InterfaceRemoveHandler.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.server.services.net;
 
-import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.registry.Resource;
@@ -34,7 +33,7 @@ import org.jboss.dmr.ModelNode;
  *
  * @author Brian Stansberry
  */
-public class InterfaceRemoveHandler extends AbstractRemoveStepHandler {
+public class InterfaceRemoveHandler extends org.jboss.as.controller.operations.common.InterfaceRemoveHandler {
 
     public static final InterfaceRemoveHandler INSTANCE = new InterfaceRemoveHandler();
 


### PR DESCRIPTION
…cause legacy controller in transformer tests expect it

This is needed to allow the WFLY-9339 fix to work, which in turn is required for the WFCORE-3259 fix to work.

WF Core 3 dropped the seemingly pointless controller module InterfaceRemoveHandler, but on legacy controllers used in subsystem tests ControllerInitializer is expecting to invoke a constructor on InterfaceDefinition that has InterfaceRemoveHandler as the type of one of the params. So without this you get errors.