### PR TITLE
[WFCORE-3331] license of org.wildfly.core:wildfly-elytron-integration

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -37,15 +37,6 @@
         <test.level>INFO</test.level>
     </properties>
 
-
-    <licenses>
-        <license>
-            <name>Apache 2</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
remove licenses tag from pom.xml to inherit project dual license

issue: https://issues.jboss.org/browse/WFCORE-3331