### PR TITLE
Fix the test.level system property used to override the default root …

### DIFF
--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -36,10 +36,6 @@
 
     <name>WildFly: Controller Core</name>
 
-    <properties>
-        <test.level>INFO</test.level>
-    </properties>
-
     <dependencies>
 
         <dependency>

--- a/core-management/core-management-subsystem/pom.xml
+++ b/core-management/core-management-subsystem/pom.xml
@@ -36,10 +36,6 @@
 
     <name>WildFly: Core Management Subsystem</name>
 
-    <properties>
-        <test.level>INFO</test.level>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/elytron/pom.xml
+++ b/elytron/pom.xml
@@ -33,8 +33,6 @@
     <properties>
         <!-- TODO Elytron Remove once parent on M17 -->
         <version.org.apache.ds>2.0.0-M17</version.org.apache.ds>
-
-        <test.level>INFO</test.level>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
 
         <server.output.dir.prefix>wildfly</server.output.dir.prefix>
         <wildfly.build.output.dir>dist/target/${server.output.dir.prefix}-${wildfly.core.release.version}</wildfly.build.output.dir>
+        <test.level>INFO</test.level>
 
         <!--
             See ChildFirstClassLoaderBuilder in model-test for the explanation of the org.jboss.model.test.cache.root and org.jboss.model.test.classpath.cache properties.
@@ -309,7 +310,7 @@
                               </property>
                               <property>
                                   <name>test.level</name>
-                                  <value>${test.level:INFO}</value>
+                                  <value>${test.level}</value>
                               </property>
                           </systemProperties>
                           <argLine>${surefire.system.args}</argLine>

--- a/protocol/pom.xml
+++ b/protocol/pom.xml
@@ -35,10 +35,6 @@
     <artifactId>wildfly-protocol</artifactId>
     <name>WildFly: Protocol Utilities</name>
 
-    <properties>
-        <test.level>INFO</test.level>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/remoting/tests/pom.xml
+++ b/remoting/tests/pom.xml
@@ -38,10 +38,6 @@
     <name>WildFly: Remoting Subsystem Test</name>
     <description>This is not in the remoting subsystem as it introduces circular dependencies</description>
 
-    <properties>
-        <test.level>INFO</test.level>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/threads/pom.xml
+++ b/threads/pom.xml
@@ -36,10 +36,6 @@
 
     <name>WildFly: Threading Subsystem</name>
 
-    <properties>
-        <test.level>INFO</test.level>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.wildfly.core</groupId>


### PR DESCRIPTION
…logger level for tests.

I can file a JIRA if needed, but this is just a simple fix to allow the `-Dtest.level` system property to work for tests.