### PR TITLE
CLI deployment command completion issues in domain mode

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/AbstractCommaCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/AbstractCommaCompleter.java
@@ -1,0 +1,72 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import org.aesh.command.completer.OptionCompleter;
+import org.wildfly.core.cli.command.aesh.CLICompleterInvocation;
+
+/**
+ * Base class to complete values separated by ',' character.
+ *
+ * @author jdenise@redhat.com
+ */
+public abstract class AbstractCommaCompleter implements OptionCompleter<CLICompleterInvocation> {
+
+    protected abstract List<String> getItems(CLICompleterInvocation completerInvocation);
+
+    @Override
+    public void complete(CLICompleterInvocation completerInvocation) {
+        if (completerInvocation.getCommandContext().getModelControllerClient() != null) {
+            completerInvocation.setAppendSpace(false);
+            List<String> items = getItems(completerInvocation);
+            if (items != null && !items.isEmpty()) {
+                List<String> candidates = new ArrayList<>();
+                candidates.addAll(items);
+                String buffer = completerInvocation.getGivenCompleteValue();
+                if (!buffer.isEmpty()) {
+                    final String[] specified = buffer.split(",+");
+                    candidates.removeAll(Arrays.asList(specified));
+                    if (buffer.charAt(buffer.length() - 1) == ',') {
+                        completerInvocation.addAllCompleterValues(candidates);
+                        completerInvocation.setOffset(0);
+                        return;
+                    }
+                    final String chunk = specified[specified.length - 1];
+                    final Iterator<String> iterator = candidates.iterator();
+                    List<String> remaining = new ArrayList<>();
+                    while (iterator.hasNext()) {
+                        String i = iterator.next();
+                        if (!i.startsWith(chunk)) {
+                            remaining.add(i);
+                            iterator.remove();
+                        }
+                    }
+                    if (candidates.isEmpty() && !remaining.isEmpty()) {
+                        candidates.add(",");
+                        completerInvocation.setOffset(0);
+                    } else {
+                        completerInvocation.setOffset(chunk.length());
+                    }
+                }
+                completerInvocation.addAllCompleterValues(candidates);
+            }
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/AbstractCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/AbstractCompleter.java
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.aesh.command.completer.OptionCompleter;
+import org.wildfly.core.cli.command.aesh.CLICompleterInvocation;
+
+/**
+ * Base class for completion of discrete values.
+ *
+ * @author jdenise@redhat.com
+ */
+public abstract class AbstractCompleter implements OptionCompleter<CLICompleterInvocation> {
+
+    @Override
+    public void complete(CLICompleterInvocation completerInvocation) {
+        if (completerInvocation.getCommandContext().getModelControllerClient() != null) {
+            List<String> items = getItems(completerInvocation);
+            if (items != null && !items.isEmpty()) {
+                List<String> candidates = new ArrayList<>();
+                String opBuffer = completerInvocation.getGivenCompleteValue();
+                if (opBuffer.isEmpty()) {
+                    candidates.addAll(items);
+                } else {
+                    for (String name : items) {
+                        if (name.startsWith(opBuffer)) {
+                            candidates.add(name);
+                        }
+                    }
+                    Collections.sort(candidates);
+                }
+                completerInvocation.addAllCompleterValues(candidates);
+            }
+        }
+    }
+
+    protected abstract List<String> getItems(CLICompleterInvocation completerInvocation);
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/AbstractDeployCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/AbstractDeployCommand.java
@@ -17,18 +17,15 @@ package org.jboss.as.cli.impl.aesh.cmd.deployment;
 
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.CommandWithPermissions;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.Permissions;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.option.Option;
-import org.aesh.command.completer.OptionCompleter;
 import org.jboss.as.cli.Attachments;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.accesscontrol.AccessRequirement;
 import org.wildfly.core.cli.command.aesh.CLICompleterInvocation;
-import org.jboss.as.cli.impl.CommaSeparatedCompleter;
+import org.jboss.as.cli.impl.aesh.cmd.AbstractCommaCompleter;
 import org.jboss.as.cli.impl.aesh.cmd.HeadersCompleter;
 import org.jboss.as.cli.impl.aesh.cmd.HeadersConverter;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.OptionActivators.AllServerGroupsActivator;
@@ -46,25 +43,13 @@ import org.wildfly.core.cli.command.BatchCompliantCommand;
 @CommandDefinition(name = "deployment-deploy", description = "")
 public abstract class AbstractDeployCommand extends CommandWithPermissions implements BatchCompliantCommand {
 
-    public static class ServerGroupsCompleter implements
-            OptionCompleter<CLICompleterInvocation> {
+    public static class ServerGroupsCompleter extends AbstractCommaCompleter {
 
         @Override
-        public void complete(CLICompleterInvocation completerInvocation) {
+        protected List<String> getItems(CLICompleterInvocation completerInvocation) {
             CommandWithPermissions rc = (CommandWithPermissions) completerInvocation.getCommand();
-
-            CommaSeparatedCompleter comp = new CommaSeparatedCompleter() {
-                @Override
-                protected Collection<String> getAllCandidates(CommandContext ctx) {
-                    return rc.getPermissions().getServerGroupAddPermission().
-                            getAllowedOn(ctx);
-                }
-            };
-            List<String> candidates = new ArrayList<>();
-            int offset = comp.complete(completerInvocation.getCommandContext(),
-                    completerInvocation.getGivenCompleteValue(), 0, candidates);
-            completerInvocation.addAllCompleterValues(candidates);
-            completerInvocation.setOffset(offset);
+            return rc.getPermissions().getServerGroupAddPermission().
+                    getAllowedOn(completerInvocation.getCommandContext());
         }
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/AbstractUndeployCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/AbstractUndeployCommand.java
@@ -18,23 +18,19 @@ package org.jboss.as.cli.impl.aesh.cmd.deployment;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.CommandWithPermissions;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.Permissions;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.aesh.command.Command;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
-import org.aesh.command.completer.OptionCompleter;
 import org.aesh.command.option.Option;
 import org.jboss.as.cli.Attachments;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.Util;
-import org.jboss.as.cli.impl.CommaSeparatedCompleter;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.AccessRequirements;
 import org.jboss.as.cli.impl.aesh.cmd.security.ControlledCommandActivator;
 import org.jboss.as.cli.impl.aesh.cmd.HeadersCompleter;
@@ -45,9 +41,9 @@ import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.core.cli.command.BatchCompliantCommand;
 import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
-import org.wildfly.core.cli.command.aesh.CLICompleterInvocation;
 import org.wildfly.core.cli.command.aesh.activator.HideOptionActivator;
 import org.jboss.as.cli.impl.aesh.cmd.LegacyBridge;
+import org.jboss.as.cli.impl.aesh.cmd.deployment.AbstractDeployCommand.ServerGroupsCompleter;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.OptionActivators;
 
 /**
@@ -60,31 +56,6 @@ import org.jboss.as.cli.impl.aesh.cmd.deployment.security.OptionActivators;
 @CommandDefinition(name = "abstract-undeploy-deployment", description = "", activator = ControlledCommandActivator.class)
 public abstract class AbstractUndeployCommand extends CommandWithPermissions
         implements Command<CLICommandInvocation>, BatchCompliantCommand, LegacyBridge {
-
-    public static class ServerGroupsCompleter implements
-            OptionCompleter<CLICompleterInvocation> {
-
-        @Override
-        public void complete(CLICompleterInvocation completerInvocation) {
-            UndeployCommand rc = (UndeployCommand) completerInvocation.getCommand();
-
-            CommaSeparatedCompleter comp = new CommaSeparatedCompleter() {
-                @Override
-                protected Collection<String> getAllCandidates(CommandContext ctx) {
-                    try {
-                        return Util.getServerGroupsReferencingDeployment(rc.name, ctx.getModelControllerClient());
-                    } catch (CommandLineException ex) {
-                        return Collections.emptyList();
-                    }
-                }
-            };
-            List<String> candidates = new ArrayList<>();
-            int offset = comp.complete(completerInvocation.getCommandContext(),
-                    completerInvocation.getGivenCompleteValue(), 0, candidates);
-            completerInvocation.addAllCompleterValues(candidates);
-            completerInvocation.setOffset(offset);
-        }
-    }
 
     @Deprecated
     @Option(hasValue = false, activator = HideOptionActivator.class)

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/EnableCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/EnableCommand.java
@@ -17,18 +17,17 @@ package org.jboss.as.cli.impl.aesh.cmd.deployment;
 
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.Permissions;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.aesh.command.CommandDefinition;
 import org.aesh.command.CommandException;
 import org.aesh.command.CommandResult;
-import org.aesh.command.completer.OptionCompleter;
 import org.aesh.command.option.Argument;
 import org.aesh.command.option.Option;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.aesh.cmd.AbstractCompleter;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.AccessRequirements;
 import org.jboss.as.cli.impl.aesh.cmd.security.ControlledCommandActivator;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.OptionActivators.NameActivator;
@@ -48,30 +47,17 @@ import org.jboss.as.cli.impl.aesh.cmd.LegacyBridge;
 public class EnableCommand extends AbstractDeployCommand implements LegacyBridge {
 
     public static class NameCompleter
-            implements OptionCompleter<CLICompleterInvocation> {
+            extends AbstractCompleter {
 
         @Override
-        public void complete(CLICompleterInvocation completerInvocation) {
+        protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+            List<String> deployments = Collections.emptyList();
             if (completerInvocation.getCommandContext().getModelControllerClient() != null) {
-                List<String> deployments
+                deployments
                         = Util.getDeployments(completerInvocation.getCommandContext().
                                 getModelControllerClient());
-                if (!deployments.isEmpty()) {
-                    List<String> candidates = new ArrayList<>();
-                    String opBuffer = completerInvocation.getGivenCompleteValue();
-                    if (opBuffer.isEmpty()) {
-                        candidates.addAll(deployments);
-                    } else {
-                        for (String name : deployments) {
-                            if (name.startsWith(opBuffer)) {
-                                candidates.add(name);
-                            }
-                        }
-                        Collections.sort(candidates);
-                    }
-                    completerInvocation.addAllCompleterValues(candidates);
-                }
             }
+            return deployments;
         }
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/InfoCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/InfoCommand.java
@@ -19,6 +19,7 @@ import org.jboss.as.cli.impl.aesh.cmd.deployment.security.CommandWithPermissions
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.Permissions;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -30,12 +31,13 @@ import org.aesh.command.option.Option;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.aesh.cmd.AbstractCompleter;
 import org.jboss.as.cli.impl.aesh.cmd.HeadersCompleter;
 import org.jboss.as.cli.impl.aesh.cmd.HeadersConverter;
 import org.jboss.as.cli.impl.aesh.cmd.security.ControlledCommandActivator;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.AccessRequirements;
 import org.jboss.as.cli.impl.aesh.cmd.deployment.security.OptionActivators.InfoNameActivator;
-import org.jboss.as.cli.impl.aesh.cmd.deployment.security.OptionActivators.InfoServerGroupsActivator;
+import org.jboss.as.cli.impl.aesh.cmd.deployment.security.OptionActivators.InfoServerGroupActivator;
 import org.jboss.as.cli.util.SimpleTable;
 import org.jboss.as.cli.util.StrictSizeTable;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -43,6 +45,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.wildfly.core.cli.command.DMRCommand;
 import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
+import org.wildfly.core.cli.command.aesh.CLICompleterInvocation;
 import org.wildfly.core.cli.command.aesh.activator.HideOptionActivator;
 
 /**
@@ -53,6 +56,21 @@ import org.wildfly.core.cli.command.aesh.activator.HideOptionActivator;
  */
 @CommandDefinition(name = "info", description = "", activator = ControlledCommandActivator.class)
 public class InfoCommand extends CommandWithPermissions implements DMRCommand {
+
+    public static class ServerGroupCompleter
+            extends AbstractCompleter {
+
+        @Override
+        protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+            List<String> groups = Collections.emptyList();
+            if (completerInvocation.getCommandContext().getModelControllerClient() != null) {
+                CommandWithPermissions rc = (CommandWithPermissions) completerInvocation.getCommand();
+                return rc.getPermissions().getServerGroupAddPermission().
+                        getAllowedOn(completerInvocation.getCommandContext());
+            }
+            return groups;
+        }
+    }
 
     private static final String ADDED = "added";
     private static final String ENABLED = "ENABLED";
@@ -77,8 +95,8 @@ public class InfoCommand extends CommandWithPermissions implements DMRCommand {
             required = false)
     public ModelNode headers;
 
-    @Option(name = "server-group", activator = InfoServerGroupsActivator.class,
-            completer = AbstractDeployCommand.ServerGroupsCompleter.class,
+    @Option(name = "server-group", activator = InfoServerGroupActivator.class,
+            completer = ServerGroupCompleter.class,
             required = false)
     public String serverGroup;
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/security/OptionActivators.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/security/OptionActivators.java
@@ -204,10 +204,10 @@ public interface OptionActivators {
         }
     }
 
-    public static class InfoServerGroupsActivator extends AbstractRejectOptionActivator
+    public static class InfoServerGroupActivator extends AbstractRejectOptionActivator
             implements DomainOptionActivator {
 
-        public InfoServerGroupsActivator() {
+        public InfoServerGroupActivator() {
             super(DependOptionActivator.ARGUMENT_NAME);
         }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/security/OptionActivators.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/security/OptionActivators.java
@@ -146,6 +146,9 @@ public interface OptionActivators {
                     isSatisfied(cmd.getCommandContext())) {
                 return false;
             }
+            if (cmd.getCommandContext().isDomainMode()) {
+                return false;
+            }
             return super.isActivated(processedCommand);
         }
     }
@@ -173,24 +176,18 @@ public interface OptionActivators {
                     isSatisfied(cmd.getCommandContext())) {
                 return false;
             }
+            if (cmd.getCommandContext().isDomainMode()) {
+                return false;
+            }
             return super.isActivated(processedCommand);
         }
     }
 
-    public static class ServerGroupsActivator extends AbstractDependRejectOptionActivator
+    public static class ServerGroupsActivator extends AbstractRejectOptionActivator
             implements DomainOptionActivator {
 
-        private static final Set<String> EXPECTED = new HashSet<>();
-        private static final Set<String> NOT_EXPECTED = new HashSet<>();
-
-        static {
-            // Argument.
-            EXPECTED.add(DependOptionActivator.ARGUMENT_NAME);
-            NOT_EXPECTED.add("all-server-groups");
-            NOT_EXPECTED.add("replace");
-        }
         public ServerGroupsActivator() {
-            super(false, EXPECTED, NOT_EXPECTED);
+            super("all-server-groups", "replace");
         }
 
         @Override
@@ -231,21 +228,11 @@ public interface OptionActivators {
         }
     }
 
-    public static class AllServerGroupsActivator extends AbstractDependRejectOptionActivator
+    public static class AllServerGroupsActivator extends AbstractRejectOptionActivator
             implements DomainOptionActivator {
 
-        private static final Set<String> EXPECTED = new HashSet<>();
-        private static final Set<String> NOT_EXPECTED = new HashSet<>();
-
-        static {
-            // Argument.
-            EXPECTED.add(DependOptionActivator.ARGUMENT_NAME);
-            NOT_EXPECTED.add("server-groups");
-            NOT_EXPECTED.add("replace");
-        }
-
         public AllServerGroupsActivator() {
-            super(false, EXPECTED, NOT_EXPECTED);
+            super("server-groups", "replace");
         }
 
         @Override
@@ -263,20 +250,11 @@ public interface OptionActivators {
         }
     }
 
-    public static class AllRelevantServerGroupsActivator extends AbstractDependRejectOptionActivator
+    public static class AllRelevantServerGroupsActivator extends AbstractRejectOptionActivator
             implements DomainOptionActivator {
 
         public AllRelevantServerGroupsActivator() {
-            super(false, EXPECTED, NOT_EXPECTED);
-        }
-
-        private static final Set<String> EXPECTED = new HashSet<>();
-        private static final Set<String> NOT_EXPECTED = new HashSet<>();
-
-        static {
-            // Argument.
-            EXPECTED.add(DependOptionActivator.ARGUMENT_NAME);
-            NOT_EXPECTED.add("server-groups");
+            super("server-groups");
         }
 
         @Override
@@ -294,20 +272,11 @@ public interface OptionActivators {
         }
     }
 
-    public static class UndeployServerGroupsActivator extends AbstractDependRejectOptionActivator
+    public static class UndeployServerGroupsActivator extends AbstractRejectOptionActivator
             implements DomainOptionActivator {
 
         public UndeployServerGroupsActivator() {
-            super(false, EXPECTED, NOT_EXPECTED);
-        }
-
-        private static final Set<String> EXPECTED = new HashSet<>();
-        private static final Set<String> NOT_EXPECTED = new HashSet<>();
-
-        static {
-            // Argument.
-            EXPECTED.add(DependOptionActivator.ARGUMENT_NAME);
-            NOT_EXPECTED.add("all-relevant-server-groups");
+            super("all-relevant-server-groups");
         }
 
         @Override

--- a/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/deployment/command_resources.properties
+++ b/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/deployment/command_resources.properties
@@ -107,9 +107,10 @@ deployment will be deployed.
 
 deployment.deployment-deploy-content.option.replace.description=\
 If the deployment with the specified name already exists, by default, deploy \
-will be aborted and the corresponding message will printed. Switch --replace (or -r) \
+will be aborted and the corresponding message will printed. Option --replace (or -r) \
 will replace the replacement of the existing deployment with the one specified in the \
-command arguments.
+command arguments. In domain mode it can't be used when server groups are specified. \
+As a consequence, the deployment will be not added to the server groups.
 
 deployment.deployment-deploy-content.option.runtime-name.description=\
 Optional, the runtime name for the deployment. This will form the basis for such \

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -2512,6 +2512,92 @@ public class CliCompletionTestCase {
         }
     }
 
+    @Test
+    public void testCommandsDeployment() throws Exception {
+        CommandContext ctx = CLITestUtil.getCommandContext(testSupport,
+                System.in, System.out);
+        ctx.connectController();
+        try {
+            testDeployAction("deploy-file", true);
+            testDeployAction("deploy-url", false);
+            testDisableAction("disable-all");
+            testDisableAction("disable foo");
+            testEnableAction("enable-all");
+            testEnableAction("enable foo");
+            testDeploymentInfo();
+            testUndeploy();
+            testCliArchiveAction("deploy-cli-archive");
+            testCliArchiveAction("undeploy-cli-archive");
+        } finally {
+            ctx.terminateSession();
+        }
+    }
+
+    private void testDeployAction(String action, boolean unmanaged) {
+        {
+            String cmd = "deployment " + action + " foo ";
+            List<String> candidates = complete(ctx, cmd, null, cmd.length());
+            assertTrue(candidates.toString(), candidates.contains("--all-server-groups"));
+            assertTrue(candidates.toString(), candidates.contains("--server-groups="));
+            assertFalse(candidates.toString(), candidates.contains("--disabled"));
+            assertFalse(candidates.toString(), candidates.contains("--enabled"));
+            assertTrue(candidates.toString(), candidates.contains("--replace"));
+            assertTrue(candidates.toString(), candidates.contains("--name="));
+            assertTrue(candidates.toString(), candidates.contains("--runtime-name="));
+            if (unmanaged) {
+                assertTrue(candidates.toString(), candidates.contains("--unmanaged"));
+            }
+        }
+        {
+            String cmd = "deployment " + action + " foo --all-server-groups ";
+            List<String> candidates = complete(ctx, cmd, null, cmd.length());
+            assertFalse(candidates.toString(), candidates.contains("--replace"));
+        }
+        {
+            String cmd = "deployment " + action + " foo --server-groups=foo ";
+            List<String> candidates = complete(ctx, cmd, null, cmd.length());
+            assertFalse(candidates.toString(), candidates.contains("--replace"));
+        }
+        {
+            String cmd = "deployment " + action + " foo --replace ";
+            List<String> candidates = complete(ctx, cmd, null, cmd.length());
+            assertFalse(candidates.toString(), candidates.contains("--all-server-groups"));
+            assertFalse(candidates.toString(), candidates.contains("--server-groups="));
+        }
+    }
+
+    private void testDisableAction(String action) {
+        String cmd = "deployment " + action + " ";
+        List<String> candidates = complete(ctx, cmd, null, cmd.length());
+        assertTrue(candidates.toString(), candidates.contains("--all-relevant-server-groups"));
+        assertTrue(candidates.toString(), candidates.contains("--server-groups="));
+    }
+
+    private void testDeploymentInfo() {
+        String cmd = "deployment info ";
+        List<String> candidates = complete(ctx, cmd, null, cmd.length());
+        assertTrue(candidates.toString(), candidates.contains("--server-group="));
+    }
+
+    private void testEnableAction(String action) {
+        String cmd = "deployment " + action + " ";
+        List<String> candidates = complete(ctx, cmd, null, cmd.length());
+        assertTrue(candidates.toString(), candidates.contains("--all-server-groups"));
+        assertTrue(candidates.toString(), candidates.contains("--server-groups="));
+    }
+
+    private void testUndeploy() {
+        String cmd = "deployment undeploy foo ";
+        List<String> candidates = complete(ctx, cmd, null, cmd.length());
+        assertTrue(candidates.toString(), candidates.contains("--all-relevant-server-groups"));
+        assertTrue(candidates.toString(), candidates.contains("--server-groups="));
+    }
+
+    private void testCliArchiveAction(String action) {
+        String cmd = "deployment " + action + " foo ";
+        List<String> candidates = complete(ctx, cmd, null, cmd.length());
+        assertTrue(candidates.toString(), candidates.contains("--script="));
+    }
 
     /**
      * Legacy way of CLI completion

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/CliCompletionTestCase.java
@@ -35,12 +35,12 @@ import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.suites.CLITestSuite;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test completion of properties with and without rollout support.
@@ -2514,23 +2514,16 @@ public class CliCompletionTestCase {
 
     @Test
     public void testCommandsDeployment() throws Exception {
-        CommandContext ctx = CLITestUtil.getCommandContext(testSupport,
-                System.in, System.out);
-        ctx.connectController();
-        try {
-            testDeployAction("deploy-file", true);
-            testDeployAction("deploy-url", false);
-            testDisableAction("disable-all");
-            testDisableAction("disable foo");
-            testEnableAction("enable-all");
-            testEnableAction("enable foo");
-            testDeploymentInfo();
-            testUndeploy();
-            testCliArchiveAction("deploy-cli-archive");
-            testCliArchiveAction("undeploy-cli-archive");
-        } finally {
-            ctx.terminateSession();
-        }
+        testDeployAction("deploy-file", true);
+        testDeployAction("deploy-url", false);
+        testDisableAction("disable-all");
+        testDisableAction("disable foo");
+        testEnableAction("enable-all");
+        testEnableAction("enable foo");
+        testDeploymentInfo();
+        testUndeploy();
+        testCliArchiveAction("deploy-cli-archive");
+        testCliArchiveAction("undeploy-cli-archive");
     }
 
     private void testDeployAction(String action, boolean unmanaged) {
@@ -2564,6 +2557,10 @@ public class CliCompletionTestCase {
             assertFalse(candidates.toString(), candidates.contains("--all-server-groups"));
             assertFalse(candidates.toString(), candidates.contains("--server-groups="));
         }
+        {
+            String cmd = "deployment " + action + " foo ";
+            testServerGroupsCompletion(cmd);
+        }
     }
 
     private void testDisableAction(String action) {
@@ -2571,6 +2568,7 @@ public class CliCompletionTestCase {
         List<String> candidates = complete(ctx, cmd, null, cmd.length());
         assertTrue(candidates.toString(), candidates.contains("--all-relevant-server-groups"));
         assertTrue(candidates.toString(), candidates.contains("--server-groups="));
+        testServerGroupsCompletion(cmd);
     }
 
     private void testDeploymentInfo() {
@@ -2584,6 +2582,7 @@ public class CliCompletionTestCase {
         List<String> candidates = complete(ctx, cmd, null, cmd.length());
         assertTrue(candidates.toString(), candidates.contains("--all-server-groups"));
         assertTrue(candidates.toString(), candidates.contains("--server-groups="));
+        testServerGroupsCompletion(cmd);
     }
 
     private void testUndeploy() {
@@ -2591,12 +2590,34 @@ public class CliCompletionTestCase {
         List<String> candidates = complete(ctx, cmd, null, cmd.length());
         assertTrue(candidates.toString(), candidates.contains("--all-relevant-server-groups"));
         assertTrue(candidates.toString(), candidates.contains("--server-groups="));
+        testServerGroupsCompletion(cmd);
     }
 
     private void testCliArchiveAction(String action) {
         String cmd = "deployment " + action + " foo ";
         List<String> candidates = complete(ctx, cmd, null, cmd.length());
         assertTrue(candidates.toString(), candidates.contains("--script="));
+    }
+
+    private void testServerGroupsCompletion(String command) {
+        String cmd = command + " " + "--server-groups=";
+        List<String> candidates = complete(ctx, cmd, null, cmd.length());
+        assertTrue(candidates.toString(), candidates.size() >= 2);
+        List<String> sgroups = candidates;
+        String sg1 = candidates.get(0).substring(0, candidates.get(0).length() / 2);
+        cmd = command + " " + "--server-groups=" + sg1;
+        candidates = complete(ctx, cmd, null, 0);
+        assertEquals(candidates.toString(), Arrays.asList(sgroups.get(0)), candidates);
+        cmd = command + " " + "--server-groups=" + sgroups.get(0);
+        candidates = complete(ctx, cmd, null, 0);
+        assertEquals(candidates.toString(), Arrays.asList(","), candidates);
+        cmd = command + " " + "--server-groups=" + sgroups.get(0) + ",";
+        candidates = complete(ctx, cmd, null, 0);
+        assertFalse(candidates.toString(), candidates.contains(sgroups.get(0)));
+        cmd = command + " " + "--server-groups="
+                + sgroups.get(0) + "," + sgroups.get(1);
+        candidates = complete(ctx, cmd, null, 0);
+        assertFalse(candidates.toString(), candidates.contains(sgroups.get(1)));
     }
 
     /**

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/CliCompletionTestCase.java
@@ -205,6 +205,64 @@ public class CliCompletionTestCase {
         assertTrue(candidates.toString(), candidates.contains("deployment"));
         assertTrue(candidates.toString(), candidates.contains("deployment-info"));
         assertTrue(candidates.toString(), candidates.contains("deployment-overlay"));
+
+        testDeployAction("deploy-file", true);
+        testDeployAction("deploy-url", false);
+        testDisableAction("disable-all");
+        testDisableAction("disable foo");
+        testEnableAction("enable-all");
+        testEnableAction("enable foo");
+        testDeploymentInfo();
+        testUndeploy();
+        testList();
+    }
+
+    private void testDeployAction(String action, boolean unmanaged) {
+        String cmd = "deployment " + action + " foo ";
+        List<String> candidates = complete(ctx, cmd, null);
+        assertFalse(candidates.toString(), candidates.contains("--all-server-groups"));
+        assertFalse(candidates.toString(), candidates.contains("--server-groups="));
+        assertTrue(candidates.toString(), candidates.contains("--disabled"));
+        assertTrue(candidates.toString(), candidates.contains("--enabled"));
+        assertTrue(candidates.toString(), candidates.contains("--replace"));
+        assertTrue(candidates.toString(), candidates.contains("--name="));
+        assertTrue(candidates.toString(), candidates.contains("--runtime-name="));
+        if (unmanaged) {
+            assertTrue(candidates.toString(), candidates.contains("--unmanaged"));
+        }
+    }
+
+    private void testDisableAction(String action) {
+        String cmd = "deployment " + action + " ";
+        List<String> candidates = complete(ctx, cmd, null);
+        assertFalse(candidates.toString(), candidates.contains("--all-relevant-server-groups"));
+        assertFalse(candidates.toString(), candidates.contains("--server-groups="));
+    }
+
+    private void testEnableAction(String action) {
+        String cmd = "deployment " + action + " ";
+        List<String> candidates = complete(ctx, cmd, null);
+        assertFalse(candidates.toString(), candidates.contains("--all-server-groups"));
+        assertFalse(candidates.toString(), candidates.contains("--server-groups="));
+    }
+
+    private void testDeploymentInfo() {
+        String cmd = "deployment info ";
+        List<String> candidates = complete(ctx, cmd, null);
+        assertFalse(candidates.toString(), candidates.contains("--server-group="));
+    }
+
+    private void testUndeploy() {
+        String cmd = "deployment undeploy foo ";
+        List<String> candidates = complete(ctx, cmd, null);
+        assertFalse(candidates.toString(), candidates.contains("--all-relevant-server-groups"));
+        assertFalse(candidates.toString(), candidates.contains("--server-groups="));
+    }
+
+    private void testList() {
+        String cmd = "deployment list ";
+        List<String> candidates = complete(ctx, cmd, null);
+        assertTrue(candidates.toString(), candidates.contains("--l"));
     }
 
     @Test


### PR DESCRIPTION
Completion in domain mode had been overlooked for the new deployment actions.
Fix for WFCORE-3564 server-groups completion. Refactored completion and introduced Abstract completers. Added unit tests.
Fix for WFCORE-3567 option completion. Added unit tests.

