### PR TITLE
[WFCORE-3374] The property test.level might not be (re)defined in the module's pom …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
                               </property>
                               <property>
                                   <name>test.level</name>
-                                  <value>${test.level}</value>
+                                  <value>${test.level:INFO}</value>
                               </property>
                           </systemProperties>
                           <argLine>${surefire.system.args}</argLine>


### PR DESCRIPTION
The property test.level might not be (re)defined in the module's pom which may lead to failure in tests logging with a level of "" instead of INFO.

Jira: https://issues.jboss.org/browse/WFCORE-3374