### PR TITLE
Work around WFCORE-3302 / REM3-303 by sleeping

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/support/ChannelServer.java
+++ b/controller/src/test/java/org/jboss/as/controller/support/ChannelServer.java
@@ -50,6 +50,9 @@ import org.xnio.channels.AcceptingChannel;
  * @version $Revision: 1.1 $
  */
 public class ChannelServer implements Closeable {
+
+    private static boolean firstCreate = true;
+
     private final Endpoint endpoint;
     private Registration registration;
     private final AcceptingChannel<StreamConnection> streamServer;
@@ -65,6 +68,19 @@ public class ChannelServer implements Closeable {
             throw new IllegalArgumentException("Null configuration");
         }
         configuration.validate();
+
+        // Hack WFCORE-3302/REM3-303 workaround
+        if (firstCreate) {
+            firstCreate = false;
+        } else {
+            try {
+                // wait in case the previous socket has not closed
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
 
         // TODO WFCORE-3302 -- Endpoint.getCurrent() should be ok
         final Endpoint endpoint = Endpoint.builder().setEndpointName(configuration.getEndpointName()).build();

--- a/controller/src/test/java/org/jboss/as/controller/test/TransactionalProtocolClientTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/TransactionalProtocolClientTestCase.java
@@ -65,6 +65,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xnio.FutureResult;
 import org.xnio.IoFuture;
+import org.xnio.IoUtils;
 import org.xnio.OptionMap;
 
 /**
@@ -139,7 +140,7 @@ public class TransactionalProtocolClientTestCase {
         for(final Channel channel : channels) {
             channel.close();
         }
-        channelServer.close();
+        IoUtils.safeClose(channelServer);
         channelServer = null;
     }
 

--- a/protocol/src/test/java/org/jboss/as/protocol/mgmt/support/RemoteChannelPairSetup.java
+++ b/protocol/src/test/java/org/jboss/as/protocol/mgmt/support/RemoteChannelPairSetup.java
@@ -133,7 +133,7 @@ public class RemoteChannelPairSetup implements RemotingChannelPairSetup {
     }
 
     public void shutdownRemoting() throws IOException, InterruptedException {
-        channelServer.close();
+        IoUtils.safeClose(channelServer);
         executorService.shutdown();
         executorService.awaitTermination(1L, TimeUnit.DAYS);
         executorService.shutdownNow();


### PR DESCRIPTION
Really ugly but timing on ci.wildfly.org seems to have changed recently such that these failures are pretty common again, plus they've always been common on brontes and there's a Critical JBEAP to make that go away. The failures are common enough that I can't really argue with the Critical designation.

Workaround for https://issues.jboss.org/browse/WFCORE-3302.  Doesn't really resolve it, although it's ok to resolve the issue since we have REM3-303 for the basic problem.