### PR TITLE
[WFLY-3377] thread-factory resource creation

### DIFF
--- a/threads/src/main/java/org/jboss/as/threads/ThreadFactoryAdd.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadFactoryAdd.java
@@ -55,10 +55,12 @@ public class ThreadFactoryAdd extends AbstractAddStepHandler {
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
 
         ModelNode priorityModelNode = PoolAttributeDefinitions.PRIORITY.resolveModelAttribute(context, model);
+        ModelNode groupNameModelNode = PoolAttributeDefinitions.GROUP_NAME.resolveModelAttribute(context, model);
+        ModelNode threadNamePatternModelNode = PoolAttributeDefinitions.THREAD_NAME_PATTERN.resolveModelAttribute(context, model);
 
-        final String threadNamePattern = PoolAttributeDefinitions.THREAD_NAME_PATTERN.resolveModelAttribute(context, model).asString();
+        final String threadNamePattern = threadNamePatternModelNode.isDefined() ? threadNamePatternModelNode.asString() : null;
         final Integer priority = priorityModelNode.isDefined() ? new Integer(priorityModelNode.asInt()) : null;
-        final String groupName = PoolAttributeDefinitions.GROUP_NAME.resolveModelAttribute(context, model).asString();
+        final String groupName = groupNameModelNode.isDefined() ? groupNameModelNode.asString() : null;
 
         final String name = context.getCurrentAddressValue();
 

--- a/threads/src/main/java/org/jboss/as/threads/ThreadFactoryService.java
+++ b/threads/src/main/java/org/jboss/as/threads/ThreadFactoryService.java
@@ -66,7 +66,7 @@ public final class ThreadFactoryService implements Service<ThreadFactory> {
     }
 
     public synchronized void start(final StartContext context) throws StartException {
-        final ThreadGroup threadGroup = new ThreadGroup(threadGroupName);
+        final ThreadGroup threadGroup = (threadGroupName != null) ? new ThreadGroup(threadGroupName) : null;
         value = doPrivileged(new PrivilegedAction<ThreadFactory>() {
             public ThreadFactory run() {
                 return new JBossThreadFactory(threadGroup, Boolean.FALSE, priority, namePattern, null, null);


### PR DESCRIPTION
* do not use the values of group-name and thread-name-pattern if the
  attibutes are not defined in the model.

JIRA: https://issues.jboss.org/browse/WFCORE-3377