### PR TITLE
[WFCORE-3656] Replace commons-logging implementation.

### DIFF
--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -152,8 +152,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
 
         <dependency>

--- a/core-feature-pack/src/license/core-feature-pack-licenses.xml
+++ b/core-feature-pack/src/license/core-feature-pack-licenses.xml
@@ -166,8 +166,8 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>org.jboss.logmanager</groupId>
-      <artifactId>commons-logging-jboss-logmanager</artifactId>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>commons-logging-jboss-logging</artifactId>
       <licenses>
         <license>
           <name>Apache License 2.0</name>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/commons/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/commons/logging/main/module.xml
@@ -23,8 +23,8 @@
     </properties>
 
     <dependencies>
-        <!-- This allows the org.jboss.logmanager.commons.logging module to be private while keeping this module public -->
-        <module name="org.jboss.logmanager.commons.logging" export="true"/>
+        <!-- This allows the org.jboss.logging.commons.logging module to be private while keeping this module public -->
+        <module name="org.jboss.logging.commons.logging" export="true"/>
     </dependencies>
 </module>
 

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logging/commons/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/logging/commons/logging/main/module.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright 2016 Red Hat, Inc.
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~     http://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,18 +19,18 @@
   ~ limitations under the License.
   -->
 
-<module xmlns="urn:jboss:module:1.6" name="org.jboss.logmanager.commons.logging" version="${org.jboss.logmanager:commons-logging-jboss-logmanager}">
+<module xmlns="urn:jboss:module:1.7" name="org.jboss.logging.commons.logging" version="${org.jboss.logging:commons-logging-jboss-logging}">
 
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${org.jboss.logmanager:commons-logging-jboss-logmanager}"/>
+        <artifact name="${org.jboss.logging:commons-logging-jboss-logging}"/>
     </resources>
 
     <dependencies>
-        <module name="org.jboss.logmanager"/>
+        <module name="org.jboss.logging"/>
     </dependencies>
 </module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <version.org.jboss.jboss-vfs>3.2.12.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.3.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
+        <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Beta1</version.org.jboss.logging.commons-logging-jboss-logging>
         <version.org.jboss.logmanager.jboss-logmanager>2.0.9.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.4.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.4.Final</version.org.jboss.marshalling.jboss-marshalling>
@@ -1209,9 +1209,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.jboss.logmanager</groupId>
-                <artifactId>commons-logging-jboss-logmanager</artifactId>
-                <version>${version.org.jboss.logmanager.commons-logging-jboss-logmanager}</version>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>commons-logging-jboss-logging</artifactId>
+                <version>${version.org.jboss.logging.commons-logging-jboss-logging}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -83,8 +83,8 @@
             <artifactId>jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>commons-logging-jboss-logmanager</artifactId>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/AbstractLoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/AbstractLoggingProfilesTestCase.java
