### PR TITLE
[WFCORE-3500] Upgrade JSON-P from 1.0.4 to 1.1.2. This is a requireme…

### DIFF
--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -44,6 +44,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectodd.vdx</groupId>
             <artifactId>vdx-core</artifactId>
         </dependency>

--- a/core-feature-pack/src/license/core-feature-pack-licenses.xml
+++ b/core-feature-pack/src/license/core-feature-pack-licenses.xml
@@ -24,6 +24,22 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+      <licenses>
+        <license>
+          <name>Common Development and Distribution License 1.1</name>
+          <url>https://javaee.github.io/glassfish/LICENSE</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>GNU General Public License v2.0 only</name>
+          <url>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>stax2-api</artifactId>
       <licenses>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
@@ -29,14 +29,9 @@
     </properties>
 
     <dependencies>
-        <module name="org.glassfish.javax.json" export="false">
-            <exports>
-                <include-set>
-                    <path name="javax/json"/>
-                    <path name="javax/json/spi"/>
-                    <path name="javax/json/stream"/>
-                </include-set>
-            </exports>
-        </module>
+        <module name="org.glassfish.javax.json" services="import" />
     </dependencies>
+    <resources>
+        <artifact name="${javax.json:javax.json-api}"/>
+    </resources>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
@@ -29,9 +29,9 @@
     </properties>
 
     <dependencies>
+        <module name="javax.json.api" />
     </dependencies>
     <resources>
         <artifact name="${org.glassfish:javax.json}"/>
     </resources>
-
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <version.commons-lang>2.6</version.commons-lang>
         <version.io.undertow>1.4.22.Final</version.io.undertow>
         <version.javax.inject.javax.inject>1</version.javax.inject.javax.inject>
+        <version.javax.json.javax-json-api>1.1.2</version.javax.json.javax-json-api>
         <version.junit>4.12</version.junit>
         <version.log4j>1.2.17</version.log4j>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds> <!-- TODO Elytron - Bump to M17 -->
@@ -102,7 +103,7 @@
         <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.fusesource.jansi>1.16</version.org.fusesource.jansi>
-        <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
+        <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
         <version.org.aesh-readline>1.3</version.org.aesh-readline>
         <version.org.jboss.byteman>3.0.9</version.org.jboss.byteman>
         <version.org.aesh>1.0</version.org.aesh>
@@ -941,6 +942,12 @@
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>${version.javax.inject.javax.inject}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>javax.json</groupId>
+                <artifactId>javax.json-api</artifactId>
+                <version>${version.javax.json.javax-json-api}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
…nt for Java EE 8.

https://issues.jboss.org/browse/WFCORE-3500

Previously the implementation packed the API. The 1.1 implementation now correctly does not package the API. This is why there is now a hard dependency on the API.
  