### PR TITLE
[WFCORE-2951] Add JSON formatter to the logging subsystem

### DIFF
--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -162,6 +162,12 @@
             <artifactId>jboss-stdio</artifactId>
         </dependency>
 
+        <!-- Required for the json-formatter -->
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+        </dependency>
+
         <!-- Test dependencies -->
 
         <!-- Would be brought in transitively by wildfly-controller normally. Required for ParseUtils -->

--- a/logging/src/main/java/org/jboss/as/logging/Element.java
+++ b/logging/src/main/java/org/jboss/as/logging/Element.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.logging.formatters.JsonFormatterResourceDefinition;
 
 /**
  *
@@ -56,6 +57,7 @@ enum Element {
     HANDLER(CommonAttributes.HANDLER),
     HANDLERS(CommonAttributes.HANDLERS),
     HOSTNAME(SyslogHandlerResourceDefinition.HOSTNAME),
+    JSON_FORMATTER(JsonFormatterResourceDefinition.NAME),
     LEVEL(CommonAttributes.LEVEL),
     LEVEL_RANGE(CommonAttributes.LEVEL_RANGE_LEGACY),
     LOGGER(LoggerResourceDefinition.LOGGER),

--- a/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
+++ b/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
@@ -13,6 +13,7 @@ enum KnownModelVersion {
     VERSION_3_0_0(ModelVersion.create(3, 0, 0), false),
     VERSION_4_0_0(ModelVersion.create(4, 0, 0), false),
     VERSION_5_0_0(ModelVersion.create(5, 0, 0), false),
+    VERSION_6_0_0(ModelVersion.create(6, 0, 0), false),
     ;
     private final ModelVersion modelVersion;
     private final boolean hasTransformers;

--- a/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
+++ b/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
@@ -7,12 +7,12 @@ import org.jboss.as.controller.ModelVersion;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-enum KnownModelVersion {
+public enum KnownModelVersion {
     VERSION_1_5_0(ModelVersion.create(1, 5, 0), true), // EAP 6.4
     VERSION_2_0_0(ModelVersion.create(2, 0, 0), true),
     VERSION_3_0_0(ModelVersion.create(3, 0, 0), false),
     VERSION_4_0_0(ModelVersion.create(4, 0, 0), false),
-    VERSION_5_0_0(ModelVersion.create(5, 0, 0), false),
+    VERSION_5_0_0(ModelVersion.create(5, 0, 0), true),
     VERSION_6_0_0(ModelVersion.create(6, 0, 0), false),
     ;
     private final ModelVersion modelVersion;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -56,6 +56,7 @@ import org.jboss.as.controller.transform.description.ResourceTransformationDescr
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
 import org.jboss.as.logging.LoggingProfileOperations.LoggingProfileAdd;
 import org.jboss.as.logging.deployments.resources.LoggingDeploymentResources;
+import org.jboss.as.logging.formatters.JsonFormatterResourceDefinition;
 import org.jboss.as.logging.logging.LoggingLogger;
 import org.jboss.as.logging.logmanager.WildFlyLogContextSelector;
 import org.jboss.as.logging.stdio.LogContextStdioContextSelector;
@@ -300,6 +301,7 @@ public class LoggingExtension implements Extension {
         registration.registerSubModel(SyslogHandlerResourceDefinition.INSTANCE);
         registration.registerSubModel(PatternFormatterResourceDefinition.INSTANCE);
         registration.registerSubModel(CustomFormatterResourceDefinition.INSTANCE);
+        registration.registerSubModel(JsonFormatterResourceDefinition.INSTANCE);
 
         if (registerTransformers) {
             registerTransformers(subsystem,
@@ -315,23 +317,28 @@ public class LoggingExtension implements Extension {
                     customHandlerResourceDefinition,
                     SyslogHandlerResourceDefinition.INSTANCE,
                     PatternFormatterResourceDefinition.INSTANCE,
-                    CustomFormatterResourceDefinition.INSTANCE);
+                    CustomFormatterResourceDefinition.INSTANCE,
+                    JsonFormatterResourceDefinition.INSTANCE);
         }
     }
 
     private void registerTransformers(final SubsystemRegistration registration, final TransformerResourceDefinition... defs) {
         ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(registration.getSubsystemVersion());
 
-        registerTransformers(chainedBuilder, registration.getSubsystemVersion(), KnownModelVersion.VERSION_2_0_0, defs);
+        registerTransformers(chainedBuilder, registration.getSubsystemVersion(), KnownModelVersion.VERSION_5_0_0, defs);
+        registerTransformers(chainedBuilder, KnownModelVersion.VERSION_5_0_0, KnownModelVersion.VERSION_2_0_0, defs);
         // Version 1.5.0 has the periodic-size-rotating-file-handler and the suffix attribute on the size-rotating-file-handler.
         // Neither of these are in 2.0.0 (WildFly 8.x). Mapping from 3.0.0 to 1.5.0 is required
         registerTransformers(chainedBuilder, KnownModelVersion.VERSION_3_0_0, KnownModelVersion.VERSION_1_5_0, defs);
 
         chainedBuilder.buildAndRegister(registration, new ModelVersion[] {
                 KnownModelVersion.VERSION_2_0_0.getModelVersion(),
+                KnownModelVersion.VERSION_5_0_0.getModelVersion(),
         }, new ModelVersion[] {
                 KnownModelVersion.VERSION_1_5_0.getModelVersion(),
                 KnownModelVersion.VERSION_3_0_0.getModelVersion(),
+                KnownModelVersion.VERSION_4_0_0.getModelVersion(),
+                KnownModelVersion.VERSION_5_0_0.getModelVersion(),
         });
     }
 

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -84,7 +84,7 @@ public class LoggingExtension implements Extension {
 
     static final GenericSubsystemDescribeHandler DESCRIBE_HANDLER = GenericSubsystemDescribeHandler.create(LoggingChildResourceComparator.INSTANCE);
 
-    private static final int MANAGEMENT_API_MAJOR_VERSION = 5;
+    private static final int MANAGEMENT_API_MAJOR_VERSION = 6;
     private static final int MANAGEMENT_API_MINOR_VERSION = 0;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
@@ -238,6 +238,7 @@ public class LoggingExtension implements Extension {
         setParser(context, Namespace.LOGGING_2_0, new LoggingSubsystemParser_2_0());
         setParser(context, Namespace.LOGGING_3_0, new LoggingSubsystemParser_3_0());
         setParser(context, Namespace.LOGGING_4_0, new LoggingSubsystemParser_4_0());
+        setParser(context, Namespace.LOGGING_5_0, new LoggingSubsystemParser_5_0());
 
         // Hack to ensure the Element and Attribute enums are loaded during this call which
         // is part of concurrent boot. These enums trigger a lot of classloading and static

--- a/logging/src/main/java/org/jboss/as/logging/LoggingOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingOperations.java
@@ -46,7 +46,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-final class LoggingOperations {
+public final class LoggingOperations {
 
     /**
      * Get the address name from the operation.
@@ -190,7 +190,7 @@ final class LoggingOperations {
     /**
      * A base step handler for logging operations.
      */
