### PR TITLE
Fix for WFCORE-3640, CLI output swallowed with script + prompting

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/ReadlineConsole.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ReadlineConsole.java
@@ -680,10 +680,12 @@ public class ReadlineConsole {
     }
 
     public String readLine(Prompt prompt, Completion completer) throws InterruptedException, IOException {
-        // If there are some output collected, flush it.
-        printCollectedOutput();
-        // New collector
-        outputCollector = createCollector();
+        if (started) {
+            // If there are some output collected, flush it.
+            printCollectedOutput();
+            // New collector
+            outputCollector = createCollector();
+        }
 
         // Keep a reference on the caller thread in case Ctrl-C is pressed
         // and thread needs to be interrupted.


### PR DESCRIPTION
Check that the console is started prior to reset collected output.
Manual testing of the fix.
