### PR TITLE
WFCORE-3594 Reload is racey with regard to reading the process state

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessReloadHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessReloadHandler.java
@@ -83,12 +83,12 @@ public abstract class ProcessReloadHandler<T extends RunningModeControl> impleme
                     @Override
                     public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
                         if(resultAction == OperationContext.ResultAction.KEEP) {
+                            processState.setStopping();
                             service.addListener(new AbstractServiceListener<Object>() {
                                 @Override
                                 public void listenerAdded(final ServiceController<?> controller) {
                                     Future<?> stopping = executor.submit(() -> {
                                         reloadContext.reloadInitiated(runningModeControl);
-                                        processState.setStopping();
                                         controller.setMode(ServiceController.Mode.NEVER);
                                     });
                                     try {


### PR DESCRIPTION
Presently when issuing a reload operation the process state is updated asyncrounously,
which means that it is possible for a subsequent read of the process-state to return
a state of 'running' even though the server is actually in the process of reloading.

This can cause intermittent failures in any tests that perform a reload, as the general
pattern followed by these tests is to do a reload and then check the process state in a
loop until it is back to 'running'.