### PR TITLE
[WFCORE-3682] try to add other stage failure description in a RollbackHandler from context attachment.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -88,6 +88,7 @@ import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.notification.Notification;
 import org.jboss.as.controller.notification.NotificationSupport;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.ReadResourceHandler;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.ConfigurationPersister;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -976,6 +977,11 @@ abstract class AbstractOperationContext implements OperationContext {
                 && (isRollbackOnRuntimeFailure() || currentStage == Stage.MODEL || currentStage == Stage.DOMAIN)) {
             activeStep.response.get(OUTCOME).set(FAILED);
             activeStep.response.get(ROLLED_BACK).set(true);
+
+            // runtime failure description needs to be attached to context to roll back in previous stage.
+            if (isRollbackOnRuntimeFailure() && activeStep.response.hasDefined(FAILURE_DESCRIPTION)) {
+                attach(ReadResourceHandler.ROLLBACKED_FAILURE_DESC, activeStep.response.get(FAILURE_DESCRIPTION));
+            }
             resultAction = ResultAction.ROLLBACK;
             ControllerLogger.MGMT_OP_LOGGER.tracef("Rolling back on failed response %s to operation %s on address %s in stage %s",
                     activeStep.response, activeStep.operationId.name, activeStep.operationId.address, currentStage);

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -57,6 +57,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.UnauthorizedException;
+import org.jboss.as.controller.OperationContext.AttachmentKey;
 import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.access.AuthorizationResult;
 import org.jboss.as.controller.access.ResourceNotAddressableException;
@@ -108,6 +109,8 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
             .build();
 
     public static final OperationStepHandler RESOLVE_INSTANCE = new ReadResourceHandler(true);
+
+    public static final AttachmentKey<ModelNode> ROLLBACKED_FAILURE_DESC = AttachmentKey.create(ModelNode.class);
 
     private final ParametersValidator validator = new ParametersValidator() {
 

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadResourceWithRuntimeResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadResourceWithRuntimeResourceTestCase.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.controller.test;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROXIES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
@@ -65,6 +66,8 @@ import org.junit.Test;
  */
 public class ReadResourceWithRuntimeResourceTestCase extends AbstractControllerTestBase {
 
+    public static final String FAILURE_DESC = "Fail with a failure description";
+
     private ManagementModel managementModel;
 
     @Test
@@ -108,6 +111,13 @@ public class ReadResourceWithRuntimeResourceTestCase extends AbstractControllerT
         assertTrue(children.keys().contains("C"));
         ModelNode resourceB = children.get("B");
         assertEquals(-1, resourceB.get("attr").asLong());
+
+        // WFCORE-3682 Test to check Stage.Runtime failure description is roll back to result.
+        res = managementModel.getRootResource().requireChild(MockProxyController.ADDRESS.getElement(0));
+        res.registerChild(PathElement.pathElement("resource", "D"), Resource.Factory.create(true));
+        result = executeCheckForFailure(operation);
+        assertTrue("failure description should be included in result", result.hasDefined(FAILURE_DESCRIPTION));
+        assertTrue(result.get(FAILURE_DESCRIPTION).asString().contains(FAILURE_DESC));
     }
 
     @Override
@@ -132,6 +142,17 @@ public class ReadResourceWithRuntimeResourceTestCase extends AbstractControllerT
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 context.getResult().set(-1);
+            }
+        });
+
+        // /subsystem=mysubsystem/resource=D is a runtime-only resource fail at Stage.Runtime
+        ManagementResourceRegistration runtimeResourceD = subsystemRegistration.registerSubModel(
+                new SimpleResourceDefinition(new SimpleResourceDefinition.Parameters(PathElement.pathElement("resource", "D"), new NonResolvingResourceDescriptionResolver()).setRuntime()));
+        AttributeDefinition runtimeAttrD = TestUtils.createAttribute("attrD", ModelType.LONG);
+        runtimeResourceD.registerReadOnlyAttribute(runtimeAttrD, new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                throw new RuntimeException(FAILURE_DESC);
             }
         });
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3682

`Stage.Runtime` failure description does not roll back to final response in `Stage.Model` for read-resource operation with `include-runtime` flag.

This attaches failure description into context in case process is rolling back, and adds it to outermost `DefaultPrepareStepHandler` response in case its failure description is undefined after rolling back.