### PR TITLE
[WFCORE-3234] Add Elytron model and schema version 2.

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -211,7 +211,7 @@
                             <includes>
                                 <include>*.xml</include>
                             </includes>
-                            <systemId>src/main/resources/schema/wildfly-elytron_1_1.xsd</systemId>
+                            <systemId>src/main/resources/schema/wildfly-elytron_2_0.xsd</systemId>
                         </validationSet>
                         <validationSet>
                             <dir>src/main/resources/subsystem-templates</dir>

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
@@ -58,7 +58,8 @@ public class ElytronExtension implements Extension {
      */
     public static final String NAMESPACE_1_0 = "urn:wildfly:elytron:1.0";
     public static final String NAMESPACE_1_1 = "urn:wildfly:elytron:1.1";
-    public static final String CURRENT_NAMESPACE = NAMESPACE_1_1;
+    public static final String NAMESPACE_2_0 = "urn:wildfly:elytron:2.0";
+    public static final String CURRENT_NAMESPACE = NAMESPACE_2_0;
 
     /**
      * The name of our subsystem within the model.
@@ -72,8 +73,9 @@ public class ElytronExtension implements Extension {
 
     static final ModelVersion ELYTRON_1_0_0 = ModelVersion.create(1);
     static final ModelVersion ELYTRON_1_1_0 = ModelVersion.create(1, 1);
+    static final ModelVersion ELYTRON_2_0_0 = ModelVersion.create(2);
 
-    private static final ModelVersion ELYTRON_CURRENT = ELYTRON_1_1_0;
+    private static final ModelVersion ELYTRON_CURRENT = ELYTRON_2_0_0;
 
     static final String ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
@@ -105,6 +107,7 @@ public class ElytronExtension implements Extension {
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_0, new ElytronSubsystemParser(NAMESPACE_1_0));
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_1, new ElytronSubsystemParser(NAMESPACE_1_1));
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_2_0, new ElytronSubsystemParser(NAMESPACE_2_0));
     }
 
     @Override

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -47,9 +47,11 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
     public void registerTransformers(SubsystemTransformerRegistration registration) {
         ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(registration.getCurrentSubsystemVersion());
 
-        // Current 1.1.0 to 1.0.0, aka WildFly Core 3.0.0/3.0.1
-        buildTransformers_1_0(chainedBuilder.createBuilder(registration.getCurrentSubsystemVersion(), ElytronExtension.ELYTRON_1_0_0));
-        chainedBuilder.buildAndRegister(registration, new ModelVersion[]{ElytronExtension.ELYTRON_1_0_0});
+        // 1.1.0 to 1.0.0, aka WildFly Core 3.0.0/3.0.1
+        buildTransformers_1_0(chainedBuilder.createBuilder(ElytronExtension.ELYTRON_1_1_0, ElytronExtension.ELYTRON_1_0_0));
+        // Current 2.0.0 to 1.1.0 aka WildFly Core 3.0.2
+        buildTransformers_1_1(chainedBuilder.createBuilder(registration.getCurrentSubsystemVersion(), ElytronExtension.ELYTRON_1_1_0));
+        chainedBuilder.buildAndRegister(registration, new ModelVersion[]{ElytronExtension.ELYTRON_1_1_0, ElytronExtension.ELYTRON_1_0_0});
     }
 
     private void buildTransformers_1_0(ResourceTransformationDescriptionBuilder builder) {
@@ -83,6 +85,10 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
             .getAttributeBuilder()
                 .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(ElytronDescriptionConstants.AUTHENTICATION)), AuthenticationClientDefinitions.FORWARDING_MODE)
                 .addRejectCheck(RejectAttributeChecker.DEFINED, AuthenticationClientDefinitions.FORWARDING_MODE);
+
+    }
+
+    private void buildTransformers_1_1(ResourceTransformationDescriptionBuilder builder) {
 
     }
 }

--- a/elytron/src/main/resources/schema/wildfly-elytron_2_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_2_0.xsd
@@ -1,0 +1,4950 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:wildfly:elytron:2.0"
+            xmlns="urn:wildfly:elytron:2.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.0">
+
+    <!-- The subsystem root element -->
+    <xs:element name="subsystem" type="subsystemType"/>
+
+    <xs:complexType name="subsystemType">
+        <xs:all>
+            <xs:element name="security-properties" type="securityPropertiesType" minOccurs="0" />
+            <xs:element name="authentication-client" type="authenticationClientType" minOccurs="0" />
+            <xs:element name="providers" type="providersType" minOccurs="0" />
+            <xs:element name="audit-logging" type="auditLoggingType" minOccurs="0" />
+            <xs:element name="security-domains" type="securityDomainsType" minOccurs="0" />
+            <xs:element name="security-realms" type="realmsType" minOccurs="0" />
+            <xs:element name="credential-security-factories" type="credentialSecurityFactoriesType" minOccurs="0" />
+            <xs:element name="mappers" type="mappersType" minOccurs="0" />
+            <xs:element name="http" type="httpType" minOccurs="0" />
+            <xs:element name="sasl" type="saslType" minOccurs="0" />
+            <xs:element name="tls" type="tlsType" minOccurs="0" />
+            <xs:element name="credential-stores" type="credentialStoresType" minOccurs="0" />
+            <xs:element name="dir-contexts" type="dirContextsType" minOccurs="0" />
+            <xs:element name="policy" type="policyType" minOccurs="0" />
+        </xs:all>
+        <xs:attribute name="default-authentication-context" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the default authentication context to be associated with all deployments.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="initial-providers" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a capability providing a Provider[] which will be registered globally ahead of all existing Provider registrations.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final-providers" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a capability providing a Provider[] which will be registered globally after all existing Provider registrations.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="disallowed-providers" type="stringListType">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of providers that are disallowed, and will be removed from the providers list.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        Security Properties
+     -->
+
+    <xs:complexType name="securityPropertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                Type to contain a list of security properties to be set.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="security-property" type="propertyType" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="propertyType">
+        <xs:annotation>
+            <xs:documentation>
+                Representation of a key/value property pair.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The key for this property.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The value for this property.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <!--
+        Authentication Client
+     -->
+
+    <xs:complexType name="authenticationClientType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the authentication client definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="authentication-configuration" type="authenticationConfigurationType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="authentication-context" type="authenticationContextType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="authenticationConfigurationType">
+        <xs:annotation>
+            <xs:documentation>
+                Authentication configuration definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mechanism-properties" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        An ordered list of properties to be used to configure all of the providers.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="credential-reference" type="credentialReferenceType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used by the configuration.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the authentication-configuration, note names used for authentication-configurations must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="extends" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a previously defined authentication configuration to extend.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="anonymous" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                  Enables anonymous authentication.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name to use for authentication.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authorization-name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name to use for authorization.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="host" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the host to use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="protocol" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The protocol to use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="port" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    The port to use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The realm to use.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-domain" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a security domain to use for a forwarded identity.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="forwarding-mode" default="authentication">
+            <xs:simpleType>
+                <xs:annotation>
+                    <xs:documentation>
+                        The type of identity forwarding to use when security-domain is specified. The value "authenticaiton" forwards
+                        the identity of the currently authenticated user, including credentials. The value "authorization" forwards
+                        the underlying authorization identity, which allows for a different identity to be used for authentication.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="authentication" />
+                    <xs:enumeration value="authorization" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name = "sasl-mechanism-selector" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The SASL mechanism selector string. Allows to specify allowed/forbidden SASL mechanisms.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="kerberos-security-factory" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a kerberos security factory used to obtain a GSS kerberos credential.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="authenticationContextType">
+        <xs:annotation>
+            <xs:documentation>
+                Authentication context definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="match-rule" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        An ordered list of match-rules to be defined on this authentication context.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="match-abstract-type" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on abstract type.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-abstract-type-authority" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on abstract type authority.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-host" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on host.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-local-security-domain" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on local security domain.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-no-user" type="xs:boolean" default="false">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on no user.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-path" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on path.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-port" type="xs:int">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on port.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-protocol" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on protocol.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-urn" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on urn.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="match-user" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Match based on user.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="authentication-configuration" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The AuthenticationConfiguration to use with this match.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="ssl-context" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The SSLContext to use with this match.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the authentication-context, note names used for authentication-contexts must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="extends" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a previously defined authentication context to extend.
+
+                    match-rules defined here are added after the rules of the parent.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        Providers
+     -->
+
+     <xs:complexType name="providersType">
+         <xs:annotation>
+             <xs:documentation>
+                 Container of Provider configuration.
+             </xs:documentation>
+         </xs:annotation>
+         <xs:choice maxOccurs="unbounded">
+             <xs:element name="aggregate-providers" type="aggregateProvidersType" />
+             <xs:element name="provider-loader" type="providerLoaderType" />
+         </xs:choice>
+     </xs:complexType>
+
+    <xs:complexType name="aggregateProvidersType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalDecoder definition that is actually an aggregation of other PrincipalDecoders.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="providers" type="providersRefType" minOccurs="2" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name to use to represent this provider loader in the management model.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+     </xs:complexType>
+
+         <xs:complexType name="providersRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a Provider[] resource.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+     <xs:complexType name="providerLoaderType">
+         <xs:annotation>
+             <xs:documentation>
+                 Definition of a single provider loader.
+             </xs:documentation>
+         </xs:annotation>
+         <xs:sequence>
+             <xs:element name="configuration" minOccurs="0" >
+                 <xs:complexType>
+                     <xs:sequence>
+                         <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                     </xs:sequence>
+                 </xs:complexType>
+             </xs:element>
+         </xs:sequence>
+         <xs:attribute name="name" type="xs:string" use="required">
+             <xs:annotation>
+                 <xs:documentation>
+                     The name to use to represent this provider loader in the management model.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="module" type="xs:string">
+             <xs:annotation>
+                 <xs:documentation>
+                     The name of the module to use to load the providers.
+
+                     If this is not specified the ClassLoader used to load the service will be used instead.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="class-names" type="stringListType">
+             <xs:annotation>
+                 <xs:documentation>
+                     The fully qualified class names of the providers to load.
+
+                     If this attribute is not specified then service loader based discovery will be used instead.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="path" type="xs:string">
+             <xs:annotation>
+                 <xs:documentation>
+                     The path to the configuration to use to initialise the provider.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="relative-to" type="xs:string">
+             <xs:annotation>
+                 <xs:documentation>
+                     A reference to a previously defined path that the path of the configuration is
+                     relative to.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:attribute>
+         <xs:attribute name="argument" type="xs:string">
+             <xs:annotation>
+                 <xs:documentation>
+                     Argument to pass into the constructor as the Provider is instantiated.
+
+                     Can only be used where the class names to load are specified.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:attribute>
+     </xs:complexType>
+
+    <!--
+        Audit Logging
+     -->
+
+    <xs:complexType name="auditLoggingType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the security domain definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="aggregate-security-event-listener" type="aggregateSecurityEventListener" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="file-audit-log" type="fileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="periodic-rotating-file-audit-log" type="periodicRotatingFileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="size-rotating-file-audit-log" type="sizeRotatingFileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="syslog-audit-log" type="syslogAuditLogType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="formatType">
+        <xs:annotation>
+            <xs:documentation>
+                The format type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SIMPLE" />
+            <xs:enumeration value="JSON" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="transportType">
+        <xs:annotation>
+            <xs:documentation>
+                The syslog transport method type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="TCP" />
+            <xs:enumeration value="UDP" />
+            <xs:enumeration value="SSL_TCP" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="auditLogType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all audit log types.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the audit log.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateSecurityEventListener">
+        <xs:annotation>
+            <xs:documentation>
+                A security event listener definition that is actually an aggregation of other security event listeners.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="auditLogType">
+                <xs:sequence>
+                    <xs:element name="security-event-listener" type="securityEventListenerRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="securityEventListenerRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a security event listener.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="fileAuditLogType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit log definition for persisting an audit log to a local file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="auditLogType">
+                <xs:attribute name="path" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path to write the audit log to.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to a previously defined path that the path of the audit log is
+                            relative to.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="synchronized" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether every event should be immediately synchronised to disk.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="format" default="SIMPLE" type="formatType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The format to use to log the event.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="periodicRotatingFileAuditLogType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit log definition for persisting an audit log to a local file rotating the log after a time period
+                derived from the given suffix string, which should be in a format understood by java.time.format.DateTimeFormatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fileAuditLogType">
+                <xs:attribute name="suffix" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The suffix string in a format which can be understood by java.time.format.DateTimeFormatter.
+                            The period of the rotation is automatically calculated based on the suffix.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="sizeRotatingFileAuditLogType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit log definition for persisting an audit log to a local file rotating the log after the
+                size of the file grows beyond a certain point and keeping a fixed number of backups.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="fileAuditLogType">
+                <xs:attribute name="max-backup-index" default="1" type="xs:long" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The maximum number of files to backup when rotating.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="rotate-on-boot" type="xs:boolean" default="false" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the file should be rotated before the a new file is set.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="rotate-size" default="10m" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The log file size the file should rotate at.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="suffix" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Format of date used as suffix of log file names in java.time.format.DateTimeFormatter.
+                            The suffix does not play a role in determining when the file should be rotated.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="syslogAuditLogType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit log definition for persisting an audit log to a local file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="auditLogType">
+                <xs:attribute name="server-address" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Address of the server to send syslog messages to.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="port" type="xs:int" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The port number the remote syslog server is listening on.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="transport" type="transportType" default="TCP">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The transport to use to communicate with the syslog server.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="format" type="formatType" default="SIMPLE">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The format to use to log the event.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="host-name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The host name to send within all events sent to the syslog server.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="ssl-context" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of ssl-context used to secure connection to the syslog server.
+                            Applies only when SSL_TCP transport is used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!--
+        Domains and Realms
+     -->
+
+    <xs:complexType name="securityDomainsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the security domain definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="security-domain" type="securityDomainType" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="securityDomainType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type for the definition of a single security domain.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="realm" type="realmRefType" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="default-realm" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Which of the listed realms should be the default?
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pre-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the PrincipalTransformer to be applied before the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="post-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the PrincipalTransformer to be applied after the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="principal-decoder" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the PrincipalDecoder to be used by this domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RealmMapper to be used by this security domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RoleMapper to be used by the domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="permission-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the PermissionMapper to be used by the domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="trusted-security-domains" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of references to security domains that are trusted by this security domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="outflow-anonymous" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Where automatic outflow to a security domain is configured, if outflowing
+                    the current identity is not authorized should the
+                    anonymous identity of that domain be used instead?
+
+                    Outflowing an identity replaces any previously
+                    established identity for the outflow domain for the
+                    ongoing call, outflowing anonymous has the effect of
+                    clearing the identity.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="outflow-security-domains" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of references to security domains that any identity established for this
+                    domain should automatically outflow to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-event-listener" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a security event listener to be notified of security events
+                    emitted from this domain.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="realmRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a security realm.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The PrincipalTransformer to be associated with this realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-decoder" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The RoleDecoder to be associated with this realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The RoleMapper to be associated with this realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="realmsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the security realm definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="aggregate-realm" type="aggregateRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-realm" type="customRealmType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                      Custom realm definitions can implement either the SecurityRealm interface or the ModifiableSecurityRealm interface.
+
+                      Regardless of which interface is implemented management operations will not be exposed to manage the realm.  However other
+                      services that depend on the realm will still be able to perform a type check and cast to gain access to the modification API.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="custom-modifiable-realm" type="customRealmType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                      Custom realm configured as being modifiable will be expected to implement the ModifiableSecurityRealm interface.
+
+                      By configuring a realm as being modifiable management operations will be made available to manipulate the realm.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="identity-realm" type="identityRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="jdbc-realm" type="jdbcRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="key-store-realm" type="keyStoreRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="properties-realm" type="propertiesRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="ldap-realm" type="ldapRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="filesystem-realm" type="fileSystemRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="token-realm" type="tokenRealmType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="caching-realm" type="cachingRealmType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="realmType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all realm definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the realm, note names used for realms must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A realm definition that is an aggregation of two realms, one for the authentication steps
+                and one for loading the identity for the authorization steps.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="authentication-realm" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the realm to use for the authentication steps (obtaining or validating credentials).
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="authorization-realm" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the realm to use for the authorization steps (loading of the identity).
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="cachingRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A realm definition that enables caching to another security realm. Caching strategy is LRU (Least Recently Used) where least accessed entries are discarded when maximum number of entries is reached.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="realm" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A reference to a cacheable security realm.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="maximum-entries" type="xs:int" use="optional" default="16">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The maximum number of entries to keep in the cache.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="maximum-age" type="xs:long" use="optional" default="-1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The time in milliseconds that an item can stay in the cache.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+	<xs:complexType name="customRealmType">
+		<xs:annotation>
+			<xs:documentation>
+				Realm definition for a custom realm implementation.
+
+				Generally subsystems that provide security realms should make them available
+				using the capabilities and requirements features of the application
+				server, this custom mechanism is provided for truly isolated realm implementations.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+		    <xs:extension base="realmType">
+		        <xs:sequence>
+		            <xs:element name="configuration" type="customComponentConfiguration" minOccurs="0">
+		                <xs:annotation>
+		                    <xs:documentation>
+		                        The configuration to apply to the SecurityRealm implementation.
+
+		                        Note: If configuration is supplied the realm MUST implement the Configurable interface.
+		                    </xs:documentation>
+		                </xs:annotation>
+		            </xs:element>
+		        </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+		    </xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+
+    <xs:complexType name="identityRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                Realm definition for a realm which contains a single pre-defined identity.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="identity" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the identity.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="attribute-name" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of an attribute to associate with the identity.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="attribute-values" type="stringListType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The values to associate with the identities attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="jdbcRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A security realm definition backed by database using JDBC.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:sequence>
+                    <xs:element name="principal-query" type="authenticationQueryType" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="authenticationQueryType">
+        <xs:annotation>
+            <xs:documentation>
+                The authentication query used to authenticate users based on specific key types.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="clear-password-mapper" type="clearPasswordMapperType" minOccurs="0"/>
+            <xs:element name="bcrypt-mapper" type="bcryptMapperType" minOccurs="0"/>
+            <xs:element name="simple-digest-mapper" type="simpleDigestMapperType" minOccurs="0"/>
+            <xs:element name="salted-simple-digest-mapper" type="saltedSimpleDigestMapperType" minOccurs="0"/>
+            <xs:element name="scram-mapper" type="scramMapperType" minOccurs="0"/>
+            <xs:element name="attribute-mapping" type="jdbcAttributeMappingType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="sql" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The SQL statement used to obtain the keys(as table columns) for a specific user and map them accordingly with their type.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="data-source" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the datasource used to connect to the database.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jdbcAttributeMappingType">
+        <xs:sequence>
+            <xs:element name="attribute" type="jdbcAttributeType" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jdbcAttributeType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration used to map a specific column in a table as an identity attribute.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from a query that representing the mapped attribute.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="to" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the identity attribute mapped from a column returned from a SQL query.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="clearPasswordMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Clear Password key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user's password.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="bcryptMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Bcrypt key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user's password.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="salt-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the password's salt, if supported.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="iteration-count-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the password's iteration count, if supported.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="saltedSimpleDigestMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Salted Simple Digest key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="algorithm" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The encryption algorithm name to use.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+            	<xs:restriction base="xs:string">
+                	<xs:enumeration value="password-salt-digest-md5" />
+            		<xs:enumeration value="password-salt-digest-sha-1" />
+            		<xs:enumeration value="password-salt-digest-sha-256" />
+            		<xs:enumeration value="password-salt-digest-sha-384" />
+            		<xs:enumeration value="password-salt-digest-sha-512" />
+            		<xs:enumeration value="salt-password-digest-md5" />
+            		<xs:enumeration value="salt-password-digest-sha-1" />
+            		<xs:enumeration value="salt-password-digest-sha-256" />
+            		<xs:enumeration value="salt-password-digest-sha-384" />
+            		<xs:enumeration value="salt-password-digest-sha-512" />
+            	</xs:restriction>
+        	</xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user's password.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="salt-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the password's salt, if supported.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="simpleDigestMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Simple Digest key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="algorithm" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The encryption algorithm name to use.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+            	<xs:restriction base="xs:string">
+                	<xs:enumeration value="simple-digest-md2" />
+            		<xs:enumeration value="simple-digest-md5" />
+            		<xs:enumeration value="simple-digest-sha-1" />
+            		<xs:enumeration value="simple-digest-sha-256" />
+            		<xs:enumeration value="simple-digest-sha-384" />
+            		<xs:enumeration value="simple-digest-sha-512" />
+            	</xs:restriction>
+        	</xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user's password.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="scramMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A key mapper that maps a column returned from a SQL query to a Scram key type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="algorithm" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The encryption algorithm name to use.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+            	<xs:restriction base="xs:string">
+                	<xs:enumeration value="scram-sha-1" />
+            		<xs:enumeration value="scram-sha-256" />
+            	</xs:restriction>
+        	</xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="password-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the user's password.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="salt-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the password's salt, if supported.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="iteration-count-index" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The column index from an authentication query that represents the password's iteration count, if supported.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="keyStoreRealmType">
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:attribute name="key-store" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the KeyStore to be used by this realm.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                Realm definition for a realm backed by a properties file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:all>
+                    <xs:element name="users-properties">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The location of the properties file containing the users and their passwords.
+                                The file should contain realm name declaration.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType >
+                            <xs:complexContent>
+                                <xs:extension base="basicFileType">
+                                    <xs:attribute name="plain-text" type="xs:boolean" default="false">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Are the passwords in properties file stored in plain text or pre-hashed?
+                                                (Pre-hashed form: HEX( MD5( username ":" realm ":" password ) ) )
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                    <xs:attribute name="digest-realm-name" type="xs:string">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                The realm name to use for digested passwords if one is not discovered in the properties file.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:extension>
+                            </xs:complexContent>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="groups-properties" type="basicFileType" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The location of the properties file containing the users and their groups.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:all>
+                <xs:attribute name="groups-attribute" type="xs:string" default="groups">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the attribute in the returned AuthorizationIdentity that should contain the group membership information for the identity.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- Ldap Security Realm -->
+
+    <xs:complexType name="ldapRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A security realm definition backed by LDAP.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:all>
+                    <xs:element name="identity-mapping" type="identityMappingType" nillable="false"/>
+                </xs:all>
+                <xs:attribute name="dir-context" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of dir-context used to connect to the LDAP server.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="direct-verification" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should this realm instance support verification of credentials by directly connecting to LDAP as the account being authenticated?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="allow-blank-password" type="xs:boolean" use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should direct verification in this realm to allow login attempt with blank password?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!-- FileSystem Security Realm -->
+    <xs:complexType name="fileSystemRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                A simple security realm definition backed by the filesystem.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:all>
+                    <xs:element name="file" type="basicFileType">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The location of the file to use to handle the security realm.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:all>
+                <xs:attribute name="levels" type="xs:int" default="2">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The number of levels of directory hashing to apply
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="encoded" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the identity names should be stored encoded (Base32) in file names.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="tokenRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                Realm definition for a token realm where authentication and authorization are handled by
+                a given token validator.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmType">
+                <xs:choice>
+                    <xs:element name="jwt" type="jwtTokenRealmValidatorType"/>
+                    <xs:element name="oauth2-introspection" type="oauth2IntrospectionTokenRealmValidatorType"/>
+                </xs:choice>
+                <xs:attribute name="principal-claim" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the claim that should be used to obtain the principal's name. Defaults to 'username'.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="jwtTokenRealmValidatorType">
+        <xs:annotation>
+            <xs:documentation>
+                A token validator to be used in conjunction with a token-based realm that handles security tokens based on the JWT/JWS standard.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="issuer" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of strings representing the issuers supported by this configuration. During validation JWT tokens must have an "iss" claim that contains one of the values defined here.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="audience" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A list of strings representing the audiences supported by this configuration. During validation JWT tokens must have an "aud" claim that contains one of the values defined here.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="public-key" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A public key in PEM Format. During validation, if a public key is provided, signature will be verified based on the key you provided here.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-store" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A key store from where the certificate with a public key should be loaded from.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="certificate" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the certificate with a public key to load from the key store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="oauth2IntrospectionTokenRealmValidatorType">
+        <xs:annotation>
+            <xs:documentation>
+                A token validator to be used in conjunction with a token-based realm that handles OAuth2 Access Tokens and validate them based on RFC-7662 (OAuth2 Token Introspection).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="client-id" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The identifier of a client registered within the OAuth2 Authorization Server that will be used to authenticate this server in order to validate bearer tokens arriving to this server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="client-secret" type="stringListType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The secret of the client identified by the given client-id.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="introspection-url" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    An URL pointing to a RFC-7662 OAuth2 Token Introspection compatible endpoint.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="client-ssl-context" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A predefined client-ssl-context that will be used to connect to the token introspection endpoint when using SSL/TLS. This configuration is mandatory if the given token introspection url is using SSL/TLS.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="host-name-verification-policy" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A policy that defines how host names should be verified when using HTTPS. Allowed values: "ANY".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="dirContextsType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration options that define how to connect to the LDAP server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="dir-context" type="dirContextType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="dirContextType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration options that define how to connect to the LDAP server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="properties" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="credential-reference" type="credentialReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The credential reference to credential store or clear text (password)
+                        to use to authenticate and connect to the LDAP server.
+                        Can be omitted if authentication-level is "none" (anonymous).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the connection. Allows to refer the DirContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="url" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The connection url.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-level" type="xs:string" use="optional" default="simple">
+            <xs:annotation>
+                <xs:documentation>
+                    The authentication level (security level/authentication mechanism) to use.
+                    Corresponds to SECURITY_AUTHENTICATION ("java.naming.security.authentication") environment property.
+                    Allowed values: "none", "simple", sasl_mech, where sasl_mech is a space-separated list of SASL mechanism names.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="principal" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The principal to authenticate and connect to the LDAP server.
+                    Can be omitted if authentication-level is "none" (anonymous).
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enable-connection-pooling" type="xs:boolean" default="false" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates if connection pooling is enabled.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="referral-mode" type="xs:string" default="ignore" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    If LDAP referrals should be followed.
+                    Corresponds to REFERRAL ("java.naming.referral") environment property.
+                    Allowed values: "ignore", "follow", "throw".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ssl-context" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of ssl-context used to secure connection to the LDAP server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-context" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of authentication-context used to secure connection and to authenticate to the LDAP server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connection-timeout" type="xs:integer" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The timeout for connecting to the LDAP server in milliseconds.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="read-timeout" type="xs:integer" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The read timeout for an LDAP operation in milliseconds.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of module that will be used to load custom context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="identityMappingType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration options that define how principals are mapped to their corresponding entries in the underlying LDAP server.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="attribute-mapping" type="ldapAttributeMappingType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The attribute mappings defined for this resource.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="user-password-mapper" type="userPasswordMapperType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The user password credential mapping defined for this resource.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="otp-credential-mapper" type="otpCredentialMapperType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The user password credential mapping defined for this resource.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="x509-credential-mapper" type="x509CredentialMapperType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The X509 user certificate credential mapping defined for this resource.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="new-identity-attributes" type="ldapNewIdentityAttributesType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The attributes of newly created identities. Required for modifiability.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="rdn-identifier" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The RDN part of the principal's DN to be used to obtain the principal's name from an LDAP entry.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="search-base-dn" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The base DN to be used when executing queries.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="use-recursive-search" type="xs:boolean" default="false" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates if queries are recursive.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="filter-name" type="xs:string" use="optional" default="(rdn_identifier={0})">
+            <xs:annotation>
+                <xs:documentation>
+                    The LDAP filter for getting identity by name.
+                    The string "{0}" will be replaced by searched identity name and the "rdn_identifier" will be the value of the attribute "rdn-identifier".
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="iterator-filter" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The LDAP filter for iterating over identities of the realm. Optional, but required for modifiability.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="new-identity-parent-dn" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The DN of parent of newly created identities. Optional, but required for modifiability.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapAttributeMappingType">
+        <xs:sequence>
+            <xs:element name="attribute" type="ldapAttributeType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ldapAttributeType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration used to map a specific LDAP attribute as an identity attribute.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="from" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an identity attribute.
+                    If not defined, DN of the whole entry is used as value.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the identity attribute mapped from a specific LDAP attribute.
+                    If not provided, the name of the attribute is the same as define in 'from'.
+                    If the 'from' is not defined too, value 'dn' is used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="reference" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of LDAP attribute containing DN of entry to obtain value from.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="filter" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The filter to use to obtain the values for a specific attribute.
+                    String "{0}" will be replaced by username, "{1}" by user identity DN.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="filter-base-dn" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the context where the filter should be performed.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="search-recursive" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates if attribute LDAP search queries are recursive.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-recursion" type="xs:int" use="optional" default="0">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets recursive roles assignment - value determine maximum depth of recursion. (0 for no recursion)
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="role-recursion-name" type="xs:string" use="optional" default="cn">
+            <xs:annotation>
+                <xs:documentation>
+                    Determine LDAP attribute of role entry which will be substitute for "{0}" in filter-name when searching roles of role.
+                    Used only when role-recursion is set.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="extract-rdn" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The RDN key to use as the value for an attribute, in case the value in its raw form is in X.500 format.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="userPasswordMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration used to map a specific LDAP attribute (userPassword usually) as an identity password credential.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an identity user password credential.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="writable" type="xs:boolean" default="false" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    If the password credential is writable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="verifiable" type="xs:boolean" default="true" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    If the password credential is verifiable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="otpCredentialMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration allowing to use the LDAP as storage of one time password (OTP) credentials.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="algorithm-from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an OTP credential algorithm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="hash-from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to a Base64 encoded OTP credential hash.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="seed-from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an OTP credential seed.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sequence-from" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an OTP credential sequence number.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="x509CredentialMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                The configuration allowing to use LDAP as storage of X509 credentials.
+                X509 credential is user certificate or information allowing to identify it.
+                (serial number, subject DN, digest of certificate)
+                At least one *-from attribute should be specified. This definition will be ignored otherwise.
+                If more *-from attributes is defined, user certificate must match all defined criteria.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="digest-from" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to a user certificate digest.
+                    If not defined, certificate digest will not be checked.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="digest-algorithm" type="xs:string" use="optional" default="SHA-1">
+            <xs:annotation>
+                <xs:documentation>
+                    The digest algorithm (hash function) used to compute digest of the user certificate.
+                    Will be used only if digest-from have been defined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="certificate-from" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to an encoded user certificate.
+                    If not defined, encoded certificate will not be checked.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="serial-number-from" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to a serial number of user certificate.
+                    If not defined, serial number will not be checked.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="subject-dn-from" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute to map to a subject DN of user certificate.
+                    If not defined, subject DN will not be checked.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapNewIdentityAttributesType">
+        <xs:sequence>
+            <xs:element name="attribute" type="ldapNewIdentityAttributeType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ldapNewIdentityAttributeType">
+        <xs:annotation>
+            <xs:documentation>
+                Attribute of newly created LDAP identity.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the LDAP attribute.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="value" type="stringListType" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The value(s) of LDAP attribute delimited by space.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="credentialSecurityFactoriesType">
+        <xs:annotation>
+            <xs:documentation>
+                A container type to hold SecurityFactory definitions to obtain Credential instances.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="custom-credential-security-factory" type="customCredentialSecurityFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="kerberos-security-factory" type="kerberosSecurityFactory" minOccurs="0" maxOccurs="unbounded" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="credentialSecurityFactoryType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all SecurityFactory definitions which return a Credential.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the SecurityFactory, note names used for SecurityFactories must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customCredentialSecurityFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom credential SecurityFactory implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="credentialSecurityFactoryType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                        type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the SecurityFactory implementation.
+
+                                Note: If configuration is supplied the SecurityFactory MUST implement the Configurable interface.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="kerberosSecurityFactory">
+        <xs:complexContent>
+            <xs:extension base="credentialSecurityFactoryType">
+                <xs:sequence>
+                    <xs:element name="option" maxOccurs="unbounded" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The Krb5LoginModule additional option.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:attribute name="name" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The key of the option.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="value" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The value of the option.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="principal" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The principal represented by the KeyTab
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="path" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path to the KeyTab to use to obtain the credential.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the standard paths provided by the system.
+                            If 'relative-to' is provided, the value of the 'path' attribute is treated as relative
+                            to the path specified by this attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="minimum-remaining-lifetime" type="xs:int" default="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            How much lifetime (in seconds) should a cached credential have remaining before it is recreated.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="request-lifetime" type="xs:int">
+                    <xs:annotation>
+                        <xs:documentation>
+                            How much lifetime (in seconds) should be requested for newly created credentials.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="server" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If this for use server side or client side?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="obtain-kerberos-ticket" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should the KerberosTicket also be obtained and associated with the credential.
+
+                            This is required to be true where credentials are delegated to the server.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="debug" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should the JAAS step of obtaining the credential have debug logging enabled.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="wrap-gss-credential" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should generated GSS credentials be wrapped to prevent improper disposal or not?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="required" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Is the keytab file with adequate principal required to exist at the time the service starts?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="mechanism-names" type="stringListType" default="KRB5 SPNEGO">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The mechanism names the credential should be usable with.
+                            Names will be converted to OIDs and used together with OIDs from mechanism-oids attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="mechanism-oids" type="stringListType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The mechanism OIDs the credential should be usable with.
+                            Will be used together with OIDs derived from names from mechanism-names attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!--
+        General Mappers and Rewriters
+     -->
+
+    <xs:complexType name="mappersType">
+        <xs:annotation>
+            <xs:documentation>
+                A general container type to hold the various name rewriter and mapper definitions
+                as used within the subsystem.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="aggregate-principal-decoder" type="aggregatePrincipalDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="concatenating-principal-decoder" type="concatenatingPrincipalDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="constant-principal-decoder" type="constantPrincipalDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-principal-decoder" type="customPrincipalDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="x500-attribute-principal-decoder" type="x500AttributePrincipalDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-principal-transformer" type="aggregatePrincipalTransformerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="chained-principal-transformer" type="chainedPrincipalTransformerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="constant-principal-transformer" type="constantPrincipalTransformer" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-principal-transformer" type="customPrincipalTransformerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="regex-principal-transformer" type="regexPrincipalTransformerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="regex-validating-principal-transformer" type="regexValidatingPrincipalTransformer" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-permission-mapper" type="customPermissionMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="logical-permission-mapper" type="logicalPermissionMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="simple-permission-mapper" type="simplePermissionMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="constant-permission-mapper" type="constantPermissionMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="constant-realm-mapper" type="constantRealmMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-realm-mapper" type="customRealmMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="simple-regex-realm-mapper" type="simpleRegexRealmMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="mapped-regex-realm-mapper" type="mappedRegexRealmMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-role-decoder" type="customRoleDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="simple-role-decoder" type="simpleRoleDecoderType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="add-prefix-role-mapper" type="addPrefixRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="add-suffix-role-mapper" type="addSuffixRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-role-mapper" type="aggregateRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="constant-role-mapper" type="constantRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-role-mapper" type="customRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="logical-role-mapper" type="logicalRoleMapperType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="permissionMapperType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all PermissionMapper definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the PermissionMapper, note names used for PermissionMappers must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customPermissionMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom PermissionMapper implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="permissionMapperType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                        type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the PermissionMapper implementation.
+
+                                Note: If configuration is supplied the PermissionMapper MUST implement the Configurable interface.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="logicalPermissionMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A PermissionMapper definition for a PermissionMapper that performs a logical operation using two referenced PermissionMappers.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="permissionMapperType">
+                <xs:attribute name="logical-operation" type="logicalPermissionMappingsType" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The logical operation to perform using the two referenced PermissionMappers.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="left" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the PermissionMapper to use to the left of the operation.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="right" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the PermissionMapper to use to the right of the operation.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="logicalPermissionMappingsType">
+        <xs:annotation>
+            <xs:documentation>
+                The supported set of logical operations.
+                "and" assigns permissions which was assigned by both mappers
+                "or" assigns permissions which was assigned by at least one of mappers
+                "xor" assigns permissions which was assigned by exactly one of mappers
+                "unless" assigns permissions which was assigned by left mapper but not by right mapper
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="and" />
+            <xs:enumeration value="or" />
+            <xs:enumeration value="xor" />
+            <xs:enumeration value="unless" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="simplePermissionMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A simple permission mapper that maps from defined principal and role names to predefined permissions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="permissionMapperType">
+                <xs:sequence>
+                    <xs:element name="permission-mapping" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="principal" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="name" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The name of the principal. 
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                         </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                                <xs:element name="role" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="name" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The name of the role. 
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                         </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                                <xs:element name="permission" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="class-name" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The fully qualified class name of the permission.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                         </xs:attribute>
+                                         <xs:attribute name="module" type="xs:string">
+                                             <xs:annotation>
+                                                 <xs:documentation>
+                                                             The module to use to load the permission class.
+                                                 </xs:documentation>
+                                             </xs:annotation>
+                                         </xs:attribute>
+                                         <xs:attribute name="target-name" type="xs:string">
+                                                     <xs:annotation>
+                                                                 <xs:documentation>
+                                                     The target-name to pass to the constructor of the permission.
+                                                 </xs:documentation>
+                                             </xs:annotation>
+                                         </xs:attribute>
+                                         <xs:attribute name="action" type="xs:string">
+                                             <xs:annotation>
+                                                 <xs:documentation>
+                                                     The action to pass to the constructor of the permission.
+                                                 </xs:documentation>
+                                             </xs:annotation>
+                                         </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                            <xs:attribute name="match-all" type="xs:boolean" default="false" />
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="mapping-mode" type="simpleMappingMode" default="first" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constantPermissionMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that always returns a pre-defined set of permissions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="permissionMapperType">
+                <xs:sequence>
+                    <xs:element name="permission" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:attribute name="class-name" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The fully qualified class name of the permission.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="module" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The module to use to load the permission class.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="target-name" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The target-name to pass to the constructor of the permission.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="action" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The action to pass to the constructor of the permission.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="simpleMappingMode">
+        <xs:annotation>
+            <xs:documentation>
+                How multiple matching permission mappings will be combined.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="and" />
+            <xs:enumeration value="or" />
+            <xs:enumeration value="xor" />
+            <xs:enumeration value="unless" />
+            <xs:enumeration value="first" />
+        </xs:restriction>
+    </xs:simpleType>
+
+
+    <xs:complexType name="principalDecoderType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all PrincipalDecoder definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the PrincipalDecoder, note names used for PrincipalDecoders must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customPrincipalDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom PrincipalDecoder implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalDecoderType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                        type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the PrincipalDecoder implementation.
+
+                                Note: If configuration is supplied the PrincipalDecoder MUST implement the Configurable interface.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="aggregatePrincipalDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalDecoder definition that is actually an aggregation of other PrincipalDecoders.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalDecoderType">
+                <xs:sequence>
+                    <xs:element name="principal-decoder" type="principalDecoderRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="principalDecoderRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a PrincipalDecoder
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="concatenatingPrincipalDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalDecoder definition that is actually a concatenation of other PrincipalDecoders.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalDecoderType">
+                <xs:sequence>
+                    <xs:element name="principal-decoder" type="principalDecoderRefType" minOccurs="2" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attribute name="joiner" type="xs:string" default=".">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The string to use to join the results of the other PrincipalDecoders.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constantPrincipalDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalDecoder that always returns the same constant.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalDecoderType">
+                <xs:attribute name="constant" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The constant value that will always be returned by this PrincipalDecoder.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="x500AttributePrincipalDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalDecoder definition based on a X500 attribute.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalDecoderType">
+                <xs:attribute name="oid" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The oid of the attribute to map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="attribute-name" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The oid of the attribute to map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <!-- exactly one of [oid, attribute-name] must be defined -->
+                <!--<xs:assert test="(@oid and not(@attribute-name)) or (not(@oid) and @attribute-name)"/>--><!-- require XSD 1.1 -->
+                <xs:attribute name="joiner" type="xs:string" default=".">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The joining string.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="start-segment" type="xs:int" default="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The 0-based starting occurrence of the attribute to map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="maximum-segments" type="xs:int" default="2147483647">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The maximum number of occurrences of the attribute to map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="reverse" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            When set to true, the attribute values will be processed and returned in reverse order.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="convert" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If the Principal is not already an X500Principal should conversion be attempted?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="required-oids" type="stringListType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The OIDs of the attributes that must be present in the principal.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="required-attributes" type="stringListType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The attribute names of the attributes that must be present in the principal.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="principalTransformerType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all PrincipalTransformer definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the PrincipalTransformer, note names used for PrincipalTransformer must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="regexPrincipalTransformerType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer definition using regular expressions and Matcher based
+                replacement.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:attribute name="pattern" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The regular expression to use for this PrincipalTransformer.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="replacement" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The replacement string for this PrincipalTransformer.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="replace-all" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Should all occurrences be replaced or just the first?
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="regexValidatingPrincipalTransformer">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer that instead of rewriting the name validates that it is
+                correct according to the supplied regular expression.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:attribute name="pattern" type="xs:string"
+                    use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The regular expression to use for this PrincipalTransformer.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="match" type="xs:boolean"
+                    default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If set to true, the name must match the given pattern to make validation successful.
+                            If set to false, the name must not match the given pattern to make validation successful.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constantPrincipalTransformer">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer that always returns the same constant.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:attribute name="constant" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The constant value that will always be returned by this PrincipalTransformer.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customPrincipalTransformerType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom PrincipalTransformer implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                        type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the PrincipalTransformer implementation.
+
+                                Note: If configuration is supplied the PrincipalTransformer MUST implement the Configurable interface.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="aggregatePrincipalTransformerType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer aggregating more PrincipalTransformers - original principal is tried to be transformed
+                by individual transformers in given order until some of them return non-null principal - that is returned.
+
+                Typically can be used with chained principal transformers beginning with validating principal
+                transformer - to transform principals in different forms differently.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:sequence>
+                    <xs:element name="principal-transformer" type="principalTransformerRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="chainedPrincipalTransformerType">
+        <xs:annotation>
+            <xs:documentation>
+                A PrincipalTransformer definition that is actually a chain of other PrincipalTransformers.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="principalTransformerType">
+                <xs:sequence>
+                    <xs:element name="principal-transformer" type="principalTransformerRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="principalTransformerRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a PrincipalTransformer.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="realmMapperType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all RealmMapper definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the RealmMapper, note names used for RealmMappers must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customRealmMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom RealmMapper implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmMapperType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                        type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the RealmMapper implementation.
+
+                                Note: If configuration is supplied the RealmMapper MUST implement the Configurable interface.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constantRealmMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RealmMapper that always returns the same constant.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmMapperType">
+                <xs:attribute name="realm-name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The constant value that will always be returned by this RealmMapper.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="simpleRegexRealmMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A simple RealmMapper definition that attempts to extract the realm name using the capture group from the regular expression, if that does not provide a
+                match then the delegate RealmMapper is used instead.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmMapperType">
+                <xs:attribute name="pattern" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The regular expression which must contain at least one capture group to extract the realm from the name.
+                            If the regular expression matches more than one capture group, the first capture group is used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="delegate-realm-mapper" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The RealmMapper to delegate to if the pattern does not match.  If no delegate is specified then the default realm on
+                            the domain will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="mappedRegexRealmMapperType">
+        <xs:annotation>
+            <xs:documentation>
+              A RealmMapper implementation that first uses a regular expression to extract the realm name, this is then converted using the configured mapping of realm names.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="realmMapperType">
+                <xs:sequence>
+                    <xs:element name="realm-mapping" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:attribute name="from" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The realm name to map from.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="to" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The realm name to map to.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="pattern" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The regular expression which must contain at least one capture group to extract the realm from the name.
+                            If the regular expression matches more than one capture group, the first capture group is used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="delegate-realm-mapper" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The RealmMapper to delegate to if the pattern does not match.  If no delegate is specified then the default realm on
+                            the domain will be used instead.
+                            If the username does not match the pattern and a delegate realm-mapper is present, the result of delegate-realm-mapper is mapped via the realm-map.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="roleDecoderType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all RoleDecoder definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the RoleDecoder, note names used for RoleDecoders must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customRoleDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom RoleDecoder implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleDecoderType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                        type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the RoleDecoder implementation.
+
+                                Note: If configuration is supplied the RoleDecoder MUST implement the Configurable interface.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="simpleRoleDecoderType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleDecoder definition that maps a single attribute to roles.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleDecoderType">
+                <xs:attribute name="attribute" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The attribute to take from the identity and map directly to roles.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="roleMapperType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all RoleMapper definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the RoleMapper, note names used for RoleMappers must be unique
+                    across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="addPrefixRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that adds a specified prefix to every role.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:attribute name="prefix" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The prefix to add to each role.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="addSuffixRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that adds a specified suffix to every role.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:attribute name="suffix" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The suffix to add to each role.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that is actually an aggregation of other RoleMappers.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:sequence>
+                    <xs:element name="role-mapper" type="roleMapperRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                Generic definition for a custom RoleMapper implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                        type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the RoleMapper implementation.
+
+                                Note: If configuration is supplied the RoleMapper MUST implement the Configurable interface.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="constantRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition that always returns a pre-defined set of roles.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:sequence>
+                    <xs:element name="role" minOccurs="1" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:attribute name="name" type="xs:string">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The role to be returned by the RoleMapper.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="logicalRoleMappingsType">
+        <xs:annotation>
+            <xs:documentation>
+                The supported set of logical operations.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="and" />
+            <xs:enumeration value="minus" />
+            <xs:enumeration value="or" />
+            <xs:enumeration value="xor" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="logicalRoleMapperType">
+        <xs:annotation>
+            <xs:documentation>
+                A RoleMapper definition for a RoleMapper that performs a logical operation using two refereced RoleMappers.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="roleMapperType">
+                <xs:attribute name="logical-operation" type="logicalRoleMappingsType" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The logicial operation to perform using the two referenced RoleMappers.
+
+                            Allowed values: "and", "minus", "or", "xor".
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="left" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the RoleMapper to use to the left of the operation.
+
+                            If not set the identity role mapper will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="right" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the RoleMapper to use to the right of the operation.
+
+                            If not set the identity role mapper will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="roleMapperRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a RoleMapper
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the referenced RoleMapper.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        Mechanism Configuration
+    -->
+
+    <xs:complexType name="mechanismConfigurationType">
+        <xs:annotation>
+            <xs:documentation>
+                Wrapper type to contain the configuration of the authentication mechanisms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mechanism" type="mechanismType" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        An ordered list of mechanism configurations, at the time of authentication the mechanism name,
+                        host name, and protocol as specified by the mechanism will be compared against this list
+                        for a first match.
+
+                        To configure a default configuration provide a definition with no mechanism-name, host-name, or
+                        protocol and place it at the end of the list. Any definitions after a default definition will
+                        never match.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="mechanismType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of configuration to be used by authentication mechanisms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mechanism-realm" type="mechanismRealmType" minOccurs="0" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="mechanism-name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    This configuration will only apply where a mechanism with the name specified is used.
+
+                    If this attribute is omitted then this will match any mechanism name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="host-name" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    This configuration will only apply when the host name specified is provided by the mechanism.
+
+                    If this attribute is omitted then this will match any host name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="protocol" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    This configuration will only apply when the protocol specified is provided by the mechanism.
+
+                    If this attributed is omitted then this will match any protocol.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pre-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply before the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="post-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply after the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A final principal transformer to apply for this mechanism realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RealmMapper to be used by this mechanism.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="credential-security-factory" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                  A reference to the security factory to obtain the credential for this mechanism.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="mechanismRealmType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a realm name specific to the mechanism.
+
+                This is the realm name that a mechanism may present to the remote client being authenticated, if a mechanism
+                only supports a single realm then only the first will be used and the remainder ignored.
+
+                If a mechanism does not support realm names then the entire list will be ignored.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="realm-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pre-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply before the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="post-realm-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply after the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final-principal-transformer" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    A final principal transformer to apply for this mechanism realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm-mapper" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RealmMapper to be used by this mechanism realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        HTTP Components
+     -->
+
+     <xs:complexType name="httpType">
+         <xs:annotation>
+             <xs:documentation>
+                 Complex type definition to hold the various HTTP definitions within the subsystem.
+             </xs:documentation>
+         </xs:annotation>
+         <xs:choice maxOccurs="unbounded">
+             <xs:element name="http-authentication-factory" type="httpAuthenticationFactoryType" minOccurs="0"/>
+             <xs:element name="aggregate-http-server-mechanism-factory" type="aggregateHttpServerMechanismFactoryType" minOccurs="0" />
+             <xs:element name="configurable-http-server-mechanism-factory" type="configurableHttpServerMechanismFactoryType" minOccurs="0" />
+             <xs:element name="provider-http-server-mechanism-factory" type="providerHttpServerMechanismFactoryType" minOccurs="0" />
+             <xs:element name="service-loader-http-server-mechanism-factory" type="serviceLoaderHttpServerMechanismFactoryType" minOccurs="0" />
+         </xs:choice>
+     </xs:complexType>
+
+     <xs:complexType name="httpAuthenticationFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type for the definition of the server side HTTP authentication policy.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mechanism-configuration" minOccurs="0" type="mechanismConfigurationType"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="security-domain" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The security-domain referenced by this resource.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="http-server-mechanism-factory" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The http-server-mechanism-factory referenced by this resource.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="httpServerMechanismFactoryType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all http server factory definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the http server factory, note names used for http server factories must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateHttpServerMechanismFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A HTTP server factory definition that is actually an aggregation of other HTTP server factories.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="httpServerMechanismFactoryType">
+                <xs:sequence>
+                    <xs:element name="http-server-mechanism-factory" type="httpServerMechanismFactoryRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="configurableHttpServerMechanismFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A HTTP server factory definition that wraps another HTTP server factory and applies the specified configuration and filtering.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="httpServerMechanismFactoryType">
+                <xs:all>
+                    <xs:element name="filters" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Filters to be applied to the available mechanisms by name.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="filter" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="pattern" type="xs:string" >
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A regular expression that filters mechanism names using a regular expression pattern.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="enabling" type="xs:boolean" default="true">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    When set to true all mechanisms are disabled unless enabled by matching one of the defined filters.
+
+                                                    When set to false all mechanisms are enabled unless disabled by matching one of the defined filters.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="properties" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Additional properties that should be passed to the factory for HTTP mechanism detection and creation.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:all>
+                <xs:attribute name="http-server-mechanism-factory" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the HTTP server factory to be wrapped by this configuration.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="providerHttpServerMechanismFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A HTTP server factory definition that searches an array of Provider instances for all available HTTP server factories.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="httpServerMechanismFactoryType">
+                <xs:attribute name="providers" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the Provider[] capability to obtain the array of Providers to use.
+
+                            If not specified the system registered Providers are used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="serviceLoaderHttpServerMechanismFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A HTTP server factory definition that uses a ServiceLoader to search for HTTP server factory implementations.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="httpServerMechanismFactoryType">
+                <xs:attribute name="module" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the module to use.
+
+                            If this is not specified the ClassLoader used to load the service will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="httpServerMechanismFactoryRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a HTTP server mechanism factory.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <!--
+        SASL Components
+     -->
+
+    <xs:complexType name="saslType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type definition type to hold the various SASL definitions within the subsystem.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="sasl-authentication-factory" type="saslAuthenticationFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-sasl-server-factory" type="aggregateSaslServerFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="configurable-sasl-server-factory" type="configurableSaslServerFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="mechanism-provider-filtering-sasl-server-factory" type="mechanismProviderFilteringSaslServerFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="provider-sasl-server-factory" type="providerSaslServerFactoryType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="service-loader-sasl-server-factory" type="serviceLoaderSaslServerFactoryType" minOccurs="0" maxOccurs="unbounded" />
+         </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="saslAuthenticationFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                The SASL authentication policy for the server side.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="mechanism-configuration" minOccurs="0" type="mechanismConfigurationType"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="security-domain" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The security-domain referenced by this resource.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sasl-server-factory" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The sasl-server-factory referenced by this resource.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="saslServerFactoryType" abstract="true">
+        <xs:annotation>
+            <xs:documentation>
+                Base type for all sasl server factory definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name for the sasl server factory, note names used for sasl server factories must be unique across the whole context.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="aggregateSaslServerFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A SASL server factory definition that is actually an aggregation of other SASL server factories.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="saslServerFactoryType">
+                <xs:sequence>
+                    <xs:element name="sasl-server-factory" type="saslServerFactoryRefType" minOccurs="2" maxOccurs="unbounded" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="configurableSaslServerFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A SaslServerFactory definition that wraps another SaslServerFactory and applies the specified configuration and filtering.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="saslServerFactoryType">
+                <xs:all>
+                    <xs:element name="filters" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Filters to be applied to the available mechanisms by name.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="filter" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="enabling" type="xs:boolean" default="true">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    When set to true all mechanisms are disabled unless enabled by matching one of the defined filters.
+                                                    When set to false all mechanisms are enabled unless disabled by matching one of the defined filters.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="pattern" type="xs:string" >
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A regular expression filter that filters mechanism names using a regular expression pattern.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="predefined" type="xs:string" >
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    A predefined filter to filter mechanisms.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="properties" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Additional properties that should be passed to the factory for SASL mechanism detection and creation.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:all>
+                <xs:attribute name="sasl-server-factory" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the SaslServerFactory to be wrapped by this configuration.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="protocol" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Override the protocol specified when creating a SASL mechanism.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="server-name" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Override the server name specified when creating a SASL mechanism.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="predefinedFilterType">
+        <xs:annotation>
+            <xs:documentation>
+                The supported set of predefined filters.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="HASH_MD5" />
+            <xs:enumeration value="HASH_SHA" />
+            <xs:enumeration value="HASH_SHA_256" />
+            <xs:enumeration value="HASH_SHA_384" />
+            <xs:enumeration value="HASH_SHA_512" />
+            <xs:enumeration value="GS2" />
+            <xs:enumeration value="SCRAM" />
+            <xs:enumeration value="DIGEST" />
+            <xs:enumeration value="IEC_ISO_9798" />
+            <xs:enumeration value="EAP" />
+            <xs:enumeration value="MUTUAL" />
+            <xs:enumeration value="BINDING" />
+            <xs:enumeration value="RECOMMENDED" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="mechanismProviderFilteringSaslServerFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A SaslServerFactory definition that wraps another SaslServerFactory and enables filtering of mechanisms based on the mechanism name and Provider name and version.
+
+                Any mechanisms loaded by factories not located using a Provider will not be filtered by this definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="saslServerFactoryType">
+                <xs:sequence>
+                    <xs:element name="filters" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Filters to be applied to the available mechanisms by name.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="filter" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                        <xs:attribute name="mechanism-name" type="xs:string">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                   This configuration will only apply where a mechanism with the name specified is used.
+
+                                                   If this attribute is omitted then this will match any mechanism name.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="provider-name" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    The name of the provider to match against.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="provider-version" type="xs:double">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    Version to compare against the version reported by the provider.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="version-comparison" type="inequalityType" default="less-than">
+                                            <xs:annotation>
+                                                <xs:documentation>
+                                                    When set to 'less-than' a Provider will match against the filter if the Provider's version is less-than the version specified here.
+
+                                                    Setting to 'greater-than' has the opposite effect.
+
+                                                    Has no effect if a provider-version has not been specified in the filter.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attribute name="sasl-server-factory" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the SaslServerFactory to be wrapped by this configuration.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="enabling" type="xs:boolean" default="true">
+                    <xs:annotation>
+                        <xs:documentation>
+                            When set to true all provider loaded mechanisms are disabled unless macthed by one of the filters defined here.
+
+                            When set to false all provider loaded mechanisms are enabled unless matched.
+
+                            Any mechanisms from a factory not loaded by a Provider are unaffected.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="inequalityType">
+        <xs:annotation>
+            <xs:documentation>
+                The type of equality check to use in a comparison.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="less-than" />
+            <xs:enumeration value="greater-than" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="providerSaslServerFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A SaslServerFactory definition that searches an array of Provider instances for all available SaslServerFactories.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="saslServerFactoryType">
+                <xs:attribute name="providers" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Reference to the Provider[] capability to obtain the array of Providers to use.
+
+                            If not specified the system registered Providers are used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="serviceLoaderSaslServerFactoryType">
+        <xs:annotation>
+            <xs:documentation>
+                A SaslServerFactory definition that uses a ServiceLoader to search for SaslServerFactory implementations.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="saslServerFactoryType">
+                <xs:attribute name="module" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of the module to use.
+
+                            If this is not specified the ClassLoader used to load the service will be used instead.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="saslServerFactoryRefType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a SaslServerFactory
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <!--
+        TLS Components
+     -->
+
+    <xs:complexType name="tlsType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type to contain the definitions of the various components needed
+                for SSL, the end result being that these components can be combined together to
+                create a fully defined SSLContext.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="key-stores" type="keyStoresType" minOccurs="0" />
+            <xs:element name="key-managers" type="keyManagersType" minOccurs="0" />
+            <xs:element name="trust-managers" type="trustManagersType" minOccurs="0"/>
+            <xs:element name="server-ssl-contexts" type="serverSSLContextsType" minOccurs="0" />
+            <xs:element name="client-ssl-contexts" type="clientSSLContextsType" minOccurs="0" />
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="keyManagersType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for KeyManager definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="key-manager" type="keyManagerType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="keyManagerType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a single KeyManager.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="credential-reference" type="credentialReferenceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used by the underlying KeyManager when accessing the entries in the underlying KeyStore.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this KeyManager.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="algorithm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The algorithm name to use to initialise the KeyManagerFactory.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-store" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the KeyStore to use with the KeyManager.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias-filter" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A filter to apply to the aliases provided by KeyStore to choose key to use from keys in KeyStore.
+
+                    Can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use to
+                    instantiate the KeyManagerFactory, if the provider is not
+                    specified then the first provider found that can
+                    create an instance of the specified 'type' will be
+                    used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers defined within the subsystem to obtain the Providers
+                    to search for the one that can create the required KeyManagerFactory type.
+
+                    If this is not specified then the global list of Providers is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="trustManagersType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for TrustManager definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="trust-manager" type="trustManagerType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="trustManagerType">
+        <xs:annotation>
+            <xs:documentation>
+                Definition of a single TrustManager.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="certificate-revocation-list" type="certificateRevocationListType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this TrustManager.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="algorithm" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The algorithm name to use to initialise the TrustManagerFactory.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-store" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the KeyStore to use with the TrustManager.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias-filter" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A filter to apply to the aliases provided by KeyStore.
+
+                    Can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use to
+                    instantiate the TrustManagerFactory, if the provider is not
+                    specified then the first provider found that can
+                    create an instance of the specified 'type' will be
+                    used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers defined within the subsystem to obtain the Providers
+                    to search for the one that can create the required TrustManagerFactory type.
+
+                    If this is not specified then the global list of Providers is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="certificateRevocationListType">
+        <xs:annotation>
+            <xs:documentation>
+                Enables certificate revocation list checks to a trust manager.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The path to the configuration to use to initialise the provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The base path of the certificate revocation list file.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maximum-cert-path" type="xs:int" use="optional" default="5">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of non-self-issued intermediate certificates that may exist in a certification path.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serverSSLContextsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for Server SSLContext definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="server-ssl-context" type="serverSSLContextType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="serverSSLContextType">
+        <xs:annotation>
+            <xs:documentation>
+                Definitions of a single server side SSLContext.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this Server side SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="security-domain" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the SecurityDomain to use for authentication during SSL session establishment.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cipher-suite-filter" type="xs:string" use="optional" default="DEFAULT">
+            <xs:annotation>
+                <xs:documentation>
+                    The filter to be applied to the cipher suites made available by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="protocols" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    List of protocols supported by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="want-client-auth" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    To request (but not to require) a client certificate on SSL handshake.
+                    If a security domain is referenced and supports X509 evidence, this will be set to true automatically.
+                    Ignored when need-client-auth is set.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="need-client-auth" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    To require a client certificate on SSL handshake.
+                    Connection without trusted client certificate (see trust-manager) will be rejected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="authentication-optional" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Rejecting of the client certificate by the security domain will not prevent the connection.
+                    Allows a fall through to use other authentication mechanisms (like form login) when the client certificate is rejected by security domain.
+                    Has an effect only when the security domain is set.
+                    This does not bypass the underlying trust manager check - see need-client-auth to allow connection without client certificate.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="use-cipher-suites-order" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Configure the SSLContext to honor local cipher suites preference.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="maximum-session-cache-size" type="xs:int" default="-1">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of SSL sessions in the cache. The default value -1 means use the JVM default value. Value zero means there is no limit.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="session-timeout" type="xs:int" default="-1">
+            <xs:annotation>
+                <xs:documentation>
+                    The timeout for SSL sessions, in seconds. The default value -1 means use the JVM default value. Value zero means there is no limit.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="wrap" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Should the resulting SSLEngine, SSLSocketFactory, and SSLSocket instances returned by this SSLContext
+                    be wrapped to prevent further configuration changes.
+
+                    Note:  The WildFly HTTP2 support requires raw access to these objects so if HTTP2 is being used this
+                    should be set to false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-manager" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the KeyManager to be used by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="trust-manager" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the TrustManager to be used by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pre-realm-principal-transformer" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply before the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="post-realm-principal-transformer" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A principal transformer to apply after the realm is selected.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="final-principal-transformer" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A final principal transformer to apply for this mechanism realm.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="realm-mapper" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to a RealmMapper to be used by this mechanism.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use.
+                    If not specified, all providers from providers will be passed to the SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers to obtain the Provider[] to use to load the SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="clientSSLContextsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for client SSLContext definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="client-ssl-context" type="clientSSLContextType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="clientSSLContextType">
+        <xs:annotation>
+            <xs:documentation>
+                Definitions of a single client side SSLContext.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this client side SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cipher-suite-filter" type="xs:string" use="optional" default="DEFAULT">
+            <xs:annotation>
+                <xs:documentation>
+                    The filter to be applied to the cipher suites made available by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="protocols" type="stringListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    List of protocols supported by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="key-manager" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the KeyManager to be used by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="trust-manager" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Reference to the TrustManagers to be used by this SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use.
+                    If not specified, all providers from providers will be passed to the SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers to obtain the Provider[] to use to load the SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="keyStoresType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for the KeyStore definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence maxOccurs="unbounded">
+            <xs:choice>
+                <xs:element name="key-store" type="keyStoreType" />
+                <xs:element name="ldap-key-store" type="ldapKeyStoreType" />
+                <xs:element name="filtering-key-store" type="filteringKeyStoreType" />
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="keyStoreImplementationType">
+        <xs:annotation>
+            <xs:documentation>
+                keystore implementation details
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="type" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The KeyStore type, e.g. jks, pkcs#12.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use to
+                    instantiate the KeyStore, if the provider is not
+                    specified then the first provider found that can
+                    create an instance of the specified 'type' will be
+                    used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers defined within the subsystem to obtain the Providers
+                    to search for the one that can create the required KeyStore type.
+
+                    If this is not specified then the global list of Providers is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="keyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual names KeyStore definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="credential-reference" type="credentialReferenceType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The credential reference to credential store or clear text (password)
+                        to use to initialize or load the KeyStore.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="implementation" type="keyStoreImplementationType" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Implementation details
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="file" type="fileType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The location of the file to use to initialise the KeyStore instance.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="alias-filter" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A filter to apply to the aliases made available by this KeyStore.
+
+                    Can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ldapKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual names LdapKeyStore definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="new-item-template" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Configuration for item creation. Define how will look LDAP entry of newly created keystore item.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                    <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Attribute of newly created entry. At least objectClass attribute and required
+                                attributes (which are not part of keystore item) should be defined here.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:attribute name="name" type="xs:string" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The LDAP attribute name.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                            <xs:attribute name="value" type="stringListType" use="required">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        The default value(s) of LDAP attribute delimited by space.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:complexType>
+                    </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="new-item-path" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP path, where will be newly created keystore items created.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="new-item-rdn" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP attribute name, which will be part of new entry path.
+                                Into value of this attribute will be passed alias of the keystore item.
+                                (Can be independent on alias-attribute - alias is used here only as initial entry name,
+                                as it is only identification of item, which keystore has.)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="search" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Search LDAP configuration
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="path" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP path, where will be keystore items searched.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="recursive" type="xs:boolean" use="optional" default="true">
+                        <xs:annotation>
+                            <xs:documentation>
+                                If the search in search-path should be recursive.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="time-limit" type="xs:integer" use="optional" default="10000">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The time limit for LDAP search in milliseconds.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="filter-alias" type="xs:string" use="optional" default="(alias_attribute={0})">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP filter, which will be used to obtain keystore item by alias.
+                                The string "{0}" will be replaced by the searched alias and the "alias_attribute" value will be the value of the attribute "alias-attribute".
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="filter-certificate" type="xs:string" use="optional" default="(certificate_attribute={0})">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP filter, which will be used to obtain keystore item by certificate.
+                                The string "{0}" will be replaced by searched encoded certificate and the "certificate_attribute" will be the value of the attribute "certificate-attribute".
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="filter-iterate" type="xs:string" use="optional" default="(alias_attribute=*)">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP filter, which will be used to obtain keystore item by certificate.
+                                The "alias_attribute" will be the value of the attribute "alias-attribute".
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="attribute-mapping" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Mapping of keystore item parts to LDAP attributes.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="alias-attribute" type="xs:string" use="optional" default="cn">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP attribute, where is item alias expected.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="certificate-attribute" type="xs:string" use="optional" default="usercertificate">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP attribute, where is encoded certificate expected.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="certificate-type" type="xs:string" use="optional" default="X.509">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The type of certificate. Used for decoding of byte array from certificate-attribute.
+                                For possible certificate types see Java documentation of CertificateFactory.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="certificate-chain-attribute" type="xs:string" use="optional" default="userSMIMECertificate">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP attribute, where is encoded certificate expected.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="certificate-chain-encoding" type="xs:string" use="optional" default="PKCS7">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The encoding of CertPath, which is used to store certificate chain into certificate-chain-attribute.
+                                For possible chain encodings see Java documentation of CertPath.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+
+                    <xs:attribute name="key-attribute" type="xs:string" use="optional" default="userPKCS12">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The LDAP attribute, where is encoded key expected.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="key-type" type="xs:string" use="optional" default="PKCS12">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The type of key. Used for decoding of byte array from key-attribute.
+                                For possible KeyStore types see Java documentation of KeyStore.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of ldap-key-store used to referencing it.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="dir-context" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of dir-context used to connect to the LDAP server.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="filteringKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual names filtering KeyStore definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="key-store" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of key-store, which will be used as source of data.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias-filter" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    A filter to apply to the aliases made available by this KeyStore.
+
+                    Can either be a comma separated list of aliases to return or one of the following formats ALL:-alias1:-alias2, NONE:+alias1:+alias2
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!--
+        Credential Store Components
+     -->
+
+    <xs:complexType name="credentialStoresType">
+        <xs:annotation>
+            <xs:documentation>
+                Complex type to contain the definitions of the credential stores.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="credential-store" type="credentialStoreType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="credentialStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An individual credential store definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="implementation-properties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Map of credentials store implementation specific properties.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="property" type="propertyType" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="credential-reference" type="credentialReferenceType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Credential to be used by as protection parameter for the Credential Store.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="type" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The credential store type, e.g. KeyStoreCredentialStore.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="provider-name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the provider to use to instantiate the CredentialStoreSpi.
+                    If the provider is not specified then the first provider found that can
+                    create an instance of the specified 'type' will be used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers defined within the subsystem to obtain the Providers
+                    to search for the one that can create the required CredentialStore type.
+                    If this is not specified then the global list of Providers is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="other-providers" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the providers defined within the subsystem to obtain the Providers
+                    to search for the one that can create the required JCA objects within credential store.
+                    This is valid only for key-store based  CredentialStore.
+                    If this is not specified then the global list of Providers is used instead.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to a previously defined path that the file name is
+                    relative to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="location" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    File name of credential store storage.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="modifiable" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether credential store is modifiable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="create" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether credential store should create storage when it doesn't exist.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
+    </xs:complexType>
+
+    <!--
+       General Types
+    -->
+
+    <xs:complexType name="basicFileType">
+        <xs:annotation>
+            <xs:documentation>
+                Minimal attributes required to specify the location to a file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="relative-to" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A reference to a previously defined path that the file name is
+                    relative to.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="path" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The remaining path to the file referenced.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="fileType">
+        <xs:annotation>
+            <xs:documentation>
+                A reference to a file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="basicFileType">
+                <xs:attribute name="required" type="xs:boolean"
+                              use="optional" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            It is possible that a KeyStore definition can be created to a
+                            non-existent file and the file be automatically created when the store is saved, however
+                            no error will be reported where the file does not exist to begin with.
+
+                            If the intent is that the store will always exist in advance set
+                            this to 'true' so that an error will be reported if the file is missing.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+	<xs:attributeGroup name="customComponentAttributes">
+		<xs:annotation>
+			<xs:documentation>The attributes required for a custom component.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="module" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>
+					The module to use to load the custom component.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="class-name" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation>
+					The fully qualified class name of the custom component implementation to
+					load.
+
+					The specified class must have a public no-args constructor.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+
+	<xs:complexType name="customComponentConfiguration">
+		<xs:annotation>
+			<xs:documentation>
+				The optional configuration for a custom component.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="property" type="propertyType" maxOccurs="unbounded" />
+		</xs:sequence>
+	</xs:complexType>
+
+    <xs:simpleType name="stringListType">
+        <xs:annotation>
+            <xs:documentation>A list of String.</xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:string"/>
+    </xs:simpleType>
+
+    <!-- Credential Reference Types -->
+    <xs:attributeGroup name="credentialReferenceStoreBased">
+        <xs:annotation>
+            <xs:documentation>
+                Group of attributes used when referencing credential through credential store.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="store" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Credential store name used to fetch credential with given 'alias' from.
+                    Credential store name has to be defined elsewhere.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="alias" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Alias of credential in the credential store.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="type" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Type of credential to be fetched from credential store.
+                    It is usually fully qualified class name.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    <xs:complexType name="credentialReferenceType">
+        <xs:attributeGroup ref="credentialReferenceStoreBased"/>
+        <xs:attribute name="clear-text" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Credential/password in clear text. Use just for testing purpose.
+                    Otherwise use credential store to mask the actual credential from your configuration.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="policyType">
+        <xs:annotation>
+            <xs:documentation>
+                A definition that sets up a policy provider.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="jacc-policy" type="jaccPolicyType" minOccurs="0" />
+            <xs:element name="custom-policy" type="customPolicyType" minOccurs="0" />
+        </xs:choice>
+        <xs:attribute name="default-policy" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of a default policy provider. If this is not specified then the name of the resource will be used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jaccPolicyType">
+        <xs:annotation>
+            <xs:documentation>
+                A policy provider definition that sets up JACC and related services.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of this provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="policy" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of a java.security.Policy implementation referencing a policy provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="configuration-factory" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of a javax.security.jacc.PolicyConfigurationFactory implementation referencing a policy configuration factory provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the module to load the provider from.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customPolicyType">
+        <xs:annotation>
+            <xs:documentation>
+                A custom policy provider definition.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of this provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="class-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of a java.security.Policy implementation referencing a policy provider.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="module" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the module to load the provider from.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+</xs:schema>

--- a/elytron/src/main/resources/subsystem-templates/elytron-empty.xml
+++ b/elytron/src/main/resources/subsystem-templates/elytron-empty.xml
@@ -17,4 +17,4 @@
   ~ limitations under the License.
   -->
 <!-- Empty Elytron subsystem definition to be included in standalone.xml while using wildfly-extension plugin -->
-<subsystem xmlns="urn:wildfly:elytron:1.1"/>
+<subsystem xmlns="urn:wildfly:elytron:2.0"/>

--- a/elytron/src/main/resources/subsystem-templates/elytron.xml
+++ b/elytron/src/main/resources/subsystem-templates/elytron.xml
@@ -19,7 +19,7 @@
 
 <config default-supplement="standalone" >
     <extension-module>org.wildfly.extension.elytron</extension-module>
-    <subsystem xmlns="urn:wildfly:elytron:1.1" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
+    <subsystem xmlns="urn:wildfly:elytron:2.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
         <providers>
             <aggregate-providers name="combined-providers">
                 <providers name="elytron" />

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemBaseParsingTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemBaseParsingTestCase.java
@@ -33,7 +33,7 @@ public class SubsystemBaseParsingTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-elytron_1_1.xsd";
+        return "schema/wildfly-elytron_2_0.xsd";
     }
 
     @Override

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1" default-authentication-context="child">
+<subsystem xmlns="urn:wildfly:elytron:2.0" default-authentication-context="child">
     <authentication-client>
         <authentication-context name="child"/>
     </authentication-client>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/authentication-client.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/authentication-client.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1" default-authentication-context="child">
+<subsystem xmlns="urn:wildfly:elytron:2.0" default-authentication-context="child">
     <authentication-client>
         <authentication-configuration name="base" anonymous="true" />
         <authentication-configuration name="most"

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <mappers>
         <custom-permission-mapper name="CustomPermissionMapper" class-name="org.wildfly.elytron.CustomPermissionMapper" module="l.m" />
         <custom-permission-mapper name="CustomPermissionMapper2" class-name="org.wildfly.elytron.CustomPermissionMapper" module="l.m" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/credential-security-factories.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/credential-security-factories.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <credential-security-factories>
         <custom-credential-security-factory name="CustomFactory" module="a.b.c" class-name="org.wildfly.security.ElytronFactory">
             <configuration>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/credential-stores.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/credential-stores.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <credential-stores>
         <credential-store name="test1" relative-to="jboss.server.data.dir" location="test1.store" create="true">
             <implementation-properties>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/domain-test.xml
@@ -1,5 +1,5 @@
 <!-- for needs of DomainTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <security-domains>
         <security-domain name="MyDomain" default-realm="FileRealm" realm-mapper="MyRealmMapper" permission-mapper="MyPermissionMapper"
                          pre-realm-principal-transformer="NameRewriterXY" post-realm-principal-transformer="NameRewriterYU" trusted-security-domains="AnotherDomain">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/domain.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/domain.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <audit-logging>
         <file-audit-log name="local-file" path="audit.log" relative-to="jboss.home.dir" synchronized="false" format="JSON" />
     </audit-logging>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/http.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/http.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <providers>
         <provider-loader name="TestProviderLoader" module="test.module" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/identity-management.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/identity-management.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1" initial-providers="elytron">
+<subsystem xmlns="urn:wildfly:elytron:2.0" initial-providers="elytron">
     <providers>
         <provider-loader name="elytron" class-names="org.wildfly.security.WildFlyElytronProvider" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/jacc-with-providers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/jacc-with-providers.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <policy default-policy="elytron-a">
         <jacc-policy name="elytron-a" policy="a.b.Policy" configuration-factory="a.b.PolicyConfigurationFactory" module="a.b"/>
         <jacc-policy name="elytron-b" policy="a.b.Policy" configuration-factory="a.b.PolicyConfigurationFactory" module="a.b"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/ldap.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/ldap.xml
@@ -1,5 +1,5 @@
 <!-- for needs of LdapTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:1.1" initial-providers="elytron">
+<subsystem xmlns="urn:wildfly:elytron:2.0" initial-providers="elytron">
    <authentication-client>
       <authentication-configuration name="ldapAuthConfig" authentication-name="uid=server,dc=users,dc=elytron,dc=wildfly,dc=org">
          <credential-reference clear-text="serverPassword"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers-test.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <security-domains>
         <security-domain name="TestingDomain" default-realm="PropRealm" pre-realm-principal-transformer="tree">
             <realm name="PropRealm"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <mappers>
         <custom-permission-mapper name="CustomPermissionMapper" class-name="org.wildfly.elytron.CustomPermissionMapper" module="l.m" />
         <custom-permission-mapper name="CustomPermissionMapper2" class-name="org.wildfly.elytron.CustomPermissionMapper" module="l.m" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/providers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/providers.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1" disallowed-providers="a b c">
+<subsystem xmlns="urn:wildfly:elytron:2.0" disallowed-providers="a b c">
     <providers>
         <aggregate-providers name="AggregateProviders">
             <providers name="ModelConfigured" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/realms-test.xml
@@ -1,5 +1,5 @@
 <!-- for needs of RealmsTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:1.1" initial-providers="elytron">
+<subsystem xmlns="urn:wildfly:elytron:2.0" initial-providers="elytron">
     <providers>
         <provider-loader name="elytron" class-names="org.wildfly.security.WildFlyElytronProvider" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/sasl-test.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/sasl-test.xml
@@ -1,5 +1,5 @@
 <!-- for needs of TlsTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:1.1" initial-providers="elytron">
+<subsystem xmlns="urn:wildfly:elytron:2.0" initial-providers="elytron">
     <providers>
         <provider-loader name="elytron" class-names="org.wildfly.security.WildFlyElytronProvider" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/sasl.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/sasl.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <providers>
          <provider-loader name="TestProviderLoader" module="test.module" />
      </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/security-properties.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/security-properties.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <security-properties>
         <security-property name="a" value="b" />
         <security-property name="c" value="d" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/security-realms.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/security-realms.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <security-realms>
         <aggregate-realm name="AggregateOne" authentication-realm="RealmThree" authorization-realm="RealmFour" />
         <custom-realm name="CustomOne" class-name="org.wildfly.security.ElytronRealm" module="a.b.c" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-ibm.xml
@@ -1,5 +1,5 @@
 <!-- for needs of SaslTestCase and KeyStoresTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <providers>
         <provider-loader name="ManagerProviderLoader" class-names="com.ibm.crypto.provider.IBMJCE com.ibm.jsse.IBMJSSEProvider com.ibm.jsse2.IBMJSSEProvider2 com.ibm.security.jgss.IBMJGSSProvider com.ibm.security.cert.IBMCertPath com.ibm.security.cmskeystore.CMSProvider com.ibm.security.jgss.mech.spnego.IBMSPNEGO" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls-sun.xml
@@ -1,5 +1,5 @@
 <!-- for needs of SaslTestCase and KeyStoresTestCase -->
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <providers>
         <provider-loader name="ManagerProviderLoader" class-names="com.sun.net.ssl.internal.ssl.Provider" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/tls.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <providers>
         <provider-loader name="custom-loader" />
     </providers>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/transformers-1.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/transformers-1.0.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:wildfly:elytron:1.1">
+<subsystem xmlns="urn:wildfly:elytron:2.0">
     <authentication-client>
         <authentication-configuration name="base" anonymous="true" />
         <authentication-configuration name="forward-authz"


### PR DESCRIPTION
This change just bumps the model and schema version, multiple engineers are now starting to work on new model changes for WildFly Core 4 and this will also enable migration to persistent resource definitions to commence.