### PR TITLE
[WFCORE-3600] Add a new org.wildfly.javax.json module to temporally a…

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/javax/json/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/javax/json/main/module.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!-- Please note this is a temporary module and will be removed -->
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.javax.json" version="${org.glassfish:javax.json}">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.glassfish:javax.json}"/>
+    </resources>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/security/elytron-private/main/module.xml
@@ -43,7 +43,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.threads"/>
         <module name="javax.api" />
-        <module name="javax.json.api"/>
+        <module name="org.wildfly.javax.json"/>
         <module name="javax.security.jacc.api" optional="true"/>
         <module name="sun.jdk"/>
         <module name="org.wildfly.common"/>


### PR DESCRIPTION
…llow core modules to depend on it until we update to JSON-P 1.1 in WildFly.

https://issues.jboss.org/browse/WFCORE-3600

This introduced a new temporary module in core for core components to rely on. This is required so the wrong module is not loaded if the `ee8.preview.mode` property is set to `true` in WildFly. Note this module *will* go away eventually.