### PR TITLE
[WFCORE-3413] Introduce version strings into module configurations

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/ibm/jdk/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/ibm/jdk/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="ibm.jdk">
+<module xmlns="urn:jboss:module:1.6" name="ibm.jdk">
     <resources>
 
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/io/undertow/core/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/io/undertow/core/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="io.undertow.core">
+<module xmlns="urn:jboss:module:1.6" name="io.undertow.core">
     <resources>
         <artifact name="${io.undertow:undertow-core}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/io/undertow/core/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/io/undertow/core/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.6" name="io.undertow.core">
+<module xmlns="urn:jboss:module:1.6" name="io.undertow.core" version="${io.undertow:undertow-core}">
     <resources>
         <artifact name="${io.undertow:undertow-core}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/javax/api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/javax/api/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="javax.api">
+<module xmlns="urn:jboss:module:1.6" name="javax.api">
     <dependencies>
         <module name="javax.sql.api" export="true"/>
         <system export="true">

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/javax/interceptor/api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/javax/interceptor/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="javax.interceptor.api">
+<module xmlns="urn:jboss:module:1.6" name="javax.interceptor.api" version="${org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec}">
     <resources>
         <artifact name="${org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/javax/interceptor/api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/javax/interceptor/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.interceptor.api">
+<module xmlns="urn:jboss:module:1.6" name="javax.interceptor.api">
     <resources>
         <artifact name="${org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.json.api">
+<module xmlns="urn:jboss:module:1.6" name="javax.json.api">
 
     <properties>
         <property name="jboss.api" value="public"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/javax/security/jacc/api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/javax/security/jacc/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="javax.security.jacc.api">
+<module xmlns="urn:jboss:module:1.6" name="javax.security.jacc.api" version="${org.jboss.spec.javax.security.jacc:jboss-jacc-api_1.5_spec}">
     <dependencies>
         <module name="javax.servlet.api" optional="true"/>
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/javax/security/jacc/api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/javax/security/jacc/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.security.jacc.api">
+<module xmlns="urn:jboss:module:1.6" name="javax.security.jacc.api">
     <dependencies>
         <module name="javax.servlet.api" optional="true"/>
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/javax/sql/api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/javax/sql/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.sql.api">
+<module xmlns="urn:jboss:module:1.6" name="javax.sql.api">
     <resources/>
 
     <dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/javax/xml/stream/api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/javax/xml/stream/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="javax.xml.stream.api">
+<module xmlns="urn:jboss:module:1.6" name="javax.xml.stream.api">
 
     <dependencies>
         <system export="true">

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/aesh/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/aesh/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.aesh">
+<module xmlns="urn:jboss:module:1.6" name="org.aesh" version="${org.aesh:aesh-readline}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/aesh/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/aesh/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.aesh">
+<module xmlns="urn:jboss:module:1.6" name="org.aesh">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/commons/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/commons/logging/main/module.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.commons.logging">
+<module xmlns="urn:jboss:module:1.6" name="org.apache.commons.logging">
 
     <properties>
         <property name="jboss.api" value="public"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/log4j/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/log4j/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.log4j">
+<module xmlns="urn:jboss:module:1.6" name="org.apache.log4j">
 
     <properties>
         <property name="jboss.api" value="public"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/xerces/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/xerces/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.xerces">
+<module xmlns="urn:jboss:module:1.6" name="org.apache.xerces">
 
     <resources>
         <artifact name="${xerces:xercesImpl}"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/xerces/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/xerces/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.apache.xerces">
+<module xmlns="urn:jboss:module:1.6" name="org.apache.xerces" version="${xerces:xercesImpl}">
 
     <resources>
         <artifact name="${xerces:xercesImpl}"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/xml-resolver/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/xml-resolver/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.apache.xml-resolver">
