### PR TITLE
[WFCORE-3658] Introducing wildfly-url-http component

### DIFF
--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -292,6 +292,11 @@
             <artifactId>wildfly-openssl-solaris-sparcv9</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.wildfly.url.http</groupId>
+            <artifactId>wildfly-url-http</artifactId>
+        </dependency>
+
         <!-- Add this dependency to make sure that the core model is tested before we build the server -->
         <dependency>
             <groupId>org.wildfly.core</groupId>
@@ -492,6 +497,41 @@
         <dependency>
             <groupId>xml-resolver</groupId>
             <artifactId>xml-resolver</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore-nio</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpasyncclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.james</groupId>
+            <artifactId>apache-mime4j</artifactId>
         </dependency>
 
     </dependencies>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/commons/codec/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/commons/codec/main/module.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.5" name="org.apache.commons.codec" version="${commons-codec:commons-codec}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${commons-codec:commons-codec}"/>
+    </resources>
+
+    <dependencies>
+    </dependencies>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/main/module.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.5" name="org.apache.httpcomponents" version="${org.apache.httpcomponents:httpclient}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.apache.httpcomponents:httpclient}"/>
+        <artifact name="${org.apache.httpcomponents:httpcore}"/>
+        <artifact name="${org.apache.httpcomponents:httpcore-nio}"/>
+        <artifact name="${org.apache.httpcomponents:httpasyncclient}"/>
+        <artifact name="${org.apache.httpcomponents:httpmime}"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.apache.commons.codec"/>
+        <module name="org.apache.commons.logging"/>
+        <module name="org.apache.james.mime4j"/>
+    </dependencies>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/james/mime4j/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/james/mime4j/main/module.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.5" name="org.apache.james.mime4j" version="${org.apache.james:apache-mime4j}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.apache.james:apache-mime4j}"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.apache.commons.logging"/>
+    </dependencies>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -96,6 +96,7 @@
         <module name="io.undertow.core" />
         <module name="org.wildfly.common"/>
         <module name="org.wildfly.extension.core-management-client" />
+        <module name="org.wildfly.url.http.wildfly-url-http" services="import"/>
         <module name="sun.jdk" services="export" export="true"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
@@ -58,5 +58,6 @@
         <module name="org.jboss.as.server" export="true"/>
         <module name="org.jboss.vfs" services="import"/>
         <module name="org.wildfly.security.elytron-private" services="import"/>
+        <module name="org.wildfly.url.http.wildfly-url-http" services="import"/>
     </dependencies>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/url/http/wildfly-url-http/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/url/http/wildfly-url-http/main/module.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2018, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.6" name="org.wildfly.url.http.wildfly-url-http" version="${org.wildfly.url.http:wildfly-url-http}">
+
+    <resources>
+        <artifact name="${org.wildfly.url.http:wildfly-url-http}"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.apache.httpcomponents"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.wildfly.security.elytron"/>
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
          -->
 
         <version.com.io7m.xom>1.2.10</version.com.io7m.xom>
+        <version.commons-codec>1.10</version.commons-codec>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
         <version.io.undertow>2.0.1.Final</version.io.undertow>
@@ -95,6 +96,8 @@
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds> <!-- TODO Elytron - Bump to M17 -->
         <version.org.apache.httpcomponents.httpclient>4.5.2</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.4.4</version.org.apache.httpcomponents.httpcore>
+        <version.org.apache.httpcomponents.httpasyncclient>4.1.3</version.org.apache.httpcomponents.httpasyncclient>
+        <version.org.apache.james.apache-mime4j>0.6</version.org.apache.james.apache-mime4j>
         <version.org.apache.maven>3.5.0</version.org.apache.maven>
         <version.org.apache.maven.resolver>1.1.0</version.org.apache.maven.resolver>
         <version.org.apache.xerces>2.11.0.SP5</version.org.apache.xerces>
@@ -158,6 +161,7 @@
         <version.org.wildfly.security.elytron>1.2.3.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron.tool>1.1.3.Final</version.org.wildfly.security.elytron.tool>
         <version.org.wildfly.security.elytron-web.undertow-server>1.1.0.Final</version.org.wildfly.security.elytron-web.undertow-server>
+        <version.org.wildfly.url.http.wildfly-url-http>1.0.2.Final</version.org.wildfly.url.http.wildfly-url-http>
         <version.xml-resolver>1.2</version.xml-resolver> <!-- Apache xml-resolver -->
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
@@ -1057,6 +1061,40 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpasyncclient</artifactId>
+                <version>${version.org.apache.httpcomponents.httpasyncclient}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${version.commons-codec}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.james</groupId>
+                <artifactId>apache-mime4j</artifactId>
+                <version>${version.org.apache.james.apache-mime4j}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
               <groupId>org.apache.maven</groupId>
               <artifactId>maven-resolver-provider</artifactId>
               <version>${version.org.apache.maven}</version>
@@ -1602,6 +1640,12 @@
                         <groupId>*</groupId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly.url.http</groupId>
+                <artifactId>wildfly-url-http</artifactId>
+                <version>${version.org.wildfly.url.http.wildfly-url-http}</version>
             </dependency>
 
             <!-- JSR-353 JSONP RI implementation -->


### PR DESCRIPTION
This PR introduce new component into WildFly (as discussed with @dmlloyd):
https://github.com/wildfly/wildfly-url-http

URL handler should ensure using correct Elytron AuthenticationContext for authentication/identity propagation/ssl by URL calls.

As it requires apache httpclient and it should be in wildfly-core (as discussed),
dependencies was moved into wildfly-core too.

https://issues.jboss.org/browse/WFCORE-3658