### PR TITLE
[WFCORE-3205 & WFCORE-3698] Fix embedded server property setting and update the logging works

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -49,6 +49,7 @@ import org.jboss.logmanager.LogContext;
 import org.jboss.modules.ModuleLoader;
 import org.jboss.stdio.NullOutputStream;
 import org.jboss.stdio.StdioContext;
+import org.wildfly.core.embedded.Configuration;
 import org.wildfly.core.embedded.EmbeddedManagedProcess;
 import org.wildfly.core.embedded.EmbeddedProcessFactory;
 import org.wildfly.core.embedded.EmbeddedProcessStartException;
@@ -250,13 +251,20 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
 
             String[] cmds = cmdsList.toArray(new String[cmdsList.size()]);
 
-            EmbeddedManagedProcess hostController;
+            final Configuration.Builder configBuilder;
             if (this.jbossHome == null) {
-                // Modular environment
-                hostController = EmbeddedProcessFactory.createHostController(ModuleLoader.forClass(getClass()), jbossHome, cmds);
+                // Modular environment, note that the jbossHome here is resolved from the JBOSS_HOME environment
+                // variable and should never be null according to the getJBossHome() method.
+                configBuilder = Configuration.Builder.of(jbossHome)
+                        .setModuleLoader(ModuleLoader.forClass(getClass()))
+                        .setCommandArguments(cmds);
             } else {
-                hostController = EmbeddedProcessFactory.createHostController(jbossHome.getAbsolutePath(), null, null, cmds);
+                configBuilder = Configuration.Builder.of(jbossHome.getAbsoluteFile())
+                        .setCommandArguments(cmds);
             }
+            // Disables the logging subsystem from registering an embedded log context if the subsystem is present
+            WildFlySecurityManager.setPropertyPrivileged("org.wildfly.logging.embedded", "false");
+            final EmbeddedManagedProcess hostController = EmbeddedProcessFactory.createHostController(configBuilder.build());
             hostController.start();
 
             hostControllerReference.set(new EmbeddedProcessLaunch(hostController, restorer, true));

--- a/embedded/pom.xml
+++ b/embedded/pom.xml
@@ -67,16 +67,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jboss.stdio</groupId>
-            <artifactId>jboss-stdio</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller-client</artifactId>
             <exclusions>
@@ -159,17 +149,6 @@
         </dependency>
 
         <!-- Compile time only dependencies not needed at runtime -->
-        <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>

--- a/embedded/src/main/java/org/wildfly/core/embedded/ChainedContext.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/ChainedContext.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.embedded;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.wildfly.core.embedded.logging.EmbeddedLogger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class ChainedContext implements Context {
+
+    private final List<Context> contexts;
+
+    ChainedContext() {
+        contexts = new ArrayList<>();
+    }
+
+    void add(final Context context) {
+        contexts.add(context);
+    }
+
+    @Override
+    public void activate() {
+        for (Context context : contexts) {
+            context.activate();
+        }
+    }
+
+    @Override
+    public void restore() {
+        for (int i = (contexts.size() - 1); i >= 0; i--) {
+            final Context context = contexts.get(i);
+            try {
+                context.restore();
+            } catch (Exception e) {
+                EmbeddedLogger.ROOT_LOGGER.failedToRestoreContext(e, context);
+            }
+        }
+    }
+}

--- a/embedded/src/main/java/org/wildfly/core/embedded/Configuration.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/Configuration.java
@@ -1,0 +1,410 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.embedded;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleLoader;
+import org.wildfly.core.embedded.logging.EmbeddedLogger;
+
+/**
+ * Represents a configuration for the embedded server.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface Configuration {
+
+    /**
+     * Hints which logger provider should be used.
+     */
+    enum LoggerHint {
+        DEFAULT(null, null),
+        // Don't set the system package for the JBoss Log Manager. This causes some loggers to be set on the log context
+        // from the logging subsystem as opposed to the log context created by the user.
+        JBOSS_LOG_MANAGER("jboss", null),
+        LOG4J("log4j", "org.apache.log4j"),
+        LOG4J2("log4j2", "org.apache.logging.log4j"),
+        LOGBACK("slf4j", "org.slf4j"),
+        JUL("jdk", null);
+
+        private final String providerCode;
+        private final String systemPackage;
+
+        LoggerHint(final String providerCode, final String systemPackage) {
+            this.providerCode = providerCode;
+            this.systemPackage = systemPackage;
+        }
+
+        /**
+         * The provider code for the JBoss Logging provider.
+         *
+         * @return the provider code
+         */
+        public String getProviderCode() {
+            return providerCode;
+        }
+    }
+
+    /**
+     * The path to the servers directory.
+     *
+     * @return the servers directory
+     */
+    Path getJBossHome();
+
+    /**
+     * The module loader to use.
+     *
+     * @return the module loader
+     */
+    ModuleLoader getModuleLoader();
+
+    /**
+     * An array of boot arguments.
+     *
+     * @return the boot arguments or an empty array
+     */
+    String[] getCommandArguments();
+
+
+    /**
+     * A builder for creating the {@linkplain Configuration configuration}
+     */
+    @SuppressWarnings({"WeakerAccess", "unused", "UnusedReturnValue"})
+    class Builder {
+        private static final String SYSPROP_KEY_CLASS_PATH = "java.class.path";
+        private static final String SYSPROP_KEY_JBOSS_MODULES_DIR = "jboss.modules.dir";
+        private static final String SYSPROP_KEY_LOGGING_PROVIDER = "org.jboss.logging.provider";
+        private static final String SYSPROP_KEY_MODULE_PATH = "module.path";
+        private static final String SYSPROP_KEY_SYSTEM_MODULES = "jboss.modules.system.pkgs";
+
+        private static final String JBOSS_MODULES_DIR_NAME = "modules";
+
+        private static final AtomicBoolean MODULE_LOADER_CONFIGURED = new AtomicBoolean(false);
+
+        private final Path jbossHome;
+        private final List<String> cmdArgs;
+        private final List<String> systemPackages;
+        private LoggerHint loggerHint;
+        private ModuleLoader moduleLoader;
+        private String modulePath;
+
+        /**
+         * Creates a new builder for the configuration.
+         *
+         * @param jbossHome the servers home directory
+         */
+        private Builder(final File jbossHome) {
+            this(jbossHome.toPath());
+        }
+
+        /**
+         * Creates a new builder for the configuration.
+         *
+         * @param jbossHome the servers home directory
+         */
+        private Builder(final Path jbossHome) {
+            this.jbossHome = jbossHome;
+            cmdArgs = new ArrayList<>();
+            systemPackages = new ArrayList<>();
+        }
+
+        /**
+         * Creates a new builder for the configuration.
+         *
+         * @param jbossHome the servers home directory
+         */
+        public static Builder of(final File jbossHome) {
+            if (jbossHome == null) {
+                throw EmbeddedLogger.ROOT_LOGGER.nullVar("jbossHome");
+            }
+            return new Builder(jbossHome);
+        }
+
+        /**
+         * Creates a new builder for the configuration.
+         *
+         * @param jbossHome the servers home directory
+         */
+        public static Builder of(final Path jbossHome) {
+            if (jbossHome == null) {
+                throw EmbeddedLogger.ROOT_LOGGER.nullVar("jbossHome");
+            }
+            return new Builder(jbossHome);
+        }
+
+        /**
+         * Adds a command argument.
+         *
+         * @param arg the argument to add, if {@code null} the argument is ignored
+         *
+         * @return this builder
+         */
+        public Builder addCommandArgument(final String arg) {
+            if (arg != null) {
+                cmdArgs.add(arg);
+            }
+            return this;
+        }
+
+        /**
+         * Adds the arguments to the command line arguments,
+         *
+         * @param args the arguments to add, if {@code null} the argument is ignored
+         *
+         * @return this builder
+         */
+        public Builder addCommandArguments(final String... args) {
+            if (args != null) {
+                cmdArgs.addAll(Arrays.asList(args));
+            }
+            return this;
+        }
+
+        /**
+         * Sets the command line arguments replacing any previously set arguments.
+         *
+         * @param args the arguments to set, if {@code null} the arguments are cleared
+         *
+         * @return this builder
+         */
+        public Builder setCommandArguments(final String... args) {
+            cmdArgs.clear();
+            return addCommandArguments(args);
+        }
+
+        /**
+         * Sets a hint for the JBoss Logging facade on which log manager the loggers so delegate to.
+         * <p>
+         * Sets the {@code org.jboss.logging.provider} system property and adds the hinted logging module to the list
+         * of system packages.
+         * </p>
+         *
+         * @param loggerHint the logger hint
+         *
+         * @return this builder
+         */
+        public Builder setLoggerHint(final LoggerHint loggerHint) {
+            this.loggerHint = loggerHint;
+            return this;
+        }
+
+        /**
+         * Sets the module loader. If the value is {@code null} a default module loader will be configured and used.
+         *
+         * @param moduleLoader the module loader or {@code null} to use the default
+         *
+         * @return this builder
+         */
+        public Builder setModuleLoader(final ModuleLoader moduleLoader) {
+            this.moduleLoader = moduleLoader;
+            return this;
+        }
+
+        /**
+         * Sets the path to the modules for the server. If {@code null} the system property {@code module.path} will
+         * be used if present. If the property is not present the modules directory will be determined from the servers
+         * {@linkplain #getJBossHome() home directory}.
+         * <p>
+         * Note that this value is only used if the {@linkplain #setModuleLoader(ModuleLoader) module loader} is
+         * {@code null}. Also note that once the module loader is created changing this property, even for new
+         * configurations, will have no effect in the same JVM.
+         * </p>
+         *
+         * @param modulePath the module path
+         *
+         * @return this builder
+         */
+        public Builder setModulePath(final String modulePath) {
+            if (MODULE_LOADER_CONFIGURED.get()) {
+                EmbeddedLogger.ROOT_LOGGER.moduleLoaderAlreadyConfigured(SYSPROP_KEY_MODULE_PATH);
+            }
+            this.modulePath = modulePath;
+            return this;
+        }
+
+        /**
+         * Adds a system package for the module loader.
+         * <p>
+         * Note that this value is only used if the {@linkplain #setModuleLoader(ModuleLoader) module loader} is
+         * {@code null}. Also note that once the module loader is created changing this property, even for new
+         * configurations, will have no effect in the same JVM.
+         * </p>
+         *
+         * @param systemPackage the system package to add, {@code null} values are ignored
+         *
+         * @return this builder
+         */
+        public Builder addSystemPackage(final String systemPackage) {
+            if (MODULE_LOADER_CONFIGURED.get()) {
+                EmbeddedLogger.ROOT_LOGGER.moduleLoaderAlreadyConfigured(SYSPROP_KEY_SYSTEM_MODULES);
+            }
+            if (systemPackage != null) {
+                this.systemPackages.add(systemPackage);
+            }
+            return this;
+        }
+
+        /**
+         * Adds the system packages for the module loader.
+         * <p>
+         * Note that this value is only used if the {@linkplain #setModuleLoader(ModuleLoader) module loader} is
+         * {@code null}. Also note that once the module loader is created changing this property, even for new
+         * configurations, will have no effect in the same JVM.
+         * </p>
+         *
+         * @param systemPackages the system packages to add, {@code null} values are ignored
+         *
+         * @return this builder
+         */
+        public Builder addSystemPackages(final String... systemPackages) {
+            if (MODULE_LOADER_CONFIGURED.get()) {
+                EmbeddedLogger.ROOT_LOGGER.moduleLoaderAlreadyConfigured(SYSPROP_KEY_SYSTEM_MODULES);
+            }
+            if (systemPackages != null) {
+                this.systemPackages.addAll(Arrays.asList(systemPackages));
+            }
+            return this;
+        }
+
+        /**
+         * Sets the system packages for the module loader.
+         * <p>
+         * Note that this value is only used if the {@linkplain #setModuleLoader(ModuleLoader) module loader} is
+         * {@code null}. Also note that once the module loader is created changing this property, even for new
+         * configurations, will have no effect in the same JVM.
+         * </p>
+         *
+         * @param systemPackages the system package to add, {@code null} clears the previously set system packages
+         *
+         * @return this builder
+         */
+        public Builder setSystemPackages(final String... systemPackages) {
+            if (MODULE_LOADER_CONFIGURED.get()) {
+                EmbeddedLogger.ROOT_LOGGER.moduleLoaderAlreadyConfigured(SYSPROP_KEY_SYSTEM_MODULES);
+            }
+            this.systemPackages.clear();
+            return addSystemPackages(systemPackages);
+        }
+
+        /**
+         * Creates a new immutable configuration.
+         *
+         * @return the configuration
+         */
+        public Configuration build() {
+            final Path jbossHome = this.jbossHome;
+            final LoggerHint loggerHint = this.loggerHint == null ? LoggerHint.DEFAULT : this.loggerHint;
+            configureLogging(loggerHint);
+            final String[] cmdArgs = this.cmdArgs.toArray(new String[0]);
+            final String[] systemPackages = this.systemPackages.toArray(new String[0]);
+            final ModuleLoader moduleLoader;
+            if (this.moduleLoader == null) {
+                final String modulePath = SecurityActions.getPropertyPrivileged(SYSPROP_KEY_MODULE_PATH,
+                        jbossHome.resolve(JBOSS_MODULES_DIR_NAME).toAbsolutePath().toString());
+                moduleLoader = setupModuleLoader(modulePath, systemPackages);
+                MODULE_LOADER_CONFIGURED.set(true);
+            } else {
+                moduleLoader = this.moduleLoader;
+            }
+            return new Configuration() {
+                @Override
+                public Path getJBossHome() {
+                    return jbossHome;
+                }
+
+                @Override
+                public ModuleLoader getModuleLoader() {
+                    return moduleLoader;
+                }
+
+                @Override
+                public String[] getCommandArguments() {
+                    return Arrays.copyOf(cmdArgs, cmdArgs.length);
+                }
+            };
+        }
+
+        private void configureLogging(final LoggerHint loggerHint) {
+            final String providerCode = loggerHint.providerCode;
+            if (SecurityActions.getPropertyPrivileged(SYSPROP_KEY_LOGGING_PROVIDER) == null && providerCode != null) {
+                SecurityActions.setPropertyPrivileged(SYSPROP_KEY_LOGGING_PROVIDER, providerCode);
+            }
+            final String systemPackage = loggerHint.systemPackage;
+            if (systemPackage != null && !systemPackages.contains(systemPackage)) {
+                systemPackages.add(systemPackage);
+            }
+        }
+
+        private static String trimPathToModulesDir(String modulePath) {
+            int index = modulePath.indexOf(File.pathSeparator);
+            return index == -1 ? modulePath : modulePath.substring(0, index);
+        }
+
+        private static ModuleLoader setupModuleLoader(final String modulePath, final String... systemPackages) {
+
+            assert modulePath != null : "modulePath not null";
+
+            // verify the the first element of the supplied modules path exists, and if it does not, stop and allow the user to correct.
+            // Once modules are initialized and loaded we can't change Module.BOOT_MODULE_LOADER (yet).
+
+            final Path moduleDir = Paths.get(trimPathToModulesDir(modulePath));
+            if (Files.notExists(moduleDir) || !Files.isDirectory(moduleDir)) {
+                throw new RuntimeException("The first directory of the specified module path " + modulePath + " is invalid or does not exist.");
+            }
+
+            // deprecated property
+            SecurityActions.setPropertyPrivileged(SYSPROP_KEY_JBOSS_MODULES_DIR, moduleDir.toAbsolutePath().toString());
+
+            final String classPath = SecurityActions.getPropertyPrivileged(SYSPROP_KEY_CLASS_PATH);
+            try {
+                // Set up sysprop env
+                SecurityActions.clearPropertyPrivileged(SYSPROP_KEY_CLASS_PATH);
+                SecurityActions.setPropertyPrivileged(SYSPROP_KEY_MODULE_PATH, modulePath);
+
+                final StringBuilder packages = new StringBuilder("org.jboss.modules,org.jboss.dmr,org.jboss.threads,org.jboss.as.controller.client");
+                if (systemPackages != null) {
+                    for (String packageName : systemPackages) {
+                        packages.append(",");
+                        packages.append(packageName);
+                    }
+                }
+                SecurityActions.setPropertyPrivileged(SYSPROP_KEY_SYSTEM_MODULES, packages.toString());
+
+                // Get the module loader
+                return Module.getBootModuleLoader();
+            } finally {
+                // Return to previous state for classpath prop
+                if (classPath != null) {
+                    SecurityActions.setPropertyPrivileged(SYSPROP_KEY_CLASS_PATH, classPath);
+                }
+            }
+        }
+    }
+
+}

