### PR TITLE
Revert "Work around the WFCORE-2235 problem to avoid intermittent failures fo…"

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/InterdependentDeploymentTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/deployment/InterdependentDeploymentTestCase.java
@@ -281,10 +281,9 @@ public class InterdependentDeploymentTestCase {
         for (String dep : dependencies) {
             sb.append(
                     "      <module name=\"deployment.").append(dep).append("\"");
-            // FIXME WFCORE-2235 this should work, but it fails intermittently
-            //if (dep.equals("interrelated-c.jar")) {
-            //    sb.append(" optional=\"true\"");
-            //}
+            if (dep.equals("interrelated-c.jar")) {
+                sb.append(" optional=\"true\"");
+            }
             sb.append("/>\n");
         }
         sb.append(


### PR DESCRIPTION
Reverts wildfly/wildfly-core#2773

The test still intermittently fails despite this change, so it wasn't helping with that and we should restore the original version.

I'm tempted to @ Ignore the entire test but it covers an important scenario. Perhaps the issue isn't the "optional" bit but rather the chained dependencies. That's still an important scenario but less so than the test overall and maybe disabling that bit will avoid the intermittent issue. 

@ropalka FYI