### PR TITLE
[WFCORE-3116] Add support for digest-sha-384 for Elytron set-password operation

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableRealmDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ModifiableRealmDecorator.java
@@ -418,6 +418,7 @@ class ModifiableRealmDecorator extends DelegatingResourceDefinition {
                             DigestPassword.ALGORITHM_DIGEST_MD5,
                             DigestPassword.ALGORITHM_DIGEST_SHA,
                             DigestPassword.ALGORITHM_DIGEST_SHA_256,
+                            DigestPassword.ALGORITHM_DIGEST_SHA_384,
                             DigestPassword.ALGORITHM_DIGEST_SHA_512
                     ))
                     .build();

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractMgmtSaslTestBase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/AbstractMgmtSaslTestBase.java
@@ -85,6 +85,7 @@ public abstract class AbstractMgmtSaslTestBase {
     protected static final String DIGEST_ALGORITHM_MD5 = "digest-md5";
     protected static final String DIGEST_ALGORITHM_SHA = "digest-sha";
     protected static final String DIGEST_ALGORITHM_SHA256 = "digest-sha-256";
+    protected static final String DIGEST_ALGORITHM_SHA384 = "digest-sha-384";
     protected static final String DIGEST_ALGORITHM_SHA512 = "digest-sha-512";
 
     protected static final int CONNECTION_TIMEOUT_IN_MS = TimeoutUtil.adjust(6 * 1000);
@@ -156,7 +157,7 @@ public abstract class AbstractMgmtSaslTestBase {
      */
     @Test
     public void testOtherMechsFail() throws Exception {
-        Arrays.asList("ANONYMOUS", "", "1" + getMechanism(), getMechanism() + "1", "DIGEST-MD5", "DIGEST-SHA", "DIGEST-SHA-256",
+        Arrays.asList("ANONYMOUS", "", "1" + getMechanism(), getMechanism() + "1", "DIGEST-MD5", "DIGEST-SHA", "DIGEST-SHA-256", "DIGEST-SHA-384",
                 "DIGEST-SHA-512", "PLAIN", "SCRAM-SHA-1", "JBOSS-LOCAL-USER").forEach(s -> {
                     if (!getMechanism().equals(s)) {
                         assertMechFails(s);
@@ -170,7 +171,7 @@ public abstract class AbstractMgmtSaslTestBase {
      */
     @Test
     public void testOtherDigestMechsFail() throws Exception {
-        Arrays.asList("MD5", "SHA", "SHA-256", "SHA-512").forEach(s -> {
+        Arrays.asList("MD5", "SHA", "SHA-256", "SHA-384", "SHA-512").forEach(s -> {
             final String mech = "DIGEST-" + s;
             if (!getMechanism().equals(mech)) {
                 assertDigestMechFails(mech, mech.toLowerCase(Locale.ROOT));
@@ -335,6 +336,7 @@ public abstract class AbstractMgmtSaslTestBase {
                 addUserWithDigestPass(cli, DIGEST_ALGORITHM_MD5);
                 addUserWithDigestPass(cli, DIGEST_ALGORITHM_SHA);
                 addUserWithDigestPass(cli, DIGEST_ALGORITHM_SHA256);
+                addUserWithDigestPass(cli, DIGEST_ALGORITHM_SHA384);
                 addUserWithDigestPass(cli, DIGEST_ALGORITHM_SHA512);
             }
 

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DefaultRealmDigestMgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DefaultRealmDigestMgmtSaslTestCase.java
@@ -76,6 +76,11 @@ public class DefaultRealmDigestMgmtSaslTestCase {
     }
 
     @Test
+    public void testDigestSha384() throws Exception {
+        assertDefaultRealmWorks("DIGEST-SHA-384");
+    }
+
+    @Test
     public void testDigestSha512() throws Exception {
         assertDefaultRealmWorks("DIGEST-SHA-512");
     }

--- a/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestSha384MgmtSaslTestCase.java
+++ b/testsuite/elytron/src/test/java/org/wildfly/test/integration/elytron/sasl/mgmt/DigestSha384MgmtSaslTestCase.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.test.integration.elytron.sasl.mgmt;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.test.security.common.TestRunnerConfigSetupTask;
+import org.wildfly.test.security.common.elytron.ConfigurableElement;
+
+import java.util.List;
+
+/**
+ * Tests Digest SHA-384 SASL mechanism used for management interface.
+ *
+ * @author Josef Cacek
+ * @author Yeray Borges
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerSetup({ DigestSha384MgmtSaslTestCase.ServerSetup.class })
+public class DigestSha384MgmtSaslTestCase extends AbstractMgmtSaslTestBase {
+
+    private static final String MECHANISM = "DIGEST-SHA-384";
+
+    @Override
+    protected String getMechanism() {
+        return MECHANISM;
+    }
+
+    /**
+     * Tests that client is able to use mechanism when server allows it.
+     */
+    @Test
+    public void testCorrectMechanismPasses() throws Exception {
+        assertMechPassWhoAmI(MECHANISM, USERNAME);
+    }
+
+    @Test
+    public void testCorrectDigestMechPasses() throws Exception {
+        assertDigestMechPassWhoAmI(MECHANISM, DIGEST_ALGORITHM_SHA384);
+    }
+
+    /**
+     * Setup task which configures Elytron security domains and remoting connectors for this test.
+     */
+    public static class ServerSetup extends TestRunnerConfigSetupTask {
+
+        @Override
+        protected ConfigurableElement[] getConfigurableElements() {
+            List<ConfigurableElement> elements = createConfigurableElementsForSaslMech(MECHANISM);
+            return elements.toArray(new ConfigurableElement[elements.size()]);
+        }
+    }
+}


### PR DESCRIPTION
This issue depends on https://github.com/wildfly-security/wildfly-elytron/pull/1021 and has to be merged with that one. 
Tests will fail if it is merged with the incorrect Elytron version.

Issue: https://issues.jboss.org/browse/WFCORE-3116
JBEAP issue: https://issues.jboss.org/browse/JBEAP-12316