### PR TITLE
[WFCORE-3454] Ensure the dist archives contain the correct content. R…

### DIFF
--- a/build/assembly.xml
+++ b/build/assembly.xml
@@ -37,7 +37,7 @@
             <directory>target</directory>
             <outputDirectory/>
             <includes>
-                <include>${server.output.dir.prefix}-core-${project.version}/**</include>
+                <include>${server.output.dir.prefix}-${wildfly.core.release.version}/**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -53,7 +53,7 @@
     </dependencies>
 
     <build>
-        <finalName>${server.output.dir.prefix}-core-${project.version}</finalName>
+        <finalName>${server.output.dir.prefix}-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.wildfly.build</groupId>
@@ -98,7 +98,7 @@
                                         <descriptor>assembly.xml</descriptor>
                                     </descriptors>
                                     <recompressZippedFiles>true</recompressZippedFiles>
-                                    <finalName>${server.output.dir.prefix}-core-${project.version}</finalName>
+                                    <finalName>${server.output.dir.prefix}-${project.version}</finalName>
                                     <appendAssemblyId>false</appendAssemblyId>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                     <workDirectory>${project.build.directory}/assembly/work</workDirectory>

--- a/core-feature-pack/assembly.xml
+++ b/core-feature-pack/assembly.xml
@@ -32,7 +32,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
-            <directory>target/${server.output.dir.prefix}-core-feature-pack-${project.version}</directory>
+            <directory>target/${server.output.dir.prefix}-feature-pack-${project.version}</directory>
             <outputDirectory/>            
         </fileSet>
     </fileSets>

--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -487,7 +487,7 @@
     </dependencies>
 
     <build>
-        <finalName>${server.output.dir.prefix}-core-feature-pack-${project.version}</finalName>
+        <finalName>${server.output.dir.prefix}-feature-pack-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -526,7 +526,7 @@
                                 <descriptor>assembly.xml</descriptor>
                             </descriptors>
                             <recompressZippedFiles>true</recompressZippedFiles>
-                            <finalName>${server.output.dir.prefix}-core-feature-pack-${project.version}</finalName>
+                            <finalName>${server.output.dir.prefix}-feature-pack-${project.version}</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
                             <outputDirectory>target/</outputDirectory>
                             <workDirectory>target/assembly/work</workDirectory>

--- a/dist/assembly-src.xml
+++ b/dist/assembly-src.xml
@@ -37,7 +37,7 @@
     <fileSets>
         <fileSet>
             <directory>..</directory>
-            <outputDirectory>${server.output.dir.prefix}-${project.version}-src</outputDirectory>
+            <outputDirectory>${server.output.dir.prefix}-${wildfly.core.release.version}-src</outputDirectory>
             <includes>
                 <include>**/*.xml</include>
                 <include>**/src/**</include>

--- a/dist/assembly.xml
+++ b/dist/assembly.xml
@@ -28,6 +28,7 @@
     <id>distro</id>
     <formats>
        <format>zip</format>
+        <format>tar.gz</format>
     </formats>
 
     <includeBaseDirectory>false</includeBaseDirectory>
@@ -37,7 +38,7 @@
             <directory>target</directory>
             <outputDirectory/>
             <includes>
-                <include>${server.output.dir.prefix}-core-${project.version}/**</include>
+                <include>${server.output.dir.prefix}-${wildfly.core.release.version}/**</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -64,6 +64,7 @@
                 </property>
             </activation>
             <build>
+                <finalName>${server.output.dir.prefix}-${wildfly.core.release.version}</finalName>
                 <plugins>
                     <plugin>
                         <groupId>org.wildfly.build</groupId>
@@ -93,7 +94,7 @@
                                 <phase>process-classes</phase>
                                 <configuration>
                                     <overwrite>true</overwrite>
-                                    <outputDirectory>${basedir}/target/${server.output.dir.prefix}-core-${project.version}</outputDirectory>
+                                    <outputDirectory>${basedir}/target/${project.build.finalName}</outputDirectory>
                                     <resources>
                                         <resource>
                                             <directory>src/distribution/resources</directory>
@@ -119,7 +120,7 @@
                                         <descriptor>assembly.xml</descriptor>
                                     </descriptors>
                                     <recompressZippedFiles>true</recompressZippedFiles>
-                                    <finalName>${server.output.dir.prefix}-core-${project.version}</finalName>
+                                    <finalName>${project.build.finalName}</finalName>
                                     <appendAssemblyId>false</appendAssemblyId>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                     <workDirectory>${project.build.directory}/assembly/work</workDirectory>
@@ -136,7 +137,7 @@
                                     <descriptors>
                                         <descriptor>assembly-src.xml</descriptor>
                                     </descriptors>
-                                    <finalName>${server.output.dir.prefix}-core-${project.version}</finalName>
+                                    <finalName>${project.build.finalName}</finalName>
                                     <appendAssemblyId>true</appendAssemblyId>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                     <workDirectory>${project.build.directory}/assembly-src/work</workDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <!-- Checkstyle configuration -->
         <linkXRef>false</linkXRef>
 
-        <server.output.dir.prefix>wildfly</server.output.dir.prefix>
+        <server.output.dir.prefix>wildfly-core</server.output.dir.prefix>
         <wildfly.build.output.dir>dist/target/${server.output.dir.prefix}-${wildfly.core.release.version}</wildfly.build.output.dir>
         <test.level>INFO</test.level>
 
@@ -906,13 +906,13 @@
 
             <dependency>
                 <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-vault-test-feature-pack</artifactId>
+                <artifactId>wildfly-core-vault-test-feature-pack</artifactId>
                 <type>pom</type>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-vault-test-feature-pack</artifactId>
+                <artifactId>wildfly-core-vault-test-feature-pack</artifactId>
                 <type>zip</type>
                 <version>${project.version}</version>
             </dependency>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -84,7 +84,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-vault-test-feature-pack</artifactId>
+            <artifactId>wildfly-core-vault-test-feature-pack</artifactId>
             <type>zip</type>
         </dependency>
 

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-vault-test-feature-pack</artifactId>
+            <artifactId>wildfly-core-vault-test-feature-pack</artifactId>
             <type>zip</type>
         </dependency>
         <dependency>

--- a/testsuite/elytron/server-provisioning.xml
+++ b/testsuite/elytron/server-provisioning.xml
@@ -1,6 +1,6 @@
 <server-provisioning xmlns="urn:wildfly:server-provisioning:1.1" copy-module-artifacts="false">
     <feature-packs>
         <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-feature-pack" version="${project.version}" />
-        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-vault-test-feature-pack" version="${project.version}" />
+        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-vault-test-feature-pack" version="${project.version}" />
     </feature-packs>
 </server-provisioning>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-vault-test-feature-pack</artifactId>
+            <artifactId>wildfly-core-vault-test-feature-pack</artifactId>
             <type>zip</type>
         </dependency>
         <dependency>

--- a/testsuite/manualmode/server-provisioning.xml
+++ b/testsuite/manualmode/server-provisioning.xml
@@ -22,6 +22,6 @@
 <server-provisioning xmlns="urn:wildfly:server-provisioning:1.1" copy-module-artifacts="false">
     <feature-packs>
         <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-feature-pack" version="${project.version}" />
-        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-vault-test-feature-pack" version="${project.version}" />
+        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-vault-test-feature-pack" version="${project.version}" />
     </feature-packs>
 </server-provisioning>

--- a/testsuite/rbac/pom.xml
+++ b/testsuite/rbac/pom.xml
@@ -57,7 +57,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-vault-test-feature-pack</artifactId>
+            <artifactId>wildfly-core-vault-test-feature-pack</artifactId>
             <type>zip</type>
         </dependency>
         <dependency>

--- a/testsuite/rbac/server-provisioning.xml
+++ b/testsuite/rbac/server-provisioning.xml
@@ -22,6 +22,6 @@
 <server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
     <feature-packs>
         <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-feature-pack" version="${project.version}" />
-        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-vault-test-feature-pack" version="${project.version}" />
+        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-vault-test-feature-pack" version="${project.version}" />
     </feature-packs>
 </server-provisioning>

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-vault-test-feature-pack</artifactId>
+            <artifactId>wildfly-core-vault-test-feature-pack</artifactId>
             <type>zip</type>
         </dependency>
         <dependency>

--- a/testsuite/standalone/server-provisioning.xml
+++ b/testsuite/standalone/server-provisioning.xml
@@ -22,6 +22,6 @@
 <server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
     <feature-packs>
         <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-feature-pack" version="${project.version}" />
-        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-vault-test-feature-pack" version="${project.version}" />
+        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-vault-test-feature-pack" version="${project.version}" />
     </feature-packs>
 </server-provisioning>

--- a/testsuite/vault-test-feature-pack/pom.xml
+++ b/testsuite/vault-test-feature-pack/pom.xml
@@ -34,7 +34,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>wildfly-vault-test-feature-pack</artifactId>
+    <artifactId>wildfly-core-vault-test-feature-pack</artifactId>
 
     <name>WildFly: Vault Test Feature Pack</name>
     <packaging>pom</packaging>


### PR DESCRIPTION
…enamed the wildfly-vault-test-feature-pack maven module to wildfly-core-vault-test-feature-pack.

https://issues.jboss.org/browse/WFCORE-3454

One thing to note here is I did rename the `wildfly-vault-test-feature-pack` maven module to `wildfly-core-vault-test-feature-pack`. This was due to the fact that the default `server.output.dir.prefix` property was set to `wildfly` and for core should likely be `wildfly-core`. This feature pack seems to only be used in WildFly Core. If we feel this shouldn't change I can remove that change. I didn't see any usage in WildFly.