@@ -1,0 +1,330 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.logging.profiles;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
+import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.core.testrunner.ManagementClient;
+
+/**
+ * @author Petr Křemenský <pkremens@redhat.com>
+ */
+abstract class AbstractLoggingProfilesTestCase extends AbstractLoggingTestCase {
+
+    private static final String PROFILE1 = "dummy-profile1";
+    private static final String PROFILE2 = "dummy-profile2";
+    private static final String RUNTIME_NAME1 = "logging1.jar";
+    private static final String RUNTIME_NAME2 = "logging2.jar";
+
+    private static final String LOG_FILE_NAME = "profiles-test.log";
+    private static final String PROFILE1_LOG_NAME = "dummy-profile1.log";
+    private static final String PROFILE2_LOG_NAME = "dummy-profile2.log";
+    private static final String CHANGED_LOG_NAME = "dummy-profile1-changed.log";
+    private static final String LOG_DIR = resolveRelativePath("jboss.server.log.dir");
+    private static final Path logFile = Paths.get(LOG_DIR, LOG_FILE_NAME);
+    private static final Path dummyLog1 = Paths.get(LOG_DIR, PROFILE1_LOG_NAME);
+    private static final Path dummyLog2 = Paths.get(LOG_DIR, PROFILE2_LOG_NAME);
+    private static final Path dummyLog1Changed = Paths.get(LOG_DIR, CHANGED_LOG_NAME);
+
+    private final Class<? extends ServiceActivator> serviceActivator;
+    private final int profile1LogCount;
+
+    protected AbstractLoggingProfilesTestCase(final Class<? extends ServiceActivator> serviceActivator, final int profile1LogCount) {
+        this.serviceActivator = serviceActivator;
+        this.profile1LogCount = profile1LogCount;
+    }
+
+    static class LoggingProfilesTestCaseSetup extends ServerReload.SetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient) throws Exception {
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            ModelNode op = Operations.createAddOperation(createAddress("periodic-rotating-file-handler", "LOGGING_TEST"));
+            op.get("append").set("true");
+            op.get("suffix").set(".yyyy-MM-dd");
+            ModelNode file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(LOG_FILE_NAME);
+            op.get("file").set(file);
+            op.get("formatter").set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n");
+            builder.addStep(op);
+
+            op = Operations.createOperation("add-handler", createAddress("root-logger", "ROOT"));
+            op.get("name").set("LOGGING_TEST");
+            builder.addStep(op);
+
+            // create dummy-profile1
+            builder.addStep(Operations.createAddOperation(createAddress("logging-profile", "dummy-profile1")));
+
+            // add file handler
+            op = Operations.createAddOperation(createAddress("logging-profile", "dummy-profile1", "periodic-rotating-file-handler", "DUMMY1"));
+            op.get("level").set("ERROR");
+            op.get("append").set("true");
+            op.get("suffix").set(".yyyy-MM-dd");
+            file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(PROFILE1_LOG_NAME);
+            op.get("file").set(file);
+            op.get("formatter").set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n");
+            builder.addStep(op);
+
+            // add root logger
+            op = Operations.createAddOperation(createAddress("logging-profile", "dummy-profile1", "root-logger", "ROOT"));
+            op.get("level").set("INFO");
+            ModelNode handlers = op.get("handlers");
+            handlers.add("DUMMY1");
+            op.get("handlers").set(handlers);
+            builder.addStep(op);
+
+            // create dummy-profile2
+            builder.addStep(Operations.createAddOperation(createAddress("logging-profile", "dummy-profile2")));
+
+            // add file handler
+            op = Operations.createAddOperation(createAddress("logging-profile", "dummy-profile2", "periodic-rotating-file-handler", "DUMMY2"));
+            op.get("level").set("INFO");
+            op.get("append").set("true");
+            op.get("suffix").set(".yyyy-MM-dd");
+            file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(PROFILE2_LOG_NAME);
+            op.get("file").set(file);
+            op.get("formatter").set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n");
+            builder.addStep(op);
+
+            // add root logger
+            op = Operations.createAddOperation(createAddress("logging-profile", "dummy-profile2", "root-logger", "ROOT"));
+            op.get("level").set("INFO");
+            handlers = op.get("handlers");
+            handlers.add("DUMMY2");
+            op.get("handlers").set(handlers);
+            builder.addStep(op);
+
+            executeOperation(builder.build());
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient) throws Exception {
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            // remove LOGGING_TEST from root-logger
+            ModelNode op = Operations.createOperation("remove-handler", createAddress("root-logger", "ROOT"));
+            op.get("name").set("LOGGING_TEST");
+            builder.addStep(op);
+
+            // remove custom file handler
+            builder.addStep(Operations.createRemoveOperation(createAddress("periodic-rotating-file-handler", "LOGGING_TEST")));
+
+            // remove dummy-profile1
+            builder.addStep(Operations.createRemoveOperation(createAddress("logging-profile", "dummy-profile1")));
+
+            // remove dummy-profile2
+            builder.addStep(Operations.createRemoveOperation(createAddress("logging-profile", "dummy-profile2")));
+
+            executeOperation(builder.build());
+
+            // delete log files only if this did not fail
+            Files.deleteIfExists(logFile);
+            Files.deleteIfExists(dummyLog1);
+            Files.deleteIfExists(dummyLog2);
+            Files.deleteIfExists(dummyLog1Changed);
+
+            super.tearDown(client);
+        }
+    }
+
+    @Test
+    public void noWarningTest() throws Exception {
+        try {
+            deploy(RUNTIME_NAME1, PROFILE1, false);
+            deploy(RUNTIME_NAME2, PROFILE2, false);
+            try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    // Look for message id in order to support all languages.
+                    if (line.contains(PROFILE1) || line.contains(PROFILE2)) {
+                        Assert.fail("Every deployment should have defined its own logging profile. But found this line in logs: "
+                                + line);
+                    }
+                }
+            }
+        } finally {
+            undeploy(RUNTIME_NAME1, RUNTIME_NAME2);
+        }
+    }
+
+    @Test
+    public void testProfiles() throws Exception {
+        // Test the first profile
+        try {
+            deploy(RUNTIME_NAME1, PROFILE1);
+            // make some logs
+            int statusCode = getResponse("DummyProfile1: Test log message from 1");
+            assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        } finally {
+            undeploy(RUNTIME_NAME1);
+        }
+
+        // Test the next profile
+        try {
+            deploy(RUNTIME_NAME2, PROFILE2);
+            // make some logs
+            int statusCode = getResponse("DummyProfile2: Test log message from 2");
+            assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+        } finally {
+            undeploy(RUNTIME_NAME2);
+        }
+
+        // Check that only one log record is in the first file
+        Assert.assertTrue("dummy-profile1.log was not created", Files.exists(dummyLog1));
+        try (final BufferedReader reader = Files.newBufferedReader(dummyLog1, StandardCharsets.UTF_8)) {
+            String line = reader.readLine();
+            Assert.assertNotNull("Log file dummy-profile1.log is empty and should not be.", line);
+            Assert.assertTrue(
+                    "\"LoggingServlet is logging error message\" should be presented in dummy-profile1.log",
+                    line.contains("DummyProfile1: Test log message from 1"));
+            // Read lines until we expect no more
+            for (int i = 1; i < profile1LogCount; i++) {
+                Assert.assertNotNull(String.format("Expected %d log records but only got %d", profile1LogCount, i)
+                        , reader.readLine());
+            }
+            Assert.assertTrue("Only " + profile1LogCount + " log should be found in dummy-profile1.log",
+                    reader.readLine() == null);
+        }
+
+        // Check that only one log record is in the second file
+        Assert.assertTrue("dummy-profile2.log was not created", Files.exists(dummyLog2));
+        try (final BufferedReader reader = Files.newBufferedReader(dummyLog2, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                // The UndertowService also logs one line, this line should be ignored
+                if (line.contains("UndertowService")) continue;
+                if (!line.contains("DummyProfile2: Test log message from 2")) {
+                    Assert.fail("dummy-profile2 should not contains this line: "
+                            + line);
+                }
+            }
+        }
+
+        // Check a file that should not have been written to
+        try (final BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.contains("Test log message from")) {
+                    Assert.fail("LoggingServlet messages should be presented only in files specified in profiles, but found: "
+                            + line);
+                }
+            }
+        }
+
+        // Change the file for the first profile
+        try {
+            deploy(RUNTIME_NAME1, PROFILE1);
+            // Change logging level of file handler on dummy-profile1 from ERROR to
+            // INFO
+            final ModelNode address = createAddress("logging-profile", PROFILE1, "periodic-rotating-file-handler", "DUMMY1");
+            final ModelNode file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(CHANGED_LOG_NAME);
+            ModelNode op = Operations.createWriteAttributeOperation(address, "file", file);
+            executeOperation(op);
+
+            // make some logs
+            int statusCode = getResponse("DummyProfile1: Changed test message 1");
+            assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+
+            // check logs, after logging level change we should see also INFO and
+            // ... messages
+            try (final BufferedReader reader = Files.newBufferedReader(dummyLog1Changed, StandardCharsets.UTF_8)) {
+                String line = reader.readLine();
+                Assert.assertNotNull("Log file " + CHANGED_LOG_NAME + " is empty and should not be.", line);
+                Assert.assertTrue(
+                        "\"LoggingServlet is logging error message\" should be presented in " + CHANGED_LOG_NAME,
+                        line.contains("DummyProfile1: Changed test message 1"));
+                // Read lines until we expect no more
+                for (int i = 1; i < profile1LogCount; i++) {
+                    Assert.assertNotNull(String.format("Expected %d log records but only got %d", profile1LogCount, i)
+                            , reader.readLine());
+                }
+                Assert.assertNull("Only " + profile1LogCount + " log should be found in " + CHANGED_LOG_NAME, reader.readLine());
+            }
+        } finally {
+            undeploy(RUNTIME_NAME1);
+        }
+    }
+
+    @Test
+    public void testDeploymentConfigurationResource() throws Exception {
+        try {
+            deploy(RUNTIME_NAME1, PROFILE1);
+            // Get the resulting model
+            final ModelNode loggingConfiguration = readDeploymentResource(RUNTIME_NAME1, "profile-" + PROFILE1);
+
+            Assert.assertTrue("No logging subsystem resource found on the deployment", loggingConfiguration.isDefined());
+
+            // Check the handler exists on the configuration
+            final ModelNode handler = loggingConfiguration.get("handler", "DUMMY1");
+            Assert.assertTrue("The DUMMY1 handler was not found effective configuration", handler.isDefined());
+            Assert.assertEquals("The level should be ERROR", "ERROR", handler.get("level").asString());
+        } finally {
+            undeploy(RUNTIME_NAME1);
+        }
+    }
+
+    private void deploy(final String name, final String profileName) throws IOException {
+        deploy(name, profileName, true);
+    }
+
+    private void deploy(final String name, final String profileName, final boolean useServiceActivator) throws IOException {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, name);
+        if (useServiceActivator) {
+            archive.addClasses(LoggingServiceActivator.DEPENDENCIES);
+            archive.addAsServiceProviderAndClasses(ServiceActivator.class, serviceActivator);
+        }
+        archive.addAsResource(new StringAsset("Dependencies: io.undertow.core\nLogging-Profile: " + profileName), "META-INF/MANIFEST.MF");
+        addPermissions(archive);
+        deploy(archive, name);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/CommonsLoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/CommonsLoggingProfilesTestCase.java
@@ -19,7 +19,6 @@
 
 package org.jboss.as.test.integration.logging.profiles;
 
