### PR TITLE
Fix for WFCORE-3289, variable substitution completion issue

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/AttachmentHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/AttachmentHandler.java
@@ -89,10 +89,10 @@ public class AttachmentHandler extends BatchModeCommandHandler {
             public int complete(CommandContext ctx, String buffer, int cursor,
                     List<String> candidates) {
 
-                final String originalLine = ctx.getParsedCommandLine().getOriginalLine();
+                final String substitutedLine = ctx.getParsedCommandLine().getSubstitutedLine();
                 boolean skipWS;
                 int wordCount;
-                if (Character.isWhitespace(originalLine.charAt(0))) {
+                if (Character.isWhitespace(substitutedLine.charAt(0))) {
                     skipWS = true;
                     wordCount = 0;
                 } else {
@@ -100,16 +100,16 @@ public class AttachmentHandler extends BatchModeCommandHandler {
                     wordCount = 1;
                 }
                 int cmdStart = 1;
-                while (cmdStart < originalLine.length()) {
+                while (cmdStart < substitutedLine.length()) {
                     if (skipWS) {
-                        if (!Character.isWhitespace(originalLine.charAt(cmdStart))) {
+                        if (!Character.isWhitespace(substitutedLine.charAt(cmdStart))) {
                             skipWS = false;
                             ++wordCount;
                             if (wordCount == 3) {
                                 break;
                             }
                         }
-                    } else if (Character.isWhitespace(originalLine.charAt(cmdStart))) {
+                    } else if (Character.isWhitespace(substitutedLine.charAt(cmdStart))) {
                         skipWS = true;
                     }
                     ++cmdStart;
@@ -121,7 +121,7 @@ public class AttachmentHandler extends BatchModeCommandHandler {
                 } else if (wordCount != 3) {
                     return -1;
                 } else {
-                    cmd = originalLine.substring(cmdStart);
+                    cmd = substitutedLine.substring(cmdStart);
                     // remove --operation=
                     int i = cmd.indexOf("=");
                     if (i > 0) {
@@ -141,9 +141,9 @@ public class AttachmentHandler extends BatchModeCommandHandler {
 
                 // escaping index correction
                 int escapeCorrection = 0;
-                int start = originalLine.length() - 1 - buffer.length();
+                int start = substitutedLine.length() - 1 - buffer.length();
                 while (start - escapeCorrection >= 0) {
-                    final char ch = originalLine.charAt(start - escapeCorrection);
+                    final char ch = substitutedLine.charAt(start - escapeCorrection);
                     if (Character.isWhitespace(ch) || ch == '=') {
                         break;
                     }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/EchoDMRHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/EchoDMRHandler.java
@@ -42,10 +42,10 @@ public class EchoDMRHandler extends CommandHandlerWithHelp {
                 @Override
                 public int complete(CommandContext ctx, String buffer, int cursor, List<String> candidates) {
 
-                    final String originalLine = ctx.getParsedCommandLine().getOriginalLine();
+                    final String substituedLine = ctx.getParsedCommandLine().getSubstitutedLine();
                     boolean skipWS;
                     int wordCount;
-                    if(Character.isWhitespace(originalLine.charAt(0))) {
+                    if(Character.isWhitespace(substituedLine.charAt(0))) {
                         skipWS = true;
                         wordCount = 0;
                     } else {
@@ -53,16 +53,16 @@ public class EchoDMRHandler extends CommandHandlerWithHelp {
                         wordCount = 1;
                     }
                     int cmdStart = 1;
-                    while(cmdStart < originalLine.length()) {
+                    while(cmdStart < substituedLine.length()) {
                         if(skipWS) {
-                            if(!Character.isWhitespace(originalLine.charAt(cmdStart))) {
+                            if(!Character.isWhitespace(substituedLine.charAt(cmdStart))) {
                                 skipWS = false;
                                 ++wordCount;
                                 if(wordCount == 2) {
                                     break;
                                 }
                             }
-                        } else if(Character.isWhitespace(originalLine.charAt(cmdStart))) {
+                        } else if(Character.isWhitespace(substituedLine.charAt(cmdStart))) {
                             skipWS = true;
                         }
                         ++cmdStart;
@@ -74,7 +74,7 @@ public class EchoDMRHandler extends CommandHandlerWithHelp {
                     } else if(wordCount != 2) {
                         return -1;
                     } else {
-                        cmd = originalLine.substring(cmdStart);
+                        cmd = substituedLine.substring(cmdStart);
                     }
 
                     int cmdResult = ctx.getDefaultCommandCompleter().complete(ctx, cmd, cmd.length(), candidates);
@@ -84,9 +84,9 @@ public class EchoDMRHandler extends CommandHandlerWithHelp {
 
                     // escaping index correction
                     int escapeCorrection = 0;
-                    int start = originalLine.length() - 1 - buffer.length();
+                    int start = substituedLine.length() - 1 - buffer.length();
                     while(start - escapeCorrection >= 0) {
-                        final char ch = originalLine.charAt(start - escapeCorrection);
+                        final char ch = substituedLine.charAt(start - escapeCorrection);
                         if(Character.isWhitespace(ch) || ch == '=') {
                             break;
                         }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchEditLineHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchEditLineHandler.java
@@ -55,10 +55,10 @@ public class BatchEditLineHandler extends CommandHandlerWithHelp {
                         return -1;
                     }
 
-                    final String originalLine = ctx.getParsedCommandLine().getOriginalLine();
+                    final String substitutedLine = ctx.getParsedCommandLine().getSubstitutedLine();
                     boolean skipWS;
                     int wordCount;
-                    if(Character.isWhitespace(originalLine.charAt(0))) {
+                    if(Character.isWhitespace(substitutedLine.charAt(0))) {
                         skipWS = true;
                         wordCount = 0;
                     } else {
@@ -66,16 +66,16 @@ public class BatchEditLineHandler extends CommandHandlerWithHelp {
                         wordCount = 1;
                     }
                     int cmdStart = 1;
-                    while(cmdStart < originalLine.length()) {
+                    while(cmdStart < substitutedLine.length()) {
                         if(skipWS) {
-                            if(!Character.isWhitespace(originalLine.charAt(cmdStart))) {
+                            if(!Character.isWhitespace(substitutedLine.charAt(cmdStart))) {
                                 skipWS = false;
                                 ++wordCount;
                                 if(wordCount == 3) {
                                     break;
                                 }
                             }
-                        } else if(Character.isWhitespace(originalLine.charAt(cmdStart))) {
+                        } else if(Character.isWhitespace(substitutedLine.charAt(cmdStart))) {
                             skipWS = true;
                         }
                         ++cmdStart;
@@ -87,7 +87,7 @@ public class BatchEditLineHandler extends CommandHandlerWithHelp {
                     } else if(wordCount != 3) {
                         return -1;
                     } else {
-                        cmd = originalLine.substring(cmdStart);
+                        cmd = substitutedLine.substring(cmdStart);
                     }
 
                     int cmdResult = ctx.getDefaultCommandCompleter().complete(ctx, cmd, cmd.length(), candidates);
@@ -97,9 +97,9 @@ public class BatchEditLineHandler extends CommandHandlerWithHelp {
 
                     // escaping index correction
                     int escapeCorrection = 0;
-                    int start = originalLine.length() - 1 - buffer.length();
+                    int start = substitutedLine.length() - 1 - buffer.length();
                     while(start - escapeCorrection >= 0) {
-                        final char ch = originalLine.charAt(start - escapeCorrection);
+                        final char ch = substitutedLine.charAt(start - escapeCorrection);
                         if(Character.isWhitespace(ch) || ch == '=') {
                             break;
                         }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ifelse/IfHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ifelse/IfHandler.java
@@ -68,23 +68,23 @@ public class IfHandler extends CommandHandlerWithHelp {
                         return -1;
                     }
 
-                    final String originalLine = args.getOriginalLine();
+                    final String substitutedLine = args.getSubstitutedLine();
                     String conditionStr;
                     try {
                         conditionStr = condition.getValue(args, true);
                     } catch (CommandFormatException e) {
                         return -1;
                     }
-                    int i = originalLine.indexOf(conditionStr);
+                    int i = substitutedLine.indexOf(conditionStr);
                     if(i < 0) {
                         return -1;
                     }
-                    i = originalLine.indexOf("of ", i + conditionStr.length());
+                    i = substitutedLine.indexOf("of ", i + conditionStr.length());
                     if(i < 0) {
                         return -1;
                     }
 
-                    final String cmd = originalLine.substring(i + 3);
+                    final String cmd = substitutedLine.substring(i + 3);
 /*                    final DefaultCallbackHandler parsedLine = new DefaultCallbackHandler();
                     try {
                         parsedLine.parse(ctx.getCurrentNodePath(), cmd);
@@ -100,9 +100,9 @@ public class IfHandler extends CommandHandlerWithHelp {
 
                     // escaping index correction
                     int escapeCorrection = 0;
-                    int start = originalLine.length() - 1 - buffer.length();
+                    int start = substitutedLine.length() - 1 - buffer.length();
                     while(start - escapeCorrection >= 0) {
-                        final char ch = originalLine.charAt(start - escapeCorrection);
+                        final char ch = substitutedLine.charAt(start - escapeCorrection);
                         if(Character.isWhitespace(ch) || ch == '=') {
                             break;
                         }

--- a/cli/src/main/java/org/jboss/as/cli/operation/ParsedCommandLine.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/ParsedCommandLine.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.jboss.as.cli.CommandLineFormat;
+import org.jboss.as.cli.parsing.StateParser.SubstitutedLine;
 
 
 /**
@@ -43,6 +44,8 @@ public interface ParsedCommandLine {
      * (of commands, variables, system properties, etc) performed
      */
     String getSubstitutedLine();
+
+    SubstitutedLine getSubstitutions();
 
     boolean isRequestComplete();
 
@@ -91,6 +94,12 @@ public interface ParsedCommandLine {
     int getLastSeparatorIndex();
 
     int getLastChunkIndex();
+
+    int getLastSeparatorOriginalIndex();
+
+    int getLastChunkOriginalIndex();
+
+    int getOriginalOffset(int offset);
 
     String getLastParsedPropertyName();
 

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
@@ -64,7 +64,7 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
         @Override
         public int complete(CommandContext ctx, String buffer, int cursor, List<String> candidates) {
             try {
-                ParserUtil.parseHeaders(buffer, parsedOp);
+                parsedOp.parseHeaders(buffer, ctx);
             } catch (CommandFormatException e) {
                 //e.printStackTrace();
                 return -1;
@@ -78,18 +78,18 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
                 candidates.add("=");
                 return buffer.length();
             }
-            int result = SimpleTabCompleter.BOOLEAN.complete(ctx, buffer.substring(parsedOp.getLastChunkIndex()), cursor, candidates);
+            int result = SimpleTabCompleter.BOOLEAN.complete(ctx, buffer.substring(parsedOp.getLastChunkOriginalIndex()), cursor, candidates);
             // Special case when the value is already complete, add a separator.
             if (candidates.size() == 1) {
-                if (candidates.get(0).equals(buffer.substring(parsedOp.getLastChunkIndex()))) {
+                if (candidates.get(0).equals(buffer.substring(parsedOp.getLastChunkOriginalIndex()))) {
                     candidates.clear();
-                    candidates.add(buffer.substring(parsedOp.getLastChunkIndex()) + ";");
+                    candidates.add(buffer.substring(parsedOp.getLastChunkOriginalIndex()) + ";");
                 }
             }// No value...
             if(result < 0) {
                 return result;
             }
-            return parsedOp.getLastChunkIndex() + result;
+            return parsedOp.getOriginalOffset(parsedOp.getLastChunkIndex() + result);
         }};
 
     private static final CommandLineCompleter INT_HEADER_COMPLETER = new CommandLineCompleter(){
@@ -99,7 +99,7 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
         @Override
         public int complete(CommandContext ctx, String buffer, int cursor, List<String> candidates) {
             try {
-                ParserUtil.parseHeaders(buffer, parsedOp);
+                ParserUtil.parseHeaders(buffer, parsedOp, ctx);
             } catch (CommandFormatException e) {
                 //e.printStackTrace();
                 return -1;

--- a/cli/src/main/java/org/jboss/as/cli/parsing/ParserUtil.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/ParserUtil.java
@@ -26,6 +26,7 @@ import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineFormat;
 import org.jboss.as.cli.operation.CommandLineParser;
+import org.jboss.as.cli.parsing.StateParser.SubstitutedLine;
 import org.jboss.as.cli.parsing.command.ArgumentListState;
 import org.jboss.as.cli.parsing.command.ArgumentState;
 import org.jboss.as.cli.parsing.command.ArgumentValueNotFinishedException;
@@ -74,20 +75,38 @@ public class ParserUtil {
         if(commandLine == null) {
             return null;
         }
+        SubstitutedLine sl = parseLine(commandLine, handler, strict, ctx);
+        return sl == null ? null : sl.getSubstitued();
+    }
+
+    public static SubstitutedLine parseLine(String commandLine, final CommandLineParser.CallbackHandler handler, boolean strict,
+            CommandContext ctx) throws CommandFormatException {
+        if (commandLine == null) {
+            return null;
+        }
         final ParsingStateCallbackHandler callbackHandler = getCallbackHandler(handler);
-        return StateParser.parse(commandLine, callbackHandler, InitialState.INSTANCE, strict, ctx);
+        return StateParser.parseLine(commandLine, callbackHandler, InitialState.INSTANCE, strict, ctx);
     }
 
     /**
      * Returns the string which was actually parsed with all the substitutions performed
      */
     public static String parseOperationRequest(String commandLine, final CommandLineParser.CallbackHandler handler) throws CommandFormatException {
-        if(commandLine == null) {
+        SubstitutedLine sl = parseOperationRequestLine(commandLine, handler);
+        return sl == null ? null : sl.getSubstitued();
+    }
+
+    /**
+     * Returns the string which was actually parsed with all the substitutions
+     * performed
+     */
+    public static SubstitutedLine parseOperationRequestLine(String commandLine, final CommandLineParser.CallbackHandler handler) throws CommandFormatException {
+        if (commandLine == null) {
             return null;
         }
         final ParsingStateCallbackHandler callbackHandler = getCallbackHandler(handler);
         handler.setFormat(OperationFormat.INSTANCE);
-        return StateParser.parse(commandLine, callbackHandler, OperationRequestState.INSTANCE);
+        return StateParser.parseLine(commandLine, callbackHandler, OperationRequestState.INSTANCE);
     }
 
     /**
@@ -97,8 +116,32 @@ public class ParserUtil {
         if(commandLine == null) {
             return null;
         }
+        SubstitutedLine sl = parseHeadersLine(commandLine, handler, null);
+        return sl == null ? null : sl.getSubstitued();
+    }
+
+    /**
+     * Returns the string which was actually parsed with all the substitutions
+     * performed
+     */
+    public static String parseHeaders(String commandLine, final CommandLineParser.CallbackHandler handler, CommandContext ctx) throws CommandFormatException {
+        if (commandLine == null) {
+            return null;
+        }
+        SubstitutedLine sl = parseHeadersLine(commandLine, handler, ctx);
+        return sl == null ? null : sl.getSubstitued();
+    }
+
+    /**
+     * Returns the string which was actually parsed with all the substitutions
+     * performed
+     */
+    public static SubstitutedLine parseHeadersLine(String commandLine, final CommandLineParser.CallbackHandler handler, final CommandContext ctx) throws CommandFormatException {
+        if (commandLine == null) {
+            return null;
+        }
         final ParsingStateCallbackHandler callbackHandler = getCallbackHandler(handler);
-        return StateParser.parse(commandLine, callbackHandler, HeaderListState.INSTANCE);
+        return StateParser.parseLine(commandLine, callbackHandler, HeaderListState.INSTANCE, ctx);
     }
 
     /**

--- a/cli/src/main/java/org/jboss/as/cli/parsing/StateParser.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/StateParser.java
@@ -22,7 +22,10 @@
 package org.jboss.as.cli.parsing;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
+import java.util.List;
 
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
@@ -53,27 +56,57 @@ public class StateParser {
      * Returns the string which was actually parsed with all the substitutions performed
      */
     public static String parse(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState) throws CommandFormatException {
-        return parse(str, callbackHandler, initialState, true);
+        return parseLine(str, callbackHandler, initialState).getSubstitued();
+    }
+
+    /**
+     * Returns the string which was actually parsed with all the substitutions
+     * performed
+     */
+    public static SubstitutedLine parseLine(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState) throws CommandFormatException {
+        return parseLine(str, callbackHandler, initialState, true);
     }
 
     /**
      * Returns the string which was actually parsed with all the substitutions performed
      */
     public static String parse(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState, boolean strict) throws CommandFormatException {
-        return parse(str, callbackHandler, initialState, strict, null);
+        return parseLine(str, callbackHandler, initialState, strict).getSubstitued();
     }
+
+    /**
+     * Returns the string which was actually parsed with all the substitutions
+     * performed
+     */
+    public static SubstitutedLine parseLine(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState, boolean strict) throws CommandFormatException {
+        return parseLine(str, callbackHandler, initialState, strict, null);
+    }
+
+    /**
+     * Returns the string which was actually parsed with all the substitutions
+     * performed
+     */
+    public static SubstitutedLine parseLine(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState, CommandContext ctx) throws CommandFormatException {
+        return parseLine(str, callbackHandler, initialState, true, ctx);
+    }
+
 
     /**
      * Returns the string which was actually parsed with all the substitutions performed
      */
     public static String parse(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState,
             boolean strict, CommandContext ctx) throws CommandFormatException {
+        return parseLine(str, callbackHandler, initialState, strict, ctx).getSubstitued();
+    }
+
+    public static SubstitutedLine parseLine(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState,
+            boolean strict, CommandContext ctx) throws CommandFormatException {
 
         try {
             return doParse(str, callbackHandler, initialState, strict, ctx);
-        } catch(CommandFormatException e) {
+        } catch (CommandFormatException e) {
             throw e;
-        } catch(Throwable t) {
+        } catch (Throwable t) {
             throw new CommandFormatException("Failed to parse '" + str + "'", t);
         }
     }
@@ -81,19 +114,11 @@ public class StateParser {
     /**
      * Returns the string which was actually parsed with all the substitutions performed
      */
-    protected static String doParse(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState,
-            boolean strict) throws CommandFormatException {
-        return doParse(str, callbackHandler, initialState, strict, null);
-    }
-
-    /**
-     * Returns the string which was actually parsed with all the substitutions performed
-     */
-    protected static String doParse(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState,
+    protected static SubstitutedLine doParse(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState,
             boolean strict, CommandContext cmdCtx) throws CommandFormatException {
 
         if (str == null || str.isEmpty()) {
-            return str;
+            return new SubstitutedLine(str);
         }
 
         ParsingContextImpl ctx = new ParsingContextImpl();
@@ -103,7 +128,69 @@ public class StateParser {
         ctx.strict = strict;
         ctx.cmdCtx = cmdCtx;
 
-        return ctx.parse();
+        ctx.substitued.substitued = ctx.parse();
+        return ctx.substitued;
+    }
+
+    public static class SubstitutedLine {
+
+        private final List<Substitution> substitutions = new ArrayList<>();
+        private String substitued;
+        private int currentOriginalIndex;
+
+        SubstitutedLine() {
+        }
+
+        SubstitutedLine(String str) {
+            substitued = str;
+        }
+
+        public String getSubstitued() {
+            return substitued;
+        }
+
+        public List<Substitution> getSubstitions() {
+            return Collections.unmodifiableList(substitutions);
+        }
+
+        public int getOriginalOffset(int substituedOffset) {
+            if (substitutions.isEmpty()) {
+                return substituedOffset;
+            }
+            int delta = 0;
+            for (Substitution sub : getSubstitions()) {
+                if (sub.substitutionIndex >= substituedOffset) {
+                    break;
+                } else {
+                    delta += sub.original.length() - sub.substitution.length();
+                }
+            }
+            return substituedOffset + delta;
+        }
+
+        private void add(String original, String substitution, int location) {
+            //compute original index;
+            int orig = location - currentOriginalIndex;
+            currentOriginalIndex += substitution.length() - original.length();
+            substitutions.add(new Substitution(original, substitution, location, orig));
+        }
+
+    }
+
+    public static class Substitution {
+
+        private final String original;
+        private final String substitution;
+        private final int substitutionIndex;
+        private final int originalIndex;
+
+        private Substitution(String original, String substitution, int substitutionIndex, int originalIndex) {
+            this.original = original;
+            this.substitution = substitution;
+            this.substitutionIndex = substitutionIndex;
+            this.originalIndex = originalIndex;
+        }
+
     }
 
     static class ParsingContextImpl implements ParsingContext {
@@ -119,7 +206,7 @@ public class StateParser {
         boolean strict;
         CommandFormatException error;
         CommandContext cmdCtx;
-
+        private final SubstitutedLine substitued = new SubstitutedLine();
         private final Deque<Character> lookFor = new ArrayDeque<Character>();
         /** to not meet the same character at the same position multiple times */
         int lastMetLookForIndex = -1;
@@ -241,6 +328,7 @@ public class StateParser {
                     throw new UnresolvedVariableException(name, "Unrecognized variable " + name);
                 }
             } else {
+                substitued.add("$" + name, value, location);
                 StringBuilder buf = new StringBuilder(input.length() - name.length() + value.length());
                 buf.append(input.substring(0, location)).append(value);
                 if (endIndex < input.length()) {

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/VariablesTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/VariablesTestCase.java
@@ -277,7 +277,8 @@ public class VariablesTestCase {
     public void testLastChunkIndex() throws Exception {
         final ParsedCommandLine parsed = parse("$myvar:re");
         assertEquals("re", parsed.getOperationName());
-        assertEquals(7, parsed.getLastChunkIndex());
+        assertEquals(7, parsed.getLastChunkOriginalIndex());
+        assertEquals(19, parsed.getLastChunkIndex());
     }
 
     @Test

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -1386,4 +1386,131 @@ public class CliCompletionTestCase {
             ctx.terminateSession();
         }
     }
+
+    @Test
+    public void testVariablesCompletion() throws Exception {
+        CommandContext ctx = CLITestUtil.getCommandContext(testSupport,
+                System.in, System.out);
+        ctx.connectController();
+        try {
+            ctx.handle("set varName=foo");
+            ctx.handle("set varName2=barbarbarbar");
+            {
+                String cmd = "/deployment=$";
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), Arrays.asList("varName", "varName2"),
+                        candidates);
+            }
+
+            {
+                String cmd = "/deployment=$varName:read-co";
+                List<String> candidates = new ArrayList<>();
+                int offset = ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), 21, offset);
+                assertEquals(candidates.toString(), Arrays.asList("read-content"),
+                        candidates);
+            }
+
+            {
+                String cmd = "/server-group=$varName/deployment=$varName2:wh";
+                List<String> candidates = new ArrayList<>();
+                int offset = ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), 44, offset);
+                assertEquals(candidates.toString(), Arrays.asList("whoami"),
+                        candidates);
+            }
+
+            {
+                String cmd = "/server-group=$varName/deployment=$varName2:read-resource() {a";
+                List<String> candidates = new ArrayList<>();
+                int offset = ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), 61, offset);
+                assertEquals(candidates.toString(), Arrays.asList("allow-resource-service-restart"),
+                        candidates);
+            }
+
+            {
+                String cmd = "/server-group=$varName/deployment=$varName2:read-resource() {allow-resource-service-restart";
+                List<String> candidates = new ArrayList<>();
+                int offset = ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), 91, offset);
+                assertEquals(candidates.toString(), Arrays.asList("="),
+                        candidates);
+            }
+
+            {
+                String cmd = "/server-group=$varName/deployment=$varName2:read-resource() {allow-resource-service-restart=t";
+                List<String> candidates = new ArrayList<>();
+                int offset = ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), 92, offset);
+                assertEquals(candidates.toString(), Arrays.asList("true"),
+                        candidates);
+            }
+
+            {
+                String cmd = "/server-group=$varName/deployment=$varName2:read-resource() {allow-resource-service-restart=$varName2;rollback-on-runtime-failure=f";
+                List<String> candidates = new ArrayList<>();
+                int offset = ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), 130, offset);
+                assertEquals(candidates.toString(), Arrays.asList("false"),
+                        candidates);
+            }
+
+            {
+                String cmd = "attachment display --operation=/server-group=$varName/deployment=$varName2:wh";
+                List<String> candidates = new ArrayList<>();
+                int offset = ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), 75, offset);
+                assertEquals(candidates.toString(), Arrays.asList("whoami"),
+                        candidates);
+            }
+
+            {
+                String cmd = "if () of /server-group=$varName/deployment=$varName2:wh";
+                List<String> candidates = new ArrayList<>();
+                int offset = ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), 53, offset);
+                assertEquals(candidates.toString(), Arrays.asList("whoami"),
+                        candidates);
+            }
+
+            {
+                ctx.handle("batch");
+                try {
+                    ctx.handle(":read-resource");
+                    String cmd = "edit-batch-line 1 /server-group=$varName/deployment=$varName2:wh";
+                    List<String> candidates = new ArrayList<>();
+                    int offset = ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                            cmd.length(), candidates);
+                    assertEquals(candidates.toString(), 62, offset);
+                    assertEquals(candidates.toString(), Arrays.asList("whoami"),
+                            candidates);
+                } finally {
+                    ctx.handle("discard-batch");
+                }
+            }
+
+            {
+                String cmd = "echo-dmr /server-group=$varName/deployment=$varName2:wh";
+                List<String> candidates = new ArrayList<>();
+                int offset = ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertEquals(candidates.toString(), 53, offset);
+                assertEquals(candidates.toString(), Arrays.asList("whoami"),
+                        candidates);
+            }
+        } finally {
+            ctx.terminateSession();
+        }
+    }
 }


### PR DESCRIPTION
Handling variable substitution:
- fixed operation completion in commands (echo-dmr, if, edit-batch-line, attachment)
- support for multiple variables in a path

Added new completion unit tests.
