### PR TITLE
[WFCORE-1383] Startup success detection mechanism fails if JBOSS_HOME…

### DIFF
--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/init.d/wildfly-init-debian.sh
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/init.d/wildfly-init-debian.sh
@@ -95,13 +95,20 @@ if [ -z "$JBOSS_MODE" ]; then
 	JBOSS_MODE=standalone
 fi
 
+if [ -z "$JBOSS_BASE_DIR" ]; then
+         JBOSS_BASE_DIR="$JBOSS_HOME/$JBOSS_MODE"
+else
+         JBOSS_OPTS="$JBOSS_OPTS -Djboss.server.base.dir=$JBOSS_BASE_DIR"
+fi
+
+JBOSS_MARKERFILE=$JBOSS_BASE_DIR/tmp/startup-marker
+
 # Startup mode script
 if [ "$JBOSS_MODE" = "standalone" ]; then
 	JBOSS_SCRIPT="$JBOSS_HOME/bin/standalone.sh"
 	if [ -z "$JBOSS_CONFIG" ]; then
 		JBOSS_CONFIG=standalone.xml
 	fi
-	JBOSS_MARKERFILE="$JBOSS_HOME/standalone/tmp/startup-marker"
 else
 	JBOSS_SCRIPT="$JBOSS_HOME/bin/domain.sh"
 	if [ -z "$JBOSS_DOMAIN_CONFIG" ]; then
@@ -110,7 +117,6 @@ else
 	if [ -z "$JBOSS_HOST_CONFIG" ]; then
 		JBOSS_HOST_CONFIG=host.xml
 	fi
-	JBOSS_MARKERFILE="$JBOSS_HOME/domain/tmp/startup-marker"
 fi
 
 # Check startup file

--- a/core-feature-pack/src/main/resources/content/docs/contrib/scripts/init.d/wildfly-init-redhat.sh
+++ b/core-feature-pack/src/main/resources/content/docs/contrib/scripts/init.d/wildfly-init-redhat.sh
@@ -114,13 +114,20 @@ if [ -z "$JBOSS_MODE" ]; then
 	JBOSS_MODE=standalone
 fi
 
+if [ -z "$JBOSS_BASE_DIR" ]; then
+         JBOSS_BASE_DIR="$JBOSS_HOME/$JBOSS_MODE"
+else
+         JBOSS_OPTS="$JBOSS_OPTS -Djboss.server.base.dir=$JBOSS_BASE_DIR"
+fi
+
+JBOSS_MARKERFILE=$JBOSS_BASE_DIR/tmp/startup-marker
+
 # Startup mode script
 if [ "$JBOSS_MODE" = "standalone" ]; then
 	JBOSS_SCRIPT=$JBOSS_HOME/bin/standalone.sh
 	if [ -z "$JBOSS_CONFIG" ]; then
 		JBOSS_CONFIG=standalone.xml
 	fi
-	JBOSS_MARKERFILE=$JBOSS_HOME/standalone/tmp/startup-marker
 else
 	JBOSS_SCRIPT=$JBOSS_HOME/bin/domain.sh
 	if [ -z "$JBOSS_DOMAIN_CONFIG" ]; then
@@ -129,7 +136,6 @@ else
 	if [ -z "$JBOSS_HOST_CONFIG" ]; then
 		JBOSS_HOST_CONFIG=host.xml
 	fi
-	JBOSS_MARKERFILE=$JBOSS_HOME/domain/tmp/startup-marker
 fi
 
 # Helper function to check status of wildfly service


### PR DESCRIPTION
… and jboss.server.base.dir are set differently.

Jira: https://issues.jboss.org/browse/WFCORE-1383

Proposed fix for this issue:

The marker file is created at: $JBOSS_BASE_DIR/tmp/startup-marker instead of under $JBOSS_HOME when the actual JVM process starts, and there is no simple way to know what the JBOSS_BASE_DIR is before the standalone.sh|domain.sh starts.

Introducing the JBOSS_BASE_DIR variable into the startup scripts make it simple to implement, and it works.