### PR TITLE
[WFCORE-3641] Upgrading JBoss MSC to 1.3.1.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.4.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.3.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.7.0.Final</version.org.jboss.modules.jboss-modules>
-        <version.org.jboss.msc.jboss-msc>1.3.0.Final</version.org.jboss.msc.jboss-msc>
+        <version.org.jboss.msc.jboss-msc>1.3.2.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.5.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.0.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>


### PR DESCRIPTION
This upgrade brings in [MSC-204] fixes for container shutdown
freeze regressions. See [WFCORE-3590] for more information.