### PR TITLE
Fix for WFCORE-3236, iteration of collections for CLI

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/loop/DoneHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/loop/DoneHandler.java
@@ -1,0 +1,51 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.handlers.loop;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.handlers.CommandHandlerWithHelp;
+import org.jboss.as.cli.impl.ArgumentWithoutValue;
+
+/**
+ *
+ * @author jfdenise
+ */
+public class DoneHandler extends CommandHandlerWithHelp {
+
+    private final ArgumentWithoutValue discard = new ArgumentWithoutValue(this, "--discard");
+
+    public DoneHandler() {
+        super("done", true);
+    }
+
+    @Override
+    public boolean isAvailable(CommandContext ctx) {
+        return ForControlFlow.get(ctx) != null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.as.cli.handlers.CommandHandlerWithHelp#doHandle(org.jboss.as.cli.CommandContext)
+     */
+    @Override
+    protected void doHandle(CommandContext ctx) throws CommandLineException {
+
+        final ForControlFlow forCF = ForControlFlow.get(ctx);
+        if (forCF == null) {
+            throw new CommandLineException("done is not available outside 'for' loop");
+        }
+        forCF.run(ctx, discard.isPresent(ctx.getParsedCommandLine()));
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/handlers/loop/ForControlFlow.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/loop/ForControlFlow.java
@@ -1,0 +1,133 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.handlers.loop;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContext.Scope;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.CommandLineRedirection;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.operation.ParsedCommandLine;
+import org.jboss.as.cli.parsing.command.CommandFormat;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Implements the loop iteration logic.
+ *
+ * @author jfdenise
+ */
+class ForControlFlow implements CommandLineRedirection {
+
+    private static final String CTX_KEY = "FOR";
+
+    static ForControlFlow get(CommandContext ctx) {
+        return (ForControlFlow) ctx.get(Scope.CONTEXT, CTX_KEY);
+    }
+
+    private CommandLineRedirection.Registration registration;
+
+    private final List<ModelNode> result;
+    private final List<String> forBlock = new ArrayList<>();
+    private final String varName;
+
+    ForControlFlow(CommandContext ctx, String varName, String iterable) throws CommandLineException {
+        if (varName == null) {
+            throw new IllegalArgumentException("Variable is null");
+        }
+        if (iterable == null) {
+            throw new IllegalArgumentException("Iterable is null");
+        }
+        if (ctx.getVariable(varName) != null) {
+            throw new CommandFormatException("Variable " + varName + " already exists.");
+        }
+
+        final ModelControllerClient client = ctx.getModelControllerClient();
+        if (client == null) {
+            throw new CommandLineException("The connection to the controller has not been established.");
+        }
+
+        this.varName = varName;
+        ModelNode forRequest = ctx.buildRequest(iterable);
+
+        ModelNode targetValue;
+        try {
+            targetValue = ctx.execute(forRequest, "for iterable");
+        } catch (IOException e) {
+            throw new CommandLineException("iterable request failed", e);
+        }
+        if (!targetValue.hasDefined(Util.RESULT)) {
+            throw new CommandLineException("iterable request failed, no result");
+        }
+        ModelNode mn = targetValue.get(Util.RESULT);
+        result = mn.asList();
+        // Define the variable with a dummy value. That is required for operations in the block
+        // referencing this variable otherwise parsing would fail.
+        ctx.setVariable(varName, "null");
+        ctx.set(Scope.CONTEXT, CTX_KEY, this);
+    }
+
+    @Override
+    public void set(CommandLineRedirection.Registration registration) {
+        this.registration = registration;
+    }
+
+    @Override
+    public void handle(CommandContext ctx) throws CommandLineException {
+
+        final ParsedCommandLine line = ctx.getParsedCommandLine();
+        if (line.getFormat() == CommandFormat.INSTANCE) {
+            // let the help through
+            final String cmd = line.getOperationName();
+            if ("for".equals(cmd)) {
+                throw new CommandFormatException("for is not allowed while in for block");
+            }
+            if (line.hasProperty("--help")
+                    || line.hasProperty("-h")
+                    || "done".equals(cmd) || "help".equals(cmd)) {
+                registration.handle(line);
+                return;
+            }
+        }
+        forBlock.add(line.getOriginalLine());
+    }
+
+    void run(CommandContext ctx, boolean discard) throws CommandLineException {
+        try {
+            registration.unregister();
+            if (!discard) {
+                for (ModelNode v : result) {
+                    String value = v.asString();
+                    ctx.setVariable(varName, value);
+                    for (String cmd : forBlock) {
+                        ctx.handle(cmd);
+                    }
+                }
+            }
+        } finally {
+            ctx.setVariable(varName, null);
+            if (registration.isActive()) {
+                registration.unregister();
+            }
+            ctx.remove(Scope.CONTEXT, CTX_KEY);
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/handlers/loop/ForHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/loop/ForHandler.java
@@ -1,0 +1,161 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.handlers.loop;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.CommandLineCompleter;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.batch.BatchManager;
+import org.jboss.as.cli.handlers.CommandHandlerWithHelp;
+import org.jboss.as.cli.impl.ArgumentWithValue;
+import org.jboss.as.cli.impl.DefaultCompleter;
+import org.jboss.as.cli.impl.DefaultCompleter.CandidatesProvider;
+import org.jboss.as.cli.operation.ParsedCommandLine;
+
+/**
+ *
+ * @author jfdenise
+ */
+public class ForHandler extends CommandHandlerWithHelp {
+
+    private final ArgumentWithValue varName;
+    private final ArgumentWithValue in;
+
+    public ForHandler() {
+        super("for", true);
+
+        varName = new ArgumentWithValue(this, 0, "--var");
+        varName.addCantAppearAfter(helpArg);
+
+        in = new ArgumentWithValue(this, new DefaultCompleter(new CandidatesProvider() {
+            @Override
+            public Collection<String> getAllCandidates(CommandContext ctx) {
+                return Collections.singletonList("in");
+            }
+        }), 1, "--in");
+        in.addRequiredPreceding(varName);
+
+        final ArgumentWithValue line = new ArgumentWithValue(this, new CommandLineCompleter() {
+            @Override
+            public int complete(CommandContext ctx, String buffer, int cursor, List<String> candidates) {
+                final ParsedCommandLine args = ctx.getParsedCommandLine();
+                final String lnStr = in.getValue(args);
+                if (lnStr == null) {
+                    return -1;
+                }
+
+                final String originalLine = args.getOriginalLine();
+                String varNameStr;
+                try {
+                    varNameStr = varName.getValue(args, true);
+                } catch (CommandFormatException e) {
+                    return -1;
+                }
+                int i = originalLine.indexOf(varNameStr);
+                if (i < 0) {
+                    return -1;
+                }
+                i = originalLine.indexOf("in ", i + varNameStr.length());
+                if (i < 0) {
+                    return -1;
+                }
+
+                final String cmd = originalLine.substring(i + 3);
+                /*                    final DefaultCallbackHandler parsedLine = new DefaultCallbackHandler();
+                    try {
+                        parsedLine.parse(ctx.getCurrentNodePath(), cmd);
+                    } catch (CommandFormatException e) {
+                        return -1;
+                    }
+                    int cmdResult = OperationRequestCompleter.INSTANCE.complete(ctx, parsedLine, cmd, 0, candidates);
+                 */
+                int cmdResult = ctx.getDefaultCommandCompleter().complete(ctx, cmd, cmd.length(), candidates);
+                if (cmdResult < 0) {
+                    return cmdResult;
+                }
+
+                // escaping index correction
+                int escapeCorrection = 0;
+                int start = originalLine.length() - 1 - buffer.length();
+                while (start - escapeCorrection >= 0) {
+                    final char ch = originalLine.charAt(start - escapeCorrection);
+                    if (Character.isWhitespace(ch) || ch == '=') {
+                        break;
+                    }
+                    ++escapeCorrection;
+                }
+
+                return buffer.length() + escapeCorrection - (cmd.length() - cmdResult);
+            }
+        }, Integer.MAX_VALUE, "--line") {
+        };
+        line.addRequiredPreceding(in);
+    }
+
+    @Override
+    public boolean isAvailable(CommandContext ctx) {
+        return ForControlFlow.get(ctx) == null && !ctx.getBatchManager().isBatchActive();
+    }
+
+    /* (non-Javadoc)
+     * @see org.jboss.as.cli.handlers.CommandHandlerWithHelp#doHandle(org.jboss.as.cli.CommandContext)
+     */
+    @Override
+    protected void doHandle(CommandContext ctx) throws CommandLineException {
+        if (ForControlFlow.get(ctx) != null) {
+            throw new CommandFormatException("for is not allowed while in for block");
+        }
+        final BatchManager batchManager = ctx.getBatchManager();
+        if (batchManager.isBatchActive()) {
+            throw new CommandFormatException("for is not allowed while in batch mode.");
+        }
+        String argsStr = ctx.getArgumentsString();
+        if (argsStr == null) {
+            throw new CommandFormatException("The command is missing arguments.");
+        }
+        final ParsedCommandLine args = ctx.getParsedCommandLine();
+        final String varName = this.varName.getOriginalValue(args, true);
+        int i = argsStr.indexOf(varName);
+        if (i < 0) {
+            throw new CommandFormatException("Failed to locate '" + varName + "' in '" + argsStr + "'");
+        }
+        i = argsStr.indexOf("in", i + varName.length());
+        if (i < 0) {
+            throw new CommandFormatException("Failed to locate 'in' in '" + argsStr + "'");
+        }
+        final String requestStr = argsStr.substring(i + 2);
+        ctx.registerRedirection(new ForControlFlow(ctx, varName, requestStr));
+    }
+
+    /**
+     * It has to accept everything since we don't know what kind of command will
+     * be edited.
+     */
+    @Override
+    public boolean hasArgument(CommandContext ctx, int index) {
+        return true;
+    }
+
+    @Override
+    public boolean hasArgument(CommandContext ctx, String name) {
+        return true;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -149,6 +149,8 @@ import org.jboss.as.cli.handlers.jca.DataSourceAddCompositeHandler;
 import org.jboss.as.cli.handlers.jca.JDBCDriverInfoHandler;
 import org.jboss.as.cli.handlers.jca.JDBCDriverNameProvider;
 import org.jboss.as.cli.handlers.jca.XADataSourceAddCompositeHandler;
+import org.jboss.as.cli.handlers.loop.DoneHandler;
+import org.jboss.as.cli.handlers.loop.ForHandler;
 import org.jboss.as.cli.handlers.module.ASModuleHandler;
 import org.jboss.as.cli.handlers.trycatch.CatchHandler;
 import org.jboss.as.cli.handlers.trycatch.EndTryHandler;
@@ -531,6 +533,10 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         cmdRegistry.registerHandler(new IfHandler(), "if");
         cmdRegistry.registerHandler(new ElseHandler(), "else");
         cmdRegistry.registerHandler(new EndIfHandler(), "end-if");
+
+        // for
+        cmdRegistry.registerHandler(new ForHandler(), "for");
+        cmdRegistry.registerHandler(new DoneHandler(), "done");
 
         // data-source
         final DefaultCompleter driverNameCompleter = new DefaultCompleter(JDBCDriverNameProvider.INSTANCE);

--- a/cli/src/main/resources/help/done.txt
+++ b/cli/src/main/resources/help/done.txt
@@ -1,0 +1,12 @@
+SYNOPSIS
+
+    done [--discard]
+
+DESCRIPTION
+
+    Ends the 'for' block and executes the iteration.
+
+ARGUMENTS
+
+ --discard    - Optional. Ends the 'for' block and discard it.
+

--- a/cli/src/main/resources/help/for.txt
+++ b/cli/src/main/resources/help/for.txt
@@ -1,0 +1,25 @@
+SYNOPSIS
+
+    for <variable_name> in <command_line>
+
+DESCRIPTION
+
+    Starts for/done control flow.
+    The for statement includes command_line (which is a CLI command
+    or an operation) that is executed at the beginning of the for
+    control flow. The operation must returns a collection that is iterated.
+    The defined variable value is set to the current collection item. The variable
+    scope is the for block (terminated by done).
+
+    NB: for can't be used inside a batch, but batch can be used in for blocks.
+
+    Example of a loop that displays the manifest of all deployments:
+    
+
+ARGUMENTS
+
+    command_line  - CLI command or an operation whose response
+                    must contain a collection of items. During each iteration,
+                    each item string value is set as the variable value.
+
+    variable_name - A variable that stores the value of each collection item.

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -1513,4 +1513,40 @@ public class CliCompletionTestCase {
             ctx.terminateSession();
         }
     }
+
+    @Test
+    public void testFor() throws Exception {
+        CommandContext ctx = CLITestUtil.getCommandContext(testSupport,
+                System.in, System.out);
+        ctx.connectController();
+        {
+            String cmd = "for var ";
+            List<String> candidates = new ArrayList<>();
+            ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                    cmd.length(), candidates);
+            assertEquals(candidates.toString(), Arrays.asList("in"), candidates);
+        }
+
+        {
+            String cmd = "for var in ";
+            List<String> candidates = new ArrayList<>();
+            ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                    cmd.length(), candidates);
+            assertFalse(candidates.toString(), candidates.isEmpty());
+            assertTrue(candidates.toString(), candidates.contains(":"));
+        }
+
+        {
+            String cmd = "done ";
+            ctx.handle("for var in :read-resource");
+            try {
+                List<String> candidates = new ArrayList<>();
+                ctx.getDefaultCommandCompleter().complete(ctx, cmd,
+                        cmd.length(), candidates);
+                assertTrue(candidates.toString(), candidates.contains("--discard"));
+            } finally {
+                ctx.handle("done --discard");
+            }
+        }
+    }
 }

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIScriptSupportTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIScriptSupportTestCase.java
@@ -115,8 +115,8 @@ public class CLIScriptSupportTestCase {
     @Test
     public void testBatch() {
         serverController.start();
+        CLI cli = CLI.newInstance();
         try {
-            CLI cli = CLI.newInstance();
             cli.connect(serverController.getClient().getMgmtAddress(),
                     serverController.getClient().getMgmtPort(), null, null);
             addProperty(cli, "prop1", "prop1_a");
@@ -129,6 +129,9 @@ public class CLIScriptSupportTestCase {
             assertEquals("prop1_b", readProperty(cli, "prop1"));
             assertEquals("prop2_b", readProperty(cli, "prop2"));
         } finally {
+            removeProperty(cli, "prop1");
+            removeProperty(cli, "prop2");
+            cli.terminate();
             serverController.stop();
         }
     }
@@ -160,6 +163,10 @@ public class CLIScriptSupportTestCase {
         Result res = cli.cmd("/system-property=" + name
                 + ":read-attribute(name=value)");
         return res.getResponse().get("result").asString();
+    }
+
+    private static void removeProperty(CLI cli, String name) {
+        cli.cmd("/system-property=" + name + ":remove");
     }
 
     private static void writeProperty(CLI cli, String name, String value) {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ForLoopTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ForLoopTestCase.java
@@ -1,0 +1,174 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+public class ForLoopTestCase extends AbstractCliTestBase {
+
+    @BeforeClass
+    public static void before() throws Exception {
+        AbstractCliTestBase.initCLI();
+    }
+
+    @AfterClass
+    public static void after() throws Exception {
+        AbstractCliTestBase.closeCLI();
+    }
+
+    @Test
+    public void testSimpleFor() throws Exception {
+        addProperty("prop1", "prop1_a");
+        addProperty("prop2", "prop2_a");
+        try {
+            cli.sendLine("set var=+");
+            cli.sendLine("for propName in :read-children-names(child-type=system-property");
+            cli.sendLine("set var=$var+$propName");
+            cli.sendLine("done");
+            cli.sendLine("echo $var");
+            String line = cli.readOutput();
+            assertTrue(line, line.equals("++prop1+prop2"));
+        } finally {
+            cli.sendLine("set var=");
+            removeProperties();
+        }
+    }
+
+    @Test
+    public void testDiscard() throws Exception {
+        addProperty("prop1", "prop1_a");
+        addProperty("prop2", "prop2_a");
+        try {
+            cli.sendLine("set var=+");
+            cli.sendLine("for propName in :read-children-names(child-type=system-property");
+            cli.sendLine("set var=$var+$propName");
+            cli.sendLine("done --discard");
+            cli.sendLine("echo $var");
+            String line = cli.readOutput();
+            assertTrue(line, line.equals("+"));
+        } finally {
+            cli.sendLine("set var=");
+            removeProperties();
+        }
+    }
+
+    @Test
+    public void testVarAlreadyExists() throws Exception {
+        cli.sendLine("set var=+");
+        try {
+            assertFalse(cli.sendLine("for var in :read-children-names(child-type=system-property", true));
+        } finally {
+            cli.sendLine("set var=");
+        }
+    }
+
+    @Test
+    public void testInvalidNestedOp() throws Exception {
+        cli.sendLine("for var in :read-children-names(child-type=system-property", true);
+        try {
+            assertFalse(cli.sendLine("for var in :read-children-names(child-type=system-property", true));
+        } finally {
+            cli.sendLine("done");
+        }
+    }
+
+    @Test
+    public void testInvalidOps() throws Exception {
+        assertFalse(cli.sendLine("for var in :read-wrong", true));
+        assertFalse(cli.sendLine("for var in", true));
+        assertFalse(cli.sendLine("for var", true));
+        assertFalse(cli.sendLine("for", true));
+    }
+
+    private void removeProperties() {
+        cli.sendLine("for propName in :read-children-names(child-type=system-property");
+        cli.sendLine("/system-property=$propName:remove");
+        cli.sendLine("done");
+        checkEmpty();
+    }
+
+    private void checkEmpty() {
+        cli.sendLine("if (result==[]) of :read-children-names(child-type=system-property");
+        cli.sendLine("echo EMPTY");
+        cli.sendLine("else");
+        cli.sendLine("echo FAILURE");
+        cli.sendLine("end-if");
+        String line = cli.readOutput();
+        assertTrue(line, line.contains("EMPTY") && !line.contains("FAILURE"));
+    }
+
+    @Test
+    public void testForNobatch() throws Exception {
+        cli.sendLine("batch");
+        try {
+            assertFalse(cli.sendLine("for propName in :read-children-names(child-type=system-property", true));
+        } finally {
+            cli.sendLine("discard-batch");
+        }
+
+    }
+
+    @Test
+    public void testForBatch() throws Exception {
+        addProperty("prop1", "prop1_a");
+        addProperty("prop2", "prop2_a");
+        try {
+            cli.sendLine("for propName in :read-children-names(child-type=system-property");
+            cli.sendLine("batch");
+            cli.sendLine("/system-property=$propName:remove");
+            cli.sendLine("run-batch");
+            cli.sendLine("done");
+            checkEmpty();
+        } finally {
+            removeProperties();
+        }
+    }
+
+    @Test
+    public void testForIf() throws Exception {
+        addProperty("prop1", "prop1_a");
+        addProperty("prop2", "prop1_a");
+        addProperty("prop3", "prop1_a");
+        addProperty("prop4", "prop1_a");
+        addProperty("prop5", "prop1_a");
+        try {
+            cli.sendLine("for propName in :read-children-names(child-type=system-property");
+            cli.sendLine("if (result!=[]) of :read-children-names(child-type=system-property");
+            cli.sendLine("/system-property=$propName:remove");
+            cli.sendLine("end-if");
+            cli.sendLine("done");
+            checkEmpty();
+        } finally {
+            removeProperties();
+        }
+    }
+
+    private void addProperty(String name, String value) {
+        cli.sendLine("/system-property=" + name + ":add(value=" + value + ")");
+    }
+}


### PR DESCRIPTION
Introduce ability to iterate over DMR collections and execute commands for each item.
Added new unit tests.
