### PR TITLE
[WFCORE-3579] LocalClient should establish an AccessAuditContext for …

### DIFF
--- a/core-security/implementation/src/main/java/org/jboss/as/core/security/AccessMechanism.java
+++ b/core-security/implementation/src/main/java/org/jboss/as/core/security/AccessMechanism.java
@@ -39,5 +39,11 @@ public enum AccessMechanism {
     /**
      * The request was submitted over JMX and subsequently converted to a management operation.
      */
-    JMX
+    JMX,
+    /**
+     * The request was submitted by an in-vm client on behalf of a user. For example, the server is embedded
+     * and the user is using a {@code LocalModelControllerClient}.  An in-vm client not performing operations
+     * on behalf of a user (e.g. a client used by the deployment-scanner) will not have this mechanism set.
+     */
+    IN_VM_USER
 }


### PR DESCRIPTION
…all user calls (but only for user calls)

https://issues.jboss.org/browse/WFCORE-3579

This updates the client used by in-vm callers, including the offline CLI, to establish an AccessAuditContext when the client is for end user use (as opposed to internal functions like the deployment-scanner and the content repository cleaner.) A check for an AccessAuditContext is the basis of the WFCORE-184 fix that prevents end users being able to invoke ops while boot is in progress. Preventing that is the fix for the specific problem reported in the JIRA. 

Mergers: Please talk with me before merging.  