### PR TITLE
[WFCORE-3292] Use correct attributes for remoting configuration in th…

### DIFF
--- a/controller/src/test/resources/wildfly-config.xml
+++ b/controller/src/test/resources/wildfly-config.xml
@@ -25,7 +25,7 @@
 <configuration>
     <endpoint name="test-endpoint" xmlns="urn:jboss-remoting:5.0">
         <connections>
-            <connection uri="remote://localhost:32123" immediate="true"/>
+            <connection destination="remote://localhost:32123"/>
         </connections>
     </endpoint>
 </configuration>

--- a/protocol/src/test/resources/wildfly-config.xml
+++ b/protocol/src/test/resources/wildfly-config.xml
@@ -25,7 +25,7 @@
 <configuration>
     <endpoint name="test-endpoint" xmlns="urn:jboss-remoting:5.0">
         <connections>
-            <connection uri="remote://localhost:32123" immediate="true"/>
+            <connection destination="remote://localhost:32123"/>
         </connections>
     </endpoint>
 </configuration>


### PR DESCRIPTION
…e wildfly-config.xml for tests.

https://issues.jboss.org/browse/WFCORE-3292

This likely doesn't create any real issues with it being incorrect. However it should probably use the correct attributes.