### PR TITLE
[WFCORE-3231] Logging subsystem: Fix SuffixValidator to allow 's' or 'S' symbols in text quoted using single quotes in suffix.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/validators/SuffixValidator.java
+++ b/logging/src/main/java/org/jboss/as/logging/validators/SuffixValidator.java
@@ -53,10 +53,21 @@ public class SuffixValidator extends ModelTypeValidator {
         if (value.isDefined()) {
             final String suffix = value.asString();
             try {
-                if (denySeconds && (suffix.contains("s") || suffix.contains("S"))) {
-                    throw createOperationFailure(LoggingLogger.ROOT_LOGGER.suffixContainsMillis(suffix));
-                }
                 new SimpleDateFormat(suffix);
+                if (denySeconds) {
+                    for (int i = 0; i < suffix.length(); i++) {
+                        char c = suffix.charAt(i);
+                        if (c == '\'') {
+                            c = suffix.charAt(++i);
+                            while (c != '\'') {
+                                c = suffix.charAt(++i);
+                            }
+                        }
+                        if (c == 's' || c == 'S') {
+                            throw createOperationFailure(LoggingLogger.ROOT_LOGGER.suffixContainsMillis(suffix));
+                        }
+                    }
+                }
             } catch (IllegalArgumentException e) {
                 throw createOperationFailure(LoggingLogger.ROOT_LOGGER.invalidSuffix(suffix));
             }

--- a/logging/src/test/java/org/jboss/as/logging/validators/SuffixValidatorTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/validators/SuffixValidatorTestCase.java
@@ -42,11 +42,13 @@ public class SuffixValidatorTestCase {
             // no-op
         }
         try {
-            validator.validateParameter("suffix", new ModelNode("this is a bad pattern"));
+            //invalid pattern with one single quote
+            validator.validateParameter("suffix", new ModelNode(".yyyy-MM-dd'custom suffix"));
             Assert.assertTrue("The model should be invalid", false);
         } catch (OperationFailedException e) {
             // no-op
         }
-        validator.validateParameter("suffix", new ModelNode(".yyyy-MM-dd"));
+        //valid pattern with custom suffix
+        validator.validateParameter("suffix", new ModelNode(".yyyy-MM-dd'custom suffix'"));
     }
 }


### PR DESCRIPTION
wildfly-core: https://issues.jboss.org/browse/WFCORE-3231
JBEAP: https://issues.jboss.org/browse/JBEAP-12952