### PR TITLE
[WFCORE-3458] External CS, PKCS11 can't be configured with externalPath

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
@@ -32,8 +32,11 @@ import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -76,6 +79,7 @@ import org.wildfly.security.credential.PasswordCredential;
 import org.wildfly.security.credential.store.CredentialStore;
 import org.wildfly.security.credential.store.CredentialStoreException;
 import org.wildfly.security.credential.store.UnsupportedCredentialTypeException;
+import org.wildfly.security.credential.store.impl.KeyStoreCredentialStore;
 import org.wildfly.security.password.PasswordFactory;
 import org.wildfly.security.password.interfaces.ClearPassword;
 import org.wildfly.security.password.spec.ClearPasswordSpec;
@@ -86,6 +90,10 @@ import org.wildfly.security.password.spec.ClearPasswordSpec;
  * @author <a href="mailto:pskopek@redhat.com">Peter Skopek</a>
  */
 final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
+
+    // KeyStore backed credential store supported attributes
+    private static final String CS_KEY_STORE_TYPE_ATTRIBUTE = "keyStoreType";
+    private static final List<String> filebasedKeystoreTypes = Collections.unmodifiableList(Arrays.asList("JKS", "JCEKS", "PKCS12"));
 
     static final ServiceUtil<CredentialStore> CREDENTIAL_STORE_UTIL = ServiceUtil.newInstance(CREDENTIAL_STORE_RUNTIME_CAPABILITY, ElytronDescriptionConstants.CREDENTIAL_STORE, CredentialStore.class);
 
@@ -272,15 +280,12 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
             String location = LOCATION.resolveModelAttribute(context, model).asStringOrNull();
             boolean modifiable =  MODIFIABLE.resolveModelAttribute(context, model).asBoolean();
             boolean create = CREATE.resolveModelAttribute(context, model).asBoolean();
-            final Map<String, String> implementationAttributes;
+            final Map<String, String> implementationAttributes = new HashMap<>();
             ModelNode implAttrModel = IMPLEMENTATION_PROPERTIES.resolveModelAttribute(context, model);
             if (implAttrModel.isDefined()) {
-                implementationAttributes = new HashMap<>();
                 for (String s : implAttrModel.keys()) {
                     implementationAttributes.put(s, implAttrModel.require(s).asString());
                 }
-            } else {
-                implementationAttributes = null;
             }
             String type = TYPE.resolveModelAttribute(context, model).asStringOrNull();
             String providers = PROVIDERS.resolveModelAttribute(context, model).asStringOrNull();
@@ -289,6 +294,15 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
             String name = credentialStoreName(operation);
             String relativeTo = RELATIVE_TO.resolveModelAttribute(context, model).asStringOrNull();
             ServiceTarget serviceTarget = context.getServiceTarget();
+
+            if (type == null || type.equals(KeyStoreCredentialStore.KEY_STORE_CREDENTIAL_STORE)) {
+                implementationAttributes.putIfAbsent(CS_KEY_STORE_TYPE_ATTRIBUTE, "JCEKS");
+            }
+
+            String implAttrKeyStoreType = implementationAttributes.get(CS_KEY_STORE_TYPE_ATTRIBUTE);
+            if (location == null && implAttrKeyStoreType != null && filebasedKeystoreTypes.contains(implAttrKeyStoreType.toUpperCase(Locale.ENGLISH))) {
+                throw ROOT_LOGGER.filebasedKeystoreLocationMissing(implAttrKeyStoreType);
+            }
 
             // ----------- credential store service ----------------
             final CredentialStoreService csService;

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -353,6 +353,9 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 920, value = "Credential alias '%s' of credential type '%s' does not exist in the store")
     OperationFailedException credentialDoesNotExist(String alias, String credentialType);
 
+    @Message(id = 921, value = "Location parameter is not specified for filebased keystore type '%s'")
+    OperationFailedException filebasedKeystoreLocationMissing(String type);
+
     @Message(id = Message.NONE, value = "Reload dependent services which might already have cached the secret value")
     String reloadDependantServices();
 


### PR DESCRIPTION
elytron-subsystem: https://issues.jboss.org/browse/WFCORE-3458
JBEAP: https://issues.jboss.org/browse/JBEAP-13978

Removing the requirement "if location is not set in CLI, default
credential-store name is used as location"

When location is not set for most common filebased keystore types (JKS,
JCEKS and PKCS12), Elytron will throw exception.

Elytron PR: https://github.com/wildfly-security/wildfly-elytron/pull/1051