### PR TITLE
[WFCORE-3604] Attribute required-attributes of Elytron x500-attribute-principal-decoder cannot be added to configuration

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/PrincipalDecoderDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PrincipalDecoderDefinitions.java
@@ -188,14 +188,13 @@ class PrincipalDecoderDefinitions {
                 final boolean convert = CONVERT.resolveModelAttribute(context, model).asBoolean();
 
                 final List<String> requiredOids = REQUIRED_OIDS.unwrap(context, model);
-                List<String> list = new ArrayList<>();
+                final List<String> list = new ArrayList<>(requiredOids);
                 for (String name : REQUIRED_ATTRIBUTES.unwrap(context, model)) {
                     String s = OidsUtil.attributeNameToOid(OidsUtil.Category.RDN, name);
                     list.add(s);
                 }
-                requiredOids.addAll(list);
 
-                return () -> new X500AttributePrincipalDecoder(oid, joiner, startSegment, maximumSegments, reverse, convert, requiredOids.toArray(new String[requiredOids.size()]));
+                return () -> new X500AttributePrincipalDecoder(oid, joiner, startSegment, maximumSegments, reverse, convert, list.toArray(new String[list.size()]));
             }
 
         };

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/compare-mappers.xml
@@ -45,7 +45,7 @@
         <x500-attribute-principal-decoder name="X500PrincipalDecoderOne" oid="2.5.4.3" joiner="," maximum-segments="6" />
         <x500-attribute-principal-decoder name="X500PrincipalDecoderTwo" oid="2.5.4.3" joiner="." start-segment="2" maximum-segments="6" reverse="true" />
         <x500-attribute-principal-decoder name="X500PrincipalDecoderThree" oid="2.5.4.3" joiner="." start-segment="2" maximum-segments="6" reverse="true" convert="true" required-oids="2.5.4.3 2.5.4.11"/>
-
+        <x500-attribute-principal-decoder name="X500PrincipalDecoderFour" attribute-name="cn" required-attributes="cn"/>
         <aggregate-principal-transformer name="AggregateOne">
             <principal-transformer name="CustomOne" />
             <principal-transformer name="RegexOne" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/mappers.xml
@@ -45,7 +45,7 @@
         <x500-attribute-principal-decoder name="X500PrincipalDecoderOne" oid="2.5.4.3" joiner="," maximum-segments="6" />
         <x500-attribute-principal-decoder name="X500PrincipalDecoderTwo" oid="2.5.4.3" joiner="." start-segment="2" maximum-segments="6" reverse="true" />
         <x500-attribute-principal-decoder name="X500PrincipalDecoderThree" oid="2.5.4.3" joiner="." start-segment="2" maximum-segments="6" reverse="true" convert="true" required-oids="2.5.4.3 2.5.4.11"/>
-
+        <x500-attribute-principal-decoder name="X500PrincipalDecoderFour" attribute-name="cn" required-attributes="cn"/>
         <aggregate-principal-transformer name="AggregateOne">
             <principal-transformer name="CustomOne" />
             <principal-transformer name="RegexOne" />


### PR DESCRIPTION
REQUIRED_OIDS attribute unwrap returns an immutable array throwing an UnsupportedOperationException when new elements are added. This patch fixes this situation.

Jira issue: https://issues.jboss.org/browse/WFCORE-3604