### PR TITLE
Revert "WFCORE-3594 Reload is racey with regard to reading the process state"

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessReloadHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ProcessReloadHandler.java
@@ -83,12 +83,12 @@ public abstract class ProcessReloadHandler<T extends RunningModeControl> impleme
                     @Override
                     public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
                         if(resultAction == OperationContext.ResultAction.KEEP) {
-                            processState.setStopping();
                             service.addListener(new AbstractServiceListener<Object>() {
                                 @Override
                                 public void listenerAdded(final ServiceController<?> controller) {
                                     Future<?> stopping = executor.submit(() -> {
                                         reloadContext.reloadInitiated(runningModeControl);
+                                        processState.setStopping();
                                         controller.setMode(ServiceController.Mode.NEVER);
                                     });
                                     try {


### PR DESCRIPTION
Reverts wildfly/wildfly-core#3098

@stuartwdouglas FYI. 

Since this went in we are seeing failures in ProcessStateListenerTestCase.  

Also, looking at some logs from those I realize that this change has moved some state change notification work previously done on an executor thread onto the main operation handler thread.  That needs consideration, as the logging like this is not good. 

```
&amp#27;[0m&amp#27;[31m11:39:14,006 ERROR [org.wildfly.extension.core.management] (management-handler-thread - 1) WFLYCM0003: Error invoking the process state listener my-listener: java.lang.InterruptedException
    at java.util.concurrent.FutureTask.awaitDone(FutureTask.java:404)
    at java.util.concurrent.FutureTask.get(FutureTask.java:204)
    at org.wildfly.extension.core.management.ProcessStateListenerService.transition(ProcessStateListenerService.java:150)
    at org.wildfly.extension.core.management.ProcessStateListenerService.lambda$new$0(ProcessStateListenerService.java:100)
    at java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:335)
    at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:327)
    at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:263)
    at org.jboss.as.controller.ControlledProcessStateService.stateChanged(ControlledProcessStateService.java:105)
    at org.jboss.as.controller.ControlledProcessState.setStopping(ControlledProcessState.java:127)
    at org.jboss.as.controller.operations.common.ProcessReloadHandler$1$1.handleResult(ProcessReloadHandler.java:86)
    at org.jboss.as.controller.AbstractOperationContext$Step.invokeResultHandler(AbstractOperationContext.java:1500)
    at org.jboss.as.controller.AbstractOperationContext$Step.handleResult(AbstractOperationContext.java:1482)
    at org.jboss.as.controller.AbstractOperationContext$Step.finalizeInternal(AbstractOperationContext.java:1439)
    at org.jboss.as.controller.AbstractOperationContext$Step.finalizeStep(AbstractOperationContext.java:1412)
    at org.jboss.as.controller.AbstractOperationContext$Step.access$400(AbstractOperationContext.java:1286)
    at org.jboss.as.controller.AbstractOperationContext.executeResultHandlerPhase(AbstractOperationContext.java:859)
    at org.jboss.as.controller.AbstractOperationContext.executeDoneStage(AbstractOperationContext.java:845)
    at org.jboss.as.controller.AbstractOperationContext.processStages(AbstractOperationContext.java:752)
    at org.jboss.as.controller.AbstractOperationContext.executeOperation(AbstractOperationContext.java:450)
    at org.jboss.as.controller.OperationContextImpl.executeOperation(OperationContextImpl.java:1408)
    at org.jboss.as.controller.ModelControllerImpl.internalExecute(ModelControllerImpl.java:418)
    at org.jboss.as.controller.ModelControllerImpl.lambda$execute$1(ModelControllerImpl.java:243)
    at org.wildfly.security.auth.server.SecurityIdentity.runAs(SecurityIdentity.java:263)
    at org.wildfly.security.auth.server.SecurityIdentity.runAs(SecurityIdentity.java:229)
    at org.jboss.as.controller.ModelControllerImpl.execute(ModelControllerImpl.java:243)
    at org.jboss.as.controller.remote.ModelControllerClientOperationHandler$ExecuteRequestHandler.doExecute(ModelControllerClientOperationHandler.java:217)
    at org.jboss.as.controller.remote.ModelControllerClientOperationHandler$ExecuteRequestHandler.access$400(ModelControllerClientOperationHandler.java:137)
    at org.jboss.as.controller.remote.ModelControllerClientOperationHandler$ExecuteRequestHandler$1$1.run(ModelControllerClientOperationHandler.java:161)
    at org.jboss.as.controller.remote.ModelControllerClientOperationHandler$ExecuteRequestHandler$1$1.run(ModelControllerClientOperationHandler.java:157)
    at org.wildfly.security.auth.server.SecurityIdentity.runAs(SecurityIdentity.java:287)
    at org.wildfly.security.auth.server.SecurityIdentity.runAs(SecurityIdentity.java:244)
    at org.jboss.as.controller.AccessAuditContext.doAs(AccessAuditContext.java:254)
    at org.jboss.as.controller.AccessAuditContext.doAs(AccessAuditContext.java:225)
    at org.jboss.as.controller.remote.ModelControllerClientOperationHandler$ExecuteRequestHandler$1.execute(ModelControllerClientOperationHandler.java:157)
    at org.jboss.as.protocol.mgmt.ManagementRequestContextImpl$1.doExecute(ManagementRequestContextImpl.java:70)
    at org.jboss.as.protocol.mgmt.ManagementRequestContextImpl$AsyncTaskRunner.run(ManagementRequestContextImpl.java:160)
    at org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:1979)
    at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1481)
    at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1374)
    at java.lang.Thread.run(Thread.java:748)
    at org.jboss.threads.JBossThread.run(JBossThread.java:485)
```