### PR TITLE
Revert "[WFCORE-3522] Partial workaround: allow user services to take precedence for JAX-RS client builders"

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/ModuleSpecProcessor.java
@@ -48,7 +48,6 @@ import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.modules.ModuleSpec;
 import org.jboss.modules.ResourceLoaderSpec;
-import org.jboss.modules.filter.ClassFilters;
 import org.jboss.modules.filter.MultiplePathFilterBuilder;
 import org.jboss.modules.filter.PathFilter;
 import org.jboss.modules.filter.PathFilters;
@@ -207,26 +206,6 @@ public class ModuleSpecProcessor implements DeploymentUnitProcessor {
         DEFAULT_PERMISSIONS = permissions;
     }
 
-    private static final PathFilter JAXRS_CLIENT_BUILDER_FILTER = PathFilters.is("META-INF/services/javax.ws.rs.client.ClientBuilder");
-
-    private static final DependencySpec ONLY_JAXRS_CLIENT_BUILDER_DEP = DependencySpec.createLocalDependencySpec(
-        PathFilters.getMetaInfServicesFilter(),
-        PathFilters.acceptAll(),
-        JAXRS_CLIENT_BUILDER_FILTER,
-        PathFilters.rejectAll(),
-        ClassFilters.rejectAll(),
-        ClassFilters.rejectAll()
-    );
-
-    private static final DependencySpec NOT_JAXRS_CLIENT_BUILDER_DEP = DependencySpec.createLocalDependencySpec(
-        PathFilters.acceptAll(),
-        PathFilters.acceptAll(),
-        PathFilters.not(JAXRS_CLIENT_BUILDER_FILTER),
-        PathFilters.acceptAll(),
-        ClassFilters.acceptAll(),
-        ClassFilters.acceptAll()
-    );
-
     private ServiceName createModuleService(final DeploymentPhaseContext phaseContext, final DeploymentUnit deploymentUnit,
                                             final List<ResourceRoot> resourceRoots, final List<ResourceRoot> parentResourceRoots,
                                             final ModuleSpecification moduleSpecification, final ModuleIdentifier moduleIdentifier) throws DeploymentUnitProcessingException {
@@ -254,16 +233,14 @@ public class ModuleSpecProcessor implements DeploymentUnitProcessor {
             addResourceRoot(specBuilder, resourceRoot, permFactories);
         }
 
-        specBuilder.addDependency(ONLY_JAXRS_CLIENT_BUILDER_DEP);
-
         createDependencies(specBuilder, dependencies, false);
         createDependencies(specBuilder, userDependencies, false);
 
         if (moduleSpecification.isLocalLast()) {
             createDependencies(specBuilder, localDependencies, moduleSpecification.isLocalDependenciesTransitive());
-            specBuilder.addDependency(NOT_JAXRS_CLIENT_BUILDER_DEP);
+            specBuilder.addDependency(DependencySpec.createLocalDependencySpec());
         } else {
-            specBuilder.addDependency(NOT_JAXRS_CLIENT_BUILDER_DEP);
+            specBuilder.addDependency(DependencySpec.createLocalDependencySpec());
             createDependencies(specBuilder, localDependencies, moduleSpecification.isLocalDependenciesTransitive());
         }
 


### PR DESCRIPTION
Reverts wildfly/wildfly-core#3082

https://issues.jboss.org/browse/WFCORE-3522

This is causing issues with module linking where service loaders are being discovered twice for EAR deployments.