### PR TITLE
[WFCORE-3327] Convert remoting subsystem configuration=endpoint resource into just an alias exposing attributes on its parent

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ExtensionContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExtensionContext.java
@@ -35,6 +35,18 @@ import org.jboss.as.controller.services.path.PathManager;
 public interface ExtensionContext {
 
     /**
+     * The various types of contexts in which an {@link Extension} can be asked to initialize.
+     */
+    enum ContextType {
+        /** The {@code Extension} will be used to extend the functionality of a server instance */
+        SERVER,
+        /** The {@code Extension} will be for use in domain-wide profiles managed by a Host Controller.*/
+        DOMAIN,
+        /** The {@code Extension} will be used to extend the functionality of a Host Controller */
+        HOST_CONTROLLER
+    }
+
+    /**
      * Convenience variant of {@link #registerSubsystem(String, int, int, int)} that uses {@code 0}
      * as the {@code microVersion}.
      *
@@ -134,6 +146,12 @@ public interface ExtensionContext {
     SubsystemRegistration registerSubsystem(String name, int majorVersion, int minorVersion, int microVersion, boolean deprecated);
 
     /**
+     * Gets the type of this context.
+     * @return the context type. Will not be {@code null}
+     */
+    ContextType getType();
+
+    /**
      * Gets the type of the current process.
      * @return the current process type. Will not be {@code null}
      */
@@ -144,6 +162,8 @@ public interface ExtensionContext {
      * @return the current running mode. Will not be {@code null}
      */
     RunningMode getRunningMode();
+
+
 
     /**
      * Gets whether it is valid for the extension to register resources, attributes or operations that do not

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistry.java
@@ -553,6 +553,11 @@ public class ExtensionRegistry {
         }
 
         @Override
+        public ContextType getType() {
+            return extensionRegistryType.getContextType();
+        }
+
+        @Override
         public ProcessType getProcessType() {
             return processType;
         }

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistryType.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionRegistryType.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.controller.extension;
 
+import org.jboss.as.controller.ExtensionContext;
+
 /**
  * Enum of places an extension registry can be added
  *
@@ -31,25 +33,34 @@ public enum ExtensionRegistryType {
     /**
      * The extension registry is for a standalone or managed server.
      */
-    SERVER,
+    SERVER(ExtensionContext.ContextType.SERVER),
 
     /**
      * The extension registry is for the host model part in a host controller.
      */
-    HOST,
+    HOST(ExtensionContext.ContextType.HOST_CONTROLLER),
 
     /**
      * The extension registry is for the domain model part in a host controller running as a slave.
      * <em>NB</em> it is not known during bootup of the host.xml part if we are a slave or not. But
      * once we reach the domain part it is known.
      */
-    MASTER,
+    MASTER(ExtensionContext.ContextType.DOMAIN),
 
     /**
      * The extension registry is for the domain model part in a host controller running as a slave.
      * <em>NB</em> it is not known during bootup of the host.xml part if we are a slave or not. But
      * once we reach the domain part it is known.
      */
-    SLAVE;
+    SLAVE(ExtensionContext.ContextType.DOMAIN);
 
+    private final ExtensionContext.ContextType contextType;
+
+    ExtensionRegistryType(ExtensionContext.ContextType contextType) {
+        this.contextType = contextType;
+    }
+
+    public ExtensionContext.ContextType getContextType() {
+        return contextType;
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/transform/CompositeOperationTransformer.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/CompositeOperationTransformer.java
@@ -58,11 +58,10 @@ class CompositeOperationTransformer implements OperationTransformer {
 
     @Override
     public TransformedOperation transformOperation(final TransformationContext context, final PathAddress address, final ModelNode operation) throws OperationFailedException {
-        return transformOperation(context, address, operation, false);
+        return transformOperation(context, operation);
     }
 
-    TransformedOperation transformOperation(final TransformationContext context, final PathAddress address, final ModelNode operation, final boolean nested) throws OperationFailedException {
-        assert address.size() == 0;
+    private TransformedOperation transformOperation(final TransformationContext context, final ModelNode operation) throws OperationFailedException {
         final ModelNode composite = operation.clone();
         composite.get(STEPS).setEmptyList();
         final TransformationTarget target = context.getTarget();
@@ -75,10 +74,10 @@ class CompositeOperationTransformer implements OperationTransformer {
             final TransformedOperation result;
             if(stepAddress.size() == 0 && COMPOSITE.equals(operationName)) {
                 // Process nested steps directly
-                result = transformOperation(context, PathAddress.EMPTY_ADDRESS, step, false);
+                result = transformOperation(context, step);
             } else {
                 //If this is an alias, get the real address before transforming
-                ImmutableManagementResourceRegistration reg = context.getResourceRegistration(stepAddress);
+                ImmutableManagementResourceRegistration reg = context.getResourceRegistrationFromRoot(stepAddress);
                 final PathAddress useAddress;
                 if (reg != null && reg.isAlias()) {
                     useAddress = reg.getAliasEntry().convertToTargetAddress(stepAddress, AliasEntry.AliasContext.create(step, context));

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/OptionList.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/OptionList.java
@@ -18,6 +18,14 @@ public class OptionList {
 
     }
 
+    public static OptionMap resolveOptions(final ExpressionResolver context, final ModelNode model, OptionAttributeDefinition... attributes) throws OperationFailedException {
+        OptionMap.Builder builder = OptionMap.builder();
+        for (OptionAttributeDefinition attr : attributes) {
+            attr.resolveOption(context, model, builder);
+        }
+        return builder.getMap();
+    }
+
     public static OptionMap resolveOptions(final ExpressionResolver context, final ModelNode model, Collection<OptionAttributeDefinition> attributes) throws OperationFailedException {
         OptionMap.Builder builder = OptionMap.builder();
         for (OptionAttributeDefinition attr : attributes) {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/EndpointConfigFactory.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/EndpointConfigFactory.java
@@ -44,7 +44,7 @@ public final class EndpointConfigFactory {
         OptionMap.Builder builder = OptionMap.builder()
         .set(Options.TCP_NODELAY, Boolean.TRUE)
         .set(Options.REUSE_ADDRESSES, true)
-        .addAll(OptionList.resolveOptions(resolver, model, RemotingEndpointResource.OPTIONS));
+        .addAll(OptionList.resolveOptions(resolver, model, RemotingSubsystemRootResource.OPTIONS));
 
         return builder.getMap();
     }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingEndpointRemove.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingEndpointRemove.java
@@ -1,0 +1,61 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.remoting;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Handles a remove of the configuration=endpoint resource by undefining all endpoint config attribute on the parent.
+ *
+ * @author Brian Stansberry
+ */
+class RemotingEndpointRemove extends ModelOnlyRemoveStepHandler {
+
+    @Override
+    protected void performRemove(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        // For any attribute that is defined in the parent resource, add an immediate 'write-attribute'
+        // step against the parent to undefine it
+        PathAddress parentAddress = context.getCurrentAddress().getParent();
+        ModelNode parentModel = context.readResourceFromRoot(parentAddress, false).getModel();
+        OperationStepHandler writeHandler = null;
+        ModelNode baseWriteOp = null;
+        for (AttributeDefinition ad : RemotingEndpointResource.ATTRIBUTES.values()) {
+            String attr = ad.getName();
+            if (parentModel.hasDefined(attr)) {
+                if (writeHandler == null) {
+                    writeHandler = context.getRootResourceRegistration().getOperationHandler(parentAddress, WRITE_ATTRIBUTE_OPERATION);
+                    baseWriteOp = Util.createEmptyOperation(WRITE_ATTRIBUTE_OPERATION, parentAddress);
+                }
+                ModelNode writeOp = baseWriteOp.clone();
+                writeOp.get(NAME).set(attr);
+                writeOp.get(VALUE).set(new ModelNode());
+                context.addStep(writeOp, writeHandler, OperationContext.Stage.MODEL, true);
+            }
+        }
+    }
+}

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingEndpointResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingEndpointResource.java
@@ -21,120 +21,75 @@
 */
 package org.jboss.as.remoting;
 
-import static org.jboss.as.remoting.RemotingSubsystemRootResource.IO_WORKER_CAPABILITY;
-import static org.jboss.as.remoting.RemotingSubsystemRootResource.REMOTING_ENDPOINT_CAPABILITY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.logging.Level;
-
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.PersistentResourceDefinition;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
-import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
-import org.jboss.as.controller.SimpleAttributeDefinition;
-import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.operations.validation.StringLengthValidator;
-import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
-import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.remoting.logging.RemotingLogger;
 import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
-import org.jboss.remoting3.RemotingOptions;
-import org.wildfly.extension.io.OptionAttributeDefinition;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
  */
-public class RemotingEndpointResource extends PersistentResourceDefinition {
-    protected static final SimpleAttributeDefinition WORKER = new SimpleAttributeDefinitionBuilder(CommonAttributes.WORKER, ModelType.STRING)
-            .setRequired(false)
-            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setValidator(new StringLengthValidator(1))
-            .setDefaultValue(new ModelNode("default"))
-            .setCapabilityReference(IO_WORKER_CAPABILITY, REMOTING_ENDPOINT_CAPABILITY)
-            .build();
+class RemotingEndpointResource extends SimpleResourceDefinition {
 
 
-    public static final OptionAttributeDefinition SEND_BUFFER_SIZE = OptionAttributeDefinition.builder("send-buffer-size", RemotingOptions.SEND_BUFFER_SIZE).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_SEND_BUFFER_SIZE)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition RECEIVE_BUFFER_SIZE = OptionAttributeDefinition.builder("receive-buffer-size", RemotingOptions.RECEIVE_BUFFER_SIZE).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_RECEIVE_BUFFER_SIZE)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition BUFFER_REGION_SIZE = OptionAttributeDefinition.builder("buffer-region-size", RemotingOptions.BUFFER_REGION_SIZE).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition TRANSMIT_WINDOW_SIZE = OptionAttributeDefinition.builder("transmit-window-size", RemotingOptions.TRANSMIT_WINDOW_SIZE).setDefaultValue(new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_TRANSMIT_WINDOW_SIZE)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition RECEIVE_WINDOW_SIZE = OptionAttributeDefinition.builder("receive-window-size", RemotingOptions.RECEIVE_WINDOW_SIZE).setDefaultValue(new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_RECEIVE_WINDOW_SIZE)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition MAX_OUTBOUND_CHANNELS = OptionAttributeDefinition.builder("max-outbound-channels", RemotingOptions.MAX_OUTBOUND_CHANNELS).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_MAX_OUTBOUND_CHANNELS)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition MAX_INBOUND_CHANNELS = OptionAttributeDefinition.builder("max-inbound-channels", RemotingOptions.MAX_INBOUND_CHANNELS).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_MAX_INBOUND_CHANNELS)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition AUTHORIZE_ID = OptionAttributeDefinition.builder("authorize-id", RemotingOptions.AUTHORIZE_ID).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition AUTH_REALM = OptionAttributeDefinition.builder("auth-realm", RemotingOptions.AUTH_REALM).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition AUTHENTICATION_RETRIES = OptionAttributeDefinition.builder("authentication-retries", RemotingOptions.AUTHENTICATION_RETRIES).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_AUTHENTICATION_RETRIES)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition MAX_OUTBOUND_MESSAGES = OptionAttributeDefinition.builder("max-outbound-messages", RemotingOptions.MAX_OUTBOUND_MESSAGES).setDefaultValue(new ModelNode(RemotingOptions.OUTGOING_CHANNEL_DEFAULT_MAX_OUTBOUND_MESSAGES)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition MAX_INBOUND_MESSAGES = OptionAttributeDefinition.builder("max-inbound-messages", RemotingOptions.MAX_INBOUND_MESSAGES).setDefaultValue(new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_MAX_OUTBOUND_MESSAGES)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition HEARTBEAT_INTERVAL = OptionAttributeDefinition.builder("heartbeat-interval", RemotingOptions.HEARTBEAT_INTERVAL).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition MAX_INBOUND_MESSAGE_SIZE = OptionAttributeDefinition.builder("max-inbound-message-size", RemotingOptions.MAX_INBOUND_MESSAGE_SIZE).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_MAX_INBOUND_MESSAGE_SIZE)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition MAX_OUTBOUND_MESSAGE_SIZE = OptionAttributeDefinition.builder("max-outbound-message-size", RemotingOptions.MAX_OUTBOUND_MESSAGE_SIZE).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_MAX_OUTBOUND_MESSAGE_SIZE)).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition SERVER_NAME = OptionAttributeDefinition.builder("server-name", RemotingOptions.SERVER_NAME).setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-    public static final OptionAttributeDefinition SASL_PROTOCOL = OptionAttributeDefinition.builder("sasl-protocol", RemotingOptions.SASL_PROTOCOL)
-            .setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_SASL_PROTOCOL))
-            .setAllowExpression(true)
-            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES).build();
-
-
-    protected static final PathElement ENDPOINT_PATH = PathElement.pathElement("configuration", "endpoint");
-    protected static final Collection<AttributeDefinition> ATTRIBUTES;
+    static final PathElement ENDPOINT_PATH = PathElement.pathElement("configuration", "endpoint");
+    static final Map<String, AttributeDefinition> ATTRIBUTES;
 
     static final RemotingEndpointResource INSTANCE = new RemotingEndpointResource();
 
-    public static final java.util.List<OptionAttributeDefinition> OPTIONS = Arrays.asList(SEND_BUFFER_SIZE, RECEIVE_BUFFER_SIZE, BUFFER_REGION_SIZE, TRANSMIT_WINDOW_SIZE, RECEIVE_WINDOW_SIZE,
-            MAX_OUTBOUND_CHANNELS, MAX_INBOUND_CHANNELS, AUTHORIZE_ID, AUTH_REALM, AUTHENTICATION_RETRIES, MAX_OUTBOUND_MESSAGES,
-            MAX_INBOUND_MESSAGES, HEARTBEAT_INTERVAL, MAX_INBOUND_MESSAGE_SIZE, MAX_OUTBOUND_MESSAGE_SIZE, SERVER_NAME, SASL_PROTOCOL);
-
     static {
-        ATTRIBUTES = new LinkedHashSet<AttributeDefinition>(Collections.singletonList(WORKER));
-        ATTRIBUTES.addAll(OPTIONS);
+        Map<String, AttributeDefinition> attrs = new LinkedHashMap<>();
+        assert RemotingSubsystemRootResource.WORKER.getName().equals(RemotingSubsystemRootResource.WORKER.getXmlName());
+        attrs.put(RemotingSubsystemRootResource.WORKER.getName(), RemotingSubsystemRootResource.WORKER);
+        for (AttributeDefinition ad : RemotingSubsystemRootResource.OPTIONS) {
+            assert ad.getName().equals(ad.getXmlName());
+            attrs.put(ad.getName(), ad);
+        }
+        ATTRIBUTES = Collections.unmodifiableMap(attrs);
     }
 
     private RemotingEndpointResource() {
-        super(ENDPOINT_PATH, RemotingExtension.getResourceDescriptionResolver("endpoint"));
+        super(new Parameters(ENDPOINT_PATH, RemotingExtension.getResourceDescriptionResolver("endpoint"))
+                .setAddHandler(new RemotingEndpointAdd())
+                .setRemoveHandler(new RemotingEndpointRemove())
+                .setAddRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES) // if this is added post-boot we assume it will trigger a restart required, although in rare cases it might not
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES) // we assume it will trigger a restart required, although in rare cases it might not
+                .setDeprecatedSince(ModelVersion.create(5))
+        );
     }
 
-    public Collection<AttributeDefinition> getAttributes() {
-        //noinspection unchecked
-        return ATTRIBUTES;
-    }
-
-    @Override
-    public void registerOperations(ManagementResourceRegistration resourceRegistration) {
-        super.registerOperations(resourceRegistration);
-        super.registerAddOperation(resourceRegistration, new RemotingEndpointAdd(), OperationEntry.Flag.RESTART_NONE);
-        super.registerRemoveOperation(resourceRegistration, ReloadRequiredRemoveStepHandler.INSTANCE, OperationEntry.Flag.RESTART_NONE);
-    }
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        //register as normal
-        super.registerAttributes(resourceRegistration);
-        //override
-        resourceRegistration.unregisterAttribute(WORKER.getName());
-        resourceRegistration.registerReadWriteAttribute(WORKER, null, new WorkerAttributeWriteHandler(WORKER));
+        OperationStepHandler toParentHandler = new ToParentHandler();
+        for (AttributeDefinition ad : ATTRIBUTES.values()) {
+            resourceRegistration.registerReadWriteAttribute(ad, toParentHandler, toParentHandler);
+        }
     }
 
