### PR TITLE
WFCORE-3592 Expose external ServiceTarget to DUP processing

### DIFF
--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -311,6 +311,7 @@ public final class ServerService extends AbstractControllerService {
                 public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
                     phaseContext.getDeploymentUnit().putAttachment(Attachments.SERVICE_MODULE_LOADER, injectedModuleLoader.getValue());
                     phaseContext.getDeploymentUnit().putAttachment(Attachments.EXTERNAL_MODULE_SERVICE, injectedExternalModuleService.getValue());
+                    phaseContext.getDeploymentUnit().putAttachment(Attachments.EXTERNAL_SERVICE_TARGET, serviceTarget);
                 }
 
                 @Override

--- a/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Attachments.java
@@ -46,6 +46,7 @@ import org.jboss.jandex.Index;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StabilityMonitor;
 import org.jboss.vfs.VirtualFile;
 
@@ -201,6 +202,14 @@ public final class Attachments {
      * Support for integrating with services and other runtime API provided by managed capabilities.
      */
     public static final AttachmentKey<CapabilityServiceSupport> CAPABILITY_SERVICE_SUPPORT = AttachmentKey.create(CapabilityServiceSupport.class);
+
+    /**
+     * A service target that can be used to install services outside the scope of the deployment.
+     *
+     * These services will not be removed automatically on undeploy, so if this is used some other strategy must be used
+     * to handle undeployment.
+     */
+    public static final AttachmentKey<ServiceTarget> EXTERNAL_SERVICE_TARGET = AttachmentKey.create(ServiceTarget.class);
 
     //
     // VALIDATE


### PR DESCRIPTION
This ServiceTarget can be used to install services outside the scope of a deployment, while still being monitored by the container state monitor.