### PR TITLE
[WFCORE-3406] explicitly get the exclusive lock for standalone server in BlockerExtension

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -159,6 +159,8 @@ public class BlockerExtension implements Extension {
             boolean forMe = false;
             if (context.getProcessType() == ProcessType.STANDALONE_SERVER) {
                 forMe = true;
+                // WFCORE-3406 explicitly get the exclusive lock for standalone server
+                context.acquireControllerLock();
             } else {
                 context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS); // To help with WFCORE-263 testing, get the exclusive lock on this process
                 Resource rootResource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3406
It explicitly gets the exclusive lock for standalone server by calling acquireControllerLock(). JavaDoc on Method states:
> The lock is automatically released when the execute method of the handler that invoked this method returns.

I have manually added new BlockerExtension to test with standalone server as "steps to reproduce" in issue WFCORE-3406. It returns back correct locked time and operation.