### PR TITLE
[WFCORE-3619] Standard configs should not include an empty endpoint e…

### DIFF
--- a/remoting/subsystem/src/main/resources/subsystem-templates/remoting.xml
+++ b/remoting/subsystem/src/main/resources/subsystem-templates/remoting.xml
@@ -3,7 +3,6 @@
 <config>
    <extension-module>org.jboss.as.remoting</extension-module>
    <subsystem xmlns="urn:jboss:domain:remoting:4.0">
-       <endpoint/>
        <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
    </subsystem>
 </config>


### PR DESCRIPTION
…lement in remoting subsystem as we will not persist that

https://issues.jboss.org/browse/WFCORE-3619

The "endpoint" element represents an attribute group, and we do not persist empty elements for attribute groups that don't have any member attributes defined.