### PR TITLE
CLI, security SSL commands

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -72,12 +72,18 @@ public class Util {
     public static final String ACCESS_TYPE = "access-type";
     public static final String ADD = "add";
     public static final String ADDRESS = "address";
+    public static final String ADMIN_ONLY = "ADMIN_ONLY";
+    public static final String ALGORITHM = "algorithm";
+    public static final String ALIAS = "alias";
+    public static final String ALIAS_FILTER = "alias-filter";
     public static final String ALLOWED = "allowed";
     public static final String ALLOW_RESOURCE_SERVICE_RESTART = "allow-resource-service-restart";
     public static final String ALTERNATIVES = "alternatives";
+    public static final String APPLICATION_REALM = "ApplicationRealm";
     public static final String ARCHIVE = "archive";
     public static final String ATTACHED_STREAMS = "attached-streams";
     public static final String ATTRIBUTES = "attributes";
+    public static final String AUTHENTICATION_OPTIONAL = "authentication-optional";
     public static final String BLOCKING_TIMEOUT = "blocking-timeout";
     public static final String BROWSE_CONTENT = "browse-content";
     public static final String BYTES = "bytes";
@@ -85,11 +91,14 @@ public class Util {
     public static final String CAPABILITY_REGISTRY = "capability-registry";
     public static final String CHILDREN = "children";
     public static final String CHILD_TYPE = "child-type";
+    public static final String CLEAR_TEXT = "clear-text";
     public static final String COMBINED_DESCRIPTIONS = "combined-descriptions";
     public static final String COMPOSITE = "composite";
     public static final String CONCURRENT_GROUPS = "concurrent-groups";
     public static final String CONTENT = "content";
     public static final String CORE_SERVICE = "core-service";
+    public static final String CREDENTIAL_REFERENCE = "credential-reference";
+    public static final String CIPHER_SUITE_FILTER = "cipher-suite-filter";
     public static final String DATASOURCES = "datasources";
     public static final String DEFAULT = "default";
     public static final String DEPLOY = "deploy";
@@ -99,29 +108,50 @@ public class Util {
     public static final String DEPLOYMENT_OVERLAY = "deployment-overlay";
     public static final String DEPTH = "depth";
     public static final String DESCRIPTION = "description";
+    public static final String DISTINGUISHED_NAME = "distinguished-name";
     public static final String DOMAIN_FAILURE_DESCRIPTION = "domain-failure-description";
     public static final String DOMAIN_RESULTS = "domain-results";
     public static final String DRIVER_MODULE_NAME = "driver-module-name";
     public static final String DRIVER_NAME = "driver-name";
+    public static final String ELYTRON = "elytron";
     public static final String ENABLED = "enabled";
     public static final String EXECUTE = "execute";
+    public static final String EXPORT_CERTIFICATE = "export-certificate";
     public static final String EXPRESSIONS_ALLOWED = "expressions-allowed";
     public static final String EXTENSION = "extension";
     public static final String FAILURE_DESCRIPTION = "failure-description";
     public static final String FILESYSTEM_PATH = "filesystem-path";
+    public static final String FINAL_PRINCIPAL_TRANSFORMER = "final-principal-transformer";
+    public static final String POST_REALM_PRINCIPAL_TRANSFORMER = "post-realm-principal-transformer";
+    public static final String PROVIDER_NAME = "provider-name";
+    public static final String PRE_REALM_PRINCIPAL_TRANSFORMER = "pre-realm-principal-transformer";
     public static final String FULL_REPLACE_DEPLOYMENT = "full-replace-deployment";
     public static final String FALSE = "false";
+    public static final String GENERATE_KEY_PAIR = "generate-key-pair";
+    public static final String GENERATE_CERTIFICATE_SIGNING_REQUEST = "generate-certificate-signing-request";
     public static final String HEAD_COMMENT_ALLOWED = "head-comment-allowed";
     public static final String HOST = "host";
+    public static final String HTTP_INTERFACE = "http-interface";
+    public static final String HTTPS = "https";
+    public static final String HTTPS_LISTENER = "https-listener";
     public static final String ID = "id";
+    public static final String IMPORT_CERTIFICATE = "import-certificate";
     public static final String IN_SERIES = "in-series";
     public static final String INCLUDE_DEFAULTS = "include-defaults";
     public static final String INCLUDE_RUNTIME = "include-runtime";
     public static final String INCLUDE_SINGLETONS = "include-singletons";
     public static final String INPUT_STREAM_INDEX = "input-stream-index";
     public static final String INSTALLED_DRIVERS_LIST = "installed-drivers-list";
+    public static final String JBOSS_SERVER_CONFIG_DIR = "jboss.server.config.dir";
+    public static final String KEY_MANAGER = "key-manager";
+    public static final String KEY_SIZE = "key-size";
+    public static final String KEY_STORE = "key-store";
+    public static final String KEY_STORE_REALM = "key-store-realm";
     public static final String LOCAL_HOST_NAME = "local-host-name";
+    public static final String MANAGEMENT = "management";
     public static final String MANAGEMENT_CLIENT_CONTENT = "management-client-content";
+    public static final String MANAGEMENT_HTTPS = "management-https";
+    public static final String MANAGEMENT_INTERFACE = "management-interface";
     public static final String MASTER = "master";
     public static final String MAX_FAILED_SERVERS = "max-failed-servers";
     public static final String MAX_FAILURE_PERCENTAGE = "max-failure-percentage";
@@ -131,17 +161,23 @@ public class Util {
     public static final String MODULE = "module";
     public static final String MODULE_SLOT = "module-slot";
     public static final String NAME = "name";
+    public static final String NATIVE_INTERFACE = "native-interface";
+    public static final String NEED_CLIENT_AUTH = "need-client-auth";
     public static final String NILLABLE = "nillable";
+    public static final String NORMAL = "normal";
     public static final String OPERATION = "operation";
     public static final String OPERATIONS = "operations";
     public static final String OPERATION_HEADERS = "operation-headers";
     public static final String OUTCOME = "outcome";
     public static final String PATH = "path";
+    public static final String PEM = "pem";
     public static final String PERSISTENT = "persistent";
     public static final String PROBLEM = "problem";
     public static final String PRODUCT_NAME = "product-name";
     public static final String PRODUCT_VERSION = "product-version";
     public static final String PROFILE = "profile";
+    public static final String PROTOCOLS = "protocols";
+    public static final String PROVIDERS = "providers";
     public static final String READ = "read";
     public static final String READ_ATTRIBUTE = "read-attribute";
     public static final String READ_CHILDREN_NAMES = "read-children-names";
@@ -153,6 +189,7 @@ public class Util {
     public static final String READ_WRITE = "read-write";
     public static final String READ_RESOURCE = "read-resource";
     public static final String READ_RESOURCE_DESCRIPTION = "read-resource-description";
+    public static final String REALM_MAPPER = "realm-mapper";
     public static final String REDEPLOY = "redeploy";
     public static final String REDEPLOY_AFFECTED = "redeploy-affected";
     public static final String REDEPLOY_LINKS = "redeploy-links";
@@ -178,15 +215,26 @@ public class Util {
     public static final String ROLLOUT_PLAN = "rollout-plan";
     public static final String ROLLOUT_PLANS = "rollout-plans";
     public static final String RUNTIME_NAME = "runtime-name";
+    public static final String RUNNING_MODE = "running-mode";
+    public static final String SECURE_SOCKET_BINDING = "secure-socket-binding";
+    public static final String SECURITY_DOMAIN = "security-domain";
+    public static final String SECURITY_REALM = "security-realm";
     public static final String SERVER = "server";
     public static final String SERVER_GROUP = "server-group";
+    public static final String SERVER_SSL_CONTEXT = "server-ssl-context";
     public static final String SHUTDOWN = "shutdown";
+    public static final String SOCKET_BINDING = "socket-binding";
+    public static final String SOCKET_BINDING_GROUP = "socket-binding-group";
+    public static final String SSL_CONTEXT = "ssl-context";
+    public static final String STANDARD_SOCKETS = "standard-sockets";
+    public static final String START_MODE = "start-mode";
     public static final String STATUS = "status";
     public static final String STEP_1 = "step-1";
     public static final String STEP_2 = "step-2";
     public static final String STEP_3 = "step-3";
     public static final String STEPS = "steps";
     public static final String STORAGE = "storage";
+    public static final String STORE = "store";
     public static final String SUBDEPLOYMENT = "subdeployment";
     public static final String SUBSYSTEM = "subsystem";
     public static final String SUCCESS = "success";
@@ -194,16 +242,23 @@ public class Util {
     public static final String TIMEOUT = "timeout";
     public static final String TRIM_DESCRIPTIONS = "trim-descriptions";
     public static final String TRUE = "true";
+    public static final String TRUST_MANAGER = "trust-manager";
+    public static final String TRUST_CACERTS = "trust-cacerts";
     public static final String TYPE = "type";
     public static final String UNDEFINE_ATTRIBUTE = "undefine-attribute";
     public static final String UNDEPLOY = "undeploy";
+    public static final String UNDERTOW = "undertow";
     public static final String UPLOAD_DEPLOYMENT_STREAM = "upload-deployment-stream";
     public static final String URL = "url";
+    public static final String USE_CIPHER_SUITES_ORDER = "use-cipher-suites-order";
     public static final String UUID = "uuid";
     public static final String VALID = "valid";
+    public static final String VALIDATE = "validate";
+    public static final String VALIDITY = "validity";
     public static final String VALIDATE_ADDRESS = "validate-address";
     public static final String VALUE = "value";
     public static final String VALUE_TYPE = "value-type";
+    public static final String WANT_CLIENT_AUTH = "want-client-auth";
     public static final String WRITE = "write";
     public static final String WRITE_ATTRIBUTE = "write-attribute";
 
@@ -517,6 +572,78 @@ public class Util {
             }
         }
         return groupNames;
+    }
+
+    public static List<String> getManagementInterfaces(ModelControllerClient client) {
+
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_CHILDREN_NAMES);
+            builder.addNode(Util.CORE_SERVICE, Util.MANAGEMENT);
+            builder.addProperty(Util.CHILD_TYPE, Util.MANAGEMENT_INTERFACE);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = client.execute(request);
+            if (isSuccess(outcome)) {
+                return getList(outcome);
+            }
+        } catch (Exception e) {
+        }
+
+        return Collections.emptyList();
+    }
+
+    public static List<String> getUndertowServerNames(ModelControllerClient client) {
+
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_CHILDREN_NAMES);
+            builder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
+            builder.addProperty(Util.CHILD_TYPE, Util.SERVER);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = client.execute(request);
+            if (isSuccess(outcome)) {
+                return getList(outcome);
+            }
+        } catch (Exception e) {
+        }
+
+        return Collections.emptyList();
+    }
+
+    public static List<String> getStandardSocketBindings(ModelControllerClient client) {
+
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_CHILDREN_NAMES);
+            builder.addNode(Util.SOCKET_BINDING_GROUP, Util.STANDARD_SOCKETS);
+            builder.addProperty(Util.CHILD_TYPE, Util.SOCKET_BINDING);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = client.execute(request);
+            if (isSuccess(outcome)) {
+                return getList(outcome);
+            }
+        } catch (Exception e) {
+        }
+
+        return Collections.emptyList();
     }
 
     public static List<String> getDeployments(ModelControllerClient client) {
@@ -1508,5 +1635,17 @@ public class Util {
                 && mn.get(FILESYSTEM_PATH).asBoolean()
                 && mn.has(ATTACHED_STREAMS)
                 && mn.get(ATTACHED_STREAMS).asBoolean();
+    }
+
+    public static String getRunningMode(CommandContext ctx) throws IOException, OperationFormatException {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_ATTRIBUTE);
+        builder.addProperty(Util.NAME, Util.RUNNING_MODE);
+        ModelNode response = ctx.getModelControllerClient().execute(builder.buildRequest());
+        if (isSuccess(response)) {
+            return response.get(Util.RESULT).asString();
+        } else {
+            return null;
+        }
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -168,6 +168,7 @@ import org.jboss.as.cli.impl.aesh.cmd.HelpCommand;
 import org.jboss.as.cli.impl.aesh.cmd.VersionCommand;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.DeploymentCommand;
 import org.jboss.as.cli.impl.aesh.cmd.operation.OperationCommandContainer;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
 import org.jboss.as.cli.operation.CommandLineParser;
 import org.jboss.as.cli.operation.NodePathFormatter;
 import org.jboss.as.cli.operation.OperationCandidatesProvider;
@@ -604,6 +605,9 @@ public class CommandContextImpl implements CommandContext, ModelControllerClient
         final AtomicReference<EmbeddedProcessLaunch> embeddedServerLaunch = EmbeddedControllerHandlerRegistrar.registerEmbeddedCommands(cmdRegistry, this);
         cmdRegistry.registerHandler(new ReloadHandler(this, embeddedServerLaunch), "reload");
         cmdRegistry.registerHandler(new ShutdownHandler(this, embeddedServerLaunch), "shutdown");
+
+        cmdRegistry.addCommand(new SecurityCommand(this, embeddedServerLaunch));
+
         registerExtraHandlers();
 
         extLoader = new ExtensionsLoader(cmdRegistry, aeshCommands.getRegistry(), this);

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/CLICommandInvocationImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/CLICommandInvocationImpl.java
@@ -32,6 +32,7 @@ import org.aesh.command.CommandRuntime;
 import org.aesh.command.invocation.CommandInvocation;
 import org.aesh.command.invocation.CommandInvocationConfiguration;
 import org.aesh.command.parser.CommandLineParserException;
+import org.aesh.readline.completion.Completion;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.impl.ReadlineConsole;
 import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
@@ -121,7 +122,7 @@ class CLICommandInvocationImpl implements CLICommandInvocation {
 
     @Override
     public String inputLine(Prompt prompt) throws InterruptedException {
-        return shell.readLine();
+        return shell.readLine(prompt);
     }
 
     @Override
@@ -156,6 +157,14 @@ class CLICommandInvocationImpl implements CLICommandInvocation {
     @Override
     public CommandInvocationConfiguration getConfiguration() {
         return config;
+    }
+
+    @Override
+    public String inputLine(Prompt prompt, Completion completer) throws InterruptedException, IOException {
+        if (console != null) {
+            return console.readLine(prompt, completer);
+        }
+        return null;
     }
 
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/RelativeFile.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/RelativeFile.java
@@ -13,22 +13,25 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package org.wildfly.core.cli.command.aesh;
+package org.jboss.as.cli.impl.aesh.cmd;
 
-import java.io.IOException;
-import org.aesh.command.invocation.CommandInvocation;
-import org.aesh.readline.Prompt;
-import org.aesh.readline.completion.Completion;
-import org.jboss.as.cli.CommandContext;
+import java.io.File;
 
 /**
- * CLI specific {@code CommandInvocation} that exposes
- * {@link org.jboss.as.cli.CommandContext}.
+ * Use this type for file option that are bound to a relative-to option.
  *
  * @author jdenise@redhat.com
  */
-public interface CLICommandInvocation extends CommandInvocation {
-    CommandContext getCommandContext();
+public class RelativeFile extends File {
 
-    String inputLine(Prompt prompt, Completion completer) throws InterruptedException, IOException;
+    private final String originalPath;
+
+    public RelativeFile(String originalPath, File absolutePath) {
+        super(absolutePath.getAbsolutePath());
+        this.originalPath = originalPath;
+    }
+
+    public String getOriginalPath() {
+        return originalPath;
+    }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/RelativeFilePathConverter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/RelativeFilePathConverter.java
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd;
+
+import org.aesh.command.converter.Converter;
+import org.aesh.command.converter.ConverterInvocation;
+import org.aesh.command.impl.converter.FileConverter;
+import org.aesh.command.validator.OptionValidatorException;
+
+/**
+ * A converter that builds a RelativeFile that contains both absolute and
+ * relative paths.
+ *
+ * @author jdenise@redhat.com
+ */
+public class RelativeFilePathConverter implements Converter<RelativeFile, ConverterInvocation> {
+
+    private FileConverter converter = new FileConverter();
+
+    @Override
+    public RelativeFile convert(ConverterInvocation converterInvocation) throws OptionValidatorException {
+        return new RelativeFile(converterInvocation.getInput(), converter.convert(converterInvocation));
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/HttpServerCommandActivator.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/HttpServerCommandActivator.java
@@ -1,0 +1,39 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security;
+
+import org.aesh.command.impl.internal.ParsedCommand;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.HTTPServer;
+
+/**
+ * Activator to control undertow related commands visibility and executability.
+ *
+ * @author jdenise@redhat.com
+ */
+public class HttpServerCommandActivator extends SecurityCommandActivator {
+
+    @Override
+    public boolean isActivated(ParsedCommand command) {
+        if (!super.isActivated(command)) {
+            return false;
+        }
+        try {
+            return HTTPServer.isUnderowSupported(getCommandContext());
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommand.java
@@ -1,0 +1,223 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.aesh.command.Command;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.GroupCommand;
+import org.aesh.command.GroupCommandDefinition;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.embedded.EmbeddedProcessLaunch;
+import org.jboss.as.cli.impl.aesh.cmd.AbstractCompleter;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+import org.jboss.as.cli.impl.aesh.cmd.security.ssl.HTTPServerDisableSSLCommand;
+import org.jboss.as.cli.impl.aesh.cmd.security.ssl.HTTPServerEnableSSLCommand;
+import org.jboss.as.cli.impl.aesh.cmd.security.ssl.ManagementDisableSSLCommand;
+import org.jboss.as.cli.impl.aesh.cmd.security.ssl.ManagementEnableSSLCommand;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
+import org.wildfly.core.cli.command.aesh.CLICompleterInvocation;
+
+/**
+ * Parent command of all security related commands. Contains definitions of all
+ * option names and option completers. This is the class to evolve when adding
+ * new sub commands. Contains utility methods to execute remote requests and
+ * reload the server.
+ *
+ * @author jdenise@redhat.com
+ */
+@GroupCommandDefinition(name = "security", description = "")
+public class SecurityCommand implements GroupCommand<CLICommandInvocation, Command> {
+
+    public static final FailureConsumer DEFAULT_FAILURE_CONSUMER = new FailureConsumer() {
+
+        @Override
+        public void failureOccured(CommandContext ctx, ModelNode reply) throws CommandException {
+            throw new CommandException(Util.getFailureDescription(reply));
+        }
+    };
+
+    public interface FailureConsumer {
+        void failureOccured(CommandContext ctx, ModelNode reply) throws CommandException;
+    }
+
+    public static final String OPT_FILE_SYSTEM_REALM = "file-system-realm";
+    public static final String OPT_USER_ROLE_DECODER = "user-role-decoder";
+    public static final String OPT_USER_PROPERTIES_FILE = "user-properties-file";
+    public static final String OPT_GROUP_PROPERTIES_FILE = "group-properties-file";
+    public static final String OPT_RELATIVE_TO = "relative-to";
+    public static final String OPT_NO_RELOAD = "no-reload";
+    public static final String OPT_EXPOSED_REALM_NAME = "exposed-realm-name";
+
+    public static final String OPT_NEW_SECURITY_DOMAIN_NAME = "new-security-domain-name";
+    public static final String OPT_NEW_AUTH_FACTORY_NAME = "new-auth-factory-name";
+    public static final String OPT_NEW_SECURITY_REALM_NAME = "new-security-realm-name";
+
+    public static final String OPT_MECHANISM = "mechanism";
+    public static final String OPT_SUPER_USER = "super-user";
+
+    public static final String OPT_INTERACTIVE = "interactive";
+
+    public static final String OPT_EXT_TRUST_STORE = "external-trust-store";
+
+    public static final String OPT_KEY_STORE_NAME = "key-store-name";
+    public static final String OPT_KEY_STORE_PATH = "key-store-path";
+
+    public static final String OPT_TRUSTED_CERTIFICATE_PATH = "trusted-certificate-path";
+    public static final String OPT_TRUST_STORE_NAME = "trust-store-name";
+    public static final String OPT_NEW_TRUST_STORE_NAME = "new-trust-store-name";
+    public static final String OPT_NEW_TRUST_MANAGER_NAME = "new-trust-manager-name";
+    public static final String OPT_TRUST_STORE_FILE_NAME = "trust-store-file-name";
+    public static final String OPT_TRUST_STORE_FILE_PASSWORD = "trust-store-file-password";
+    public static final String OPT_NO_TRUSTED_CERTIFICATE_VALIDATION = "no-trusted-certificate-validation";
+
+    public static final String OPT_KEY_STORE_PATH_RELATIVE_TO = "key-store-path-relative-to";
+    public static final String OPT_KEY_STORE_PASSWORD = "key-store-password";
+    public static final String OPT_KEY_STORE_TYPE = "key-store-type";
+
+    public static final String OPT_MANAGEMENT_INTERFACE = "management-interface";
+
+    public static final String OPT_HTTP_SECURE_SOCKET_BINDING = "http-secure-socket-binding";
+
+    public static final String OPT_NEW_KEY_MANAGER_NAME = "new-key-manager-name";
+    public static final String OPT_NEW_SSL_CONTEXT_NAME = "new-ssl-context-name";
+    public static final String OPT_NEW_KEY_STORE_NAME = "new-key-store-name";
+
+    public static final String OPT_SERVER_NAME = "server-name";
+    public static final String OPT_NO_OVERRIDE_SECURITY_REALM = "no-override-security-realm";
+    public static final String OPT_SECURITY_DOMAIN = "security-domain";
+
+    private final CommandContext ctx;
+    private final AtomicReference<EmbeddedProcessLaunch> embeddedServerRef;
+
+    public SecurityCommand(CommandContext ctx, AtomicReference<EmbeddedProcessLaunch> embeddedServerRef) {
+        this.ctx = ctx;
+        this.embeddedServerRef = embeddedServerRef;
+    }
+
+    @Override
+    public List<Command> getCommands() {
+        List<Command> commands = new ArrayList<>();
+        commands.add(new ManagementEnableSSLCommand(ctx));
+        commands.add(new ManagementDisableSSLCommand(embeddedServerRef));
+        commands.add(new HTTPServerEnableSSLCommand(ctx));
+        commands.add(new HTTPServerDisableSSLCommand());
+        return commands;
+    }
+
+    public static class OptionCompleters {
+
+        public static class KeyStoreNameCompleter extends AbstractCompleter {
+
+            @Override
+            protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+                return ElytronUtil.getKeyStoreNames(completerInvocation.getCommandContext().
+                        getModelControllerClient());
+            }
+        }
+
+        public static class KeyStoreTypeCompleter extends AbstractCompleter {
+
+            @Override
+            protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+                return Arrays.asList(ElytronUtil.JKS, ElytronUtil.PKCS12);
+            }
+        }
+
+        public static class ServerNameCompleter extends AbstractCompleter {
+
+            @Override
+            protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+                return Util.getUndertowServerNames(completerInvocation.getCommandContext().getModelControllerClient());
+            }
+        }
+
+        public static class ManagementInterfaceCompleter extends AbstractCompleter {
+
+            @Override
+            protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+                return Util.getManagementInterfaces(completerInvocation.getCommandContext().getModelControllerClient());
+            }
+        }
+
+        public static class SecureSocketBindingCompleter extends AbstractCompleter {
+
+            @Override
+            protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+                return Util.getStandardSocketBindings(completerInvocation.getCommandContext().getModelControllerClient());
+            }
+        }
+    }
+
+    @Override
+    public CommandResult execute(CLICommandInvocation commandInvocation)
+            throws CommandException, InterruptedException {
+        throw new CommandException("Command action is missing.");
+    }
+
+    public static String formatOption(String name) {
+        return "--" + name;
+    }
+
+    public static void execute(CommandContext ctx, ModelNode request,
+            FailureConsumer consumer) throws CommandException {
+        ModelNode response;
+        try {
+            response = ctx.getModelControllerClient().execute(request);
+        } catch (IOException ex) {
+            try {
+                consumer.failureOccured(ctx, null);
+            } catch (Exception ex2) {
+                ex.addSuppressed(ex2);
+            }
+            throw new CommandException(ex);
+        }
+        if (!Util.isSuccess(response)) {
+            try {
+                consumer.failureOccured(ctx, response);
+            } catch (Exception ex) {
+                if (ex instanceof CommandException) {
+                    throw (CommandException) ex;
+                }
+                throw new CommandException(ex);
+            }
+        }
+    }
+
+    public static void execute(CommandContext ctx,
+            ModelNode request, FailureConsumer consumer,
+            boolean noReload) throws CommandException {
+        execute(ctx, request, consumer);
+        if (!noReload) {
+            try {
+                String mode = Util.getRunningMode(ctx);
+                ctx.handle("reload --admin-only=" + (Util.ADMIN_ONLY.equals(mode) ? true : false));
+                ctx.printLine("Server reloaded.");
+            } catch (Exception ex) {
+                throw new CommandException(ex.getLocalizedMessage(), ex);
+            }
+        } else {
+            ctx.printLine("Warning: server has not been reloaded. Call 'reload' to apply changes.");
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommandActivator.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommandActivator.java
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security;
+
+import org.aesh.command.impl.internal.ParsedCommand;
+import org.jboss.as.cli.impl.aesh.cmd.ConnectedActivator;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+
+/**
+ * Activator to control security related commands visibility and executability.
+ *
+ * @author jdenise@redhat.com
+ */
+public class SecurityCommandActivator extends ConnectedActivator {
+    @Override
+    public boolean isActivated(ParsedCommand command) {
+        if (!super.isActivated(command)) {
+            return false;
+        }
+        if (getCommandContext().isDomainMode()) {
+            return false;
+        }
+        try {
+            return ElytronUtil.isElytronSupported(getCommandContext());
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/DefaultResourceNames.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/DefaultResourceNames.java
@@ -1,0 +1,98 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.operation.OperationFormatException;
+
+/**
+ * Class that exposes all default values.
+ *
+ * @author jdenise@redhat.com
+ */
+public class DefaultResourceNames {
+
+    public static String buildDefaultKeyStoreName(String name, CommandContext ctx) throws OperationFormatException, IOException {
+        int i = 1;
+        String computedName = name;
+        while (ElytronUtil.keyStoreExists(ctx, computedName)) {
+            computedName = name + "_" + i;
+            i += 1;
+        }
+        return computedName;
+    }
+
+    public static String buildDefaultKeyStoreName(File path, CommandContext ctx) throws OperationFormatException, IOException {
+        return buildDefaultKeyStoreName(path.getName(), ctx);
+    }
+
+    public static String buildDefaultKeyStorePath(File path, CommandContext ctx) throws OperationFormatException, IOException {
+        return buildDefaultKeyStoreName(path.getName(), ctx);
+    }
+
+    public static String buildDefaultKeyStoreAlias(String dn, CommandContext ctx) throws OperationFormatException, IOException {
+        return dn.substring(0, dn.indexOf("="));
+    }
+
+    static String buildDefaultKeyStoreType(String type, CommandContext ctx) {
+        return ElytronUtil.JKS;
+    }
+
+    static String buildDefaultKeyManagerName(CommandContext ctx, String keystoreName) throws IOException, OperationFormatException {
+        int i = 1;
+        String computedName = "key-manager-" + keystoreName;
+        while (ElytronUtil.keyManagerExists(ctx, computedName)) {
+            computedName = "key-manager-" + keystoreName + "_" + i;
+            i += 1;
+        }
+        return computedName;
+    }
+
+    static String buildDefaultSSLContextName(CommandContext ctx, String keystoreName) throws IOException, OperationFormatException {
+        int i = 1;
+        String computedName = "ssl-context-" + keystoreName;
+        while (ElytronUtil.serverSSLContextExists(ctx, computedName)) {
+            computedName = "ssl-context-" + keystoreName + "_" + i;
+            i += 1;
+        }
+        return computedName;
+    }
+
+    public static String getDefaultManagementInterfaceName(CommandContext ctx) {
+        return Util.HTTP_INTERFACE;
+    }
+
+    static List<String> getDefaultProtocols(CommandContext ctx) {
+        return Arrays.asList(ElytronUtil.TLS_V1_2);
+    }
+
+    static String getDefaultHttpSecureSocketBindingName(String managementInterface, CommandContext ctx) {
+        return Util.MANAGEMENT_HTTPS;
+    }
+
+    public static String getDefaultServerName(CommandContext context) {
+        return HTTPServer.DEFAULT_SERVER;
+    }
+
+    static String getDefaultApplicationLegacyRealm() {
+        return Util.APPLICATION_REALM;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ElytronUtil.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ElytronUtil.java
@@ -1,0 +1,451 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Utility class to interact with Elytron subsystem.
+ *
+ * @author jdenise@redhat.com
+ */
+public abstract class ElytronUtil {
+
+    public static final String JKS = "JKS";
+    public static final String PKCS12 = "PKCS12";
+    public static final String TLS_V1_2 = "TLSv1.2";
+
+    private ElytronUtil() {
+    }
+
+    static String retrieveKeyStorePassword(CommandContext ctx, String name) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_ATTRIBUTE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, name);
+        builder.addProperty(Util.NAME, Util.CREDENTIAL_REFERENCE);
+        ModelNode request = builder.buildRequest();
+        ModelNode response = ctx.getModelControllerClient().execute(request);
+        String password = null;
+        if (Util.isSuccess(response)) {
+            if (response.hasDefined(Util.RESULT)) {
+                ModelNode res = response.get(Util.RESULT);
+                if (res.hasDefined(Util.CLEAR_TEXT)) {
+                    password = res.get(Util.CLEAR_TEXT).asString();
+                }
+            }
+        }
+        return password;
+    }
+
+    static String findMatchingKeyStore(CommandContext ctx, File path, String relativeTo, String password, String type, Boolean required, String alias) throws OperationFormatException, IOException {
+        ModelNode resource = buildKeyStoreResource(path, relativeTo, password, type, required, alias);
+        List<String> names = findMatchingResources(ctx, Util.KEY_STORE, resource);
+        if (names.isEmpty()) {
+            return null;
+        }
+        return names.get(0);
+    }
+
+    static List<String> findMatchingKeyStores(CommandContext ctx, File path, String relativeTo) throws OperationFormatException, IOException {
+        ModelNode resource = buildKeyStoreResource(path, relativeTo, null, null, null, null);
+        return findMatchingResources(ctx, Util.KEY_STORE, resource);
+    }
+
+    private static ModelNode buildKeyStoreResource(File path, String relativeTo,
+            String password, String type, Boolean required, String alias) throws IOException {
+        ModelNode localKS = new ModelNode();
+        if (path != null) {
+            localKS.get(Util.PATH).set(path.getPath());
+        }
+        if (relativeTo != null) {
+            localKS.get(Util.RELATIVE_TO).set(relativeTo);
+        } else {
+            localKS.get(Util.RELATIVE_TO);
+        }
+        if (password != null) {
+            localKS.get(Util.CREDENTIAL_REFERENCE).set(buildCredentialReferences(password));
+        }
+        if (type != null) {
+            localKS.get(Util.TYPE).set(type);
+        }
+        if (required != null) {
+            localKS.get(Util.REQUIRED).set(required);
+        }
+        if (alias != null) {
+            localKS.get(Util.ALIAS_FILTER, alias);
+        } else {
+            localKS.get(Util.ALIAS_FILTER);
+        }
+        return localKS;
+    }
+
+    private static ModelNode buildKeyManagerResource(KeyStore keyStore, String alias, String algorithm) {
+        ModelNode localKM = new ModelNode();
+        if (keyStore.getPassword() != null) {
+            localKM.get(Util.CREDENTIAL_REFERENCE).set(buildCredentialReferences(keyStore.getPassword()));
+        }
+        localKM.get(Util.KEY_STORE).set(keyStore.getName());
+        if (alias != null) {
+            localKM.get(Util.ALIAS_FILTER, alias);
+        } else {
+            localKM.get(Util.ALIAS_FILTER);
+        }
+        if (algorithm != null) {
+            localKM.get(Util.ALGORITHM, algorithm);
+        } else {
+            localKM.get(Util.ALGORITHM);
+        }
+        return localKM;
+    }
+
+    private static ModelNode buildTrustManagerResource(KeyStore keyStore, String alias, String algorithm) {
+        // No password in trust-store
+        ModelNode mn = buildKeyManagerResource(keyStore, alias, algorithm);
+        mn.remove(Util.CREDENTIAL_REFERENCE);
+        return mn;
+    }
+
+    private static List<String> findMatchingResources(CommandContext ctx, String type,
+            ModelNode resource) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_CHILDREN_RESOURCES);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addProperty(Util.CHILD_TYPE, type);
+        ModelNode request = builder.buildRequest();
+        ModelNode response = ctx.getModelControllerClient().execute(request);
+        List<String> matches = new ArrayList<>();
+        if (Util.isSuccess(response)) {
+            if (response.hasDefined(Util.RESULT)) {
+                ModelNode res = response.get(Util.RESULT);
+                for (String ksName : res.keys()) {
+                    ModelNode ks = res.get(ksName);
+                    List<String> meaninglessKeys = new ArrayList<>();
+                    for (String k : ks.keys()) {
+                        if (!resource.keys().contains(k)) {
+                            meaninglessKeys.add(k);
+                        }
+                    }
+                    for (String s : meaninglessKeys) {
+                        ks.remove(s);
+                    }
+                    if (resource.equals(ks)) {
+                        matches.add(ksName);
+                    }
+                }
+            }
+        }
+        return matches;
+    }
+
+    static String findMatchingKeyManager(CommandContext ctx, KeyStore keyStore,
+            String alias, String algorithm) throws OperationFormatException, IOException {
+        ModelNode resource = buildKeyManagerResource(keyStore, alias, algorithm);
+        List<String> names = findMatchingResources(ctx, Util.KEY_MANAGER, resource);
+        if (names.isEmpty()) {
+            return null;
+        }
+        return names.get(0);
+    }
+
+    static String findMatchingTrustManager(CommandContext ctx, KeyStore keyStore,
+            String alias, String algorithm) throws OperationFormatException, IOException {
+        ModelNode resource = buildTrustManagerResource(keyStore, alias, algorithm);
+        List<String> names = findMatchingResources(ctx, Util.TRUST_MANAGER, resource);
+        if (names.isEmpty()) {
+            return null;
+        }
+        return names.get(0);
+    }
+
+    static String findMatchingSSLContext(CommandContext ctx, ServerSSLContext sslCtx) throws OperationFormatException, IOException {
+        List<String> names = findMatchingResources(ctx, Util.SERVER_SSL_CONTEXT, sslCtx.buildResource());
+        if (names.isEmpty()) {
+            return null;
+        }
+        return names.get(0);
+    }
+
+    static ModelNode addKeyStore(CommandContext ctx, String name, File path,
+            String relativeTo, String password, String type, Boolean required, String alias) throws Exception {
+        ModelNode mn = buildKeyStoreResource(path, relativeTo, password, type, required, alias);
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, name);
+        for (String k : mn.keys()) {
+            builder.getModelNode().get(k).set(mn.get(k));
+        }
+        return builder.buildRequest();
+    }
+
+    static ModelNode generateKeyPair(CommandContext ctx, String name, String dn, String alias, Long validity, String keyAlg, int keySize) throws Exception {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.GENERATE_KEY_PAIR);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, name);
+        builder.getModelNode().get(Util.DISTINGUISHED_NAME).set(dn);
+        builder.getModelNode().get(Util.ALGORITHM).set(keyAlg);
+        builder.getModelNode().get(Util.KEY_SIZE).set(keySize);
+        builder.getModelNode().get(Util.ALIAS).set(alias);
+        if (validity != null) {
+            builder.getModelNode().get(Util.VALIDITY).set(validity);
+        }
+        return builder.buildRequest();
+    }
+
+    static ModelNode importCertificate(CommandContext ctx, File trustedCertificate,
+            String alias, boolean validate, KeyStore trustStore, boolean trust) throws OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.IMPORT_CERTIFICATE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, trustStore.getName());
+        builder.getModelNode().get(Util.ALIAS).set(alias);
+        builder.getModelNode().get(Util.PATH).set(trustedCertificate.getAbsolutePath());
+        builder.getModelNode().get(Util.TRUST_CACERTS).set(trust);
+        builder.getModelNode().get(Util.VALIDATE).set(validate);
+        return builder.buildRequest();
+    }
+
+    static ModelNode storeKeyStore(CommandContext ctx, String name) throws OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.STORE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, name);
+        return builder.buildRequest();
+    }
+
+    static ModelNode removeKeyStore(CommandContext ctx, String name) throws Exception {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.REMOVE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, name);
+        return builder.buildRequest();
+    }
+
+    static ModelNode exportCertificate(CommandContext ctx, String name, File path, String relativeTo, String alias, boolean pem) throws Exception {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.EXPORT_CERTIFICATE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, name);
+        builder.getModelNode().get(Util.PATH).set(path.getPath());
+        builder.getModelNode().get(Util.ALIAS).set(alias);
+        if (relativeTo != null) {
+            builder.getModelNode().get(Util.RELATIVE_TO).set(relativeTo);
+        }
+        builder.getModelNode().get(Util.PEM).set(pem);
+        return builder.buildRequest();
+    }
+
+    static ModelNode generateSigningRequest(CommandContext ctx, String name,
+            File path, String relativeTo, String alias) throws Exception {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.GENERATE_CERTIFICATE_SIGNING_REQUEST);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, name);
+        builder.getModelNode().get(Util.PATH).set(path.getPath());
+        builder.getModelNode().get(Util.ALIAS).set(alias);
+        if (relativeTo != null) {
+            builder.getModelNode().get(Util.RELATIVE_TO).set(relativeTo);
+        }
+        return builder.buildRequest();
+    }
+
+    static ModelNode addKeyManager(CommandContext ctx, KeyStore keyStore, String name, String alias, String algorithm) throws Exception {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_MANAGER, name);
+        ModelNode mn = buildKeyManagerResource(keyStore, alias, algorithm);
+        for (String k : mn.keys()) {
+            builder.getModelNode().get(k).set(mn.get(k));
+        }
+        builder.getModelNode().get(Util.CREDENTIAL_REFERENCE).set(buildCredentialReferences(keyStore.getPassword()));
+        return builder.buildRequest();
+    }
+
+    static ModelNode addTrustManager(CommandContext ctx, KeyStore keyStore, String name, String alias, String algorithm) throws Exception {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.TRUST_MANAGER, name);
+        ModelNode mn = buildKeyManagerResource(keyStore, alias, algorithm);
+        for (String k : mn.keys()) {
+            builder.getModelNode().get(k).set(mn.get(k));
+        }
+        if (keyStore.getPassword() != null) {
+            builder.getModelNode().get(Util.CREDENTIAL_REFERENCE).set(buildCredentialReferences(keyStore.getPassword()));
+        }
+        return builder.buildRequest();
+    }
+
+    static ModelNode addServerSSLContext(CommandContext ctx, ServerSSLContext sslCtx, String name) throws Exception {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.SERVER_SSL_CONTEXT, name);
+        ModelNode mn = sslCtx.buildResource();
+        for (String k : mn.keys()) {
+            builder.getModelNode().get(k).set(mn.get(k));
+        }
+        return builder.buildRequest();
+    }
+
+    private static ModelNode buildCredentialReferences(String password) {
+        ModelNode mn = new ModelNode();
+        mn.get(Util.CLEAR_TEXT).set(password);
+        return mn;
+    }
+
+    static boolean keyManagerExists(CommandContext ctx, String name) throws IOException, OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_MANAGER, name);
+        return Util.isSuccess(ctx.getModelControllerClient().execute(builder.buildRequest()));
+    }
+
+    public static boolean trustManagerExists(CommandContext ctx, String name) throws IOException, OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.TRUST_MANAGER, name);
+        return Util.isSuccess(ctx.getModelControllerClient().execute(builder.buildRequest()));
+    }
+
+    public static boolean keyStoreExists(CommandContext ctx, String name) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, name);
+        return Util.isSuccess(ctx.getModelControllerClient().execute(builder.buildRequest()));
+    }
+
+    public static boolean serverSSLContextExists(CommandContext ctx, String name) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.SERVER_SSL_CONTEXT, name);
+        return Util.isSuccess(ctx.getModelControllerClient().execute(builder.buildRequest()));
+    }
+
+    public static List<String> getKeyStoreNames(ModelControllerClient client) {
+        return getNames(client, Util.KEY_STORE);
+    }
+
+    private static List<String> getNames(ModelControllerClient client, String type) {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_CHILDREN_NAMES);
+            builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+            builder.addProperty(Util.CHILD_TYPE, type);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = client.execute(request);
+            if (Util.isSuccess(outcome)) {
+                return Util.getList(outcome);
+            }
+        } catch (Exception e) {
+        }
+
+        return Collections.emptyList();
+    }
+
+    private static ModelNode getChildResource(String name, String type, CommandContext ctx) {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_RESOURCE);
+            builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+            builder.addNode(type, name);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+            if (Util.isSuccess(outcome)) {
+                return outcome.get(Util.RESULT);
+            }
+        } catch (Exception e) {
+        }
+        return null;
+    }
+
+    public static ServerSSLContext getServerSSLContext(CommandContext context, String sslContextName) {
+        ModelNode sslContext = getChildResource(sslContextName, Util.SERVER_SSL_CONTEXT, context);
+        ServerSSLContext ctx = null;
+        if (sslContext != null) {
+            String kmName = sslContext.get(Util.KEY_MANAGER).asString();
+            ModelNode km = getChildResource(kmName, Util.KEY_MANAGER, context);
+            String ksName = km.get(Util.KEY_STORE).asString();
+            KeyStore keyStore = new KeyStore(ksName, null, true);
+            KeyManager keyManager = new KeyManager(kmName, keyStore, true);
+            KeyManager trustManager = null;
+            if (sslContext.hasDefined(Util.TRUST_MANAGER)) {
+                trustManager = new KeyManager(sslContext.get(Util.TRUST_MANAGER).asString(), keyStore, true);
+            }
+            ctx = new ServerSSLContext(ksName, keyManager, trustManager, true);
+        }
+        return ctx;
+    }
+
+    public static KeyStore getKeyStore(CommandContext ctx, String name) throws OperationFormatException, IOException {
+        String password;
+        password = ElytronUtil.retrieveKeyStorePassword(ctx, name);
+
+        if (password == null) {
+            // Can be null for trust-store, inconcistency in API.
+            //throw new OperationFormatException("Can't retrieve password for " + name);
+        }
+        return new KeyStore(name, password, true);
+    }
+
+    public static boolean isElytronSupported(CommandContext commandContext) throws IOException, OperationFormatException {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        ModelNode response = commandContext.getModelControllerClient().execute(builder.buildRequest());
+        return Util.isSuccess(response);
+    }
+
+    public static boolean isKeyStoreManagementSupported(CommandContext commandContext) throws IOException, OperationFormatException {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_OPERATION_DESCRIPTION);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE, "?");
+        builder.addProperty(Util.NAME, Util.GENERATE_KEY_PAIR);
+        ModelNode response = commandContext.getModelControllerClient().execute(builder.buildRequest());
+        return Util.isSuccess(response);
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/HTTPServer.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/HTTPServer.java
@@ -1,0 +1,141 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import static org.jboss.as.cli.Util.isSuccess;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Utility class to interact with undertow subsystem.
+ *
+ * @author jdenise@redhat.com
+ */
+public class HTTPServer {
+
+    public static final String DEFAULT_SERVER = "default-server";
+
+    public static void enableSSL(String serverName, boolean noOverride, CommandContext context, SSLSecurityBuilder builder) throws OperationFormatException {
+        if (serverName == null) {
+            serverName = DefaultResourceNames.getDefaultServerName(context);
+        }
+        if (serverName == null) {
+            throw new OperationFormatException("No default server name found.");
+        }
+        final String sName = serverName;
+        if (!noOverride) {
+            builder.addStep(writeServerAttribute(serverName, Util.SECURITY_REALM, null),
+                    new SSLSecurityBuilder.FailureDescProvider() {
+                        @Override
+                        public String stepFailedDescription() {
+                            return "Writing "
+                                    + Util.SECURITY_REALM
+                            + " attribute on http-server " + sName;
+                }
+            });
+        }
+        builder.addStep(writeServerAttribute(serverName, Util.SSL_CONTEXT,
+                builder.getServerSSLContext().getName()), new SSLSecurityBuilder.FailureDescProvider() {
+            @Override
+            public String stepFailedDescription() {
+                return "Writing "
+                        + Util.SSL_CONTEXT
+                        + " attribute on http-server " + sName;
+            }
+        });
+    }
+
+    private static ModelNode writeServerAttribute(String serverName, String name, String value) throws OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.WRITE_ATTRIBUTE);
+        builder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
+        builder.addNode(Util.SERVER, serverName);
+        builder.addNode(Util.HTTPS_LISTENER, Util.HTTPS);
+        builder.addProperty(Util.NAME, name);
+        if (value != null) {
+            builder.addProperty(Util.VALUE, value);
+        }
+        return builder.buildRequest();
+    }
+
+    public static String disableSSL(CommandContext context, String serverName, ModelNode steps) throws OperationFormatException {
+        if (serverName == null) {
+            serverName = DefaultResourceNames.getDefaultServerName(context);
+        }
+        steps.add(writeServerAttribute(serverName, Util.SSL_CONTEXT, null));
+        steps.add(writeServerAttribute(serverName, Util.SECURITY_REALM, DefaultResourceNames.getDefaultApplicationLegacyRealm()));
+        return serverName;
+    }
+
+    public static String getSSLContextName(String serverName, CommandContext ctx) throws IOException, OperationFormatException {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        builder.setOperationName(Util.READ_ATTRIBUTE);
+        builder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
+        builder.addNode(Util.SERVER, serverName);
+        builder.addNode(Util.HTTPS_LISTENER, Util.HTTPS);
+        builder.addProperty(Util.NAME, Util.SSL_CONTEXT);
+        request = builder.buildRequest();
+
+        final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+        if (isSuccess(outcome)) {
+            if (outcome.hasDefined(Util.RESULT)) {
+                return outcome.get(Util.RESULT).asString();
+            }
+        }
+
+        return null;
+    }
+
+    private static List<String> getNames(ModelControllerClient client, String type) {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_CHILDREN_NAMES);
+            builder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
+            builder.addProperty(Util.CHILD_TYPE, type);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = client.execute(request);
+            if (Util.isSuccess(outcome)) {
+                return Util.getList(outcome);
+            }
+        } catch (Exception e) {
+        }
+
+        return Collections.emptyList();
+    }
+
+    public static boolean isUnderowSupported(CommandContext commandContext) throws IOException, OperationFormatException {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
+        ModelNode response = commandContext.getModelControllerClient().execute(builder.buildRequest());
+        return Util.isSuccess(response);
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/InteractiveSecurityBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/InteractiveSecurityBuilder.java
@@ -1,0 +1,383 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.io.File;
+import java.util.List;
+import java.util.UUID;
+import org.aesh.command.CommandException;
+import org.aesh.readline.Prompt;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_NAME;
+import org.jboss.as.cli.impl.aesh.cmd.security.ssl.PromptFileCompleter;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
+
+/**
+ * An SSL security builder that handles interaction with user to collect
+ * required information.
+ *
+ * @author jdenise@redhat.com
+ */
+public class InteractiveSecurityBuilder extends SSLSecurityBuilder {
+
+    private class DNWizard {
+
+        private static final String UNKNOWN = "Unknown";
+        private String name = UNKNOWN;
+        private String orgUnit = UNKNOWN;
+        private String org = UNKNOWN;
+        private String city = UNKNOWN;
+        private String state = UNKNOWN;
+        private String countryCode = UNKNOWN;
+
+        private String buildDN() throws InterruptedException {
+            String dnString = null;
+            boolean correct = false;
+            while (!correct) {
+                name = prompt("What is your first and last name?", name);
+                orgUnit = prompt("What is the name of your organizational unit?", orgUnit);
+                org = prompt("What is the name of your organization?", org);
+                city = prompt("What is the name of your City or Locality?", city);
+                state = prompt("What is the name of your State or Province?", state);
+                countryCode = prompt("What is the two-letter country code for this unit?", countryCode);
+                dnString = buildDNString();
+                String res = commandInvocation.inputLine(new Prompt("Is " + dnString + " correct y/n [y]?"));
+                if (res != null && res.equals("y")) {
+                    correct = true;
+                    break;
+                } else if (res != null && res.equals("n")) {
+                    correct = false;
+                } else if (res != null && res.length() == 0) {
+                    correct = true;
+                    break;
+                } else {
+                    correct = false;
+                }
+            }
+            return dnString;
+        }
+
+        private String buildDNString() {
+            return "CN=" + name + ", OU=" + orgUnit + ", O=" + org + ", L="
+                    + city + ", ST=" + state + ", C=" + countryCode;
+        }
+
+        private String prompt(String prompt, String value) throws InterruptedException {
+            String res = commandInvocation.inputLine(new Prompt(prompt + " [" + value + "]: "));
+            if (res == null || res.length() == 0) {
+                res = value;
+            }
+            return res;
+        }
+    }
+
+    private String dn;
+    private String password;
+    private String alias;
+    private CLICommandInvocation commandInvocation;
+    private String validity;
+    private String keyStoreName;
+    private String clientCertificate;
+    private String trustStoreFileName;
+    private String trustStorePassword;
+    private boolean validateCertificate;
+
+    public static final String PLACE_HOLDER = "<need user input>";
+    private String keyStoreFile;
+
+    private final String defaultKeyStoreFile;
+    private final String defaultTrustStoreFile;
+
+    private static final String KEY_ALG = "RSA";
+    private static final int KEY_SIZE = 1024;
+
+    public InteractiveSecurityBuilder(String defaultKeyStoreFile, String defaultTrustStoreFile) throws CommandException {
+        this.defaultKeyStoreFile = defaultKeyStoreFile;
+        this.defaultTrustStoreFile = defaultTrustStoreFile;
+    }
+
+    public InteractiveSecurityBuilder setCommandInvocation(CLICommandInvocation commandInvocation) {
+        this.commandInvocation = commandInvocation;
+        return this;
+    }
+
+    @Override
+    public void buildRequest(CommandContext ctx, boolean buildRequest) throws Exception {
+        // Collect all information
+
+        if (buildRequest) {
+            keyStoreFile = PLACE_HOLDER;
+            dn = PLACE_HOLDER;
+            password = PLACE_HOLDER;
+            alias = PLACE_HOLDER;
+            validity = PLACE_HOLDER;
+            clientCertificate = File.separator + PLACE_HOLDER;
+            trustStorePassword = PLACE_HOLDER;
+            trustStoreFileName = PLACE_HOLDER;
+        } else {
+            ctx.printLine("Please provide required pieces of information to enable SSL:");
+        }
+        String relativeTo = Util.JBOSS_SERVER_CONFIG_DIR;
+        boolean ok = false;
+        Long v = null;
+        String certName;
+        String csrName;
+        // First keystore file name
+        while (keyStoreFile == null) {
+            keyStoreFile = commandInvocation.inputLine(new Prompt("Key-store file name (default " + defaultKeyStoreFile + "): "));
+            if (keyStoreFile != null && keyStoreFile.length() == 0) {
+                keyStoreFile = defaultKeyStoreFile;
+            }
+            //Check that we are not going to corrupt existing key-stores that are referencing the exact same file.
+            List<String> ksNames = ElytronUtil.findMatchingKeyStores(ctx, new File(keyStoreFile), relativeTo);
+            if (!ksNames.isEmpty()) {
+                throw new CommandException("Error, the file " + keyStoreFile + " is already referenced from " + ksNames
+                        + " resources. Use " + SecurityCommand.formatOption(OPT_KEY_STORE_NAME) + " option or choose another file name.");
+            }
+        }
+        int i = keyStoreFile.indexOf(".");
+        if (i > 0) {
+            certName = keyStoreFile.substring(0, i);
+        } else {
+            certName = keyStoreFile;
+        }
+        csrName = certName + ".csr";
+        certName += ".pem";
+
+        // then password
+        while (password == null) {
+            password = commandInvocation.inputLine(new Prompt("Password (blank generated): "));
+            if (password != null && password.length() == 0) {
+                password = SSLSecurityBuilder.generateRandomPassword();
+            }
+        }
+
+        // then prompt for dn
+        if (dn == null) {
+            dn = new DNWizard().buildDN();
+        }
+
+        // then validity
+        while (validity == null) {
+            validity = commandInvocation.inputLine(new Prompt("Validity (in days, blank default): "));
+            if (validity != null) {
+                if (validity.length() == 0) {
+                    v = null;
+                } else {
+                    try {
+                        v = Long.parseLong(validity);
+                    } catch (NumberFormatException e) {
+                        ctx.printLine("Invalid number " + validity);
+                        validity = null;
+                    }
+                }
+            }
+        }
+
+        // then alias
+        while (alias == null) {
+            alias = commandInvocation.inputLine(new Prompt("Alias (blank generated): "));
+            if (alias != null && alias.length() == 0) {
+                alias = "alias-" + UUID.randomUUID().toString();
+            }
+        }
+
+        boolean mutual = false;
+        if (!buildRequest) {
+            // Two way.
+            String twoWay = null;
+            while (twoWay == null) {
+                twoWay = commandInvocation.inputLine(new Prompt("Enable SSL Mutual Authentication y/n (blank n):"));
+                if (twoWay != null && twoWay.equals("y")) {
+                    mutual = true;
+                    break;
+                } else if (twoWay != null && twoWay.equals("n")) {
+                    mutual = false;
+                    break;
+                } else if (twoWay != null && twoWay.length() == 0) {
+                    mutual = false;
+                    break;
+                } else {
+                    twoWay = null;
+                }
+            }
+            if (mutual) {
+                // Prompt for certificate.
+                PromptFileCompleter completer = new PromptFileCompleter(commandInvocation.getConfiguration().getAeshContext());
+                while (clientCertificate == null || clientCertificate.length() == 0) {
+                    clientCertificate = commandInvocation.inputLine(new Prompt("Client certificate (path to pem file): "), completer);
+                    if (clientCertificate != null && clientCertificate.length() > 0) {
+                        if (!new File(clientCertificate).exists()) {
+                            clientCertificate = null;
+                            ctx.printLine("The specified file doesn't exist");
+                        }
+                    }
+                }
+
+                // Prompt for validity.
+                String val = null;
+                while (val == null) {
+                    val = commandInvocation.inputLine(new Prompt("Validate certificate y/n (blank y): "));
+                    if (val != null && val.equals("y")) {
+                        validateCertificate = true;
+                        break;
+                    } else if (val != null && val.equals("n")) {
+                        validateCertificate = false;
+                        break;
+                    } else if (val != null && val.length() == 0) {
+                        validateCertificate = true;
+                        break;
+                    } else {
+                        val = null;
+                    }
+                }
+
+                // a trust-store file name
+                while (trustStoreFileName == null) {
+                    trustStoreFileName = commandInvocation.inputLine(new Prompt("Trust-store file name (" + defaultTrustStoreFile + "): "));
+                    if (trustStoreFileName != null && trustStoreFileName.length() == 0) {
+                        trustStoreFileName = defaultTrustStoreFile;
+                    }
+                    // Check that we are not going to corrupt existing key-stores that are referencing the exact same file.
+                    List<String> ksNames = ElytronUtil.findMatchingKeyStores(ctx, new File(trustStoreFileName), Util.JBOSS_SERVER_CONFIG_DIR);
+                    if (!ksNames.isEmpty()) {
+                        throw new CommandException("Error, the file " + trustStoreFileName + " is already referenced from " + ksNames
+                                + " resources. Use " + SecurityCommand.formatOption(SecurityCommand.OPT_TRUST_STORE_NAME) + " option or choose another file name.");
+                    }
+                }
+
+                // a trust-store password
+                while (trustStorePassword == null) {
+                    trustStorePassword = commandInvocation.inputLine(new Prompt("Password (blank generated): "));
+                    if (trustStorePassword != null && trustStorePassword.length() == 0) {
+                        trustStorePassword = SSLSecurityBuilder.generateRandomPassword();
+                    }
+                }
+            }
+        }
+
+        if (!buildRequest) {
+            String reply = null;
+            while (reply == null) {
+                ctx.printLine("\nSSL options:");
+                ctx.printLine("key store file: " + keyStoreFile + "\n"
+                        + "distinguished name: " + dn + "\n"
+                        + "password: " + password + "\n"
+                        + "validity: " + (validity.length() == 0 ? "default" : validity) + "\n"
+                        + "alias: " + alias);
+                if (mutual) {
+                    ctx.printLine("client certificate: " + clientCertificate);
+                    ctx.printLine("trust store file: " + trustStoreFileName);
+                    ctx.printLine("trust store password: " + trustStorePassword);
+                }
+                ctx.printLine("Server keystore file " + keyStoreFile
+                        + ", certificate file " + certName + " and " + csrName
+                        + " file will be generated in server configuration directory.");
+                if (mutual) {
+                    ctx.printLine("Server truststore file " + trustStoreFileName + " will be generated in server configuration directory.");
+                }
+
+                reply = commandInvocation.inputLine(new Prompt("Do you confirm y/n :"));
+                if (reply != null && reply.equals("y")) {
+                    ok = true;
+                    break;
+                } else if (reply != null && !reply.equals("n")) {
+                    reply = null;
+                }
+            }
+            if (!ok) {
+                throw new CommandException("Ignoring, command not executed.");
+            }
+        }
+
+        String type = DefaultResourceNames.buildDefaultKeyStoreType(null, ctx);
+
+        String id = UUID.randomUUID().toString();
+        setKeyManagerName("key-manager-" + id);
+        setSSLContextName("ssl-context-" + id);
+
+        keyStoreName = "key-store-" + id;
+        ModelNode request = ElytronUtil.addKeyStore(ctx, keyStoreName, new File(keyStoreFile), relativeTo, password, type, false, null);
+        try {
+            // For now that is a workaround because we can't add and call operation in same composite.
+            // REMOVE WHEN WFCORE-3491 is fixed.
+            if (buildRequest) { // echo-dmr
+                addStep(request, NO_DESC);
+            } else {
+                SecurityCommand.execute(ctx, request, SecurityCommand.DEFAULT_FAILURE_CONSUMER);
+            }
+            // Hard coded algorithm and key size.
+            ModelNode request2 = ElytronUtil.generateKeyPair(ctx, keyStoreName, dn, alias, v, KEY_ALG, KEY_SIZE);
+            addStep(request2, new FailureDescProvider() {
+                @Override
+                public String stepFailedDescription() {
+                    return "Generating key-pair from "
+                            + keyStoreName;
+                }
+            });
+            needKeyStoreStore(keyStoreName);
+            final String cName = certName;
+            ModelNode request4 = ElytronUtil.exportCertificate(ctx, keyStoreName, new File(certName), relativeTo, alias, true);
+            addFinalstep(request4, new FailureDescProvider() {
+                @Override
+                public String stepFailedDescription() {
+                    return "Exporting certificate " + cName
+                            + " from key-store " + keyStoreName;
+                }
+            });
+            ModelNode request5 = ElytronUtil.generateSigningRequest(ctx, keyStoreName, new File(csrName), relativeTo, alias);
+            addFinalstep(request5, new FailureDescProvider() {
+                @Override
+                public String stepFailedDescription() {
+                    return "Generating signing request "
+                            + " from key-store " + keyStoreName;
+                }
+            });
+            // Two way certificate
+            if (clientCertificate != null) {
+                setTrustedCertificatePath(new File(clientCertificate));
+                setTrustStoreFileName(trustStoreFileName);
+                setTrustStoreFilePassword(trustStorePassword);
+                setValidateCertificate(validateCertificate);
+            }
+        } catch (Exception ex) {
+            try {
+                failureOccured(ctx, null);
+            } catch (Exception ex2) {
+                ex.addSuppressed(ex2);
+            }
+            throw ex;
+        }
+        super.buildRequest(ctx, buildRequest);
+    }
+
+    @Override
+    protected KeyStore buildKeyStore(CommandContext ctx, boolean buildRequest) throws Exception {
+        return new KeyStore(keyStoreName, password, alias, false);
+    }
+
+    @Override
+    public void doFailureOccured(CommandContext ctx) throws Exception {
+        // REMOVE WHEN WFCORE-3491 is fixed.
+        if (keyStoreName != null) {
+            ModelNode req = ElytronUtil.removeKeyStore(ctx, keyStoreName);
+            SecurityCommand.execute(ctx, req, SecurityCommand.DEFAULT_FAILURE_CONSUMER);
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/KeyManager.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/KeyManager.java
@@ -13,22 +13,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package org.wildfly.core.cli.command.aesh;
-
-import java.io.IOException;
-import org.aesh.command.invocation.CommandInvocation;
-import org.aesh.readline.Prompt;
-import org.aesh.readline.completion.Completion;
-import org.jboss.as.cli.CommandContext;
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
 
 /**
- * CLI specific {@code CommandInvocation} that exposes
- * {@link org.jboss.as.cli.CommandContext}.
+ * KeyManager model class.
  *
  * @author jdenise@redhat.com
  */
-public interface CLICommandInvocation extends CommandInvocation {
-    CommandContext getCommandContext();
+public class KeyManager {
+    private final String name;
+    private final KeyStore keyStore;
+    private final boolean exists;
 
-    String inputLine(Prompt prompt, Completion completer) throws InterruptedException, IOException;
+    public KeyManager(String name, KeyStore keyStore, boolean exists) {
+        this.name = name;
+        this.keyStore = keyStore;
+        this.exists = exists;
+    }
+
+    public boolean exists() {
+        return exists;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public KeyStore getKeyStore() {
+        return keyStore;
+    }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/KeyStore.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/KeyStore.java
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+/**
+ * KeyStore model class.
+ *
+ * @author jdenise@redhat.com
+ */
+public class KeyStore {
+    private final String name;
+    private final String password;
+    private final boolean exists;
+    private final String alias;
+
+    public KeyStore(String name, String password, String alias, boolean exists) {
+        this.name = name;
+        this.password = password;
+        this.exists = exists;
+        this.alias = alias;
+    }
+
+    public KeyStore(String name, String password, boolean exists) {
+        this(name, password, null, exists);
+    }
+
+    public boolean exists() {
+        return exists;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/KeyStoreNameSecurityBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/KeyStoreNameSecurityBuilder.java
@@ -13,22 +13,31 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
  */
-package org.wildfly.core.cli.command.aesh;
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
 
-import java.io.IOException;
-import org.aesh.command.invocation.CommandInvocation;
-import org.aesh.readline.Prompt;
-import org.aesh.readline.completion.Completion;
+import org.aesh.command.CommandException;
 import org.jboss.as.cli.CommandContext;
 
 /**
- * CLI specific {@code CommandInvocation} that exposes
- * {@link org.jboss.as.cli.CommandContext}.
+ * An SSL Security builder that retrieves an existing KeyStore.
  *
  * @author jdenise@redhat.com
  */
-public interface CLICommandInvocation extends CommandInvocation {
-    CommandContext getCommandContext();
+public class KeyStoreNameSecurityBuilder extends SSLSecurityBuilder {
 
-    String inputLine(Prompt prompt, Completion completer) throws InterruptedException, IOException;
+    private final String name;
+
+    public KeyStoreNameSecurityBuilder(String name) throws CommandException {
+        this.name = name;
+    }
+
+    @Override
+    protected KeyStore buildKeyStore(CommandContext ctx, boolean buildRequest) throws Exception {
+        return ElytronUtil.getKeyStore(ctx, name);
+    }
+
+    @Override
+    protected void doFailureOccured(CommandContext ctx) {
+    }
+
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/KeyStorePathSecurityBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/KeyStorePathSecurityBuilder.java
@@ -1,0 +1,112 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.io.File;
+import org.aesh.command.CommandException;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * An SSL Security builder that builds or reuses a KeyStore based on a file
+ * path.
+ *
+ * @author jdenise@redhat.com
+ */
+public class KeyStorePathSecurityBuilder extends SSLSecurityBuilder {
+
+    private final File path;
+    private final String password;
+    private String relativeTo;
+    private String type;
+    private String name;
+
+    public KeyStorePathSecurityBuilder(File path, String password) throws CommandException {
+        if (path == null || password == null) {
+            throw new CommandException("key-store path and password can't be null");
+        }
+        this.path = path;
+        this.password = password;
+    }
+
+    public KeyStorePathSecurityBuilder setRelativeTo(String relativeTo) {
+        this.relativeTo = relativeTo;
+        return this;
+    }
+
+    public KeyStorePathSecurityBuilder setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public KeyStorePathSecurityBuilder setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    protected KeyStore buildKeyStore(CommandContext ctx, boolean buildRequest) throws Exception {
+        boolean lookupExisting = false;
+        validateOptions(ctx);
+        if (name == null) {
+            name = DefaultResourceNames.buildDefaultKeyStoreName(path, ctx);
+            lookupExisting = true;
+        }
+        if (type == null) {
+            type = DefaultResourceNames.buildDefaultKeyStoreType(type, ctx);
+        }
+
+        String kName = null;
+        // Lookup for existing resource if no name has been provided.
+        if (lookupExisting) {
+            kName = ElytronUtil.findMatchingKeyStore(ctx, path, relativeTo, password, type, null, null);
+        }
+        boolean existing = false;
+        if (kName == null) {
+            ModelNode request = ElytronUtil.addKeyStore(ctx, name, path, relativeTo, password, type, null, null);
+            addStep(request, new FailureDescProvider() {
+                @Override
+                public String stepFailedDescription() {
+                    return "Adding key-store using file "
+                            + path;
+                }
+            });
+        } else {
+            existing = true;
+            name = kName;
+        }
+        return new KeyStore(name, password, existing);
+    }
+
+    private void validateOptions(CommandContext ctx) throws Exception {
+        if (relativeTo == null) {
+            if (!path.exists()) {
+                throw new CommandException("key-store path doesn't exist");
+            }
+        }
+        if (name != null) {
+            if (ElytronUtil.keyStoreExists(ctx, name)) {
+                throw new CommandException("key-store " + name + " already exists");
+            }
+        }
+    }
+
+    @Override
+    protected void doFailureOccured(CommandContext ctx) {
+        // Nothing to cleanup.
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ManagementInterfaces.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ManagementInterfaces.java
@@ -1,0 +1,139 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.io.IOException;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Utility class to interact with management interfaces from core management.
+ *
+ * @author jdenise@redhat.com
+ */
+public class ManagementInterfaces {
+
+    public static void enableSSL(String managementInterface, String secureSocketBinding,
+            CommandContext ctx, SSLSecurityBuilder builder) throws IOException, OperationFormatException {
+        if (managementInterface == null) {
+            managementInterface = DefaultResourceNames.getDefaultManagementInterfaceName(ctx);
+        }
+        if (managementInterface == null) {
+            throw new OperationFormatException("No default management interface found.");
+        }
+        if (Util.HTTP_INTERFACE.equals(managementInterface)) {
+            if (secureSocketBinding == null) {
+                secureSocketBinding = DefaultResourceNames.getDefaultHttpSecureSocketBindingName(managementInterface, ctx);
+            }
+            enableHTTPS(secureSocketBinding, builder);
+        } else {
+            if (secureSocketBinding != null) {
+                throw new OperationFormatException("secure-sockect-binding not applicable to interface " + managementInterface);
+            }
+            enableNativeSSL(managementInterface, ctx, builder);
+        }
+    }
+
+    public static String disableSSL(CommandContext context, String managementInterface, ModelNode steps)
+            throws IOException, OperationFormatException {
+        if (managementInterface == null) {
+            managementInterface = DefaultResourceNames.getDefaultManagementInterfaceName(context);
+        }
+        if (managementInterface == null) {
+            throw new OperationFormatException("No default management interface found.");
+        }
+        steps.add(writeInterfaceAttribute(managementInterface, Util.SSL_CONTEXT, null));
+        if (Util.HTTP_INTERFACE.equals(managementInterface)) {
+            steps.add(writeInterfaceAttribute(managementInterface, Util.SECURE_SOCKET_BINDING, null));
+        }
+        return managementInterface;
+    }
+
+    private static void enableHTTPS(String secureSocketBinding, SSLSecurityBuilder security) throws OperationFormatException {
+        security.addStep(writeInterfaceAttribute(Util.HTTP_INTERFACE,
+                Util.SSL_CONTEXT, security.getServerSSLContext().getName()), new SSLSecurityBuilder.FailureDescProvider() {
+            @Override
+            public String stepFailedDescription() {
+                return "Writing " + Util.SSL_CONTEXT + " attribute of "
+                        + Util.HTTP_INTERFACE;
+            }
+        });
+        security.addStep(writeInterfaceAttribute(Util.HTTP_INTERFACE,
+                Util.SECURE_SOCKET_BINDING, secureSocketBinding), new SSLSecurityBuilder.FailureDescProvider() {
+            @Override
+            public String stepFailedDescription() {
+                return "Writing " + Util.SECURE_SOCKET_BINDING + " attribute of "
+                        + Util.HTTP_INTERFACE;
+            }
+        });
+    }
+
+    private static ModelNode writeInterfaceAttribute(String itf, String name, String value) throws OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.WRITE_ATTRIBUTE);
+        builder.addNode(Util.CORE_SERVICE, Util.MANAGEMENT);
+        builder.addNode(Util.MANAGEMENT_INTERFACE, itf);
+        builder.addProperty(Util.NAME, name);
+        if (value != null) {
+            builder.addProperty(Util.VALUE, value);
+        }
+        return builder.buildRequest();
+    }
+
+    private static void enableNativeSSL(String managementInterface, CommandContext ctx,
+            SSLSecurityBuilder security) throws OperationFormatException {
+        security.addStep(writeInterfaceAttribute(managementInterface,
+                Util.SSL_CONTEXT, security.getServerSSLContext().getName()), new SSLSecurityBuilder.FailureDescProvider() {
+            @Override
+            public String stepFailedDescription() {
+                return "Writing " + Util.SECURE_SOCKET_BINDING + " attribute of "
+                        + managementInterface;
+            }
+        });
+    }
+
+    public static String getManagementInterfaceSSLContextName(CommandContext ctx, String interfaceName) throws IOException, OperationFormatException {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_ATTRIBUTE);
+            builder.addNode(Util.CORE_SERVICE, Util.MANAGEMENT);
+            builder.addNode(Util.MANAGEMENT_INTERFACE, interfaceName);
+            builder.addProperty(Util.NAME, Util.SSL_CONTEXT);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+            if (Util.isSuccess(outcome)) {
+                ModelNode mn = outcome.get(Util.RESULT);
+                if (mn.isDefined()) {
+                    return outcome.get(Util.RESULT).asString();
+                } else {
+                    return null;
+                }
+            }
+        } catch (Exception e) {
+        }
+
+        return null;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/SSLSecurityBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/SSLSecurityBuilder.java
@@ -1,0 +1,455 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.io.File;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import org.aesh.command.CommandException;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_TRUST_STORE_NAME;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * Base class to build a complete SSL configuration set of requests.
+ *
+ * @author jdenise@redhat.com
+ */
+public abstract class SSLSecurityBuilder implements SecurityCommand.FailureConsumer {
+
+    public FailureDescProvider NO_DESC = new FailureDescProvider() {
+        @Override
+        public String stepFailedDescription() {
+            return null;
+        }
+    };
+
+    public interface FailureDescProvider {
+
+        String stepFailedDescription();
+    }
+
+    private final List<FailureDescProvider> providers = new ArrayList<>();
+    private final List<FailureDescProvider> finalProviders = new ArrayList<>();
+    private final List<FailureDescProvider> effectiveProviders = new ArrayList<>();
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    private String sslContextName;
+    private String keyManagerName;
+    private final ModelNode composite = new ModelNode();
+    private ServerSSLContext sslContext;
+    private File trustedCertificate;
+    private String trustStoreName;
+    private String trustStoreFileName;
+    private String generatedTrustStore;
+    private String trustStoreFilePassword;
+    private String newTrustStoreName;
+    private String newTrustManagerName;
+
+    private boolean validateCertificate;
+
+    private final Set<String> ksToStore = new HashSet<>();
+    private final List<ModelNode> finalSteps = new ArrayList<>();
+
+    public SSLSecurityBuilder() throws CommandException {
+        composite.get(Util.OPERATION).set(Util.COMPOSITE);
+        composite.get(Util.ADDRESS).setEmptyList();
+    }
+
+    protected void needKeyStoreStore(String keyStoreName) {
+        ksToStore.add(keyStoreName);
+    }
+
+    protected void addFinalstep(ModelNode step, FailureDescProvider ex) {
+        finalSteps.add(step);
+        finalProviders.add(ex);
+    }
+
+    public void setNewTrustStoreName(String newTrustStoreName) {
+        this.newTrustStoreName = newTrustStoreName;
+    }
+
+    public void setNewTrustManagerName(String newTrustManagerName) {
+        this.newTrustManagerName = newTrustManagerName;
+    }
+
+    // Sort and order steps to avoid unwanted generation
+    public ModelNode buildExecutableRequest(CommandContext ctx) throws Exception {
+        try {
+            for (FailureDescProvider h : providers) {
+                effectiveProviders.add(h);
+            }
+            // In case some key-store needs to be persisted
+            for (String ks : ksToStore) {
+                composite.get(Util.STEPS).add(ElytronUtil.storeKeyStore(ctx, ks));
+                effectiveProviders.add(new FailureDescProvider() {
+                    @Override
+                    public String stepFailedDescription() {
+                        return "Storing the key-store " + ksToStore;
+                    }
+                });
+            }
+            // Final steps
+            for (int i = 0; i < finalSteps.size(); i++) {
+                composite.get(Util.STEPS).add(finalSteps.get(i));
+                effectiveProviders.add(finalProviders.get(i));
+            }
+            return composite;
+        } catch (Exception ex) {
+            try {
+                failureOccured(ctx, null);
+            } catch (Exception ex2) {
+                ex.addSuppressed(ex2);
+            }
+            throw ex;
+        }
+    }
+
+    public File getTrustedCertificatePath() {
+        return trustedCertificate;
+    }
+
+    public void setTrustedCertificatePath(File trustedCertificate) {
+        this.trustedCertificate = trustedCertificate;
+    }
+
+    public void setValidateCertificate(boolean validateCertificate) {
+        this.validateCertificate = validateCertificate;
+    }
+
+    public void addStep(ModelNode step, FailureDescProvider ex) {
+        Objects.requireNonNull(step);
+        Objects.requireNonNull(ex);
+        composite.get(Util.STEPS).add(step);
+        providers.add(ex);
+    }
+
+    public ServerSSLContext getServerSSLContext() {
+        return sslContext;
+    }
+
+    public SSLSecurityBuilder setSSLContextName(String sslContextName) {
+        this.sslContextName = sslContextName;
+        return this;
+    }
+
+    public SSLSecurityBuilder setKeyManagerName(String keyManagerName) {
+        this.keyManagerName = keyManagerName;
+        return this;
+    }
+
+    protected abstract KeyStore buildKeyStore(CommandContext ctx, boolean workaroundComposite) throws Exception;
+
+    public void buildRequest(CommandContext ctx, boolean buildRequest) throws Exception {
+        KeyStore keyStore;
+        KeyManager km;
+        try {
+            // First build the keyStore.
+            keyStore = buildKeyStore(ctx, buildRequest);
+
+            // The trust manager
+            KeyManager trustManager = buildTrustManager(ctx, buildRequest);
+
+            // Then the key manager
+            km = buildKeyManager(ctx, keyManagerName, keyStore);
+
+            // Finally the SSLContext;
+            sslContext = buildServerSSLContext(ctx, km, trustManager);
+        } catch (Exception ex) {
+            try {
+                failureOccured(ctx, null);
+            } catch (Exception ex2) {
+                ex.addSuppressed(ex2);
+            }
+            throw ex;
+        }
+    }
+
+    protected KeyManager buildTrustManager(CommandContext ctx, boolean buildRequest) throws Exception {
+        KeyManager trustManager = null;
+        if (trustedCertificate != null || trustStoreName != null) {
+            KeyStore trustStore = null;
+            String id = UUID.randomUUID().toString();
+            // create a new key-store for the trustore and import the certificate.
+            if (newTrustStoreName == null) {
+                newTrustStoreName = "trust-store-" + id;
+            } else if (ElytronUtil.keyStoreExists(ctx, newTrustStoreName)) {
+                throw new CommandException("The key-store " + newTrustStoreName + " already exists");
+            }
+            if (trustStoreName == null) {
+                if (trustStoreFileName == null) {
+                    trustStoreFileName = "server-" + id + ".trustore";
+                } else {
+                    List<String> ksNames = ElytronUtil.findMatchingKeyStores(ctx, new File(trustStoreFileName), Util.JBOSS_SERVER_CONFIG_DIR);
+                    if (!ksNames.isEmpty()) {
+                        throw new CommandException("Error, the file " + trustStoreFileName + " is already referenced from " + ksNames
+                                + " resources. Use " + SecurityCommand.formatOption(OPT_TRUST_STORE_NAME) + " option or choose another file name.");
+                    }
+                }
+                generatedTrustStore = newTrustStoreName;
+                String password = trustStoreFilePassword == null ? generateRandomPassword() : trustStoreFilePassword;
+                ModelNode request = ElytronUtil.addKeyStore(ctx, newTrustStoreName, new File(trustStoreFileName),
+                        Util.JBOSS_SERVER_CONFIG_DIR, password, ElytronUtil.JKS, false, null);
+                // For now that is a workaround because we can't add and call operation in same composite.
+                // REMOVE WHEN WFCORE-3491 is fixed.
+                if (buildRequest) { // echo-dmr
+                    addStep(request, NO_DESC);
+                } else {
+                    SecurityCommand.execute(ctx, request, SecurityCommand.DEFAULT_FAILURE_CONSUMER);
+                }
+                trustStore = new KeyStore(newTrustStoreName, password, false);
+                // import the certificate, hard code that we check against cacert.
+                ModelNode certImport = ElytronUtil.importCertificate(ctx, trustedCertificate, id, validateCertificate, trustStore, true);
+                addStep(certImport, new FailureDescProvider() {
+                    @Override
+                    public String stepFailedDescription() {
+                        return "Importing certificate "
+                                + trustedCertificate.getAbsolutePath()
+                                + " in trust-store " + newTrustStoreName;
+                    }
+                });
+                needKeyStoreStore(trustStore.getName());
+            } else {
+                trustStore = ElytronUtil.getKeyStore(ctx, trustStoreName);
+            }
+            //Create a trust-manager
+            trustManager = buildTrustManager(ctx, newTrustManagerName, trustStore);
+        }
+        return trustManager;
+    }
+
+    private KeyManager buildKeyManager(CommandContext ctx, String ksManagerName, KeyStore keyStore) throws Exception {
+        boolean lookupExisting = false;
+        if (ksManagerName == null) {
+            ksManagerName = DefaultResourceNames.buildDefaultKeyManagerName(ctx, keyStore.getName());
+            lookupExisting = true;
+        } else if (ElytronUtil.keyManagerExists(ctx, ksManagerName)) {
+            throw new CommandException("The key-manager " + ksManagerName + " already exists");
+        }
+        String name = null;
+        boolean exists = false;
+        // Lookup for a matching key manager only if the keystore already exists,
+        // the KeyManager doesn't exist and no name has been provided
+        if (keyStore.exists() && lookupExisting) {
+            name = ElytronUtil.findMatchingKeyManager(ctx, keyStore, null, null);
+        }
+        if (name == null) {
+            name = ksManagerName;
+            final String kmName = name;
+            addStep(ElytronUtil.addKeyManager(ctx, keyStore, ksManagerName, null, null), new FailureDescProvider() {
+                @Override
+                public String stepFailedDescription() {
+                    return "Adding key-manager " + kmName;
+                }
+            });
+        } else {
+            exists = true;
+        }
+        return new KeyManager(name, keyStore, exists);
+    }
+
+    private KeyManager buildTrustManager(CommandContext ctx, String ksManagerName, KeyStore keyStore) throws Exception {
+        boolean lookupExisting = false;
+        if (ksManagerName == null) {
+            ksManagerName = DefaultResourceNames.buildDefaultKeyManagerName(ctx, keyStore.getName());
+            lookupExisting = true;
+        } else if (ElytronUtil.trustManagerExists(ctx, ksManagerName)) {
+            throw new CommandException("The key-manager " + ksManagerName + " already exists");
+        }
+        String name = null;
+        boolean exists = false;
+        // Lookup for a matching key manager only if the keystore already exists.
+        if (keyStore.exists() && lookupExisting) {
+            name = ElytronUtil.findMatchingTrustManager(ctx, keyStore, null, null);
+        }
+        if (name == null) {
+            name = ksManagerName;
+            final String tmName = ksManagerName;
+            addStep(ElytronUtil.addTrustManager(ctx, keyStore, ksManagerName, null, null), new FailureDescProvider() {
+                @Override
+                public String stepFailedDescription() {
+                    return "Adding trust-manager " + tmName;
+                }
+            });
+        } else {
+            exists = true;
+        }
+        return new KeyManager(name, keyStore, exists);
+    }
+
+    private ServerSSLContext buildServerSSLContext(CommandContext ctx, KeyManager manager, KeyManager trustManager) throws Exception {
+        boolean lookupExisting = false;
+        if (sslContextName == null) {
+            sslContextName = DefaultResourceNames.buildDefaultSSLContextName(ctx, manager.getKeyStore().getName());
+            lookupExisting = true;
+        } else if (ElytronUtil.serverSSLContextExists(ctx, sslContextName)) {
+            throw new CommandException("The ssl-context " + sslContextName + " already exists");
+        }
+        List<String> lst = DefaultResourceNames.getDefaultProtocols(ctx);
+        String name = null;
+        boolean exists = false;
+
+        boolean need = trustManager != null;
+        String tm = trustManager == null ? null : trustManager.getName();
+        // Lookup for a matching sslContext only if the keymanager already exists
+        // and no name has been provided
+        if (manager.exists() && lookupExisting) {
+            ServerSSLContext sslCtx = new ServerSSLContext(null, manager, trustManager, false);
+            sslCtx.setNeed(need);
+            sslCtx.setProtocols(lst);
+            name = ElytronUtil.findMatchingSSLContext(ctx, sslCtx);
+        }
+
+        if (name == null) {
+            name = sslContextName;
+        } else {
+            exists = true;
+        }
+        ServerSSLContext sslCtx = new ServerSSLContext(name, manager, trustManager, exists);
+        sslCtx.setNeed(need);
+        sslCtx.setProtocols(lst);
+        if (!exists) {
+            addStep(ElytronUtil.addServerSSLContext(ctx, sslCtx, sslContextName), new FailureDescProvider() {
+                @Override
+                public String stepFailedDescription() {
+                    return "Adding ssl-context " + sslContextName;
+                }
+            });
+        }
+
+        return sslCtx;
+    }
+
+    private String getFailedStepDescription(CommandContext ctx, ModelNode responseNode) {
+        if (responseNode == null) {
+            return null;
+        }
+        ModelNode mn = responseNode.get(Util.RESULT);
+        StringBuilder msg = new StringBuilder();
+        if (mn.isDefined()) {
+            int index = 0;
+            ModelNode fd = responseNode.get(Util.FAILURE_DESCRIPTION);
+            if (fd.isDefined()) {
+                for (Property prop : mn.asPropertyList()) {
+                    ModelNode val = prop.getValue();
+                    if (val.hasDefined(Util.FAILURE_DESCRIPTION)) {
+                        String description = effectiveProviders.get(index).
+                                stepFailedDescription();
+                        msg.append("\nERROR, security changes have not been applied.\n");
+                        if (description != null) {
+                            msg.append("Failed action: ").append(description).append("\n");
+                        }
+                        msg.append("Cause: ").append(val.get(Util.FAILURE_DESCRIPTION).asString()).append("\n");
+                        break;
+                    }
+                    index += 1;
+                }
+            }
+        }
+
+        return msg.toString();
+    }
+
+    @Override
+    public void failureOccured(CommandContext ctx, ModelNode mn) throws CommandException {
+        StringBuilder builder = new StringBuilder();
+        boolean failure = false;
+        // A step failed
+        if (mn != null) {
+            String desc = getFailedStepDescription(ctx, mn);
+            builder.append(desc).append("\n");
+            failure = true;
+        }
+        try {
+            // REMOVE WHEN WFCORE-3491 is fixed.
+            if (generatedTrustStore != null) {
+                ModelNode req = ElytronUtil.removeKeyStore(ctx, generatedTrustStore);
+                SecurityCommand.execute(ctx, req, SecurityCommand.DEFAULT_FAILURE_CONSUMER);
+            }
+        } catch (Exception ex) {
+            builder.append("Error while cleaning up key-stores " + ex).append("\n");
+            failure = true;
+        } finally {
+            try {
+                doFailureOccured(ctx);
+            } catch (Exception ex) {
+                builder.append("Error while cleaning up " + ex);
+                failure = true;
+            }
+        }
+        if (failure) {
+            throw new CommandException(builder.toString());
+        }
+    }
+
+    protected abstract void doFailureOccured(CommandContext ctx) throws Exception;
+
+    /**
+     * @return the trustStoreName
+     */
+    public String getTrustStoreName() {
+        return trustStoreName;
+    }
+
+    /**
+     * @param trustStoreName the trustStoreName to set
+     */
+    public void setTrustStoreName(String trustStoreName) {
+        this.trustStoreName = trustStoreName;
+    }
+
+    /**
+     * @return the trustStoreFileName
+     */
+    public String getTrustStoreFileName() {
+        return trustStoreFileName;
+    }
+
+    /**
+     * @param trustStoreFileName the trustStoreFileName to set
+     */
+    public void setTrustStoreFileName(String trustStoreFileName) {
+        this.trustStoreFileName = trustStoreFileName;
+    }
+
+    public void setTrustStoreFilePassword(String trustStoreFilePassword) {
+        this.trustStoreFilePassword = trustStoreFilePassword;
+    }
+
+    static String generateRandomPassword() {
+        return generateRandomString(8);
+    }
+
+    static String generateRandomString(int length) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < length; i++) {
+            int index = (int) (RANDOM.nextDouble() * CHARS.length());
+            builder.append(CHARS.substring(index, index + 1));
+        }
+        return builder.toString();
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ServerSSLContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ServerSSLContext.java
@@ -1,0 +1,321 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.util.List;
+import org.jboss.as.cli.Util;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Server SSLContext model class.
+ *
+ * @author jdenise@redhat.com
+ */
+public class ServerSSLContext {
+
+    private final String name;
+    private final KeyManager keyManager;
+    private final KeyManager trustManager;
+    private final boolean exists;
+
+    private List<String> protocols;
+    private boolean authenticationOptional;
+    private String cipherSuiteFilter = "DEFAULT";
+    private String finalPrincipalTransformer;
+    private String postRealmPrincipalTransformer;
+    private String preRealmPrincipalTransformer;
+    private String providerName;
+    private List<String> providers;
+    private String realmMapper;
+    private String securityDomain;
+    private boolean want;
+    private boolean need;
+    private boolean useCipherSuiteOrder;
+
+    public ServerSSLContext(String name, KeyManager keyManager,
+            KeyManager trustManager, boolean exists) {
+        this.name = name;
+        this.keyManager = keyManager;
+        this.trustManager = trustManager;
+        this.exists = exists;
+    }
+
+    public boolean exists() {
+        return exists;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public KeyManager getKeyManager() {
+        return keyManager;
+    }
+
+    public KeyManager getTrustManager() {
+        return trustManager;
+    }
+
+    /**
+     * @return the protocols
+     */
+    public List<String> getProtocols() {
+        return protocols;
+    }
+
+    /**
+     * @param protocols the protocols to set
+     */
+    public void setProtocols(List<String> protocols) {
+        this.protocols = protocols;
+    }
+
+    /**
+     * @return the authenticationOptional
+     */
+    public boolean isAuthenticationOptional() {
+        return authenticationOptional;
+    }
+
+    /**
+     * @param authenticationOptional the authenticationOptional to set
+     */
+    public void setAuthenticationOptional(boolean authenticationOptional) {
+        this.authenticationOptional = authenticationOptional;
+    }
+
+    /**
+     * @return the cipherSuiteFilter
+     */
+    public String getCipherSuiteFilter() {
+        return cipherSuiteFilter;
+    }
+
+    /**
+     * @param cipherSuiteFilter the cipherSuiteFilter to set
+     */
+    public void setCipherSuiteFilter(String cipherSuiteFilter) {
+        this.cipherSuiteFilter = cipherSuiteFilter;
+    }
+
+    /**
+     * @return the finalPrincipalTransformer
+     */
+    public String getFinalPrincipalTransformer() {
+        return finalPrincipalTransformer;
+    }
+
+    /**
+     * @param finalPrincipalTransformer the finalPrincipalTransformer to set
+     */
+    public void setFinalPrincipalTransformer(String finalPrincipalTransformer) {
+        this.finalPrincipalTransformer = finalPrincipalTransformer;
+    }
+
+    /**
+     * @return the postRealmPrincipalTransformer
+     */
+    public String getPostRealmPrincipalTransformer() {
+        return postRealmPrincipalTransformer;
+    }
+
+    /**
+     * @param postRealmPrincipalTransformer the postRealmPrincipalTransformer to
+     * set
+     */
+    public void setPostRealmPrincipalTransformer(String postRealmPrincipalTransformer) {
+        this.postRealmPrincipalTransformer = postRealmPrincipalTransformer;
+    }
+
+    /**
+     * @return the preRealmPrincipalTransformer
+     */
+    public String getPreRealmPrincipalTransformer() {
+        return preRealmPrincipalTransformer;
+    }
+
+    /**
+     * @param preRealmPrincipalTransformer the preRealmPrincipalTransformer to
+     * set
+     */
+    public void setPreRealmPrincipalTransformer(String preRealmPrincipalTransformer) {
+        this.preRealmPrincipalTransformer = preRealmPrincipalTransformer;
+    }
+
+    /**
+     * @return the providerName
+     */
+    public String getProviderName() {
+        return providerName;
+    }
+
+    /**
+     * @param providerName the providerName to set
+     */
+    public void setProviderName(String providerName) {
+        this.providerName = providerName;
+    }
+
+    /**
+     * @return the providers
+     */
+    public List<String> getProviders() {
+        return providers;
+    }
+
+    /**
+     * @param providers the providers to set
+     */
+    public void setProviders(List<String> providers) {
+        this.providers = providers;
+    }
+
+    /**
+     * @return the realmMapper
+     */
+    public String getRealmMapper() {
+        return realmMapper;
+    }
+
+    /**
+     * @param realmMapper the realmMapper to set
+     */
+    public void setRealmMapper(String realmMapper) {
+        this.realmMapper = realmMapper;
+    }
+
+    /**
+     * @return the securityDomain
+     */
+    public String getSecurityDomain() {
+        return securityDomain;
+    }
+
+    /**
+     * @param securityDomain the securityDomain to set
+     */
+    public void setSecurityDomain(String securityDomain) {
+        this.securityDomain = securityDomain;
+    }
+
+    /**
+     * @return the want
+     */
+    public boolean isWant() {
+        return want;
+    }
+
+    /**
+     * @param want the want to set
+     */
+    public void setWant(boolean want) {
+        this.want = want;
+    }
+
+    /**
+     * @return the need
+     */
+    public boolean isNeed() {
+        return need;
+    }
+
+    /**
+     * @param need the need to set
+     */
+    public void setNeed(boolean need) {
+        this.need = need;
+    }
+
+    /**
+     * @return the useCipherSuiteOrder
+     */
+    public boolean isUseCipherSuiteOrder() {
+        return useCipherSuiteOrder;
+    }
+
+    /**
+     * @param useCipherSuiteOrder the useCipherSuiteOrder to set
+     */
+    public void setUseCipherSuiteOrder(boolean useCipherSuiteOrder) {
+        this.useCipherSuiteOrder = useCipherSuiteOrder;
+    }
+
+    public ModelNode buildResource() {
+        ModelNode sslCtx = new ModelNode();
+        sslCtx.get(Util.KEY_MANAGER).set(keyManager.getName());
+        sslCtx.get(Util.WANT_CLIENT_AUTH).set(want);
+        sslCtx.get(Util.NEED_CLIENT_AUTH).set(need);
+        if (trustManager != null) {
+            sslCtx.get(Util.TRUST_MANAGER).set(trustManager.getName());
+        } else {
+            sslCtx.get(Util.TRUST_MANAGER);
+        }
+        if (protocols != null) {
+            ModelNode protocolsNode = sslCtx.get(Util.PROTOCOLS);
+            for (String p : protocols) {
+                protocolsNode.add(p);
+            }
+        } else {
+            sslCtx.get(Util.PROTOCOLS);
+        }
+        sslCtx.get(Util.AUTHENTICATION_OPTIONAL).set(authenticationOptional);
+        if (cipherSuiteFilter != null) {
+            sslCtx.get(Util.CIPHER_SUITE_FILTER).set(cipherSuiteFilter);
+        } else {
+            sslCtx.get(Util.CIPHER_SUITE_FILTER);
+        }
+        if (finalPrincipalTransformer != null) {
+            sslCtx.get(Util.FINAL_PRINCIPAL_TRANSFORMER).set(finalPrincipalTransformer);
+        } else {
+            sslCtx.get(Util.FINAL_PRINCIPAL_TRANSFORMER);
+        }
+        if (postRealmPrincipalTransformer != null) {
+            sslCtx.get(Util.POST_REALM_PRINCIPAL_TRANSFORMER).set(postRealmPrincipalTransformer);
+        } else {
+            sslCtx.get(Util.POST_REALM_PRINCIPAL_TRANSFORMER);
+        }
+        if (preRealmPrincipalTransformer != null) {
+            sslCtx.get(Util.PRE_REALM_PRINCIPAL_TRANSFORMER).set(preRealmPrincipalTransformer);
+        } else {
+            sslCtx.get(Util.PRE_REALM_PRINCIPAL_TRANSFORMER);
+        }
+        if (providerName != null) {
+            sslCtx.get(Util.PROVIDER_NAME).set(providerName);
+        } else {
+            sslCtx.get(Util.PROVIDER_NAME);
+        }
+        if (providers != null) {
+            ModelNode providersNode = sslCtx.get(Util.PROVIDERS);
+            for (String p : providers) {
+                providersNode.add(p);
+            }
+        } else {
+            sslCtx.get(Util.PROVIDERS);
+        }
+        if (realmMapper != null) {
+            sslCtx.get(Util.REALM_MAPPER).set(realmMapper);
+        } else {
+            sslCtx.get(Util.REALM_MAPPER);
+        }
+        if (securityDomain != null) {
+            sslCtx.get(Util.SECURITY_DOMAIN).set(securityDomain);
+        } else {
+            sslCtx.get(Util.SECURITY_DOMAIN);
+        }
+        sslCtx.get(Util.USE_CIPHER_SUITES_ORDER).set(useCipherSuiteOrder);
+        return sslCtx;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/AbstractEnableSSLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/AbstractEnableSSLCommand.java
@@ -1,0 +1,294 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.ssl;
+
+import org.jboss.as.cli.impl.aesh.cmd.RelativeFile;
+import org.jboss.as.cli.impl.aesh.cmd.RelativeFilePathConverter;
+import java.io.File;
+import java.io.IOException;
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.impl.completer.FileOptionCompleter;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_INTERACTIVE;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_PASSWORD;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_PATH;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_PATH_RELATIVE_TO;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_TYPE;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_KEY_MANAGER_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_KEY_STORE_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_SSL_CONTEXT_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_TRUST_MANAGER_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_TRUST_STORE_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_RELOAD;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_TRUSTED_CERTIFICATE_VALIDATION;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_TRUSTED_CERTIFICATE_PATH;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_TRUST_STORE_FILE_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_TRUST_STORE_FILE_PASSWORD;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_TRUST_STORE_NAME;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.formatOption;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.InteractiveSecurityBuilder;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.KeyStoreNameSecurityBuilder;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.KeyStorePathSecurityBuilder;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.SSLSecurityBuilder;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.cli.command.DMRCommand;
+import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
+
+/**
+ * Base class for any command that enables SSL.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "abstract-ssl-enable", description = "")
+public abstract class AbstractEnableSSLCommand implements Command<CLICommandInvocation>, DMRCommand {
+
+    @Option(name = OPT_KEY_STORE_NAME, completer = OptionCompleters.KeyStoreNameCompleter.class,
+            activator = OptionActivators.KeyStoreNameActivator.class)
+    String keystoreName;
+
+    @Option(name = OPT_KEY_STORE_PATH, activator = OptionActivators.KeyStorePathActivator.class,
+            converter = RelativeFilePathConverter.class, completer = FileOptionCompleter.class)
+    RelativeFile keystorePath;
+
+    @Option(name = OPT_KEY_STORE_PATH_RELATIVE_TO, activator = OptionActivators.KeyStorePathDependentActivator.class)
+    String keystorePathRelativeTo;
+
+    @Option(name = OPT_KEY_STORE_PASSWORD, activator = OptionActivators.KeyStorePathDependentActivator.class)
+    String keystorePassword;
+
+    @Option(name = OPT_TRUSTED_CERTIFICATE_PATH, activator = OptionActivators.TrustedCertificateActivator.class)
+    File trustedCertificatePath;
+
+    @Option(name = OPT_NO_TRUSTED_CERTIFICATE_VALIDATION, activator = OptionActivators.ValidateTrustedCertificateActivator.class, hasValue = false)
+    boolean noTrustedCertificateValidation;
+
+    @Option(name = OPT_TRUST_STORE_NAME, completer = OptionCompleters.KeyStoreNameCompleter.class,
+            activator = OptionActivators.TrustStoreNameActivator.class)
+    String trustStoreName;
+
+    @Option(name = OPT_TRUST_STORE_FILE_NAME, activator = OptionActivators.TrustStoreFileNameActivator.class)
+    String trustStoreFileName;
+
+    @Option(name = OPT_NEW_TRUST_STORE_NAME, activator = OptionActivators.NewTrustStoreNameActivator.class)
+    String newTrustStoreName;
+
+    @Option(name = OPT_NEW_TRUST_MANAGER_NAME, activator = OptionActivators.NewTrustManagerNameActivator.class)
+    String newTrustManagerName;
+
+    @Option(name = OPT_TRUST_STORE_FILE_PASSWORD, activator = OptionActivators.TrustStoreFilePasswordActivator.class)
+    String trustStoreFilePassword;
+
+    @Option(name = OPT_KEY_STORE_TYPE, activator = OptionActivators.KeyStorePathDependentActivator.class,
+            completer = OptionCompleters.KeyStoreTypeCompleter.class)
+    String keyStoreType;
+
+    @Option(name = OPT_NEW_KEY_MANAGER_NAME, activator = OptionActivators.NewKeyManagerNameActivator.class)
+    String newKeyManagerName;
+
+    @Option(name = OPT_NEW_SSL_CONTEXT_NAME, activator = OptionActivators.NewSSLContextNameActivator.class)
+    String newSslContextName;
+
+    @Option(name = OPT_NEW_KEY_STORE_NAME,
+            activator = OptionActivators.NewKeyStoreNameActivator.class)
+    String newKeystoreName;
+
+    @Option(name = OPT_NO_RELOAD, hasValue = false, activator = OptionActivators.NoReloadActivator.class)
+    boolean noReload;
+
+    @Option(name = OPT_INTERACTIVE, hasValue = false, activator = OptionActivators.InteractiveActivator.class)
+    boolean interactive;
+
+    protected abstract void secure(CommandContext ctx, SSLSecurityBuilder ssl) throws CommandException;
+
+    private final CommandContext initCtx;
+
+    protected AbstractEnableSSLCommand(CommandContext initCtx) {
+        this.initCtx = initCtx;
+    }
+
+    CommandContext getCommandContext() {
+        return initCtx;
+    }
+
+    @Override
+    public ModelNode buildRequest(CommandContext context) throws CommandFormatException {
+        try {
+            return buildSecurityRequest(context, null).buildExecutableRequest(context);
+        } catch (Exception ex) {
+            throw new CommandFormatException(ex.getLocalizedMessage() == null
+                    ? ex.toString() : ex.getLocalizedMessage());
+        }
+    }
+
+    private SSLSecurityBuilder buildSecurityRequest(CommandContext context, CLICommandInvocation commandInvocation) throws Exception {
+        SSLSecurityBuilder builder = validateOptions(context);
+        if (builder instanceof InteractiveSecurityBuilder) {
+            ((InteractiveSecurityBuilder) builder).setCommandInvocation(commandInvocation);
+        }
+
+        builder.buildRequest(context, commandInvocation == null);
+        secure(context, builder);
+        return builder;
+    }
+
+    protected abstract boolean isSSLEnabled(CommandContext ctx) throws Exception;
+
+    protected abstract String getTarget(CommandContext ctx);
+
+    @Override
+    public CommandResult execute(CLICommandInvocation commandInvocation) throws CommandException, InterruptedException {
+        CommandContext ctx = commandInvocation.getCommandContext();
+        String target = getTarget(ctx);
+        try {
+            if (isSSLEnabled(ctx)) {
+                throw new CommandException("SSL is already enabled for " + target);
+            }
+        } catch (Exception ex) {
+            throw new CommandException(ex.getLocalizedMessage(), ex);
+        }
+
+        SSLSecurityBuilder builder;
+        try {
+            builder = buildSecurityRequest(ctx, commandInvocation);
+        } catch (Exception ex) {
+            throw new CommandException(ex.getLocalizedMessage());
+        }
+        try {
+            SecurityCommand.execute(ctx, builder.buildExecutableRequest(ctx), builder, noReload);
+        } catch (Exception ex) {
+            if (ex instanceof CommandException) {
+                throw (CommandException) ex;
+            } else {
+                throw new CommandException(ex.getLocalizedMessage());
+            }
+        }
+        commandInvocation.getCommandContext().printLine("SSL enabled for " + target);
+        commandInvocation.getCommandContext().printLine("ssl-context is " + builder.getServerSSLContext().getName());
+        commandInvocation.getCommandContext().printLine("key-manager is " + builder.getServerSSLContext().getKeyManager().getName());
+        commandInvocation.getCommandContext().printLine("key-store   is " + builder.getServerSSLContext().getKeyManager().getKeyStore().getName());
+
+        return CommandResult.SUCCESS;
+    }
+
+    abstract String getDefaultKeyStoreFileName(CommandContext ctx);
+
+    abstract String getDefaultTrustStoreFileName(CommandContext ctx);
+
+    private SSLSecurityBuilder validateOptions(CommandContext ctx) throws CommandException, IOException, OperationFormatException {
+        if (keystoreName == null && keystorePath == null && !interactive) {
+            throw new CommandException("One of " + formatOption(OPT_INTERACTIVE)
+                    + ", " + formatOption(OPT_KEY_STORE_NAME) + ", " + formatOption(OPT_KEY_STORE_PATH) + " must be set");
+        }
+
+        SSLSecurityBuilder builder = null;
+
+        if (keystorePath != null) {
+            if (builder != null) {
+                invalidUseCase();
+            }
+            if (keystoreName != null) {
+                throw new CommandException(formatOption(OPT_KEY_STORE_NAME) + " can't be used with " + formatOption(OPT_KEY_STORE_PATH));
+            }
+            File path;
+            if (keystorePathRelativeTo != null) {
+                path = new File(keystorePath.getOriginalPath());
+            } else {
+                path = keystorePath;
+                if (!path.exists()) {
+                    throw new CommandException("File " + path + " doesn't exist.");
+                }
+            }
+            KeyStorePathSecurityBuilder kspBuilder = new KeyStorePathSecurityBuilder(path, keystorePassword);
+            kspBuilder.setRelativeTo(keystorePathRelativeTo).setType(keyStoreType).
+                    setName(newKeystoreName);
+            builder = kspBuilder;
+        }
+
+        if (keystoreName != null) {
+            if (builder != null) {
+                invalidUseCase();
+            }
+            if (newKeystoreName != null || keystorePassword != null || keyStoreType != null || keystorePathRelativeTo != null || keystorePath != null) {
+                throw new CommandException("key-store file related options can't be used with " + formatOption(OPT_KEY_STORE_NAME));
+            }
+            if (!ElytronUtil.keyStoreExists(ctx, keystoreName)) {
+                throw new CommandException("key-store " + keystoreName + " doesn't exist");
+            }
+            builder = new KeyStoreNameSecurityBuilder(keystoreName);
+        }
+
+        if (interactive) { // Fully handled by prompting.
+            if (builder != null) {
+                invalidUseCase();
+            }
+            checkKeyStoreOperationsSupported(ctx, OPT_INTERACTIVE);
+            builder = new InteractiveSecurityBuilder(getDefaultKeyStoreFileName(ctx),
+                    getDefaultTrustStoreFileName(ctx));
+        }
+
+        if (trustedCertificatePath != null) {
+            checkKeyStoreOperationsSupported(ctx, OPT_TRUSTED_CERTIFICATE_PATH);
+            if (!trustedCertificatePath.exists()) {
+                throw new CommandException("The client certificate path " + trustedCertificatePath + " doesn't exist");
+            }
+            if (trustStoreName != null) {
+                throw new CommandException(formatOption(OPT_TRUST_STORE_NAME) + " can't be used when " + formatOption(OPT_TRUSTED_CERTIFICATE_PATH) + " is in use");
+            }
+        }
+
+        if (trustStoreName != null) {
+            if (!ElytronUtil.keyStoreExists(ctx, trustStoreName)) {
+                throw new CommandException("key-store " + trustStoreName + " doesn't exist");
+            }
+        }
+
+        if (builder != null) {
+            builder.setTrustedCertificatePath(trustedCertificatePath);
+            builder.setValidateCertificate(!noTrustedCertificateValidation);
+            builder.setTrustStoreFileName(trustStoreFileName);
+            builder.setTrustStoreFilePassword(trustStoreFilePassword);
+            builder.setTrustStoreName(trustStoreName);
+            builder.setNewTrustStoreName(newTrustStoreName);
+            builder.setNewTrustManagerName(newTrustManagerName);
+            builder.setKeyManagerName(newKeyManagerName);
+            builder.setSSLContextName(newSslContextName);
+        }
+
+        return builder;
+    }
+
+    private static void checkKeyStoreOperationsSupported(CommandContext ctx, String option)
+            throws IOException, OperationFormatException, CommandException {
+        if (!ElytronUtil.isKeyStoreManagementSupported(ctx)) {
+            throw new CommandException("Operations to manage key-store are not available, the option " + formatOption(option) + " can't be used");
+        }
+    }
+
+    private static void invalidUseCase() throws CommandException {
+        throw new CommandException("Only one of " + formatOption(OPT_INTERACTIVE)
+                + ", " + formatOption(OPT_KEY_STORE_NAME) + ", " + formatOption(OPT_KEY_STORE_PATH) + "must  be set");
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/HTTPServerDisableSSLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/HTTPServerDisableSSLCommand.java
@@ -1,0 +1,77 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.ssl;
+
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.aesh.cmd.security.HttpServerCommandActivator;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_RELOAD;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_SERVER_NAME;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.HTTPServer;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.cli.command.DMRCommand;
+import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "disable-ssl-http-server", description = "", activator = HttpServerCommandActivator.class)
+public class HTTPServerDisableSSLCommand implements Command<CLICommandInvocation>, DMRCommand {
+    @Option(name = OPT_NO_RELOAD, hasValue = false)
+    boolean noReload;
+
+    @Option(name = OPT_SERVER_NAME, completer = OptionCompleters.ServerNameCompleter.class)
+    String serverName;
+
+    @Override
+    public CommandResult execute(CLICommandInvocation commandInvocation) throws CommandException, InterruptedException {
+        CommandContext ctx = commandInvocation.getCommandContext();
+        ModelNode request;
+        try {
+            request = buildRequest(ctx);
+        } catch (CommandFormatException ex) {
+            throw new CommandException(ex.getLocalizedMessage(), ex);
+        }
+        SecurityCommand.execute(ctx, request, SecurityCommand.DEFAULT_FAILURE_CONSUMER, noReload);
+        ctx.printLine("SSL disabled for " + serverName);
+        return CommandResult.SUCCESS;
+    }
+
+    @Override
+    public ModelNode buildRequest(CommandContext context) throws CommandFormatException {
+        ModelNode composite = new ModelNode();
+        composite.get(Util.OPERATION).set(Util.COMPOSITE);
+        composite.get(Util.ADDRESS).setEmptyList();
+        try {
+            serverName = HTTPServer.disableSSL(context,
+                    serverName, composite.get(Util.STEPS));
+        } catch (Exception ex) {
+            throw new CommandFormatException(ex.getLocalizedMessage() == null
+                    ? ex.toString() : ex.getLocalizedMessage(), ex);
+        }
+        return composite;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/HTTPServerEnableSSLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/HTTPServerEnableSSLCommand.java
@@ -1,0 +1,87 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.ssl;
+
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.impl.aesh.cmd.security.HttpServerCommandActivator;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_OVERRIDE_SECURITY_REALM;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_SERVER_NAME;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.DefaultResourceNames;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.SSLSecurityBuilder;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.HTTPServer;
+
+/**
+ * Command to enable SSL for a given undertow server.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "enable-ssl-http-server", description = "", activator = HttpServerCommandActivator.class)
+public class HTTPServerEnableSSLCommand extends AbstractEnableSSLCommand {
+
+    @Option(name = OPT_SERVER_NAME, completer = OptionCompleters.ServerNameCompleter.class)
+    String serverName;
+
+    @Option(name = OPT_NO_OVERRIDE_SECURITY_REALM,
+            activator = OptionActivators.NoOverrideSecurityRealmActivator.class,
+            hasValue = false)
+    boolean noOverride;
+
+    public HTTPServerEnableSSLCommand(CommandContext ctx) {
+        super(ctx);
+    }
+
+    @Override
+    protected void secure(CommandContext ctx, SSLSecurityBuilder builder) throws CommandException {
+        try {
+            HTTPServer.enableSSL(serverName, noOverride, ctx, builder);
+        } catch (Exception ex) {
+            throw new CommandException(ex);
+        }
+    }
+
+    @Override
+    protected boolean isSSLEnabled(CommandContext ctx) throws Exception {
+        String target = serverName;
+        if (target == null) {
+            target = DefaultResourceNames.getDefaultServerName(ctx);
+        }
+        return HTTPServer.getSSLContextName(target, ctx) != null;
+    }
+
+    @Override
+    protected String getTarget(CommandContext ctx) {
+        String target = serverName;
+        if (target == null) {
+            target = DefaultResourceNames.getDefaultServerName(ctx);
+        }
+        return target;
+    }
+
+    @Override
+    String getDefaultKeyStoreFileName(CommandContext ctx) {
+        return getTarget(ctx) + ".keystore";
+    }
+
+    @Override
+    String getDefaultTrustStoreFileName(CommandContext ctx) {
+        return getTarget(ctx) + ".truststore";
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/ManagementDisableSSLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/ManagementDisableSSLCommand.java
@@ -1,0 +1,164 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.ssl;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.embedded.EmbeddedProcessLaunch;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MANAGEMENT_INTERFACE;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_RELOAD;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommandActivator;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ManagementInterfaces;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.cli.command.DMRCommand;
+import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "disable-ssl-management", description = "", activator = SecurityCommandActivator.class)
+public class ManagementDisableSSLCommand implements Command<CLICommandInvocation>, DMRCommand {
+
+    @Option(name = OPT_NO_RELOAD, hasValue = false)
+    boolean noReload;
+
+    @Option(name = OPT_MANAGEMENT_INTERFACE, completer = OptionCompleters.ManagementInterfaceCompleter.class)
+    String managementInterface;
+
+    private final AtomicReference<EmbeddedProcessLaunch> embeddedServerRef;
+
+    public ManagementDisableSSLCommand(AtomicReference<EmbeddedProcessLaunch> embeddedServerRef) {
+        this.embeddedServerRef = embeddedServerRef;
+    }
+
+    @Override
+    public CommandResult execute(CLICommandInvocation commandInvocation) throws CommandException, InterruptedException {
+        CommandContext ctx = commandInvocation.getCommandContext();
+        ModelNode request;
+        try {
+            request = buildRequest(ctx);
+        } catch (CommandFormatException ex) {
+            throw new CommandException(ex.getLocalizedMessage(), ex);
+        }
+        execute(ctx, request);
+        return CommandResult.SUCCESS;
+    }
+
+    private void execute(CommandContext ctx, ModelNode request) throws CommandException {
+        ModelNode response;
+        try {
+            response = ctx.getModelControllerClient().execute(request);
+        } catch (IOException ex) {
+            throw new CommandException(ex);
+        }
+        if (!Util.isSuccess(response)) {
+            throw new CommandException(Util.getFailureDescription(response));
+        }
+
+        if (!noReload) {
+            try {
+                reload(ctx);
+                ctx.printLine("Server reloaded.");
+                reconnect(ctx);
+                ctx.printLine("Reconnected to server.");
+            } catch (CommandLineException ex) {
+                throw new CommandException(ex.getLocalizedMessage(), ex);
+            }
+        } else {
+            ctx.printLine("Warning: server has not been reloaded. Call 'reload' to apply changes.");
+        }
+        ctx.printLine("SSL disabled for " + managementInterface);
+    }
+
+    private void reload(CommandContext ctx) throws CommandException, OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        try {
+            String mode = Util.getRunningMode(ctx);
+            builder.setOperationName(Util.RELOAD);
+            builder.addProperty(Util.START_MODE, Util.ADMIN_ONLY.equals(mode) ? Util.ADMIN_ONLY : Util.NORMAL);
+            ModelNode response;
+            response = ctx.getModelControllerClient().execute(builder.buildRequest());
+            if (!Util.isSuccess(response)) {
+                throw new CommandException(Util.getFailureDescription(response));
+            }
+        } catch (IOException ex) {
+            throw new CommandException(ex);
+        }
+    }
+
+    private boolean isEmbedded() {
+        return embeddedServerRef != null && embeddedServerRef.get() != null;
+    }
+
+    private void reconnect(CommandContext ctx) throws CommandLineException {
+        if (isEmbedded()) {
+            return;
+        }
+
+        final long start = System.currentTimeMillis();
+        final long timeoutMillis = ctx.getConfig().getConnectionTimeout() + 1000;
+        Exception exception;
+        while (true) {
+            try {
+                ctx.connectController();
+                break;
+            } catch (Exception ex) {
+                // Ignore and try again
+                exception = ex;
+            }
+            if (System.currentTimeMillis() - start > timeoutMillis) {
+                ctx.disconnectController();
+                throw new CommandLineException("Failed to re-establish connection in " + (System.currentTimeMillis() - start)
+                        + "ms." + (exception != null ? exception : ""));
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                ctx.disconnectController();
+                throw new CommandLineException("Interrupted while pausing before reconnecting.", e);
+            }
+        }
+    }
+
+    @Override
+    public ModelNode buildRequest(CommandContext context) throws CommandFormatException {
+        ModelNode composite = new ModelNode();
+        composite.get(Util.OPERATION).set(Util.COMPOSITE);
+        composite.get(Util.ADDRESS).setEmptyList();
+        try {
+            managementInterface = ManagementInterfaces.disableSSL(context,
+                    managementInterface, composite.get(Util.STEPS));
+        } catch (Exception ex) {
+            throw new CommandFormatException(ex.getLocalizedMessage() == null
+                    ? ex.toString() : ex.getLocalizedMessage(), ex);
+        }
+        return composite;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/ManagementEnableSSLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/ManagementEnableSSLCommand.java
@@ -1,0 +1,90 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.ssl;
+
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_HTTP_SECURE_SOCKET_BINDING;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MANAGEMENT_INTERFACE;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommandActivator;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.DefaultResourceNames;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ManagementInterfaces;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.SSLSecurityBuilder;
+
+/**
+ * A command to enable SSL for a given management interface.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "enable-ssl-management", description = "", activator = SecurityCommandActivator.class)
+public class ManagementEnableSSLCommand extends AbstractEnableSSLCommand {
+
+    private static final String DEFAULT_KEY_STORE_FILE_NAME = "management.keystore";
+    private static final String DEFAULT_TRUST_STORE_FILE_NAME = "management.truststore";
+
+    @Option(name = OPT_MANAGEMENT_INTERFACE, completer = OptionCompleters.ManagementInterfaceCompleter.class,
+            activator = OptionActivators.ManagementInterfaceActivator.class)
+    String managementInterface;
+
+    @Option(name = OPT_HTTP_SECURE_SOCKET_BINDING, activator = OptionActivators.SecureSocketBindingActivator.class,
+            completer = OptionCompleters.SecureSocketBindingCompleter.class)
+    String secureSocketBinding;
+
+    public ManagementEnableSSLCommand(CommandContext ctx) {
+        super(ctx);
+    }
+
+    @Override
+    protected void secure(CommandContext ctx, SSLSecurityBuilder builder) throws CommandException {
+        try {
+            ManagementInterfaces.enableSSL(managementInterface, secureSocketBinding, ctx, builder);
+        } catch (Exception ex) {
+            throw new CommandException(ex);
+        }
+    }
+
+    @Override
+    String getDefaultKeyStoreFileName(CommandContext ctx) {
+        return DEFAULT_KEY_STORE_FILE_NAME;
+    }
+
+    @Override
+    String getDefaultTrustStoreFileName(CommandContext ctx) {
+        return DEFAULT_TRUST_STORE_FILE_NAME;
+    }
+
+    @Override
+    protected boolean isSSLEnabled(CommandContext ctx) throws Exception {
+        String target = managementInterface;
+        if (target == null) {
+            target = DefaultResourceNames.getDefaultManagementInterfaceName(ctx);
+        }
+        return ManagementInterfaces.getManagementInterfaceSSLContextName(ctx, target) != null;
+    }
+
+    @Override
+    protected String getTarget(CommandContext ctx) {
+        String target = managementInterface;
+        if (target == null) {
+            target = DefaultResourceNames.getDefaultManagementInterfaceName(ctx);
+        }
+        return target;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/OptionActivators.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/OptionActivators.java
@@ -1,0 +1,251 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.ssl;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.aesh.command.impl.internal.ParsedCommand;
+import org.jboss.as.cli.Util;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_INTERACTIVE;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_PATH;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MANAGEMENT_INTERFACE;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_TRUSTED_CERTIFICATE_PATH;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_TRUST_STORE_NAME;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+import org.wildfly.core.cli.command.aesh.activator.AbstractDependOptionActivator;
+import org.wildfly.core.cli.command.aesh.activator.AbstractDependOneOfOptionActivator;
+import org.wildfly.core.cli.command.aesh.activator.AbstractDependRejectOptionActivator;
+import org.wildfly.core.cli.command.aesh.activator.AbstractRejectOptionActivator;
+import org.wildfly.core.cli.command.aesh.activator.DependOneOfOptionActivator;
+
+/**
+ * Option activators in use in the SSL commands. Activators are controlling the
+ * visibility of options during completion. They are the input of help synopsis
+ * generator.
+ *
+ * @author jdenise@redhat.com
+ */
+public interface OptionActivators {
+
+    public static class InteractiveActivator extends AbstractRejectOptionActivator {
+
+        public InteractiveActivator() {
+            super(OPT_KEY_STORE_NAME, OPT_KEY_STORE_PATH);
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand processedCommand) {
+            AbstractEnableSSLCommand cmd = (AbstractEnableSSLCommand) processedCommand.command();
+            try {
+                if (!ElytronUtil.isKeyStoreManagementSupported(cmd.getCommandContext())) {
+                    return false;
+                }
+            } catch (Exception ex) {
+                return false;
+            }
+            return super.isActivated(processedCommand);
+        }
+    }
+
+    public static class KeyStorePathActivator extends AbstractRejectOptionActivator {
+
+        public KeyStorePathActivator() {
+            super(OPT_KEY_STORE_NAME, OPT_INTERACTIVE);
+        }
+    }
+
+    public static class KeyStoreNameActivator extends AbstractRejectOptionActivator {
+
+        public KeyStoreNameActivator() {
+            super(OPT_KEY_STORE_PATH, OPT_INTERACTIVE);
+        }
+    }
+
+    public static class TrustStoreNameActivator extends AbstractRejectOptionActivator implements DependOneOfOptionActivator {
+        private static class DependsOnOf extends AbstractDependOneOfOptionActivator {
+
+            DependsOnOf() {
+                super(OPT_KEY_STORE_NAME, OPT_KEY_STORE_PATH);
+            }
+        }
+        private static DependsOnOf dof = new DependsOnOf();
+        public TrustStoreNameActivator() {
+            super(OPT_TRUSTED_CERTIFICATE_PATH);
+        }
+
+        @Override
+        public Set<String> getOneOfDependsOn() {
+            return dof.getOneOfDependsOn();
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand processedCommand) {
+            if (!dof.isActivated(processedCommand)) {
+                return false;
+            }
+            return super.isActivated(processedCommand);
+        }
+    }
+
+    public static class TrustStoreFileNameActivator extends AbstractDependRejectOptionActivator {
+
+        private static final Set<String> DEPEND = new HashSet<>();
+        private static final Set<String> REJECT = new HashSet<>();
+
+        static {
+            DEPEND.add(OPT_TRUSTED_CERTIFICATE_PATH);
+            REJECT.add(OPT_TRUST_STORE_NAME);
+        }
+
+        public TrustStoreFileNameActivator() {
+            super(false, DEPEND, REJECT);
+        }
+    }
+
+    public static class NewTrustStoreNameActivator extends AbstractDependOptionActivator {
+
+        public NewTrustStoreNameActivator() {
+            super(false, OPT_TRUSTED_CERTIFICATE_PATH);
+        }
+    }
+
+    public static class NewTrustManagerNameActivator extends AbstractDependOneOfOptionActivator {
+
+        public NewTrustManagerNameActivator() {
+            super(OPT_TRUSTED_CERTIFICATE_PATH, OPT_TRUST_STORE_NAME);
+        }
+    }
+
+    public static class TrustStoreFilePasswordActivator extends AbstractDependOptionActivator {
+
+        public TrustStoreFilePasswordActivator() {
+            super(false, OPT_TRUSTED_CERTIFICATE_PATH);
+        }
+    }
+
+    public static class NewKeyStoreNameActivator extends AbstractDependOptionActivator {
+
+        public NewKeyStoreNameActivator() {
+            super(false, OPT_KEY_STORE_PATH);
+        }
+    }
+
+    public static class NewSSLContextNameActivator extends AbstractDependOneOfOptionActivator {
+
+        public NewSSLContextNameActivator() {
+            super(OPT_KEY_STORE_PATH, OPT_KEY_STORE_NAME);
+        }
+    }
+
+    public static class NewKeyManagerNameActivator extends AbstractDependOneOfOptionActivator {
+
+        public NewKeyManagerNameActivator() {
+            super(OPT_KEY_STORE_PATH, OPT_KEY_STORE_NAME);
+        }
+    }
+
+    public static class ManagementInterfaceActivator extends AbstractDependOneOfOptionActivator {
+
+        public ManagementInterfaceActivator() {
+            super(OPT_KEY_STORE_PATH, OPT_KEY_STORE_NAME, OPT_INTERACTIVE);
+        }
+    }
+
+    public static class TrustedCertificateActivator extends AbstractRejectOptionActivator implements DependOneOfOptionActivator {
+
+        private static class DependsOnOf extends AbstractDependOneOfOptionActivator {
+
+            DependsOnOf() {
+                super(OPT_KEY_STORE_NAME, OPT_KEY_STORE_PATH);
+            }
+        }
+        private static DependsOnOf dof = new DependsOnOf();
+
+        public TrustedCertificateActivator() {
+            super(OPT_TRUST_STORE_NAME);
+        }
+
+        @Override
+        public Set<String> getOneOfDependsOn() {
+            return dof.getOneOfDependsOn();
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand processedCommand) {
+            AbstractEnableSSLCommand cmd = (AbstractEnableSSLCommand) processedCommand.command();
+            try {
+                if (!ElytronUtil.isKeyStoreManagementSupported(cmd.getCommandContext())) {
+                    return false;
+                }
+            } catch (Exception ex) {
+                return false;
+            }
+            if (!dof.isActivated(processedCommand)) {
+                return false;
+            }
+            return super.isActivated(processedCommand);
+        }
+    }
+
+    public static class ValidateTrustedCertificateActivator extends AbstractDependOptionActivator {
+
+        public ValidateTrustedCertificateActivator() {
+            super(false, OPT_TRUSTED_CERTIFICATE_PATH);
+        }
+    }
+
+    public static class NoReloadActivator extends AbstractDependOneOfOptionActivator {
+
+        public NoReloadActivator() {
+            super(OPT_KEY_STORE_PATH, OPT_KEY_STORE_NAME, OPT_INTERACTIVE);
+        }
+    }
+
+    public static class NoOverrideSecurityRealmActivator extends AbstractDependOneOfOptionActivator {
+
+        public NoOverrideSecurityRealmActivator() {
+            super(OPT_KEY_STORE_PATH, OPT_KEY_STORE_NAME);
+        }
+    }
+
+
+    public static class KeyStorePathDependentActivator extends AbstractDependOptionActivator {
+
+        public KeyStorePathDependentActivator() {
+            super(false, OPT_KEY_STORE_PATH);
+        }
+    }
+
+    public static class SecureSocketBindingActivator extends AbstractDependOptionActivator {
+
+        public SecureSocketBindingActivator() {
+            super(false, OPT_MANAGEMENT_INTERFACE);
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand processedCommand) {
+            ManagementEnableSSLCommand cmd = (ManagementEnableSSLCommand) processedCommand.command();
+            if (cmd.managementInterface == null) {
+                return false;
+            }
+            if (Util.HTTP_INTERFACE.equals(cmd.managementInterface)) {
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/PromptFileCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/ssl/PromptFileCompleter.java
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.ssl;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.aesh.impl.util.FileLister;
+import org.aesh.readline.AeshContext;
+import org.aesh.readline.completion.CompleteOperation;
+import org.aesh.readline.completion.Completion;
+
+/**
+ * Completion of file during user interaction.
+ *
+ * @author jdenise@redhat.com
+ */
+public class PromptFileCompleter implements Completion {
+    private final AeshContext ctx;
+
+    public PromptFileCompleter(AeshContext ctx) {
+        this.ctx = ctx;
+    }
+    @Override
+    public void complete(CompleteOperation completeOperation) {
+        List<String> candidates = new ArrayList<>();
+        int cursor = new FileLister(completeOperation.getBuffer(),
+                ctx.getCurrentWorkingDirectory()).
+                findMatchingDirectories(candidates);
+        completeOperation.addCompletionCandidates(candidates);
+        completeOperation.setOffset(cursor);
+        completeOperation.doAppendSeparator(false);
+    }
+
+}

--- a/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/command_resources.properties
+++ b/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/command_resources.properties
@@ -1,0 +1,19 @@
+# Copyright 2017 Red Hat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+security.description=\
+The main command to configure security. This command exposes a set of actions \
+to configure SSL. This command is only available if CLI is connected to a \
+managed process (or embedded server) that is running in standalone mode and supports elytron.\n\
+\nTIPS: Use 'echo-dmr security <sub command> <options>' in order to \
+visualize the composite request that would be sent to enable SSL.

--- a/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/ssl/command_resources.properties
+++ b/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/ssl/command_resources.properties
@@ -1,0 +1,225 @@
+# Copyright 2017 Red Hat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+security.abstract-ssl-enable.option.interactive.description=\
+Use this option to have CLI to prompt user for the information required to setup one way or \
+two way SSL configuration.\n\
+Warning: This option is only available if the elytron subsystem supports advanced key-store\
+ manipulation.
+
+security.abstract-ssl-enable.option.key-store-name.description=\
+Mandatory if no --key-store-path is used. This is the name of an existing key-store resource.\
+Completion exposes existing key-stores.
+
+security.abstract-ssl-enable.option.key-store-name.value=key-store name
+
+security.abstract-ssl-enable.option.key-store-password.description=\
+Mandatory if --key-store-path is used. The key-store password.
+
+security.abstract-ssl-enable.option.key-store-password.value=password
+
+security.abstract-ssl-enable.option.key-store-path.description=\
+Mandatory if no --key-store-name is used. The key-store absolute \
+(if --key-store-path-relative-to is not used) or relative (if not used) path.
+
+security.abstract-ssl-enable.option.key-store-path.value=key-store path
+
+security.abstract-ssl-enable.option.key-store-path-relative-to.description=\
+Optional, to be used with the --key-store-path option. Makes the provided path \
+relative to a system property (eg:jboss.server.config.dir).
+
+security.abstract-ssl-enable.option.key-store-path-relative-to.value=system property
+
+security.abstract-ssl-enable.option.key-store-type.description=\
+Optional, to be used with the --key-store-path option. The type of the key-store. \
+By default JKS is used. Completion exposes the main supported types.
+
+security.abstract-ssl-enable.option.key-store-type.value=type\
+
+security.abstract-ssl-enable.option.new-key-manager-name.description=\
+Optional, name of the created key-manager resource. By default a name is computed \
+based on the key-store path or name.
+
+security.abstract-ssl-enable.option.new-key-manager-name.value=key-manager name
+
+security.abstract-ssl-enable.option.new-key-store-name.description=\
+Optional, to be used with the --key-store-path option. Name of the created key-store \
+resource. By default a name is computed based on the key-store path.
+
+security.abstract-ssl-enable.option.new-key-store-name.value=key-store name
+
+security.abstract-ssl-enable.option.new-ssl-context-name.description=\
+Optional, name of the created ssl-context resource. By default a name is computed \
+based on the key-store path or name.
+
+security.abstract-ssl-enable.option.new-ssl-context-name.value=ssl-context name
+
+security.abstract-ssl-enable.option.new-trust-manager-name.description=\
+Optional, name of the created trust-manager resource. By default a name is computed \
+based on the trust-store path or name.
+
+security.abstract-ssl-enable.option.new-trust-manager-name.value=trust-manager name\
+
+security.abstract-ssl-enable.option.new-trust-store-name.description=\
+Optional, name of the created trust-store resource. By default a name is computed \
+based on the trust-store path.
+
+security.abstract-ssl-enable.option.new-trust-store-name.value=trust-store name
+
+security.abstract-ssl-enable.option.no-reload.description=\
+Optional, by default the server is reloaded once the configuration changes have been applied. \
+In order to not reload the server, use this option.\n\
+NB: reload is done in start-mode=<the mode the current server is running>.
+
+security.abstract-ssl-enable.option.no-trusted-certificate-validation.description=\
+By default the imported certificate is validated, use this option to disable validation.
+
+security.abstract-ssl-enable.option.trusted-certificate-path.description=\
+Path to the client certificate to import. If the certificate is already imported \
+in a trust-store, use the option --trust-store-name.\n\
+Warning: This option is only available if the elytron subsystem supports advanced key-store\
+ manipulation.
+
+security.abstract-ssl-enable.option.trusted-certificate-path.value=certificate path
+
+security.abstract-ssl-enable.option.trust-store-file-name.description=\
+Optional, the name of the generated trust-store file. By default management.truststore is used.\n\
+Warning: This option is only available if the elytron subsystem supports advanced key-store\
+ manipulation.
+
+security.abstract-ssl-enable.option.trust-store-file-name.value=file name
+
+security.abstract-ssl-enable.option.trust-store-file-password.description=\
+Optional, generated trust-store file password. By default a password is generated.\n\
+Warning: This option is only available if the elytron subsystem supports advanced key-store\
+ manipulation.
+
+security.abstract-ssl-enable.option.trust-store-file-password.value=password
+
+security.abstract-ssl-enable.option.trust-store-name.description=\
+The name of an existing trust-store that contains the client certificate. Completion \
+ proposes existing trust-store.
+
+security.abstract-ssl-enable.option.trust-store-name.value=name
+
+security.abstract-ssl-enable.option.validate-trusted-certificate.description=\
+Optional, by default, the imported certificate is validated, use this option to disable validation.\n\
+Warning: This option is only available if the elytron subsystem supports advanced key-store\
+ manipulation.
+
+security.disable-ssl-management.description=\
+Disable SSL for a given management interface. By default the 'http-interface' is the \
+target of this command.\n\
+Once SSL has been disabled, CLI reloads the server (start-mode=<the mode the current \
+server is running>) and attempts to reconnect.\n\
+\n\
+TIPS: Use 'echo-dmr security ssl-disable-management <options>' in order to \
+visualize the composite request that would be sent to enable SSL.
+
+security.disable-ssl-management.option.no-reload.description=\
+Optional, by default the server is reloaded once the configuration changes have been applied. \
+In order to not reload and have CLI to reconnect to the server, use this option.\n\
+NB: reload is done in start-mode=<the mode the current server is running>.
+
+security.disable-ssl-management.option.management-interface.description=\
+Optional, the name of the management interface for which SSL will be disabled. By default 'http-interface' \
+is the target of this command. Completion proposes the set of enabled interfaces.
+
+security.disable-ssl-management.option.management-interface.value=management interface
+
+security.enable-ssl-management.option.http-secure-socket-binding.description=\
+Optional, the name of the secure socket-binding to use with the management http-interface. \
+By default 'https' is use.
+
+security.enable-ssl-management.option.http-secure-socket-binding.value=socket binding
+
+security.enable-ssl-management.option.management-interface.description=\
+Optional, the name of the management interface to apply SSL to. By default http-interface \
+is the interface in use.
+
+security.enable-ssl-management.option.management-interface.value=management interface
+
+security.enable-ssl-management.description=\
+Enable SSL for a given management interface. By default 'http-interface' is the \
+target of this command. Other management interface can be targeted thanks to the \
+--management-interface option.\n\
+\n\
+This command offers 3 ways to setup SSL.\n\
+\n\
+1) --interactive, the command prompts user for the information needed to enable SSL. \
+NB: The server certificate, certificate signing request file, server key-store, \
+server trust-store (if any) will be generated in the server configuration directory.\n\
+\n\
+2) By using the path of an existing key-store \
+file (--key-store-path option)\n\
+\n\
+3) By using an existing key-store already added in the server \
+(--key-store-name option).\n\
+\n\
+This command tries to limit the set of created resources by identifying existing resources \
+that can be reused to full-fill the security requirements.\n\
+\n\
+TIPS: Use 'echo-dmr security ssl-enable-management [<options>]' in order to \
+visualize the composite request that would be sent to enable SSL.
+
+
+security.enable-ssl-http-server.description=\
+Enable https for an undertow http server. This command is only available if the undertow \
+subsystem is present. By default the 'default-server' is the target of \
+this command. Other server name can be specified thanks to the --server-name option.\
+\n\
+This command offers 3 ways to setup SSL.\n\
+\n\
+1) --interactive, the command prompts user for the information needed to enable SSL. \
+NB: The server certificate, certificate signing request file, server key-store, \
+server trust-store (if any) will be generated in the server configuration directory.\n\
+\n\
+2) By using the path of an existing key-store \
+file (--key-store-path option)\n\
+\n\
+3) By using an existing key-store already added in the server \
+(--key-store-name option).\n\
+\n\
+This command tries to limit the set of created resources by identifying existing resources \
+that can be reused to full-fill the security requirements.\n\
+\n\
+TIPS: Use 'echo-dmr security ssl-enable-https-server [<options>]' in order to \
+visualize the composite request that would be sent to enable SSL.
+
+security.enable-ssl-http-server.option.server-name.description=\
+Optional, the name of the http server to apply SSL to.
+
+security.enable-ssl-http-server.option.server-name.value=server name
+
+security.enable-ssl-http-server.option.no-override-security-realm.description=\
+Optional, by default the legacy security-realm attached to the https server will be erased. \
+Use this option to not erase it.
+
+security.disable-ssl-http-server.description=\
+Disable https for the undertow http server. This command is only available if the undertow subsystem \
+is present. By default the 'default-server' is the target of \
+this command. Other server name can be specified thanks to the --server-name option.\
+\n\
+TIPS: Use 'echo-dmr security ssl-disable-https-server <options>' in order to \
+visualize the composite request that would be sent to enable SSL.
+
+security.disable-ssl-http-server.option.no-reload.description=\
+Optional, by default the server is reloaded once the configuration changes have been applied. \
+In order to not reload the server, use this option.\n\
+NB: reload is done in start-mode=<the mode the current server is running>.
+
+security.disable-ssl-http-server.option.server-name.description=\
+Optional, the name of the http server. By default 'default-server' is used.
+
+security.disable-ssl-http-server.option.server-name.value=server name

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
@@ -1,0 +1,1153 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContextFactory;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.CommandContextConfiguration;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+public class SecurityCommandsTestCase {
+
+    private static final ByteArrayOutputStream consoleOutput = new ByteArrayOutputStream();
+
+    private static CommandContext ctx;
+
+    private static final String GENERATED_KEY_STORE_FILE_NAME = "gen-key-store.keystore";
+    private static final String GENERATED_PEM_FILE_NAME = "gen-key-store.pem";
+    private static final String GENERATED_CSR_FILE_NAME = "gen-key-store.csr";
+    private static final String GENERATED_KEY_STORE_PASSWORD = "mysecret";
+    private static final String GENERATED_KEY_STORE_ALIAS = "myalias";
+    private static final String GENERATED_TRUST_STORE_FILE_NAME = "gen-trust-store.truststore";
+
+    private static final String SERVER_KEY_STORE_FILE = "cli-security-test-server.keystore";
+    private static final String CLIENT_KEY_STORE_FILE = "cli-security-test-client.keystore";
+    private static final String CLIENT_CERTIFICATE_FILE = "cli-security-test-client-certificate.pem";
+    private static final String KEY_STORE_PASSWORD = "secret";
+
+    private static final String KEY_STORE_NAME = "ks1";
+    private static final String KEY_MANAGER_NAME = "km1";
+    private static final String TRUST_STORE_NAME = "ts1";
+    private static final String TRUST_MANAGER_NAME = "tm1";
+    private static final String SSL_CONTEXT_NAME = "sslCtx1";
+    private static File serverKeyStore;
+    private static File clientKeyStore;
+    private static File clientCertificate;
+
+    @ClassRule
+    public static final TemporaryFolder temporaryUserHome = new TemporaryFolder();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Create ctx, used to setup the test and do the final reload.
+        CommandContextConfiguration.Builder configBuilder = new CommandContextConfiguration.Builder();
+        configBuilder.setConsoleOutput(consoleOutput).
+                setController("remote+http://" + TestSuiteEnvironment.getServerAddress()
+                        + ":" + TestSuiteEnvironment.getServerPort());
+        ctx = CommandContextFactory.getInstance().newCommandContext(configBuilder.build());
+        ctx.connectController();
+
+        // generate key-store file for server.
+        ctx.handle("/subsystem=elytron/key-store=cli-server-key-store:add(path=" + SERVER_KEY_STORE_FILE + " ,type=JKS"
+                + ", relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + ", credential-reference={clear-text=" + KEY_STORE_PASSWORD + "})");
+        ctx.handle("/subsystem=elytron/key-store=cli-server-key-store:generate-key-pair(distinguished-name=\"CN=CA\", algorithm=RSA, key-size=1024, alias=localhost)");
+        ctx.handle("/subsystem=elytron/key-store=cli-server-key-store:store()");
+        // Remove the key-store resource.
+        ctx.handle("/subsystem=elytron/key-store=cli-server-key-store:remove()");
+        serverKeyStore = new File(TestSuiteEnvironment.getJBossHome() + File.separator
+                + "standalone" + File.separator + "configuration" + File.separator + SERVER_KEY_STORE_FILE);
+        if (!serverKeyStore.exists()) {
+            throw new Exception("No key-store generated");
+        }
+
+        // generate key-store file for client.
+        ctx.handle("/subsystem=elytron/key-store=cli-client-key-store:add(path=" + CLIENT_KEY_STORE_FILE + " ,type=JKS"
+                + ", relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + ", credential-reference={clear-text=" + KEY_STORE_PASSWORD + "})");
+        ctx.handle("/subsystem=elytron/key-store=cli-client-key-store:generate-key-pair(distinguished-name=\"CN=CA\", algorithm=RSA, key-size=1024, alias=client)");
+        ctx.handle("/subsystem=elytron/key-store=cli-client-key-store:store()");
+
+        // export the client certificate.
+        ctx.handle("/subsystem=elytron/key-store=cli-client-key-store:export-certificate(relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                + ",path=" + CLIENT_CERTIFICATE_FILE + ", alias=client, pem=true)");
+
+        // Remove the key-store resource.
+        ctx.handle("/subsystem=elytron/key-store=cli-client-key-store:remove()");
+
+        clientKeyStore = new File(TestSuiteEnvironment.getJBossHome() + File.separator + "standalone"
+                + File.separator + "configuration" + File.separator + CLIENT_KEY_STORE_FILE);
+        if (!clientKeyStore.exists()) {
+            throw new Exception("No key-store generated");
+        }
+        clientCertificate = new File(TestSuiteEnvironment.getJBossHome() + File.separator + "standalone"
+                + File.separator + "configuration" + File.separator + CLIENT_CERTIFICATE_FILE);
+        if (!clientCertificate.exists()) {
+            throw new Exception("No certificate exported");
+        }
+
+    }
+
+    @After
+    public void cleanupTest() throws Exception {
+        try {
+            eraseInterfaces();
+        } finally {
+            try {
+                removeTLS();
+            } finally {
+                ctx.handle("reload");
+            }
+        }
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        if (serverKeyStore != null) {
+            serverKeyStore.delete();
+        }
+        if (clientKeyStore != null) {
+            clientKeyStore.delete();
+        }
+        if (clientCertificate != null) {
+            clientCertificate.delete();
+        }
+        if (ctx != null) {
+            try {
+                ctx.handle("reload");
+            } finally {
+                ctx.terminateSession();
+            }
+        }
+    }
+
+    @Test
+    public void testEmbedded() throws Exception {
+        CliProcessWrapper cli = new CliProcessWrapper()
+                .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString());
+        try {
+            cli.executeInteractive();
+            cli.clearOutput();
+            String prompt = "[standalone@embedded /]";
+            Assert.assertTrue(cli.getOutput(), cli.pushLineAndWaitForResults("embed-server --std-out=echo", prompt));
+            Assert.assertTrue(cli.getOutput(), cli.pushLineAndWaitForResults("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                    + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --key-store-password=" + KEY_STORE_PASSWORD + " --no-reload", prompt));
+
+            // Disable ssl
+            Assert.assertTrue(cli.getOutput(), cli.pushLineAndWaitForResults("security disable-ssl-management --no-reload", prompt));
+
+            // Re-enable
+            Assert.assertTrue(cli.getOutput(), cli.pushLineAndWaitForResults("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                    + " --key-store-password=" + KEY_STORE_PASSWORD + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                    + " --no-reload", prompt));
+
+            // Disable ssl
+            Assert.assertTrue(cli.getOutput(), cli.pushLineAndWaitForResults("security disable-ssl-management --no-reload", prompt));
+        } finally {
+            cli.destroyProcess();
+        }
+    }
+
+    @Test
+    public void testInvalidEnableSSL() throws Exception {
+        assertEmptyModel(null);
+        {
+            boolean failed = false;
+            try {
+                ctx.handle("security enable-ssl-management");
+            } catch (Exception ex) {
+                failed = true;
+                // XXX OK, expected
+            }
+            Assert.assertTrue(failed);
+            assertEmptyModel(null);
+        }
+
+        {
+            boolean failed = false;
+            try {
+                ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                        + " --key-store-password=" + KEY_STORE_PASSWORD + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --no-reload"
+                        + " --management-interface=foo");
+            } catch (Exception ex) {
+                failed = true;
+                // XXX OK, expected
+            }
+            Assert.assertTrue(failed);
+            assertEmptyModel(null);
+        }
+
+        // Call the command with an invalid key-store-path.
+        {
+            boolean failed = false;
+            try {
+                ctx.handle("security enable-ssl-management --key-store-path=" + "foo.bar"
+                        + " --key-store-password=" + KEY_STORE_PASSWORD + " --no-reload");
+            } catch (Exception ex) {
+                failed = true;
+                // XXX OK, expected
+            }
+            Assert.assertTrue(failed);
+            assertEmptyModel(null);
+        }
+        {
+            // Call the command with no password.
+            boolean failed = false;
+            try {
+                ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                        + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --no-reload");
+            } catch (Exception ex) {
+                failed = true;
+                // XXX OK, expected
+            }
+            Assert.assertTrue(failed);
+            assertEmptyModel(null);
+        }
+        {
+            // Call the command with an invalid key-store-name.
+            boolean failed = false;
+            try {
+                ctx.handle("security enable-ssl-management --key-store-name=" + "foo.bar" + " --no-reload");
+            } catch (Exception ex) {
+                failed = true;
+                // XXX OK, expected
+            }
+            Assert.assertTrue(failed);
+            assertEmptyModel(null);
+        }
+        {
+            boolean failed = false;
+            // call the command with both key-store-name and path
+            ctx.handle("/subsystem=elytron/key-store=foo:add(path=foo.bar, type=JKS"
+                    + ", relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + ", credential-reference={clear-text=" + KEY_STORE_PASSWORD + "})");
+            try {
+                try {
+                    ctx.handle("security enable-ssl-management --key-store-name=foo"
+                            + " --key-store-path=" + SERVER_KEY_STORE_FILE
+                            + " --key-store-password=" + KEY_STORE_PASSWORD
+                            + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --no-reload");
+                } catch (Exception ex) {
+                    failed = true;
+                    // XXX OK, expected
+                }
+            } finally {
+                ctx.handle("/subsystem=elytron/key-store=foo:remove()");
+            }
+            Assert.assertTrue(failed);
+            assertEmptyModel(null);
+        }
+
+        {
+            boolean failed = false;
+            // call the command with both trust-store-name and certificate path
+            ctx.handle("/subsystem=elytron/key-store=foo:add(path=foo.bar, type=JKS"
+                    + ", relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + ", credential-reference={clear-text=" + KEY_STORE_PASSWORD + "})");
+            try {
+                try {
+                    ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                            + " --key-store-password=" + KEY_STORE_PASSWORD
+                            + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                            + " --trusted-certificate-path=" + clientCertificate.getAbsolutePath()
+                            + " --trust-store-name=foo"
+                            + " --trust-store-file-name=" + GENERATED_TRUST_STORE_FILE_NAME
+                            + " --trust-store-file-password=" + GENERATED_KEY_STORE_PASSWORD
+                            + " --new-trust-store-name=" + TRUST_STORE_NAME
+                            + " --new-trust-manager-name=" + TRUST_MANAGER_NAME
+                            + " --new-key-store-name=" + KEY_STORE_NAME
+                            + " --new-key-manager-name=" + KEY_MANAGER_NAME
+                            + " --new-ssl-context-name=" + SSL_CONTEXT_NAME
+                            + " --no-reload");
+                } catch (Exception ex) {
+                    failed = true;
+                    // XXX OK, expected
+                }
+            } finally {
+                ctx.handle("/subsystem=elytron/key-store=foo:remove()");
+            }
+            Assert.assertTrue(failed);
+            assertEmptyModel(null);
+        }
+    }
+
+    @Test
+    public void testEnableSSLTwoWay() throws Exception {
+        assertEmptyModel(null);
+        // first validation must fail
+        boolean failed = false;
+        try {
+            ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                    + " --key-store-password=" + KEY_STORE_PASSWORD
+                    + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                    + " --trusted-certificate-path=" + clientCertificate.getAbsolutePath()
+                    + " --trust-store-file-name=" + GENERATED_TRUST_STORE_FILE_NAME
+                    + " --trust-store-file-password=" + GENERATED_KEY_STORE_PASSWORD
+                    + " --new-trust-store-name=" + TRUST_STORE_NAME
+                    + " --new-trust-manager-name=" + TRUST_MANAGER_NAME
+                    + " --new-key-store-name=" + KEY_STORE_NAME
+                    + " --new-key-manager-name=" + KEY_MANAGER_NAME
+                    + " --new-ssl-context-name=" + SSL_CONTEXT_NAME
+                    + " --no-reload");
+        } catch (Exception ex) {
+            failed = true;
+        }
+        Assert.assertTrue(failed);
+
+        // Call the command without validation and no-reload.
+        ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                + " --key-store-password=" + KEY_STORE_PASSWORD
+                + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                + " --trusted-certificate-path=" + clientCertificate.getAbsolutePath()
+                + " --trust-store-file-name=" + GENERATED_TRUST_STORE_FILE_NAME
+                + " --trust-store-file-password=" + GENERATED_KEY_STORE_PASSWORD
+                + " --new-trust-store-name=" + TRUST_STORE_NAME
+                + " --new-trust-manager-name=" + TRUST_MANAGER_NAME
+                + " --new-key-store-name=" + KEY_STORE_NAME
+                + " --new-key-manager-name=" + KEY_MANAGER_NAME
+                + " --new-ssl-context-name=" + SSL_CONTEXT_NAME
+                + " --no-trusted-certificate-validation"
+                + " --no-reload");
+        File genTrustStore = null;
+        try {
+            assertTLSNumResources(2, 1, 1, 1);
+            // Check that the trustStore has been generated.
+            genTrustStore = new File(TestSuiteEnvironment.getJBossHome() + File.separator + "standalone"
+                    + File.separator + "configuration" + File.separator + GENERATED_TRUST_STORE_FILE_NAME);
+            Assert.assertTrue(genTrustStore.exists());
+
+            // Check the model contains the provided values.
+            checkModel(null, SERVER_KEY_STORE_FILE, Util.JBOSS_SERVER_CONFIG_DIR,
+                    KEY_STORE_PASSWORD, GENERATED_TRUST_STORE_FILE_NAME,
+                    GENERATED_KEY_STORE_PASSWORD, KEY_STORE_NAME, KEY_MANAGER_NAME,
+                    TRUST_STORE_NAME, TRUST_MANAGER_NAME, SSL_CONTEXT_NAME);
+        } finally {
+            if (genTrustStore != null) {
+                genTrustStore.delete();
+            }
+        }
+
+        ctx.handle("security disable-ssl-management --no-reload");
+
+        // Re-use the trust-store generated in previous step.
+        ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                + " --key-store-password=" + KEY_STORE_PASSWORD
+                + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                + " --trust-store-name=" + TRUST_STORE_NAME
+                + " --no-reload");
+        assertTLSNumResources(2, 1, 1, 1);
+        // Check that the model has not been updated.
+        checkModel(null, SERVER_KEY_STORE_FILE, Util.JBOSS_SERVER_CONFIG_DIR,
+                KEY_STORE_PASSWORD, GENERATED_TRUST_STORE_FILE_NAME,
+                GENERATED_KEY_STORE_PASSWORD, KEY_STORE_NAME, KEY_MANAGER_NAME,
+                TRUST_STORE_NAME, TRUST_MANAGER_NAME, SSL_CONTEXT_NAME);
+
+        ctx.handle("security disable-ssl-management --no-reload");
+    }
+
+    @Test
+    public void testEnableSSLHttp() throws Exception {
+        testEnableSSL(Util.HTTP_INTERFACE);
+    }
+
+    @Test
+    public void testEnableSSL() throws Exception {
+        testEnableSSL(null);
+    }
+
+    @Test
+    public void testEnableSSLNative() throws Exception {
+        enableNative();
+        try {
+            testEnableSSL("native-interface");
+        } finally {
+            disableNative();
+        }
+    }
+
+    @Test
+    public void testEnableSSLInteractiveNoGeneration() throws Exception {
+        assertEmptyModel(null);
+        CliProcessWrapper cli = new CliProcessWrapper().
+                addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString()).
+                addCliArgument("--controller=remote+http://"
+                        + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort()).
+                addCliArgument("--connect");
+        File genKeyStore = null;
+        File genTrustStore = null;
+        File genServerCertificate = null;
+        File genCsr = null;
+        try {
+            cli.executeInteractive();
+            cli.clearOutput();
+            Assert.assertTrue(cli.pushLineAndWaitForResults("security enable-ssl-management --interactive --no-reload", "Key-store file name"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_FILE_NAME, "Password"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_PASSWORD, "What is your first and last name? [Unknown]"));
+
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your organizational unit? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your organization? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your City or Locality? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your State or Province? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the two-letter country code for this unit? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Is CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct y/n [y]"));
+
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", "Validity"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Alias"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_ALIAS, "Enable SSL Mutual Authentication"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", "Client certificate (path to pem file)"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(clientCertificate.getAbsolutePath(), "Validate certificate"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", "Trust-store file name"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_TRUST_STORE_FILE_NAME, "Password"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_PASSWORD, "Do you confirm"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", null));
+            assertEmptyModel(null);
+            // Check that the files have been generated.
+            genKeyStore = new File(TestSuiteEnvironment.getJBossHome() + File.separator + "standalone"
+                    + File.separator + "configuration" + File.separator + GENERATED_KEY_STORE_FILE_NAME);
+            Assert.assertFalse(genKeyStore.exists());
+            genTrustStore = new File(TestSuiteEnvironment.getJBossHome() + File.separator + "standalone"
+                    + File.separator + "configuration" + File.separator + GENERATED_TRUST_STORE_FILE_NAME);
+            Assert.assertFalse(genTrustStore.exists());
+            genServerCertificate = new File(TestSuiteEnvironment.getSystemProperty("jboss.home") + File.separator + "standalone"
+                    + File.separator + "configuration" + File.separator + GENERATED_PEM_FILE_NAME);
+            Assert.assertFalse(genServerCertificate.exists());
+            genCsr = new File(TestSuiteEnvironment.getSystemProperty("jboss.home") + File.separator + "standalone"
+                    + File.separator + "configuration" + File.separator + GENERATED_CSR_FILE_NAME);
+            Assert.assertFalse(genCsr.exists());
+
+            ctx.handle("security disable-ssl-management --no-reload");
+        } catch (Throwable ex) {
+            throw new Exception(cli.getOutput(), ex);
+        } finally {
+            if (genKeyStore != null) {
+                genKeyStore.delete();
+            }
+            if (genTrustStore != null) {
+                genTrustStore.delete();
+            }
+            if (genServerCertificate != null) {
+                genServerCertificate.delete();
+            }
+            if (genCsr != null) {
+                genCsr.delete();
+            }
+            cli.destroyProcess();
+        }
+    }
+
+    @Test
+    public void testEnableSSLInteractiveConfirm() throws Exception {
+        testEnableSSLInteractiveConfirm(null);
+    }
+
+    @Test
+    public void testEnableSSLInteractiveConfirmNative() throws Exception {
+        enableNative();
+        try {
+            testEnableSSLInteractiveConfirm("native-interface");
+        } finally {
+            disableNative();
+        }
+    }
+
+    @Test
+    public void testEnableSSLInteractiveConfirmHttp() throws Exception {
+        testEnableSSLInteractiveConfirm(Util.HTTP_INTERFACE);
+    }
+
+    @Test
+    public void testEnableSSLInteractiveNoConfirm() throws Exception {
+        assertEmptyModel(null);
+        CliProcessWrapper cli = new CliProcessWrapper().
+                addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString()).
+                addCliArgument("--controller=remote+http://"
+                        + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort()).
+                addCliArgument("--connect");
+        try {
+            cli.executeInteractive();
+            cli.clearOutput();
+            Assert.assertTrue(cli.pushLineAndWaitForResults("security enable-ssl-management --interactive --no-reload", "Key-store file name"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Password"));
+
+            //Loop until DN has been provided.
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is your first and last name? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your organizational unit? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your organization? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your City or Locality? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your State or Province? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the two-letter country code for this unit? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Is CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct y/n [y]"));
+            cli.clearOutput();
+            Assert.assertTrue(cli.pushLineAndWaitForResults("n", "What is your first and last name? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("foo", "What is the name of your organizational unit? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("bar", "What is the name of your organization? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("foofoo", "What is the name of your City or Locality? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("barbar", "What is the name of your State or Province? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("toto", "What is the two-letter country code for this unit? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("TO", "Is CN=foo, OU=bar, O=foofoo, L=barbar, ST=toto, C=TO correct y/n [y]"));
+            //Loop until value is valid.
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", "Validity"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("Hello", "Validity"));
+
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Alias"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Enable SSL Mutual Authentication"));
+            cli.clearOutput();
+            // Loop until value is y or n.
+            Assert.assertTrue(cli.pushLineAndWaitForResults("TT", "Enable SSL Mutual Authentication"));
+            cli.clearOutput();
+            Assert.assertTrue(cli.pushLineAndWaitForResults("COCO", "Enable SSL Mutual Authentication"));
+
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", "Client certificate (path to pem file)"));
+            cli.clearOutput();
+            //Loop until certificate file exists
+            Assert.assertTrue(cli.pushLineAndWaitForResults("foo.bar", "Client certificate (path to pem file)"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(clientCertificate.getAbsolutePath(), "Validate certificate"));
+
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Trust-store file name"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Password"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Do you confirm"));
+            cli.clearOutput();
+            Assert.assertTrue(cli.pushLineAndWaitForResults("PP", "Do you confirm"));
+            cli.clearOutput();
+            cli.clearOutput();
+            Assert.assertTrue(cli.pushLineAndWaitForResults("COCO", "Do you confirm"));
+
+            Assert.assertTrue(cli.pushLineAndWaitForResults("n", null));
+            assertEmptyModel(null);
+        } catch (Throwable ex) {
+            throw new Exception(cli.getOutput(), ex);
+        } finally {
+            cli.destroyProcess();
+        }
+    }
+
+    @Test
+    public void testKeyStoreDifferentPassword() throws Exception {
+        assertEmptyModel(null);
+        // Create a credential store and alias
+        ctx.handle("/subsystem=elytron/credential-store=cs:add(credential-reference={clear-text=cs-secret},"
+                + "create,location=cs.store,relative-to=jboss.server.config.dir");
+        try {
+            ctx.handle("/subsystem=elytron/credential-store=cs:add-alias(alias=xxx,secret-value=secret");
+            ctx.handle("/subsystem=elytron/key-store=ks1:add(credential-reference={alias=xxx,store=cs},type=JKS,relative-to="
+                    + Util.JBOSS_SERVER_CONFIG_DIR + ",path=" + SERVER_KEY_STORE_FILE);
+            assertTLSNumResources(1, 0, 0, 0);
+            // Don't reuse the ks because different credential-reference
+            ctx.handle("security enable-ssl-management --key-store-path="
+                    + SERVER_KEY_STORE_FILE
+                    + " --key-store-password=" + KEY_STORE_PASSWORD
+                    + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --no-reload");
+            assertTLSNumResources(2, 1, 0, 1);
+            ctx.handle("security disable-ssl-management --no-reload");
+        } finally {
+            File credentialStores = new File(TestSuiteEnvironment.getJBossHome() + File.separator + "standalone"
+                    + File.separator + "configuration" + File.separator + "cs.store");
+            credentialStores.delete();
+        }
+    }
+
+    @Test
+    public void testKeyStoreDifferentAlias() throws Exception {
+        assertEmptyModel(null);
+        // add a key-store with different alias.
+        ctx.handle("/subsystem=elytron/key-store=ks3:add(credential-reference={clear-text=secret},"
+                + "type=JKS,relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + ",path=" + SERVER_KEY_STORE_FILE + ",alias-filter=foo");
+        assertTLSNumResources(1, 0, 0, 0);
+        //Don't reuse the key-store because different alias-filter
+        ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                + " --key-store-password=" + KEY_STORE_PASSWORD
+                + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --no-reload");
+        assertTLSNumResources(2, 1, 0, 1);
+        ctx.handle("security disable-ssl-management --no-reload");
+    }
+
+    @Test
+    public void testKeyManagerDifferentAlgorithm() throws Exception {
+        assertEmptyModel(null);
+        // add a key-store that will be reused.
+        ctx.handle("/subsystem=elytron/key-store=ks1:add(credential-reference={clear-text=secret},"
+                + "type=JKS,relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + ",path=" + SERVER_KEY_STORE_FILE);
+        // A leymanager that will be not re-used.
+        ctx.handle("/subsystem=elytron/key-manager=km:add(algorithm=PKIX,credential-reference={clear-text=secret},key-store=ks1");
+        assertTLSNumResources(1, 1, 0, 0);
+        //Reuse the key-store but create a new key-manager
+        ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                + " --key-store-password=" + KEY_STORE_PASSWORD
+                + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --no-reload");
+        assertTLSNumResources(1, 2, 0, 1);
+        ctx.handle("security disable-ssl-management --no-reload");
+    }
+
+    @Test
+    public void testKeyManagerDifferentAlias() throws Exception {
+        assertEmptyModel(null);
+        // add a key-store that will be reused.
+        ctx.handle("/subsystem=elytron/key-store=ks1:add(credential-reference={clear-text=secret},"
+                + "type=JKS,relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + ",path=" + SERVER_KEY_STORE_FILE);
+        // A keymanager that will be not re-used.
+        ctx.handle("/subsystem=elytron/key-manager=km:add(alias-filter=foo,credential-reference={clear-text=secret},key-store=ks1");
+        assertTLSNumResources(1, 1, 0, 0);
+        //Reuse the key-store but create a new key-manager
+        ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                + " --key-store-password=" + KEY_STORE_PASSWORD
+                + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --no-reload");
+        assertTLSNumResources(1, 2, 0, 1);
+        ctx.handle("security disable-ssl-management --no-reload");
+    }
+
+    @Test
+    public void testSSLContextDifferentNeedWant() throws Exception {
+        assertEmptyModel(null);
+        // add a key-store that will be reused.
+        ctx.handle("/subsystem=elytron/key-store=ks1:add(credential-reference={clear-text=secret},"
+                + "type=JKS,relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + ",path=" + SERVER_KEY_STORE_FILE);
+        // A keymanager that will be reused.
+        ctx.handle("/subsystem=elytron/key-manager=km:add(credential-reference={clear-text=secret},key-store=ks1");
+        // An SSLContext not reused.
+        ctx.handle("/subsystem=elytron/server-ssl-context=ctx:add(key-manager=km,need-client-auth=true,want-client-auth=true)");
+        assertTLSNumResources(1, 1, 0, 1);
+        //Reuse the key-store but create a new key-manager
+        ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                + " --key-store-password=" + KEY_STORE_PASSWORD
+                + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --no-reload");
+        assertTLSNumResources(1, 1, 0, 2);
+        ctx.handle("security disable-ssl-management --no-reload");
+    }
+
+    @Test
+    public void testSSLContextDifferentTrustManager() throws Exception {
+        assertEmptyModel(null);
+        // add a key-store that will be reused.
+        ctx.handle("/subsystem=elytron/key-store=ks1:add(credential-reference={clear-text=secret},"
+                + "type=JKS,relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + ",path=" + SERVER_KEY_STORE_FILE);
+        // A keymanager that will be reused.
+        ctx.handle("/subsystem=elytron/key-manager=km:add(credential-reference={clear-text=secret},key-store=ks1");
+        // A trust manager.
+        ctx.handle("/subsystem=elytron/trust-manager=tm:add(key-store=ks1");
+        // An SSLContext not reused.
+        ctx.handle("/subsystem=elytron/server-ssl-context=ctx:add(key-manager=km,trust-manager=tm)");
+        assertTLSNumResources(1, 1, 1, 1);
+        //Reuse the key-store but create a new key-manager
+        ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                + " --key-store-password=" + KEY_STORE_PASSWORD
+                + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --no-reload");
+        assertTLSNumResources(1, 1, 1, 2);
+        ctx.handle("security disable-ssl-management --no-reload");
+    }
+
+    private static void enableNative() throws CommandLineException {
+        ctx.handle("/socket-binding-group=standard-sockets/socket-binding=management-native:add(port=9999,interface=management)");
+        ctx.handle("/core-service=management/management-interface=native-interface:add(security-realm=ManagementRealm, socket-binding=management-native)");
+    }
+
+    private static void disableNative() throws CommandLineException {
+        ctx.handle("/core-service=management/management-interface=native-interface:remove()");
+        ctx.handle("/socket-binding-group=standard-sockets/socket-binding=management-native:remove()");
+    }
+
+    private void testEnableSSL(String mgmtInterface) throws Exception {
+        assertEmptyModel(mgmtInterface);
+        // Call the command but no-reload.
+        ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                + " --key-store-password=" + KEY_STORE_PASSWORD + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR + " --no-reload"
+                + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+
+        // A new key-store
+        List<String> ks = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
+        Assert.assertEquals(1, ks.size());
+        // A new keyManager
+        List<String> km = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
+        Assert.assertEquals(1, km.size());
+        // A new SSLContext
+        List<String> sslCtx = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
+        Assert.assertEquals(1, sslCtx.size());
+        // Http-interface is secured.
+        String usedSslCtx = getManagementInterfaceSSLContextName(ctx, mgmtInterface);
+        Assert.assertNotNull(usedSslCtx);
+        Assert.assertEquals(sslCtx.get(0), usedSslCtx);
+
+        // Disable ssl, resources shouldn't be deleted
+        ctx.handle("security disable-ssl-management --no-reload"
+                + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+        String usedSslCtx2 = getManagementInterfaceSSLContextName(ctx, mgmtInterface);
+        Assert.assertNull(usedSslCtx2);
+        List<String> ks2 = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
+        Assert.assertEquals(ks, ks2);
+        List<String> km2 = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
+        Assert.assertEquals(km, km2);
+        List<String> sslCtx2 = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
+        Assert.assertEquals(sslCtx, sslCtx2);
+
+        // Re-enable, no new resources should be created.
+        ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                + " --key-store-password=" + KEY_STORE_PASSWORD + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                + " --no-reload" + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+        String usedSslCtx3 = getManagementInterfaceSSLContextName(ctx, mgmtInterface);
+        Assert.assertNotNull(usedSslCtx3);
+        List<String> ks3 = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
+        Assert.assertEquals(ks, ks3);
+        List<String> km3 = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
+        Assert.assertEquals(km, km3);
+        List<String> sslCtx3 = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
+        Assert.assertEquals(sslCtx, sslCtx3);
+
+        // Try to enable again, exception should be thrown.
+        boolean failed = false;
+        try {
+            ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                    + " --key-store-password=" + KEY_STORE_PASSWORD
+                    + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                    + " --no-reload" + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+        } catch (Exception ex) {
+            failed = true;
+            // XXX OK, expected
+        }
+        Assert.assertTrue(failed);
+
+        // Disable ssl
+        ctx.handle("security disable-ssl-management --no-reload" + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+
+        // Enable SSL with key-store-name, no new resources created.
+        ctx.handle("security enable-ssl-management --key-store-name=" + ks.get(0)
+                + " --no-reload" + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+        String usedSslCtx4 = getManagementInterfaceSSLContextName(ctx, mgmtInterface);
+        Assert.assertNotNull(usedSslCtx4);
+        List<String> ks4 = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
+        Assert.assertEquals(ks, ks4);
+        List<String> km4 = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
+        Assert.assertEquals(km, km4);
+        List<String> sslCtx4 = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
+        Assert.assertEquals(sslCtx, sslCtx4);
+
+        // Disable ssl
+        ctx.handle("security disable-ssl-management --no-reload"
+                + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+
+        // Enable SSL, provide new key-store, key-manager and ssl-context names;
+        ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                + " --key-store-password=" + KEY_STORE_PASSWORD + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                + " --new-key-store-name=" + KEY_STORE_NAME + " --new-key-manager-name="
+                + KEY_MANAGER_NAME + " --new-ssl-context-name=" + SSL_CONTEXT_NAME + " --no-reload"
+                + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+        String usedSslCtx5 = getManagementInterfaceSSLContextName(ctx, mgmtInterface);
+        Assert.assertEquals(SSL_CONTEXT_NAME, usedSslCtx5);
+        List<String> ks5 = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
+        Assert.assertEquals(2, ks5.size());
+        Assert.assertTrue(ks5.contains(KEY_STORE_NAME));
+        List<String> km5 = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
+        Assert.assertEquals(2, km5.size());
+        Assert.assertTrue(km5.contains(KEY_MANAGER_NAME));
+        List<String> sslCtx5 = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
+        Assert.assertEquals(2, sslCtx5.size());
+        Assert.assertTrue(sslCtx5.contains(SSL_CONTEXT_NAME));
+
+        checkModel(mgmtInterface, SERVER_KEY_STORE_FILE, Util.JBOSS_SERVER_CONFIG_DIR,
+                KEY_STORE_PASSWORD, null,
+                null, KEY_STORE_NAME, KEY_MANAGER_NAME, null, null, SSL_CONTEXT_NAME);
+
+        // Disable ssl
+        ctx.handle("security disable-ssl-management --no-reload"
+                + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+
+        // Enable SSL, provide same new-key-store-name, exception thrown because already exists
+        failed = false;
+        try {
+            ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                    + " --key-store-password=" + KEY_STORE_PASSWORD + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                    + " --new-key-store-name=" + KEY_STORE_NAME + " --no-reload"
+                    + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+        } catch (Exception ex) {
+            // XXX OK expected
+            failed = true;
+        }
+        Assert.assertTrue(failed);
+        // Check that it has not been enabled.
+        Assert.assertNull(getManagementInterfaceSSLContextName(ctx, mgmtInterface));
+
+        // Enable SSL, provide same new-key-manager-name, exception thrown because already exists
+        failed = false;
+        try {
+            ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                    + " --key-store-password=" + KEY_STORE_PASSWORD + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                    + " --new-key-manager-name=" + KEY_MANAGER_NAME + " --no-reload"
+                    + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+        } catch (Exception ex) {
+            // XXX OK expected
+            failed = true;
+        }
+        Assert.assertTrue(failed);
+        // Check that it has not been enabled.
+        Assert.assertNull(getManagementInterfaceSSLContextName(ctx, mgmtInterface));
+
+        // Enable SSL, provide same new-key-manager-name, exception thrown because already exists
+        failed = false;
+        try {
+            ctx.handle("security enable-ssl-management --key-store-path=" + SERVER_KEY_STORE_FILE
+                    + " --key-store-password=" + KEY_STORE_PASSWORD + " --key-store-path-relative-to=" + Util.JBOSS_SERVER_CONFIG_DIR
+                    + " --new-ssl-context-name=" + SSL_CONTEXT_NAME + " --no-reload"
+                    + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+        } catch (Exception ex) {
+            // XXX OK expected
+            failed = true;
+        }
+        Assert.assertTrue(failed);
+        // Check that it has not been enabled.
+        Assert.assertNull(getManagementInterfaceSSLContextName(ctx, mgmtInterface));
+    }
+
+    private void testEnableSSLInteractiveConfirm(String mgmtInterface) throws Exception {
+        assertEmptyModel(mgmtInterface);
+        CliProcessWrapper cli = new CliProcessWrapper().
+                addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString()).
+                addCliArgument("--controller=remote+http://"
+                        + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort()).
+                addCliArgument("--connect");
+        File genKeyStore = null;
+        File genTrustStore = null;
+        File genServerCertificate = null;
+        File genCsr = null;
+        try {
+            cli.executeInteractive();
+            cli.clearOutput();
+            Assert.assertTrue(cli.pushLineAndWaitForResults("security enable-ssl-management --interactive --no-reload"
+                    + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface), "Key-store file name"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_FILE_NAME, "Password"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_PASSWORD, "What is your first and last name? [Unknown]"));
+
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your organizational unit? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your organization? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your City or Locality? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your State or Province? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the two-letter country code for this unit? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Is CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct y/n [y]"));
+
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", "Validity"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Alias"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_ALIAS, "Enable SSL Mutual Authentication"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", "Client certificate (path to pem file)"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(clientCertificate.getAbsolutePath(), "Validate certificate"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("n", "Trust-store file name"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_TRUST_STORE_FILE_NAME, "Password"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_PASSWORD, "Do you confirm"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", null));
+            assertTLSNumResources(2, 1, 1, 1);
+            // Check that the files have been generated.
+            genKeyStore = new File(TestSuiteEnvironment.getJBossHome() + File.separator + "standalone"
+                    + File.separator + "configuration" + File.separator + GENERATED_KEY_STORE_FILE_NAME);
+            Assert.assertTrue(genKeyStore.exists());
+            genTrustStore = new File(TestSuiteEnvironment.getJBossHome() + File.separator + "standalone"
+                    + File.separator + "configuration" + File.separator + GENERATED_TRUST_STORE_FILE_NAME);
+            Assert.assertTrue(genTrustStore.exists());
+            genServerCertificate = new File(TestSuiteEnvironment.getSystemProperty("jboss.home") + File.separator + "standalone"
+                    + File.separator + "configuration" + File.separator + GENERATED_PEM_FILE_NAME);
+            Assert.assertTrue(genServerCertificate.exists());
+            genCsr = new File(TestSuiteEnvironment.getSystemProperty("jboss.home") + File.separator + "standalone"
+                    + File.separator + "configuration" + File.separator + GENERATED_CSR_FILE_NAME);
+            Assert.assertTrue(genCsr.exists());
+            // Check the model contains the provided values.
+            List<String> ksList = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
+            List<String> kmList = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
+            List<String> tmList = getNames(ctx.getModelControllerClient(), Util.TRUST_MANAGER);
+            List<String> sslContextList = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
+            ModelNode trustManager = getResource(Util.TRUST_MANAGER, tmList.get(0), null);
+            checkModel(mgmtInterface, GENERATED_KEY_STORE_FILE_NAME, Util.JBOSS_SERVER_CONFIG_DIR,
+                    GENERATED_KEY_STORE_PASSWORD, GENERATED_TRUST_STORE_FILE_NAME,
+                    GENERATED_KEY_STORE_PASSWORD, ksList.get(0), kmList.get(0),
+                    trustManager.get(Util.KEY_STORE).asString(), tmList.get(0), sslContextList.get(0));
+
+            ctx.handle("security disable-ssl-management --no-reload"
+                    + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface));
+            cli.clearOutput();
+            // Test that existing key-store file makes the command to abort.
+            Assert.assertTrue(cli.pushLineAndWaitForResults("security enable-ssl-management --interactive --no-reload"
+                    + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface), "Key-store file name"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_FILE_NAME, null));
+
+            //Test that existing trust-store file makes command to abort
+            Assert.assertTrue(cli.pushLineAndWaitForResults("security enable-ssl-management --interactive --no-reload"
+                    + (mgmtInterface == null ? "" : " --management-interface=" + mgmtInterface), "Key-store file name"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("foo", "Password"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_PASSWORD, "What is your first and last name? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your organizational unit? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your organization? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your City or Locality? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the name of your State or Province? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "What is the two-letter country code for this unit? [Unknown]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Is CN=Unknown, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct y/n [y]"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", "Validity"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("", "Alias"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_KEY_STORE_ALIAS, "Enable SSL Mutual Authentication"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("y", "Client certificate (path to pem file)"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(clientCertificate.getAbsolutePath(), "Validate certificate"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults("n", "Trust-store file name"));
+            Assert.assertTrue(cli.pushLineAndWaitForResults(GENERATED_TRUST_STORE_FILE_NAME, null));
+
+        } catch (Throwable ex) {
+            throw new Exception(cli.getOutput(), ex);
+        } finally {
+            if (genKeyStore != null) {
+                genKeyStore.delete();
+            }
+            if (genTrustStore != null) {
+                genTrustStore.delete();
+            }
+            if (genServerCertificate != null) {
+                genServerCertificate.delete();
+            }
+            if (genCsr != null) {
+                genCsr.delete();
+            }
+            cli.destroyProcess();
+        }
+    }
+
+    private static String getManagementInterfaceSSLContextName(CommandContext ctx, String interfaceName) throws IOException, OperationFormatException {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_ATTRIBUTE);
+            builder.addNode(Util.CORE_SERVICE, Util.MANAGEMENT);
+            builder.addNode(Util.MANAGEMENT_INTERFACE, interfaceName == null ? Util.HTTP_INTERFACE : interfaceName);
+            builder.addProperty(Util.NAME, Util.SSL_CONTEXT);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+            if (Util.isSuccess(outcome)) {
+                ModelNode mn = outcome.get(Util.RESULT);
+                if (mn.isDefined()) {
+                    return outcome.get(Util.RESULT).asString();
+                } else {
+                    return null;
+                }
+            }
+        } catch (Exception e) {
+        }
+
+        return null;
+    }
+
+    private static List<String> getNames(ModelControllerClient client, String type) {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_CHILDREN_NAMES);
+            builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+            builder.addProperty(Util.CHILD_TYPE, type);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = client.execute(request);
+            if (Util.isSuccess(outcome)) {
+                return Util.getList(outcome);
+            }
+        } catch (Exception e) {
+        }
+
+        return Collections.emptyList();
+    }
+
+    private static void removeTLS() throws CommandLineException {
+        List<String> sslContextList = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
+        for (String ssl : sslContextList) {
+            ctx.handle("/subsystem=elytron/server-ssl-context=" + ssl + ":remove");
+        }
+        List<String> kmList = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
+        for (String km : kmList) {
+            ctx.handle("/subsystem=elytron/key-manager=" + km + ":remove");
+        }
+        List<String> tmList = getNames(ctx.getModelControllerClient(), Util.TRUST_MANAGER);
+        for (String tm : tmList) {
+            ctx.handle("/subsystem=elytron/trust-manager=" + tm + ":remove");
+        }
+        List<String> ksList = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
+        for (String ks : ksList) {
+            ctx.handle("/subsystem=elytron/key-store=" + ks + ":remove");
+        }
+        List<String> credentialStoreList = getNames(ctx.getModelControllerClient(), "credential-store");
+        for (String cs : credentialStoreList) {
+            ctx.handle("/subsystem=elytron/credential-store=" + cs + ":remove");
+        }
+    }
+
+    private static void eraseInterfaces() throws CommandLineException {
+        ctx.handle("/core-service=management/management-interface=http-interface:write-attribute(name=" + Util.SSL_CONTEXT + ")");
+        ctx.handle("/core-service=management/management-interface=http-interface:write-attribute(name=" + Util.SECURE_SOCKET_BINDING + ")");
+    }
+
+    private static void assertEmptyModel(String mgmtInterface) throws Exception {
+        String ssl = getManagementInterfaceSSLContextName(ctx, mgmtInterface);
+        Assert.assertNull(ssl);
+        assertTLSEmpty();
+    }
+
+    private static void assertTLSNumResources(int numKS, int numKeyManager, int numTrustManager, int numSSLContext) throws Exception {
+        List<String> ks = getNames(ctx.getModelControllerClient(), Util.KEY_STORE);
+        Assert.assertEquals(numKS, ks.size());
+        List<String> km = getNames(ctx.getModelControllerClient(), Util.KEY_MANAGER);
+        Assert.assertEquals(numKeyManager, km.size());
+        List<String> tm = getNames(ctx.getModelControllerClient(), Util.TRUST_MANAGER);
+        Assert.assertEquals(numTrustManager, tm.size());
+        List<String> sslCtx = getNames(ctx.getModelControllerClient(), Util.SERVER_SSL_CONTEXT);
+        Assert.assertEquals(numSSLContext, sslCtx.size());
+    }
+
+    private static void assertTLSEmpty() throws Exception {
+        assertTLSNumResources(0, 0, 0, 0);
+    }
+
+    private static ModelNode buildKeyStoreResource(File path, String relativeTo,
+            String password, String type, Boolean required, String alias) throws IOException {
+        ModelNode localKS = new ModelNode();
+        if (path != null) {
+            localKS.get(Util.PATH).set(path.getPath());
+        }
+        if (relativeTo != null) {
+            localKS.get(Util.RELATIVE_TO).set(relativeTo);
+        } else {
+            localKS.get(Util.RELATIVE_TO);
+        }
+        if (password != null) {
+            localKS.get(Util.CREDENTIAL_REFERENCE).set(buildCredentialReferences(password));
+        }
+        if (type != null) {
+            localKS.get(Util.TYPE).set(type);
+        }
+        if (required != null) {
+            localKS.get(Util.REQUIRED).set(required);
+        }
+        if (alias != null) {
+            localKS.get(Util.ALIAS_FILTER, alias);
+        }
+        return localKS;
+    }
+
+    private static ModelNode buildSSLContextResource(String trustManager, String keyManager, Boolean want, Boolean need) throws IOException {
+        ModelNode sslContext = new ModelNode();
+        if (trustManager != null) {
+            sslContext.get(Util.TRUST_MANAGER).set(trustManager);
+        }
+        if (keyManager != null) {
+            sslContext.get(Util.KEY_MANAGER).set(keyManager);
+        }
+        if (want != null) {
+            sslContext.get(Util.WANT_CLIENT_AUTH).set(want);
+        }
+        if (need != null) {
+            sslContext.get(Util.NEED_CLIENT_AUTH).set(need);
+        }
+        sslContext.get(Util.PROTOCOLS).add("TLSv1.2");
+        return sslContext;
+    }
+
+    private static ModelNode buildCredentialReferences(String password) {
+        ModelNode mn = new ModelNode();
+        mn.get(Util.CLEAR_TEXT).set(password);
+        return mn;
+    }
+
+    private static ModelNode getResource(String type, String name, ModelNode filter) throws Exception {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(type, name);
+        request = builder.buildRequest();
+
+        final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+        if (Util.isSuccess(outcome)) {
+            ModelNode res = outcome.get(Util.RESULT);
+            if (filter != null) {
+                List<String> toRemove = new ArrayList<>();
+                for (String k : res.keys()) {
+                    if (!filter.hasDefined(k)) {
+                        toRemove.add(k);
+                    }
+                }
+                for (String k : toRemove) {
+                    res.remove(k);
+                }
+            }
+            return res;
+        } else {
+            return null;
+        }
+    }
+
+    private static void checkModel(String mgmtInterface, String keyStoreFile, String relativeTo,
+            String password, String trustStoreFile, String tsPassword,
+            String keyStoreName, String keyManagerName, String trustStoreName, String trustManagerName, String sslContextName) throws Exception {
+        mgmtInterface = mgmtInterface == null ? Util.HTTP_INTERFACE : mgmtInterface;
+
+        // Check the model contains the provided values.
+        ModelNode expectedKeyStore = buildKeyStoreResource(new File(keyStoreFile), relativeTo, password, "JKS", false, null);
+
+        ModelNode kManager = getResource(Util.KEY_MANAGER, keyManagerName, null);
+        ModelNode tManager;
+        if (trustManagerName != null) {
+            tManager = getResource(Util.TRUST_MANAGER, trustManagerName, null);
+            ModelNode expectedTrustStore = buildKeyStoreResource(new File(trustStoreFile), relativeTo, tsPassword, "JKS", false, null);
+            ModelNode ts = getResource(Util.KEY_STORE, tManager.get(Util.KEY_STORE).asString(), expectedTrustStore);
+            Assert.assertEquals(trustStoreName, tManager.get(Util.KEY_STORE).asString());
+            Assert.assertEquals(expectedTrustStore, ts);
+        }
+
+        Assert.assertEquals(keyStoreName, kManager.get(Util.KEY_STORE).asString());
+        ModelNode ks = getResource(Util.KEY_STORE, kManager.get(Util.KEY_STORE).asString(), expectedKeyStore);
+
+        Assert.assertEquals(expectedKeyStore, ks);
+
+        //Check that the SSLContext properly references both km and ts
+        ModelNode expectedSSLContext = buildSSLContextResource(trustManagerName, keyManagerName, false, trustManagerName != null);
+        ModelNode actualSSLContext = getResource(Util.SERVER_SSL_CONTEXT, sslContextName, expectedSSLContext);
+        Assert.assertEquals(expectedSSLContext, actualSSLContext);
+
+        //Check that the sslContext is referenced from the interface
+        String usedSslCtx = getManagementInterfaceSSLContextName(ctx, mgmtInterface);
+        Assert.assertEquals(usedSslCtx, sslContextName);
+    }
+}


### PR DESCRIPTION
Only the last commit is meaningful, other commits will be merged prior to this one by the PR: https://github.com/wildfly/wildfly-core/pull/2949

Commands to enable/disable ssl for management interfaces and http-server. 
JIRA: https://issues.jboss.org/browse/WFCORE-3447

Community doc PR: https://github.com/wildfly/wildfly/pull/10810
Wildfly full tests PR: https://github.com/wildfly/wildfly/pull/10811
Automated tests for management interfaces. undertow http-server tests are added by QE internal testsuite. Specific http-server tests will be added to WF repo once upgrade to core done. 
For info, custom jobs of the tests run using this PR branch:
https://ci.wildfly.org/viewLog.html?buildId=87429&tab=buildResultsDiv&buildTypeId=WF_WildFlyCoreIntegrationExperiments
https://ci.wildfly.org/viewLog.html?buildId=87431&tab=buildResultsDiv&buildTypeId=WF_WildFlyCoreIntegrationExperimentsWindows

