### PR TITLE
WFCORE-3445 Update jandex to 2.0.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-parent</artifactId>
-      <version>24</version>
+      <version>25</version>
     </parent>
 
     <groupId>org.wildfly.core</groupId>
@@ -107,7 +107,7 @@
         <version.org.jboss.byteman>3.0.6</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.1.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.0.Final</version.org.jboss.invocation>
-        <version.org.jboss.jandex>2.0.3.Final</version.org.jboss.jandex>
+        <version.org.jboss.jandex>2.0.4.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.4.1.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.12.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>


### PR DESCRIPTION
includes https://issues.jboss.org/browse/JANDEX-41 fix for running on JDK9