### PR TITLE
[WFCORE-3409] If the user has overridden the module.path system prope…

### DIFF
--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedProcessFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedProcessFactory.java
@@ -136,7 +136,7 @@ public class EmbeddedProcessFactory {
         }
 
         if (modulePath == null)
-            modulePath = jbossHomeDir.getAbsolutePath() + File.separator + JBOSS_MODULES_DIR_NAME;
+            modulePath = WildFlySecurityManager.getPropertyPrivileged("module.path", jbossHomeDir.getAbsolutePath() + File.separator + JBOSS_MODULES_DIR_NAME);
 
         return createStandaloneServer(setupModuleLoader(modulePath, systemPackages), jbossHomeDir, cmdargs);
     }
@@ -210,8 +210,9 @@ public class EmbeddedProcessFactory {
             throw EmbeddedLogger.ROOT_LOGGER.invalidJBossHome(jbossHomePath);
         }
 
-        if (modulePath == null)
-            modulePath = jbossHomeDir.getAbsolutePath() + File.separator + JBOSS_MODULES_DIR_NAME;
+        if (modulePath == null) {
+            modulePath = WildFlySecurityManager.getPropertyPrivileged("module.path", jbossHomeDir.getAbsolutePath() + File.separator + JBOSS_MODULES_DIR_NAME);
+        }
 
         return createHostController(setupModuleLoader(modulePath, systemPackages), jbossHomeDir, cmdargs);
     }


### PR DESCRIPTION
…rty use that value before assuming we want the path based on the JBOSS_HOME directory.

https://issues.jboss.org/browse/WFCORE-3409

This replaces #3088 