--- a/embedded/src/main/java/org/wildfly/core/embedded/Context.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/Context.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.embedded;
+
+/**
+ * A context used to activate and restore the environment for embedded containers.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface Context {
+
+    /**
+     * Activates the context for the current embedded environment.
+     */
+    void activate();
+
+    /**
+     * Restores the previous context.
+     */
+    void restore();
+}

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
@@ -284,7 +284,7 @@ public class EmbeddedHostControllerFactory {
                 final Value<ControlledProcessStateService> processStateServiceValue = (Value<ControlledProcessStateService>) serviceContainer.getRequiredService(ControlledProcessStateService.SERVICE_NAME);
                 controlledProcessStateService = processStateServiceValue.getValue();
                 controlledProcessStateService.addPropertyChangeListener(processStateListener);
-                establishModelControllerClient(controlledProcessStateService.getCurrentState(), false);
+                establishModelControllerClient(controlledProcessStateService.getCurrentState(), true);
             } catch (RuntimeException rte) {
                 if (hostControllerBootstrap != null) {
                     hostControllerBootstrap.failed();

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedHostControllerFactory.java
@@ -59,7 +59,6 @@ import org.jboss.modules.ModuleLoader;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.value.Value;
-import org.jboss.stdio.StdioContext;
 import org.wildfly.core.embedded.logging.EmbeddedLogger;
 
 /**
@@ -230,7 +229,6 @@ public class EmbeddedHostControllerFactory {
         private ModelControllerClient modelControllerClient;
         private ExecutorService executorService;
         private ControlledProcessStateService controlledProcessStateService;
-        private boolean uninstallStdIo;
 
         public HostControllerImpl(final File jbossHomeDir, String[] cmdargs, Properties systemProps, Map<String, String> systemEnv, ModuleLoader moduleLoader) {
             this.cmdargs = cmdargs;
@@ -261,13 +259,6 @@ public class EmbeddedHostControllerFactory {
                         HostControllerImpl.this.exit();
                     }
                 });
-                // Take control of stdio
-                try {
-                    StdioContext.install();
-                    uninstallStdIo = true;
-                } catch (IllegalStateException ignored) {
-                    // already installed
-                }
 
                 // Determine the ServerEnvironment
                 HostControllerEnvironment environment = createHostControllerEnvironment(jbossHomeDir, cmdargs, startTime);
@@ -395,14 +386,6 @@ public class EmbeddedHostControllerFactory {
                     Thread.currentThread().interrupt();
                 } catch (Exception ex) {
                     ServerLogger.ROOT_LOGGER.error(ex.getLocalizedMessage(), ex);
-                }
-            }
-
-            if (uninstallStdIo) {
-                try {
-                    StdioContext.uninstall();
-                } catch (IllegalStateException ignored) {
-                    // something else already did
                 }
             }
 

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedManagedProcessImpl.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedManagedProcessImpl.java
@@ -37,8 +37,9 @@ class EmbeddedManagedProcessImpl implements EmbeddedManagedProcess, StandaloneSe
     private final Method methodStart;
     private final Method methodStop;
     private final Method methodGetModelControllerClient;
+    private final Context context;
 
-    EmbeddedManagedProcessImpl(Class<?> processClass, Object managedProcess) {
+    EmbeddedManagedProcessImpl(Class<?> processClass, Object managedProcess, Context context) {
         this.managedProcess = managedProcess;
         // Get a handle on the {@link EmbeddedManagedProcess} methods
         try {
@@ -48,16 +49,22 @@ class EmbeddedManagedProcessImpl implements EmbeddedManagedProcess, StandaloneSe
         } catch (final NoSuchMethodException nsme) {
             throw EmbeddedLogger.ROOT_LOGGER.cannotGetReflectiveMethod(nsme, nsme.getMessage(), processClass.getName());
         }
+        this.context = context;
     }
 
     @Override
     public void start() throws EmbeddedProcessStartException {
+        context.activate();
         invokeOnServer(methodStart);
     }
 
     @Override
     public void stop()  {
-        safeInvokeOnServer(methodStop);
+        try {
+            safeInvokeOnServer(methodStop);
+        } finally {
+            context.restore();
+        }
     }
 
     @Override

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedProcessFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedProcessFactory.java
@@ -134,6 +134,7 @@ public class EmbeddedProcessFactory {
     public static StandaloneServer createStandaloneServer(ModuleLoader moduleLoader, File jbossHomeDir, String... cmdargs) {
         final ChainedContext context = new ChainedContext();
         context.add(new StandaloneSystemPropertyContext(jbossHomeDir.toPath()));
+        context.add(new LoggerContext(moduleLoader));
 
         setupVfsModule(moduleLoader);
 
@@ -207,6 +208,7 @@ public class EmbeddedProcessFactory {
     public static HostController createHostController(ModuleLoader moduleLoader, File jbossHomeDir, String[] cmdargs) {
         final ChainedContext context = new ChainedContext();
         context.add(new HostControllerSystemPropertyContext(jbossHomeDir.toPath()));
+        context.add(new LoggerContext(moduleLoader));
 
         setupVfsModule(moduleLoader);
 

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
@@ -52,7 +52,6 @@ import org.jboss.msc.service.ServiceActivator;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.value.Value;
-import org.jboss.stdio.StdioContext;
 import org.wildfly.core.embedded.logging.EmbeddedLogger;
 
 /**
@@ -216,7 +215,6 @@ public class EmbeddedStandaloneServerFactory {
         private ModelControllerClient modelControllerClient;
         private ExecutorService executorService;
         private ControlledProcessStateService controlledProcessStateService;
-        private boolean uninstallStdIo;
 
         public StandaloneServerImpl(String[] cmdargs, Properties systemProps, Map<String, String> systemEnv, ModuleLoader moduleLoader) {
             this.cmdargs = cmdargs;
@@ -258,14 +256,6 @@ public class EmbeddedStandaloneServerFactory {
                         StandaloneServerImpl.this.exit();
                     }
                 });
-
-                // Take control of stdio
-                try {
-                    StdioContext.install();
-                    uninstallStdIo = true;
-                } catch (IllegalStateException ignored) {
-                    // already installed
-                }
 
                 // Determine the ServerEnvironment
                 ServerEnvironment serverEnvironment = Main.determineEnvironment(cmdargs, systemProps, systemEnv, ServerEnvironment.LaunchType.EMBEDDED, startTime).getServerEnvironment();
@@ -366,13 +356,6 @@ public class EmbeddedStandaloneServerFactory {
                 }
             }
 
-            if (uninstallStdIo) {
-                try {
-                    StdioContext.uninstall();
-                } catch (IllegalStateException ignored) {
-                    // something else already did
-                }
-            }
 
             SystemExiter.initialize(SystemExiter.Exiter.DEFAULT);
         }

--- a/embedded/src/main/java/org/wildfly/core/embedded/HostControllerSystemPropertyContext.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/HostControllerSystemPropertyContext.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.embedded;
+
+import java.nio.file.Path;
+
+/**
+ * A system property context for an embedded server domain environment.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+final class HostControllerSystemPropertyContext extends SystemPropertyContext {
+    private static final String DOMAIN_BASE_DIR = "jboss.domain.base.dir";
+    private static final String DOMAIN_CONFIG_DIR = "jboss.domain.config.dir";
+    private static final String DOMAIN_CONTENT_DIR = "jboss.domain.content.dir";
+    private static final String DOMAIN_DATA_DIR = "jboss.domain.data.dir";
+    private static final String DOMAIN_DEPLOYMENT_DIR = "jboss.domain.deployment.dir";
+    private static final String DOMAIN_LOG_DIR = "jboss.domain.log.dir";
+    private static final String DOMAIN_TEMP_DIR = "jboss.domain.temp.dir";
+    private static final String JBOSS_DOMAIN_MASTER_ADDRESS = "jboss.domain.master.address";
+    private static final String DOMAIN_SERVERS_DIR = "jboss.domain.servers.dir";
+
+    /**
+     * Creates a new system property context for a domain environment.
+     *
+     * @param jbossHomeDir the JBoss home directory
+     */
+    HostControllerSystemPropertyContext(final Path jbossHomeDir) {
+        super(jbossHomeDir);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    void configureProperties() {
+        final Path baseDir = resolveBaseDir(DOMAIN_BASE_DIR, "domain");
+        addPropertyIfAbsent(DOMAIN_BASE_DIR, baseDir.toString());
+        addPropertyIfAbsent(DOMAIN_CONFIG_DIR, resolvePath(baseDir, "configuration"));
+        addPropertyIfAbsent(DOMAIN_DATA_DIR, resolvePath(baseDir, "data"));
+        addPropertyIfAbsent(DOMAIN_CONTENT_DIR, resolvePath(baseDir, "data", "content"));
+        addPropertyIfAbsent(DOMAIN_DEPLOYMENT_DIR, resolvePath(baseDir, "data", "content"));
+        addPropertyIfAbsent(DOMAIN_LOG_DIR, resolvePath(baseDir, "log"));
+        addPropertyIfAbsent(DOMAIN_TEMP_DIR, resolvePath(baseDir, "tmp"));
+        checkProperty(JBOSS_DOMAIN_MASTER_ADDRESS);
+        checkProperty(DOMAIN_SERVERS_DIR);
+    }
+}

--- a/embedded/src/main/java/org/wildfly/core/embedded/SecurityActions.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/SecurityActions.java
@@ -1,17 +1,20 @@
 /*
-Copyright 2018 Red Hat, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.wildfly.core.embedded;
@@ -27,8 +30,26 @@ import java.security.PrivilegedAction;
  * Privileged actions used by more than one class in this module.
  *
  * @author Brian Stansberry
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 final class SecurityActions {
+
+    static void clearPropertyPrivileged(final String key) {
+        if (System.getSecurityManager() == null) {
+            System.clearProperty(key);
+            return;
+        }
+        doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return System.clearProperty(key);
+            }
+        });
+    }
+
+    static String getPropertyPrivileged(final String key) {
+        return getPropertyPrivileged(key, null);
+    }
 
     static String getPropertyPrivileged(final String name, final String def) {
         final SecurityManager sm = getSecurityManager();
@@ -43,16 +64,15 @@ final class SecurityActions {
         });
     }
 
-    static void setPropertyPrivileged(final String name, final String value) {
+    static String setPropertyPrivileged(final String name, final String value) {
         final SecurityManager sm = getSecurityManager();
         if (sm == null) {
-            setProperty(name, value);
+            return setProperty(name, value);
         } else {
-            doPrivileged(new PrivilegedAction<Void>() {
+            return doPrivileged(new PrivilegedAction<String>() {
                 @Override
-                public Void run() {
-                    setProperty(name, value);
-                    return null;
+                public String run() {
+                    return setProperty(name, value);
                 }
             });
         }

--- a/embedded/src/main/java/org/wildfly/core/embedded/StandaloneSystemPropertyContext.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/StandaloneSystemPropertyContext.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.embedded;
+
+import java.nio.file.Path;
+
+/**
+ * A system property context for an embedded server standalone environment.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+final class StandaloneSystemPropertyContext extends SystemPropertyContext {
+    private static final String SERVER_BASE_DIR = "jboss.server.base.dir";
+    private static final String SERVER_CONFIG_DIR = "jboss.server.config.dir";
+    private static final String SERVER_CONTENT_DIR = "jboss.server.content.dir";
+    private static final String SERVER_DATA_DIR = "jboss.server.data.dir";
+    private static final String SERVER_DEPLOY_DIR = "jboss.server.deploy.dir";
+    private static final String SERVER_LOG_DIR = "jboss.server.log.dir";
+    private static final String SERVER_TEMP_DIR = "jboss.server.temp.dir";
+
+    /**
+     * Creates a new system property context for a standalone environment.
+     *
+     * @param jbossHomeDir the JBoss home directory
+     */
+    StandaloneSystemPropertyContext(final Path jbossHomeDir) {
+        super(jbossHomeDir);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    void configureProperties() {
+        final Path baseDir = resolveBaseDir(SERVER_BASE_DIR, "standalone");
+        addPropertyIfAbsent(SERVER_BASE_DIR, baseDir.toString());
+        addPropertyIfAbsent(SERVER_CONFIG_DIR, resolvePath(baseDir, "configuration"));
+        addPropertyIfAbsent(SERVER_DATA_DIR, resolvePath(baseDir, "data"));
+        addPropertyIfAbsent(SERVER_CONTENT_DIR, resolvePath(baseDir, "data", "content"));
+        addPropertyIfAbsent(SERVER_DEPLOY_DIR, resolvePath(baseDir, "data", "content"));
+        addPropertyIfAbsent(SERVER_LOG_DIR, resolvePath(baseDir, "log"));
+        addPropertyIfAbsent(SERVER_TEMP_DIR, resolvePath(baseDir, "tmp"));
+    }
+}

--- a/embedded/src/main/java/org/wildfly/core/embedded/SystemPropertyContext.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/SystemPropertyContext.java
@@ -1,0 +1,170 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.embedded;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.wildfly.core.embedded.logging.EmbeddedLogger;
+
+/**
+ * An abstract instance of a context which sets and restores system properties.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class SystemPropertyContext implements Context {
+    private static final String HOME_DIR = "jboss.home.dir";
+    private static final String HOST_NAME = "jboss.host.name";
+    private static final String NODE_NAME = "jboss.node.name";
+    private static final String QUALIFIED_HOST_NAME = "jboss.qualified.host.name";
+    private static final String SERVER_NAME = "jboss.server.name";
+
+    private final Path jbossHomeDir;
+    private final Map<String, String> propertiesToReset = new HashMap<>();
+    private final Set<String> propertiesToClear = new HashSet<>();
+
+    /**
+     * Creates a new system property context.
+     *
+     * @param jbossHomeDir the JBoss home directory
+     */
+    SystemPropertyContext(final Path jbossHomeDir) {
+        if (jbossHomeDir == null) {
+            throw EmbeddedLogger.ROOT_LOGGER.nullVar("jbossHomeDir");
+        }
+        this.jbossHomeDir = jbossHomeDir;
+    }
+
+    @Override
+    public void activate() {
+        addOrReplaceProperty(HOME_DIR, jbossHomeDir);
+        checkProperty("jboss.server.persist.config");
+        checkProperty(HOST_NAME);
+        checkProperty(NODE_NAME);
+        checkProperty(QUALIFIED_HOST_NAME);
+        checkProperty(SERVER_NAME);
+        checkProperty("org.jboss.resolver.warning");
+        configureProperties();
+    }
+
+    @Override
+    public void restore() {
+        final Iterator<String> toClear = propertiesToClear.iterator();
+        while (toClear.hasNext()) {
+            SecurityActions.clearPropertyPrivileged(toClear.next());
+            toClear.remove();
+        }
+        final Iterator<Map.Entry<String, String>> toReset = propertiesToReset.entrySet().iterator();
+        while (toReset.hasNext()) {
+            final Map.Entry<String, String> entry = toReset.next();
+            SecurityActions.setPropertyPrivileged(entry.getKey(), entry.getValue());
+            toReset.remove();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName() + "(propertiesToReset=" + propertiesToReset + ", propertiesToClear="
+                + propertiesToClear + ")";
+    }
+
+    /**
+     * Configures additional system properties.
+     */
+    abstract void configureProperties();
+
+    /**
+     * Adds or replaces the system property. If the system property already exists with a different value on
+     * {@link #restore()} the system property will be set back to it's previous value.
+     *
+     * @param name  the name of the property
+     * @param value the value to set
+     */
+    @SuppressWarnings("WeakerAccess")
+    void addOrReplaceProperty(final String name, final Object value) {
+        final String currentValue = SecurityActions.setPropertyPrivileged(name, value.toString());
+        if (currentValue != null) {
+            propertiesToReset.put(name, currentValue);
+        } else {
+            propertiesToClear.add(name);
+        }
+    }
+
+    /**
+     * Adds a system property only if the property does not currently exist. If the property does not exist on
+     * {@link #restore()} the property will be cleared.
+     *
+     * @param name  the name of the property
+     * @param value the value to set if the property is absent
+     */
+    void addPropertyIfAbsent(final String name, final Object value) {
+        final String currentValue = SecurityActions.getPropertyPrivileged(name);
+        if (currentValue == null) {
+            SecurityActions.setPropertyPrivileged(name, value.toString());
+            propertiesToClear.add(name);
+        }
+    }
+
+    /**
+     * If the property does not exist it will be added to the properties to be cleared when the context is
+     * {@linkplain #restore() restored}.
+     *
+     * @param name the name of the property
+     */
+    void checkProperty(final String name) {
+        if (SecurityActions.getPropertyPrivileged(name) == null) {
+            propertiesToClear.add(name);
+        }
+    }
+
+    /**
+     * Resolves the base directory. If the system property is set that value will be used. Otherwise the path is
+     * resolved from the home directory.
+     *
+     * @param name    the system property name
+     * @param dirName the directory name relative to the base directory
+     *
+     * @return the resolved base directory
+     */
+    Path resolveBaseDir(final String name, final String dirName) {
+        final String currentDir = SecurityActions.getPropertyPrivileged(name);
+        if (currentDir == null) {
+            return jbossHomeDir.resolve(dirName);
+        }
+        return Paths.get(currentDir);
+    }
+
+    /**
+     * Resolves a path relative to the base path.
+     *
+     * @param base  the base path
+     * @param paths paths relative to the base directory
+     *
+     * @return the resolved path
+     */
+    static Path resolvePath(final Path base, final String... paths) {
+        return Paths.get(base.toString(), paths);
+    }
+}

--- a/embedded/src/main/java/org/wildfly/core/embedded/logging/EmbeddedLogger.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/logging/EmbeddedLogger.java
@@ -28,9 +28,11 @@ import java.lang.reflect.Method;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.modules.ModuleLoader;
+import org.wildfly.core.embedded.Context;
 import org.wildfly.core.embedded.EmbeddedProcessStartException;
 
 /**
@@ -208,4 +210,8 @@ public interface EmbeddedLogger extends BasicLogger {
 
     @Message(id = 143, value = "No directory called '%s' exists under '%s'")
     IllegalArgumentException embeddedServerDirectoryNotFound(String string, String absolutePath);
+
+    @Message(id = 146, value = "Failed to restore context %s")
+    @LogMessage(level = Logger.Level.ERROR)
+    void failedToRestoreContext(@Cause Throwable cause, Context context);
 }

--- a/embedded/src/main/java/org/wildfly/core/embedded/logging/EmbeddedLogger.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/logging/EmbeddedLogger.java
@@ -211,6 +211,10 @@ public interface EmbeddedLogger extends BasicLogger {
     @Message(id = 143, value = "No directory called '%s' exists under '%s'")
     IllegalArgumentException embeddedServerDirectoryNotFound(String string, String absolutePath);
 
+    @Message(id = 145, value = "The module loader has already been configured. Changing the %s property will have no effect.")
+    @LogMessage(level = Logger.Level.WARN)
+    void moduleLoaderAlreadyConfigured(String propertyName);
+
     @Message(id = 146, value = "Failed to restore context %s")
     @LogMessage(level = Logger.Level.ERROR)
     void failedToRestoreContext(@Cause Throwable cause, Context context);

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -23,8 +23,6 @@
 package org.jboss.as.logging;
 
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -35,6 +33,7 @@ import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition.Parameters;
@@ -79,6 +78,7 @@ public class LoggingExtension implements Extension {
     private static final String RESOURCE_NAME = LoggingExtension.class.getPackage().getName() + ".LocalDescriptions";
 
     private static final String SKIP_LOG_MANAGER_PROPERTY = "org.wildfly.logging.skipLogManagerCheck";
+    private static final String EMBEDDED_PROPERTY = "org.wildfly.logging.embedded";
 
     public static final String SUBSYSTEM_NAME = "logging";
 
@@ -151,28 +151,43 @@ public class LoggingExtension implements Extension {
 
     @Override
     public void initialize(final ExtensionContext context) {
-        // The logging subsystem requires JBoss Log Manager to be used. Note this can be overridden and may fail late
-        // instead of early. The reason to allow for the comparison to be overridden is some environments may wrap
-        // the log manager. As long as the delegate log manager is JBoss Log Manager we should be okay.
-        if (getBooleanProperty(SKIP_LOG_MANAGER_PROPERTY)) {
-            LoggingLogger.ROOT_LOGGER.debugf("System property %s was set to true. Skipping the log manager check.", SKIP_LOG_MANAGER_PROPERTY);
-            // Since we're overriding we will check the log manager system property and log a warning if the value is
-            // not org.jboss.logmanager.LogManager.
-            final String logManagerName = WildFlySecurityManager.getPropertyPrivileged("java.util.logging.manager", null);
-            if (!org.jboss.logmanager.LogManager.class.getName().equals(logManagerName)) {
-                LoggingLogger.ROOT_LOGGER.unknownLogManager(logManagerName);
+        final ProcessType processType = context.getProcessType();
+        final boolean embedded = processType == ProcessType.EMBEDDED_HOST_CONTROLLER || processType == ProcessType.EMBEDDED_SERVER;
+        final WildFlyLogContextSelector contextSelector;
+
+        // For embedded servers we want to use a custom default LogContext
+        if (embedded) {
+            // Use the standard WildFlyLogContextSelector if we should wrap the current log context
+            if (getBooleanProperty(EMBEDDED_PROPERTY, true)) {
+                contextSelector = WildFlyLogContextSelector.Factory.createEmbedded();
+            } else {
+                contextSelector = WildFlyLogContextSelector.Factory.create();
             }
         } else {
-            // Testing the log manager must use the FQCN as the classes may be loaded via different class loaders
-            if (!java.util.logging.LogManager.getLogManager().getClass().getName().equals(org.jboss.logmanager.LogManager.class.getName())) {
-                throw LoggingLogger.ROOT_LOGGER.extensionNotInitialized();
-            }
-        }
-        final WildFlyLogContextSelector contextSelector = WildFlyLogContextSelector.Factory.create();
-        LogContext.setLogContextSelector(contextSelector);
 
-        // Install STDIO context selector
-        StdioContext.setStdioContextSelector(new LogContextStdioContextSelector(StdioContext.getStdioContext()));
+            // The logging subsystem requires JBoss Log Manager to be used. Note this can be overridden and may fail late
+            // instead of early. The reason to allow for the comparison to be overridden is some environments may wrap
+            // the log manager. As long as the delegate log manager is JBoss Log Manager we should be okay.
+            if (getBooleanProperty(SKIP_LOG_MANAGER_PROPERTY, false)) {
+                LoggingLogger.ROOT_LOGGER.debugf("System property %s was set to true. Skipping the log manager check.", SKIP_LOG_MANAGER_PROPERTY);
+                // Since we're overriding we will check the log manager system property and log a warning if the value is
+                // not org.jboss.logmanager.LogManager.
+                final String logManagerName = WildFlySecurityManager.getPropertyPrivileged("java.util.logging.manager", null);
+                if (!org.jboss.logmanager.LogManager.class.getName().equals(logManagerName)) {
+                    LoggingLogger.ROOT_LOGGER.unknownLogManager(logManagerName);
+                }
+            } else {
+                // Testing the log manager must use the FQCN as the classes may be loaded via different class loaders
+                if (!java.util.logging.LogManager.getLogManager().getClass().getName().equals(org.jboss.logmanager.LogManager.class.getName())) {
+                    throw LoggingLogger.ROOT_LOGGER.extensionNotInitialized();
+                }
+            }
+            contextSelector = WildFlyLogContextSelector.Factory.create();
+
+            // Install STDIO context selector
+            StdioContext.setStdioContextSelector(new LogContextStdioContextSelector(StdioContext.getStdioContext()));
+        }
+        LogContext.setLogContextSelector(contextSelector);
 
         // Load logging API modules
         try {
@@ -362,16 +377,12 @@ public class LoggingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, namespace.getUriString(), parser);
     }
 
-    private static boolean getBooleanProperty(final String property) {
-        if (WildFlySecurityManager.isChecking()) {
-            return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-                @Override
-                public Boolean run() {
-                    return Boolean.getBoolean(property);
-                }
-            });
+    private static boolean getBooleanProperty(final String property, final boolean dft) {
+        final String value = WildFlySecurityManager.getPropertyPrivileged(property, null);
+        if (value == null) {
+            return dft;
         }
-        return Boolean.getBoolean(property);
+        return value.isEmpty() || Boolean.parseBoolean(value);
     }
 
     public static class LoggingChildResourceComparator implements Comparator<PathElement> {

--- a/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelectorImpl.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelectorImpl.java
@@ -40,11 +40,8 @@ class WildFlyLogContextSelectorImpl implements WildFlyLogContextSelector {
 
     private final AtomicInteger counter;
 
-    public WildFlyLogContextSelectorImpl() {
+    WildFlyLogContextSelectorImpl(final LogContext defaultLogContext) {
         counter = new AtomicInteger(0);
-        // Use the current log context as the default, not LogContext.DEFAULT_LOG_CONTEXT_SELECTOR
-        // This allows embedding use cases to control the log context
-        final LogContext defaultLogContext = LogContext.getLogContext();
         contextSelector = new ClassLoaderLogContextSelector(new LogContextSelector() {
             @Override
             public LogContext getLogContext() {

--- a/testsuite/embedded/pom.xml
+++ b/testsuite/embedded/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>wildfly-core-testsuite</artifactId>
+        <groupId>org.wildfly.core</groupId>
+        <version>5.0.0.Beta1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>wildfly-core-testsuite-embedded</artifactId>
+    <description>WildFly Core Test Suite: Embedded Integration Tests</description>
+
+    <properties>
+        <jboss.test.start.timeout>20</jboss.test.start.timeout>
+        <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+        <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+        <jbossas.project.dir>${jbossas.ts.dir}</jbossas.project.dir>
+        <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-embedded</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                    <!-- parallel>none</parallel -->
+                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+
+                    <!-- Always use a new fork so each test gets it's own embedded environment -->
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+
+                    <environmentVariables>
+                        <JBOSS_HOME>${wildfly.home}</JBOSS_HOME>
+                    </environmentVariables>
+
+                    <systemPropertyVariables>
+                        <jboss.home>${wildfly.home}</jboss.home>
+                        <!-- Default the log manager and jboss-logging to use JUL -->
+                        <java.util.logging.manager>java.util.logging.LogManager</java.util.logging.manager>
+                        <org.jboss.logging.provider>jdk</org.jboss.logging.provider>
+                        <!-- This can go away once the logging extension is designed to ignore the check for embedded containers -->
+                        <org.wildfly.logging.skipLogManagerCheck>true</org.wildfly.logging.skipLogManagerCheck>
+                        <jboss.test.start.timeout>${jboss.test.start.timeout}</jboss.test.start.timeout>
+                        <jboss.test.log.dir>${project.build.directory}${file.separator}test-logs</jboss.test.log.dir>
+                        <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>
+                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.build</groupId>
+                <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>server-provisioning</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <config-file>server-provisioning.xml</config-file>
+                            <server-name>wildfly-core</server-name>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/testsuite/embedded/pom.xml
+++ b/testsuite/embedded/pom.xml
@@ -76,8 +76,6 @@
                         <!-- Default the log manager and jboss-logging to use JUL -->
                         <java.util.logging.manager>java.util.logging.LogManager</java.util.logging.manager>
                         <org.jboss.logging.provider>jdk</org.jboss.logging.provider>
-                        <!-- This can go away once the logging extension is designed to ignore the check for embedded containers -->
-                        <org.wildfly.logging.skipLogManagerCheck>true</org.wildfly.logging.skipLogManagerCheck>
                         <jboss.test.start.timeout>${jboss.test.start.timeout}</jboss.test.start.timeout>
                         <jboss.test.log.dir>${project.build.directory}${file.separator}test-logs</jboss.test.log.dir>
                         <jvm.args>-Dmaven.repo.local=${settings.localRepository} ${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</jvm.args>

--- a/testsuite/embedded/server-provisioning.xml
+++ b/testsuite/embedded/server-provisioning.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
+    <feature-packs>
+        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-feature-pack" version="${project.version}" />
+    </feature-packs>
+</server-provisioning>

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/AbstractTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/AbstractTestCase.java
@@ -30,6 +30,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.dmr.ModelNode;
@@ -135,6 +137,10 @@ class AbstractTestCase {
     };
 
     static ModelNode executeOperation(final ModelControllerClient client, final ModelNode op) throws IOException {
+        return executeOperation(client, OperationBuilder.create(op).build());
+    }
+
+    private static ModelNode executeOperation(final ModelControllerClient client, final Operation op) throws IOException {
         final ModelNode result = client.execute(op);
         if (!Operations.isSuccessfulOutcome(result)) {
             Assert.fail(String.format("Failed to execute op: %s%nFailure Description: %s", op, Operations.getFailureDescription(result)));

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/AbstractTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/AbstractTestCase.java
@@ -1,0 +1,153 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.wildfly.core.embedded.EmbeddedManagedProcess;
+import org.wildfly.core.embedded.EmbeddedProcessStartException;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("Convert2Lambda")
+class AbstractTestCase {
+
+    static final ModelNode EMPTY_ADDRESS = new ModelNode().addEmptyList();
+
+    static {
+        EMPTY_ADDRESS.protect();
+    }
+
+    private ExecutorService service;
+
+    @Before
+    public void configureExecutor() {
+        service = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void shutdownExecutor() {
+        service.shutdownNow();
+    }
+
+    void startAndWaitFor(final EmbeddedManagedProcess server, final Function<EmbeddedManagedProcess, Boolean> check) throws TimeoutException, InterruptedException, EmbeddedProcessStartException {
+        server.start();
+        waitFor(server, check);
+    }
+
+    void waitFor(final EmbeddedManagedProcess server, final Function<EmbeddedManagedProcess, Boolean> check) throws TimeoutException, InterruptedException {
+        final Callable<Boolean> callable = new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws InterruptedException {
+                long timeout = Environment.TIMEOUT * 1000;
+                final long sleep = 100L;
+                while (timeout > 0) {
+                    long before = System.currentTimeMillis();
+                    if (check.apply(server)) {
+                        return true;
+                    }
+                    timeout -= (System.currentTimeMillis() - before);
+                    TimeUnit.MILLISECONDS.sleep(sleep);
+                    timeout -= sleep;
+                }
+                return false;
+            }
+        };
+        try {
+            final Future<Boolean> future = service.submit(callable);
+            if (!future.get()) {
+                throw new TimeoutException(String.format("The embedded server did not start within %s seconds.", Environment.TIMEOUT));
+            }
+        } catch (ExecutionException e) {
+            throw new RuntimeException("Failed to determine if the embedded server is running.", e);
+        }
+    }
+
+    static final Function<EmbeddedManagedProcess, Boolean> STANDALONE_CHECK = new Function<EmbeddedManagedProcess, Boolean>() {
+        private final ModelNode op = Operations.createReadAttributeOperation(EMPTY_ADDRESS, "server-state");
+
+        @Override
+        public Boolean apply(final EmbeddedManagedProcess server) {
+
+            try {
+                final ModelControllerClient client = server.getModelControllerClient();
+                final ModelNode result = client.execute(op);
+                if (Operations.isSuccessfulOutcome(result) &&
+                        ClientConstants.CONTROLLER_PROCESS_STATE_RUNNING.equals(Operations.readResult(result).asString())) {
+                    return true;
+                }
+            } catch (IllegalStateException | IOException ignore) {
+            }
+            return false;
+        }
+    };
+
+    static final Function<EmbeddedManagedProcess, Boolean> HOST_CONTROLLER_CHECK = new Function<EmbeddedManagedProcess, Boolean>() {
+        @Override
+        public Boolean apply(final EmbeddedManagedProcess server) {
+
+            try {
+                final ModelControllerClient client = server.getModelControllerClient();
+                final ModelNode hostAddress = determineHostAddress(client);
+                final ModelNode op = Operations.createReadAttributeOperation(hostAddress, "host-state");
+                final ModelNode result = client.execute(op);
+                if (Operations.isSuccessfulOutcome(result) &&
+                        ClientConstants.CONTROLLER_PROCESS_STATE_RUNNING.equals(Operations.readResult(result).asString())) {
+                    return true;
+                }
+            } catch (IllegalStateException | IOException ignore) {
+            }
+            return false;
+        }
+    };
+
+    static ModelNode executeOperation(final ModelControllerClient client, final ModelNode op) throws IOException {
+        final ModelNode result = client.execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.fail(String.format("Failed to execute op: %s%nFailure Description: %s", op, Operations.getFailureDescription(result)));
+        }
+        return Operations.readResult(result);
+    }
+
+    private static ModelNode determineHostAddress(final ModelControllerClient client) throws IOException {
+        final ModelNode op = Operations.createReadAttributeOperation(EMPTY_ADDRESS, "local-host-name");
+        ModelNode response = client.execute(op);
+        if (Operations.isSuccessfulOutcome(response)) {
+            return Operations.createAddress("host", Operations.readResult(response).asString());
+        }
+        throw new IOException("Failed to determine host name: " + Operations.readResult(response).asString());
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/EmbeddedTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/EmbeddedTestCase.java
@@ -40,8 +40,7 @@ public class EmbeddedTestCase extends AbstractTestCase {
 
     @Test
     public void testStartAndStopStandalone() throws Exception {
-        final StandaloneServer server = EmbeddedProcessFactory.createStandaloneServer(Environment.JBOSS_HOME.toString(),
-                Environment.MODULE_PATH.toString(), null, null);
+        final StandaloneServer server = EmbeddedProcessFactory.createStandaloneServer(Environment.createConfigBuilder().build());
 
         try {
             server.start();
@@ -60,8 +59,7 @@ public class EmbeddedTestCase extends AbstractTestCase {
 
     @Test
     public void testStartAndStopHostController() throws Exception {
-        final HostController server = EmbeddedProcessFactory.createHostController(Environment.JBOSS_HOME.toString(),
-                Environment.MODULE_PATH.toString(), null, null);
+        final HostController server = EmbeddedProcessFactory.createHostController(Environment.createConfigBuilder().build());
 
         try {
             server.start();

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/EmbeddedTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/EmbeddedTestCase.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.core.embedded.EmbeddedManagedProcess;
+import org.wildfly.core.embedded.EmbeddedProcessFactory;
+import org.wildfly.core.embedded.HostController;
+import org.wildfly.core.embedded.StandaloneServer;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class EmbeddedTestCase extends AbstractTestCase {
+
+    @Test
+    public void testStartAndStopStandalone() throws Exception {
+        final StandaloneServer server = EmbeddedProcessFactory.createStandaloneServer(Environment.JBOSS_HOME.toString(),
+                Environment.MODULE_PATH.toString(), null, null);
+
+        try {
+            server.start();
+            testRunning(server, STANDALONE_CHECK);
+        } finally {
+            server.stop();
+        }
+
+        try {
+            server.start();
+            testRunning(server, STANDALONE_CHECK);
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    public void testStartAndStopHostController() throws Exception {
+        final HostController server = EmbeddedProcessFactory.createHostController(Environment.JBOSS_HOME.toString(),
+                Environment.MODULE_PATH.toString(), null, null);
+
+        try {
+            server.start();
+            testRunning(server, HOST_CONTROLLER_CHECK);
+        } finally {
+            server.stop();
+        }
+
+        try {
+            server.start();
+            testRunning(server, HOST_CONTROLLER_CHECK);
+        } finally {
+            server.stop();
+        }
+    }
+
+    private void testRunning(final EmbeddedManagedProcess server, final Function<EmbeddedManagedProcess, Boolean> check)
+            throws IOException, TimeoutException, InterruptedException {
+        waitFor(server, check);
+        // Ensure the server has started
+        try (ModelControllerClient client = server.getModelControllerClient()) {
+            final ModelNode op = Operations.createReadAttributeOperation(AbstractTestCase.EMPTY_ADDRESS, "launch-type");
+            final ModelNode result = executeOperation(client, op);
+            Assert.assertEquals("EMBEDDED", result.asString());
+        }
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/Environment.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/Environment.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Environment {
+
+    public static final Path JBOSS_HOME;
+    public static final Path MODULE_PATH;
+    public static final Path LOG_DIR;
+    public static final int TIMEOUT;
+
+    static {
+        String jbossHome = System.getProperty("jboss.home");
+        if (isNullOrEmpty(jbossHome)) {
+            jbossHome = System.getenv("JBOSS_HOME");
+        }
+
+        if (isNullOrEmpty(jbossHome)) {
+            throw new RuntimeException("Failed to configure environment. No jboss.home system property or JBOSS_HOME " +
+                    "environment variable set.");
+        }
+        JBOSS_HOME = Paths.get(jbossHome).toAbsolutePath();
+
+        String modulePath = System.getProperty("module.path");
+        if (isNullOrEmpty(modulePath)) {
+            MODULE_PATH = JBOSS_HOME.resolve("modules");
+        } else {
+            MODULE_PATH = Paths.get(modulePath).toAbsolutePath();
+        }
+
+        LOG_DIR = Paths.get(System.getProperty("jboss.test.log.dir"));
+        final String timeoutString = System.getProperty("jboss.test.start.timeout", "20");
+        TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(timeoutString));
+    }
+
+    private static boolean isNullOrEmpty(final String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/Environment.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/Environment.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.jboss.as.test.shared.TimeoutUtil;
+import org.wildfly.core.embedded.Configuration;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -56,6 +57,11 @@ public class Environment {
         LOG_DIR = Paths.get(System.getProperty("jboss.test.log.dir"));
         final String timeoutString = System.getProperty("jboss.test.start.timeout", "20");
         TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(timeoutString));
+    }
+
+    static Configuration.Builder createConfigBuilder() {
+        return Configuration.Builder.of(JBOSS_HOME)
+                .setModulePath(MODULE_PATH.toString());
     }
 
     private static boolean isNullOrEmpty(final String value) {

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/LoggingTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/LoggingTestCase.java
@@ -20,14 +20,23 @@
 package org.wildfly.core.test.embedded;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.wildfly.core.embedded.Configuration;
+import org.wildfly.core.embedded.Configuration.LoggerHint;
 import org.wildfly.core.embedded.EmbeddedManagedProcess;
 import org.wildfly.core.embedded.EmbeddedProcessFactory;
 import org.wildfly.core.embedded.EmbeddedProcessStartException;
@@ -35,33 +44,119 @@ import org.wildfly.core.embedded.EmbeddedProcessStartException;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
+@SuppressWarnings("UseOfSystemOutOrSystemErr")
 public abstract class LoggingTestCase extends AbstractTestCase {
+    private static final PrintStream DFT_STDOUT = System.out;
+    private static final PrintStream DFT_STDERR = System.err;
+    private static final ByteArrayOutputStream STDOUT = new ByteArrayOutputStream();
+    private static final ByteArrayOutputStream STDERR = new ByteArrayOutputStream();
 
-    protected void testStandalone(final String logPackage, final String filename) throws Exception {
-        final String[] systemPkgs = logPackage == null ? null : new String[] {logPackage};
-        test(EmbeddedProcessFactory.createStandaloneServer(Environment.JBOSS_HOME.toString(),
-                Environment.MODULE_PATH.toString(), systemPkgs, null), filename, STANDALONE_CHECK);
+    @BeforeClass
+    public static void replaceStreams() {
+        System.setOut(new PrintStream(STDOUT));
+        System.setErr(new PrintStream(STDERR));
     }
 
-    protected void testHostController(final String logPackage, final String filename) throws Exception {
-        final String[] systemPkgs = logPackage == null ? null : new String[] {logPackage};
-        test(EmbeddedProcessFactory.createHostController(Environment.JBOSS_HOME.toString(),
-                Environment.MODULE_PATH.toString(), systemPkgs, null), filename, HOST_CONTROLLER_CHECK);
+    @AfterClass
+    public static void restoreStreams() {
+        System.setOut(DFT_STDOUT);
+        System.setErr(DFT_STDERR);
     }
 
-    private void test(final EmbeddedManagedProcess server, final String filename,
-                      final Function<EmbeddedManagedProcess, Boolean> check) throws EmbeddedProcessStartException,
+    @After
+    public void clearStreams() throws IOException {
+        if (STDOUT.size() > 0) {
+            DFT_STDOUT.write(STDOUT.toByteArray());
+            DFT_STDOUT.flush();
+            STDOUT.reset();
+        }
+        if (STDERR.size() > 0) {
+            DFT_STDERR.write(STDERR.toByteArray());
+            DFT_STDERR.flush();
+            STDERR.reset();
+        }
+    }
+
+    protected void testStandalone(final LoggerHint loggerHint, final String filename, final String expectedPrefix) throws Exception {
+        testStandalone(loggerHint, filename, expectedPrefix, true);
+    }
+
+    protected void testStandalone(final LoggerHint loggerHint, final String filename, final String expectedPrefix,
+                                  final boolean validateConsoleOutput) throws Exception {
+        // We need to explicitly override the JBoss Logging provider property as it's set in surefire
+        if (loggerHint != null) {
+            System.setProperty("org.jboss.logging.provider", loggerHint.getProviderCode());
+        }
+        final Configuration configuration = Environment.createConfigBuilder()
+                .setLoggerHint(loggerHint)
+                .build();
+        test(EmbeddedProcessFactory.createStandaloneServer(configuration), filename, expectedPrefix, STANDALONE_CHECK, validateConsoleOutput);
+    }
+
+    protected void testHostController(final LoggerHint loggerHint, final String filename, final String expectedPrefix) throws Exception {
+        testHostController(loggerHint, filename, expectedPrefix, true);
+    }
+
+    protected void testHostController(final LoggerHint loggerHint, final String filename, final String expectedPrefix,
+                                      final boolean validateConsoleOutput) throws Exception {
+        // We need to explicitly override the JBoss Logging provider property as it's set in surefire
+        if (loggerHint != null) {
+            System.setProperty("org.jboss.logging.provider", loggerHint.getProviderCode());
+        }
+        final Configuration configuration = Environment.createConfigBuilder()
+                .setLoggerHint(loggerHint)
+                .build();
+        test(EmbeddedProcessFactory.createHostController(configuration), filename, expectedPrefix, HOST_CONTROLLER_CHECK, validateConsoleOutput);
+    }
+
+    private void test(final EmbeddedManagedProcess server, final String filename, final String expectedPrefix,
+                      final Function<EmbeddedManagedProcess, Boolean> check, final boolean validateConsoleOutput) throws EmbeddedProcessStartException,
             IOException, TimeoutException, InterruptedException {
         final Path logFile = Environment.LOG_DIR.resolve(filename);
         try {
             startAndWaitFor(server, check);
             // Check for existence of the file and just ensure it's not empty
             Assert.assertTrue(String.format("Expected file \"%s\" to exist", logFile), Files.exists(logFile));
-            try (BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
-                Assert.assertNotNull(String.format("Expected file \"%s\" to not be empty", logFile), reader.readLine());
+            final List<String> invalidLines = new ArrayList<>();
+            if (expectedPrefix == null) {
+                // Since no prefix is expected just check if the file is empty
+                try (BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+                    Assert.assertNotNull("Log file should have at least one line: " + logFile, reader.readLine());
+                }
+            } else {
+                final List<String> lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+                Assert.assertFalse("No lines found in file " + logFile, lines.isEmpty());
+                for (String line : lines) {
+                    if (!line.startsWith(expectedPrefix)) {
+                        invalidLines.add(line);
+                    }
+                }
+                if (!invalidLines.isEmpty()) {
+                    final StringBuilder msg = new StringBuilder(64);
+                    msg.append("The following lines did not contain the prefix \"")
+                            .append(expectedPrefix)
+                            .append('"')
+                            .append(System.lineSeparator());
+                    for (String line : invalidLines) {
+                        msg.append('\t').append(line).append(System.lineSeparator());
+                    }
+                    Assert.fail(msg.toString());
+                }
+            }
+
+            // Check that stdout and stderr are empty
+            if (validateConsoleOutput) {
+                System.out.flush();
+                System.err.flush();
+                Assert.assertEquals(String.format("The following messages were found on the console: %n%s", STDOUT.toString()), 0, STDOUT.size());
+                Assert.assertEquals(String.format("The following messages were found on the console: %n%s", STDERR.toString()), 0, STDERR.size());
             }
         } finally {
             server.stop();
         }
+    }
+
+    protected static boolean isIbmJdk() {
+        return System.getProperty("java.vendor").startsWith("IBM");
     }
 }

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/LoggingTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/LoggingTestCase.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import org.junit.Assert;
+import org.wildfly.core.embedded.EmbeddedManagedProcess;
+import org.wildfly.core.embedded.EmbeddedProcessFactory;
+import org.wildfly.core.embedded.EmbeddedProcessStartException;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public abstract class LoggingTestCase extends AbstractTestCase {
+
+    protected void testStandalone(final String logPackage, final String filename) throws Exception {
+        final String[] systemPkgs = logPackage == null ? null : new String[] {logPackage};
+        test(EmbeddedProcessFactory.createStandaloneServer(Environment.JBOSS_HOME.toString(),
+                Environment.MODULE_PATH.toString(), systemPkgs, null), filename, STANDALONE_CHECK);
+    }
+
+    protected void testHostController(final String logPackage, final String filename) throws Exception {
+        final String[] systemPkgs = logPackage == null ? null : new String[] {logPackage};
+        test(EmbeddedProcessFactory.createHostController(Environment.JBOSS_HOME.toString(),
+                Environment.MODULE_PATH.toString(), systemPkgs, null), filename, HOST_CONTROLLER_CHECK);
+    }
+
+    private void test(final EmbeddedManagedProcess server, final String filename,
+                      final Function<EmbeddedManagedProcess, Boolean> check) throws EmbeddedProcessStartException,
+            IOException, TimeoutException, InterruptedException {
+        final Path logFile = Environment.LOG_DIR.resolve(filename);
+        try {
+            startAndWaitFor(server, check);
+            // Check for existence of the file and just ensure it's not empty
+            Assert.assertTrue(String.format("Expected file \"%s\" to exist", logFile), Files.exists(logFile));
+            try (BufferedReader reader = Files.newBufferedReader(logFile, StandardCharsets.UTF_8)) {
+                Assert.assertNotNull(String.format("Expected file \"%s\" to not be empty", logFile), reader.readLine());
+            }
+        } finally {
+            server.stop();
+        }
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/SystemPropertyResetTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/SystemPropertyResetTestCase.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.core.embedded.EmbeddedProcessFactory;
+import org.wildfly.core.embedded.HostController;
+import org.wildfly.core.embedded.StandaloneServer;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class SystemPropertyResetTestCase extends AbstractTestCase {
+
+    @Test
+    public void testStandaloneSystemProperties() throws Exception {
+        final Map<String, String> setProperties = Collections.singletonMap("jboss.server.log.dir", Environment.LOG_DIR.toString());
+        setSystemProperties(setProperties);
+
+        final Path baseDir = Environment.JBOSS_HOME.resolve("standalone");
+
+        final Map<String, String> expectedProperties = new HashMap<>();
+        expectedProperties.put("jboss.server.base.dir", resolvePath(baseDir));
+        expectedProperties.put("jboss.server.config.dir", resolvePath(baseDir, "configuration"));
+        expectedProperties.put("jboss.server.content.dir", resolvePath(baseDir, "data", "content"));
+        expectedProperties.put("jboss.server.data.dir", resolvePath(baseDir, "data"));
+        expectedProperties.put("jboss.server.temp.dir", resolvePath(baseDir, "tmp"));
+
+        final StandaloneServer server = EmbeddedProcessFactory.createStandaloneServer(Environment.JBOSS_HOME.toString(),
+                Environment.MODULE_PATH.toString(), null, null);
+
+        validateNullProperties(expectedProperties.keySet());
+        validateProperties(setProperties);
+
+        startAndWaitFor(server, STANDALONE_CHECK);
+        // Ensure the server has started
+        try (ModelControllerClient client = server.getModelControllerClient()) {
+            final ModelNode op = Operations.createReadAttributeOperation(AbstractTestCase.EMPTY_ADDRESS, "launch-type");
+            final ModelNode result = executeOperation(client, op);
+            Assert.assertEquals("EMBEDDED", result.asString());
+        }
+        // The properties should now be set
+        validateProperties(expectedProperties);
+        validateProperties(setProperties);
+
+        // Stop the server and validate the properties have been reset
+        server.stop();
+        validateNullProperties(expectedProperties.keySet());
+        validateProperties(setProperties);
+    }
+
+    @Test
+    public void testHostControllerSystemProperties() throws Exception {
+
+        final Map<String, String> setProperties = Collections.singletonMap("jboss.domain.log.dir", Environment.LOG_DIR.toString());
+        setSystemProperties(setProperties);
+
+        final Path baseDir = Environment.JBOSS_HOME.resolve("domain");
+
+        final Map<String, String> expectedProperties = new HashMap<>();
+        expectedProperties.put("jboss.domain.base.dir", resolvePath(baseDir));
+        expectedProperties.put("jboss.domain.config.dir", resolvePath(baseDir, "configuration"));
+        expectedProperties.put("jboss.domain.content.dir", resolvePath(baseDir, "data", "content"));
+        expectedProperties.put("jboss.domain.data.dir", resolvePath(baseDir, "data"));
+        expectedProperties.put("jboss.domain.temp.dir", resolvePath(baseDir, "tmp"));
+
+        final HostController server = EmbeddedProcessFactory.createHostController(Environment.JBOSS_HOME.toString(),
+                Environment.MODULE_PATH.toString(), null, null);
+
+        validateNullProperties(expectedProperties.keySet());
+        validateProperties(setProperties);
+
+        startAndWaitFor(server, HOST_CONTROLLER_CHECK);
+        // Ensure the server has started
+        try (ModelControllerClient client = server.getModelControllerClient()) {
+            final ModelNode op = Operations.createReadAttributeOperation(AbstractTestCase.EMPTY_ADDRESS, "launch-type");
+            final ModelNode result = executeOperation(client, op);
+            Assert.assertEquals("EMBEDDED", result.asString());
+        }
+        // The properties should now be set
+        validateProperties(expectedProperties);
+        validateProperties(setProperties);
+
+        // Stop the server and validate the properties have been reset
+        server.stop();
+        validateNullProperties(expectedProperties.keySet());
+        validateProperties(setProperties);
+    }
+
+    private static void validateNullProperties(final Set<String> expected) {
+        for (String name : expected) {
+            Assert.assertNull(String.format("Expected property %s to be null.", name), System.getProperty(name));
+        }
+    }
+
+    private static void validateProperties(final Map<String, String> expected) {
+        for (Map.Entry<String, String> entry : expected.entrySet()) {
+            final String key = entry.getKey();
+            final String expectedValue = entry.getValue();
+            final String foundValue = System.getProperty(key);
+            Assert.assertEquals(String.format("Expected value %s for key %s, but found %s", expectedValue, key, foundValue), expectedValue, foundValue);
+        }
+    }
+
+    private static void setSystemProperties(final Map<String, String> props) {
+        for (Map.Entry<String, String> entry : props.entrySet()) {
+            Assert.assertNull(System.setProperty(entry.getKey(), entry.getValue()));
+        }
+    }
+
+    private static String resolvePath(final Path baseDir, final String... paths) {
+        return Paths.get(baseDir.toString(), paths).toAbsolutePath().toString();
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/SystemPropertyResetTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/SystemPropertyResetTestCase.java
@@ -54,8 +54,7 @@ public class SystemPropertyResetTestCase extends AbstractTestCase {
         expectedProperties.put("jboss.server.data.dir", resolvePath(baseDir, "data"));
         expectedProperties.put("jboss.server.temp.dir", resolvePath(baseDir, "tmp"));
 
-        final StandaloneServer server = EmbeddedProcessFactory.createStandaloneServer(Environment.JBOSS_HOME.toString(),
-                Environment.MODULE_PATH.toString(), null, null);
+        final StandaloneServer server = EmbeddedProcessFactory.createStandaloneServer(Environment.createConfigBuilder().build());
 
         validateNullProperties(expectedProperties.keySet());
         validateProperties(setProperties);
@@ -92,8 +91,7 @@ public class SystemPropertyResetTestCase extends AbstractTestCase {
         expectedProperties.put("jboss.domain.data.dir", resolvePath(baseDir, "data"));
         expectedProperties.put("jboss.domain.temp.dir", resolvePath(baseDir, "tmp"));
 
-        final HostController server = EmbeddedProcessFactory.createHostController(Environment.JBOSS_HOME.toString(),
-                Environment.MODULE_PATH.toString(), null, null);
+        final HostController server = EmbeddedProcessFactory.createHostController(Environment.createConfigBuilder().build());
 
         validateNullProperties(expectedProperties.keySet());
         validateProperties(setProperties);

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/JBossLogManagerHostControllerTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/JBossLogManagerHostControllerTestCase.java
@@ -19,7 +19,9 @@
 
 package org.wildfly.core.test.embedded.host.controller;
 
+import org.junit.Assume;
 import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
 import org.wildfly.core.test.embedded.LoggingTestCase;
 
 /**
@@ -30,8 +32,12 @@ public class JBossLogManagerHostControllerTestCase extends LoggingTestCase {
 
     @Test
     public void testLogManager() throws Exception {
+        // The IBM JDK creates a logger early on doesn't allow the JBoss Log Manager to be used. For now we will ignore
+        // the test when the IBM JDK is being used.
+        Assume.assumeFalse(isIbmJdk());
         System.setProperty("test.log.file", "test-standalone-jbl.log");
-        System.setProperty("org.jboss.logging.provider", "jboss");
-        testHostController("org.jboss.logmanager", "test-standalone-jbl.log");
+        System.setProperty("logging.configuration", getClass().getResource("/logging.properties").toExternalForm());
+        System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
+        testHostController(Configuration.LoggerHint.JBOSS_LOG_MANAGER, "test-standalone-jbl.log", "[jboss-logmanager]");
     }
 }

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/JBossLogManagerHostControllerTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/JBossLogManagerHostControllerTestCase.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded.host.controller;
+
+import org.junit.Test;
+import org.wildfly.core.test.embedded.LoggingTestCase;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JBossLogManagerHostControllerTestCase extends LoggingTestCase {
+
+
+    @Test
+    public void testLogManager() throws Exception {
+        System.setProperty("test.log.file", "test-standalone-jbl.log");
+        System.setProperty("org.jboss.logging.provider", "jboss");
+        testHostController("org.jboss.logmanager", "test-standalone-jbl.log");
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/JulHostControllerTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/JulHostControllerTestCase.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded.host.controller;
+
+import java.nio.file.Path;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.handlers.FileHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.core.test.embedded.Environment;
+import org.wildfly.core.test.embedded.LoggingTestCase;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JulHostControllerTestCase extends LoggingTestCase {
+
+    private Handler currentHandler;
+
+    @Before
+    public void configureLogManager() throws Exception {
+        final PatternFormatter formatter = new PatternFormatter("[jul] %d{HH:mm:ss,SSS} %-5p [%c] %s%e%n");
+        final Path logFile = Environment.LOG_DIR.resolve("test-hc-jul.log");
+        // We will use a JBoss File handler here for convenience
+        final FileHandler handler = new FileHandler(formatter, logFile.toFile(), false);
+        handler.setAutoFlush(true);
+        currentHandler = handler;
+        Logger.getLogger("").addHandler(handler);
+    }
+
+    @After
+    public void resetLogManager() {
+        Logger.getLogger("").removeHandler(currentHandler);
+    }
+
+    @Test
+    public void testLogManager() throws Exception {
+        testStandalone(null, "test-hc-jul.log");
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/JulHostControllerTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/JulHostControllerTestCase.java
@@ -28,6 +28,7 @@ import org.jboss.logmanager.handlers.FileHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
 import org.wildfly.core.test.embedded.Environment;
 import org.wildfly.core.test.embedded.LoggingTestCase;
 
@@ -56,6 +57,6 @@ public class JulHostControllerTestCase extends LoggingTestCase {
 
     @Test
     public void testLogManager() throws Exception {
-        testStandalone(null, "test-hc-jul.log");
+        testHostController(Configuration.LoggerHint.JUL, "test-hc-jul.log", "[jul]", false);
     }
 }

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/Log4jHostControllerTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/Log4jHostControllerTestCase.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded.host.controller;
+
+import org.junit.Test;
+import org.wildfly.core.test.embedded.LoggingTestCase;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Log4jHostControllerTestCase extends LoggingTestCase {
+
+    @Test
+    public void testLog4j() throws Exception {
+        System.setProperty("test.log.file", "test-hc-log4j.log");
+        System.setProperty("org.jboss.logging.provider", "log4j");
+        testHostController("org.apache.log4j", "test-hc-log4j.log");
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/Log4jHostControllerTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/host/controller/Log4jHostControllerTestCase.java
@@ -20,6 +20,7 @@
 package org.wildfly.core.test.embedded.host.controller;
 
 import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
 import org.wildfly.core.test.embedded.LoggingTestCase;
 
 /**
@@ -30,7 +31,6 @@ public class Log4jHostControllerTestCase extends LoggingTestCase {
     @Test
     public void testLog4j() throws Exception {
         System.setProperty("test.log.file", "test-hc-log4j.log");
-        System.setProperty("org.jboss.logging.provider", "log4j");
-        testHostController("org.apache.log4j", "test-hc-log4j.log");
+        testHostController(Configuration.LoggerHint.LOG4J, "test-hc-log4j.log", "[log4j]");
     }
 }

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/JBossLogManagerStandaloneTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/JBossLogManagerStandaloneTestCase.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded.standalone;
+
+import org.junit.Test;
+import org.wildfly.core.test.embedded.LoggingTestCase;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JBossLogManagerStandaloneTestCase extends LoggingTestCase {
+
+
+    @Test
+    public void testLogManager() throws Exception {
+        System.setProperty("test.log.file", "test-standalone-jbl.log");
+        System.setProperty("org.jboss.logging.provider", "jboss");
+        testStandalone("org.jboss.logmanager", "test-standalone-jbl.log");
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/JBossLogManagerStandaloneTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/JBossLogManagerStandaloneTestCase.java
@@ -19,7 +19,9 @@
 
 package org.wildfly.core.test.embedded.standalone;
 
+import org.junit.Assume;
 import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
 import org.wildfly.core.test.embedded.LoggingTestCase;
 
 /**
@@ -30,8 +32,12 @@ public class JBossLogManagerStandaloneTestCase extends LoggingTestCase {
 
     @Test
     public void testLogManager() throws Exception {
+        // The IBM JDK creates a logger early on doesn't allow the JBoss Log Manager to be used. For now we will ignore
+        // the test when the IBM JDK is being used.
+        Assume.assumeFalse(isIbmJdk());
         System.setProperty("test.log.file", "test-standalone-jbl.log");
-        System.setProperty("org.jboss.logging.provider", "jboss");
-        testStandalone("org.jboss.logmanager", "test-standalone-jbl.log");
+        System.setProperty("logging.configuration", getClass().getResource("/logging.properties").toExternalForm());
+        System.setProperty("java.util.logging.manager", "org.jboss.logmanager.LogManager");
+        testStandalone(Configuration.LoggerHint.JBOSS_LOG_MANAGER, "test-standalone-jbl.log", "[jboss-logmanager]");
     }
 }

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/JulStandaloneTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/JulStandaloneTestCase.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded.standalone;
+
+import java.nio.file.Path;
+import java.util.logging.Handler;
+import java.util.logging.Logger;
+
+import org.jboss.logmanager.formatters.PatternFormatter;
+import org.jboss.logmanager.handlers.FileHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.wildfly.core.test.embedded.Environment;
+import org.wildfly.core.test.embedded.LoggingTestCase;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JulStandaloneTestCase extends LoggingTestCase {
+
+    private Handler currentHandler;
+
+    @Before
+    public void configureLogManager() throws Exception {
+        final PatternFormatter formatter = new PatternFormatter("[jul] %d{HH:mm:ss,SSS} %-5p [%c] %s%e%n");
+        final Path logFile = Environment.LOG_DIR.resolve("test-standalone-jul.log");
+        // We will use a JBoss File handler here for convenience
+        final FileHandler handler = new FileHandler(formatter, logFile.toFile(), false);
+        handler.setAutoFlush(true);
+        currentHandler = handler;
+        Logger.getLogger("").addHandler(handler);
+    }
+
+    @After
+    public void resetLogManager() {
+        Logger.getLogger("").removeHandler(currentHandler);
+    }
+
+    @Test
+    public void testLogManager() throws Exception {
+        testStandalone(null, "test-standalone-jul.log");
+    }
+}

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/JulStandaloneTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/JulStandaloneTestCase.java
@@ -28,6 +28,7 @@ import org.jboss.logmanager.handlers.FileHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
 import org.wildfly.core.test.embedded.Environment;
 import org.wildfly.core.test.embedded.LoggingTestCase;
 
@@ -56,6 +57,6 @@ public class JulStandaloneTestCase extends LoggingTestCase {
 
     @Test
     public void testLogManager() throws Exception {
-        testStandalone(null, "test-standalone-jul.log");
+        testStandalone(Configuration.LoggerHint.JUL, "test-standalone-jul.log", "[jul]", false);
     }
 }

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/Log4jStandaloneTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/Log4jStandaloneTestCase.java
@@ -20,6 +20,7 @@
 package org.wildfly.core.test.embedded.standalone;
 
 import org.junit.Test;
+import org.wildfly.core.embedded.Configuration;
 import org.wildfly.core.test.embedded.LoggingTestCase;
 
 /**
@@ -31,7 +32,6 @@ public class Log4jStandaloneTestCase extends LoggingTestCase {
     @Test
     public void testLog4j() throws Exception {
         System.setProperty("test.log.file", "test-standalone-log4j.log");
-        System.setProperty("org.jboss.logging.provider", "log4j");
-        testStandalone("org.apache.log4j", "test-standalone-log4j.log");
+        testStandalone(Configuration.LoggerHint.LOG4J, "test-standalone-log4j.log", "[log4j]");
     }
 }

--- a/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/Log4jStandaloneTestCase.java
+++ b/testsuite/embedded/src/test/java/org/wildfly/core/test/embedded/standalone/Log4jStandaloneTestCase.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.core.test.embedded.standalone;
+
+import org.junit.Test;
+import org.wildfly.core.test.embedded.LoggingTestCase;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Log4jStandaloneTestCase extends LoggingTestCase {
+
+
+    @Test
+    public void testLog4j() throws Exception {
+        System.setProperty("test.log.file", "test-standalone-log4j.log");
+        System.setProperty("org.jboss.logging.provider", "log4j");
+        testStandalone("org.apache.log4j", "test-standalone-log4j.log");
+    }
+}

--- a/testsuite/embedded/src/test/resources/log4j.properties
+++ b/testsuite/embedded/src/test/resources/log4j.properties
@@ -1,0 +1,27 @@
+#
+# JBoss, Home of Professional Open Source.
+#
+# Copyright 2018 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Root logger option
+log4j.rootLogger=INFO, file
+
+log4j.appender.file=org.apache.log4j.FileAppender
+log4j.appender.file.file=${jboss.test.log.dir}${file.separator}${test.log.file}
+log4j.appender.file.immediateFlush=true
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=[log4j] %d{ABSOLUTE} %5p [%c] %m%n

--- a/testsuite/embedded/src/test/resources/logging.properties
+++ b/testsuite/embedded/src/test/resources/logging.properties
@@ -1,0 +1,40 @@
+#
+# JBoss, Home of Professional Open Source.
+#
+# Copyright 2018 Red Hat, Inc., and individual contributors
+# as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Additional logger names to configure (root logger is always configured)
+loggers=
+
+# Root logger level
+logger.level=INFO
+# Root logger handlers
+logger.handlers=FILE
+
+# Console handler configuration
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.properties=autoFlush,append,fileName
+handler.FILE.level=INFO
+handler.FILE.autoFlush=true
+handler.FILE.append=false
+handler.FILE.fileName=${jboss.test.log.dir}${file.separator}${test.log.file}
+handler.FILE.formatter=PATTERN
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%e%n

--- a/testsuite/embedded/src/test/resources/logging.properties
+++ b/testsuite/embedded/src/test/resources/logging.properties
@@ -37,4 +37,4 @@ handler.FILE.formatter=PATTERN
 # Formatter pattern configuration
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] %s%e%n
+formatter.PATTERN.pattern=[jboss-logmanager] %d{HH:mm:ss,SSS} %-5p [%c] %s%e%n

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIEmbedServerTestCase.java
@@ -820,9 +820,11 @@ public class CLIEmbedServerTestCase extends AbstractCliTestBase {
         try {
             // save the current value
             currBaseDir = WildFlySecurityManager.getPropertyPrivileged(JBOSS_SERVER_BASE_DIR, null);
-            //if (currBaseDir == null) {
-            //    currBaseDir = ROOT + File.separator + "standalone";
-            //}
+            // The current directory isn't set until the embedded server is started, just use the root directory if the
+            // property was not previously set.
+            if (currBaseDir == null) {
+                currBaseDir = ROOT + File.separator + "standalone";
+            }
             CLIEmbedUtil.copyServerBaseDir(ROOT, "standalone", newStandalone, true);
             String newBaseDir = ROOT + File.separator + newStandalone;
             WildFlySecurityManager.setPropertyPrivileged(propName, newBaseDir + File.separator + value);

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -71,6 +71,7 @@
         <module>standalone</module>
         <module>vault-test-feature-pack</module>
         <module>elytron</module>
+        <module>embedded</module>
     </modules>
 
 


### PR DESCRIPTION
# JIRA's
https://issues.jboss.org/browse/WFCORE-3205
https://issues.jboss.org/browse/WFCORE-3698

# General Comments
These commits are admittedly a bit out of order. If needed I can organize them a bit better or squash the last 3 into one commit.

# First commit (WFCORE-3698)
This simply adds a new `Context` API which the `EmbeddedManagedProcess` uses as a setup/tear down type of solution. It sets up and removes system properties that the container will set honoring user defined system properties.

# Second Commit
This commit adds a new embedded test suite.

# Third and Forth Commits
These commits could likely be squashed. These third commit just adds a new `LoggerContext` which is used to configure a `ModuleLogger` that delegates to JBoss Logging

The forth commit adds a new `Configuration` API to the embedded API. It also allows the logging subsystem to ignore the log manager check if the subsystem is present.