### PR TITLE
Fix for WFCORE-3575, CLI, failed connect side effect

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
+++ b/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
@@ -290,7 +290,6 @@ public class CLI {
         if (isConnected()) {
             throw new IllegalStateException("Already connected to server.");
         }
-        terminate();
         CommandContext newContext = null;
         try {
             newContext = callable.call();
@@ -309,6 +308,8 @@ public class CLI {
             }
             throw new IllegalStateException(ex);
         }
+        // We have a new connected context, terminate the current one.
+        terminate();
         ctx = newContext;
     }
 

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIScriptSupportTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIScriptSupportTestCase.java
@@ -136,6 +136,27 @@ public class CLIScriptSupportTestCase {
         }
     }
 
+    @Test
+    public void testFailedConnect() {
+        CLI cli = CLI.newInstance();
+        try {
+            // Make an invalid connect
+            checkFail(() -> cli.connect(TestSuiteEnvironment.getServerAddress(),
+                    123,
+                    null,
+                    null));
+            // re-use the same instance to start an embedded server.
+            executeCommand(cli, "embed-server --std-out=echo");
+            try {
+                executeCommand(cli, ":read-resource()");
+            } finally {
+                executeCommand(cli, "stop-embedded-server");
+            }
+        } finally {
+            cli.terminate();
+        }
+    }
+
     private static void checkFail(Runnable runner) {
         boolean failed = false;
         try {


### PR DESCRIPTION
The current context can only be terminated if connection succeeds.
Added test to mimic jdr script logic.