### PR TITLE
[WFCORE-3404] Elytron audit non-synchronized by default

### DIFF
--- a/elytron/src/main/resources/subsystem-templates/elytron.xml
+++ b/elytron/src/main/resources/subsystem-templates/elytron.xml
@@ -85,7 +85,7 @@
     <supplement name="domain">
         <replacement placeholder="AUDIT_DEFINITIONS">
             <audit-logging>
-                <file-audit-log name="local-audit" path="audit.log" relative-to="jboss.server.log.dir" format="JSON" />
+                <file-audit-log name="local-audit" path="audit.log" relative-to="jboss.server.log.dir" synchronized="false" format="JSON" />
             </audit-logging>
         </replacement>
         <replacement placeholder="DOMAIN_DEFINITIONS">


### PR DESCRIPTION
Elytron logging has performance impact when set to be synchronized.
Changing default to use non-synchronized audit logging.
Keeping audit logging disabled in default configuration. (Even through it should not be necessary for non-sychronized audit logging.)

https://issues.jboss.org/browse/WFCORE-3404
https://issues.jboss.org/browse/JBEAP-10639