### PR TITLE
[WFCORE-3597] Allow reload handler to signal when to send the early r…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -60,6 +60,7 @@ import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StabilityMonitor;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
@@ -161,6 +162,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
     private final InjectedValue<ControllerInstabilityListener> injectedInstabilityListener = new InjectedValue<ControllerInstabilityListener>();
     private final ExpressionResolver expressionResolver;
     private volatile ModelControllerImpl controller;
+    private volatile StabilityMonitor stabilityMonitor;
     private ConfigurationPersister configurationPersister;
     private final ManagedAuditLogger auditLogger;
     private final BootErrorCollector bootErrorCollector;
@@ -330,7 +332,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
         ManagementResourceRegistration rootResourceRegistration = ManagementResourceRegistration.Factory.forProcessType(processType).createRegistration(rootResourceDefinition, authorizerConfig, capabilityRegistry);
         final ModelControllerImpl controller = new ModelControllerImpl(container, target,
                 rootResourceRegistration,
-                new ContainerStateMonitor(container),
+                new ContainerStateMonitor(container, getStabilityMonitor()),
                 configurationPersister, processType, runningModeControl, prepareStep,
                 processState, executorService, expressionResolver, authorizer, securityIdentitySupplier, auditLogger, notificationSupport,
                 bootErrorCollector, createExtraValidationStepHandler(), capabilityRegistry, getPartialModelIndicator(),
@@ -550,11 +552,19 @@ public abstract class AbstractControllerService implements Service<ModelControll
         return PartialModelIndicator.DEFAULT;
     }
 
+    protected final StabilityMonitor getStabilityMonitor() {
+        if (stabilityMonitor == null) {
+            stabilityMonitor = new StabilityMonitor();
+        }
+        return stabilityMonitor;
+    }
+
     public void stop(final StopContext context) {
         capabilityRegistry.clear();
         capabilityRegistry.publish();
         ServiceNameFactory.clearCache();
         controller = null;
+        stabilityMonitor = null;
         processState.setStopping();
         Runnable r = new Runnable() {
             @Override

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -826,7 +826,7 @@ abstract class AbstractOperationContext implements OperationContext {
                     public void rollback() {
                         ref.set(ResultAction.ROLLBACK);
                     }
-                }, primaryResponse);
+                }, primaryResponse, this);
             }
             resultAction = ref.get();
 

