### PR TITLE
[WFCORE-3230] Domain management audit logging: Fix SuffixValidator to allow 's' or 'S' symbols in text quoted using single quotes in suffix.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/validators/SuffixValidator.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/validators/SuffixValidator.java
@@ -51,10 +51,21 @@ public class SuffixValidator extends ModelTypeValidator {
         if (value.isDefined()) {
             final String suffix = value.asString();
             try {
-                if (denySeconds && (suffix.contains("s") || suffix.contains("S"))) {
-                    throw DomainManagementLogger.ROOT_LOGGER.suffixContainsMillis(suffix);
-                }
                 new SimpleDateFormat(suffix);
+                if (denySeconds) {
+                    for (int i = 0; i < suffix.length(); i++) {
+                        char c = suffix.charAt(i);
+                        if (c == '\'') {
+                            c = suffix.charAt(++i);
+                            while (c != '\'') {
+                                c = suffix.charAt(++i);
+                            }
+                        }
+                        if (c == 's' || c == 'S') {
+                            throw DomainManagementLogger.ROOT_LOGGER.suffixContainsMillis(suffix);
+                        }
+                    }
+                }
             } catch (IllegalArgumentException e) {
                 throw DomainManagementLogger.ROOT_LOGGER.invalidSuffix(suffix);
             }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogPeriodicRotatingFileHandlerTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogPeriodicRotatingFileHandlerTestCase.java
@@ -22,12 +22,14 @@
 
 package org.jboss.as.domain.management.security.auditlog;
 
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.domain.management.audit.AuditLogHandlerResourceDefinition;
 import org.jboss.as.domain.management.audit.FileAuditLogHandlerResourceDefinition;
 import org.jboss.as.domain.management.audit.JsonAuditLogFormatterResourceDefinition;
 import org.jboss.as.domain.management.audit.PeriodicRotatingFileAuditLogHandlerResourceDefinition;
+import org.jboss.as.domain.management.audit.validators.SuffixValidator;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Before;
@@ -375,4 +377,23 @@ public class AuditLogPeriodicRotatingFileHandlerTestCase extends AbstractAuditLo
         executeForResult(op);
     }
 
+    @Test
+    public void testSuffixValidator() throws Exception {
+        final SuffixValidator validator = new SuffixValidator();
+        try {
+            validator.validateParameter("suffix", new ModelNode("s"));
+            Assert.assertTrue("The model should be invalid", false);
+        } catch (OperationFailedException e) {
+            // no-op
+        }
+        try {
+            //invalid pattern with one single quote
+            validator.validateParameter("suffix", new ModelNode(".yyyy-MM-dd'custom suffix"));
+            Assert.assertTrue("The model should be invalid", false);
+        } catch (OperationFailedException e) {
+            // no-op
+        }
+        //valid pattern with custom suffix
+        validator.validateParameter("suffix", new ModelNode(".yyyy-MM-dd'custom suffix'"));
+    }
 }


### PR DESCRIPTION
wildfly-core: https://issues.jboss.org/browse/WFCORE-3230
JBEAP: https://issues.jboss.org/browse/JBEAP-12951