### PR TITLE
[WFCORE-3731] Minor code cleanup in CommandCommandHandler, Connection…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/CommandCommandHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/CommandCommandHandler.java
@@ -70,9 +70,6 @@ public class CommandCommandHandler extends CommandHandlerWithHelp {
             public int complete(CommandContext ctx, String buffer, int cursor, List<String> candidates) {
                 int offset = 0;
                 int result = OperationRequestCompleter.ARG_VALUE_COMPLETER.complete(ctx, buffer, cursor + offset, candidates) - offset;
-                if(result < 0) {
-                    return result;
-                }
                 return result;
             }}, "--node-type") {
             @Override

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ConnectionInfoHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ConnectionInfoHandler.java
@@ -23,7 +23,6 @@ package org.jboss.as.cli.handlers;
 
 
 import java.io.IOException;
-import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Map;
 
@@ -105,17 +104,14 @@ public class ConnectionInfoHandler extends CommandHandlerWithHelp {
             boolean sslConn = lastChain != null;
             if (sslConn) {
                 try {
-                    for (Certificate current : lastChain) {
-                        if (current instanceof X509Certificate) {
-                            X509Certificate x509Current = (X509Certificate) current;
-                            Map<String, String> fingerprints = FingerprintGenerator.generateFingerprints(x509Current);
-                            st.addLine(new String[] {"Subject", x509Current.getSubjectX500Principal().getName()});
-                            st.addLine(new String[] {"Issuer", x509Current.getIssuerDN().getName()});
-                            st.addLine(new String[] {"Valid from", x509Current.getNotBefore().toString()});
-                            st.addLine(new String[] {"Valid to", x509Current.getNotAfter().toString()});
-                            for (String alg : fingerprints.keySet()) {
-                                st.addLine(new String[] {alg, fingerprints.get(alg)});
-                            }
+                    for (X509Certificate x509Current : lastChain) {
+                        Map<String, String> fingerprints = FingerprintGenerator.generateFingerprints(x509Current);
+                        st.addLine(new String[] {"Subject", x509Current.getSubjectX500Principal().getName()});
+                        st.addLine(new String[] {"Issuer", x509Current.getIssuerDN().getName()});
+                        st.addLine(new String[] {"Valid from", x509Current.getNotBefore().toString()});
+                        st.addLine(new String[] {"Valid to", x509Current.getNotAfter().toString()});
+                        for (String alg : fingerprints.keySet()) {
+                            st.addLine(new String[] {alg, fingerprints.get(alg)});
                         }
                     }
                 } catch (CommandLineException cle) {

--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/security/RealmIdentityManager.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/security/RealmIdentityManager.java
@@ -156,7 +156,7 @@ public class RealmIdentityManager implements IdentityManager {
 
     private Account verify(String id, PasswordCredential credential) {
         assertMechanism(AuthMechanism.PLAIN);
-        if (credential instanceof PasswordCredential == false) {
+        if (credential == null) {
             return null;
         }
 


### PR DESCRIPTION
…InfoHandler, RealmIdentityManager

CommandCommandHandler - removal of unnecessary if, checked with Jean-Francois Denise
ConnectionInfoHandler - lastChainCertificate is X509Certificate[], instanceof check is not necessary
RealmIdentityManager - credential is always PasswordCredential, only null check is relevant

JIRA: https://issues.jboss.org/browse/WFCORE-3731