### PR TITLE
WFCORE-3595 SuspendOnSoftKillTestCase can fail intermittently

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnSoftKillTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/suspend/SuspendOnSoftKillTestCase.java
@@ -198,6 +198,15 @@ public class SuspendOnSoftKillTestCase {
             }
             Assert.assertEquals("SUSPENDING", suspendState);
 
+            final HttpURLConnection conn = (HttpURLConnection) new URL(address).openConnection();
+            try {
+                conn.setDoInput(true);
+                int responseCode = conn.getResponseCode();
+                Assert.assertEquals(503, responseCode);
+            } finally {
+                conn.disconnect();
+            }
+
             // Send a request that will trigger the first request to complete
             HttpRequest.get(address + "?" + TestUndertowService.SKIP_GRACEFUL + "=true", TimeoutUtil.adjust(30), TimeUnit.SECONDS);
             // Confirm 1st request completed
@@ -208,18 +217,6 @@ public class SuspendOnSoftKillTestCase {
                 Assert.assertEquals("SUSPENDED", serverController.getClient().executeForResult(op).asString());
             } catch (RuntimeException ok) {
                 // ignore; it's fine if the server's down
-            }
-
-            final HttpURLConnection conn = (HttpURLConnection) new URL(address).openConnection();
-            try {
-                conn.setDoInput(true);
-                int responseCode = conn.getResponseCode();
-                Assert.assertEquals(503, responseCode);
-            } catch (IOException ok) {
-                // ignore; it's fine if the server's down
-            }
-            finally {
-                conn.disconnect();
             }
 
             waitForServerShutdown();


### PR DESCRIPTION
The issue is that TestUndertowService is designed for testing suspend/resume rather than an actual graceful shutdown. Because it attempts to perform a dispatch() and queue a task rather than just immediately setting a 503 response it is possible that this request will fail with a 500 response if the XNIO executor is in the process of shutting down.
It would be better if this test checked for a 503 before the skip-graceful request is made.