### PR TITLE
[WFCORE-3541] ScramDigestPassword into set-password operation

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -394,6 +394,7 @@ interface ElytronDescriptionConstants {
     String SASL_MECHANISM_SELECTOR = "sasl-mechanism-selector";
     String SASL_SERVER_FACTORIES = "sasl-server-factories";
     String SASL_SERVER_FACTORY = "sasl-server-factory";
+    String SCRAM_DIGEST = "scram-digest";
     String SCRAM_MAPPER = "scram-mapper";
     String SEARCH = "search";
     String SEARCH_BASE_DN = "search-base-dn";

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -762,56 +762,41 @@ elytron.modifiable-security-realm.remove-identity-attribute.name=The name of the
 elytron.modifiable-security-realm.remove-identity-attribute.value=The value of the attribute.
 elytron.modifiable-security-realm.set-password=Add a password to an existing identity.
 elytron.modifiable-security-realm.set-password.identity=The name of the identity.
-elytron.modifiable-security-realm.set-password.bcrypt=A password using the Bcrypt algorithm.
-elytron.modifiable-security-realm.set-password.bcrypt.iteration-count=The iteration count or cost to apply to the password.
-elytron.modifiable-security-realm.set-password.bcrypt.salt=The salt to apply to the password.
-elytron.modifiable-security-realm.set-password.bcrypt.password=The actual password to set.
-elytron.modifiable-security-realm.bcrypt=A password using the Bcrypt algorithm.
-elytron.modifiable-security-realm.bcrypt.name=The credential name.
+
+elytron.modifiable-security-realm.bcrypt.algorithm=The algorithm used to encrypt the password.
 elytron.modifiable-security-realm.bcrypt.iteration-count=The iteration count or cost to apply to the password.
 elytron.modifiable-security-realm.bcrypt.salt=The salt to apply to the password.
 elytron.modifiable-security-realm.bcrypt.password=The actual password to set.
-elytron.modifiable-security-realm.bcrypt.algorithm=The algorithm used to encrypt the password.
-elytron.modifiable-security-realm.set-password.clear=A password in clear text.
-elytron.modifiable-security-realm.set-password.clear.password=The actual password to set.
-elytron.modifiable-security-realm.clear=A password in clear text.
-elytron.modifiable-security-realm.clear.name=The credential name.
+elytron.modifiable-security-realm.set-password.bcrypt=A password using the Bcrypt algorithm.
+
 elytron.modifiable-security-realm.clear.password=The actual password to set.
-elytron.modifiable-security-realm.set-password.simple-digest=A simple digest password.
-elytron.modifiable-security-realm.set-password.simple-digest.algorithm=The algorithm used to encrypt the password.
-elytron.modifiable-security-realm.set-password.simple-digest.password=The actual password to set.
-elytron.modifiable-security-realm.simple-digest=A simple digest password.
-elytron.modifiable-security-realm.simple-digest.name=The credential name.
+elytron.modifiable-security-realm.set-password.clear=A password in clear text.
+
 elytron.modifiable-security-realm.simple-digest.algorithm=The algorithm used to encrypt the password.
 elytron.modifiable-security-realm.simple-digest.password=The actual password to set.
-elytron.modifiable-security-realm.set-password.salted-simple-digest=A salted simple digest password.
-elytron.modifiable-security-realm.salted-simple-digest.name=The credential name.
-elytron.modifiable-security-realm.set-password.salted-simple-digest.algorithm=The algorithm used to encrypt the password.
-elytron.modifiable-security-realm.set-password.salted-simple-digest.salt=The salt to apply to the password.
-elytron.modifiable-security-realm.set-password.salted-simple-digest.password=The actual password to set.
-elytron.modifiable-security-realm.salted-simple-digest=A salted simple digest password.
+elytron.modifiable-security-realm.set-password.simple-digest=A simple digest password.
+
 elytron.modifiable-security-realm.salted-simple-digest.algorithm=The algorithm used to encrypt the password.
 elytron.modifiable-security-realm.salted-simple-digest.salt=The salt to apply to the password.
 elytron.modifiable-security-realm.salted-simple-digest.password=The actual password to set.
-elytron.modifiable-security-realm.set-password.digest=A digest password.
-elytron.modifiable-security-realm.set-password.digest.algorithm=The algorithm used to encrypt the password.
-elytron.modifiable-security-realm.set-password.digest.realm=The realm.
-elytron.modifiable-security-realm.set-password.digest.password=The actual password to set.
-elytron.modifiable-security-realm.digest=A digest password.
-elytron.modifiable-security-realm.digest.name=The credential name.
+elytron.modifiable-security-realm.set-password.salted-simple-digest=A salted simple digest password.
+
 elytron.modifiable-security-realm.digest.algorithm=The algorithm used to encrypt the password.
 elytron.modifiable-security-realm.digest.realm=The realm.
 elytron.modifiable-security-realm.digest.password=The actual password to set.
-elytron.modifiable-security-realm.otp=A one-time password, used by the OTP SASL mechanism.
+elytron.modifiable-security-realm.set-password.digest=A digest password.
+
 elytron.modifiable-security-realm.otp.algorithm=The algorithm used to encrypt the password.
-elytron.modifiable-security-realm.otp.password=The actual password to set.
 elytron.modifiable-security-realm.otp.seed=The seed used to generate the hash.
 elytron.modifiable-security-realm.otp.sequence=The sequence number used to generate the hash.
+elytron.modifiable-security-realm.otp.password=The actual password to set.
 elytron.modifiable-security-realm.set-password.otp=A one-time password, used by the OTP SASL mechanism.
-elytron.modifiable-security-realm.set-password.algorithm=The algorithm used to encrypt the password.
-elytron.modifiable-security-realm.set-password.otp.password=The actual password to set.
-elytron.modifiable-security-realm.set-password.otp.seed=The seed used to generate the hash.
-elytron.modifiable-security-realm.set-password.otp.sequence=The sequence number used to generate the hash.
+
+elytron.modifiable-security-realm.scram-digest.algorithm=The algorithm used to encrypt the password.
+elytron.modifiable-security-realm.scram-digest.iteration-count=The iteration count or cost to apply to the password.
+elytron.modifiable-security-realm.scram-digest.salt=The salt to apply to the password.
+elytron.modifiable-security-realm.scram-digest.password=The actual password to set.
+elytron.modifiable-security-realm.set-password.scram-digest=A password using the SCRAM digest algorithm.
 
 elytron.caching-realm=A realm definition that enables caching to another security realm. Caching strategy is LRU (Least Recently Used) where least accessed entries are discarded when maximum number of entries is reached.
 # Operations

--- a/elytron/src/test/java/org/wildfly/extension/elytron/IdentityOperationsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/IdentityOperationsTestCase.java
@@ -50,6 +50,7 @@ import org.wildfly.security.password.interfaces.BCryptPassword;
 import org.wildfly.security.password.interfaces.DigestPassword;
 import org.wildfly.security.password.interfaces.OneTimePassword;
 import org.wildfly.security.password.interfaces.SaltedSimpleDigestPassword;
+import org.wildfly.security.password.interfaces.ScramDigestPassword;
 import org.wildfly.security.password.interfaces.SimpleDigestPassword;
 import org.wildfly.security.password.util.PasswordUtil;
 import org.wildfly.security.permission.PermissionVerifier;
@@ -256,7 +257,7 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
     }
 
     @Test
