### PR TITLE
Controller Boot Thread should have its TCCL set to the same as the TC…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -363,10 +363,12 @@ public abstract class AbstractControllerService implements Service<ModelControll
         this.processState.setStarting();
 
         final long bootStackSize = getBootStackSize();
+        final ClassLoader bootTCCL = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
         final Thread bootThread = new Thread(null, new Runnable() {
             public void run() {
                 try {
                     try {
+                        WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(bootTCCL);
                         boot(new BootContext() {
                             public ServiceTarget getServiceTarget() {
                                 return target;


### PR DESCRIPTION
…CL of the thread calling AbstractControllerService.start()

MSC before calling start() sets the TCCL to the classloader of the service impl, so this means in production the TCCL will be the CL of the server or host-controller modules.


HOLD: this is just an experiment. I saw code that looks wrong so I'm seeing what the simple fix does.