+<module xmlns="urn:jboss:module:1.6" name="org.apache.xml-resolver" version="${xml-resolver:xml-resolver}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/xml-resolver/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/xml-resolver/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.apache.xml-resolver">
+<module xmlns="urn:jboss:module:1.6" name="org.apache.xml-resolver">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/woodstox/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/woodstox/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.6" name="org.codehaus.woodstox">
+<module xmlns="urn:jboss:module:1.6" name="org.codehaus.woodstox" version="${com.fasterxml.woodstox:woodstox-core}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/woodstox/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/woodstox/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.codehaus.woodstox">
+<module xmlns="urn:jboss:module:1.6" name="org.codehaus.woodstox">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/fusesource/jansi/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/fusesource/jansi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.fusesource.jansi">
+<module xmlns="urn:jboss:module:1.6" name="org.fusesource.jansi" version="${org.fusesource.jansi:jansi}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/fusesource/jansi/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/fusesource/jansi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.fusesource.jansi">
+<module xmlns="urn:jboss:module:1.6" name="org.fusesource.jansi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.glassfish.javax.json">
+<module xmlns="urn:jboss:module:1.6" name="org.glassfish.javax.json" version="${org.glassfish:javax.json}">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.glassfish.javax.json">
+<module xmlns="urn:jboss:module:1.6" name="org.glassfish.javax.json">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.cli">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.cli">
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.controller-client">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.controller-client" version="${org.wildfly.core:wildfly-controller-client}">
 
     <exports>
         <exclude path="org/jboss/as/controller/client/logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.controller-client">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.controller-client">
 
     <exports>
         <exclude path="org/jboss/as/controller/client/logging"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.controller">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.controller">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.controller">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.controller" version="${org.wildfly.core:wildfly-controller}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/core-security-api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/core-security-api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.core-security-api">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.core-security-api">
     <properties>
         <property name="jboss.api" value="deprecated"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/core-security-api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/core-security-api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.core-security-api">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.core-security-api" version="${org.wildfly.core:wildfly-core-security-api}">
     <properties>
         <property name="jboss.api" value="deprecated"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/core-security/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/core-security/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.core-security">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.core-security" version="${org.wildfly.core:wildfly-core-security}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/core-security/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/core-security/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.core-security">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.core-security">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-repository/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-repository/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.deployment-repository">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.deployment-repository">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-repository/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-repository/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.deployment-repository">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.deployment-repository" version="${org.wildfly.core:wildfly-deployment-repository}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-scanner/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-scanner/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.deployment-scanner">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.deployment-scanner" version="${org.wildfly.core:wildfly-deployment-scanner}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-scanner/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-scanner/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.deployment-scanner">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.deployment-scanner">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-add-user/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-add-user/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.domain-add-user">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.domain-add-user">
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-error-context/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-error-context/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.domain-http-error-context">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.domain-http-error-context">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-error-context/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-error-context/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.domain-http-error-context">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.domain-http-error-context" version="${org.wildfly.core:wildfly-domain-http-error-context}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.domain-http-interface">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.domain-http-interface">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.domain-http-interface">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.domain-http-interface" version="${org.wildfly.core:wildfly-domain-http-interface}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-management/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-management/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.domain-management">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.domain-management">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-management/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/domain-management/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.domain-management">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.domain-management" version="${org.wildfly.core:wildfly-domain-management}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.host-controller">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.host-controller">
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.host-controller">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.host-controller" version="${org.wildfly.core:wildfly-host-controller}">
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.jmx">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.jmx">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.jmx">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.jmx" version="${org.wildfly.core:wildfly-jmx}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.logging">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.logging" version="${org.wildfly.core:wildfly-logging}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.logging">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.logging">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/management-client-content/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/management-client-content/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.management-client-content">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.management-client-content" version="${org.wildfly.core:wildfly-management-client-content}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/management-client-content/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/management-client-content/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.management-client-content">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.management-client-content">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.network">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.network" version="${org.wildfly.core:wildfly-network}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.network">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.network">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/patching/cli/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/patching/cli/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.patching.cli">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.patching.cli">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/patching/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/patching/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.patching">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.patching">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/patching/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/patching/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.patching">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.patching" version="${org.wildfly.core:wildfly-patching}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/platform-mbean/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/platform-mbean/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.platform-mbean">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.platform-mbean">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/platform-mbean/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/platform-mbean/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.platform-mbean">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.platform-mbean" version="${org.wildfly.core:wildfly-platform-mbean}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/process-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/process-controller/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.process-controller">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.process-controller">
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/process-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/process-controller/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.process-controller">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.process-controller" version="${org.wildfly.core:wildfly-process-controller}">
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.protocol">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.protocol">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.protocol">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.protocol" version="${org.wildfly.core:wildfly-protocol}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.remoting">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.remoting">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.remoting">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.remoting" version="${org.wildfly.core:wildfly-remoting}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.server">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.server" version="${org.wildfly.core:wildfly-server}">
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.server">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.server">
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.standalone">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.standalone">
     <properties>
         <property name="jboss.api" value="private"/>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/threads/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/threads/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.threads">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.threads">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/threads/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/threads/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.threads">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.threads" version="${org.wildfly.core:wildfly-threads}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/version/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/version/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.version">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.version" version="${org.wildfly.core:wildfly-version}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/version/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/version/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.as.version">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.as.version">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/classfilewriter/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/classfilewriter/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.classfilewriter">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.classfilewriter">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/classfilewriter/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/classfilewriter/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.classfilewriter">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.classfilewriter" version="${org.jboss.classfilewriter:jboss-classfilewriter}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/dmr/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/dmr/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.dmr">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.dmr" version="${org.jboss:jboss-dmr}">
     <resources>
         <artifact name="${org.jboss:jboss-dmr}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/dmr/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/dmr/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.dmr">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.dmr">
     <resources>
         <artifact name="${org.jboss:jboss-dmr}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/invocation/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/invocation/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.invocation">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.invocation">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/invocation/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/invocation/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.invocation">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.invocation" version="${org.jboss.invocation:jboss-invocation}">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/jandex/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/jandex/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.jandex">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.jandex">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/jandex/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/jandex/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.jandex">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.jandex" version="${org.jboss:jandex}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.log4j.logmanager">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.log4j.logmanager" version="${org.jboss.logmanager:log4j-jboss-logmanager}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.log4j.logmanager">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.log4j.logmanager">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logging/jul-to-slf4j-stub/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logging/jul-to-slf4j-stub/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.logging.jul-to-slf4j-stub">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.logging.jul-to-slf4j-stub" version="${org.jboss.logging:jul-to-slf4j-stub}">
     <resources>
         <artifact name="${org.jboss.logging:jul-to-slf4j-stub}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logging/jul-to-slf4j-stub/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logging/jul-to-slf4j-stub/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.logging.jul-to-slf4j-stub">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.logging.jul-to-slf4j-stub">
     <resources>
         <artifact name="${org.jboss.logging:jul-to-slf4j-stub}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logging/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.logging">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.logging">
     <resources>
         <artifact name="${org.jboss.logging:jboss-logging}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logging/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.logging">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.logging" version="${org.jboss.logging:jboss-logging}">
     <resources>
         <artifact name="${org.jboss.logging:jboss-logging}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/commons/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/commons/logging/main/module.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.logmanager.commons.logging">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.logmanager.commons.logging">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/commons/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/commons/logging/main/module.xml
