### PR TITLE
Fix for WFCORE-3637, upgrade to aesh-readline 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.fusesource.jansi>1.16</version.org.fusesource.jansi>
         <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
-        <version.org.aesh-readline>1.3</version.org.aesh-readline>
+        <version.org.aesh-readline>1.5</version.org.aesh-readline>
         <version.org.jboss.byteman>3.0.9</version.org.jboss.byteman>
         <version.org.aesh>1.0</version.org.aesh>
         <version.org.aesh-extensions>1.0</version.org.aesh-extensions>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-3637
Although we observe 1% failure, the highlighted problem when run manually occurs much more often.
