### PR TITLE
[WFCORE-3343] / [WFCORE-3346] WildFly Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <version.org.wildfly.openssl>1.0.2.Final</version.org.wildfly.openssl>
         <version.org.wildfly.legacy.test>2.0.3.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.security.elytron>1.1.4.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron.tool>1.0.1.Final</version.org.wildfly.security.elytron.tool>
+        <version.org.wildfly.security.elytron.tool>1.0.2.Final</version.org.wildfly.security.elytron.tool>
         <version.org.wildfly.security.elytron-web.undertow-server>1.0.1.Final</version.org.wildfly.security.elytron-web.undertow-server>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
         <!-- Non-default maven plugin versions and configuration -->

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <version.org.wildfly.discovery>1.0.0.Final</version.org.wildfly.discovery>
         <version.org.wildfly.openssl>1.0.2.Final</version.org.wildfly.openssl>
         <version.org.wildfly.legacy.test>2.0.3.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.security.elytron>1.1.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.1.4.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron.tool>1.0.1.Final</version.org.wildfly.security.elytron.tool>
         <version.org.wildfly.security.elytron-web.undertow-server>1.0.1.Final</version.org.wildfly.security.elytron-web.undertow-server>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->


### PR DESCRIPTION
https://github.com/wildfly/wildfly-core/pull/2876

:exclamation: The WildFly Elytron Tool component upgrade is only included here so it can include the next .Final tag of WildFly Elytron, as the upstream PR only updates to a Beta version of WildFly Elytron no tool update is within the upstream PR.

https://issues.jboss.org/browse/WFCORE-3343
https://issues.jboss.org/browse/WFCORE-3346