### PR TITLE
allow to specify version of org.wildfly.openssl.wildfly-openssl native bits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,12 +145,28 @@
         <version.org.wildfly.common>1.3.0.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.0.0.Final</version.org.wildfly.discovery>
         <version.org.wildfly.openssl>1.0.2.Final</version.org.wildfly.openssl>
+<<<<<<< HEAD
         <version.org.wildfly.legacy.test>3.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.security.elytron>1.2.0.Beta12</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron.tool>1.0.0.Final</version.org.wildfly.security.elytron.tool>
         <version.org.wildfly.security.elytron-web.undertow-server>1.1.0.Beta1</version.org.wildfly.security.elytron-web.undertow-server>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
+=======
+        <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
+        <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
+        <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
+        <version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64>
+        <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
+        <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
+        <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
+        <version.org.wildfly.openssl.wildfly-openssl-solaris-sparcv9>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-sparcv9>
+        <version.org.wildfly.legacy.test>2.0.3.Final</version.org.wildfly.legacy.test>
+        <version.org.wildfly.security.elytron>1.1.0.Final-redhat-1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron.tool>1.0.0.Final-redhat-1</version.org.wildfly.security.elytron.tool>
+        <version.org.wildfly.security.elytron-web.undertow-server>1.0.0.Final-redhat-1</version.org.wildfly.security.elytron-web.undertow-server>
+        <version.xml-resolver>1.2.0.redhat-11</version.xml-resolver> <!-- Apache xml-resolver -->
+>>>>>>> cc7a813720... allow to specify version of org.wildfly.openssl.wildfly-openssl native bits
         <!-- Non-default maven plugin versions and configuration -->
         <version.org.zanata.plugin>3.9.1</version.org.zanata.plugin>
         <version.xml.plugin>1.0.1</version.xml.plugin>
@@ -1490,44 +1506,44 @@
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-linux-x86_64</artifactId>
-                <version>${version.org.wildfly.openssl}</version>
+                <version>${version.org.wildfly.openssl.wildfly-openssl-linux-x86_64}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-linux-i386</artifactId>
-                <version>${version.org.wildfly.openssl}</version>
+                <version>${version.org.wildfly.openssl.wildfly-openssl-linux-i386}</version>
             </dependency>
 
 
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-macosx-x86_64</artifactId>
-                <version>${version.org.wildfly.openssl}</version>
+                <version>${version.org.wildfly.openssl.wildfly-openssl-macosx-x86_64}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-windows-i386</artifactId>
-                <version>${version.org.wildfly.openssl}</version>
+                <version>${version.org.wildfly.openssl.wildfly-openssl-windows-i386}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-windows-x86_64</artifactId>
-                <version>${version.org.wildfly.openssl}</version>
+                <version>${version.org.wildfly.openssl.wildfly-openssl-windows-x86_64}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-solaris-x86_64</artifactId>
-                <version>${version.org.wildfly.openssl}</version>
+                <version>${version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.wildfly.openssl</groupId>
                 <artifactId>wildfly-openssl-solaris-sparcv9</artifactId>
-                <version>${version.org.wildfly.openssl}</version>
+                <version>${version.org.wildfly.openssl.wildfly-openssl-solaris-sparcv9}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -144,15 +144,8 @@
         <version.org.wildfly.client.config>1.0.0.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.3.0.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.0.0.Final</version.org.wildfly.discovery>
-        <version.org.wildfly.openssl>1.0.2.Final</version.org.wildfly.openssl>
-<<<<<<< HEAD
         <version.org.wildfly.legacy.test>3.0.0.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
-        <version.org.wildfly.security.elytron>1.2.0.Beta12</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron.tool>1.0.0.Final</version.org.wildfly.security.elytron.tool>
-        <version.org.wildfly.security.elytron-web.undertow-server>1.1.0.Beta1</version.org.wildfly.security.elytron-web.undertow-server>
-        <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
-=======
+        <version.org.wildfly.openssl>1.0.2.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>
@@ -161,12 +154,11 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-solaris-sparcv9>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-sparcv9>
-        <version.org.wildfly.legacy.test>2.0.3.Final</version.org.wildfly.legacy.test>
-        <version.org.wildfly.security.elytron>1.1.0.Final-redhat-1</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron.tool>1.0.0.Final-redhat-1</version.org.wildfly.security.elytron.tool>
-        <version.org.wildfly.security.elytron-web.undertow-server>1.0.0.Final-redhat-1</version.org.wildfly.security.elytron-web.undertow-server>
-        <version.xml-resolver>1.2.0.redhat-11</version.xml-resolver> <!-- Apache xml-resolver -->
->>>>>>> cc7a813720... allow to specify version of org.wildfly.openssl.wildfly-openssl native bits
+        <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
+        <version.org.wildfly.security.elytron>1.2.0.Beta12</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron.tool>1.0.0.Final</version.org.wildfly.security.elytron.tool>
+        <version.org.wildfly.security.elytron-web.undertow-server>1.1.0.Beta1</version.org.wildfly.security.elytron-web.undertow-server>
+        <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
         <!-- Non-default maven plugin versions and configuration -->
         <version.org.zanata.plugin>3.9.1</version.org.zanata.plugin>
         <version.xml.plugin>1.0.1</version.xml.plugin>


### PR DESCRIPTION
This is a delta between 4.x and other branches that I want to make go away. It's easier for me to make it go away in favor of what's in the other branches.  The change should have no functional impact.