### PR TITLE
Fix for WFCORE-3405 and WFCORE-3406 on find-non-progressing-operation

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/FindNonProgressingOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/FindNonProgressingOperationHandler.java
@@ -75,6 +75,8 @@ public class FindNonProgressingOperationHandler implements OperationStepHandler 
             DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS))
             .setReplyType(ModelType.STRING)
             .withFlag(OperationEntry.Flag.HOST_CONTROLLER_ONLY)
+            .setReadOnly()
+            .setRuntimeOnly()
             .build();
 
     static final OperationStepHandler INSTANCE = new FindNonProgressingOperationHandler();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationCancellationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationCancellationTestCase.java
@@ -186,7 +186,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterBlockModel() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.MODEL);
@@ -198,7 +197,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterBlockRuntime() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.RUNTIME);
@@ -238,7 +236,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterBlockVerify() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.VERIFY);
@@ -250,7 +247,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterBlockCompletion() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.COMMIT);
@@ -262,7 +258,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterBlockRollback() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.ROLLBACK);
@@ -275,7 +270,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterBlockOtherOpCancelOtherOp() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.COMMIT);
@@ -289,7 +283,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterBlockOtherOpCancelBlockOp() throws Exception {
         long start = System.currentTimeMillis();
         block("master", null, BlockerExtension.BlockPoint.COMMIT);
@@ -303,7 +296,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockModelCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.MODEL);
@@ -315,7 +307,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockRuntimeCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.RUNTIME);
@@ -355,7 +346,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockVerifyCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.VERIFY);
@@ -367,7 +357,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockCompletionCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.COMMIT);
@@ -381,7 +370,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockRollbackCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.ROLLBACK);
@@ -396,7 +384,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockOtherOpCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.MODEL);
@@ -410,7 +397,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockModelCancelSlave() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.MODEL);
@@ -422,7 +408,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockRuntimeCancelSlave() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.RUNTIME);
@@ -446,7 +431,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockVerifyCancelSlave() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.VERIFY);
@@ -458,7 +442,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockCompletionCancelSlave() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.COMMIT);
@@ -472,7 +455,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveBlockRollbackCancelSlave() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.ROLLBACK);
@@ -485,7 +467,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterServerBlockModelCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.MODEL);
@@ -497,7 +478,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterServerBlockRuntimeCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.RUNTIME);
@@ -537,7 +517,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterServerBlockVerifyCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.VERIFY);
@@ -549,7 +528,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterServerBlockCompletionCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.COMMIT);
@@ -563,7 +541,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterServerBlockRollbackCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.ROLLBACK);
@@ -576,7 +553,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterServerBlockModelCancelServer() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.MODEL);
@@ -588,7 +564,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterServerBlockRuntimeCancelServer() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.RUNTIME);
@@ -612,7 +587,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterServerBlockVerifyCancelServer() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.VERIFY);
@@ -624,7 +598,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterServerBlockCompletionCancelServer() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.COMMIT);
@@ -638,7 +611,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testMasterServerBlockRollbackCancelServer() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.ROLLBACK);
@@ -652,7 +624,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockModelCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.MODEL);
@@ -664,7 +635,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockRuntimeCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
@@ -704,7 +674,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockVerifyCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.VERIFY);
@@ -716,7 +685,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockCompletionCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.COMMIT);
@@ -730,7 +698,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockRollbackCancelMaster() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.ROLLBACK);
@@ -752,7 +719,6 @@ public class OperationCancellationTestCase {
     // But we test this for completeness.
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockModelCancelSlave() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.MODEL);
@@ -765,7 +731,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockRuntimeCancelSlave() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
@@ -791,7 +756,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockVerifyCancelSlave() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.VERIFY);
@@ -804,7 +768,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockCompletionCancelSlave() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.COMMIT);
@@ -819,7 +782,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockRollbackCancelSlave() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.ROLLBACK);
@@ -835,7 +797,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockModelCancelServer() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.MODEL);
@@ -847,7 +808,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockRuntimeCancelServer() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
@@ -871,7 +831,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockVerifyCancelServer() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.VERIFY);
@@ -883,7 +842,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockCompletionCancelServer() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.COMMIT);
@@ -897,7 +855,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testSlaveServerBlockRollbackCancelServer() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.ROLLBACK);
@@ -912,7 +869,6 @@ public class OperationCancellationTestCase {
     // Tests of helper methods
 
     @Test
-    //@Ignore()
     public void testCancelNonProgressingOperation() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
@@ -929,7 +885,6 @@ public class OperationCancellationTestCase {
     }
 
     @Test
-    //@Ignore()
     public void testFindNonProgressingOperation() throws Exception {
         long start = System.currentTimeMillis();
         Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
@@ -973,14 +928,12 @@ public class OperationCancellationTestCase {
 
     /** WFCORE-263 */
     @Test
-    //@Ignore()
     public void testCancellingNonProgressingDomainRollout() throws Exception {
         failNonProgressingDomainRolloutTest("cancel-non-progressing-operation", null);
     }
 
     /** WFCORE-263 */
     @Test
-    //@Ignore()
     public void testFindNonProgressingDomainRollout() throws Exception {
         failNonProgressingDomainRolloutTest("find-non-progressing-operation", null);
     }


### PR DESCRIPTION
issue: https://issues.jboss.org/browse/WFCORE-3405

1. Set runtime-only and read-only for find-non-progressing-operation and add some tests with domain server address as recommended in WFCORE-3405
2. Acquire exclusive lock for standalone server in BlockerExtension, which I think is the reason why find-non-progressing-operation does not work for standalone in manual test with BlockerExtension. Please see my examples in https://issues.jboss.org/browse/WFCORE-3406