### PR TITLE
[WFCORE-3311] Initialize the log manager early for the CLIEmbededServ…

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
@@ -117,6 +117,10 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
 
+        // Initialize the log manager before the STDIO context is initialized. This ensures that any capturing of the
+        // standard output streams in the log manager is done before they are replaced by the stdio context.
+        Class.forName("org.jboss.logmanager.LogManager", true, CLIEmbedServerTestCase.class.getClassLoader());
+
         CLIEmbedUtil.copyConfig(ROOT, "standalone", "logging.properties", "logging.properties.backup", false);
 
         // Set up ability to manipulate stdout


### PR DESCRIPTION
…erTestCase to ensure early initialization doesn't break replacing stdout.

https://issues.jboss.org/browse/WFCORE-3311

In the `org.jboss.logmanager:jboss-logmanager:2.1.0.Alpha4` `System.out` and `System.err` were captured too and used in the `ConsoleHandler`. This caused issues with embedded server logging output even if `--stdout=discard` was set. The test passed because the `StdioContext` was initialized before the log manager. Initializing the log manager before the `StdioContext` allows the log manager to capture `System.out` and `System.err` before it's been replaced.