### PR TITLE
Fix for WFCORE-3484, variable resolution in blocks, better error message

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/ifelse/IfElseControlFlow.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ifelse/IfElseControlFlow.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContext.Scope;
+import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.CommandLineRedirection;
 import org.jboss.as.cli.batch.BatchManager;
@@ -87,6 +88,9 @@ class IfElseControlFlow implements CommandLineRedirection {
             }
 
             final String cmd = line.getOperationName();
+            if ("if".equals(cmd)) {
+                throw new CommandFormatException("if is not allowed while in if block");
+            }
             if("else".equals(cmd) || "end-if".equals(cmd)) {
                 registration.handle(line);
             } else {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/trycatch/TryCatchFinallyControlFlow.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/trycatch/TryCatchFinallyControlFlow.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContext.Scope;
+import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.CommandLineRedirection;
 import org.jboss.as.cli.batch.BatchManager;
@@ -77,6 +78,9 @@ class TryCatchFinallyControlFlow implements CommandLineRedirection {
             }
 
             final String cmd = line.getOperationName();
+            if ("try".equals(cmd)) {
+                throw new CommandFormatException("try is not allowed while in try block");
+            }
             if("catch".equals(cmd) || "finally".equals(cmd) || "end-try".equals(cmd)) {
                 registration.handle(line);
             } else {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -1436,7 +1436,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
 
     private void resetArgs(String cmdLine) throws CommandFormatException {
         if (cmdLine != null) {
-            parsedCmd.parse(prefix, cmdLine, this);
+            parsedCmd.parse(prefix, cmdLine, this, redirection != null);
             setOutputTarget(parsedCmd.getOutputTarget());
         }
         this.cmdLine = cmdLine;

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultCallbackHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultCallbackHandler.java
@@ -110,12 +110,16 @@ public class DefaultCallbackHandler extends ValidatingCallbackHandler implements
     }
 
     public void parse(OperationRequestAddress initialAddress, String argsStr, CommandContext ctx) throws CommandFormatException {
+        parse(initialAddress, argsStr, ctx, false);
+    }
+
+    public void parse(OperationRequestAddress initialAddress, String argsStr, CommandContext ctx, boolean disableResolutionException) throws CommandFormatException {
         reset();
         if(initialAddress != null) {
             address = new DefaultOperationRequestAddress(initialAddress);
         }
         this.originalLine = argsStr;
-        substitutedLine = ParserUtil.parseLine(argsStr, this, validation, ctx);
+        substitutedLine = ParserUtil.parseLine(argsStr, this, validation, ctx, disableResolutionException);
     }
 
     @Deprecated

--- a/cli/src/main/java/org/jboss/as/cli/parsing/ParserUtil.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/ParserUtil.java
@@ -81,11 +81,16 @@ public class ParserUtil {
 
     public static SubstitutedLine parseLine(String commandLine, final CommandLineParser.CallbackHandler handler, boolean strict,
             CommandContext ctx) throws CommandFormatException {
+        return parseLine(commandLine, handler, strict, ctx, false);
+    }
+
+    public static SubstitutedLine parseLine(String commandLine, final CommandLineParser.CallbackHandler handler, boolean strict,
+            CommandContext ctx, boolean disableResolutionException) throws CommandFormatException {
         if (commandLine == null) {
             return null;
         }
         final ParsingStateCallbackHandler callbackHandler = getCallbackHandler(handler);
-        return StateParser.parseLine(commandLine, callbackHandler, InitialState.INSTANCE, strict, ctx);
+        return StateParser.parseLine(commandLine, callbackHandler, InitialState.INSTANCE, strict, disableResolutionException, ctx);
     }
 
     /**

--- a/cli/src/main/java/org/jboss/as/cli/parsing/StateParser.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/StateParser.java
@@ -114,9 +114,14 @@ public class StateParser {
 
     public static SubstitutedLine parseLine(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState,
             boolean strict, CommandContext ctx) throws CommandFormatException {
+        return parseLine(str, callbackHandler, initialState, strict, false, ctx);
+    }
+
+    public static SubstitutedLine parseLine(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState,
+            boolean strict, boolean disableResolutionException, CommandContext ctx) throws CommandFormatException {
 
         try {
-            return doParse(str, callbackHandler, initialState, strict, ctx);
+            return doParse(str, callbackHandler, initialState, strict, disableResolutionException, ctx);
         } catch (CommandFormatException e) {
             throw e;
         } catch (Throwable t) {
@@ -128,7 +133,7 @@ public class StateParser {
      * Returns the string which was actually parsed with all the substitutions performed
      */
     protected static SubstitutedLine doParse(String str, ParsingStateCallbackHandler callbackHandler, ParsingState initialState,
-            boolean strict, CommandContext cmdCtx) throws CommandFormatException {
+            boolean strict, boolean disableResolutionException, CommandContext cmdCtx) throws CommandFormatException {
 
         if (str == null || str.isEmpty()) {
             return new SubstitutedLine(str);
@@ -140,6 +145,7 @@ public class StateParser {
         ctx.input = str;
         ctx.strict = strict;
         ctx.cmdCtx = cmdCtx;
+        ctx.disableResolutionException = disableResolutionException;
 
         ctx.substitued.substitued = ctx.parse();
         return ctx.substitued;
@@ -217,6 +223,7 @@ public class StateParser {
         ParsingStateCallbackHandler callbackHandler;
         ParsingState initialState;
         boolean strict;
+        boolean disableResolutionException;
         CommandFormatException error;
         CommandContext cmdCtx;
         private final SubstitutedLine substitued = new SubstitutedLine();
@@ -337,7 +344,7 @@ public class StateParser {
             final String name = input.substring(location+1, endIndex);
             final String value = cmdCtx == null ? null : cmdCtx.getVariable(name);
             if(value == null) {
-                if (exceptionIfNotResolved) {
+                if (exceptionIfNotResolved && !disableResolutionException) {
                     throw new UnresolvedVariableException(name, "Unrecognized variable " + name);
                 }
             } else {

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ForLoopTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ForLoopTestCase.java
@@ -159,6 +159,8 @@ public class ForLoopTestCase extends AbstractCliTestBase {
         try {
             cli.sendLine("for propName in :read-children-names(child-type=system-property");
             cli.sendLine("if (result!=[]) of :read-children-names(child-type=system-property");
+            cli.sendLine("set foo=bar");
+            cli.sendLine("echo $foo");
             cli.sendLine("/system-property=$propName:remove");
             cli.sendLine("end-if");
             cli.sendLine("done");

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/TryCatchFinallyTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/TryCatchFinallyTestCase.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.test.integration.management.cli.ifelse.CLISystemPropertyTestBase;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
@@ -375,6 +376,28 @@ public class TryCatchFinallyTestCase extends CLISystemPropertyTestBase {
         } finally {
             ctx.terminateSession();
             cliOut.reset();
+        }
+    }
+
+    @Test
+    public void testTryInsideTry() throws Exception {
+        final CommandContext ctx = CLITestUtil.getCommandContext(cliOut);
+        boolean failed = false;
+        try {
+            ctx.connectController();
+            ctx.handle("try");
+            ctx.handle("try");
+        } catch (CommandFormatException ex) {
+            failed = true;
+        } finally {
+            try {
+                if (!failed) {
+                    throw new Exception("try inside try should have failed");
+                }
+            } finally {
+                ctx.terminateSession();
+                cliOut.reset();
+            }
         }
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/BasicIfElseTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ifelse/BasicIfElseTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.integration.management.cli.ifelse;
 import static org.junit.Assert.assertEquals;
 
 import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,6 +67,28 @@ public class BasicIfElseTestCase extends CLISystemPropertyTestBase {
             ctx.handleSafe(this.getRemovePropertyReq("match-test-values"));
             ctx.terminateSession();
             cliOut.reset();
+        }
+    }
+
+    @Test
+    public void testIfInsideIf() throws Exception {
+        final CommandContext ctx = CLITestUtil.getCommandContext(cliOut);
+        boolean failed = false;
+        try {
+            ctx.connectController();
+            ctx.handle("if result.value==\"true\" of " + this.getReadPropertyReq());
+            ctx.handle("if result.value==\"true\" of " + this.getReadPropertyReq());
+        } catch (CommandFormatException ex) {
+            failed = true;
+        } finally {
+            try {
+                if (!failed) {
+                    throw new Exception("if inside if should have failed");
+                }
+            } finally {
+                ctx.terminateSession();
+                cliOut.reset();
+            }
         }
     }
 


### PR DESCRIPTION
Disable variable resolution exception when done inside a block (if, try for). The variable could be not existing yet. Added unit test. 
Added check that if can't be called inside an if blocks and try can't be called inside try blocks.