-    abstract static class LoggingAddOperationStepHandler extends LoggingOperationStepHandler {
+    public abstract static class LoggingAddOperationStepHandler extends LoggingOperationStepHandler {
 
         @Override
         public final void execute(final OperationContext context, final ModelNode operation, final String name, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
@@ -256,7 +256,7 @@ final class LoggingOperations {
     /**
      * A base remove step handler for logging operations.
      */
-    abstract static class LoggingRemoveOperationStepHandler extends LoggingOperationStepHandler {
+    public abstract static class LoggingRemoveOperationStepHandler extends LoggingOperationStepHandler {
 
         @Override
         public final void execute(final OperationContext context, final ModelNode operation, final String name, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
@@ -293,7 +293,7 @@ final class LoggingOperations {
     /**
      * A default log handler write attribute step handler.
      */
-    abstract static class LoggingWriteAttributeHandler extends AbstractWriteAttributeHandler<ConfigurationPersistence> {
+    public abstract static class LoggingWriteAttributeHandler extends AbstractWriteAttributeHandler<ConfigurationPersistence> {
         private final AttributeDefinition[] attributes;
 
         protected LoggingWriteAttributeHandler(final AttributeDefinition[] attributes) {

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
@@ -39,6 +39,7 @@ import org.jboss.as.logging.deployments.LoggingConfigDeploymentProcessor;
 import org.jboss.as.logging.deployments.LoggingDependencyDeploymentProcessor;
 import org.jboss.as.logging.deployments.LoggingDeploymentResourceProcessor;
 import org.jboss.as.logging.deployments.LoggingProfileDeploymentProcessor;
+import org.jboss.as.logging.formatters.JsonFormatterResourceDefinition;
 import org.jboss.as.logging.logging.LoggingLogger;
 import org.jboss.as.logging.logmanager.ConfigurationPersistence;
 import org.jboss.as.logging.logmanager.WildFlyLogContextSelector;
@@ -139,6 +140,7 @@ class LoggingSubsystemAdd extends AbstractAddStepHandler {
         final List<String> configuredFormatters = logContextConfiguration.getFormatterNames();
         configuredFormatters.removeAll(resource.getChildrenNames(PatternFormatterResourceDefinition.PATTERN_FORMATTER.getName()));
         configuredFormatters.removeAll(resource.getChildrenNames(CustomFormatterResourceDefinition.CUSTOM_FORMATTER.getName()));
+        configuredFormatters.removeAll(resource.getChildrenNames(JsonFormatterResourceDefinition.NAME));
         // Formatter names could also be the name of a handler if the formatter attribute is used rather than a named-formatter
         configuredFormatters.removeAll(subsystemHandlers);
 

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -120,6 +120,24 @@ abstract class LoggingSubsystemParser implements XMLStreamConstants, XMLElementR
      * @throws XMLStreamException if a parsing error occurs
      */
     static void parsePropertyElement(final ModelNode operation, final XMLExtendedStreamReader reader) throws XMLStreamException {
+        parsePropertyElement(operation, reader, PROPERTIES.getName());
+    }
+
+    /**
+     * Parses a property element.
+     * <p>
+     *
+     * The {@code name} attribute is required. If the {@code value} attribute is not present an
+     * {@linkplain org.jboss.dmr.ModelNode UNDEFINED ModelNode} will set on the operation.
+     * </p>
+     *
+     * @param operation   the operation to add the parsed properties to
+     * @param reader      the reader to use
+     * @param wrapperName the name of the attribute that wraps the key and value attributes
+     *
+     * @throws XMLStreamException if a parsing error occurs
+     */
+    static void parsePropertyElement(final ModelNode operation, final XMLExtendedStreamReader reader, final String wrapperName) throws XMLStreamException {
         while (reader.nextTag() != END_ELEMENT) {
             final int cnt = reader.getAttributeCount();
             String name = null;
@@ -144,7 +162,7 @@ abstract class LoggingSubsystemParser implements XMLStreamConstants, XMLElementR
             if (name == null) {
                 throw missingRequired(reader, Collections.singleton(Attribute.NAME.getLocalName()));
             }
-            operation.get(PROPERTIES.getName()).add(name, (value == null ? new ModelNode() : new ModelNode(value)));
+            operation.get(wrapperName).add(name, (value == null ? new ModelNode() : new ModelNode(value)));
             if (reader.nextTag() != END_ELEMENT) {
                 throw unexpectedElement(reader);
             }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_5_0.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_5_0.java
@@ -19,6 +19,25 @@
 
 package org.jboss.as.logging;
 
+import static org.jboss.as.controller.parsing.ParseUtils.duplicateNamedElement;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.logging.formatters.JsonFormatterResourceDefinition;
+import org.jboss.as.logging.formatters.StructuredFormatterResourceDefinition;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
 /**
  * Subsystem parser for 4.0 of the logging subsystem.
  *
@@ -26,4 +45,108 @@ package org.jboss.as.logging;
  */
 @SuppressWarnings("WeakerAccess")
 class LoggingSubsystemParser_5_0 extends LoggingSubsystemParser_4_0 {
+
+    void parseFormatter(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> operations, final Set<String> names) throws XMLStreamException {
+        // Attributes
+        String name = null;
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME: {
+                    name = value;
+                    break;
+                }
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        if (!names.add(name)) {
+            throw duplicateNamedElement(reader, name);
+        }
+
+        final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
+        while (reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            if (!encountered.add(element)) {
+                throw unexpectedElement(reader);
+            }
+            switch (element) {
+                case PATTERN_FORMATTER: {
+                    final ModelNode operation = Util.createAddOperation();
+                    // Setup the operation address
+                    addOperationAddress(operation, address, PatternFormatterResourceDefinition.PATTERN_FORMATTER.getName(), name);
+                    parsePatternFormatterElement(reader, operation);
+                    operations.add(operation);
+                    break;
+                }
+                case CUSTOM_FORMATTER: {
+                    final ModelNode operation = Util.createAddOperation();
+                    // Setup the operation address
+                    addOperationAddress(operation, address, CustomFormatterResourceDefinition.CUSTOM_FORMATTER.getName(), name);
+                    parseCustomFormatterElement(reader, operation);
+                    operations.add(operation);
+                    break;
+                }
+                case JSON_FORMATTER: {
+                    final ModelNode operation = Util.createAddOperation();
+                    // Setup the operation address
+                    addOperationAddress(operation, address, JsonFormatterResourceDefinition.NAME, name);
+                    parseStructuredFormatter(reader, operation);
+                    operations.add(operation);
+                    break;
+                }
+                default: {
+                    throw unexpectedElement(reader);
+                }
+            }
+        }
+    }
+
+    void parseStructuredFormatter(final XMLExtendedStreamReader reader, final ModelNode operation) throws XMLStreamException {
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String attributeName = reader.getAttributeLocalName(i);
+            final String value = reader.getAttributeValue(i);
+            if (attributeName.equals(StructuredFormatterResourceDefinition.DATE_FORMAT.getXmlName())) {
+                StructuredFormatterResourceDefinition.DATE_FORMAT.parseAndSetParameter(value, operation, reader);
+            } else if (attributeName.equals(StructuredFormatterResourceDefinition.PRETTY_PRINT.getXmlName())) {
+                StructuredFormatterResourceDefinition.PRETTY_PRINT.parseAndSetParameter(value, operation, reader);
+            } else if (attributeName.equals(StructuredFormatterResourceDefinition.PRINT_DETAILS.getXmlName())) {
+                StructuredFormatterResourceDefinition.PRINT_DETAILS.parseAndSetParameter(value, operation, reader);
+            } else if (attributeName.equals(StructuredFormatterResourceDefinition.ZONE_ID.getXmlName())) {
+                StructuredFormatterResourceDefinition.ZONE_ID.parseAndSetParameter(value, operation, reader);
+            } else {
+                throw unexpectedAttribute(reader, i);
+            }
+        }
+
+
+        final Set<String> encountered = new HashSet<>();
+        while (reader.nextTag() != END_ELEMENT) {
+            final String elementName = reader.getLocalName();
+            if (!encountered.add(elementName)) {
+                throw unexpectedElement(reader);
+            }
+            if (elementName.equals(StructuredFormatterResourceDefinition.EXCEPTION_OUTPUT_TYPE.getXmlName())) {
+                StructuredFormatterResourceDefinition.EXCEPTION_OUTPUT_TYPE.parseAndSetParameter(readValueAttribute(reader), operation, reader);
+            } else if (elementName.equals(StructuredFormatterResourceDefinition.RECORD_DELIMITER.getXmlName())) {
+                StructuredFormatterResourceDefinition.RECORD_DELIMITER.parseAndSetParameter(readValueAttribute(reader), operation, reader);
+            } else if (elementName.equals(StructuredFormatterResourceDefinition.KEY_OVERRIDES.getXmlName())) {
+                StructuredFormatterResourceDefinition.KEY_OVERRIDES.getParser().parseElement(StructuredFormatterResourceDefinition.KEY_OVERRIDES, reader, operation);
+            } else if (elementName.equals(StructuredFormatterResourceDefinition.META_DATA.getXmlName())) {
+                parsePropertyElement(operation, reader, StructuredFormatterResourceDefinition.META_DATA.getName());
+            } else {
+                throw unexpectedElement(reader);
+            }
+        }
+    }
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_5_0.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_5_0.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging;
+
+/**
+ * Subsystem parser for 4.0 of the logging subsystem.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("WeakerAccess")
+class LoggingSubsystemParser_5_0 extends LoggingSubsystemParser_4_0 {
+}

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
@@ -75,6 +75,8 @@ import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.as.logging.formatters.StructuredFormatterResourceDefinition;
+import org.jboss.as.logging.formatters.JsonFormatterResourceDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.staxmapper.XMLElementWriter;
@@ -215,6 +217,7 @@ public class LoggingSubsystemWriter implements XMLStreamConstants, XMLElementWri
 
         writeFormatters(writer, PATTERN_FORMATTER, model);
         writeFormatters(writer, CUSTOM_FORMATTER, model);
+        writeStructuredFormatters(writer, JsonFormatterResourceDefinition.NAME, model);
     }
 
     private void writeCommonLogger(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {
@@ -363,6 +366,30 @@ public class LoggingSubsystemWriter implements XMLStreamConstants, XMLElementWri
                 final ModelNode value = model.get(attribute.getName(), name);
                 attribute.marshallAsElement(value, writer);
                 writer.writeEndElement();
+            }
+        }
+    }
+
+    private void writeStructuredFormatters(final XMLExtendedStreamWriter writer, final String elementName, final ModelNode model) throws XMLStreamException {
+        if (model.hasDefined(elementName)) {
+            for (String name : model.get(elementName).keys()) {
+                writer.writeStartElement(Element.FORMATTER.getLocalName());
+                writer.writeAttribute(NAME.getXmlName(), name);
+                final ModelNode value = model.get(elementName, name);
+                writer.writeStartElement(elementName);
+                // Write attributes first
+                StructuredFormatterResourceDefinition.DATE_FORMAT.marshallAsAttribute(value, writer);
+                StructuredFormatterResourceDefinition.PRETTY_PRINT.marshallAsAttribute(value, writer);
+                StructuredFormatterResourceDefinition.PRINT_DETAILS.marshallAsAttribute(value, writer);
+                StructuredFormatterResourceDefinition.ZONE_ID.marshallAsAttribute(value, writer);
+                // Next write elements
+                StructuredFormatterResourceDefinition.EXCEPTION_OUTPUT_TYPE.marshallAsElement(value, writer);
+                StructuredFormatterResourceDefinition.RECORD_DELIMITER.marshallAsElement(value, writer);
+                StructuredFormatterResourceDefinition.KEY_OVERRIDES.marshallAsElement(value, writer);
+                StructuredFormatterResourceDefinition.META_DATA.marshallAsElement(value, writer);
+
+                writer.writeEndElement(); // end elementName
+                writer.writeEndElement(); // end formatter
             }
         }
     }

--- a/logging/src/main/java/org/jboss/as/logging/Namespace.java
+++ b/logging/src/main/java/org/jboss/as/logging/Namespace.java
@@ -52,12 +52,14 @@ public enum Namespace {
     LOGGING_3_0("urn:jboss:domain:logging:3.0"),
 
     LOGGING_4_0("urn:jboss:domain:logging:4.0"),
+
+    LOGGING_5_0("urn:jboss:domain:logging:5.0"),
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = LOGGING_4_0;
+    public static final Namespace CURRENT = LOGGING_5_0;
 
     private final String name;
 

--- a/logging/src/main/java/org/jboss/as/logging/PropertyAttributeDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PropertyAttributeDefinition.java
@@ -50,7 +50,11 @@ public class PropertyAttributeDefinition extends SimpleAttributeDefinition imple
         if (value == null) {
             configuration.removeProperty(propertyName);
         } else {
-            configuration.setPropertyValueString(propertyName, value);
+            // Only change the property if the two resolved values do not match. We currently don't set expressions.
+            final String currentValue = configuration.getPropertyValueString(propertyName);
+            if (!value.equals(currentValue)) {
+                configuration.setPropertyValueString(propertyName, value);
+            }
         }
     }
 

--- a/logging/src/main/java/org/jboss/as/logging/TransformerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/TransformerResourceDefinition.java
@@ -12,7 +12,7 @@ import org.jboss.as.controller.transform.description.ResourceTransformationDescr
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-abstract class TransformerResourceDefinition extends SimpleResourceDefinition {
+public abstract class TransformerResourceDefinition extends SimpleResourceDefinition {
 
     protected TransformerResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver) {
         super(new Parameters(pathElement, descriptionResolver));

--- a/logging/src/main/java/org/jboss/as/logging/formatters/JsonFormatterResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/formatters/JsonFormatterResourceDefinition.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging.formatters;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.logmanager.formatters.JsonFormatter;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JsonFormatterResourceDefinition extends StructuredFormatterResourceDefinition {
+    public static final String NAME = "json-formatter";
+    private static final PathElement PATH = PathElement.pathElement(NAME);
+
+    public static final JsonFormatterResourceDefinition INSTANCE = new JsonFormatterResourceDefinition();
+
+    private JsonFormatterResourceDefinition() {
+        super(PATH, NAME, JsonFormatter.class);
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/formatters/StructuredFormatterResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/formatters/StructuredFormatterResourceDefinition.java
@@ -1,0 +1,471 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging.formatters;
+
+import static org.jboss.as.logging.Logging.createOperationFailure;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshallers;
+import org.jboss.as.controller.ObjectTypeAttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleMapAttributeDefinition;
+import org.jboss.as.controller.operations.validation.StringAllowedValuesValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.logging.ElementAttributeMarshaller;
+import org.jboss.as.logging.KnownModelVersion;
+import org.jboss.as.logging.LoggingExtension;
+import org.jboss.as.logging.LoggingOperations;
+import org.jboss.as.logging.PropertyAttributeDefinition;
+import org.jboss.as.logging.TransformerResourceDefinition;
+import org.jboss.as.logging.logging.LoggingLogger;
+import org.jboss.as.logging.resolvers.ModelNodeResolver;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.jboss.logmanager.PropertyValues;
+import org.jboss.logmanager.config.FormatterConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.formatters.StructuredFormatter;
+
+/**
+ * An abstract resource definition for {@link org.jboss.logmanager.formatters.StructuredFormatter}'s.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("Convert2Lambda")
+public abstract class StructuredFormatterResourceDefinition extends TransformerResourceDefinition {
+
+    public static final PropertyAttributeDefinition DATE_FORMAT = PropertyAttributeDefinition.Builder.of("date-format", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setPropertyName("dateFormat")
+            .build();
+
+    public static final PropertyAttributeDefinition EXCEPTION_OUTPUT_TYPE = PropertyAttributeDefinition.Builder.of("exception-output-type", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setAttributeMarshaller(ElementAttributeMarshaller.VALUE_ATTRIBUTE_MARSHALLER)
+            .setDefaultValue(new ModelNode("detailed"))
+            .setPropertyName("exceptionOutputType")
+            .setResolver(new ModelNodeResolver<String>() {
+                @Override
+                public String resolveValue(final OperationContext context, final ModelNode value) throws OperationFailedException {
+                    final String exceptionType = value.asString();
+                    if ("detailed".equals(exceptionType)) {
+                        return StructuredFormatter.ExceptionOutputType.DETAILED.name();
+                    } else if ("formatted".equals(exceptionType)) {
+                        return StructuredFormatter.ExceptionOutputType.FORMATTED.name();
+                    } else if ("detailed-and-formatted".equals(exceptionType)) {
+                        return StructuredFormatter.ExceptionOutputType.DETAILED_AND_FORMATTED.name();
+                    }
+                    // Should never be hit
+                    throw LoggingLogger.ROOT_LOGGER.invalidExceptionOutputType(exceptionType);
+                }
+            })
+            .setValidator(new StringAllowedValuesValidator("detailed", "formatted", "detailed-and-formatted"))
+            .build();
+
+    private static final SimpleAttributeDefinition EXCEPTION = SimpleAttributeDefinitionBuilder.create("exception", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_CAUSED_BY = SimpleAttributeDefinitionBuilder.create("exception-caused-by", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_CIRCULAR_REFERENCE = SimpleAttributeDefinitionBuilder.create("exception-circular-reference", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_FRAME = SimpleAttributeDefinitionBuilder.create("exception-frame", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_FRAME_CLASS = SimpleAttributeDefinitionBuilder.create("exception-frame-class", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_FRAME_LINE = SimpleAttributeDefinitionBuilder.create("exception-frame-line", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_FRAME_METHOD = SimpleAttributeDefinitionBuilder.create("exception-frame-method", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_FRAMES = SimpleAttributeDefinitionBuilder.create("exception-frames", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_MESSAGE = SimpleAttributeDefinitionBuilder.create("exception-message", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_REFERENCE_ID = SimpleAttributeDefinitionBuilder.create("exception-reference-id", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_SUPPRESSED = SimpleAttributeDefinitionBuilder.create("exception-suppressed", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition EXCEPTION_TYPE = SimpleAttributeDefinitionBuilder.create("exception-type", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition HOST_NAME = SimpleAttributeDefinitionBuilder.create("host-name", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition LEVEL = SimpleAttributeDefinitionBuilder.create("level", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition LOGGER_CLASS_NAME = SimpleAttributeDefinitionBuilder.create("logger-class-name", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition LOGGER_NAME = SimpleAttributeDefinitionBuilder.create("logger-name", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition MDC = SimpleAttributeDefinitionBuilder.create("mdc", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition MESSAGE = SimpleAttributeDefinitionBuilder.create("message", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition NDC = SimpleAttributeDefinitionBuilder.create("ndc", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition PROCESS_ID = SimpleAttributeDefinitionBuilder.create("process-id", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition PROCESS_NAME = SimpleAttributeDefinitionBuilder.create("process-name", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition RECORD = SimpleAttributeDefinitionBuilder.create("record", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition SEQUENCE = SimpleAttributeDefinitionBuilder.create("sequence", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition SOURCE_CLASS_NAME = SimpleAttributeDefinitionBuilder.create("source-class-name", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition SOURCE_FILE_NAME = SimpleAttributeDefinitionBuilder.create("source-file-name", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition SOURCE_LINE_NUMBER = SimpleAttributeDefinitionBuilder.create("source-line-number", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition SOURCE_METHOD_NAME = SimpleAttributeDefinitionBuilder.create("source-method-name", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition SOURCE_MODULE_NAME = SimpleAttributeDefinitionBuilder.create("source-module-name", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition SOURCE_MODULE_VERSION = SimpleAttributeDefinitionBuilder.create("source-module-version", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition STACK_TRACE = SimpleAttributeDefinitionBuilder.create("stack-trace", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition THREAD_ID = SimpleAttributeDefinitionBuilder.create("thread-id", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition THREAD_NAME = SimpleAttributeDefinitionBuilder.create("thread-name", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+    private static final SimpleAttributeDefinition TIMESTAMP = SimpleAttributeDefinitionBuilder.create("timestamp", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .build();
+
+    public static final ObjectTypeAttributeDefinition KEY_OVERRIDES = ObjectTypeAttributeDefinition.create("key-overrides",
+            EXCEPTION,
+            EXCEPTION_CAUSED_BY,
+            EXCEPTION_CIRCULAR_REFERENCE,
+            EXCEPTION_FRAME,
+            EXCEPTION_FRAME_CLASS,
+            EXCEPTION_FRAME_LINE,
+            EXCEPTION_FRAME_METHOD,
+            EXCEPTION_FRAMES,
+            EXCEPTION_MESSAGE,
+            EXCEPTION_REFERENCE_ID,
+            EXCEPTION_SUPPRESSED,
+            EXCEPTION_TYPE,
+            HOST_NAME,
+            LEVEL,
+            LOGGER_CLASS_NAME,
+            LOGGER_NAME,
+            MDC,
+            MESSAGE,
+            NDC,
+            PROCESS_ID,
+            PROCESS_NAME,
+            RECORD,
+            SEQUENCE,
+            SOURCE_CLASS_NAME,
+            SOURCE_FILE_NAME,
+            SOURCE_LINE_NUMBER,
+            SOURCE_METHOD_NAME,
+            SOURCE_MODULE_NAME,
+            SOURCE_MODULE_VERSION,
+            STACK_TRACE,
+            THREAD_ID,
+            THREAD_NAME,
+            TIMESTAMP
+    )
+            // This is done as the StructuredFormatter will need to be reconstructed even though there is no real
+            // service. This could be done without requiring a restart, but making a change to a key name may not be
+            // desired until both the target consumer of the log messages and the container are restarted.
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
+    public static final SimpleMapAttributeDefinition META_DATA = new SimpleMapAttributeDefinition.Builder("meta-data", ModelType.STRING, true)
+            .setAttributeMarshaller(new AttributeMarshallers.PropertiesAttributeMarshaller("meta-data", "property", true))
+            .build();
+
+    public static final PropertyAttributeDefinition PRETTY_PRINT = PropertyAttributeDefinition.Builder.of("pretty-print", ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(false))
+            .setPropertyName("prettyPrint")
+            .build();
+
+    public static final PropertyAttributeDefinition PRINT_DETAILS = PropertyAttributeDefinition.Builder.of("print-details", ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(false))
+            .setPropertyName("printDetails")
+            .build();
+
+    public static final PropertyAttributeDefinition RECORD_DELIMITER = PropertyAttributeDefinition.Builder.of("record-delimiter", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setAttributeMarshaller(ElementAttributeMarshaller.VALUE_ATTRIBUTE_MARSHALLER)
+            .setDefaultValue(new ModelNode("\n"))
+            .setPropertyName("recordDelimiter")
+            .build();
+
+    public static final PropertyAttributeDefinition ZONE_ID = PropertyAttributeDefinition.Builder.of("zone-id", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setPropertyName("zoneId")
+            .build();
+
+    private static final AttributeDefinition[] ATTRIBUTES = {
+            DATE_FORMAT,
+            EXCEPTION_OUTPUT_TYPE,
+            KEY_OVERRIDES,
+            META_DATA,
+            PRETTY_PRINT,
+            PRINT_DETAILS,
+            RECORD_DELIMITER,
+            ZONE_ID,
+    };
+
+    private static final OperationStepHandler WRITE = new LoggingOperations.LoggingWriteAttributeHandler(ATTRIBUTES) {
+
+        @SuppressWarnings("OverlyStrongTypeCast")
+        @Override
+        protected boolean applyUpdate(final OperationContext context, final String attributeName, final String addressName,
+                                      final ModelNode value, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
+            final FormatterConfiguration configuration = logContextConfiguration.getFormatterConfiguration(addressName);
+            if (attributeName.equals(META_DATA.getName())) {
+                final String metaData = modelValueToMetaData(value);
+                if (metaData != null) {
+                    configuration.setPropertyValueString("metaData", metaData);
+                } else {
+                    configuration.removeProperty("metaData");
+                }
+            } else if (attributeName.equals(KEY_OVERRIDES.getName())) {
+                // Require a restart of the resource
+                return true;
+            } else {
+                for (AttributeDefinition attribute : ATTRIBUTES) {
+                    if (attribute.getName().equals(attributeName)) {
+                        if (attribute instanceof PropertyAttributeDefinition) {
+                            final PropertyAttributeDefinition propertyAttribute = (PropertyAttributeDefinition) attribute;
+                            if (value.isDefined()) {
+                                final ModelNodeResolver<String> resolver = propertyAttribute.resolver();
+                                String resolvedValue = value.asString();
+                                if (resolver != null) {
+                                    resolvedValue = resolver.resolveValue(context, value);
+                                }
+                                configuration.setPropertyValueString(propertyAttribute.getPropertyName(), resolvedValue);
+                            } else {
+                                configuration.removeProperty(propertyAttribute.getPropertyName());
+                            }
+                        } else {
+                            if (value.isDefined()) {
+                                configuration.setPropertyValueString(attributeName, value.asString());
+                            } else {
+                                configuration.removeProperty(attributeName);
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+            return false;
+        }
+    };
+
+    /**
+     * A step handler to remove
+     */
+    private static final OperationStepHandler REMOVE = new LoggingOperations.LoggingRemoveOperationStepHandler() {
+
+        @Override
+        protected void performRemove(final OperationContext context, final ModelNode operation, final LogContextConfiguration logContextConfiguration, final String name, final ModelNode model) throws OperationFailedException {
+            context.removeResource(PathAddress.EMPTY_ADDRESS);
+        }
+
+        @Override
+        public void performRuntime(final OperationContext context, final ModelNode operation, final LogContextConfiguration logContextConfiguration, final String name, final ModelNode model) throws OperationFailedException {
+            final FormatterConfiguration configuration = logContextConfiguration.getFormatterConfiguration(name);
+            if (configuration == null) {
+                throw createOperationFailure(LoggingLogger.ROOT_LOGGER.formatterNotFound(name));
+            }
+            logContextConfiguration.removeFormatterConfiguration(name);
+        }
+    };
+
+    StructuredFormatterResourceDefinition(final PathElement pathElement, final String descriptionPrefix, final Class<? extends StructuredFormatter> type) {
+        super(
+                new Parameters(pathElement, LoggingExtension.getResourceDescriptionResolver(descriptionPrefix))
+                        .setAddHandler(new AddStructuredFormatterStepHandler(type))
+                        .setRemoveHandler(REMOVE)
+        );
+    }
+
+    @Override
+    public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
+        for (AttributeDefinition attribute : ATTRIBUTES) {
+            resourceRegistration.registerReadWriteAttribute(attribute, null, WRITE);
+        }
+    }
+
+    @Override
+    public void registerChildren(final ManagementResourceRegistration resourceRegistration) {
+        super.registerChildren(resourceRegistration);
+    }
+
+    @Override
+    public void registerTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder rootResourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+        switch (modelVersion) {
+            case VERSION_5_0_0:
+                rootResourceBuilder.rejectChildResource(getPathElement());
+                loggingProfileBuilder.rejectChildResource(getPathElement());
+                break;
+        }
+    }
+
+    private static String modelValueToMetaData(final ModelNode metaData) {
+        if (metaData.getType() != ModelType.OBJECT) {
+            return null;
+        }
+        final List<Property> properties = metaData.asPropertyList();
+        final StringBuilder result = new StringBuilder();
+        final Iterator<Property> iterator = properties.iterator();
+        while (iterator.hasNext()) {
+            final Property property = iterator.next();
+            PropertyValues.escapeKey(result, property.getName());
+            result.append('=');
+            final ModelNode value = property.getValue();
+            if (value.isDefined()) {
+                PropertyValues.escapeValue(result, value.asString());
+            }
+            if (iterator.hasNext()) {
+                result.append(',');
+            }
+        }
+        return result.toString();
+    }
+
+    private static class AddStructuredFormatterStepHandler extends LoggingOperations.LoggingAddOperationStepHandler {
+        private final Class<? extends StructuredFormatter> type;
+
+        private AddStructuredFormatterStepHandler(final Class<? extends StructuredFormatter> type) {
+            this.type = type;
+        }
+
+        @SuppressWarnings("OverlyStrongTypeCast")
+        @Override
+        public void performRuntime(final OperationContext context, final ModelNode operation, final LogContextConfiguration logContextConfiguration, final String name, final ModelNode model) throws OperationFailedException {
+            String keyOverrides = null;
+            if (model.hasDefined(KEY_OVERRIDES.getName())) {
+                keyOverrides = modelValueToMetaData(KEY_OVERRIDES.resolveModelAttribute(context, model));
+            }
+
+            FormatterConfiguration configuration = logContextConfiguration.getFormatterConfiguration(name);
+            final String className = type.getName();
+
+            if (configuration == null) {
+                LoggingLogger.ROOT_LOGGER.tracef("Adding formatter '%s' at '%s'", name, LoggingOperations.getAddress(operation));
+                if (keyOverrides == null) {
+                    configuration = logContextConfiguration.addFormatterConfiguration(null, className, name);
+                } else {
+                    configuration = logContextConfiguration.addFormatterConfiguration(null, className, name, "keyOverrides");
+                    configuration.setPropertyValueString("keyOverrides", keyOverrides);
+                }
+            } else if (isSamePropertyValue(configuration, "keyOverrides", keyOverrides)) {
+                LoggingLogger.ROOT_LOGGER.tracef("Removing then adding formatter '%s' at '%s'", name, LoggingOperations.getAddress(operation));
+                logContextConfiguration.removeFormatterConfiguration(name);
+                configuration = logContextConfiguration.addFormatterConfiguration(null, className, name, "keyOverrides");
+                configuration.setPropertyValueString("keyOverrides", keyOverrides);
+            }
+
+            // Process the attributes
+            for (AttributeDefinition attribute : ATTRIBUTES) {
+                if (attribute == META_DATA) {
+                    final String metaData = modelValueToMetaData(META_DATA.resolveModelAttribute(context, model));
+                    if (metaData != null) {
+                        if (isSamePropertyValue(configuration, "metaData", metaData)) {
+                            configuration.setPropertyValueString("metaData", metaData);
+                        }
+                    } else {
+                        configuration.removeProperty("metaData");
+                    }
+                } else if (attribute == KEY_OVERRIDES) {
+                    // Ignore the key-overrides as it was already taken care of
+                } else {
+                    if (attribute instanceof PropertyAttributeDefinition) {
+                        ((PropertyAttributeDefinition) attribute).setPropertyValue(context, model, configuration);
+                    } else {
+                        final ModelNode value = attribute.resolveModelAttribute(context, model);
+                        if (value.isDefined()) {
+                            if (isSamePropertyValue(configuration, attribute.getName(), value.asString())) {
+                                configuration.setPropertyValueString(attribute.getName(), value.asString());
+                            }
+                        } else {
+                            configuration.removeProperty(attribute.getName());
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public void updateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
+            for (AttributeDefinition attribute : ATTRIBUTES) {
+                attribute.validateAndSet(operation, model);
+            }
+        }
+
+        private static boolean isSamePropertyValue(final FormatterConfiguration configuration, final String name, final String value) {
+            final String currentValue = configuration.getPropertyValueString(name);
+            if (currentValue == null) {
+                return value != null;
+            }
+            return currentValue.equals(value);
+        }
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -943,4 +943,14 @@ public interface LoggingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 90, value = "The following path expressions could not be resolved while attempting to determine which log files are available to be read: %s")
     void unresolvablePathExpressions(Set<String> unresolvableExpressions);
+
+    /**
+     * A message indicating the exception output type is not valid.
+     *
+     * @param value the invalid value
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 91, value = "Exception output type %s is invalid.")
+    OperationFailedException invalidExceptionOutputType(String value);
 }

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -594,6 +594,59 @@ logging.pattern-formatter.color-map=The color-map attribute allows for a comma d
                                                     Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred, brightgreen, \
                                                     brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
 
+# JSON formatter descriptions
+logging.json-formatter=A formatter that formats log messages in JSON.
+logging.json-formatter.add=Adds a new JSON formatter.
+logging.json-formatter.remove=Removes the JSON formatter.
+logging.json-formatter.date-format=The date/time format pattern. The pattern must be a valid \
+  java.time.format.DateTimeFormatter.ofPattern() pattern. The default pattern is an ISO-8601 extended offset date-time \
+  format.
+logging.json-formatter.exception-output-type=Indicates how the cause of the logged message, if one is available, will be \
+  added to the JSON output.
+logging.json-formatter.key-overrides=Allows the names of the keys for the JSON properties to be overridden.
+logging.json-formatter.key-overrides.exception=Allows the default key of exception to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-caused-by=Allows the default key of causedBy to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-circular-reference=Allows the default key of circularReference to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-frame=Allows the default key of frame to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-frame-class=Allows the default key of class to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-frame-line=Allows the default key of line to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-frame-method=Allows the default key of method to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-frames=Allows the default key of frames to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-message=Allows the default key of message to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-reference-id=Allows the default key of refId to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-suppressed=Allows the default key of suppressed to be overridden to the value provided.
+logging.json-formatter.key-overrides.exception-type=Allows the default key of exceptionType to be overridden to the value provided.
+logging.json-formatter.key-overrides.host-name=Allows the default key of hostName to be overridden to the value provided.
+logging.json-formatter.key-overrides.level=Allows the default key of level to be overridden to the value provided.
+logging.json-formatter.key-overrides.logger-class-name=Allows the default key of loggerClassName to be overridden to the value provided.
+logging.json-formatter.key-overrides.logger-name=Allows the default key of loggerName to be overridden to the value provided.
+logging.json-formatter.key-overrides.mdc=Allows the default key of mdc to be overridden to the value provided.
+logging.json-formatter.key-overrides.message=Allows the default key of message to be overridden to the value provided.
+logging.json-formatter.key-overrides.ndc=Allows the default key of ndc to be overridden to the value provided.
+logging.json-formatter.key-overrides.process-id=Allows the default key of processId to be overridden to the value provided.
+logging.json-formatter.key-overrides.process-name=Allows the default key of processName to be overridden to the value provided.
+logging.json-formatter.key-overrides.record=Allows the default key of record to be overridden to the value provided.
+logging.json-formatter.key-overrides.sequence=Allows the default key of sequence to be overridden to the value provided.
+logging.json-formatter.key-overrides.source-class-name=Allows the default key of sourceClassName to be overridden to the value provided.
+logging.json-formatter.key-overrides.source-file-name=Allows the default key of sourceFileName to be overridden to the value provided.
+logging.json-formatter.key-overrides.source-line-number=Allows the default key of sourceLineNumber to be overridden to the value provided.
+logging.json-formatter.key-overrides.source-method-name=Allows the default key of sourceMethodName to be overridden to the value provided.
+logging.json-formatter.key-overrides.source-module-name=Allows the default key of sourceModuleName to be overridden to the value provided.
+logging.json-formatter.key-overrides.source-module-version=Allows the default key of sourceModuleVersion to be overridden to the value provided.
+logging.json-formatter.key-overrides.stack-trace=Allows the default key of stackTrace to be overridden to the value provided.
+logging.json-formatter.key-overrides.thread-id=Allows the default key of threadId to be overridden to the value provided.
+logging.json-formatter.key-overrides.thread-name=Allows the default key of threadName to be overridden to the value provided.
+logging.json-formatter.key-overrides.timestamp=Allows the default key of timestamp to be overridden to the value provided.
+logging.json-formatter.meta-data=Sets the meta data to use in the JSON format. Properties will be added to each log \
+  message.
+logging.json-formatter.pretty-print=Indicates whether or not pretty printing should be used when formatting.
+logging.json-formatter.print-details=Sets whether or not details should be printed. Printing the details can be \
+  expensive as the values are retrieved from the caller. The details include the source class name, source file name, \
+  source method name, source module name, source module version and source line number.
+logging.json-formatter.record-delimiter=The value to be used to indicate the end of a record. If set to null no \
+  delimiter will be used at the end of the record. The default value is a line feed.
+logging.json-formatter.zone-id=The zone ID for formatting the date and time. The system default is used if left undefined.
+
 # Custom formatter descriptions
 logging.custom-formatter=A custom formatter to be used with handlers. Note that most log records are formatted in the printf format. Formatters may require \
   invocation of the org.jboss.logmanager.ExtLogRecord#getFormattedMessage() for the message to be properly formatted.

--- a/logging/src/main/resources/schema/jboss-as-logging_5_0.xsd
+++ b/logging/src/main/resources/schema/jboss-as-logging_5_0.xsd
@@ -3,7 +3,7 @@
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~
-  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ Copyright 2017 Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -61,9 +61,9 @@
             <xs:element name="use-deployment-logging-config" type="booleanTrueValueType">
                 <xs:annotation>
                     <xs:documentation>
-                            Determines whether or not deployments should be scanned for configuration files. If set to
-                            true and a configuration file is found the log manager will be configured based on the
-                            configuration file.
+                        Determines whether or not deployments should be scanned for configuration files. If set to
+                        true and a configuration file is found the log manager will be configured based on the
+                        configuration file.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -471,6 +471,15 @@
         <xs:choice minOccurs="1" maxOccurs="1">
             <xs:element name="pattern-formatter" type="patternFormatterType" maxOccurs="1"/>
             <xs:element name="custom-formatter" type="customFormatterType" maxOccurs="1"/>
+            <xs:element name="json-formatter" type="structuredFormatterType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Defines a JSON formatter to be used to format log messages.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:choice>
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
@@ -539,6 +548,71 @@
         </xs:attribute>
     </xs:complexType>
 
+    <xs:complexType name="structuredFormatterType">
+        <xs:all>
+            <xs:element name="exception-output-type" type="exceptionOutputType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Indicates how the cause of the logged message, if one is available, will be added to the output.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="record-delimiter" type="valueType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The value to be used to indicate the end of a record. If set to null no delimiter will be used
+                        at the end of the record. The default value is a line feed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="key-overrides" type="keyOverrideType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows the names of the keys or elements for the properties to be overridden.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="meta-data" type="propertiesType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the meta data to use in the structured format. Properties will be added to each log message.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="date-format" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The date/time format pattern. The pattern must be a valid
+                    java.time.format.DateTimeFormatter.ofPattern() pattern.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pretty-print" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates whether or not pretty printing should be used when formatting.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="print-details" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets whether or not details should be printed. Printing the details can be expensive as the values
+                    are retrieved from the caller. The details include the source class name, source file name, source
+                    method name and source line number.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="zone-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The zone ID for formatting the date and time. The system default is used if left undefined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
     <xs:complexType name="customFormatterType">
         <xs:annotation>
             <xs:documentation>
@@ -563,6 +637,82 @@
             </xs:documentation>
         </xs:annotation>
         <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="exceptionOutputType">
+        <xs:annotation>
+            <xs:documentation>
+                Set the output type for exceptions. The default is detailed.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="detailed">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cause, if present, will be an array of stack trace elements. This will include
+                                suppressed exceptions and the cause of the exception.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="formatted">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cause, if present, will be a string representation of the stack trace in a
+                                stackTrace property. The property value is a string created by
+                                Throwable.printStackTrace().
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="detailed-and-formatted">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cause, if present, will be a string representation of the stack trace in a
+                                stackTrace property. The property value is a string created by
+                                Throwable.printStackTrace().
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="keyOverrideType">
+        <xs:attribute name="exception" type="xs:string"/>
+        <xs:attribute name="exception-caused-by" type="xs:string"/>
+        <xs:attribute name="exception-circular-reference" type="xs:string"/>
+        <xs:attribute name="exception-frame" type="xs:string"/>
+        <xs:attribute name="exception-frame-class" type="xs:string"/>
+        <xs:attribute name="exception-frame-line" type="xs:string"/>
+        <xs:attribute name="exception-frame-method" type="xs:string"/>
+        <xs:attribute name="exception-frames" type="xs:string"/>
+        <xs:attribute name="exception-message" type="xs:string"/>
+        <xs:attribute name="exception-reference-id" type="xs:string"/>
+        <xs:attribute name="exception-suppressed" type="xs:string"/>
+        <xs:attribute name="exception-type" type="xs:string"/>
+        <xs:attribute name="host-name" type="xs:string"/>
+        <xs:attribute name="level" type="xs:string"/>
+        <xs:attribute name="logger-class-name" type="xs:string"/>
+        <xs:attribute name="logger-name" type="xs:string"/>
+        <xs:attribute name="mdc" type="xs:string"/>
+        <xs:attribute name="message" type="xs:string"/>
+        <xs:attribute name="ndc" type="xs:string"/>
+        <xs:attribute name="process-id" type="xs:string"/>
+        <xs:attribute name="process-name" type="xs:string"/>
+        <xs:attribute name="record" type="xs:string"/>
+        <xs:attribute name="sequence" type="xs:string"/>
+        <xs:attribute name="source-class-name" type="xs:string"/>
+        <xs:attribute name="source-file-name" type="xs:string"/>
+        <xs:attribute name="source-line-number" type="xs:string"/>
+        <xs:attribute name="source-method-name" type="xs:string"/>
+        <xs:attribute name="source-module-name" type="xs:string"/>
+        <xs:attribute name="source-module-version" type="xs:string"/>
+        <xs:attribute name="stack-trace" type="xs:string"/>
+        <xs:attribute name="thread-id" type="xs:string"/>
+        <xs:attribute name="thread-name" type="xs:string"/>
+        <xs:attribute name="timestamp" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="syslogFormatterType">

--- a/logging/src/main/resources/schema/jboss-as-logging_5_0.xsd
+++ b/logging/src/main/resources/schema/jboss-as-logging_5_0.xsd
@@ -1,0 +1,609 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:logging:5.0"
+           xmlns="urn:jboss:domain:logging:5.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="5.0">
+
+    <!-- The logging subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the logging subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="logger" type="loggerType"/>
+            <xs:element name="root-logger" type="rootLoggerType"/>
+            <xs:element name="console-handler" type="consoleHandlerType"/>
+            <xs:element name="file-handler" type="fileHandlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
+            <xs:element name="periodic-size-rotating-file-handler" type="periodicSizeFileHandlerType"/>
+            <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="async-handler" type="asyncHandlerType"/>
+            <xs:element name="custom-handler" type="customHandlerType"/>
+            <xs:element name="syslog-handler" type="syslogHandlerType"/>
+            <xs:element name="formatter" type="formatterType"/>
+            <xs:element name="add-logging-api-dependencies" type="booleanTrueValueType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Determines whether or not the default logging dependencies should be added to deployments during the deployment process.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="use-deployment-logging-config" type="booleanTrueValueType">
+                <xs:annotation>
+                    <xs:documentation>
+                            Determines whether or not deployments should be scanned for configuration files. If set to
+                            true and a configuration file is found the log manager will be configured based on the
+                            configuration file.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="logging-profiles" type="logging-profilesType" minOccurs="0" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="logging-profilesType">
+        <xs:annotation>
+            <xs:documentation>
+                Contains a list of profiles available for use in deployments
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="logging-profile" type="logging-profileType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="logging-profileType">
+        <xs:annotation>
+            <xs:documentation>
+                A logging profile that can be used in a deployment for a custom logging configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="logger" type="loggerType"/>
+            <xs:element name="root-logger" type="rootLoggerType"/>
+            <xs:element name="console-handler" type="consoleHandlerType"/>
+            <xs:element name="file-handler" type="fileHandlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
+            <xs:element name="periodic-size-rotating-file-handler" type="periodicSizeFileHandlerType"/>
+            <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="async-handler" type="asyncHandlerType"/>
+            <xs:element name="custom-handler" type="customHandlerType"/>
+            <xs:element name="syslog-handler" type="syslogHandlerType"/>
+            <xs:element name="formatter" type="formatterType"/>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of free-form properties.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="value" type="xs:string" use="optional"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="refType">
+        <xs:annotation>
+            <xs:documentation>
+                A named reference to another object.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlersType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of handlers to apply to the enclosing object.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="handler" type="refType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="rootLoggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines the root logger for this log context.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all minOccurs="1" maxOccurs="1">
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="handlers" type="handlersType" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="loggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a logger category.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="rootLoggerType">
+                <xs:attribute name="use-parent-handlers" type="xs:boolean" use="optional" default="true"/>
+                <xs:attribute name="category" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="consoleHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to the console.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="target" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="name" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="System.out"/>
+                                <xs:enumeration value="System.err"/>
+                                <xs:enumeration value="console"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="fileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType" minOccurs="1"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="periodicFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after a time period derived from the given
+                suffix string, which should be in a format understood by java.text.SimpleDateFormat.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="suffix" type="valueType"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="periodicSizeFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after the size of the file grows beyond a
+                certain point or the time period derived from the given suffix string and keeping a fixed number of
+                backups. The suffix should be in a format understood by java.text.SimpleDateFormat.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
+            <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
+            <xs:element name="suffix" type="valueType"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="rotate-on-boot" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="sizeFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after the size of the file grows beyond a
+                certain point and keeping a fixed number of backups.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
+            <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
+            <xs:element name="suffix" type="valueType" minOccurs="0"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="rotate-on-boot" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="asyncHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to the sub-handlers in an asynchronous thread. Used for handlers which
+                introduce a substantial amount of lag.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="queue-length" type="queueLengthType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="overflow-action" type="overflowActionType" minOccurs="0"/>
+            <xs:element name="subhandlers" type="handlersType"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="customHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a custom handler.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="module" type="xs:string" use="required"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="syslogHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a syslog handler for UNIX/Linux based operating systems.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="server-address" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The address of the syslog server. The default is localhost.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hostname" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the host the messages are being sent from. For example the name of the host the
+                        application server is running on.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="port" type="positiveIntType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The port the syslog server is listening on. The default is 514.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="app-name" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The app name used when formatting the message in RFC5424 format. By default the app name is
+                        &quot;java&quot;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="formatter" type="syslogFormatterType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="facility" type="facilityType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="queueLengthType">
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:positiveInteger">
+                    <xs:minExclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="overflowActionType">
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="block"/>
+                    <xs:enumeration value="discard"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="positiveIntType">
+        <xs:attribute name="value" use="required" type="xs:positiveInteger"/>
+    </xs:complexType>
+
+    <xs:complexType name="booleanValueType">
+        <xs:attribute name="value" use="required" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="booleanTrueValueType">
+        <xs:attribute name="value" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="valueType">
+        <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="pathType">
+        <xs:attribute name="relative-to" use="optional" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="sizeType">
+        <xs:attribute name="value">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <!-- XSD doesn't allow ^ or $ so ^[0-9]+[bkmgtp]?$ is invalid -->
+                    <xs:pattern value="[0-9]+[bkmgtp]"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="facilityType">
+        <xs:annotation>
+            <xs:documentation>
+                Facility as defined by RFC-5424 (http://tools.ietf.org/html/rfc5424)and RFC-3164
+                (http://tools.ietf.org/html/rfc3164).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="kernel"/>
+                    <xs:enumeration value="user-level"/>
+                    <xs:enumeration value="mail-system"/>
+                    <xs:enumeration value="system-daemons"/>
+                    <xs:enumeration value="security"/>
+                    <xs:enumeration value="syslogd"/>
+                    <xs:enumeration value="line-printer"/>
+                    <xs:enumeration value="network-news"/>
+                    <xs:enumeration value="uucp"/>
+                    <xs:enumeration value="clock-daemon"/>
+                    <xs:enumeration value="security2"/>
+                    <xs:enumeration value="ftp-daemon"/>
+                    <xs:enumeration value="ntp"/>
+                    <xs:enumeration value="log-audit"/>
+                    <xs:enumeration value="log-alert"/>
+                    <xs:enumeration value="clock-daemon2"/>
+                    <xs:enumeration value="local-use-0"/>
+                    <xs:enumeration value="local-use-1"/>
+                    <xs:enumeration value="local-use-2"/>
+                    <xs:enumeration value="local-use-3"/>
+                    <xs:enumeration value="local-use-4"/>
+                    <xs:enumeration value="local-use-5"/>
+                    <xs:enumeration value="local-use-6"/>
+                    <xs:enumeration value="local-use-7"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!-- Formatters -->
+
+    <xs:complexType name="formatterType">
+        <xs:annotation>
+            <xs:documentation>
+                A formatter that can be assigned to a handler.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="pattern-formatter" type="patternFormatterType" maxOccurs="1"/>
+            <xs:element name="custom-formatter" type="customFormatterType" maxOccurs="1"/>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlerFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a formatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="pattern-formatter" type="handlerPatternFormatterType" maxOccurs="1"/>
+            <xs:element name="named-formatter" type="namedFormatterType" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="handlerPatternFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a pattern formatter. See the documentation for
+                org.jboss.logmanager.formatters.FormatStringParser
+                for more information about the format string.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="patternFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a pattern formatter. See the documentation for
+                org.jboss.logmanager.formatters.FormatStringParser
+                for more information about the format string.
+
+                The color-map attribute allows for a comma delimited list of colors to be used for different levels. The
+                format is level-name:color-name.
+
+                Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest
+
+                Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred,
+                brightgreen,
+                brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The format pattern as defined in org.jboss.logmanager.formatters.FormatStringParser.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="color-map" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The color-map attribute allows for a comma delimited list of colors to be used for different levels.
+                    The
+                    format is level-name:color-name.
+
+                    Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest
+
+                    Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred,
+                    brightgreen,
+                    brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                Defines a formatter to be used to format log messages.
+
+                Note that most log records are formatted in the printf format. Formatters may require invocation of org.jboss.logmanager.ExtLogRecord#getFormattedMessage() for the message to be properly formatted.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="module" type="xs:string" use="required"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="namedFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                The name of a defined formatter that will be used to format the log message.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="syslogFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a formatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="syslog-format" type="syslogFormatType" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="syslogFormatType">
+        <xs:annotation>
+            <xs:documentation>
+                Formats the log message according to the RFC specification.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="syslog-type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="RFC5424">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Formats the message according the the RFC-5424 specification
+                                (http://tools.ietf.org/html/rfc5424#section-6)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="RFC3164">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Formats the message according the the RFC-3164 specification
+                                (http://tools.ietf.org/html/rfc3164#section-4.1)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/logging/src/main/resources/subsystem-templates/logging.xml
+++ b/logging/src/main/resources/subsystem-templates/logging.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
    <extension-module>org.jboss.as.logging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:logging:4.0">
+   <subsystem xmlns="urn:jboss:domain:logging:5.0">
        <?HANDLERS?>
        <periodic-rotating-file-handler name="FILE" autoflush="true">
            <formatter>

--- a/logging/src/test/java/org/jboss/as/logging/AbstractOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/AbstractOperationsTestCase.java
@@ -98,15 +98,19 @@ public abstract class AbstractOperationsTestCase extends AbstractLoggingSubsyste
         assertEquals(value, SubsystemOperations.readResult(result));
     }
 
-    protected void testUndefine(final KernelServices kernelServices, final ModelNode address, final AttributeDefinition attribute) {
+    void testUndefine(final KernelServices kernelServices, final ModelNode address, final String attribute) {
         final ModelNode undefineOp = SubsystemOperations.createUndefineAttributeOperation(address, attribute);
         executeOperation(kernelServices, undefineOp);
         // Create the read operation
         final ModelNode readOp = SubsystemOperations.createReadAttributeOperation(address, attribute);
         readOp.get("include-defaults").set(false);
         final ModelNode result = executeOperation(kernelServices, readOp);
-        assertFalse("Attribute '" + attribute.getName() + "' was not undefined.", SubsystemOperations.readResult(result)
+        assertFalse("Attribute '" + attribute + "' was not undefined.", SubsystemOperations.readResult(result)
                 .isDefined());
+    }
+
+    protected void testUndefine(final KernelServices kernelServices, final ModelNode address, final AttributeDefinition attribute) {
+        testUndefine(kernelServices, address, attribute.getName());
     }
 
     protected void verifyRemoved(final KernelServices kernelServices, final ModelNode address) {

--- a/logging/src/test/java/org/jboss/as/logging/FormatterOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/FormatterOperationsTestCase.java
@@ -22,13 +22,20 @@
 
 package org.jboss.as.logging;
 
-import java.io.File;
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.logging.formatters.StructuredFormatterResourceDefinition;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.SubsystemOperations;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -36,17 +43,19 @@ import org.junit.Test;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public class FormatterOperationsTestCase extends AbstractOperationsTestCase {
-    private static final String FQCN = FormatterOperationsTestCase.class.getName();
 
-    private static File logDir;
+    private static final Map<String, String> TEST_KEY_OVERRIDES = new LinkedHashMap<>();
+    private static final Map<String, String> EXPECTED_META_DATA = new LinkedHashMap<>();
 
     @BeforeClass
-    public static void setupLoggingDir() {
-        logDir = LoggingTestEnvironment.get().getLogDir();
-        final File[] files = logDir.listFiles();
-        for (File file : (files == null ? new File[0] : files)) {
-            file.delete();
+    public static void setup() {
+        for (AttributeDefinition attribute : StructuredFormatterResourceDefinition.KEY_OVERRIDES.getValueTypes()) {
+            final String key = attribute.getName();
+            TEST_KEY_OVERRIDES.put(key, convertKey(key));
         }
+        EXPECTED_META_DATA.put("key1", "value1");
+        EXPECTED_META_DATA.put("key2", "value2");
+        EXPECTED_META_DATA.put("key3", null);
     }
 
     @After
@@ -78,6 +87,14 @@ public class FormatterOperationsTestCase extends AbstractOperationsTestCase {
         testPatternFormatter(kernelServices, PROFILE);
     }
 
+    @Test
+    public void testJsonFormatterOperations() throws Exception {
+        final KernelServices kernelServices = boot();
+
+        testJsonFormatter(kernelServices, null);
+        testJsonFormatter(kernelServices, PROFILE);
+    }
+
     private void testPatternFormatter(final KernelServices kernelServices, final String profileName) throws Exception {
         final ModelNode address = createPatternFormatterAddress(profileName, "PATTERN").toModelNode();
 
@@ -96,5 +113,141 @@ public class FormatterOperationsTestCase extends AbstractOperationsTestCase {
         // Clean-up
         executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(address));
         verifyRemoved(kernelServices, address);
+    }
+
+    private void testJsonFormatter(final KernelServices kernelServices, final String profileName) throws Exception {
+        final ModelNode address = createAddress(profileName, "json-formatter", "JSON").toModelNode();
+
+        final String dateFormat = "yyyy-MM-dd'T'HH:mm:ssSSSZ";
+
+        // Add the formatter
+        final ModelNode op = SubsystemOperations.createAddOperation(address);
+        op.get("date-format").set(dateFormat);
+        op.get("exception-output-type").set("formatted");
+        final ModelNode keyOverrides = op.get("key-overrides").setEmptyObject();
+        for (String key : TEST_KEY_OVERRIDES.keySet()) {
+            keyOverrides.get(key).set(TEST_KEY_OVERRIDES.get(key));
+        }
+
+        final ModelNode metaData = op.get("meta-data");
+        for (String key : EXPECTED_META_DATA.keySet()) {
+            final String value = EXPECTED_META_DATA.get(key);
+            if (value == null) {
+                metaData.get(key);
+            } else {
+                metaData.get(key).set(value);
+            }
+        }
+        op.get("pretty-print").set(true);
+        op.get("print-details").set(true);
+        op.get("record-delimiter").set("\r\n");
+        op.get("zone-id").set("GMT");
+        executeOperation(kernelServices, op);
+
+        // Verify we've been added with the expected values
+        validateValue(kernelServices, address, "date-format", dateFormat);
+        validateValue(kernelServices, address, "exception-output-type", "formatted");
+        validateValue(kernelServices, address, "key-overrides", TEST_KEY_OVERRIDES);
+        validateValue(kernelServices, address, "meta-data", EXPECTED_META_DATA);
+        validateValue(kernelServices, address, "pretty-print", true);
+        validateValue(kernelServices, address, "print-details", true);
+        validateValue(kernelServices, address, "record-delimiter", "\r\n");
+        validateValue(kernelServices, address, "zone-id", "GMT");
+
+        // Remove the formatter
+        executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(address));
+        verifyRemoved(kernelServices, address);
+
+        // Re-add the formatter with no parameters and test writes and undefines
+        executeOperation(kernelServices, Operations.createAddOperation(address));
+
+        testWrite(kernelServices, address, "date-format", dateFormat);
+        testWrite(kernelServices, address, "exception-output-type", "detailed-and-formatted");
+        // This will require a reload, but we should be okay since we're only testing the model
+        testWrite(kernelServices, address, "key-overrides", TEST_KEY_OVERRIDES);
+        testWrite(kernelServices, address, "meta-data", EXPECTED_META_DATA);
+        testWrite(kernelServices, address, "pretty-print", true);
+        testWrite(kernelServices, address, "print-details", true);
+        testWrite(kernelServices, address, "record-delimiter", "\r\n");
+        testWrite(kernelServices, address, "zone-id", "GMT");
+
+        testUndefine(kernelServices, address, "date-format");
+        testUndefine(kernelServices, address, "exception-output-type");
+        testUndefine(kernelServices, address, "key-overrides");
+        testUndefine(kernelServices, address, "meta-data");
+        testUndefine(kernelServices, address, "pretty-print");
+        testUndefine(kernelServices, address, "print-details");
+        testUndefine(kernelServices, address, "record-delimiter");
+        testUndefine(kernelServices, address, "zone-id");
+
+    }
+
+    private void testWrite(final KernelServices kernelServices, final ModelNode address, final String attributeName, final String value) {
+        final ModelNode writeOp = SubsystemOperations.createWriteAttributeOperation(address, attributeName, value);
+        executeOperation(kernelServices, writeOp);
+        validateValue(kernelServices, address, attributeName, value);
+    }
+
+    private void testWrite(final KernelServices kernelServices, final ModelNode address, final String attributeName, final boolean value) {
+        final ModelNode writeOp = SubsystemOperations.createWriteAttributeOperation(address, attributeName, value);
+        executeOperation(kernelServices, writeOp);
+        validateValue(kernelServices, address, attributeName, value);
+    }
+
+    private void testWrite(final KernelServices kernelServices, final ModelNode address, final String attributeName, final Map<String, String> value) {
+        final ModelNode modelValue = new ModelNode().setEmptyObject();
+        for (Map.Entry<String, String> entry : value.entrySet()) {
+            final String mapValue = entry.getValue();
+            if (mapValue == null) {
+                modelValue.get(entry.getKey());
+            } else {
+                modelValue.get(entry.getKey()).set(mapValue);
+            }
+        }
+        final ModelNode writeOp = SubsystemOperations.createWriteAttributeOperation(address, attributeName, modelValue);
+        executeOperation(kernelServices, writeOp);
+        validateValue(kernelServices, address, attributeName, value);
+    }
+
+    private void validateValue(final KernelServices kernelServices, final ModelNode address, final String attributeName, final String expectedValue) {
+        final ModelNode value = executeOperation(kernelServices, SubsystemOperations.createReadAttributeOperation(address, attributeName));
+        Assert.assertEquals(expectedValue, SubsystemOperations.readResult(value).asString());
+    }
+
+    private void validateValue(final KernelServices kernelServices, final ModelNode address, final String attributeName, final boolean expectedValue) {
+        final ModelNode value = executeOperation(kernelServices, SubsystemOperations.createReadAttributeOperation(address, attributeName));
+        Assert.assertEquals(expectedValue, SubsystemOperations.readResult(value).asBoolean());
+    }
+
+    private void validateValue(final KernelServices kernelServices, final ModelNode address, final String attributeName, final Map<String, String> expectedValues) {
+        final ModelNode value = executeOperation(kernelServices, SubsystemOperations.createReadAttributeOperation(address, attributeName));
+        Assert.assertEquals(ModelType.OBJECT, value.getType());
+        final Map<String, String> remainingKeys = new LinkedHashMap<>(expectedValues);
+        for (Property property : SubsystemOperations.readResult(value).asPropertyList()) {
+            final String key = property.getName();
+            final String expectedValue = remainingKeys.remove(key);
+            if (expectedValue == null) {
+                Assert.assertFalse(property.getValue().isDefined());
+            } else {
+                Assert.assertEquals(expectedValue, property.getValue().asString());
+            }
+        }
+
+        Assert.assertTrue(String.format("Missing keys in model:%nKeys: %s%nModel%s%n", remainingKeys, SubsystemOperations.readResult(value)), remainingKeys.isEmpty());
+    }
+
+    private static String convertKey(final String key) {
+        final char[] chars = key.toCharArray();
+        final StringBuilder result = new StringBuilder(chars.length);
+        for (int i = 0; i < chars.length; i++) {
+            final char c = chars[i];
+            if (c == '-') {
+                // We're making an assumption no characters start or end with a -
+                result.append(Character.toUpperCase(chars[++i]));
+            } else {
+                result.append(c);
+            }
+        }
+        return result.append("Override").toString();
     }
 }

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -68,7 +68,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/jboss-as-logging_4_0.xsd";
+        return "schema/jboss-as-logging_5_0.xsd";
     }
 
     @Test

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -151,12 +151,26 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(ConsoleHandlerResourceDefinition.CONSOLE_HANDLER_PATH),
                                 new RejectExpressionsConfig(ConsoleHandlerResourceDefinition.TARGET))
                         .addFailedAttribute(loggingProfileAddress.append(ConsoleHandlerResourceDefinition.CONSOLE_HANDLER_PATH),
-                                new RejectExpressionsConfig(ConsoleHandlerResourceDefinition.TARGET)));
+                                new RejectExpressionsConfig(ConsoleHandlerResourceDefinition.TARGET))
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append("json-formatter"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE));
     }
 
     @Test
     public void testTransformersEAP700() throws Exception {
-        testEap7Transformer(ModelTestControllerVersion.EAP_7_0_0, ModelVersion.create(3, 0, 0), readResource("/logging_3_0.xml") );
+        testEap7Transformer(ModelTestControllerVersion.EAP_7_0_0, ModelVersion.create(3, 0, 0), readResource("/logging_3_0.xml"));
+    }
+
+    @Test
+    public void testFailedTransformersEAP700() throws Exception {
+        final ModelTestControllerVersion controllerVersion = ModelTestControllerVersion.EAP_7_0_0;
+        final ModelVersion modelVersion = ModelVersion.create(3, 0, 0);
+
+        // Test against current
+        testEap7FailedTransformers(controllerVersion, modelVersion, readResource("/expressions.xml"),
+                new FailedOperationTransformationConfig()
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append("json-formatter"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE));
     }
 
     private void testEap7Transformer(final ModelTestControllerVersion controllerVersion, final ModelVersion legacyModelVersion, final String subsystemXml, final ModelFixer... modelFixers) throws Exception {
@@ -204,6 +218,28 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         // Create the legacy kernel
         builder.createLegacyKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance(), controllerVersion, legacyModelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-logging:" + controllerVersion.getMavenGavVersion())
+                .dontPersistXml()
+                .addSingleChildFirstClass(LoggingTestEnvironment.class, LoggingTestEnvironment.LoggingInitializer.class)
+                .configureReverseControllerCheck(LoggingTestEnvironment.getManagementInstance(), null);
+
+
+        KernelServices mainServices = builder.build();
+        KernelServices legacyServices = mainServices.getLegacyServices(legacyModelVersion);
+
+        Assert.assertNotNull(legacyServices);
+        Assert.assertTrue("main services did not boot", mainServices.isSuccessfulBoot());
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        final List<ModelNode> ops = builder.parseXml(subsystemXml);
+        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, legacyModelVersion, ops, config);
+    }
+
+    private void testEap7FailedTransformers(final ModelTestControllerVersion controllerVersion, final ModelVersion legacyModelVersion, final String subsystemXml, final FailedOperationTransformationConfig config) throws Exception {
+        final KernelServicesBuilder builder = createKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance());
+
+        // Create the legacy kernel
+        builder.createLegacyKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance(), controllerVersion, legacyModelVersion)
+                .addMavenResourceURL(controllerVersion.getCoreMavenGroupId() + ":wildfly-logging:" + controllerVersion.getCoreVersion())
                 .dontPersistXml()
                 .addSingleChildFirstClass(LoggingTestEnvironment.class, LoggingTestEnvironment.LoggingInitializer.class)
                 .configureReverseControllerCheck(LoggingTestEnvironment.getManagementInstance(), null);

--- a/logging/src/test/resources/default-subsystem.xml
+++ b/logging/src/test/resources/default-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:4.0">
+<subsystem xmlns="urn:jboss:domain:logging:5.0">
     <console-handler name="CONSOLE">
         <level name="INFO"/>
         <formatter>

--- a/logging/src/test/resources/empty-subsystem.xml
+++ b/logging/src/test/resources/empty-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:4.0">
+<subsystem xmlns="urn:jboss:domain:logging:5.0">
 
     <!-- Set-up a default logging profile -->
     <logging-profiles>

--- a/logging/src/test/resources/expressions.xml
+++ b/logging/src/test/resources/expressions.xml
@@ -122,6 +122,19 @@
         <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n}" color-map="${test.console.color:info:cyan,warn:yellow,error:red}"/>
     </formatter>
 
+    <formatter name="JSON">
+        <json-formatter date-format="${test.date.format:yyyy-MM-dd'T'HH:mm:ssSSS}"
+                pretty-print="${test.pretty.print:false}" print-details="${test.print.details:false}"
+                zone-id="${test.date.format.zoneId:GMT}">
+            <exception-output-type value="${test.exception.output.type:detailed}"/>
+            <record-delimiter value="${test.record.delimiter:\n}"/>
+            <key-overrides exception-caused-by="${test.cause.key:caused-by}" record="${test.record.key:record"/>
+            <meta-data>
+                <property name="test" value="value"/>
+            </meta-data>
+        </json-formatter>
+    </formatter>
+
     <logging-profiles>
         <logging-profile name="test-profile">
 

--- a/logging/src/test/resources/expressions_4_0.xml
+++ b/logging/src/test/resources/expressions_4_0.xml
@@ -1,26 +1,23 @@
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags. See the copyright.txt file in the
-  ~ distribution for a full listing of individual contributors.
   ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
   ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~ Lesser General Public License for more details.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this software; if not, write to the Free
-  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:5.0">
+<subsystem xmlns="urn:jboss:domain:logging:4.0">
     <add-logging-api-dependencies value="${test.add.deps:true}"/>
     <use-deployment-logging-config value="${test.use.dep.config:true}"/>
 

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -151,6 +151,17 @@
         <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n" color-map="info:cyan,warn:yellow,error:red"/>
     </formatter>
 
+    <formatter name="JSON">
+        <json-formatter date-format="yyyy-MM-dd'T'HH:mm:ssSSS" pretty-print="true" print-details="true" zone-id="GMT">
+            <exception-output-type value="detailed-and-formatted"/>
+            <record-delimiter value="\n"/>
+            <key-overrides exception-caused-by="cause" record="log-record"/>
+            <meta-data>
+                <property name="test" value="value"/>
+            </meta-data>
+        </json-formatter>
+    </formatter>
+
     <logging-profiles>
         <logging-profile name="test-profile">
 

--- a/logging/src/test/resources/logging_4_0.xml
+++ b/logging/src/test/resources/logging_4_0.xml
@@ -1,26 +1,23 @@
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2011, Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags. See the copyright.txt file in the
-  ~ distribution for a full listing of individual contributors.
   ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
   ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~ Lesser General Public License for more details.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
   ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this software; if not, write to the Free
-  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:5.0">
+<subsystem xmlns="urn:jboss:domain:logging:4.0">
     <add-logging-api-dependencies value="false"/>
     <use-deployment-logging-config value="false"/>
 

--- a/logging/src/test/resources/operations.xml
+++ b/logging/src/test/resources/operations.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:logging:4.0">
+<subsystem xmlns="urn:jboss:domain:logging:5.0">
     <console-handler name="CONSOLE">
         <level name="INFO"/>
         <formatter>

--- a/logging/src/test/resources/rollback-logging.xml
+++ b/logging/src/test/resources/rollback-logging.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:4.0">
+<subsystem xmlns="urn:jboss:domain:logging:5.0">
 
     <console-handler name="CONSOLE">
         <level name="INFO"/>

--- a/logging/src/test/resources/simple-subsystem.xml
+++ b/logging/src/test/resources/simple-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:4.0">
+<subsystem xmlns="urn:jboss:domain:logging:5.0">
 
     <file-handler name="FILE" autoflush="true">
         <formatter>

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>httpmime</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-core-vault-test-feature-pack</artifactId>
             <type>zip</type>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/formatters/JsonFormatterTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/formatters/JsonFormatterTestCase.java
@@ -1,0 +1,414 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2017 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.logging.formatters;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonValue;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
+import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ * Tests output from the JSON formatter to ensure that integration between the subsystem and the log manager is correct.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(WildflyTestRunner.class)
+public class JsonFormatterTestCase extends AbstractLoggingTestCase {
+
+    private static final String FILE_NAME = "json-file-handler.log";
+    private static final String JSON_HANDLER_NAME = "jsonFileHandler";
+    private static final String JSON_FORMATTER_NAME = "json";
+    private static final ModelNode HANDLER_ADDRESS = createAddress("file-handler", JSON_HANDLER_NAME);
+    private static final ModelNode FORMATTER_ADDRESS = createAddress("json-formatter", JSON_FORMATTER_NAME);
+    private static final ModelNode LOGGER_ADDRESS = createAddress("logger", LoggingServiceActivator.LOGGER.getName());
+
+    private Path logFile = null;
+
+    @BeforeClass
+    public static void deploy() throws Exception {
+        deploy(createDeployment(), DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void undeploy() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+    }
+
+    @Before
+    public void setLogFile() {
+        if (logFile == null) {
+            logFile = getAbsoluteLogFilePath(FILE_NAME);
+        }
+    }
+
+    @After
+    public void remove() throws Exception {
+
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+        // Remove the logger
+        builder.addStep(Operations.createRemoveOperation(LOGGER_ADDRESS));
+
+        // Remove the formatter
+        builder.addStep(Operations.createRemoveOperation(FORMATTER_ADDRESS));
+
+        // Remove the custom handler
+        builder.addStep(Operations.createRemoveOperation(HANDLER_ADDRESS));
+
+        executeOperation(builder.build());
+
+        if (logFile != null) Files.deleteIfExists(logFile);
+    }
+
+    @Test
+    public void testKeyOverrides() throws Exception {
+        final Map<String, String> keyOverrides = new HashMap<>();
+        keyOverrides.put("timestamp", "dateTime");
+        keyOverrides.put("sequence", "seq");
+        final Map<String, String> metaData = new LinkedHashMap<>();
+        metaData.put("test-key-1", "test-value-1");
+        metaData.put("key-no-value", null);
+        // Configure the subsystem
+        configure(keyOverrides, metaData, true);
+
+        final String msg = "Logging test: JsonFormatterTestCase.defaultLoggingTest";
+        final Map<String, String> params = new LinkedHashMap<>();
+        // Indicate we need an exception logged
+        params.put(LoggingServiceActivator.LOG_EXCEPTION_KEY, "true");
+        // Add an NDC value
+        params.put(LoggingServiceActivator.NDC_KEY, "test.ndc.value");
+        // Add some map entries for MDC values
+        params.put("mdcKey1", "mdcValue1");
+        params.put("mdcKey2", "mdcValue2");
+
+        final List<String> expectedKeys = createDefaultKeys();
+        expectedKeys.remove("timestamp");
+        expectedKeys.remove("sequence");
+        expectedKeys.addAll(keyOverrides.values());
+        expectedKeys.addAll(metaData.keySet());
+        expectedKeys.add("exception");
+        expectedKeys.add("stackTrace");
+        expectedKeys.add("sourceFileName");
+        expectedKeys.add("sourceMethodName");
+        expectedKeys.add("sourceClassName");
+        expectedKeys.add("sourceLineNumber");
+        expectedKeys.add("sourceModuleVersion");
+        expectedKeys.add("sourceModuleName");
+
+        final int statusCode = getResponse(msg, params);
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+
+        // Validate each line
+        for (String s : Files.readAllLines(logFile, StandardCharsets.UTF_8)) {
+            if (s.trim().isEmpty()) continue;
+            try (JsonReader reader = Json.createReader(new StringReader(s))) {
+                final JsonObject json = reader.readObject();
+                validateDefault(json, expectedKeys, msg);
+
+                // Timestamp should have been renamed to dateTime
+                Assert.assertNull("Found timestamp entry in " + s, json.get("timestamp"));
+
+                // Sequence should have been renamed to seq
+                Assert.assertNull("Found sequence entry in " + s, json.get("sequence"));
+
+                // Validate MDC
+                final JsonObject mdcObject = json.getJsonObject("mdc");
+                Assert.assertEquals("mdcValue1", mdcObject.getString("mdcKey1"));
+                Assert.assertEquals("mdcValue2", mdcObject.getString("mdcKey2"));
+
+                // Validate the meta-data
+                Assert.assertEquals("test-value-1", json.getString("test-key-1"));
+                Assert.assertEquals("Expected a null type but got " + json.get("key-no-value"),
+                        JsonValue.ValueType.NULL, json.get("key-no-value").getValueType());
+
+                validateStackTrace(json, true, true);
+            }
+        }
+    }
+
+    @Test
+    public void testNoExceptions() throws Exception {
+        configure(Collections.emptyMap(), Collections.emptyMap(), false);
+        final String msg = "Logging test: JsonFormatterTestCase.testNoExceptions";
+        int statusCode = getResponse(msg, Collections.singletonMap(LoggingServiceActivator.LOG_EXCEPTION_KEY, "false"));
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+
+        final List<String> expectedKeys = createDefaultKeys();
+
+        for (String s : Files.readAllLines(logFile, StandardCharsets.UTF_8)) {
+            if (s.trim().isEmpty()) continue;
+            try (JsonReader reader = Json.createReader(new StringReader(s))) {
+                final JsonObject json = reader.readObject();
+
+                validateDefault(json, expectedKeys, msg);
+                validateStackTrace(json, false, false);
+            }
+        }
+    }
+
+    @Test
+    public void testFormattedException() throws Exception {
+        configure(Collections.emptyMap(), Collections.emptyMap(), false);
+
+        // Change the exception-output-type
+        executeOperation(Operations.createWriteAttributeOperation(FORMATTER_ADDRESS, "exception-output-type", "formatted"));
+
+        final String msg = "Logging test: JsonFormatterTestCase.testNoExceptions";
+        int statusCode = getResponse(msg, Collections.singletonMap(LoggingServiceActivator.LOG_EXCEPTION_KEY, "true"));
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+
+        final List<String> expectedKeys = createDefaultKeys();
+        expectedKeys.add("stackTrace");
+
+        for (String s : Files.readAllLines(logFile, StandardCharsets.UTF_8)) {
+            if (s.trim().isEmpty()) continue;
+            try (JsonReader reader = Json.createReader(new StringReader(s))) {
+                final JsonObject json = reader.readObject();
+
+                validateDefault(json, expectedKeys, msg);
+                validateStackTrace(json, true, false);
+            }
+        }
+    }
+
+    @Test
+    public void testStructuredException() throws Exception {
+        configure(Collections.emptyMap(), Collections.emptyMap(), false);
+
+        // Change the exception-output-type
+        executeOperation(Operations.createWriteAttributeOperation(FORMATTER_ADDRESS, "exception-output-type", "detailed"));
+
+        final String msg = "Logging test: JsonFormatterTestCase.testNoExceptions";
+        int statusCode = getResponse(msg, Collections.singletonMap(LoggingServiceActivator.LOG_EXCEPTION_KEY, "true"));
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+
+        final List<String> expectedKeys = createDefaultKeys();
+        expectedKeys.add("exception");
+
+        for (String s : Files.readAllLines(logFile, StandardCharsets.UTF_8)) {
+            if (s.trim().isEmpty()) continue;
+            try (JsonReader reader = Json.createReader(new StringReader(s))) {
+                final JsonObject json = reader.readObject();
+
+                validateDefault(json, expectedKeys, msg);
+                validateStackTrace(json, false, true);
+            }
+        }
+    }
+
+    @Test
+    public void testDateFormat() throws Exception {
+        configure(Collections.emptyMap(), Collections.emptyMap(), false);
+
+        final String dateFormat = "yyyy-MM-dd'T'HH:mm:ssSSSZ";
+        final String timezone = "GMT";
+
+        // Change the date format and time zone
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        builder.addStep(Operations.createWriteAttributeOperation(FORMATTER_ADDRESS, "date-format", dateFormat));
+        builder.addStep(Operations.createWriteAttributeOperation(FORMATTER_ADDRESS, "zone-id", timezone));
+        executeOperation(builder.build());
+
+        final String msg = "Logging test: JsonFormatterTestCase.testNoExceptions";
+        int statusCode = getResponse(msg, Collections.singletonMap(LoggingServiceActivator.LOG_EXCEPTION_KEY, "false"));
+        Assert.assertTrue("Invalid response statusCode: " + statusCode, statusCode == HttpStatus.SC_OK);
+
+        final List<String> expectedKeys = createDefaultKeys();
+
+        for (String s : Files.readAllLines(logFile, StandardCharsets.UTF_8)) {
+            if (s.trim().isEmpty()) continue;
+            try (JsonReader reader = Json.createReader(new StringReader(s))) {
+                final JsonObject json = reader.readObject();
+
+                validateDefault(json, expectedKeys, msg);
+                validateStackTrace(json, false, false);
+
+                // Validate the date format is correct. We don't want to validate the specific date, only that it's
+                // parsable.
+                final String jsonDate = json.getString("timestamp");
+                // If the date is not parsable an exception should be thrown
+                try {
+                    DateTimeFormatter.ofPattern(dateFormat, Locale.ROOT).withZone(ZoneId.of(timezone)).parse(jsonDate);
+                } catch (Exception e) {
+                    Assert.fail(String.format("Failed to parse %s with pattern %s and zone %s: %s", jsonDate, dateFormat,
+                            timezone, e.getMessage()));
+                }
+            }
+        }
+    }
+
+    private static void validateDefault(final JsonObject json, final Collection<String> expectedKeys, final String expectedMessage) {
+        final Set<String> remainingKeys = new HashSet<>(json.keySet());
+
+        // Check all the expected keys
+        for (String key : expectedKeys) {
+            checkNonNull(json, key);
+            Assert.assertTrue("Missing key " + key + " from JSON object: " + json, remainingKeys.remove(key));
+        }
+
+        // Should have no more remaining keys
+        Assert.assertTrue("There are remaining keys that were not validated: " + remainingKeys, remainingKeys.isEmpty());
+
+        Assert.assertEquals("org.jboss.logging.Logger", json.getString("loggerClassName"));
+        Assert.assertEquals(LoggingServiceActivator.LOGGER.getName(), json.getString("loggerName"));
+        Assert.assertTrue("Invalid level found in " + json.get("level"), isValidLevel(json.getString("level")));
+        Assert.assertEquals(expectedMessage, json.getString("message"));
+    }
+
+
+    private static void validateStackTrace(final JsonObject json, final boolean validateFormatted, final boolean validateStructured) {
+        if (validateFormatted) {
+            Assert.assertNotNull(json.get("stackTrace"));
+        } else {
+            Assert.assertNull(json.get("stackTrace"));
+        }
+        if (validateStructured) {
+            validateStackTrace(json.getJsonObject("exception"));
+        } else {
+            Assert.assertNull(json.get("exception"));
+        }
+    }
+
+    private static void validateStackTrace(final JsonObject json) {
+        checkNonNull(json, "refId");
+        checkNonNull(json, "exceptionType");
+        checkNonNull(json, "message");
+        checkNonNull(json, "frames");
+        if (json.get("causedBy") != null) {
+            validateStackTrace(json.getJsonObject("causedBy").getJsonObject("exception"));
+        }
+    }
+
+    private static boolean isValidLevel(final String level) {
+        for (Logger.Level l : LoggingServiceActivator.LOG_LEVELS) {
+            if (l.name().equals(level)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void checkNonNull(final JsonObject json, final String key) {
+        Assert.assertNotNull(String.format("Missing %s in %s", key, json), json.get(key));
+    }
+
+    private static List<String> createDefaultKeys() {
+        final List<String> expectedKeys = new ArrayList<>();
+        expectedKeys.add("timestamp");
+        expectedKeys.add("sequence");
+        expectedKeys.add("loggerClassName");
+        expectedKeys.add("loggerName");
+        expectedKeys.add("level");
+        expectedKeys.add("message");
+        expectedKeys.add("threadName");
+        expectedKeys.add("threadId");
+        expectedKeys.add("mdc");
+        expectedKeys.add("ndc");
+        expectedKeys.add("hostName");
+        expectedKeys.add("processName");
+        expectedKeys.add("processId");
+        return expectedKeys;
+    }
+
+    private void configure(final Map<String, String> keyOverrides, final Map<String, String> metaData,
+                           final boolean printDetails) throws IOException {
+
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+        // Create a JSON formatter
+        ModelNode op = Operations.createAddOperation(FORMATTER_ADDRESS);
+
+        final ModelNode keyOverridesNode = op.get("key-overrides").setEmptyObject();
+        for (String key : keyOverrides.keySet()) {
+            final String value = keyOverrides.get(key);
+            if (value == null) {
+                keyOverridesNode.get(key);
+            } else {
+                keyOverridesNode.get(key).set(value);
+            }
+        }
+
+        final ModelNode metaDataNode = op.get("meta-data").setEmptyObject();
+        for (String key : metaData.keySet()) {
+            final String value = metaData.get(key);
+            if (value == null) {
+                metaDataNode.get(key);
+            } else {
+                metaDataNode.get(key).set(value);
+            }
+        }
+
+        op.get("exception-output-type").set("detailed-and-formatted");
+        op.get("print-details").set(printDetails);
+        // This should always be false so that the each line will be a separate entry since we're writing to a file
+        op.get("pretty-print").set(false);
+        builder.addStep(op);
+
+        // Create the handler
+        op = Operations.createAddOperation(HANDLER_ADDRESS);
+        final ModelNode fileNode = op.get("file").setEmptyObject();
+        fileNode.get("relative-to").set("jboss.server.log.dir");
+        fileNode.get("path").set(logFile.getFileName().toString());
+        op.get("autoFlush").set(true);
+        op.get("append").set(false);
+        op.get("named-formatter").set(JSON_FORMATTER_NAME);
+        builder.addStep(op);
+
+        // Add the handler to the root-logger
+        op = Operations.createAddOperation(LOGGER_ADDRESS);
+        op.get("handlers").setEmptyList().add(JSON_HANDLER_NAME);
+        builder.addStep(op);
+
+        executeOperation(builder.build());
+    }
+}


### PR DESCRIPTION
Analysis document https://github.com/wildfly/wildfly-proposals/pull/47
Issue: https://issues.jboss.org/browse/WFCORE-2951

The first commit bumps the logging subsystem model version and schema.

The second commit adds the `json-formatter` resource to the logging subsystem along with tests.