@@ -16,7 +16,7 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.logmanager.commons.logging">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.logmanager.commons.logging" version="${org.jboss.logmanager:commons-logging-jboss-logmanager}">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.logmanager">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.logmanager" version="${org.jboss.logmanager:jboss-logmanager}">
     <resources>
         <artifact name="${org.jboss.logmanager:jboss-logmanager}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.logmanager">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.logmanager">
     <resources>
         <artifact name="${org.jboss.logmanager:jboss-logmanager}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.marshalling">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.marshalling">
     <resources>
         <artifact name="${org.jboss.marshalling:jboss-marshalling}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.marshalling">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.marshalling" version="${org.jboss.marshalling:jboss-marshalling}">
     <resources>
         <artifact name="${org.jboss.marshalling:jboss-marshalling}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/river/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/river/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.marshalling.river">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.marshalling.river" version="${org.jboss.marshalling:jboss-marshalling-river}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/river/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/river/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.marshalling.river">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.marshalling.river">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/modules/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/modules/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.modules">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.modules">
     <dependencies>
         <system export="true">
             <paths>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/msc/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/msc/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.msc">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.msc" version="${org.jboss.msc:jboss-msc}">
 
     <properties>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/msc/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/msc/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.msc">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.msc">
 
     <properties>
         <property name="jboss.require-java-version" value="1.8"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting-jmx/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting-jmx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.remoting-jmx">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.remoting-jmx">
     <resources>
         <artifact name="${org.jboss.remotingjmx:remoting-jmx}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting-jmx/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting-jmx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.remoting-jmx">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.remoting-jmx" version="${org.jboss.remotingjmx:remoting-jmx}">
     <resources>
         <artifact name="${org.jboss.remotingjmx:remoting-jmx}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.remoting">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.remoting" version="${org.jboss.remoting:jboss-remoting}">
     <resources>
         <artifact name="${org.jboss.remoting:jboss-remoting}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.remoting">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.remoting">
     <resources>
         <artifact name="${org.jboss.remoting:jboss-remoting}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/staxmapper/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/staxmapper/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.staxmapper">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.staxmapper" version="${org.jboss:staxmapper}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/staxmapper/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/staxmapper/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.staxmapper">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.staxmapper">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/stdio/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/stdio/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.stdio">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.stdio" version="${org.jboss.stdio:jboss-stdio}">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/stdio/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/stdio/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.stdio">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.stdio">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/threads/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/threads/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.threads">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.threads" version="${org.jboss.threads:jboss-threads}">
 
    <properties>
        <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/threads/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/threads/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.threads">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.threads">
 
    <properties>
        <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/vfs/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/vfs/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.vfs">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.vfs">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/vfs/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/vfs/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.vfs">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.vfs" version="${org.jboss:jboss-vfs}">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xnio/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xnio/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.xnio">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.xnio" version="${org.jboss.xnio:xnio-api}">
     <resources>
         <artifact name="${org.jboss.xnio:xnio-api}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xnio/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xnio/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.xnio">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.xnio">
     <resources>
         <artifact name="${org.jboss.xnio:xnio-api}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xnio/nio/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xnio/nio/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.xnio.nio">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.xnio.nio" version="${org.jboss.xnio:xnio-nio}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xnio/nio/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xnio/nio/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jboss.xnio.nio">