-import org.jboss.as.test.integration.logging.LoggingServiceActivator;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
@@ -29,9 +28,9 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  */
 @RunWith(WildflyTestRunner.class)
 @ServerSetup(AbstractLoggingProfilesTestCase.LoggingProfilesTestCaseSetup.class)
-public class LoggingProfilesTestCase extends AbstractLoggingProfilesTestCase {
+public class CommonsLoggingProfilesTestCase extends AbstractLoggingProfilesTestCase {
 
-    public LoggingProfilesTestCase() {
-        super(LoggingServiceActivator.class, 2);
+    public CommonsLoggingProfilesTestCase() {
+        super(CommonsLoggingServiceActivator.class, 2);
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/CommonsLoggingServiceActivator.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/CommonsLoggingServiceActivator.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.logging.profiles;
+
+import java.util.Deque;
+import java.util.Map;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wildfly.test.undertow.UndertowServiceActivator;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class CommonsLoggingServiceActivator extends UndertowServiceActivator {
+    public static final String DEFAULT_MESSAGE = "Default log message";
+    private static final Log LOGGER = LogFactory.getLog(CommonsLoggingServiceActivator.class);
+
+    @Override
+    protected HttpHandler getHttpHandler() {
+        return new HttpHandler() {
+            @Override
+            public void handleRequest(final HttpServerExchange exchange) {
+                final Map<String, Deque<String>> params = exchange.getQueryParameters();
+                String msg = DEFAULT_MESSAGE;
+                if (params.containsKey("msg")) {
+                    msg = getFirstValue(params, "msg");
+                }
+                // Log all levels
+                LOGGER.trace(msg);
+                LOGGER.debug(msg);
+                LOGGER.info(msg);
+                LOGGER.warn(msg);
+                LOGGER.error(msg);
+                LOGGER.fatal(msg);
+                exchange.getResponseSender().send("Response sent");
+            }
+        };
+    }
+
+    private String getFirstValue(final Map<String, Deque<String>> params, final String key) {
+        if (params.containsKey(key)) {
+            final Deque<String> values = params.get(key);
+            if (values != null && !values.isEmpty()) {
+                return values.getFirst();
+            }
+        }
+        return null;
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Log4jLoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Log4jLoggingProfilesTestCase.java
@@ -19,7 +19,7 @@
 
 package org.jboss.as.test.integration.logging.profiles;
 
-import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.as.test.integration.logging.Log4jServiceActivator;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
@@ -29,9 +29,9 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  */
 @RunWith(WildflyTestRunner.class)
 @ServerSetup(AbstractLoggingProfilesTestCase.LoggingProfilesTestCaseSetup.class)
-public class LoggingProfilesTestCase extends AbstractLoggingProfilesTestCase {
+public class Log4jLoggingProfilesTestCase extends AbstractLoggingProfilesTestCase {
 
-    public LoggingProfilesTestCase() {
-        super(LoggingServiceActivator.class, 2);
+    public Log4jLoggingProfilesTestCase() {
+        super(Log4jServiceActivator.class, 2);
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Slf4jLoggingProfilesTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Slf4jLoggingProfilesTestCase.java
@@ -19,7 +19,6 @@
 
 package org.jboss.as.test.integration.logging.profiles;
 
-import org.jboss.as.test.integration.logging.LoggingServiceActivator;
 import org.junit.runner.RunWith;
 import org.wildfly.core.testrunner.ServerSetup;
 import org.wildfly.core.testrunner.WildflyTestRunner;
@@ -29,9 +28,9 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
  */
 @RunWith(WildflyTestRunner.class)
 @ServerSetup(AbstractLoggingProfilesTestCase.LoggingProfilesTestCaseSetup.class)
-public class LoggingProfilesTestCase extends AbstractLoggingProfilesTestCase {
+public class Slf4jLoggingProfilesTestCase extends AbstractLoggingProfilesTestCase {
 
-    public LoggingProfilesTestCase() {
-        super(LoggingServiceActivator.class, 2);
+    public Slf4jLoggingProfilesTestCase() {
+        super(Slf4jServiceActivator.class, 1);
     }
 }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Slf4jServiceActivator.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/profiles/Slf4jServiceActivator.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.logging.profiles;
+
+import java.util.Deque;
+import java.util.Map;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wildfly.test.undertow.UndertowServiceActivator;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Slf4jServiceActivator extends UndertowServiceActivator {
+    public static final String DEFAULT_MESSAGE = "Default log message";
+    private static final Logger LOGGER = LoggerFactory.getLogger(Slf4jServiceActivator.class);
+
+    @Override
+    protected HttpHandler getHttpHandler() {
+        return new HttpHandler() {
+            @Override
+            public void handleRequest(final HttpServerExchange exchange) {
+                final Map<String, Deque<String>> params = exchange.getQueryParameters();
+                String msg = DEFAULT_MESSAGE;
+                if (params.containsKey("msg")) {
+                    msg = getFirstValue(params, "msg");
+                }
+                // Log all levels
+                LOGGER.trace(msg);
+                LOGGER.debug(msg);
+                LOGGER.info(msg);
+                LOGGER.warn(msg);
+                LOGGER.error(msg);
+                //LOGGER.fatal(msg);
+                exchange.getResponseSender().send("Response sent");
+            }
+        };
+    }
+
+    private String getFirstValue(final Map<String, Deque<String>> params, final String key) {
+        if (params.containsKey(key)) {
+            final Deque<String> values = params.get(key);
+            if (values != null && !values.isEmpty()) {
+                return values.getFirst();
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3656

Analysis document: https://github.com/wildfly/wildfly-proposals/pull/29

The first commit simply adds tests for each supported logging API to test against logging profiles. The initial change of the Apache Commons Logging implementation to a new which delegates to JBoss Log Manager was initiated by commons-logging not working with logging profiles.

The next commit replaces the `org.jboss.logmanager:commons-logging-jboss-logmanager` implementation with `org.jboss.logging:commons-logging-jboss-logging` which delegates to JBoss Logging. There was an issue using the embedded API with Artemis if the JBoss Log Manager was not the default log manager. This prompted a change to delegate commons-logging to JBoss Logging instead which allows for common log managers to be used.

There are two minor differences in the implementations. With the new implementation a new logger is created each time a `LogFactory.getLog()` is invoked. In most cases this should be okay as loggers should generally be static or not created all that often.

The second difference is the `LogFactory` attributes are effectively static and will be shared across all log contexts. This is likely not a huge issue as these attributes are probably not used all that often.