### PR TITLE
Fix for WFCORE-3480, ls output is unfriendly if any element in return contents is longer than terminal width

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.fusesource.jansi>1.16</version.org.fusesource.jansi>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
-        <version.org.aesh-readline>1.2</version.org.aesh-readline>
+        <version.org.aesh-readline>1.3</version.org.aesh-readline>
         <version.org.jboss.byteman>3.0.6</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.1.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.0.Final</version.org.jboss.invocation>


### PR DESCRIPTION
Upgraded to aesh-readline 1.3 in which the issue is fixed.
