### PR TITLE
[WFCORE-3483] Deprecate PathAddress.navigate and remove, replace controller catches of NoSuchElementException with Resource.NoSuchResourceException

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PathAddress.java
+++ b/controller/src/main/java/org/jboss/as/controller/PathAddress.java
@@ -314,7 +314,14 @@ public class PathAddress implements Iterable<PathElement> {
      * @param create {@code true} to create the last part of the node if it does not exist
      * @return the submodel
      * @throws NoSuchElementException if the model contains no such element
+     *
+     * @deprecated manipulating a deep DMR node tree via PathAddress is no longer how the management layer works
+     *             internally, so this method has become legacy cruft. Management operation handlers
+     *             should obtain a {@link org.jboss.as.controller.registry.Resource Resource} from the
+     *             {@link org.jboss.as.controller.OperationContext#readResource(PathAddress) OperationContext}
+     *             and use the {@code Resource} API to access child resources
      */
+    @Deprecated
     public ModelNode navigate(ModelNode model, boolean create) throws NoSuchElementException {
         final Iterator<PathElement> i = pathAddressList.iterator();
         while (i.hasNext()) {
@@ -337,7 +344,13 @@ public class PathAddress implements Iterable<PathElement> {
      * @param model the model node
      * @return the submodel
      * @throws NoSuchElementException if the model contains no such element
+     *
+     * @deprecated manipulating a deep DMR node tree via PathAddress is no longer how the management layer works
+     *             internally, so this method has become legacy cruft. Management operation handlers would
+     *             use {@link org.jboss.as.controller.OperationContext#removeResource(PathAddress)} to
+     *             remove resources.
      */
+    @Deprecated
     public ModelNode remove(ModelNode model) throws NoSuchElementException {
         final Iterator<PathElement> i = pathAddressList.iterator();
         while (i.hasNext()) {

--- a/controller/src/main/java/org/jboss/as/controller/RestartParentResourceHandlerBase.java
+++ b/controller/src/main/java/org/jboss/as/controller/RestartParentResourceHandlerBase.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.controller;
 
-import java.util.NoSuchElementException;
-
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.Resource;
@@ -188,7 +186,7 @@ public abstract class RestartParentResourceHandlerBase implements OperationStepH
         try {
             Resource resource = ctx.readResourceFromRoot(address);
             return Resource.Tools.readModel(resource);
-        } catch (NoSuchElementException e) {
+        } catch (Resource.NoSuchResourceException e) {
             return null;
         }
     }
@@ -197,7 +195,7 @@ public abstract class RestartParentResourceHandlerBase implements OperationStepH
         try {
             Resource resource = ctx.getOriginalRootResource().navigate(address);
             return Resource.Tools.readModel(resource);
-        } catch (NoSuchElementException e) {
+        } catch (Resource.NoSuchResourceException e) {
             return null;
         }
     }

--- a/controller/src/main/java/org/jboss/as/controller/RestartParentWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/RestartParentWriteAttributeHandler.java
@@ -23,7 +23,6 @@
 package org.jboss.as.controller;
 
 import java.util.Collection;
-import java.util.NoSuchElementException;
 
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.Resource;
@@ -146,7 +145,7 @@ public abstract class RestartParentWriteAttributeHandler extends AbstractWriteAt
         try {
             Resource resource = ctx.readResourceFromRoot(address);
             return Resource.Tools.readModel(resource);
-        } catch (NoSuchElementException e) {
+        } catch (Resource.NoSuchResourceException e) {
             return null;
         }
     }
@@ -155,7 +154,7 @@ public abstract class RestartParentWriteAttributeHandler extends AbstractWriteAt
         try {
             Resource resource = ctx.getOriginalRootResource().navigate(address);
             return Resource.Tools.readModel(resource);
-        } catch (NoSuchElementException e) {
+        } catch (Resource.NoSuchResourceException e) {
             return null;
         }
     }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentReplaceHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentReplaceHandler.java
@@ -29,7 +29,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TO_
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.NoSuchElementException;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -85,7 +84,7 @@ public class ServerGroupDeploymentReplaceHandler implements OperationStepHandler
         try {
             // check if the domain deployment exists
             domainDeployment = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS.append(deploymentPath));
-        } catch (NoSuchElementException e) {
+        } catch (Resource.NoSuchResourceException e) {
             throw operationFailed(DomainControllerLogger.ROOT_LOGGER.noDeploymentContentWithName(name));
         }
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.remote.AbstractModelControllerOperationHandlerFactoryService;
 import org.jboss.as.controller.remote.ModelControllerClientOperationHandlerFactoryService;
 import org.jboss.as.network.SocketBindingManager;
@@ -184,7 +185,7 @@ public final class ManagementRemotingServices extends RemotingServices {
         try {
             remotingConnector = context.readResourceFromRoot(
                     PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, "jmx"), PathElement.pathElement("remoting-connector", "jmx")), false).getModel();
-        } catch (NoSuchElementException ex) {
+        } catch (Resource.NoSuchResourceException ex) {
             return;
         }
         if (!remotingConnector.hasDefined(USE_MGMT_ENDPOINT) ||


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3483

Minor thing to help make it easier to move to a cleaner exception model in future management code.