### PR TITLE
Fix for WFCORE-3225. CLI exception, keep calling stack

### DIFF
--- a/patching/src/test/java/org/jboss/as/patching/cli/ContentConflictsUnitTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/cli/ContentConflictsUnitTestCase.java
@@ -251,6 +251,7 @@ public class ContentConflictsUnitTestCase extends AbstractTaskTestCase {
                 buf.append(", ");
             }
         }
-        assertEquals(e.getMessage().split(System.getProperty("line.separator"))[0], buf.toString());
+        String msg = e.getMessage().substring(e.getMessage().indexOf(PatchLogger.ROOT_LOGGER.detectedConflicts()));
+        assertEquals(msg.split(System.getProperty("line.separator"))[0], buf.toString());
     }
 }


### PR DESCRIPTION
Throw a new CommandlineException to wrap the ExecutionException. Cleanup the exception prior to print the error message.
Fixed unit test that strictly relied on content of the thrown exception.