### PR TITLE
WFCORE-3607 WFCORE-3606 [JDK9 & 10] marshalling upgrade & fixes

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/main/module.xml
@@ -30,5 +30,6 @@
     <dependencies>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.marshalling.river" services="import"/>
+        <module name="sun.jdk" />
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/river/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/marshalling/river/main/module.xml
@@ -33,5 +33,6 @@
 
     <dependencies>
         <module name="org.jboss.marshalling"/>
+        <module name="sun.jdk" />
     </dependencies>
 </module>

--- a/deployment-scanner/pom.xml
+++ b/deployment-scanner/pom.xml
@@ -155,6 +155,25 @@
                 <byteman.host>::1</byteman.host>
             </properties>
         </profile>
+        <profile>
+            <id>JDK9</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${version.compiler.plugin}</version>
+                        <configuration>
+                            <release>8</release>
+                        </configuration>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
         <version.org.jboss.logmanager.jboss-logmanager>2.0.9.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.4.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
-        <version.org.jboss.marshalling.jboss-marshalling>2.0.2.Final</version.org.jboss.marshalling.jboss-marshalling>
+        <version.org.jboss.marshalling.jboss-marshalling>2.0.3.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.7.0.Beta3</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.3.0.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.5.Final</version.org.jboss.remoting>


### PR DESCRIPTION
WFCORE-3607 [jdk10] upgrade jboss-marshalling to make remoting work on JDK10
WFCORE-3606 [jdk9+] use release=8 for compiling deployment scanner

With this jboss-marshalling upgrade our testsuite will start working on JDK10. which will allow us to see how well do we pass it.
Without this all remoting invocations are broken on JDK 10.

superceeds #3104