### PR TITLE
[WFCORE-3476] Avoid to wait for timeout suspending a server already suspended

### DIFF
--- a/server/src/main/java/org/jboss/as/server/operations/ServerSuspendHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerSuspendHandler.java
@@ -124,7 +124,7 @@ public class ServerSuspendHandler implements OperationStepHandler {
                 };
                 suspendController.addListener(operationListener);
                 suspendController.suspend(timeout > 0 ?  timeout * 1000 : timeout);
-                if(timeout != 0) {
+                if(timeout != 0 && suspendController.getState() != SuspendController.State.SUSPENDED) {
                     try {
                         latch.await();
                     } catch (InterruptedException e) {


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/WFCORE-3476