### PR TITLE
Fix string comparison made in WFCORE-3347

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -349,7 +349,7 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
                     String[] newAlternatives = new String[length - 1];
                     int k = 0;
                     for (String alt : this.alternatives) {
-                        if (alt != alternative) {
+                        if (!alt.equals(alternative)) {
                             newAlternatives[k] = alt;
                             k++;
                         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3347

Fix wrong string comparison as pointed out in previous https://github.com/wildfly/wildfly-core/pull/2900#pullrequestreview-76091139 It should compare string content instead of object reference.