-    public void testAddBcryptPassword() throws Exception {
+    public void testBcryptPassword() throws Exception {
         KernelServices services = createKernelServicesBuilder(null)
                 .setSubsystemXmlResource("identity-management.xml")
                 .build();
@@ -321,6 +322,26 @@ public class IdentityOperationsTestCase extends AbstractSubsystemTest {
 
         operation = createSetPasswordOperation("default", realmAddress, principalName,
                 ModifiableRealmDecorator.SetPasswordHandler.SaltedSimpleDigest.OBJECT_DEFINITION, "saltedSimpleDigest", PasswordUtil.generateRandomSalt(16), null, null, SaltedSimpleDigestPassword.ALGORITHM_PASSWORD_SALT_DIGEST_SHA_256, null, null);
+        result = services.executeOperation(operation);
+        assertSuccessful(result);
+    }
+
+    @Test
+    public void testScramDigestPassword() throws Exception {
+        KernelServices services = createKernelServicesBuilder(null)
+                .setSubsystemXmlResource("identity-management.xml")
+                .build();
+        String principalName = "plainUser";
+        PathAddress realmAddress = getSecurityRealmAddress("FileSystemRealm");
+        ModelNode operation = createAddIdentityOperation(realmAddress, principalName);
+        ModelNode result = services.executeOperation(operation);
+        assertSuccessful(result);
+
+        byte[] salt = PasswordUtil.generateRandomSalt(ScramDigestPassword.DEFAULT_SALT_SIZE);
+        int iterationCount = ScramDigestPassword.DEFAULT_ITERATION_COUNT;
+
+        operation = createSetPasswordOperation("default", realmAddress, principalName,
+                ModifiableRealmDecorator.SetPasswordHandler.ScramDigest.OBJECT_DEFINITION, "scramPassword", salt, iterationCount, null, null, null, null);
         result = services.executeOperation(operation);
         assertSuccessful(result);
     }


### PR DESCRIPTION
Elytron security:
Adding scram password support into set-password operation of modifiable security realms.

https://issues.jboss.org/browse/WFCORE-3541