### PR TITLE
WFCORE-3409 embed-server doesn't honor "module.path" system property

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -255,7 +255,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
                 // Modular environment
                 hostController = EmbeddedProcessFactory.createHostController(ModuleLoader.forClass(getClass()), jbossHome, cmds);
             } else {
-                hostController = EmbeddedProcessFactory.createHostController(jbossHome.getAbsolutePath(), null, null, cmds);
+                hostController = EmbeddedProcessFactory.createHostController(jbossHome.getAbsolutePath(), WildFlySecurityManager.getPropertyPrivileged("module.path", null), null, cmds);
             }
             hostController.start();
 

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
@@ -229,7 +229,7 @@ class EmbedServerHandler extends CommandHandlerWithHelp {
                 // Modular environment
                 server = EmbeddedProcessFactory.createStandaloneServer(ModuleLoader.forClass(getClass()), jbossHome, cmds);
             } else {
-                server = EmbeddedProcessFactory.createStandaloneServer(jbossHome.getAbsolutePath(), null, null, cmds);
+                server = EmbeddedProcessFactory.createStandaloneServer(jbossHome.getAbsolutePath(), WildFlySecurityManager.getPropertyPrivileged("module.path", null), null, cmds);
             }
             server.start();
             serverReference.set(new EmbeddedProcessLaunch(server, restorer, false));


### PR DESCRIPTION
This helps tremendously with testsuite optimization (no need to copy over modules jar in manualmode)