### PR TITLE
[WFCORE-887] Log an "expressions deprecated" warning if an expression…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -629,6 +629,16 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
     }
 
     /**
+     * Marks that support for use of an expression for the attribute's value is deprecated and
+     * may be removed in a future release.
+     *
+     * @return a builder that can be used to continue building the attribute definition
+     */
+    public final BUILDER setExpressionsDeprecated() {
+        return addFlag(AttributeAccess.Flag.EXPRESSIONS_DEPRECATED);
+    }
+
+    /**
      * Sets access constraints to use with the attribute
      * @param accessConstraints the constraints
      * @return a builder that can be used to continue building the attribute definition

--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -506,6 +506,11 @@ public abstract class AttributeDefinition {
             operationObject.get(name).set(correctedValue);
         }
         ModelNode node = validateOperation(operationObject, true);
+        if (node.getType() == ModelType.EXPRESSION
+                && (referenceRecorder != null || flags.contains(AttributeAccess.Flag.EXPRESSIONS_DEPRECATED))) {
+            ControllerLogger.DEPRECATED_LOGGER.attributeExpressionDeprecated(getName(),
+                PathAddress.pathAddress(operationObject.get(ModelDescriptionConstants.OP_ADDR)).toCLIStyleString());
+        }
         model.get(name).set(node);
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -421,7 +421,7 @@ public interface ControllerLogger extends BasicLogger {
 
     @LogMessage(level = Level.INFO)
     @Message(id = 28, value = "Attribute '%s' in the resource at address '%s' is deprecated, and may be removed in " +
-            "future version. See the attribute description in the output of the read-resource-description operation " +
+            "a future version. See the attribute description in the output of the read-resource-description operation " +
             "to learn more about the deprecation.")
     void attributeDeprecated(String name, String address);
 
@@ -3510,4 +3510,12 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = 446, value = "%s or alternative(s) %s is required")
     OperationFailedException requiredWithAlternatives(String name, Set<String> alternatives);
+
+    @LogMessage(level = Level.WARN)
+    @Message(id = 447, value = "Attribute '%s' in the resource at address '%s' has been configured with an expression, " +
+            "but support for use of expressions in this attribute's value may be removed in a future version. This " +
+            "attribute configures whether a capability that can be required by other parts of the configuration is present " +
+            "or itself configures a requirement for a capability provided by another part of the configuration. " +
+            "Full support for this kind of configuration cannot be provided when an expression is used.")
+    void attributeExpressionDeprecated(String name, String address);
 }

--- a/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
@@ -146,7 +146,12 @@ public final class AttributeAccess {
          * This flag can be used in conjunction with STORAGE_RUNTIME to specify that a runtime
          * attribute can work in the absence of runtime services.
          */
-         RUNTIME_SERVICE_NOT_REQUIRED;
+        RUNTIME_SERVICE_NOT_REQUIRED,
+        /**
+         * Support for use of an expression for the value of this attribute is deprecated
+         * and may be removed in a future release.
+         */
+        EXPRESSIONS_DEPRECATED;
 
         private static final Map<EnumSet<AttributeAccess.Flag>, Set<AttributeAccess.Flag>> flagSets = new ConcurrentHashMap<>(16);
         public static Set<AttributeAccess.Flag> immutableSetOf(AttributeAccess.Flag... flags) {

--- a/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingGroupResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingGroupResourceDefinition.java
@@ -57,6 +57,7 @@ public abstract class AbstractSocketBindingGroupResourceDefinition extends Simpl
     protected static SimpleAttributeDefinition createDefaultInterface(RuntimeCapability dependentCapability) {
         return new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.DEFAULT_INTERFACE, ModelType.STRING, false)
                 .setAllowExpression(true)
+                .setExpressionsDeprecated()
                 .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
                 .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                 .setCapabilityReference("org.wildfly.network.interface", dependentCapability)

--- a/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingResourceDefinition.java
@@ -62,6 +62,7 @@ public abstract class AbstractSocketBindingResourceDefinition extends SimpleReso
 
     public static final SimpleAttributeDefinition INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.INTERFACE, ModelType.STRING, true)
             .setAllowExpression(true)
+            .setExpressionsDeprecated()
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setCapabilityReference("org.wildfly.network.interface", SOCKET_BINDING_CAPABILITY_NAME, true)

--- a/server/src/main/java/org/jboss/as/server/services/net/OutboundSocketBindingResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/OutboundSocketBindingResourceDefinition.java
@@ -45,7 +45,7 @@ import org.jboss.dmr.ModelType;
  */
 public abstract class OutboundSocketBindingResourceDefinition extends SimpleResourceDefinition {
 
-    static final String OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME = "org.wildfly.network.outbound-socket-binding";
+    private static final String OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME = "org.wildfly.network.outbound-socket-binding";
     static final RuntimeCapability<Void> OUTBOUND_SOCKET_BINDING_CAPABILITY =
             RuntimeCapability.Builder.of(OutboundSocketBindingResourceDefinition.OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME,
                     true, OutboundSocketBinding.class)
@@ -60,6 +60,7 @@ public abstract class OutboundSocketBindingResourceDefinition extends SimpleReso
 
     public static final SimpleAttributeDefinition SOURCE_INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOURCE_INTERFACE, ModelType.STRING, true)
             .setAllowExpression(true)
+            .setExpressionsDeprecated()
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .setCapabilityReference("org.wildfly.network.interface", OUTBOUND_SOCKET_BINDING_CAPABILITY)


### PR DESCRIPTION
… is used for an attribute that is either a capability reference or has been specifically flagged to produce the warn.

https://issues.jboss.org/browse/WFCORE-887
