### PR TITLE
[WFCORE-3609]:Fix milliseconds format in configuration changes operation date

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ConfigurationChangesCollector.java
+++ b/controller/src/main/java/org/jboss/as/controller/ConfigurationChangesCollector.java
@@ -119,7 +119,7 @@ public interface ConfigurationChangesCollector {
 
     static final class ConfigurationChange implements Comparable<ConfigurationChange> {
 
-        private static final DateTimeFormatter DATE_FORMAT = new DateTimeFormatterBuilder().appendInstant().toFormatter(Locale.ENGLISH);
+        private static final DateTimeFormatter DATE_FORMAT = new DateTimeFormatterBuilder().appendInstant(3).toFormatter(Locale.ENGLISH);
         private final OperationContext.ResultAction resultAction;
         private final String userId;
         private final String domainUuid;


### PR DESCRIPTION
Displaying always the milliseconds for configuration changes operation dates

Jira: https://issues.jboss.org/browse/WFCORE-3609