### PR TITLE
Fix for WFCORE-3674, CLI fix .bat file to not strip out ! from arguments

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.bat
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.bat
@@ -79,12 +79,13 @@ if errorlevel == 1 (
   echo logging.configuration already set in JAVA_OPTS
 )
 
+rem No variable that can contain '!' character can be handled once 
+rem delayed expansion has been enabled.
+set ARGS=%*
+
 rem the arguments can contain ')' character, this breaks parser. Delaying 
 rem argument evaluation at script execution fixes it.
 setlocal ENABLEDELAYEDEXPANSION
-
-rem script arguments will be evaluated at execution time.
-set ARGS=%*
 
 rem Force following commands to be loaded in memory.
 rem This protects the running script from being rewritten.


### PR DESCRIPTION
Moved the args variable definition before to enable delayed expansion.
Manual testing of '!' contained in cli script paths/arguments (passwords and commands). 
Didn't find regressions for WFCORE-2561, WFCORE-2582, WFCORE-2338.