-    class WorkerAttributeWriteHandler extends ReloadRequiredWriteAttributeHandler {
-
-        public WorkerAttributeWriteHandler(AttributeDefinition... definitions) {
-            super(definitions);
-        }
+    private static class ToParentHandler implements OperationStepHandler {
 
         @Override
-        protected void finishModelStage(OperationContext context, ModelNode operation, String attributeName, ModelNode newValue,
-                ModelNode oldValue, Resource model) throws OperationFailedException {
-            super.finishModelStage(context, operation, attributeName, newValue, oldValue, model);
-            context.addResponseWarning(Level.WARNING, RemotingLogger.ROOT_LOGGER.warningOnWorkerChange(newValue.asString()));
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            PathAddress parent = context.getCurrentAddress().getParent();
+            ModelNode parentOp = operation.clone();
+            parentOp.get(OP_ADDR).set(parent.toModelNode());
+
+            OperationStepHandler osh = context.getRootResourceRegistration().getOperationHandler(parent, operation.get(OP).asString());
+            context.addStep(parentOp, osh, OperationContext.Stage.MODEL, true);
         }
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -30,12 +30,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUB
 import java.util.List;
 import java.util.Map;
 
-import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -71,12 +71,12 @@ public class RemotingExtension implements Extension {
         return new StandardResourceDescriptionResolver(keyPrefix, RESOURCE_NAME, RemotingExtension.class.getClassLoader(), true, false);
     }
 
-    static final SensitivityClassification REMOTING_SECURITY =
+    private static final SensitivityClassification REMOTING_SECURITY =
             new SensitivityClassification(SUBSYSTEM_NAME, "remoting-security", false, true, true);
 
     static final SensitiveTargetAccessConstraintDefinition REMOTING_SECURITY_DEF = new SensitiveTargetAccessConstraintDefinition(REMOTING_SECURITY);
 
-    private static final int MANAGEMENT_API_MAJOR_VERSION = 4;
+    private static final int MANAGEMENT_API_MAJOR_VERSION = 5;
     private static final int MANAGEMENT_API_MINOR_VERSION = 0;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
@@ -92,7 +92,9 @@ public class RemotingExtension implements Extension {
         final SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, CURRENT_VERSION);
         registration.registerXMLElementWriter(RemotingSubsystemXMLPersister::new);
 
-        final ManagementResourceRegistration subsystem = registration.registerSubsystemModel(new RemotingSubsystemRootResource());
+        final boolean forDomain = context.getType() == ExtensionContext.ContextType.DOMAIN;
+        final ResourceDefinition root = RemotingSubsystemRootResource.create(context.getProcessType(), forDomain);
+        final ManagementResourceRegistration subsystem = registration.registerSubsystemModel(root);
         subsystem.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, new DescribeHandler());
 
         subsystem.registerSubModel(RemotingEndpointResource.INSTANCE);
@@ -207,29 +209,12 @@ public class RemotingExtension implements Extension {
         @Override
         protected void describe(OrderedChildTypesAttachment orderedChildTypesAttachment, Resource resource,
                                 ModelNode address, ModelNode result, ImmutableManagementResourceRegistration registration) {
-            // WFCORE-1354 only describe the configuration=endpoint resource if it has configuration;
-            // otherwise the equivalent config will be added by default. Doing this allows avoiding
-            // creation of a spurious requirement for the org.wildfly.io.worker.default capability during a
-            // profile clone op on an HC.
+            // Don't describe the configuration=endpoint resource. It's just an alias for
+            // a set of attributes on its parent and the parent description covers those.
 
-            boolean describe = true;
             PathElement pe = registration.getPathAddress().getLastElement();
-            if (pe.equals(RemotingEndpointResource.ENDPOINT_PATH))  {
-                describe = false;
-                if (resource != null) {
-                    ModelNode model = resource.getModel();
-                    if (model.isDefined()) {
-                        for (AttributeDefinition ad : RemotingEndpointResource.INSTANCE.getAttributes()) {
-                            if (model.hasDefined(ad.getName())) {
-                                describe = true;
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-            if (describe) {
-                super.describe(orderedChildTypesAttachment, resource, address, result, registration); //TODO implement describe
+            if (!pe.equals(RemotingEndpointResource.ENDPOINT_PATH)) {
+                super.describe(orderedChildTypesAttachment, resource, address, result, registration);
             }
         }
     }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem10Parser.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem10Parser.java
@@ -23,6 +23,7 @@ import static org.jboss.as.remoting.CommonAttributes.VALUE;
 
 import java.util.EnumSet;
 import java.util.List;
+
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
@@ -21,44 +21,102 @@
 */
 package org.jboss.as.remoting;
 
+import java.util.logging.Level;
+
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.CapabilityReferenceRecorder;
+import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
-import org.jboss.as.controller.RestartParentWriteAttributeHandler;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.remoting.logging.RemotingLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.jboss.msc.service.ServiceName;
 import org.jboss.remoting3.Endpoint;
+import org.jboss.remoting3.RemotingOptions;
+import org.wildfly.extension.io.OptionAttributeDefinition;
+import org.xnio.Option;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
 
+    static final String IO_WORKER_CAPABILITY = "org.wildfly.io.worker";
+    static final RuntimeCapability<Void> REMOTING_ENDPOINT_CAPABILITY =
+            RuntimeCapability.Builder.of("org.wildfly.remoting.endpoint", Endpoint.class).build();
+
+    private static final String ENDPOINT = "endpoint";
+
+    static final SimpleAttributeDefinition WORKER = new SimpleAttributeDefinitionBuilder(CommonAttributes.WORKER, ModelType.STRING)
+            .setRequired(false)
+            .setAttributeGroup(ENDPOINT)
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setValidator(new StringLengthValidator(1))
+            .setDefaultValue(new ModelNode("default"))
+            .setCapabilityReference(IO_WORKER_CAPABILITY, REMOTING_ENDPOINT_CAPABILITY)
+            .build();
+
+    private static final OptionAttributeDefinition SEND_BUFFER_SIZE = createOptionAttribute("send-buffer-size", RemotingOptions.SEND_BUFFER_SIZE, new ModelNode(RemotingOptions.DEFAULT_SEND_BUFFER_SIZE));
+    private static final OptionAttributeDefinition RECEIVE_BUFFER_SIZE = createOptionAttribute("receive-buffer-size", RemotingOptions.RECEIVE_BUFFER_SIZE, new ModelNode(RemotingOptions.DEFAULT_RECEIVE_BUFFER_SIZE));
+    private static final OptionAttributeDefinition BUFFER_REGION_SIZE = createOptionAttribute("buffer-region-size", RemotingOptions.BUFFER_REGION_SIZE, null);
+    private static final OptionAttributeDefinition TRANSMIT_WINDOW_SIZE = createOptionAttribute("transmit-window-size", RemotingOptions.TRANSMIT_WINDOW_SIZE, new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_TRANSMIT_WINDOW_SIZE));
+    private static final OptionAttributeDefinition RECEIVE_WINDOW_SIZE = createOptionAttribute("receive-window-size", RemotingOptions.RECEIVE_WINDOW_SIZE, new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_RECEIVE_WINDOW_SIZE));
+    private static final OptionAttributeDefinition MAX_OUTBOUND_CHANNELS = createOptionAttribute("max-outbound-channels", RemotingOptions.MAX_OUTBOUND_CHANNELS, new ModelNode(RemotingOptions.DEFAULT_MAX_OUTBOUND_CHANNELS));
+    private static final OptionAttributeDefinition MAX_INBOUND_CHANNELS = createOptionAttribute("max-inbound-channels", RemotingOptions.MAX_INBOUND_CHANNELS, new ModelNode(RemotingOptions.DEFAULT_MAX_INBOUND_CHANNELS));
+    private static final OptionAttributeDefinition AUTHORIZE_ID = createOptionAttribute("authorize-id", RemotingOptions.AUTHORIZE_ID, null);
+    private static final OptionAttributeDefinition AUTH_REALM = createOptionAttribute("auth-realm", RemotingOptions.AUTH_REALM, null);
+    private static final OptionAttributeDefinition AUTHENTICATION_RETRIES = createOptionAttribute("authentication-retries", RemotingOptions.AUTHENTICATION_RETRIES, new ModelNode(RemotingOptions.DEFAULT_AUTHENTICATION_RETRIES));
+    private static final OptionAttributeDefinition MAX_OUTBOUND_MESSAGES = createOptionAttribute("max-outbound-messages", RemotingOptions.MAX_OUTBOUND_MESSAGES, new ModelNode(RemotingOptions.OUTGOING_CHANNEL_DEFAULT_MAX_OUTBOUND_MESSAGES));
+    private static final OptionAttributeDefinition MAX_INBOUND_MESSAGES = createOptionAttribute("max-inbound-messages", RemotingOptions.MAX_INBOUND_MESSAGES, new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_MAX_OUTBOUND_MESSAGES));
+    private static final OptionAttributeDefinition HEARTBEAT_INTERVAL = createOptionAttribute("heartbeat-interval", RemotingOptions.HEARTBEAT_INTERVAL, new ModelNode(RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL));
+    private static final OptionAttributeDefinition MAX_INBOUND_MESSAGE_SIZE = createOptionAttribute("max-inbound-message-size", RemotingOptions.MAX_INBOUND_MESSAGE_SIZE, new ModelNode(RemotingOptions.DEFAULT_MAX_INBOUND_MESSAGE_SIZE));
+    private static final OptionAttributeDefinition MAX_OUTBOUND_MESSAGE_SIZE = createOptionAttribute("max-outbound-message-size", RemotingOptions.MAX_OUTBOUND_MESSAGE_SIZE, new ModelNode(RemotingOptions.DEFAULT_MAX_OUTBOUND_MESSAGE_SIZE));
+    private static final OptionAttributeDefinition SERVER_NAME = createOptionAttribute("server-name", RemotingOptions.SERVER_NAME, null);
+    static final OptionAttributeDefinition SASL_PROTOCOL = createOptionAttribute("sasl-protocol", RemotingOptions.SASL_PROTOCOL, new ModelNode(RemotingOptions.DEFAULT_SASL_PROTOCOL));
+
+    static final OptionAttributeDefinition[] OPTIONS = new OptionAttributeDefinition[] {
+            SEND_BUFFER_SIZE, RECEIVE_BUFFER_SIZE, BUFFER_REGION_SIZE, TRANSMIT_WINDOW_SIZE, RECEIVE_WINDOW_SIZE,
+            MAX_OUTBOUND_CHANNELS, MAX_INBOUND_CHANNELS, AUTHORIZE_ID, AUTH_REALM, AUTHENTICATION_RETRIES, MAX_OUTBOUND_MESSAGES,
+            MAX_INBOUND_MESSAGES, HEARTBEAT_INTERVAL, MAX_INBOUND_MESSAGE_SIZE, MAX_OUTBOUND_MESSAGE_SIZE, SERVER_NAME, SASL_PROTOCOL
+    };
+
+    private static final String[] SERVER_ATTR_NAMES = new String[OPTIONS.length + 1];
+    static {
+        SERVER_ATTR_NAMES[0] = WORKER.getName();
+        for (int i = 0; i < OPTIONS.length; i++) {
+            SERVER_ATTR_NAMES[i + 1] = OPTIONS[i].getName();
+        }
+    }
+
     //The defaults for these come from XnioWorker
-    static final SimpleAttributeDefinition WORKER_READ_THREADS = createIntAttribute(CommonAttributes.WORKER_READ_THREADS, Attribute.WORKER_READ_THREADS, 1);
-    static final SimpleAttributeDefinition WORKER_TASK_CORE_THREADS = createIntAttribute(CommonAttributes.WORKER_TASK_CORE_THREADS, Attribute.WORKER_TASK_CORE_THREADS, 4);
-    static final SimpleAttributeDefinition WORKER_TASK_KEEPALIVE = createIntAttribute(CommonAttributes.WORKER_TASK_KEEPALIVE, Attribute.WORKER_TASK_KEEPALIVE, 60);
-    static final SimpleAttributeDefinition WORKER_TASK_LIMIT = createIntAttribute(CommonAttributes.WORKER_TASK_LIMIT, Attribute.WORKER_TASK_LIMIT, 0x4000);
-    static final SimpleAttributeDefinition WORKER_TASK_MAX_THREADS = createIntAttribute(CommonAttributes.WORKER_TASK_MAX_THREADS, Attribute.WORKER_TASK_MAX_THREADS, 16);
-    static final SimpleAttributeDefinition WORKER_WRITE_THREADS = createIntAttribute(CommonAttributes.WORKER_WRITE_THREADS, Attribute.WORKER_WRITE_THREADS, 1);
+    static final SimpleAttributeDefinition WORKER_READ_THREADS = createWorkerAttribute(CommonAttributes.WORKER_READ_THREADS, Attribute.WORKER_READ_THREADS, 1);
+    static final SimpleAttributeDefinition WORKER_TASK_CORE_THREADS = createWorkerAttribute(CommonAttributes.WORKER_TASK_CORE_THREADS, Attribute.WORKER_TASK_CORE_THREADS, 4);
+    static final SimpleAttributeDefinition WORKER_TASK_KEEPALIVE = createWorkerAttribute(CommonAttributes.WORKER_TASK_KEEPALIVE, Attribute.WORKER_TASK_KEEPALIVE, 60);
+    static final SimpleAttributeDefinition WORKER_TASK_LIMIT = createWorkerAttribute(CommonAttributes.WORKER_TASK_LIMIT, Attribute.WORKER_TASK_LIMIT, 0x4000);
+    static final SimpleAttributeDefinition WORKER_TASK_MAX_THREADS = createWorkerAttribute(CommonAttributes.WORKER_TASK_MAX_THREADS, Attribute.WORKER_TASK_MAX_THREADS, 16);
+    static final SimpleAttributeDefinition WORKER_WRITE_THREADS = createWorkerAttribute(CommonAttributes.WORKER_WRITE_THREADS, Attribute.WORKER_WRITE_THREADS, 1);
 
-    static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, RemotingExtension.SUBSYSTEM_NAME);
 
-    static AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[]{
+    static SimpleAttributeDefinition[] LEGACY_ATTRIBUTES = new SimpleAttributeDefinition[]{
             WORKER_READ_THREADS,
             WORKER_TASK_CORE_THREADS,
             WORKER_TASK_KEEPALIVE,
@@ -67,63 +125,132 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
             WORKER_WRITE_THREADS
     };
 
-    static final String IO_WORKER_CAPABILITY = "org.wildfly.io.worker";
-    static final RuntimeCapability<Void> REMOTING_ENDPOINT_CAPABILITY =
-            RuntimeCapability.Builder.of("org.wildfly.remoting.endpoint", Endpoint.class).build();
+    private static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, RemotingExtension.SUBSYSTEM_NAME);
 
-    public RemotingSubsystemRootResource() {
+    static ResourceDefinition create(ProcessType processType, boolean forDomain) {
+        return new RemotingSubsystemRootResource(new Attributes(processType, forDomain));
+    }
+
+    private final Attributes attributes;
+
+    private RemotingSubsystemRootResource(Attributes attributes) {
         super(new Parameters(PATH, RemotingExtension.getResourceDescriptionResolver(RemotingExtension.SUBSYSTEM_NAME))
-                .setAddHandler(RemotingSubsystemAdd.INSTANCE)
+                .setAddHandler(new RemotingSubsystemAdd(attributes))
                 .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
                 .setRemoveHandler(new ReloadRequiredRemoveStepHandler())
-                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES));
+                .setRemoveRestartLevel(OperationEntry.Flag.RESTART_ALL_SERVICES)
+                .setCapabilities(REMOTING_ENDPOINT_CAPABILITY)
+        );
+        this.attributes = attributes;
     }
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        for (final AttributeDefinition attribute : ATTRIBUTES) {
-            registerReadWriteIntAttribute(resourceRegistration, attribute);
+        if (attributes.legacy != null) {
+            OperationStepHandler threadWrites = new ModelOnlyWriteAttributeHandler(attributes.legacy);
+            for (final AttributeDefinition attribute : attributes.legacy) {
+                resourceRegistration.registerReadWriteAttribute(attribute, null, threadWrites);
+            }
+        }
+
+        resourceRegistration.registerReadWriteAttribute(attributes.worker, null, new WorkerAttributeWriteHandler());
+
+        OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(attributes.options);
+        for (final AttributeDefinition attribute: attributes.options) {
+            resourceRegistration.registerReadWriteAttribute(attribute, null, writeHandler);
         }
     }
 
-    private void registerReadWriteIntAttribute(ManagementResourceRegistration resourceRegistration, AttributeDefinition attr) {
-        resourceRegistration.registerReadWriteAttribute(attr, null, new ThreadWriteAttributeHandler(attr));
+    private static OptionAttributeDefinition createOptionAttribute(String name, Option<?> option, ModelNode defaultValue) {
+        OptionAttributeDefinition.Builder builder = OptionAttributeDefinition.builder(name, option)
+                .setAllowExpression(true)
+                .setAttributeGroup(ENDPOINT)
+                .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES);
+        if (defaultValue != null) {
+            builder = builder.setDefaultValue(defaultValue);
+        }
+        return builder.build();
     }
 
-    private static SimpleAttributeDefinition createIntAttribute(String name, Attribute attribute, int defaultValue) {
+    private static SimpleAttributeDefinition createWorkerAttribute(String name, Attribute attribute, int defaultValue) {
         return SimpleAttributeDefinitionBuilder.create(name, ModelType.INT, true)
                 .setDefaultValue(new ModelNode().set(defaultValue))
+                .setAlternatives(SERVER_ATTR_NAMES)
                 .setXmlName(attribute.getLocalName())
-                .setValidator(new IntRangeValidator(1, true))
+                .setValidator(new IntRangeValidator(1))
                 .setAllowExpression(true)
                 .setDeprecated(ModelVersion.create(2,0))
                 .build();
     }
 
-    @Override
-    public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerCapability(REMOTING_ENDPOINT_CAPABILITY);
+    private static class WorkerAttributeWriteHandler extends ReloadRequiredWriteAttributeHandler {
+
+        WorkerAttributeWriteHandler() {
+            super(WORKER);
+        }
+
+        @Override
+        protected void finishModelStage(OperationContext context, ModelNode operation, String attributeName, ModelNode newValue,
+                ModelNode oldValue, Resource model) throws OperationFailedException {
+            super.finishModelStage(context, operation, attributeName, newValue, oldValue, model);
+            context.addResponseWarning(Level.WARNING, RemotingLogger.ROOT_LOGGER.warningOnWorkerChange(newValue.asString()));
+        }
     }
 
-    private static class ThreadWriteAttributeHandler extends RestartParentWriteAttributeHandler {
+    static class Attributes {
+        final boolean forDomain;
+        private final AttributeDefinition[] legacy;
+        private final AttributeDefinition worker;
+        private final AttributeDefinition[] options;
+        final AttributeDefinition[] all;
 
-        ThreadWriteAttributeHandler(AttributeDefinition definition) {
-            super(CommonAttributes.SUBSYSTEM, definition);
+        private Attributes(ProcessType processType, boolean forDomain) {
+            this.forDomain = forDomain;
+            this.options = OPTIONS;
+            if (processType.isServer()) {
+                this.worker = WORKER;
+                this.legacy = new AttributeDefinition[LEGACY_ATTRIBUTES.length];
+                for (int i = 0; i < LEGACY_ATTRIBUTES.length; i++) {
+                    // Reject any defined value, but that means there can't be a default (as that gets validated)
+                    // Also, a default is incorrect on a server, as there really is no value
+                    this.legacy[i] = SimpleAttributeDefinitionBuilder.create(LEGACY_ATTRIBUTES[i])
+                            .setValidator(WorkerThreadValidator.INSTANCE)
+                            .setDefaultValue(null)
+                            .build();
+                }
+            } else if (forDomain) {
+                this.worker = SimpleAttributeDefinitionBuilder.create(WORKER).setCapabilityReference((CapabilityReferenceRecorder) null).build();
+                this.legacy = LEGACY_ATTRIBUTES;
+            } else {
+                this.worker = WORKER;
+                this.legacy = null;
+            }
+            int count = options.length + 1 + (legacy == null ? 0 : legacy.length);
+            all = new AttributeDefinition[count];
+            int idx = 0;
+            if (legacy != null) {
+                System.arraycopy(legacy, 0, all, 0, legacy.length);
+                idx += legacy.length;
+            }
+            all[idx] = worker;
+            System.arraycopy(options, 0, all, idx + 1, options.length);
+        }
+    }
+
+    private static class WorkerThreadValidator implements ParameterValidator {
+
+        private static final ParameterValidator INSTANCE = new WorkerThreadValidator();
+
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            if (value.isDefined()) {
+                throw RemotingLogger.ROOT_LOGGER.workerConfigurationIgnored();
+            }
         }
 
         @Override
-        protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel) throws OperationFailedException {
-            RemotingSubsystemAdd.INSTANCE.launchServices(context);
-        }
-
-        @Override
-        protected ServiceName getParentServiceName(PathAddress parentAddress) {
-            return RemotingServices.SUBSYSTEM_ENDPOINT;
-        }
-
-        @Override
-        protected void validateUpdatedModel(OperationContext context, Resource model) throws OperationFailedException {
-            context.addStep(WorkerThreadPoolVsEndpointHandler.INSTANCE, OperationContext.Stage.MODEL);
+        public void validateResolvedParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            validateParameter(parameterName, value);
         }
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemXMLPersister.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemXMLPersister.java
@@ -22,18 +22,33 @@
 
 package org.jboss.as.remoting;
 
+import static org.jboss.as.remoting.CommonAttributes.AUTHENTICATION_CONTEXT;
+import static org.jboss.as.remoting.CommonAttributes.CONNECTOR;
+import static org.jboss.as.remoting.CommonAttributes.HTTP_CONNECTOR;
+import static org.jboss.as.remoting.CommonAttributes.LOCAL_OUTBOUND_CONNECTION;
+import static org.jboss.as.remoting.CommonAttributes.OUTBOUND_CONNECTION;
+import static org.jboss.as.remoting.CommonAttributes.OUTBOUND_SOCKET_BINDING_REF;
+import static org.jboss.as.remoting.CommonAttributes.POLICY;
+import static org.jboss.as.remoting.CommonAttributes.PROPERTY;
+import static org.jboss.as.remoting.CommonAttributes.PROTOCOL;
+import static org.jboss.as.remoting.CommonAttributes.REMOTE_OUTBOUND_CONNECTION;
+import static org.jboss.as.remoting.CommonAttributes.SASL;
+import static org.jboss.as.remoting.CommonAttributes.SASL_POLICY;
+import static org.jboss.as.remoting.CommonAttributes.SECURITY;
+import static org.jboss.as.remoting.CommonAttributes.SECURITY_REALM;
+import static org.jboss.as.remoting.CommonAttributes.URI;
+
 import java.util.List;
 
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLElementWriter;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
-
-import static org.jboss.as.remoting.CommonAttributes.*;
 
 /**
  * Persister for remoting subsystem 3.0 version
@@ -133,7 +148,19 @@ class RemotingSubsystemXMLPersister implements XMLStreamConstants, XMLElementWri
     }
 
     private void writeEndpointIfAttributesSet(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {
-        RemotingSubsystem30Parser.ENDPOINT_PARSER.persist(writer, model);
+        boolean defined = false;
+        for (String adName : RemotingEndpointResource.ATTRIBUTES.keySet()) {
+            if (model.hasDefined(adName)) {
+                defined = true;
+                break;
+            }
+        }
+        if (defined) {
+            writer.writeEmptyElement(RemotingEndpointResource.ENDPOINT_PATH.getValue());
+            for (AttributeDefinition ad : RemotingEndpointResource.ATTRIBUTES.values()) {
+                ad.getMarshaller().marshallAsAttribute(ad, model, true, writer);
+            }
+        }
     }
 
     private void writeConnector(final XMLExtendedStreamWriter writer, final ModelNode node, final String name) throws XMLStreamException {

--- a/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
+++ b/remoting/subsystem/src/main/resources/org/jboss/as/remoting/LocalDescriptions.properties
@@ -13,15 +13,36 @@ remoting.worker-task-max-threads=The maximum number of threads for the remoting 
 remoting.worker-task-max-threads.deprecated=Use IO subsystem worker configuration
 remoting.worker-write-threads=The number of write threads to create for the remoting worker.
 remoting.worker-write-threads.deprecated=Use IO subsystem worker configuration
+remoting.authorize-id=The SASL authorization ID.  Used as authentication user name to use if no authentication CallbackHandler is specified\
+  and the selected SASL mechanism demands a user name.
+remoting.auth-realm=The authentication realm to use if no authentication CallbackHandler is specified.
+remoting.sasl-protocol=Where a SaslServer or SaslClient are created by default the protocol specified it 'remoting', this can be used to override this.
+remoting.max-outbound-message-size=The maximum outbound message size to send.  No messages larger than this well be transmitted; attempting to do so will cause an exception on the writing side.
+remoting.buffer-region-size=The size of allocated buffer regions.
+remoting.receive-buffer-size=The size of the largest buffer that this endpoint will accept over a connection.
+remoting.authentication-retries=Specify the number of times a client is allowed to retry authentication before closing the connection.
+remoting.transmit-window-size=The maximum window size of the transmit direction for connection channels, in bytes.
+remoting.max-outbound-messages=The maximum number of concurrent outbound messages on a channel.
+remoting.send-buffer-size=The size of the largest buffer that this endpoint will transmit over a connection.
+remoting.max-inbound-messages=The maximum number of concurrent inbound messages on a channel.
+remoting.receive-window-size=The maximum window size of the receive direction for connection channels, in bytes.
+remoting.heartbeat-interval=The interval to use for connection heartbeat, in milliseconds.  If the connection is idle in the outbound direction\
+  for this amount of time, a ping message will be sent, which will trigger a corresponding reply message.
+remoting.max-inbound-message-size=The maximum inbound message size to be allowed.  Messages exceeding this size will cause an exception to be thrown on the reading side as well as the writing side.
+remoting.max-outbound-channels=The maximum number of outbound channels to support for a connection.
+remoting.max-inbound-channels=The maximum number of inbound channels to support for a connection.
+remoting.server-name=The server side of the connection passes it's name to the client in the initial greeting, by default the name is automatically discovered from the local address of the connection or it can be overridden using this.
+remoting.worker=Worker to use
 
 remoting.connector=The remoting connectors.
 remoting.configuration=Configuration options
 endpoint=Endpoint configuration
 endpoint.add=Adds endpoint
 endpoint.remove=Removes endpoint configuration
-endpoint.authorize-id=The SASL authorization ID.  Used as authentication user name to use if no authentication {@code CallbackHandler} is specified\
+endpoint.deprecated=The child resource for configuring the remoting endpoint is deprecated. Use the attributes on the parent resource to configure the remoting endpoint.
+endpoint.authorize-id=The SASL authorization ID.  Used as authentication user name to use if no authentication CallbackHandler is specified\
   and the selected SASL mechanism demands a user name.
-endpoint.auth-realm=The authentication realm to use if no authentication {@code CallbackHandler} is specified.
+endpoint.auth-realm=The authentication realm to use if no authentication CallbackHandler is specified.
 endpoint.sasl-protocol=Where a SaslServer or SaslClient are created by default the protocol specified it 'remoting', this can be used to override this.
 endpoint.max-outbound-message-size=The maximum outbound message size to send.  No messages larger than this well be transmitted; attempting to do so will cause an exception on the writing side.
 endpoint.buffer-region-size=The size of allocated buffer regions.

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingLegacySubsystemTestCase.java
@@ -181,12 +181,11 @@ public class RemotingLegacySubsystemTestCase extends AbstractSubsystemBaseTest {
 
         ModelNode model = services.readWholeModel();
         ModelNode subsystem = model.require(SUBSYSTEM).require(RemotingExtension.SUBSYSTEM_NAME);
-        for (AttributeDefinition ad : RemotingSubsystemRootResource.ATTRIBUTES) {
-            ModelNode dflt = ad.getDefaultValue();
-            assertEquals(ad.getName(), dflt == null ? new ModelNode() : dflt, subsystem.require(ad.getName()));
+        for (AttributeDefinition ad : RemotingSubsystemRootResource.LEGACY_ATTRIBUTES) {
+            assertFalse(ad.getName(), subsystem.hasDefined(ad.getName()));
         }
         ModelNode endpoint = subsystem.get(RemotingEndpointResource.ENDPOINT_PATH.getKey(), RemotingEndpointResource.ENDPOINT_PATH.getValue());
-        for (AttributeDefinition ad : RemotingEndpointResource.ATTRIBUTES) {
+        for (AttributeDefinition ad : RemotingEndpointResource.ATTRIBUTES.values()) {
             ModelNode dflt = ad.getDefaultValue();
             assertEquals(ad.getName(), dflt == null ? new ModelNode() : dflt, endpoint.require(ad.getName()));
         }
@@ -336,7 +335,7 @@ public class RemotingLegacySubsystemTestCase extends AbstractSubsystemBaseTest {
                     RemotingSubsystemTestUtil.registerIOExtension(extensionRegistry, rootRegistration);
                 } else {
                     capabilities.put(buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
-                            RemotingEndpointResource.WORKER.getDefaultValue().asString()), XnioWorker.class);
+                            RemotingSubsystemRootResource.WORKER.getDefaultValue().asString()), XnioWorker.class);
                 }
 
                 AdditionalInitialization.registerServiceCapabilities(capabilityRegistry, capabilities);

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestCase.java
@@ -22,18 +22,32 @@
 package org.jboss.as.remoting;
 
 import static org.jboss.as.controller.capability.RuntimeCapability.buildDynamicCapabilityName;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_DEFAULTS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.remoting.RemotingSubsystemTestUtil.DEFAULT_ADDITIONAL_INITIALIZATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
-
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.AbsolutePathService;
@@ -42,6 +56,7 @@ import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
 import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
@@ -57,6 +72,30 @@ import org.xnio.XnioWorker;
  * @author Tomaz Cerar
  */
 public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
+
+    private static final PathAddress ROOT_ADDRESS = PathAddress.pathAddress(SUBSYSTEM, RemotingExtension.SUBSYSTEM_NAME);
+    private static final PathAddress ENDPOINT_CONFIG_ADDRESS = ROOT_ADDRESS.append("configuration", "endpoint");
+    private static final Map<String, ModelNode> ENDPOINT_CONFIG_TEST_DATA;
+    static {
+        Map<String, ModelNode> data = new LinkedHashMap<>();
+        data.put("worker", new ModelNode("default-remoting"));
+        for (AttributeDefinition ad : RemotingSubsystemRootResource.OPTIONS) {
+            switch (ad.getType()) {
+                case INT:
+                    data.put(ad.getName(), new ModelNode(1));
+                    break;
+                case LONG:
+                    data.put(ad.getName(), new ModelNode(1L));
+                    break;
+                case STRING:
+                    data.put(ad.getName(), new ModelNode("abc"));
+                    break;
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+        ENDPOINT_CONFIG_TEST_DATA = data;
+    }
 
     public RemotingSubsystemTestCase() {
         super(RemotingExtension.SUBSYSTEM_NAME, new RemotingExtension());
@@ -123,6 +162,126 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
         super.testSchemaOfSubsystemTemplates();
     }
 
+    /**
+     * WFCORE-3327. Use the management API to add the subsystem, with the endpoint configuration done via
+     * the deprecated /subsystem=remoting/configuration=endpoint resource.
+     */
+    @Test
+    public void testEndpointConfigurationViaDeprecatedChild() throws Exception {
+        KernelServices services = createKernelServicesBuilder(createAdditionalInitialization())
+                .build();
+
+        // First, just the root resource with the endpoint unconfigured
+        ModelNode rootAdd = Util.createAddOperation(ROOT_ADDRESS);
+        services.executeForResult(rootAdd);
+        checkEndpointSettings(services, Collections.emptyMap(), true);
+
+        // Now, add the child resource with no config.
+        ModelNode childAdd = Util.createAddOperation(ENDPOINT_CONFIG_ADDRESS);
+        services.executeForResult(childAdd);
+        checkEndpointSettings(services, Collections.emptyMap(), true);
+
+        // Now add the child resource (which will work as it's forgiving) with new config
+        childAdd = Util.createAddOperation(ENDPOINT_CONFIG_ADDRESS);
+        for (Map.Entry<String, ModelNode> entry : ENDPOINT_CONFIG_TEST_DATA.entrySet()) {
+            childAdd.get(entry.getKey()).set(entry.getValue());
+        }
+        services.executeForResult(childAdd);
+        checkEndpointSettings(services, ENDPOINT_CONFIG_TEST_DATA, true);
+
+        // Remove all so we can start over
+        services.executeForResult(Util.createRemoveOperation(ROOT_ADDRESS));
+
+        // Do the adds via a composite
+        ModelNode composite = Util.createEmptyOperation(COMPOSITE, PathAddress.EMPTY_ADDRESS);
+        composite.get(STEPS).add(rootAdd);
+        composite.get(STEPS).add(childAdd);
+        services.executeForResult(composite);
+        checkEndpointSettings(services, ENDPOINT_CONFIG_TEST_DATA, true);
+
+        // Do an undefine-attribute for all children
+        for (String attr : ENDPOINT_CONFIG_TEST_DATA.keySet()) {
+            ModelNode op = Util.createEmptyOperation(UNDEFINE_ATTRIBUTE_OPERATION, ENDPOINT_CONFIG_ADDRESS);
+            op.get(NAME).set(attr);
+            services.executeForResult(op);
+        }
+        checkEndpointSettings(services, Collections.emptyMap(), false);
+
+        // Do a write-attribute for all children
+        for (Map.Entry<String, ModelNode> attr : ENDPOINT_CONFIG_TEST_DATA.entrySet()) {
+            ModelNode op = Util.getWriteAttributeOperation(ENDPOINT_CONFIG_ADDRESS, attr.getKey(), attr.getValue());
+            services.executeForResult(op);
+        }
+        checkEndpointSettings(services, ENDPOINT_CONFIG_TEST_DATA, false);
+
+        // Remove the child config
+        services.executeForResult(Util.createRemoveOperation(ENDPOINT_CONFIG_ADDRESS));
+        checkEndpointSettings(services, Collections.emptyMap(), false);
+    }
+
+    /**
+     * WFCORE-3327. Use the management API to add the subsystem, with the endpoint configuration done via
+     * the root /subsystem=remoting resource.
+     */
+    @Test
+    public void testEndpointConfigurationViaSubsystemRoot() throws Exception {
+        KernelServices services = createKernelServicesBuilder(createAdditionalInitialization())
+                .build();
+
+        // Add the root resource with the endpoint configured
+        ModelNode rootAdd = Util.createAddOperation(ROOT_ADDRESS);
+        for (Map.Entry<String, ModelNode> entry : ENDPOINT_CONFIG_TEST_DATA.entrySet()) {
+            rootAdd.get(entry.getKey()).set(entry.getValue());
+        }
+        services.executeForResult(rootAdd);
+        checkEndpointSettings(services, ENDPOINT_CONFIG_TEST_DATA, true);
+
+        // Do an undefine-attribute for all children
+        for (String attr : ENDPOINT_CONFIG_TEST_DATA.keySet()) {
+            ModelNode op = Util.createEmptyOperation(UNDEFINE_ATTRIBUTE_OPERATION, ROOT_ADDRESS);
+            op.get(NAME).set(attr);
+            services.executeForResult(op);
+        }
+        checkEndpointSettings(services, Collections.emptyMap(), false);
+
+        // Do a write-attribute for all children
+        for (Map.Entry<String, ModelNode> attr : ENDPOINT_CONFIG_TEST_DATA.entrySet()) {
+            ModelNode op = Util.getWriteAttributeOperation(ROOT_ADDRESS, attr.getKey(), attr.getValue());
+            services.executeForResult(op);
+        }
+        checkEndpointSettings(services, ENDPOINT_CONFIG_TEST_DATA, false);
+    }
+
+    private static void checkEndpointSettings(KernelServices services, Map<String, ModelNode> nonDefaults, boolean expectDefaults) throws OperationFailedException {
+        // Check the root
+        ModelNode readResource = Util.createEmptyOperation(READ_RESOURCE_OPERATION, ROOT_ADDRESS);
+        readResource.get(RECURSIVE).set(true);
+        readResource.get(INCLUDE_DEFAULTS).set(expectDefaults);
+        ModelNode result = services.executeForResult(readResource);
+        checkEndpointSettings(result, nonDefaults, expectDefaults);
+
+        // Check the child returned recursively
+        assertTrue(result.toString(), result.hasDefined("configuration", "endpoint"));
+        checkEndpointSettings(result.get("configuration", "endpoint"), nonDefaults, expectDefaults);
+
+        // Check the child independently read
+        readResource = Util.createEmptyOperation(READ_RESOURCE_OPERATION, ENDPOINT_CONFIG_ADDRESS);
+        readResource.get(INCLUDE_DEFAULTS).set(expectDefaults);
+        result = services.executeForResult(readResource);
+        checkEndpointSettings(result, nonDefaults, expectDefaults);
+    }
+
+    private static void checkEndpointSettings(ModelNode node, Map<String, ModelNode> nonDefaults, boolean expectDefaults) {
+        for (AttributeDefinition ad : RemotingEndpointResource.ATTRIBUTES.values()) {
+            ModelNode correct = nonDefaults.get(ad.getName());
+            if (expectDefaults) {
+                correct = correct == null ? ad.getDefaultValue() : correct;
+            }
+            correct = correct == null ? new ModelNode() : correct;
+            assertEquals(node.toString() + " wrong for " + ad.getName(), correct, node.get(ad.getName()));
+        }
+    }
+
     @Override
     protected String getSubsystemXml(String resource) throws IOException {
         return readResource(resource);
@@ -178,7 +337,7 @@ public class RemotingSubsystemTestCase extends AbstractSubsystemBaseTest {
                 super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration, capabilityRegistry);
                 Map<String, Class> capabilities = new HashMap<>();
                 capabilities.put(buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
-                        RemotingEndpointResource.WORKER.getDefaultValue().asString()), XnioWorker.class);
+                        RemotingSubsystemRootResource.WORKER.getDefaultValue().asString()), XnioWorker.class);
                 capabilities.put(buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
                         "default-remoting"), XnioWorker.class);
                 AdditionalInitialization.registerServiceCapabilities(capabilityRegistry, capabilities);

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestUtil.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTestUtil.java
@@ -52,7 +52,7 @@ class RemotingSubsystemTestUtil {
     static final AdditionalInitialization DEFAULT_ADDITIONAL_INITIALIZATION =
             AdditionalInitialization.withCapabilities(
                     buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY,
-                    RemotingEndpointResource.WORKER.getDefaultValue().asString()),
+                    RemotingSubsystemRootResource.WORKER.getDefaultValue().asString()),
                     // This one is specified in one of the test configs
                     buildDynamicCapabilityName(RemotingSubsystemRootResource.IO_WORKER_CAPABILITY, "default-remoting"),
                     buildDynamicCapabilityName("org.wildfly.network.outbound-socket-binding", "dummy-outbound-socket"),

--- a/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
+++ b/remoting/tests/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
@@ -63,6 +63,8 @@ import org.junit.Test;
  */
 public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemTest {
 
+    private static final AttributeDefinition[] ENDPOINT_ATTRS = RemotingEndpointResource.ATTRIBUTES.values().toArray(new AttributeDefinition[RemotingEndpointResource.ATTRIBUTES.size()]);
+
     public RemotingSubsystemTransformersTestCase() {
         super(RemotingExtension.SUBSYSTEM_NAME, new RemotingExtension());
     }
@@ -139,10 +141,10 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemTest
         List<ModelNode> ops = builder.parseXmlResource("remoting.xml");
         PathAddress subsystemAddress = PathAddress.pathAddress("subsystem", RemotingExtension.SUBSYSTEM_NAME);
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, targetModelVersion, ops, new FailedOperationTransformationConfig()
+                .addFailedAttribute(subsystemAddress,
+                        new FailedOperationTransformationConfig.NewAttributesConfig(ENDPOINT_ATTRS))
                 .addFailedAttribute(subsystemAddress.append(RemotingEndpointResource.ENDPOINT_PATH),
-                        new FailedOperationTransformationConfig.NewAttributesConfig(
-                                RemotingEndpointResource.ATTRIBUTES.toArray(new AttributeDefinition[RemotingEndpointResource.ATTRIBUTES.size()])
-                        ))
+                        new FailedOperationTransformationConfig.NewAttributesConfig(ENDPOINT_ATTRS))
                 .addFailedAttribute(subsystemAddress.append(ConnectorResource.PATH),
                         new FailedOperationTransformationConfig.NewAttributesConfig(
                                 ConnectorCommon.SASL_AUTHENTICATION_FACTORY,
@@ -231,7 +233,7 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemTest
         operation.get(OP).set(UNDEFINE_ATTRIBUTE_OPERATION);
         ModelNode address = operation.get(OP_ADDR);
         address.add(SUBSYSTEM, RemotingExtension.SUBSYSTEM_NAME);
-        for (AttributeDefinition ad : RemotingSubsystemRootResource.ATTRIBUTES) {
+        for (AttributeDefinition ad : RemotingSubsystemRootResource.LEGACY_ATTRIBUTES) {
             operation.get(NAME).set(ad.getName());
             ModelNode mainResult = mainServices.executeOperation(operation);
             assertEquals(mainResult.toJSONString(true), SUCCESS, mainResult.get(OUTCOME).asString());
@@ -243,7 +245,7 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemTest
         address.add(SUBSYSTEM, RemotingExtension.SUBSYSTEM_NAME);
         address.add(RemotingEndpointResource.ENDPOINT_PATH.getKey(), RemotingEndpointResource.ENDPOINT_PATH.getValue());
         operation.get(OP_ADDR).set(address);
-        for (AttributeDefinition ad : RemotingEndpointResource.ATTRIBUTES) {
+        for (AttributeDefinition ad : RemotingEndpointResource.ATTRIBUTES.values()) {
             ModelNode dflt = ad.getDefaultValue();
             if (dflt != null) {
                 operation.get(ad.getName()).set(dflt);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3327

Also includes required fix to 

https://issues.jboss.org/browse/WFCORE-3332

The /subsystem=remoting resource always installs an endpoint. It has a configuration=endpoint child resource that lets the user configure the endpoint, but even if not configured, the endpoint is installed, and with a lot of default values used. If the user doesn't add the configuration=endpoint child, the parent adds it anyway. There are a lot of problems with this:

1) The child resource does not provide any services but is only used to configure services provided by its parent. This is a fairly common pattern, but it's suboptimal.

2) The child resource is kind of a "default value" for its parent, providing config data even if not added by the user, in a similar way to how an attribute can have a default value if the user doesn't define it. But in the attribute case, the resource description data clearly describes this. But there is no such description mechanism for this "default value resource" concept.

3) The endpoint is capability, but the child configures a requirement. This relationship is completely obscured due to this "default value" resource usage. That's a problem for the new provisioning tooling.

This PR corrects this by 

1) Moving all the endpoint config attributes to the parent resource.
2) Adding necessary mixed domain transformers
3) Maintaining compatibility converting the configuration=endpoint child resource into a kind of proxy to the relevant attributes exposed by the parent.

There's a fair bit of side complexity, due to the fact that:

a) the 'worker' attribute is a capability reference, but for mixed domain compatibity reasons it can't register a requirement when in a /profile tree.
b) there are some 'worker-thread' attributes on the parent that only exist for mixed domain support of EAP 6.4.

The handling of these points has been adjusted to better fit with the new code.
