### PR TITLE
[WFCORE-3457] Make 'TrivialResourceDefinition' final and use a Builder instead of extending each time.

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -18,6 +18,7 @@
 
 package org.wildfly.extension.elytron;
 
+import static org.wildfly.extension.elytron.ElytronExtension.isServerOrHostController;
 import static org.wildfly.extension.elytron.Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.ELYTRON_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.MODIFIABLE_SECURITY_REALM_RUNTIME_CAPABILITY;
@@ -131,9 +132,11 @@ class ElytronDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+        final boolean serverOrHostController = isServerOrHostController(resourceRegistration);
+
         // Provider Loader
         resourceRegistration.registerSubModel(ProviderDefinitions.getAggregateProvidersDefinition());
-        resourceRegistration.registerSubModel(ProviderDefinitions.getProviderLoaderDefinition());
+        resourceRegistration.registerSubModel(ProviderDefinitions.getProviderLoaderDefinition(serverOrHostController));
 
         // Audit
         resourceRegistration.registerSubModel(AuditResourceDefinitions.getAggregateSecurityEventListenerDefinition());
@@ -158,7 +161,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(RealmDefinitions.getIdentityRealmDefinition());
         resourceRegistration.registerSubModel(new JdbcRealmDefinition());
         resourceRegistration.registerSubModel(new KeyStoreRealmDefinition());
-        resourceRegistration.registerSubModel(new PropertiesRealmDefinition());
+        resourceRegistration.registerSubModel(PropertiesRealmDefinition.create(serverOrHostController));
         resourceRegistration.registerSubModel(new TokenRealmDefinition());
         resourceRegistration.registerSubModel(ModifiableRealmDecorator.wrap(new LdapRealmDefinition()));
         resourceRegistration.registerSubModel(ModifiableRealmDecorator.wrap(new FileSystemRealmDefinition()));
@@ -226,8 +229,8 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(ModifiableKeyStoreDecorator.wrap(new FilteringKeyStoreDefinition()));
         resourceRegistration.registerSubModel(SSLDefinitions.getKeyManagerDefinition());
         resourceRegistration.registerSubModel(SSLDefinitions.getTrustManagerDefinition());
-        resourceRegistration.registerSubModel(SSLDefinitions.getServerSSLContextDefinition());
-        resourceRegistration.registerSubModel(SSLDefinitions.getClientSSLContextDefinition());
+        resourceRegistration.registerSubModel(SSLDefinitions.getServerSSLContextDefinition(serverOrHostController));
+        resourceRegistration.registerSubModel(SSLDefinitions.getClientSSLContextDefinition(serverOrHostController));
 
         // Credential Store Block
         resourceRegistration.registerSubModel(new CredentialStoreResourceDefinition());

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronExtension.java
@@ -96,10 +96,10 @@ public class ElytronExtension implements Extension {
 
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_0, ElytronSubsystemParser1_0::new);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_1, ElytronSubsystemParser1_1::new);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_2, ElytronSubsystemParser1_2::new);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_2_0, ElytronSubsystemParser2_0::new);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_0, () -> new ElytronSubsystemParser1_0());
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_1, () -> new ElytronSubsystemParser1_1());
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_2, () -> new ElytronSubsystemParser1_2());
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_2_0, () -> new ElytronSubsystemParser2_0());
     }
 
     @Override
@@ -112,7 +112,7 @@ public class ElytronExtension implements Extension {
         final ManagementResourceRegistration registration = subsystemRegistration.registerSubsystemModel(ElytronDefinition.INSTANCE);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
-        subsystemRegistration.registerXMLElementWriter(ElytronSubsystemParser2_0::new);
+        subsystemRegistration.registerXMLElementWriter(() -> new ElytronSubsystemParser2_0());
     }
 
     @SuppressWarnings("unchecked")

--- a/elytron/src/main/java/org/wildfly/extension/elytron/RealmMapperDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/RealmMapperDefinitions.java
@@ -101,7 +101,11 @@ class RealmMapperDefinitions {
             }
         };
 
-        return new TrivialResourceDefinition(ElytronDescriptionConstants.CONSTANT_REALM_MAPPER, add, CONSTANT_REALM_MAPPER_ATTRIBUTES, REALM_MAPPER_RUNTIME_CAPABILITY);
+        return TrivialResourceDefinition.builder()
+                .setPathKey(ElytronDescriptionConstants.CONSTANT_REALM_MAPPER)
+                .setAddHandler(add)
+                .setAttributes(CONSTANT_REALM_MAPPER_ATTRIBUTES)
+                .setRuntimeCapabilities(REALM_MAPPER_RUNTIME_CAPABILITY).build();
     }
 
     private static class SimpleRegexRealmMapperDefinition extends SimpleResourceDefinition {


### PR DESCRIPTION
Also update the XML reader and writer to be supplied using Lambda expressions, this avoids those classes being loaded when not used i.e. subsystem extension installed but no subsystem in config or domain mode servers.