### PR TITLE
[WFCORE-3306] add-user.sh shouldn't throw AddUserFailedException if '%' character is used in user name.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PromptNewUserState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PromptNewUserState.java
@@ -52,6 +52,11 @@ public class PromptNewUserState implements State {
             theConsole.printf(usernamePrompt);
             String temp = theConsole.readLine(" : ");
             if (temp != null && temp.length() > 0) {
+                // If the username contains '%', insert another '%' to avoid the Formatter Exception (WFCORE-3306)
+                if (temp.contains("%")) {
+                    // Insert '%' before every "%", to format the String as the initial typed username
+                    temp = temp.replaceAll("%", "%%");
+                }
                 existingUsername = temp;
             }
             // The user could have pressed Ctrl-D, in which case we do not use the default value.

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/AddUserTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/AddUserTestCase.java
@@ -29,10 +29,10 @@ import org.wildfly.security.sasl.util.UsernamePasswordHashUtil;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Properties;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 /**
  * Test the AddUser state
@@ -43,17 +43,35 @@ public class AddUserTestCase extends PropertyTestHelper {
 
     @Test
     public void testAddUser() throws IOException, StartException {
-        values.setGroups(ROLES);
-
-        AssertConsoleBuilder consoleBuilder = buildAddUserGroupAssertConsole();
-
-        AddUserState addUserState = new AddUserState(consoleMock, values);
-        addUserState.update(values);
+        AssertConsoleBuilder consoleBuilder = addUser();
 
         assertRolePropertyFile(values.getUserName());
         assertUserPropertyFile(values.getUserName());
 
         consoleBuilder.validate();
+    }
+
+    @Test
+    public void testAddUserValidUserName() throws IOException, StartException {
+        values.setUserName(USER_NAME);
+        values.setGroups(ROLES);
+
+        AssertConsoleBuilder consoleBuilder = addUser();
+        consoleBuilder.validate();
+
+        Properties properties = loadProperties(values.getGroupFiles().get(0).getAbsolutePath());
+        assertNotNull(properties.get(USER_NAME));
+    }
+
+    @Test
+    public void testAddUserInvalidUserName() throws IOException, StartException {
+        values.setUserName(INVALID_USER_NAME);
+        values.setGroups(ROLES);
+
+        addUser();
+
+        Properties properties = loadProperties(values.getGroupFiles().get(0).getAbsolutePath());
+        assertNull(properties.get(INVALID_USER_NAME));
     }
 
     @Test
@@ -219,5 +237,15 @@ public class AddUserTestCase extends PropertyTestHelper {
             assertEquals("Enabling/disabling a user just uncomment/comment out the line and must not create a new one", previousUserFileLineNumber, countLineNumberUserFile());
         }
         assertConsole.validate();
+    }
+
+    private AssertConsoleBuilder addUser() throws IOException {
+        values.setGroups(ROLES);
+
+        AssertConsoleBuilder consoleBuilder = buildAddUserGroupAssertConsole();
+
+        AddUserState addUserState = new AddUserState(consoleMock, values);
+        addUserState.update(values);
+        return consoleBuilder;
     }
 }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyTestHelper.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyTestHelper.java
@@ -48,7 +48,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class PropertyTestHelper {
 
-    protected static final String USER_NAME = "Aldo.Raine";
+    protected static final String USER_NAME = "/A.l,do-R=a\\ine";
+    protected static final String INVALID_USER_NAME = "%A#l$d!o%R?a&i*n^e><|~";
     protected static final String ROLES = "admin, jms";
     protected ConsoleMock consoleMock;
     protected StateValues values;


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3306