### PR TITLE
[WFCORE-3646] Improve reload handling in WildFly Core test runner

### DIFF
--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -354,8 +354,6 @@ public class Server {
             if (!(cause instanceof ExecutionException) && !(cause instanceof CancellationException) && !(cause instanceof SocketException) ) {
                 throw new RuntimeException(e);
             } // else ignore, this might happen if the channel gets closed before we got the response
-        }finally {
-            safeCloseClient();//close existing client
         }
     }
 
@@ -371,6 +369,10 @@ public class Server {
         operation.get(OP).set(READ_ATTRIBUTE_OPERATION);
         operation.get(NAME).set("server-state");
         while (System.currentTimeMillis() - start < timeout) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
             recreateClient();
             ModelControllerClient liveClient = client.getControllerClient();
             try {
@@ -379,10 +381,6 @@ public class Server {
                     return;
                 }
             } catch (IOException e) {
-            }
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
             }
 
         }


### PR DESCRIPTION
1) Don't close client immediately after reload; it's redundant as it's closed again when checking for running status and doing it so quickly risks interrupting the reload in progress
2) Delay 100 ms before the first status check. It takes at least that long to do a reload anyway. This aligns behavior with the ServerReload util.

https://issues.jboss.org/browse/WFCORE-3646