### PR TITLE
[WFCORE-3571] Improve CLI error handling in ListCommand

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/ListCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/ListCommand.java
@@ -135,7 +135,7 @@ public class ListCommand extends CommandWithPermissions {
             throw new CommandException("Failed to execute operation request.", e);
         }
         if (!result.hasDefined(Util.RESULT)) {
-            return null;
+            throw new CommandException("Failed to read deployment information.");
         }
         return result.get(Util.RESULT);
     }


### PR DESCRIPTION
upstream jira: https://issues.jboss.org/browse/WFCORE-3571

Minor improvement: Improve CLI error handling in ListCommand class. If management operation doesn't return correct results, CLI throw correct error message.

@jfdenise please check