### PR TITLE
[WFCORE-3323]:  Initial Elytron configuration includes mapping-mode="first" in simple-permission-mapper

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/MapperParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/MapperParser.java
@@ -1429,11 +1429,11 @@ class MapperParser {
                 ModelNode permissionMapper = permissionMappers.require(name);
                 writer.writeStartElement(SIMPLE_PERMISSION_MAPPER);
                 writer.writeAttribute(NAME, name);
-                PermissionMapperDefinitions.MAPPING_MODE.marshallAsAttribute(permissionMapper, false, writer);
+                PermissionMapperDefinitions.MAPPING_MODE.marshallAsAttribute(permissionMapper, true, writer);
                 if (permissionMapper.hasDefined(PERMISSION_MAPPINGS)) {
                     for (ModelNode permissionMapping : permissionMapper.get(PERMISSION_MAPPINGS).asList()) {
                         writer.writeStartElement(PERMISSION_MAPPING);
-                        PermissionMapperDefinitions.MATCH_ALL.marshallAsAttribute(permissionMapping, false, writer);
+                        PermissionMapperDefinitions.MATCH_ALL.marshallAsAttribute(permissionMapping, true, writer);
                         writeNameItemList(PRINCIPALS, PRINCIPAL, permissionMapping, writer);
                         writeNameItemList(ROLES, ROLE, permissionMapping, writer);
                         if (permissionMapping.hasDefined(PERMISSIONS)) {


### PR DESCRIPTION
Attribute is still marshalled even if its value is the default one.

Jira: https://issues.jboss.org/browse/WFCORE-3323
JBEAP: https://issues.jboss.org/browse/JBEAP-13303