### PR TITLE
[WFCORE-3313] Upgrade jboss-logmanager from 2.1.0.Alpha4 to 2.1.0.Alpha5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.2.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
-        <version.org.jboss.logmanager.jboss-logmanager>2.1.0.Alpha4</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.1.0.Alpha5</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.4.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.1.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.6.1.Final</version.org.jboss.modules.jboss-modules>


### PR DESCRIPTION
This contains a fix for [WFCORE-3311](https://issues.jboss.org/browse/WFCORE-3311) which logs messages to stdout on offline CLI regardless of the `--stdout=discard` setting.

JIRA: https://issues.jboss.org/browse/WFCORE-3313