### PR TITLE
WFCORE-3614 Only report on directly missing deps

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/ContainerStateMonitor.java
+++ b/controller/src/main/java/org/jboss/as/controller/ContainerStateMonitor.java
@@ -203,7 +203,7 @@ final class ContainerStateMonitor {
                 final ServiceName name = entry.getKey();
                 if (!previousMissing.contains(name)) {
                     ServiceController<?> controller = serviceRegistry.getService(name);
-                    boolean unavailable = controller != null;
+                    boolean unavailable = controller != null && controller.getMode() != ServiceController.Mode.NEVER;
                     missingServices.put(name, new MissingDependencyInfo(name, unavailable, entry.getValue()));
                 }
             }
@@ -241,13 +241,18 @@ final class ContainerStateMonitor {
 
         final StringBuilder msg = new StringBuilder();
         msg.append(forException ? ControllerLogger.ROOT_LOGGER.serviceStatusReportFailureHeader() : ControllerLogger.ROOT_LOGGER.serviceStatusReportHeader());
+        int transitiveDownCount = 0;
         if (!changeReport.getMissingServices().isEmpty()) {
-            msg.append(ControllerLogger.ROOT_LOGGER.serviceStatusReportDependencies());
+            boolean first = true;
             for (Map.Entry<ServiceName, MissingDependencyInfo> entry : changeReport.getMissingServices().entrySet()) {
                 if (!entry.getValue().isUnavailable()) {
+                    if(first) {
+                        msg.append(ControllerLogger.ROOT_LOGGER.serviceStatusReportDependencies());
+                        first = false;
+                    }
                     msg.append(ControllerLogger.ROOT_LOGGER.serviceStatusReportMissing(entry.getKey(), createDependentsString(entry.getValue().getDependents())));
                 } else {
-                    msg.append(ControllerLogger.ROOT_LOGGER.serviceStatusReportUnavailable(entry.getKey(), createDependentsString(entry.getValue().getDependents())));
+                    transitiveDownCount++;
                 }
             }
         }
@@ -280,6 +285,9 @@ final class ContainerStateMonitor {
                 }
                 msg.append('\n');
             }
+        }
+        if(transitiveDownCount > 0) {
+            msg.append(ControllerLogger.ROOT_LOGGER.servicesWithTransitiveUnavailability(transitiveDownCount));
         }
         return msg.toString();
     }
@@ -394,7 +402,7 @@ final class ContainerStateMonitor {
         }
 
         /**
-         * Gets whether the service that was missing dependencies was still installed when this report was created.
+         * Gets whether the service that was missing dependencies was still installed and has a mode that will allow it to start when this report was created.
          * Note that "installed" does not mean "started."
          *
          * @return {@code true} if the service was still installed.

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -2099,16 +2099,6 @@ public interface ControllerLogger extends BasicLogger {
     String serviceStatusReportMissing(ServiceName serviceName, String dependents);
 
     /**
-     * A message for the service status report for unavailable dependencies.
-     *
-     * @param serviceName the name of the service
-     *
-     * @return the message.
-     */
-    @Message(id = Message.NONE, value = "      %s (unavailable) dependents: %s %n")
-    String serviceStatusReportUnavailable(ServiceName serviceName, String dependents);
-
-    /**
      * A message for the service status report indicating new corrected service.
      *
      * @return the message.
@@ -3518,4 +3508,16 @@ public interface ControllerLogger extends BasicLogger {
             "or itself configures a requirement for a capability provided by another part of the configuration. " +
             "Full support for this kind of configuration cannot be provided when an expression is used.")
     void attributeExpressionDeprecated(String name, String address);
+
+
+    /**
+     * A message for the service status report for unavailable dependencies.
+     *
+     * @param count The number of missing services
+     *
+     * @return the message.
+     */
+    @Message(id = 448, value = "%s additional services are down due to their dependencies being missing or failed")
+    String servicesWithTransitiveUnavailability(int count);
+
 }


### PR DESCRIPTION
This changes the error reporting on failure to only report on services
that are missing direct dependencies. Services which did not start
due to indirect problems are no longer reported.