### PR TITLE
[WFCORE-3185] Run parallel boot tasks in coarser grained chunks

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -334,7 +334,10 @@ public abstract class AbstractControllerService implements Service<ModelControll
                 rootResourceRegistration,
                 new ContainerStateMonitor(container, getStabilityMonitor()),
                 configurationPersister, processType, runningModeControl, prepareStep,
-                processState, executorService, expressionResolver, authorizer, securityIdentitySupplier, auditLogger, notificationSupport,
+                processState, executorService,
+                getMaxParallelBootExtensionTasks(),
+                getMaxParallelBootSubsystemTasks(),
+                expressionResolver, authorizer, securityIdentitySupplier, auditLogger, notificationSupport,
                 bootErrorCollector, createExtraValidationStepHandler(), capabilityRegistry, getPartialModelIndicator(),
                 injectedInstabilityListener.getOptionalValue());
 
@@ -393,6 +396,14 @@ public abstract class AbstractControllerService implements Service<ModelControll
             }
         }, "Controller Boot Thread", bootStackSize);
         bootThread.start();
+    }
+
+    protected int getMaxParallelBootExtensionTasks() {
+        return 1;
+    }
+
+    protected int getMaxParallelBootSubsystemTasks() {
+        return 1;
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/extension/ExtensionAddHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/extension/ExtensionAddHandler.java
@@ -54,7 +54,7 @@ public class ExtensionAddHandler implements OperationStepHandler {
     /**
      * Create the AbstractAddExtensionHandler
      * @param extensionRegistry registry for extensions
-     * @param parallelBoot {@code true} is parallel initialization of extensions is in progress; {@code false} if not
+     * @param parallelBoot {@code true} if parallel initialization of extensions during boot is possible; {@code false} if not
      * @param extensionRegistryType {@code true} if this handler will execute in a master HostController
      * @param rootResourceRegistrationProvider provides access to the root {@code ManagementResourceRegistration}
      */

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -168,11 +168,11 @@ public interface ControllerLogger extends BasicLogger {
      * boot operations.
      *
      * @param cause the cause of the error.
-     * @param name  the name of subsystem.
+     * @param names  the names of subsystems.
      */
     @LogMessage(level = ERROR)
-    @Message(id = 6, value = "Failed executing subsystem %s boot operations")
-    void failedSubsystemBootOperations(@Cause Throwable cause, String name);
+    @Message(id = 6, value = "Failed executing subsystem boot operations for %s")
+    void failedSubsystemBootOperations(@Cause Throwable cause, Set<String> names);
 
     /**
      * Logs an error message indicating to failure to close the resource represented by the {@code closeable} parameter.
@@ -2186,20 +2186,21 @@ public interface ControllerLogger extends BasicLogger {
      * A message indicating the boot operations for the subsystem, represented by the {@code name} parameter, failed
      * without explanation.
      *
-     * @param name the name of the subsystem.
+     * @param names the names of the subsystems.
      *
      * @return the message.
      */
-    @Message(id = 192, value = "Boot operations for subsystem %s failed without explanation")
-    String subsystemBootOperationFailed(String name);
+    @Message(id = 192, value = "Boot operations for subsystems %s failed without explanation")
+    String subsystemBootOperationFailed(Set<String> names);
 
     /**
      * A message indicating a failure executing subsystem boot operations.
      *
+     * @param names the names of the subsystems
      * @return the message.
      */
-    @Message(id = 193, value = "Failed executing subsystem %s boot operations")
-    String subsystemBootOperationFailedExecuting(String name);
+    @Message(id = 193, value = "Failed executing subsystem boot operations for %s")
+    String subsystemBootOperationFailedExecuting(Set<String> names);
 
     /**
      * Creates an exception indicating the table is full.

--- a/controller/src/main/java/org/jboss/as/controller/parsing/ExtensionXml.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/ExtensionXml.java
@@ -71,8 +71,8 @@ public class ExtensionXml {
         this.extensionRegistry = null;
     }
     public ExtensionXml(final ModuleLoader loader, final ExecutorService executorService, final ExtensionRegistry extensionRegistry) {
-        moduleLoader = loader;
-        bootExecutor = executorService;
+        this.moduleLoader = loader;
+        this.bootExecutor = executorService;
         this.extensionRegistry = extensionRegistry;
         this.deferredExtensionContext = null;
     }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -348,7 +348,8 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
 
         // Extensions
         ExtensionRegistryType registryType = isMaster ? ExtensionRegistryType.MASTER : ExtensionRegistryType.SLAVE;
-        resourceRegistration.registerSubModel(new ExtensionResourceDefinition(extensionRegistry, true, registryType, rootResourceRegistrationProvider));
+        resourceRegistration.registerSubModel(new ExtensionResourceDefinition(extensionRegistry, extensionRegistry.getMaxParallelBootExtensionTasks() > 1,
+                registryType, rootResourceRegistrationProvider));
 
         // Domain configured host-ignored resources
         resourceRegistration.registerSubModel(new HostExcludeResourceDefinition(domainHostExcludeRegistry));

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -630,6 +630,14 @@ public class DomainModelControllerService extends AbstractControllerService impl
         };
     }
 
+    protected final int getMaxParallelBootExtensionTasks() {
+        return extensionRegistry.getMaxParallelBootExtensionTasks();
+    }
+
+    protected final int getMaxParallelBootSubsystemTasks() {
+        return extensionRegistry.getMaxParallelBootSubystemTasks();
+    }
+
     // See superclass start. This method is invoked from a separate non-MSC thread after start. So we can do a fair
     // bit of stuff
     @Override

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -409,7 +409,8 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
         super.registerChildren(hostRegistration);
 
         //Extensions
-        hostRegistration.registerSubModel(new ExtensionResourceDefinition(hostExtensionRegistry, true,
+        hostRegistration.registerSubModel(new ExtensionResourceDefinition(hostExtensionRegistry,
+                hostExtensionRegistry.getMaxParallelBootExtensionTasks() > 1,
                 ExtensionRegistryType.HOST,
                 new MutableRootResourceRegistrationProvider() {
                     @Override

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -65,6 +65,7 @@ import org.jboss.as.controller.capability.registry.RegistrationPoint;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.notification.Notification;
 import org.jboss.as.controller.notification.NotificationHandlerRegistry;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
@@ -271,11 +272,13 @@ public final class ServerService extends AbstractControllerService {
         Bootstrap.ConfigurationPersisterFactory configurationPersisterFactory = configuration.getConfigurationPersisterFactory();
         extensibleConfigurationPersister = configurationPersisterFactory.createConfigurationPersister(serverEnvironment, getExecutorServiceInjector().getOptionalValue());
         setConfigurationPersister(extensibleConfigurationPersister);
+        ExtensionRegistry exReg = configuration.getExtensionRegistry();
+        boolean parallelBoot = exReg.getMaxParallelBootExtensionTasks() > 1 && getExecutorServiceInjector().getOptionalValue() != null;
         rootResourceDefinition.setDelegate(
                 new ServerRootResourceDefinition(injectedContentRepository.getValue(),
                         extensibleConfigurationPersister, configuration.getServerEnvironment(), processState,
-                        runningModeControl, vaultReader, configuration.getExtensionRegistry(),
-                        getExecutorServiceInjector().getOptionalValue() != null,
+                        runningModeControl, vaultReader, exReg,
+                        parallelBoot,
                         (PathManagerService)injectedPathManagerService.getValue(),
                         new DomainServerCommunicationServices.OperationIDUpdater() {
                             @Override
@@ -290,6 +293,14 @@ public final class ServerService extends AbstractControllerService {
                         super.getBootErrorCollector(),
                         configuration.getCapabilityRegistry()));
         super.start(context);
+    }
+
+    protected int getMaxParallelBootExtensionTasks() {
+        return configuration.getExtensionRegistry().getMaxParallelBootExtensionTasks();
+    }
+
+    protected int getMaxParallelBootSubsystemTasks() {
+        return configuration.getExtensionRegistry().getMaxParallelBootSubystemTasks();
     }
 
     protected void boot(final BootContext context) throws ConfigurationPersistenceException {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3185

Instead of doing parallel boot with 1 task per extension (during extension initialization) and then 1 per subsystem (during subsystem op handling) this instead groups work into coarser grained chunks, with the number of chunks based on the number of available processors. Default setting is 1 subsystem chunk per processor, and 2 extension chunks per processor. This can be tweaked via **unsupported** system properties, _which only exist to allow us WildFly devs to experiment with different values and on different types of systems_.

On my 4-5 year old laptop this results in 8 chunks for subsystem work and 16 for extensions.

The number of threads used will be 2x the number of subsystem chunks, as the subsystem work needs separate chunks for Stage.MODEL vs Stage.RUNTIME, and the MODEL tasks block waiting for the overall boot op (and hence the RUNTIME tasks) to complete. So, 16 threads.  This 2x behavior is partly why by default I use 2x the # of extension chunks as subsystem ones -- the threads will be started regardless, so using them for extension work incurs no additional cost for starting up threads.  Also, quite a lot of classloading/IO may be involved in extension initialization (for example ideally all the extension's management integration classes would be loaded then.)

Testing over the summer showed no noticeable increase or decrease in boot time from this on my system. The number of threads used is much lower though, which is the point. With existing code booting WildFly's standalone-full-ha.xml results in spawning 72 threads vs the 16 here. (Note that disabling parallel boot altogether slowed down boot by about 400ms on my machine.)