+<module xmlns="urn:jboss:module:1.6" name="org.jboss.xnio.nio">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/projectodd/vdx/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/projectodd/vdx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.projectodd.vdx">
+<module xmlns="urn:jboss:module:1.6" name="org.projectodd.vdx" version="${org.projectodd.vdx:vdx-core}">
   <properties>
     <property name="jboss.api" value="private"/>
   </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/projectodd/vdx/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/projectodd/vdx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.projectodd.vdx">
+<module xmlns="urn:jboss:module:1.6" name="org.projectodd.vdx">
   <properties>
     <property name="jboss.api" value="private"/>
   </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/slf4j/impl/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/slf4j/impl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.slf4j.impl">
+<module xmlns="urn:jboss:module:1.6" name="org.slf4j.impl">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/slf4j/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/slf4j/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.slf4j">
+<module xmlns="urn:jboss:module:1.6" name="org.slf4j">
     <resources>
         <artifact name="${org.slf4j:slf4j-api}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/slf4j/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/slf4j/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.slf4j">
+<module xmlns="urn:jboss:module:1.6" name="org.slf4j" version="${org.slf4j:slf4j-api}">
     <resources>
         <artifact name="${org.slf4j:slf4j-api}"/>
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/client/config/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/client/config/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.client.config">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.client.config">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/client/config/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/client/config/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.client.config">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.client.config" version="${org.wildfly.client:wildfly-client-config}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/common/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.common">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.common">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/common/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.common">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.common" version="${org.wildfly.common:wildfly-common}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/discovery/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/discovery/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.discovery">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.discovery" version="${org.wildfly.discovery:wildfly-discovery-client}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/embedded/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/embedded/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.embedded">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.embedded" version="${org.wildfly.core:wildfly-embedded}">
     <properties>
         <!-- Core version of the embedded API is currently only meant
         for use by the CLI -->

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/embedded/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/embedded/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.embedded">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.embedded">
     <properties>
         <!-- Core version of the embedded API is currently only meant
         for use by the CLI -->

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/core-management-client/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/core-management-client/main/module.xml
@@ -24,7 +24,7 @@
   ~ */
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.core-management-client">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.core-management-client" version="${org.wildfly.core:wildfly-core-management-client}">
     <resources>
         <artifact name="${org.wildfly.core:wildfly-core-management-client}" />
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/core-management-client/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/core-management-client/main/module.xml
@@ -24,7 +24,7 @@
   ~ */
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.core-management-client">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.core-management-client">
     <resources>
         <artifact name="${org.wildfly.core:wildfly-core-management-client}" />
     </resources>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/core-management/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/core-management/main/module.xml
