### PR TITLE
[WFCORE-3587] Remove maven deps corresponding to the unneeded module deps

### DIFF
--- a/core-management/core-management-client/pom.xml
+++ b/core-management/core-management-client/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-controller</artifactId>
+            <artifactId>wildfly-controller-client</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/deployment-repository/pom.xml
+++ b/deployment-repository/pom.xml
@@ -96,10 +96,6 @@
             <artifactId>jboss-msc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.threads</groupId>
-            <artifactId>jboss-threads</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-vfs</artifactId>
         </dependency>

--- a/deployment-scanner/pom.xml
+++ b/deployment-scanner/pom.xml
@@ -95,10 +95,6 @@
             <artifactId>jboss-msc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss</groupId>
-            <artifactId>jboss-vfs</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
         </dependency>

--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -79,17 +79,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-server</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
         </dependency>
@@ -116,11 +105,6 @@
             <groupId>org.jboss.logmanager</groupId>
             <artifactId>jboss-logmanager</artifactId>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.msc</groupId>
-            <artifactId>jboss-msc</artifactId>
         </dependency>
 
         <dependency>

--- a/domain-management/pom.xml
+++ b/domain-management/pom.xml
@@ -33,7 +33,7 @@
     </parent>
 
     <artifactId>wildfly-domain-management</artifactId>
-    
+
 
     <name>WildFly: Domain Management</name>
 
@@ -52,7 +52,7 @@
 
                     <additionalClasspathElements>
                         <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
-                    </additionalClasspathElements>                                        
+                    </additionalClasspathElements>
                 </configuration>
             </plugin>
         </plugins>
@@ -103,7 +103,7 @@
             <artifactId>apacheds-server-annotations</artifactId>
             <scope>test</scope>
         </dependency>
-    
+
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
@@ -131,7 +131,7 @@
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.picketbox</groupId>
             <artifactId>picketbox</artifactId>
@@ -145,11 +145,6 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-security</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.wildfly.openssl</groupId>
-            <artifactId>wildfly-openssl-java</artifactId>
         </dependency>
 
         <dependency>
@@ -168,6 +163,6 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
-       
+
     </dependencies>
 </project>

--- a/embedded/pom.xml
+++ b/embedded/pom.xml
@@ -36,12 +36,6 @@
     <name>WildFly: Embedded</name>
 
     <dependencies>
-        <!-- For the EJB scanner -->
-        <dependency>
-            <groupId>org.jboss</groupId>
-            <artifactId>jboss-vfs</artifactId>
-            <optional>true</optional>
-        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
@@ -53,10 +47,6 @@
         <dependency>
             <groupId>org.wildfly.security</groupId>
             <artifactId>wildfly-elytron</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss</groupId>
-            <artifactId>jandex</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/host-controller/pom.xml
+++ b/host-controller/pom.xml
@@ -102,10 +102,6 @@
             <artifactId>jboss-marshalling</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.remotingjmx</groupId>
-            <artifactId>remoting-jmx</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling-river</artifactId>
             <scope>test</scope>

--- a/remoting/subsystem/pom.xml
+++ b/remoting/subsystem/pom.xml
@@ -52,10 +52,6 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-core-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-io</artifactId>
             <exclusions>
                 <exclusion>

--- a/request-controller/pom.xml
+++ b/request-controller/pom.xml
@@ -77,12 +77,6 @@
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>
-        <!--
-        <dependency>
-            <groupId>org.picketbox</groupId>
-            <artifactId>picketbox</artifactId>
-        </dependency>
-        -->
 
         <!-- Test Dependencies -->
         <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -110,10 +110,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling</artifactId>
         </dependency>

--- a/version/pom.xml
+++ b/version/pom.xml
@@ -41,21 +41,6 @@
             <groupId>org.jboss.modules</groupId>
             <artifactId>jboss-modules</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-processor</artifactId>
-            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
-                  projects that depend on this project.-->
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
This follows up #3129 with a commit that removes unneeded maven deps that correspond to the unneeded module deps.

This also helps validate the #3129 change by proving that the removed runtime deps aren't need at compile time either.