### PR TITLE
[WFCORE-3502] Fix debug options in test-runner

### DIFF
--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.ModelControllerClientConfiguration;
@@ -131,7 +133,7 @@ public class Server {
 
             commandBuilder.setJavaHome(legacyJavaHome == null ? javaHome : legacyJavaHome);
             if (jvmArgs != null) {
-                commandBuilder.setJavaOptions(jvmArgs.split("\\s+"));
+                commandBuilder.setJavaOptions(Stream.of(jvmArgs.split("\\s+")).filter(s -> !s.contains("agentlib:jdwp")).collect(Collectors.toList()));
             }
             if(Boolean.getBoolean(serverDebug)) {
                 commandBuilder.setDebug(true, serverDebugPort);


### PR DESCRIPTION
Upstream jira: https://issues.jboss.org/browse/WFCORE-3502

---

Test-runner doesn't handle debug options correctly.

If jdpa profile is used, surefire jvm uses this JVM attribute: -agentlib:jdwp=transport=dt_socket,address=${as.debug.port},server=y,suspend=y.

The same attribute is passed to started server. But server debugging should be set by wildfly.debug and wildfly.debug.port java properties. So if user wants to debug surefire with 8787 port and server with 8786 port, user uses jdpa profile, wildfly.debug property and wildfly.debug.port property and test fails:

mvn test -DfailIfNoTests=false -DtestLogToFile=false -Dtest=CdTestCase -Djpda -Dwildfly.debug=true -Dwildfly.debug.port=8786

```
ERROR: Cannot load this JVM TI agent twice, check your java command line for duplicate jdwp options.
--
Error occurred during initialization of VM
agent library failed to init: jdwp
Running null
```