@@ -24,7 +24,7 @@
   ~ */
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.core-management">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.core-management">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/discovery/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/discovery/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.discovery">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.discovery" version="${org.wildfly.core:wildfly-discovery}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.elytron">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.elytron" version="${org.wildfly.core:wildfly-elytron-integration}">
 
     <exports>
         <exclude path="org/wildfly/extension/elytron/ElytronExtension"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/elytron/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.elytron">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.elytron">
 
     <exports>
         <exclude path="org/wildfly/extension/elytron/ElytronExtension"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
@@ -24,7 +24,7 @@
   ~ */
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.io">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.io" version="${org.wildfly.core:wildfly-io}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
@@ -24,7 +24,7 @@
   ~ */
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.io">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.io">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/request-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/request-controller/main/module.xml
@@ -24,7 +24,7 @@
   ~ */
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.request-controller">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.request-controller" version="${org.wildfly.core:wildfly-request-controller}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/request-controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/request-controller/main/module.xml
@@ -24,7 +24,7 @@
   ~ */
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.request-controller">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.request-controller">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.security.manager">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.security.manager" version="${org.wildfly.core:wildfly-security-manager}">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.extension.security.manager">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.extension.security.manager">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/openssl/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/openssl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.openssl">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.openssl" version="${org.wildfly.openssl:wildfly-openssl-java}">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/openssl/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/openssl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.openssl">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.openssl">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.security.elytron-private">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.security.elytron-private" version="${org.wildfly.security:wildfly-elytron}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.security.elytron-private">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.security.elytron-private">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.security.elytron-web.undertow-server">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.security.elytron-web.undertow-server">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-web/undertow-server/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.wildfly.security.elytron-web.undertow-server">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.security.elytron-web.undertow-server" version="${org.wildfly.security.elytron-web:undertow-server}">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.security.elytron">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.security.elytron">
 
     <dependencies>
         <module name="org.wildfly.security.elytron-private" services="export" export="true">

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/manager/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/manager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.wildfly.security.manager">
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.security.manager">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="sun.jdk">
+<module xmlns="urn:jboss:module:1.6" name="sun.jdk">
     <resources>
         <!-- currently jboss modules has not way of importing services from
         classes.jar so we duplicate them here -->

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/sun/scripting/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/sun/scripting/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.5" name="sun.scripting">
+<module xmlns="urn:jboss:module:1.6" name="sun.scripting">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <version.org.jboss.logmanager.jboss-logmanager>2.1.0.Alpha5</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.4.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.2.Final</version.org.jboss.marshalling.jboss-marshalling>
-        <version.org.jboss.modules.jboss-modules>1.6.1.Final</version.org.jboss.modules.jboss-modules>
+        <version.org.jboss.modules.jboss-modules>1.6.2.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.8.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.5.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.0.Final</version.org.jboss.remotingjmx.remoting-jmx>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <version.org.projectodd.vdx>1.1.6</version.org.projectodd.vdx>
         <version.org.slf4j>1.7.22</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
-        <version.org.wildfly.build-tools>1.2.2.Final</version.org.wildfly.build-tools>
+        <version.org.wildfly.build-tools>1.2.4.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.client.config>1.0.0.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.2.0.Final</version.org.wildfly.common>


### PR DESCRIPTION
This PR is in four parts:

* The build tool upgrade enables transformation of version strings with artifact expressions
* Modules is upgraded to fix a bug in module version assignment
* The module descriptors are updated to the 1.6 schema
* The module.xml descriptors with artifacts are modified to include the correct version string