### PR TITLE
[WFCORE-3415] Faster resource tree size calculation for getMBeanCount()

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/registry/AbstractModelResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AbstractModelResource.java
@@ -23,6 +23,7 @@
 package org.jboss.as.controller.registry;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -220,6 +221,23 @@ public abstract class AbstractModelResource extends ResourceProvider.ResourcePro
         return orderedChildTypes;
     }
 
+    @Override
+    public int getTreeSize() {
+        int result = 1; // ourself
+        ResourceProvider[] providers; // don't use a Set as we don't want to lose duplicates registered under different keys!
+        synchronized (children) {
+            if (children.isEmpty()){
+                return result;
+            }
+            Collection<ResourceProvider> source = children.values();
+            providers = source.toArray(new ResourceProvider[source.size()]);
+        }
+        for (ResourceProvider provider : providers) {
+            result += provider.getTreeSize();
+        }
+        return result;
+    }
+
     protected void registerResourceProvider(final String type, final ResourceProvider provider) {
         synchronized (children) {
             if (children.containsKey(type)) {
@@ -341,6 +359,24 @@ public abstract class AbstractModelResource extends ResourceProvider.ResourcePro
         }
 
         @Override
+        public int getTreeSize() {
+            int result = 0;
+            Resource[] resources; // don't use a Set as we don't want to lose duplicates registered under different keys!
+            synchronized (children) {
+                if (children.isEmpty()) {
+                    return result;
+                }
+                Collection<Resource> values = children.values();
+                resources = values.toArray(new Resource[values.size()]);
+            }
+            for (Resource child : resources) {
+                result += child.getTreeSize();
+            }
+            return result;
+        }
+
+        @SuppressWarnings("MethodDoesntCallSuperMethod")
+        @Override
         public ResourceProvider clone() {
             final DefaultResourceProvider provider = new DefaultResourceProvider();
             synchronized (children) {
@@ -441,8 +477,14 @@ public abstract class AbstractModelResource extends ResourceProvider.ResourcePro
             return delegate.isProxy();
         }
 
+        @Override
         public Set<String> getOrderedChildTypes() {
             return delegate.getOrderedChildTypes();
+        }
+
+        @Override
+        public int getTreeSize() {
+            return delegate.getTreeSize();
         }
 
         @SuppressWarnings({"CloneDoesntCallSuperClone"})

--- a/controller/src/main/java/org/jboss/as/controller/registry/DelegatingResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/DelegatingResource.java
@@ -84,50 +84,62 @@ public class DelegatingResource extends ResourceProvider.ResourceProviderRegistr
         return getDelegate().clone();
     }
 
+    @Override
     public Resource getChild(PathElement element) {
         return getDelegate().getChild(element);
     }
 
+    @Override
     public Set<ResourceEntry> getChildren(String childType) {
         return getDelegate().getChildren(childType);
     }
 
+    @Override
     public Set<String> getChildrenNames(String childType) {
         return getDelegate().getChildrenNames(childType);
     }
 
+    @Override
     public Set<String> getChildTypes() {
         return getDelegate().getChildTypes();
     }
 
+    @Override
     public ModelNode getModel() {
         return getDelegate().getModel();
     }
 
+    @Override
     public boolean hasChild(PathElement element) {
         return getDelegate().hasChild(element);
     }
 
+    @Override
     public boolean hasChildren(String childType) {
         return getDelegate().hasChildren(childType);
     }
 
+    @Override
     public boolean isModelDefined() {
         return getDelegate().isModelDefined();
     }
 
+    @Override
     public boolean isProxy() {
         return getDelegate().isProxy();
     }
 
+    @Override
     public boolean isRuntime() {
         return getDelegate().isRuntime();
     }
 
+    @Override
     public Resource navigate(PathAddress address) {
         return getDelegate().navigate(address);
     }
 
+    @Override
     public void registerChild(PathElement address, Resource resource) {
         getDelegate().registerChild(address, resource);
     }
@@ -137,16 +149,24 @@ public class DelegatingResource extends ResourceProvider.ResourceProviderRegistr
         getDelegate().registerChild(address, index, resource);
     }
 
+    @Override
     public Resource removeChild(PathElement address) {
         return getDelegate().removeChild(address);
     }
 
+    @Override
     public Resource requireChild(PathElement element) {
         return getDelegate().requireChild(element);
     }
 
+    @Override
     public void writeModel(ModelNode newModel) {
         getDelegate().writeModel(newModel);
+    }
+
+    @Override
+    public int getTreeSize() {
+        return getDelegate().getTreeSize();
     }
 
     private Resource getDelegate() {

--- a/controller/src/main/java/org/jboss/as/controller/registry/PlaceholderResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/PlaceholderResource.java
@@ -135,6 +135,11 @@ public class PlaceholderResource implements Resource {
     }
 
     @Override
+    public int getTreeSize() {
+        return 1;
+    }
+
+    @Override
     public Resource clone() {
         return INSTANCE;
     }

--- a/controller/src/main/java/org/jboss/as/controller/registry/Resource.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/Resource.java
@@ -204,6 +204,20 @@ public interface Resource extends Cloneable {
         return copy;
     }
 
+    /**
+     * Gets the number of resources in the resource tree rooted in this resource.
+     * @return the number resources. Will not be less than {@code 1}
+     */
+    default int getTreeSize() {
+        int i = 1; // ourself
+        for (String type : getChildTypes()) {
+            for (Resource child : getChildren(type)) {
+                i += child.getTreeSize();
+            }
+        }
+        return i;
+    }
+
     interface ResourceEntry extends Resource {
 
         /**

--- a/controller/src/main/java/org/jboss/as/controller/registry/ResourceProvider.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ResourceProvider.java
@@ -33,18 +33,29 @@ public interface ResourceProvider extends Cloneable {
     Resource get(String name);
     boolean hasChildren();
     Set<String> children();
+    /** Gets the total {@link Resource#getTreeSize() tree size} of all the resources provided by this provider */
+    default int getTreeSize() {
+        int result = 0;
+        for (String name : children()) {
+            Resource res = get(name);
+            if (res != null) {
+                result += res.getTreeSize();
+            }
+        }
+        return result;
+    }
     void register(String name, Resource resource);
     void register(String value, int index, Resource resource);
     Resource remove(String name);
     ResourceProvider clone();
 
-    public abstract static class ResourceProviderRegistry {
+    abstract class ResourceProviderRegistry {
 
         protected abstract void registerResourceProvider(final String type, final ResourceProvider provider);
 
     }
 
-    public static class Tool {
+    class Tool {
 
         public static void addResourceProvider(final String name, final ResourceProvider provider, final Resource resource) {
             if (resource instanceof ResourceProviderRegistry) {

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
@@ -363,7 +363,7 @@ class WorkerResourceDefinition extends PersistentResourceDefinition {
 
                 @Override
                 public boolean hasChildren() {
-                    return false;
+                    return !children().isEmpty();
                 }
 
                 @Override

--- a/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanHelper.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanHelper.java
@@ -67,6 +67,7 @@ import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.security.AccessMechanism;
 import org.jboss.as.jmx.logging.JmxLogger;
 import org.jboss.as.jmx.model.ChildAddOperationFinder.ChildAddOperationEntry;
@@ -107,23 +108,13 @@ public class ModelControllerMBeanHelper {
     }
 
     int getMBeanCount() {
-        return new RootResourceIterator<Integer>(accessControlUtil, getRootResourceAndRegistration().getResource(), new ResourceAction<Integer>() {
-            int count;
-
-            @Override
-            public ObjectName onAddress(PathAddress address) {
-                return isExcludeAddress(address) ? null : ObjectNameAddressUtil.createObjectName(domain, address);
-            }
-
-            public boolean onResource(ObjectName address) {
-                count++;
-                return true;
-            }
-
-            public Integer getResult() {
-                return count;
-            }
-        }).iterate();
+        Resource resource = getRootResourceAndRegistration().getResource();
+        int result = resource.getTreeSize();
+        Resource platform = resource.getChild(CORE_SERVICE_PLATFORM_MBEAN.getElement(0));
+        if (platform != null) {
+            result -= platform.getTreeSize();
+        }
+        return result;
     }
 
     Set<ObjectInstance> queryMBeans(final MBeanServer mbeanServer, final ObjectName name, final QueryExp query) {

--- a/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanServerPlugin.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/ModelControllerMBeanServerPlugin.java
@@ -170,7 +170,8 @@ public class ModelControllerMBeanServerPlugin extends BaseMBeanServerPlugin {
             count += legacyHelper.getMBeanCount();
         }
         if (exprHelper != null) {
-            count += exprHelper.getMBeanCount();
+            // exprHelper has the same # of mbeans as legacyHelper, so only ask for a count if we didn't already
+            count = count > 0 ? count * 2 : exprHelper.getMBeanCount();
         }
         return count;
     }

--- a/jmx/src/main/java/org/jboss/as/jmx/model/RootResourceIterator.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/RootResourceIterator.java
@@ -21,6 +21,8 @@
 */
 package org.jboss.as.jmx.model;
 
+import java.util.Set;
+
 import javax.management.ObjectName;
 
 import org.jboss.as.controller.PathAddress;
@@ -54,8 +56,9 @@ class RootResourceIterator<T> {
 
         if (handleChildren) {
             for (String type : current.getChildTypes()) {
-                if (current.hasChildren(type)) {
-                    for (ResourceEntry entry : current.getChildren(type)) {
+                Set<ResourceEntry> children = current.getChildren(type);
+                if (children != null) {
+                    for (ResourceEntry entry : children) {
                         final PathElement pathElement = entry.getPathElement();
                         final PathAddress childAddress = address.append(pathElement);
                         doIterate(entry, childAddress);

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxFacadeRbacEnabledTestCase.java
@@ -348,7 +348,11 @@ public class JmxFacadeRbacEnabledTestCase extends AbstractControllerTestBase {
                     Assert.assertTrue(names.contains(instance.getObjectName()));
                 }
                 int number = server.getMBeanCount();
-                Assert.assertEquals(names.size(), number);
+                if (standardRole == StandardRole.ADMINISTRATOR || standardRole == StandardRole.SUPERUSER) {
+                    Assert.assertEquals(names.toString(), names.size(), number);
+                } else {
+                    Assert.assertTrue(names.toString(), names.size() < number);
+                }
 
                 try {
                     server.getMBeanInfo(ONE_A_NAME);

--- a/logging/src/main/java/org/jboss/as/logging/LoggingResource.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingResource.java
@@ -270,6 +270,22 @@ public class LoggingResource implements Resource {
     }
 
     @Override
+    public int getTreeSize() {
+        int result = delegate.getTreeSize(); // ourself
+        // Simple form
+        // result += getChildrenNames(LOG_FILE).size();
+        // Slightly optimized alternative that saves unnecessary population of a set of names
+        final String logDir = pathManager.getPathEntry(ServerEnvironment.SERVER_LOG_DIR).resolvePath();
+        try {
+            result += findFiles(logDir, getFileHandlersModel(), true).size();
+        } catch (IOException e) {
+            LoggingLogger.ROOT_LOGGER.errorProcessingLogDirectory(logDir);
+        }
+        return result;
+    }
+
+    @SuppressWarnings("MethodDoesntCallSuperMethod")
+    @Override
     public Resource clone() {
         return new LoggingResource(delegate.clone(), pathManager, fileHandlersModel);
     }

--- a/platform-mbean/src/main/java/org/jboss/as/platform/mbean/LeafPlatformMBeanResource.java
+++ b/platform-mbean/src/main/java/org/jboss/as/platform/mbean/LeafPlatformMBeanResource.java
@@ -52,4 +52,9 @@ class LeafPlatformMBeanResource extends AbstractPlatformMBeanResource {
     public Set<String> getChildTypes() {
         return Collections.emptySet();
     }
+
+    @Override
+    public int getTreeSize() {
+        return 1;
+    }
 }


### PR DESCRIPTION
The biggest thing this does is eliminate RBAC checks as a factor in determining whether a resource appears in the count. Which means, in the case of non-addressable resources the total number of mbeans a user could "see", for example via MBeanServerConnection.queryNames, could be less than the number returned by a simultaneous call to getMBeanCount().

The other big thing this does is avoiding doing two complete counts for the jboss.as and jboss.as.expr JMX domains. There should be no difference in counts between those so if both are installed it just counts one and doubles the result.

I have a variant of this that retains the old getMBeanCount logic plus adds a simpler optimization of what's already there, and then adds this, and then times all 3, logging the times and the mbean counts. Against current wildfly master, standalone-full-ha.xml, it reports, for three tests:

```
19:50:42,684 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the original RootResourceIterator approach was 752808315, resulting in a count of 805
19:50:42,699 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the non-RBAC RootResourceIterator approach was 15326911, resulting in a count of 805
19:50:42,707 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the Resource.getMBeanCount() approach was 7532190, resulting in a count of 805
```

```
19:50:57,515 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the original RootResourceIterator approach was 303192886, resulting in a count of 805
19:50:57,525 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the non-RBAC RootResourceIterator approach was 10050281, resulting in a count of 805
19:50:57,528 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the Resource.getMBeanCount() approach was 2476300, resulting in a count of 805
```

```
19:51:04,204 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the original RootResourceIterator approach was 231361182, resulting in a count of 805
19:51:04,214 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the non-RBAC RootResourceIterator approach was 10143555, resulting in a count of 805
19:51:04,217 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the Resource.getMBeanCount() approach was 2076253, resulting in a count of 805
```

The call times are roughly 100 times less, with the first call using the existing method taking 753ms! See https://issues.jboss.org/browse/WFLY-9408 for an example of a user-reported problem due to this. The approach used in this PR was also about 7ms faster than the alternative optimization approach.

If I map the user I'm connecting as to the Monitor RBAC role and then turn on RBAC, you can see the mbean count that results from not using RBAC to trim mbeans the user won't be able to address from the count:

```
19:57:54,278 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the original RootResourceIterator approach was 663849859, resulting in a count of 403
19:57:54,295 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the non-RBAC RootResourceIterator approach was 17223565, resulting in a count of 805
19:57:54,306 INFO  [org.jboss.as.jmx] (pool-3-thread-1) Elapsed getMBeanCount time using the Resource.getMBeanCount() approach was 9907518, resulting in a count of 805
```

Looking at the JMX specification (https://docs.oracle.com/javase/8/docs/technotes/guides/jmx/JMX_1_4_specification.pdf) I see nothing directly on the topic of the effect of any security checks on the result of getMBeanCount(). Section 12.1.2.4 "Permission Checking for Queries" clearly states that permission checks should remove mbeans that should not be visible according to the permission scheme from the query result, so definitely queries returning a subset of the entire mbean universe is contemplated. Now, that section is about security manager permissions, not our RBAC scheme, but it's the most on topic thing I see.