### PR TITLE
WFCORE-3588 Intermittent failures in LoggingSubsystemRollbackTestCase

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -51,13 +51,19 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <argLine>-javaagent:${org.jboss.byteman:byteman:jar}=port:${byteman.port},address:${byteman.host},boot:${org.jboss.byteman:byteman:jar} ${surefire.system.args}</argLine>
                     <systemPropertyVariables>
                         <jboss.server.log.dir>${project.build.directory}${file.separator}logs</jboss.server.log.dir>
                         <jboss.server.config.dir>${project.build.directory}${file.separator}config</jboss.server.config.dir>
+                        <org.jboss.byteman.contrib.bmunit.agent.inhibit>true</org.jboss.byteman.contrib.bmunit.agent.inhibit>
+                        <org.jboss.byteman.debug>true</org.jboss.byteman.debug>
+                        <org.jboss.byteman.contrib.bmunit.agent.host>${byteman.host}</org.jboss.byteman.contrib.bmunit.agent.host>
+                        <org.jboss.byteman.contrib.bmunit.agent.port>${byteman.port}</org.jboss.byteman.contrib.bmunit.agent.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This change makes every byteman scanner use a different port. If a test is slow to release
a port for some reason it will not interfere with subsequent tests.