### PR TITLE
[WFCORE-3287]: Generated keystore file permissions should be 600 instead of 664.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeyManagerService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeyManagerService.java
@@ -192,6 +192,10 @@ class FileKeyManagerService extends AbstractKeyManagerService {
             try (FileOutputStream stream = new FileOutputStream(path)) {
                 keyStore.store(stream, resolveKeystorePassword());
             }
+            path.setReadable(false, false);
+            path.setReadable(true, true);
+            path.setWritable(false, false);
+            path.setWritable(true, true);
             DomainManagementLogger.SECURITY_LOGGER.keystoreHasBeenCreated(path.toString(), getSha1Fingerprint(cert, "SHA-1"), getSha1Fingerprint(cert, "SHA-256"));
 
         } catch (Exception e) {


### PR DESCRIPTION
Setting the permissions.

Jira: https://issues.jboss.org/browse/WFCORE-3287
JBEAP: https://issues.jboss.org/browse/JBEAP-13150