--- a/controller/src/main/java/org/jboss/as/controller/ContainerStateMonitor.java
+++ b/controller/src/main/java/org/jboss/as/controller/ContainerStateMonitor.java
@@ -48,15 +48,16 @@ import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
 final class ContainerStateMonitor {
 
     private final ServiceRegistry serviceRegistry;
-    private final StabilityMonitor monitor = new StabilityMonitor();
-    final Set<ServiceController<?>> failed = new HashSet<ServiceController<?>>();
-    final Set<ServiceController<?>> problems = new HashSet<ServiceController<?>>();
+    private final StabilityMonitor monitor;
+    private final Set<ServiceController<?>> failed = new HashSet<ServiceController<?>>();
+    private final Set<ServiceController<?>> problems = new HashSet<ServiceController<?>>();
 
     private Set<ServiceName> previousMissingDepSet = new HashSet<ServiceName>();
     private Set<ServiceController<?>> previousFailedSet = new HashSet<>();
 
-    ContainerStateMonitor(final ServiceRegistry registry) {
+    ContainerStateMonitor(final ServiceRegistry registry, final StabilityMonitor stabilityMonitor) {
         serviceRegistry = registry;
+        monitor = stabilityMonitor;
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/ModelController.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelController.java
@@ -125,6 +125,22 @@ public interface ModelController {
          *
          * @param transaction the transaction to control the fate of the operation. Cannot be {@code null}
          * @param result the result. Cannot be {@code null}
+         * @param context the {@code OperationContext} for the operation that is prepared
+         */
+        default void operationPrepared(OperationTransaction transaction, ModelNode result, OperationContext context) {
+            operationPrepared(transaction, result);
+        }
+
+        /**
+         * Notify that an operation is complete and may be committed or rolled back.
+         *
+         * <p><strong>It is the responsibility of the user of this {@code OperationTransactionControl} to ensure that
+         * {@link OperationTransaction#commit()} or {@link OperationTransaction#rollback()} is eventually called on
+         * the provided {@code transaction}.
+         * </strong></p>
+         *
+         * @param transaction the transaction to control the fate of the operation. Cannot be {@code null}
+         * @param result the result. Cannot be {@code null}
          */
         void operationPrepared(OperationTransaction transaction, ModelNode result);
 

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -359,6 +359,11 @@ class ModelControllerImpl implements ModelController {
         // the result of the last active step in a composite operation
         final OperationTransactionControl originalResultTxControl = control == null ? null : new OperationTransactionControl() {
             @Override
+            public void operationPrepared(OperationTransaction transaction, ModelNode result, OperationContext context) {
+                control.operationPrepared(transaction, responseNode, context);
+            }
+
+            @Override
             public void operationPrepared(OperationTransaction transaction, ModelNode result) {
                 control.operationPrepared(transaction, responseNode);
             }

--- a/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
@@ -154,6 +154,16 @@ public class ProxyStepHandler implements OperationStepHandler {
 
                     @Override
                     public void operationPrepared(ModelController.OperationTransaction transaction, ModelNode response) {
+                        proxyControl.operationPrepared(transaction, transformResponse(response));
+                    }
+
+                    @Override
+                    public void operationPrepared(ModelController.OperationTransaction transaction, ModelNode response,
+                                                  OperationContext context1) {
+                        proxyControl.operationPrepared(transaction, transformResponse(response), context1);
+                    }
+
+                    private ModelNode transformResponse(ModelNode response) {
                         final ModelNode transformed;
                         // Check if we have to reject the operation
                         if(result.rejectOperation(response)) {
@@ -164,7 +174,7 @@ public class ProxyStepHandler implements OperationStepHandler {
                         } else {
                             transformed = response;
                         }
-                        proxyControl.operationPrepared(transaction, transformed);
+                        return transformed;
                     }
                 };
                 proxyController.execute(transformedOperation, messageHandler, transformingProxyControl,

--- a/controller/src/main/java/org/jboss/as/controller/remote/EarlyResponseSendListener.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/EarlyResponseSendListener.java
@@ -1,0 +1,47 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.controller.remote;
+
+import org.jboss.as.controller.OperationContext;
+
+/**
+ * Callback that can be provided to operation step handlers for operations like 'reload' and 'shutdown'
+ * where the response needs to be sent to the caller before the operation completes. The handler will
+ * invoke the callback when the operation has reached the point where it is safe to send the response.
+ * <p>
+ * No callback should be attached before the operation is committed.
+ *
+ * @author Brian Stansberry
+ */
+public interface EarlyResponseSendListener {
+    /**
+     * Key under which a listener would be
+     * {@link OperationContext#attach(OperationContext.AttachmentKey, Object) attached to an operation context}
+     * if notification that it's safe
+     */
+    OperationContext.AttachmentKey<EarlyResponseSendListener> ATTACHMENT_KEY = OperationContext.AttachmentKey.create(EarlyResponseSendListener.class);
+
+    /**
+     * Informs the management kernel that it is ok to send an early response to the operation.
+     * <strong>Note:</strong> It is valid for this method to be invoked multiple times for the same
+     * listener. It is the responsibility of the listener implementation to ensure that only one
+     * response is sent to the caller.
+     *
+     * @param resultAction the result of the operation for which an early response is being sent
+     */
+    void sendEarlyResponse(OperationContext.ResultAction resultAction);
+}

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/EarlyResponseTransactionControl.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/EarlyResponseTransactionControl.java
@@ -1,0 +1,74 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.domain.http.server;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELOAD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+import org.jboss.as.controller.ModelController;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.client.OperationResponse;
+import org.jboss.as.controller.remote.EarlyResponseSendListener;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * {@link org.jboss.as.controller.ModelController.OperationTransactionControl} that sends an
+ * early response (i.e. at operation prepared phase rather than operation completion) to the client.
+ *
+ * @author Brian Stansberry
+ */
+final class EarlyResponseTransactionControl implements ModelController.OperationTransactionControl {
+    private final ResponseCallback callback;
+    private final boolean reload;
+
+    EarlyResponseTransactionControl(ResponseCallback callback, ModelNode operation) {
+        this.callback = callback;
+        this.reload = RELOAD.equals(operation.get(OP).asString());
+    }
+
+    @Override
+    public void operationPrepared(ModelController.OperationTransaction transaction, ModelNode preparedResult) {
+        // Shouldn't be called but if it is, send the result immediately
+        operationPrepared(transaction, preparedResult, null);
+    }
+
+    @Override
+    public void operationPrepared(ModelController.OperationTransaction transaction, final ModelNode preparedResult, OperationContext context) {
+        transaction.commit();
+        if (context == null || !reload) { // TODO deal with shutdown as well, the handlers for which have some
+                                          // subtleties that need thought
+            sendResponse(preparedResult);
+        } else {
+            context.attach(EarlyResponseSendListener.ATTACHMENT_KEY, new EarlyResponseSendListener() {
+                @Override
+                public void sendEarlyResponse(OperationContext.ResultAction resultAction) {
+                    sendResponse(preparedResult);
+                }
+            });
+        }
+    }
+
+    private void sendResponse(ModelNode preparedResult) {
+        // Fix prepared result
+        preparedResult.get(OUTCOME).set(SUCCESS);
+        preparedResult.get(RESULT);
+        callback.sendResponse(OperationResponse.Factory.createSimple(preparedResult));
+    }
+}

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ResponseCallback.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ResponseCallback.java
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.domain.http.server;
+
+import org.jboss.as.controller.client.OperationResponse;
+
+/**
+ * Callback to prevent the response will be sent multiple times.
+ */
+abstract class ResponseCallback {
+    private volatile boolean complete;
+
+    void sendResponse(final OperationResponse response) {
+        if (complete) {
+            return;
+        }
+        complete = true;
+        doSendResponse(response);
+    }
+
+    abstract void doSendResponse(OperationResponse response);
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -48,7 +48,6 @@ import org.jboss.as.controller.ProcessType;
 import org.jboss.as.remoting.HttpListenerRegistryService;
 import org.jboss.as.remoting.management.ManagementRemotingServices;
 import org.jboss.as.server.BootstrapListener;
-import org.jboss.as.server.ExternalManagementRequestExecutor;
 import org.jboss.as.server.FutureServiceContainer;
 import org.jboss.as.server.Services;
 import org.jboss.as.server.logging.ServerLogger;
@@ -182,7 +181,6 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
                 .addDependency(EXECUTOR_CAPABILITY.getCapabilityServiceName(), ExecutorService.class, scheduledExecutorService.executorInjector)
                 .install();
 
-        ExternalManagementRequestExecutor.install(serviceTarget, threadGroup, EXECUTOR_CAPABILITY.getCapabilityServiceName());
 
         // Install required path services. (Only install those identified as required)
         HostPathManagerService hostPathManagerService = new HostPathManagerService(capabilityRegistry);
@@ -195,8 +193,10 @@ public class HostControllerService implements Service<AsyncFuture<ServiceContain
         serviceTarget.addService(Services.JBOSS_PRODUCT_CONFIG_SERVICE, new ValueService<ProductConfig>(productConfigValue))
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
+
         DomainModelControllerService.addService(serviceTarget, environment, runningModeControl, processState,
-                bootstrapListener, hostPathManagerService, capabilityRegistry);
+                bootstrapListener, hostPathManagerService, capabilityRegistry, threadGroup);
+
     }
 
     @Override

--- a/server/src/main/java/org/jboss/as/server/ExternalManagementRequestExecutor.java
+++ b/server/src/main/java/org/jboss/as/server/ExternalManagementRequestExecutor.java
@@ -32,6 +32,7 @@ import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StabilityMonitor;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
@@ -85,14 +86,15 @@ public class ExternalManagementRequestExecutor implements Service<ExecutorServic
     private final InjectedValue<ExecutorService> injectedExecutor = new InjectedValue<>();
     private final ThreadGroup threadGroup;
     private ExecutorService executorService;
-    private volatile StopContext stopContext;
 
     @SuppressWarnings("deprecation")
-    public static void install(ServiceTarget target, ThreadGroup threadGroup, ServiceName cleanupExecutor) {
+    public static void install(ServiceTarget target, ThreadGroup threadGroup, ServiceName cleanupExecutor,
+                               StabilityMonitor monitor) {
         final ExternalManagementRequestExecutor service = new ExternalManagementRequestExecutor(threadGroup);
-        target.addService(SERVICE_NAME, service)
+        ServiceController<?> controller = target.addService(SERVICE_NAME, service)
                 .addDependency(cleanupExecutor, ExecutorService.class, service.injectedExecutor)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND).install();
+        monitor.addController(controller);
     }
 
     private ExternalManagementRequestExecutor(ThreadGroup threadGroup) {

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -234,11 +234,13 @@ public final class ServerService extends AbstractControllerService {
                 .addAliases(JBOSS_SERVER_SCHEDULED_EXECUTOR)
                 .addDependency(MANAGEMENT_EXECUTOR, ExecutorService.class, serverScheduledExecutorService.executorInjector)
                 .install();
-        ExternalManagementRequestExecutor.install(serviceTarget, threadGroup, EXECUTOR_CAPABILITY.getCapabilityServiceName());
 
         final CapabilityRegistry capabilityRegistry = configuration.getCapabilityRegistry();
         ServerService service = new ServerService(configuration, processState, null, bootstrapListener, new ServerDelegatingResourceDefinition(),
                 runningModeControl, vaultReader, auditLogger, authorizer, securityIdentitySupplier, capabilityRegistry, suspendController);
+
+        ExternalManagementRequestExecutor.install(serviceTarget, threadGroup, EXECUTOR_CAPABILITY.getCapabilityServiceName(), service.getStabilityMonitor());
+
         ServiceBuilder<?> serviceBuilder = serviceTarget.addService(Services.JBOSS_SERVER_CONTROLLER, service);
         serviceBuilder.addDependency(DeploymentMountProvider.SERVICE_NAME,DeploymentMountProvider.class, service.injectedDeploymentRepository);
         serviceBuilder.addDependency(ContentRepository.SERVICE_NAME, ContentRepository.class, service.injectedContentRepository);


### PR DESCRIPTION
…esponse to the client rather than always sending it when the op is prepared

https://issues.jboss.org/browse/WFCORE-3597

Our remote request handlers for external end-user requests send the response to reload and shutdown early, at op preparation time instead of at completion time. This is needed so the response can go out before the services providing the connection to the client are closed. But preparation time is a bit too early. This commit allows the remote request handlers to attach an object to the OperationContext which the OSHs can use to signal when it's ok to send the response.

Currently used just for 'reload', which is the one where the too-early response is causing problems in the testsuite. Adding for shutdown will take a bit more thought.

The change looks fairly big to domain-http but that's because I factored out some common code between DomainApiHandler and DomainApiGenericOperationHandler.

This is built on top of the commit in #3121 as testing of this work resulted in the WFCORE-3624 issue appearing frequently. I've seen the WFCORE-3624 issue in other CI runs though, so that problem is not a result of this change.

Currently this is open just to get CI feedback. I'd want a lot of runs of this before merging.