### PR TITLE
WFCORE-3041 helper for WFCORE-2882

### DIFF
--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -203,6 +203,7 @@
                                 <include>*.xml</include>
                             </includes>
                             <excludes>
+                                <exclude>*-1.*.xml</exclude>
                                 <exclude>custom-policies.xml</exclude>
                                 <exclude>jacc-with-providers.xml</exclude>
                             </excludes>

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser.java
@@ -95,7 +95,7 @@ class ElytronSubsystemParser implements XMLElementReader<List<ModelNode>>, XMLEl
     private final HttpParser httpParser = new HttpParser(this);
     private final CredentialStoreParser credentialStoreParser = new CredentialStoreParser(this);
     private final DirContextParser dirContextParser = new DirContextParser(this);
-    private final PolicyParser policyParser = new PolicyParser(this);
+    private final PolicyParserTemp policyParser = new PolicyParserTemp(this);
     private final String namespace;
     private final MapperParser mapperParser;
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/PolicyDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PolicyDefinitions.java
@@ -22,6 +22,7 @@ import static org.wildfly.extension.elytron.Capabilities.JACC_POLICY_RUNTIME_CAP
 import static org.wildfly.extension.elytron.Capabilities.POLICY_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_POLICY;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.JACC_POLICY;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.NAME;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.POLICY;
 
 import java.security.AccessController;
