### PR TITLE
WFCORE-3584 Stability monitor should be exposed to DUP's

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/AbstractDeploymentUnitService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/AbstractDeploymentUnitService.java
@@ -63,7 +63,7 @@ public abstract class AbstractDeploymentUnitService implements Service<Deploymen
 
     private volatile DeploymentUnitPhaseBuilder phaseBuilder = null;
     private volatile DeploymentUnit deploymentUnit;
-    private volatile StabilityMonitor monitor;
+    volatile StabilityMonitor monitor;
 
     AbstractDeploymentUnitService(final ImmutableManagementResourceRegistration registration, final ManagementResourceRegistration mutableRegistration, final Resource resource, final CapabilityServiceSupport capabilityServiceSupport, final AbstractVaultReader vaultReader) {
         this.mutableRegistration = mutableRegistration;

--- a/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
@@ -46,6 +46,7 @@ import org.jboss.jandex.Index;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StabilityMonitor;
 import org.jboss.vfs.VirtualFile;
 
 /**
@@ -94,6 +95,8 @@ public final class Attachments {
      * A builder used to install a deployment phase
      */
     public static final AttachmentKey<DeploymentUnitPhaseBuilder> DEPLOYMENT_UNIT_PHASE_BUILDER = AttachmentKey.create(DeploymentUnitPhaseBuilder.class);
+
+    public static final AttachmentKey<StabilityMonitor> STABILITY_MONITOR = AttachmentKey.create(StabilityMonitor.class);
 
     //
     // STRUCTURE

--- a/server/src/main/java/org/jboss/as/server/deployment/RootDeploymentUnitService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/RootDeploymentUnitService.java
@@ -88,6 +88,7 @@ final class RootDeploymentUnitService extends AbstractDeploymentUnitService {
         deploymentUnit.putAttachment(Attachments.VAULT_READER_ATTACHMENT_KEY, vaultReader);
         deploymentUnit.putAttachment(Attachments.DEPLOYMENT_OVERLAY_INDEX, deploymentOverlays);
         deploymentUnit.putAttachment(Attachments.PATH_MANAGER, pathManagerInjector.getValue());
+        deploymentUnit.putAttachment(Attachments.STABILITY_MONITOR, monitor);
         if(this.isExplodedContent) {
             MountExplodedMarker.setMountExploded(deploymentUnit);
         }

--- a/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentUnitService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/SubDeploymentUnitService.java
@@ -65,6 +65,7 @@ public class SubDeploymentUnitService extends AbstractDeploymentUnitService {
         deploymentUnit.putAttachment(Attachments.VAULT_READER_ATTACHMENT_KEY, vaultReader);
         deploymentUnit.putAttachment(Attachments.DEPLOYMENT_OVERLAY_INDEX, parent.getAttachment(Attachments.DEPLOYMENT_OVERLAY_INDEX));
         deploymentUnit.putAttachment(Attachments.PATH_MANAGER, pathManager);
+        deploymentUnit.putAttachment(Attachments.STABILITY_MONITOR, monitor);
         return deploymentUnit;
     }
 


### PR DESCRIPTION
There are some use cases (e.g. shared java:global bindings) that result in services being installed outside of a deployments ServiceTarget. This means that are not added to the stability monitor, which results in intermittent test failures due to a false stability being achieved before all services have come up.
At present it is not possible to access this stability monitor, so there is no way to fix this issue.