### PR TITLE
JBEAP-13099 Duplicate record is written in property file when group name set to empty

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesFileLoader.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/PropertiesFileLoader.java
@@ -71,6 +71,9 @@ public class PropertiesFileLoader {
      * <ul>
      * <li>{@code #username=password}</li>
      * <li>{@code username=password}</li>
+     * <li>{@code #username=group1,group2,...}</li>
+     * <li>{@code username=group1,group2,...}</li>
+     * <li>{@code username=} (no group)</li>
      * </ul>
      *
      * The regular expression is used to obtain 2 capturing groups, {@code group(1)} is used to obtain the username,
@@ -98,7 +101,7 @@ public class PropertiesFileLoader {
      *
      * Note: Possessive quantifiers are used here as without them invalid test strings become a serious performance burden.
      */
-    public static final Pattern PROPERTY_PATTERN = Pattern.compile("#?+((?:[,.\\-@/a-zA-Z0-9]++|(?:\\\\[=\\\\])++)++)=(.++)");
+    public static final Pattern PROPERTY_PATTERN = Pattern.compile("#?+((?:[,.\\-@/a-zA-Z0-9]++|(?:\\\\[=\\\\])++)++)=(.*)");
     public static final String DISABLE_SUFFIX_KEY = "!disable";
 
     private final InjectedValue<PathManager> pathManager = new InjectedValue<PathManager>();


### PR DESCRIPTION
Changes for JIRA: https://issues.jboss.org/browse/JBEAP-13099
Upstream JIRA: https://issues.jboss.org/browse/WFCORE-3282
Upstream PR: https://github.com/wildfly/wildfly-core/pull/2832