@@ -101,7 +102,8 @@ class PolicyDefinitions {
             .setMinSize(1)
             .build();
 
-    private static final SimpleAttributeDefinition DEFAULT_POLICY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.DEFAULT_POLICY, ModelType.STRING)
+    // TODO make private once PolicyParser is deleted
+    static final SimpleAttributeDefinition DEFAULT_POLICY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.DEFAULT_POLICY, ModelType.STRING)
             .setRequired(false)
             .setCorrector(new ParameterCorrector() {
                 @Override
@@ -115,6 +117,7 @@ class PolicyDefinitions {
             .build();
 
     static class JaccPolicyDefinition {
+        static final SimpleAttributeDefinition NAME = RESOURCE_NAME; // TODO Remove this once PolicyParser is deleted
         static final SimpleAttributeDefinition POLICY_PROVIDER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.POLICY, ModelType.STRING, true)
                 .setDefaultValue(new ModelNode(JaccDelegatingPolicy.class.getName()))
                 .setMinSize(1)
@@ -132,6 +135,7 @@ class PolicyDefinitions {
     }
 
     static class CustomPolicyDefinition {
+        static final SimpleAttributeDefinition NAME = RESOURCE_NAME; // TODO Remove this once PolicyParser is deleted
         static final SimpleAttributeDefinition CLASS_NAME = ClassLoadingAttributeDefinitions.CLASS_NAME;
         static final SimpleAttributeDefinition MODULE = ClassLoadingAttributeDefinitions.MODULE;
         static final ObjectTypeAttributeDefinition POLICY = new ObjectTypeAttributeDefinition.Builder(ElytronDescriptionConstants.CUSTOM_POLICY, CLASS_NAME, MODULE)
@@ -552,6 +556,9 @@ class PolicyDefinitions {
             if (newValue.getType() == ModelType.LIST && newValue.asInt() == 1) {
                 // extract the single element
                 result = newValue.get(0);
+                if (result.has(NAME)) {
+                    result.remove(NAME);
+                }
             }
             return result;
         }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/PolicyParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PolicyParser.java
@@ -35,26 +35,20 @@ import static org.wildfly.extension.elytron.ElytronDescriptionConstants.JACC_POL
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.MODULE;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.NAME;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.POLICY;
-import static org.wildfly.extension.elytron.ElytronExtension.NAMESPACE_1_0;
-import static org.wildfly.extension.elytron.ElytronExtension.NAMESPACE_1_1;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import javax.xml.stream.XMLStreamException;
 
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
 import org.wildfly.extension.elytron.PolicyDefinitions.CustomPolicyDefinition;
 import org.wildfly.extension.elytron.PolicyDefinitions.JaccPolicyDefinition;
-import org.wildfly.extension.elytron._private.ElytronSubsystemMessages;
 
 /**
  * A parser for the security realm definition.
@@ -64,7 +58,6 @@ import org.wildfly.extension.elytron._private.ElytronSubsystemMessages;
 class PolicyParser {
 
     private final ElytronSubsystemParser elytronSubsystemParser;
-    private volatile PersistentResourceXMLDescription description;
 
     PolicyParser(ElytronSubsystemParser elytronSubsystemParser) {
         this.elytronSubsystemParser = elytronSubsystemParser;
@@ -74,29 +67,7 @@ class PolicyParser {
         elytronSubsystemParser.verifyNamespace(reader);
     }
 
-    private PersistentResourceXMLDescription getXmlDescription() {
-        if (description == null) {
-            String namespace = elytronSubsystemParser.getNamespace();
-            if (!namespace.equals(NAMESPACE_1_0) && !namespace.equals(NAMESPACE_1_1)) {
-                description = PersistentResourceXMLDescription.builder(PathElement.pathElement(POLICY))
-                        .addAttribute(JaccPolicyDefinition.POLICY)
-                        .addAttribute(CustomPolicyDefinition.POLICY)
-                        .build();
-            }
-        }
-        return description;
-    }
-
     void readPolicy(ModelNode parentAddress, XMLExtendedStreamReader reader, List<ModelNode> operations) throws XMLStreamException {
-        PersistentResourceXMLDescription xmlDescription = getXmlDescription();
-        if (xmlDescription == null) {
-            readPolicyLegacy(parentAddress, reader, operations);
-        } else {
-            description.parse(reader, PathAddress.pathAddress(parentAddress), operations);
-        }
-    }
-
-    private void readPolicyLegacy(ModelNode parentAddress, XMLExtendedStreamReader reader, List<ModelNode> operations) throws XMLStreamException {
         ModelNode addPolicy = new ModelNode();
 
         addPolicy.get(OP).set(ADD);
@@ -112,10 +83,7 @@ class PolicyParser {
                 String attribute = reader.getAttributeLocalName(i);
                 switch (attribute) {
                     case DEFAULT_POLICY:
-                        // Use an AD to validate the resource name, but don't add the value to the op
-                        // It's just the value in the resource address
-                        ModelNode placeholder = new ModelNode().setEmptyObject();
-                        PolicyDefinitions.RESOURCE_NAME.parseAndSetParameter(value, placeholder, reader);
+                        PolicyDefinitions.DEFAULT_POLICY.parseAndSetParameter(value, addPolicy, reader);
                         defaultPolicy = value;
                         break;
                     default:
@@ -124,59 +92,38 @@ class PolicyParser {
             }
         }
 
-        if (defaultPolicy == null) {
-            throw missingRequired(reader, DEFAULT_POLICY);
-        }
-
-        boolean providerFound = false;
+        boolean providerFound = defaultPolicy == null;
 
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             verifyNamespace(reader);
             String localName = reader.getLocalName();
             switch (localName) {
                 // Permission Mapper
-                case JACC_POLICY: {
-                    ModelNode providerModel = new ModelNode().setEmptyObject();
-                    String policyName = parseJaccPolicy(providerModel, reader);
-                    if (!providerFound && defaultPolicy.equals(policyName)) {
-                        providerFound = true;
-                        addPolicy.get(JACC_POLICY).set(providerModel);
-                    }  else {
-                        //ignore it but don't reject it as the xsd says it's allowed
-                        // But log a WARN to help notify the user
-                        ElytronSubsystemMessages.ROOT_LOGGER.discardingUnusedPolicy(JACC_POLICY, NAME, policyName);
-                    }
+                case JACC_POLICY:
+                    String jaccPolicy = parseJaccPolicy(addPolicy, reader, operations);
+                    providerFound = providerFound || defaultPolicy.equals(jaccPolicy);
                     break;
-                }
-                case CUSTOM_POLICY: {
-                    ModelNode providerModel = new ModelNode().setEmptyObject();
-                    String policyName = parseCustomPolicy(providerModel, reader);
-                    if (!providerFound && defaultPolicy.equals(policyName)) {
-                        providerFound = true;
-                        addPolicy.get(CUSTOM_POLICY).set(providerModel);
-                    } else {
-                        // ignore it but don't reject it as the xsd says it's allowed.
-                        // But log a WARN to help notify the user
-                        ElytronSubsystemMessages.ROOT_LOGGER.discardingUnusedPolicy(CUSTOM_POLICY, NAME, policyName);
-                    }
+                case CUSTOM_POLICY:
+                    String customPolicy = parseCustomPolicy(addPolicy, reader, operations);
+                    providerFound = providerFound || defaultPolicy.equals(customPolicy);
                     break;
-                }
                 default:
                     throw unexpectedElement(reader);
             }
         }
 
         if (!providerFound) {
-            throw ElytronSubsystemMessages.ROOT_LOGGER.cannotFindPolicyProvider(defaultPolicy, reader.getLocation());
+            throw missingRequired(reader, DEFAULT_POLICY);
         }
 
         addPolicy.get(OP_ADDR).set(parentAddress).add(POLICY, defaultPolicy);
         operations.add(addPolicy);
     }
 
-    private String parseJaccPolicy(ModelNode providerModel, XMLExtendedStreamReader reader)
+    private String parseJaccPolicy(ModelNode policyModel, XMLExtendedStreamReader reader, List<ModelNode> operations)
             throws XMLStreamException {
-        Set<String> requiredAttributes = new HashSet<>(Collections.singletonList(NAME));
+        ModelNode providerModel = new ModelNode();
+        Set<String> requiredAttributes = new HashSet<>(Arrays.asList(new String[] { NAME }));
         String name = null;
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -189,6 +136,7 @@ class PolicyParser {
                 switch (attribute) {
                     case NAME:
                         name = value;
+                        JaccPolicyDefinition.NAME.parseAndSetParameter(value, providerModel, reader);
                         break;
                     case POLICY:
                         JaccPolicyDefinition.POLICY_PROVIDER.parseAndSetParameter(value, providerModel, reader);
@@ -211,12 +159,21 @@ class PolicyParser {
 
         requireNoContent(reader);
 
+        ModelNode policies = policyModel.get(JACC_POLICY);
+
+        if (!policies.isDefined()) {
+            policies.setEmptyList();
+        }
+
+        policies.add(providerModel);
+
         return name;
     }
 
-    private String parseCustomPolicy(ModelNode providerModel, XMLExtendedStreamReader reader)
+    private String parseCustomPolicy(ModelNode policyModel, XMLExtendedStreamReader reader, List<ModelNode> operations)
             throws XMLStreamException {
-        Set<String> requiredAttributes = new HashSet<>(Arrays.asList(NAME, CLASS_NAME));
+        ModelNode providerModel = new ModelNode();
+        Set<String> requiredAttributes = new HashSet<>(Arrays.asList(new String[] { NAME, CLASS_NAME }));
         String name = null;
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -229,6 +186,7 @@ class PolicyParser {
                 switch (attribute) {
                     case NAME:
                         name = value;
+                        CustomPolicyDefinition.NAME.parseAndSetParameter(value, providerModel, reader);
                         break;
                     case CLASS_NAME:
                         CustomPolicyDefinition.CLASS_NAME.parseAndSetParameter(value, providerModel, reader);
@@ -248,15 +206,89 @@ class PolicyParser {
 
         requireNoContent(reader);
 
+        ModelNode policies = policyModel.get(CUSTOM_POLICY);
+
+        if (!policies.isDefined()) {
+            policies.setEmptyList();
+        }
+
+        policies.add(providerModel);
+
         return name;
     }
 
     void writePolicy(ModelNode subsystem, XMLExtendedStreamWriter writer) throws XMLStreamException {
-        PersistentResourceXMLDescription xmlDescription = getXmlDescription();
-        if (xmlDescription == null) {
-            throw new UnsupportedOperationException();
-        } else {
-            xmlDescription.persist(writer, subsystem);
+        if (!subsystem.hasDefined(POLICY)) {
+            return;
+        }
+
+        Property policy = subsystem.get(POLICY).asProperty();
+        String defaultPolicy = policy.getName();
+        ModelNode policyModel = policy.getValue();
+
+        if (policyModel.get(DEFAULT_POLICY).isDefined()) {
+            defaultPolicy = policyModel.get(DEFAULT_POLICY).asString();
+        }
+
+        boolean mappersStarted = false;
+
+        mappersStarted = mappersStarted | writeJaccPolicy(mappersStarted, defaultPolicy, policyModel, writer);
+        mappersStarted = mappersStarted | writeCustomPolicy(mappersStarted, defaultPolicy, policyModel, writer);
+
+        if (mappersStarted) {
+            writer.writeEndElement();
+        }
+    }
+
+    private boolean writeJaccPolicy(boolean started, String defaultPolicy, ModelNode subsystem, XMLExtendedStreamWriter writer) throws XMLStreamException {
+        if (subsystem.hasDefined(JACC_POLICY)) {
+            ModelNode jaccPolicies = subsystem.get(JACC_POLICY);
+
+            startPolicy(started, defaultPolicy, subsystem, writer);
+
+            for (ModelNode jaccPolicy : jaccPolicies.asList()) {
+                writer.writeStartElement(JACC_POLICY);
+
+                JaccPolicyDefinition.NAME.marshallAsAttribute(jaccPolicy, writer);
+                JaccPolicyDefinition.POLICY_PROVIDER.marshallAsAttribute(jaccPolicy, writer);
+                JaccPolicyDefinition.CONFIGURATION_FACTORY.marshallAsAttribute(jaccPolicy, writer);
+                JaccPolicyDefinition.MODULE.marshallAsAttribute(jaccPolicy, writer);
+
+                writer.writeEndElement();
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean writeCustomPolicy(boolean started, String defaultPolicy, ModelNode subsystem, XMLExtendedStreamWriter writer) throws XMLStreamException {
+        if (subsystem.hasDefined(CUSTOM_POLICY)) {
+            ModelNode jaccPolicies = subsystem.get(CUSTOM_POLICY);
+
+            startPolicy(started, defaultPolicy, subsystem, writer);
+
+            for (ModelNode customPolicy : jaccPolicies.asList()) {
+                writer.writeStartElement(CUSTOM_POLICY);
+
+                CustomPolicyDefinition.NAME.marshallAsAttribute(customPolicy, writer);
+                CustomPolicyDefinition.CLASS_NAME.marshallAsAttribute(customPolicy, writer);
+                CustomPolicyDefinition.MODULE.marshallAsAttribute(customPolicy, writer);
+
+                writer.writeEndElement();
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private void startPolicy(boolean started, String defaultPolicy, ModelNode policyModel, XMLExtendedStreamWriter writer) throws XMLStreamException {
+        if (started == false) {
+            writer.writeStartElement(POLICY);
+            writer.writeAttribute(DEFAULT_POLICY, defaultPolicy);
         }
     }
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/PolicyParserTemp.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PolicyParserTemp.java
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.wildfly.extension.elytron;
+
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CUSTOM_POLICY;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.DEFAULT_POLICY;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.JACC_POLICY;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.POLICY;
+import static org.wildfly.extension.elytron.ElytronExtension.NAMESPACE_1_0;
+import static org.wildfly.extension.elytron.ElytronExtension.NAMESPACE_1_1;
+
+import java.util.List;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.AttributeParsers;
+import org.jboss.as.controller.ObjectListAttributeDefinition;
+import org.jboss.as.controller.ObjectTypeAttributeDefinition;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+ * Temporary replacement for PolicyParser so the WFCORE-2882 work can be applied
+ * with minimal conflicts.
+ *
+ * @author Brian Stansberry
+ */
+class PolicyParserTemp  {
+
+    private final PersistentResourceXMLDescription policyParser = PersistentResourceXMLDescription.builder(PathElement.pathElement(POLICY))
+            .addAttribute(PolicyDefinitions.JaccPolicyDefinition.POLICY)
+            .addAttribute(PolicyDefinitions.CustomPolicyDefinition.POLICY)
+            .build();
+
+    private final PersistentResourceXMLDescription legacyPolicyParser = PersistentResourceXMLDescription.builder(PathElement.pathElement(POLICY))
+            .setNameAttributeName(DEFAULT_POLICY)
+            .addAttribute(new ObjectListAttributeDefinition.Builder(JACC_POLICY,
+                    new ObjectTypeAttributeDefinition.Builder(JACC_POLICY,
+                            PolicyDefinitions.RESOURCE_NAME,
+                            PolicyDefinitions.JaccPolicyDefinition.POLICY_PROVIDER,
+                            PolicyDefinitions.JaccPolicyDefinition.CONFIGURATION_FACTORY,
+                            PolicyDefinitions.JaccPolicyDefinition.MODULE)
+                            .build())
+                    .setRequired(false)
+                    .setMaxSize(1) // xsd says > 1 is ok, but the resource will reject that, so might as well reject in the parser
+                    .setAttributeParser(AttributeParsers.UNWRAPPED_OBJECT_LIST_PARSER)
+                    .build())
+            .addAttribute(new ObjectListAttributeDefinition.Builder(CUSTOM_POLICY,
+                    new ObjectTypeAttributeDefinition.Builder(CUSTOM_POLICY,
+                            PolicyDefinitions.RESOURCE_NAME,
+                            PolicyDefinitions.CustomPolicyDefinition.CLASS_NAME,
+                            PolicyDefinitions.CustomPolicyDefinition.MODULE)
+                            .build())
+                    .setRequired(false)
+                    .setMaxSize(1)  // xsd says > 1 is ok, but the resource will reject that, so might as well reject in the parser
+                    .setAttributeParser(AttributeParsers.UNWRAPPED_OBJECT_LIST_PARSER)
+                    .build())
+            .build();
+
+    private final ElytronSubsystemParser elytronSubsystemParser;
+
+    PolicyParserTemp(ElytronSubsystemParser elytronSubsystemParser) {
+        this.elytronSubsystemParser = elytronSubsystemParser;
+    }
+
+    void readPolicy(ModelNode parentAddress, XMLExtendedStreamReader reader, List<ModelNode> operations) throws XMLStreamException {
+        PersistentResourceXMLDescription description = isLegacy() ? legacyPolicyParser : policyParser;
+        description.parse(reader, PathAddress.pathAddress(parentAddress), operations);
+    }
+
+    void writePolicy(ModelNode subsystem, XMLExtendedStreamWriter writer) throws XMLStreamException {
+        if (isLegacy()) {
+            throw new UnsupportedOperationException();
+        } else {
+            policyParser.persist(writer, subsystem);
+        }
+    }
+
+    private boolean isLegacy() {
+        String namespace = elytronSubsystemParser.getNamespace();
+        return (namespace.equals(NAMESPACE_1_0) || namespace.equals(NAMESPACE_1_1));
+    }
+}

--- a/elytron/src/test/java/org/wildfly/extension/elytron/ElytronSubsystem12TestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/ElytronSubsystem12TestCase.java
@@ -1,0 +1,53 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.wildfly.extension.elytron;
+
+import java.io.IOException;
+
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+
+/**
+ * Tests of use of the wildfly-elytron_1_2.xsd.
+ *
+ * @author Brian Stansberry
+ */
+public class ElytronSubsystem12TestCase extends AbstractSubsystemBaseTest {
+
+    public ElytronSubsystem12TestCase() {
+        super(ElytronExtension.SUBSYSTEM_NAME, new ElytronExtension());
+    }
+
+    @Override
+    protected String getSubsystemXsdPath() throws Exception {
+        return "schema/wildfly-elytron_1_2.xsd";
+    }
+
+    @Override
+    public void testSchemaOfSubsystemTemplates() throws Exception {
+        //
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("elytron-subsystem-1.2.xml");
+    }
+
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) throws Exception {
+        //super.compareXml(configId, original, marshalled);
+    }
+}

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/custom-policies.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/custom-policies.xml
@@ -1,9 +1,11 @@
 <subsystem xmlns="urn:wildfly:elytron:1.1">
     <policy default-policy="custom-b">
+        <!-- Parser will no longer discard unreferenced policies
         <jacc-policy name="elytron-a" policy="a.b.Policy" configuration-factory="a.b.PolicyConfigurationFactory" module="a.b"/>
         <jacc-policy name="elytron-b" policy="a.b.Policy" configuration-factory="a.b.PolicyConfigurationFactory" module="a.b"/>
         <jacc-policy name="elytron-c" />
         <custom-policy name="custom-a" class-name="a.b.c.CustomPolicy" module="a.b.c.custom"/>
+        -->
         <custom-policy name="custom-b" class-name="a.b.c.CustomPolicy" module="a.b.c.custom"/>
     </policy>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-1.2.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-1.2.xml
@@ -1,0 +1,203 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2017, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:wildfly:elytron:1.2">
+    <security-domains>
+        <security-domain name="MyDomain" default-realm="FileRealm" realm-mapper="MyRealmMapper" permission-mapper="MyPermissionMapper"
+                         pre-realm-principal-transformer="NameRewriterXY" post-realm-principal-transformer="NameRewriterYU" trusted-security-domains="AnotherDomain">
+            <realm name="FileRealm" role-decoder="MyRoleDecoder" role-mapper="MyRoleMapper"/>
+            <realm name="PropRealm" principal-transformer="NameRewriterRealmRemover"/>
+        </security-domain>
+        <security-domain name="X500Domain" default-realm="FileRealm" principal-decoder="MyX500PrincipalDecoder">
+            <realm name="FileRealm"/>
+        </security-domain>
+        <security-domain name="X500DomainTwo" default-realm="FileRealm" principal-decoder="MyX500PrincipalDecoderTwo">
+            <realm name="FileRealm"/>
+        </security-domain>
+        <security-domain name="X500DomainThree" default-realm="FileRealm" principal-decoder="MyX500PrincipalDecoderThree">
+            <realm name="FileRealm"/>
+        </security-domain>
+        <security-domain name="AnotherDomain" default-realm="PropRealm" permission-mapper="LoginPermissionMapper" trusted-security-domains="MyDomain">
+            <realm name="PropRealm"/>
+        </security-domain>
+    </security-domains>
+    <security-realms>
+        <properties-realm name="PropRealm">
+            <users-properties path="users-hashed.properties" relative-to="jboss.server.config.dir"/>
+        </properties-realm>
+        <properties-realm name="NonDomainRealm">
+            <users-properties path="users-hashed.properties" relative-to="jboss.server.config.dir"/>
+        </properties-realm>
+        <filesystem-realm name="FileRealm" levels="2" encoded="false">
+            <file path="filesystem-realm" relative-to="jboss.server.config.dir"/>
+        </filesystem-realm>
+    </security-realms>
+    <mappers>
+        <custom-permission-mapper class-name="org.wildfly.extension.elytron.DomainTestCase$MyPermissionMapper" name="MyPermissionMapper" module="a.b.c"/>
+        <custom-permission-mapper class-name="org.wildfly.extension.elytron.DomainTestCase$LoginPermissionMapper" name="LoginPermissionMapper" module="a.b.c"/>
+        <simple-permission-mapper name="SimplePermissionMapper" mapping-mode="and">
+            <permission-mapping>
+                <principal name="John"/>
+                <principal name="Joe"/>
+                <role name="User"/>
+                <role name="Administrator"/>
+                <permission class-name="a.b.MyPermission"/>
+                <permission class-name="a.b.MyOtherPermission" target-name="../c" action="delete"/>
+            </permission-mapping>
+            <permission-mapping>
+                <principal name="John Doe"/>
+                <permission class-name="a.b.JohnPermission"/>
+            </permission-mapping>
+            <permission-mapping>
+                <principal name="User"/>
+                <permission class-name="a.b.UserPermission"/>
+            </permission-mapping>
+            <permission-mapping match-all="true"/>
+        </simple-permission-mapper>
+        <constant-permission-mapper name="ConstantPermissionMapper">
+            <permission class-name="a.b.UserPermission"/>
+        </constant-permission-mapper>
+        <concatenating-principal-decoder joiner="@" name="MyX500PrincipalDecoderThree">
+            <principal-decoder name="MyCnDecoder"/>
+            <principal-decoder name="MyDcDecoder"/>
+        </concatenating-principal-decoder>
+        <x500-attribute-principal-decoder joiner="," maximum-segments="6" name="MyX500PrincipalDecoder" oid="2.5.4.3"/>
+        <x500-attribute-principal-decoder joiner="," maximum-segments="1" name="MyX500PrincipalDecoderTwo" oid="2.5.4.3" required-oids="2.5.4.3 2.5.4.11"
+                                          required-attributes="cN" reverse="true"
+                                          start-segment="2"/>
+        <x500-attribute-principal-decoder maximum-segments="1" name="MyCnDecoder" attribute-name="Cn" start-segment="1"/>
+        <x500-attribute-principal-decoder name="MyDcDecoder" oid="0.9.2342.19200300.100.1.25"/>
+        <regex-principal-transformer name="NameRewriterXY" pattern="x(.*)" replacement="y$1"/>
+        <regex-principal-transformer name="NameRewriterYU" pattern="y(.*)" replacement="u$1"/>
+        <regex-principal-transformer name="NameRewriterRealmRemover" pattern="(.*)@.*" replacement="$1"/>
+        <simple-regex-realm-mapper name="MyRealmMapper" pattern=".*@(.*)"/>
+        <simple-role-decoder attribute="roles" name="MyRoleDecoder"/>
+        <add-prefix-role-mapper name="RolePrefixer" prefix="prefix"/>
+        <add-suffix-role-mapper name="RoleSuffixer" suffix="suffix"/>
+        <aggregate-role-mapper name="MyRoleMapper">
+            <role-mapper name="RolePrefixer"/>
+            <role-mapper name="RoleSuffixer"/>
+        </aggregate-role-mapper>
+    </mappers>
+    <tls>
+        <key-stores>
+            <key-store name="PKCS_11">
+                <credential-reference clear-text="password"/>
+                <implementation type="PKCS#11" provider-name="SunPKCS#11"/>
+            </key-store>
+            <key-store name="jks_store" alias-filter="one,two,three">
+                <credential-reference clear-text="password"/>
+                <implementation type="jks"/>
+                <file relative-to="jboss.server.config.dir" path="keystore.jks" required="true"/>
+            </key-store>
+            <key-store name="jceks_store">
+                <credential-reference clear-text="password"/>
+                <implementation type="jceks"/>
+                <file relative-to="jboss.server.config.dir" path="keystore.jceks"/>
+            </key-store>
+            <key-store name="Custom_PKCS_11">
+                <credential-reference clear-text="password"/>
+                <implementation type="PKCS#11" provider-name="SunPKCS#11" providers="custom-loader"/>
+            </key-store>
+            <filtering-key-store name="FilteringKeyStore" key-store="Custom_PKCS_11" alias-filter="NONE:+firefly"/>
+        </key-stores>
+        <key-managers>
+            <key-manager name="serverKey" algorithm="SunX509" key-store="jks_store">
+                <credential-reference clear-text="password"/>
+            </key-manager>
+            <key-manager name="serverKey2" algorithm="SunX509" key-store="jks_store" providers="custom-loader" provider-name="first">
+                <credential-reference store="credstore1" alias="password-alias" type="PasswordCredential"/>
+            </key-manager>
+            <key-manager name="clientKey" algorithm="SunX509" key-store="jks_store">
+                <credential-reference store="credstore1" alias="password-alias" type="PasswordCredential"/>
+            </key-manager>
+        </key-managers>
+        <trust-managers>
+            <trust-manager name="serverTrust" algorithm="SunX509" key-store="jks_store"/>
+            <trust-manager name="serverTrust2" algorithm="SunX509" key-store="jks_store" providers="custom-loader" provider-name="first"/>
+            <trust-manager name="trust-with-crl" algorithm="SunX509" key-store="jks_store">
+                <certificate-revocation-list path="crl.pem" relative-to="jboss.server.config.dir" maximum-cert-path="2"/>
+            </trust-manager>
+            <trust-manager name="trust-with-crl-dp" algorithm="SunX509" key-store="jks_store">
+                <certificate-revocation-list/>
+            </trust-manager>
+        </trust-managers>
+        <server-ssl-contexts>
+            <server-ssl-context name="server" protocols="TLSv1.2" want-client-auth="true" need-client-auth="true" authentication-optional="true"
+                                use-cipher-suites-order="false" maximum-session-cache-size="10"
+                                session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
+                                post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="first"/>
+        </server-ssl-contexts>
+        <client-ssl-contexts>
+            <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" key-manager="clientKey" trust-manager="serverTrust" providers="custom-loader"
+                                provider-name="first"/>
+        </client-ssl-contexts>
+    </tls>
+    <credential-security-factories>
+        <custom-credential-security-factory name="CustomFactory" module="a.b.c" class-name="org.wildfly.security.ElytronFactory">
+            <configuration>
+                <property name="a" value="b"/>
+                <property name="c" value="d"/>
+            </configuration>
+        </custom-credential-security-factory>
+
+        <kerberos-security-factory name="KerberosFactory"
+                                   principal="bob@Elytron.org"
+                                   path="bob.keytab"
+                                   relative-to="server.config.dir"
+                                   minimum-remaining-lifetime="10"
+                                   request-lifetime="120"
+                                   server="false"
+                                   obtain-kerberos-ticket="true"
+                                   debug="true"
+                                   wrap-gss-credential="true"
+                                   required="true"
+                                   mechanism-names="KRB5 KRB5LEGACY"
+                                   mechanism-oids="1.2.840.113554.1.2.2 1.3.6.1.5.5.2">
+            <option name="a" value="b"/>
+            <option name="c" value="d"/>
+        </kerberos-security-factory>
+        <kerberos-security-factory name="OptionLessKerberosFactory"
+                                   principal="bob@Elytron.org"
+                                   path="bob.keytab"
+                                   relative-to="server.config.dir"
+                                   minimum-remaining-lifetime="10"
+                                   request-lifetime="120"
+                                   server="false"
+                                   obtain-kerberos-ticket="true"
+                                   debug="true"
+                                   wrap-gss-credential="true"
+                                   mechanism-oids="1.2.840.113554.1.2.2 1.3.6.1.5.5.2"/>
+    </credential-security-factories>
+    <credential-stores>
+        <credential-store name="test1" relative-to="jboss.server.data.dir" location="test1.store" create="true">
+            <implementation-properties>
+                <property name="keyStoreType" value="JCEKS"/>
+                <property name="keyAlias" value="adminKey"/>
+            </implementation-properties>
+            <credential-reference clear-text="secret2"/>
+        </credential-store>
+        <credential-store name="test2" relative-to="jboss.server.data.dir" modifiable="true">
+            <credential-reference store="test1" alias="to_open_test2"/>
+        </credential-store>
+    </credential-stores>
+    <policy name="elytron-a">
+        <jacc-policy policy="a.b.Policy" configuration-factory="a.b.PolicyConfigurationFactory" module="a.b"/>
+    </policy>
+
+</subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/jacc-with-providers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/jacc-with-providers.xml
@@ -1,9 +1,11 @@
 <subsystem xmlns="urn:wildfly:elytron:1.1">
     <policy default-policy="elytron-a">
         <jacc-policy name="elytron-a" policy="a.b.Policy" configuration-factory="a.b.PolicyConfigurationFactory" module="a.b"/>
+        <!-- Parser will no longer discard unreferenced policies
         <jacc-policy name="elytron-b" policy="a.b.Policy" configuration-factory="a.b.PolicyConfigurationFactory" module="a.b"/>
         <jacc-policy name="elytron-c" />
         <custom-policy name="custom-a" class-name="a.b.c.CustomPolicy" module="a.b.c.custom"/>
         <custom-policy name="custom-b" class-name="a.b.c.CustomPolicy" module="a.b.c.custom"/>
+        -->
     </policy>
 </subsystem>


### PR DESCRIPTION
Goes beyond #2886 to add a commit dropping the custom policy element parsing we used in WildFly Core 3.0.6 for the 1.1 and 1.0 xsds and instead use PersistentResourceXmlDescription.
    
This is meant to make it easier to merge the WFCORE-2882 work (see #2852 ) on top of the WFCORE-3041 work. To this end the policy parsing logic has been moved to a temporary new class 'PolicyParserTemp' and the legacy 'PolicyParser' class which is no longer used, has been restored to its state prior to any WFCORE-3041 changes. (This avoid difficult to untangle merge conflicts with the WFCORE-2882 work.) The PolicyParserTemp temp class shows the proper configuration of the PersistentResourceXmlDescriptions that are needed to parse the policy resource, both for 1.0/1.1 xsds and for 1.2/2.0 xsds. WFCORE-2882 should use these descriptions.
    
Moving to PersistentResourceXmlDescription loses some custom 'forgiveness' logic we had in 3.0.6 as a compatibility aid. Forgiveness meaning the parser discarding extra jacc-policy or custom-policy elements that weren't used in the runtime anyway. I think this is ok; any need for such forgiveness was always an extreme edge case (since adding unused config would have been pointless), and by the time WildFly Core 4 is released any such xml should long since have been converted. The 1.1 and 1.0 xsds were never the base version used in a final WildFly or EAP release.