### PR TITLE
Fix for WFCORE-3649. CLI, --replace advertised for legacy command

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
@@ -85,6 +85,8 @@ public class DeployHandler extends DeploymentHandler {
 
     private static final String ALL = "*";
 
+    private static final String REPLACE_OPTION = "force";
+
     public DeployHandler(CommandContext ctx) {
         super(ctx, "deploy", true);
 
@@ -331,7 +333,7 @@ public class DeployHandler extends DeploymentHandler {
                 command.script = this.script.getValue(args);
                 c = command;
             } else {
-                DeployFileCommand command = new DeployFileCommand(ctx);
+                DeployFileCommand command = new DeployFileCommand(ctx, REPLACE_OPTION);
                 command.allServerGroups = allServerGroups;
                 command.disabled = disabled;
                 command.enabled = enabled;
@@ -357,7 +359,7 @@ public class DeployHandler extends DeploymentHandler {
                 throw new CommandLineException("Filesystem path and --url can't be "
                         + "used together.");
             }
-            DeployUrlCommand command = new DeployUrlCommand(ctx);
+            DeployUrlCommand command = new DeployUrlCommand(ctx, REPLACE_OPTION);
             command.allServerGroups = allServerGroups;
             command.disabled = disabled;
             command.enabled = enabled;
@@ -442,7 +444,7 @@ public class DeployHandler extends DeploymentHandler {
                 command.script = this.script.getValue(args);
                 c = command;
             } else {
-                DeployFileCommand command = new DeployFileCommand(ctx);
+                DeployFileCommand command = new DeployFileCommand(ctx, REPLACE_OPTION);
                 command.allServerGroups = allServerGroups;
                 command.disabled = disabled;
                 command.enabled = enabled;
@@ -463,7 +465,7 @@ public class DeployHandler extends DeploymentHandler {
                 throw new CommandFormatException("Filesystem path and --url can't be "
                         + "used together.");
             }
-            DeployUrlCommand command = new DeployUrlCommand(ctx);
+            DeployUrlCommand command = new DeployUrlCommand(ctx, REPLACE_OPTION);
             command.allServerGroups = allServerGroups;
             command.disabled = disabled;
             command.enabled = enabled;

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/AbstractDeployContentCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/AbstractDeployContentCommand.java
@@ -64,14 +64,27 @@ public abstract class AbstractDeployContentCommand extends AbstractDeployCommand
             = RuntimeNameActivator.class)
     public String runtimeName;
 
+    private final String legacyReplaceName;
+
     AbstractDeployContentCommand(CommandContext ctx,
             Permissions permissions) {
         super(ctx, AccessRequirements.deployContentAccess(permissions), permissions);
+        legacyReplaceName = null;
+    }
+
+    AbstractDeployContentCommand(CommandContext ctx,
+            Permissions permissions, String legacyReplaceName) {
+        super(ctx, AccessRequirements.deployContentAccess(permissions), permissions);
+        this.legacyReplaceName = legacyReplaceName;
     }
 
     protected abstract void checkArgument() throws CommandException;
 
     protected abstract String getCommandName();
+
+    private String getReplaceOptionName() {
+        return legacyReplaceName == null ? "--replace" : "--"+legacyReplaceName;
+    }
 
     @Override
     public CommandResult execute(CLICommandInvocation commandInvocation)
@@ -158,7 +171,7 @@ public abstract class AbstractDeployContentCommand extends AbstractDeployCommand
         if (replace) {
             if (((disabled || enabled) && ctx.isDomainMode()) || serverGroups != null
                     || allServerGroups) {
-                throw new CommandFormatException("--replace only replaces the content "
+                throw new CommandFormatException("--" + getReplaceOptionName() + " only replaces the content "
                         + "in the deployment repository and can't be used in combination with any of "
                         + "--enabled, --disabled, --server-groups or --all-server-groups.");
             }
@@ -188,7 +201,7 @@ public abstract class AbstractDeployContentCommand extends AbstractDeployCommand
             if (!ctx.isBatchMode() && Util.isDeploymentInRepository(name,
                     ctx.getModelControllerClient())) {
                 throw new CommandFormatException("'" + name + "' already exists "
-                        + "in the deployment repository (use --replace"
+                        + "in the deployment repository (use  "+ getReplaceOptionName()
                         + " to replace the existing content in the repository).");
             }
 
@@ -246,8 +259,8 @@ public abstract class AbstractDeployContentCommand extends AbstractDeployCommand
         if (!ctx.isBatchMode() && Util.isDeploymentInRepository(getName(),
                 ctx.getModelControllerClient())) {
             throw new CommandFormatException("'" + getName() + "' already exists in "
-                    + "the deployment repository (use "
-                    + "--replace to replace the existing content in the repository).");
+                    + "the deployment repository (use " + getReplaceOptionName()
+                    + " to replace the existing content in the repository).");
         }
 
         ModelNode request = buildDeploymentRequest(ctx, Util.ADD);

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/DeployFileCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/DeployFileCommand.java
@@ -61,8 +61,8 @@ public class DeployFileCommand extends AbstractDeployContentCommand {
     }
 
     @Deprecated
-    public DeployFileCommand(CommandContext ctx) {
-        this(ctx, null);
+    public DeployFileCommand(CommandContext ctx, String replaceName) {
+        super(ctx, null, replaceName);
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/DeployUrlCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/deployment/DeployUrlCommand.java
@@ -70,8 +70,8 @@ public class DeployUrlCommand extends AbstractDeployContentCommand {
     }
 
     @Deprecated
-    public DeployUrlCommand(CommandContext ctx) {
-        this(ctx, null);
+    public DeployUrlCommand(CommandContext ctx, String replaceName) {
+        super(ctx, null, replaceName);
     }
 
     @Override


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-3649

The wrong option is advertised by the error message. In case of legacy deploy command it must be --force instead of --replace.
Done manual testing of the error case.
