### PR TITLE
[WFCORE-3368] Upgrade WildFly Elytron to 1.2.0.Beta8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <version.org.wildfly.openssl>1.0.2.Final</version.org.wildfly.openssl>
         <version.org.wildfly.legacy.test>2.0.3.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
-        <version.org.wildfly.security.elytron>1.2.0.Beta7</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.2.0.Beta8</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron.tool>1.0.0.Final</version.org.wildfly.security.elytron.tool>
         <version.org.wildfly.security.elytron-web.undertow-server>1.0.0.Final</version.org.wildfly.security.elytron-web.undertow-server>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3368

As this is only an update to a Beta release there is no corresponding tool update.