### PR TITLE
Fix for WFCORE-3490, better message for non iterable operations

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/loop/ForControlFlow.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/loop/ForControlFlow.java
@@ -78,7 +78,11 @@ class ForControlFlow implements CommandLineRedirection {
             throw new CommandLineException("iterable request failed, no result");
         }
         ModelNode mn = targetValue.get(Util.RESULT);
-        result = mn.asList();
+        try {
+            result = mn.asList();
+        } catch (Exception ex) {
+            throw new CommandLineException("for cannot be used with operations that produce a non-iterable result");
+        }
         // Define the variable with a dummy value. That is required for operations in the block
         // referencing this variable otherwise parsing would fail.
         ctx.setVariable(varName, "null");

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ForLoopTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ForLoopTestCase.java
@@ -17,6 +17,7 @@ package org.jboss.as.test.integration.management.cli;
 
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
 import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
@@ -166,6 +167,20 @@ public class ForLoopTestCase extends AbstractCliTestBase {
         } finally {
             removeProperties();
         }
+    }
+
+    @Test
+    public void testNonIterableResult() {
+        cli.sendLine("set name=World");
+
+        try {
+            assertFalse(cli.sendLine("for var in :resolve-expression(expression=Hello $name!)", true));
+            String line = cli.readOutput();
+            assertEquals("for cannot be used with operations that produce a non-iterable result", line.trim());
+        } finally {
+            cli.sendLine("set name=");
+        }
+
     }
 
     private void addProperty(String name, String value) {


### PR DESCRIPTION
Catch asList exception and throw better message. Added unit test.