### PR TITLE
Revert "[WFCORE-3405] Test for find-non-progressing-operation call fr…

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationCancellationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationCancellationTestCase.java
@@ -895,7 +895,6 @@ public class OperationCancellationTestCase {
             op.get("timeout").set(0);
             ModelNode result = executeForResult(op, masterClient);
             assertEquals(result.toString(), id, result.asString());
-
         } finally {
             try {
                 blockFuture.cancel(true);
@@ -904,79 +903,39 @@ public class OperationCancellationTestCase {
                 log.error("Failed to cancel in testFindNonProgressingOperation" , toLog);
             }
         }
-
-        // WFCORE-3405 Test for find-non-progressing-operation call from domain server
-        blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
-        id = findActiveOperation(masterClient, "master", "main-one", "block", null, start);
-        try {
-            ModelNode op = Util.createEmptyOperation("find-non-progressing-operation",
-                    PathAddress.pathAddress(PathElement.pathElement(HOST, "master"))
-                            .append(PathElement.pathElement(SERVER, "main-one"))
-                            .append(MGMT_CONTROLLER));
-            op.get("timeout").set(0);
-            ModelNode result = executeForResult(op, masterClient);
-            assertEquals(result.toString(), id, result.asString());
-        } finally {
-            try {
-                blockFuture.cancel(true);
-                validateNoActiveOperation(masterClient, "master", null, id, true);
-            } catch (Exception toLog) {
-                log.error("Failed to cancel in testFindNonProgressingOperation", toLog);
-            }
-        }
     }
 
     /** WFCORE-263 */
     @Test
     public void testCancellingNonProgressingDomainRollout() throws Exception {
-        failNonProgressingDomainRolloutTest("cancel-non-progressing-operation", null);
+        failNonProgressingDomainRolloutTest("cancel-non-progressing-operation");
     }
 
     /** WFCORE-263 */
     @Test
     public void testFindNonProgressingDomainRollout() throws Exception {
-        failNonProgressingDomainRolloutTest("find-non-progressing-operation", null);
+        failNonProgressingDomainRolloutTest("find-non-progressing-operation");
     }
 
-    /** WFCORE-3405 */
-    @Test
-    public void testCancellingNonProgressingDomainRolloutFullServerAddress() throws Exception {
-        failNonProgressingDomainRolloutTest("cancel-non-progressing-operation", "main-three");
-    }
-
-    /** WFCORE-3405 */
-    @Test
-    public void testFindNonProgressingDomainRolloutFullServerAddress() throws Exception {
-        failNonProgressingDomainRolloutTest("find-non-progressing-operation", "main-three");
-    }
-
-    private void failNonProgressingDomainRolloutTest(String opName, String server) throws Exception {
+    private void failNonProgressingDomainRolloutTest(String opName) throws Exception {
         long start = System.currentTimeMillis();
-        Future<ModelNode> blockFuture = block("slave", server, BlockerExtension.BlockPoint.COMMIT);
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
         String id = null;
         try {
-            id = findActiveOperation(masterClient, "slave", server, "block", OperationContext.ExecutionStatus.COMPLETING, start);
-            ModelNode op;
-            if (server == null) {
-                op = Util.createEmptyOperation(opName, PathAddress.pathAddress(PathElement.pathElement(HOST, "slave"))
-                        .append(MGMT_CONTROLLER));
-            } else {
-                op = Util.createEmptyOperation(opName,
-                        PathAddress.pathAddress(PathElement.pathElement(HOST, "slave"))
-                        .append(PathElement.pathElement(SERVER, server))
-                        .append(MGMT_CONTROLLER));
-            }
+            id = findActiveOperation(masterClient, "slave", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
+            ModelNode op = Util.createEmptyOperation(opName,
+                    PathAddress.pathAddress(PathElement.pathElement(HOST, "slave")).append(MGMT_CONTROLLER));
             op.get("timeout").set(0);
             ModelNode cancelled = executeForResult(op, masterClient);
             assertTrue(cancelled.isDefined());
             if (opName.contains("cancel")) {
-                validateNoActiveOperation(masterClient, "slave", server, cancelled.asString(), true);
+                validateNoActiveOperation(masterClient, "slave", null, cancelled.asString(), true);
             }
         } finally {
             try {
                 blockFuture.cancel(true);
                 if (id != null) {
-                    validateNoActiveOperation(masterClient, "slave", server, id, true);
+                    validateNoActiveOperation(masterClient, "slave", null, id, true);
                 }
             } catch (Exception toLog) {
                 log.error("Failed to cancel in failNonProgressingDomainRolloutTest of " + opName , toLog);


### PR DESCRIPTION
…om domain server"

This reverts commit f98c8bf964ffa022313d0759448935f6c89591c5.

Hi @bstansberry , I have locally ran the OperationCancellationTestCase 100 times in a loop from a simple script. But I can not reproduce any failure in almost 500 runs. Since it makes too much noise on CI results (it does show some frequency on recent CI results), this reverts the new tests added in previous PR. Let's keep the operation accessible change made in https://github.com/wildfly/wildfly-core/pull/2933. 

I need to tweak a bit more about the test locally and see where the intermittent failures come from. Once it's identified, I will make a new PR to add them back.