### PR TITLE
Fix for WFCORE-3548, CLI, Command executor should create daemon thread

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandExecutor.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandExecutor.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.jboss.as.cli.CliConfig;
@@ -608,8 +609,14 @@ public class CommandExecutor {
     }
 
     private final CommandContext ctx;
-    private final ExecutorService executorService = Executors.newCachedThreadPool(
-            (r) -> new Thread(r, "CLI command executor"));
+    private final ExecutorService executorService = Executors.newCachedThreadPool(new ThreadFactory() {
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thr = new Thread(r, "CLI command executor");
+            thr.setDaemon(true);
+            return thr;
+        }
+    });
 
     private Future<?> handlerTask;
 


### PR DESCRIPTION
Make the created threads to be daemon. Manually tested with a standalone client application calling into CLI class:
CLI cli = CLI.newInstance();
cli.cmd("version");
==> process can exit.

This doesn't mean that terminate() (or disconnect if connected) shouldn't be called, that is still the way to go. It seems cleaner to have this thread a daemon.

This behaviour has been introduced in 7.1, older CLI class was not able to execute command if not connected (so no way, for example, to handle embedded nor version command without connecting).