### PR TITLE
Fix for WFCORE-3673, CLI, add examples in for/done command help

### DIFF
--- a/cli/src/main/resources/help/done.txt
+++ b/cli/src/main/resources/help/done.txt
@@ -6,6 +6,12 @@ DESCRIPTION
 
     Ends the 'for' block and executes the iteration.
 
+    For example, listing all the deployment:
+
+    for varName in :read-children-names(child-type=deployment)
+     echo Deployment $varName
+    done
+
 ARGUMENTS
 
  --discard    - Optional. Ends the 'for' block and discard it.

--- a/cli/src/main/resources/help/for.txt
+++ b/cli/src/main/resources/help/for.txt
@@ -14,7 +14,11 @@ DESCRIPTION
     NB: for can't be used inside a batch, but batch can be used in for blocks.
 
     Example of a loop that displays the manifest of all deployments:
-    
+
+    for varName in :read-children-names(child-type=deployment)
+     echo Manifest file in $varName
+     attachment display --operation=/deployment=$varName:read-content(path=META-INF/MANIFEST.MF)
+    done
 
 ARGUMENTS
 


### PR DESCRIPTION
Help change only.  The example was missing in 'for' command. Added an example in 'done' command too.
