### PR TITLE
WFCORE-3686 Add jdk.nashorn.tools

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/sun/scripting/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/sun/scripting/main/module.xml
@@ -58,6 +58,7 @@
                 <path name="jdk/nashorn/internal/runtime/scripts"/>
                 <path name="jdk/nashorn/internal/tools"/>
                 <path name="jdk/nashorn/internal/tools/resources"/>
+                <path name="jdk/nashorn/tools"/>
                 <path name="jdk/internal/dynalink"/>
                 <path name="jdk/internal/dynalink/beans"/>
                 <path name="jdk/internal/dynalink/linker"/>


### PR DESCRIPTION
Add `jdk.nashorn.tools` to module `sun.scripting`, to allow running Nashorn `jjs` scripts in a modular environment (thus allowing full use of the JBoss CLI API).

https://issues.jboss.org/browse/WFCORE-3686