### PR TITLE
[WFCORE-3741] RemoveModifiedFileTaskTestCase - safety checks for negative scenatios

### DIFF
--- a/patching/src/test/java/org/jboss/as/patching/runner/RemoveModifiedFileTaskTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/runner/RemoveModifiedFileTaskTestCase.java
@@ -35,6 +35,7 @@ import static org.jboss.as.patching.runner.TestUtils.dump;
 import static org.jboss.as.patching.runner.TestUtils.randomString;
 import static org.jboss.as.patching.runner.TestUtils.touch;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -111,6 +112,7 @@ public class RemoveModifiedFileTaskTestCase extends AbstractTaskTestCase {
     public void testRemoveModifiedFileWithSTRICT() throws Exception {
         try {
             runner.applyPatch(zippedPatch, ContentVerificationPolicy.STRICT);
+            fail("Patch shouldn't be applied - ContentVerificationPolicy.STRICT");
         } catch (ContentConflictsException e) {
             assertPatchHasNotBeenApplied(e, patch, fileRemoved.getItem(), env);
 
@@ -139,6 +141,7 @@ public class RemoveModifiedFileTaskTestCase extends AbstractTaskTestCase {
     public void testRemoveModifiedFileWithPRESERVE_ALL() throws Exception {
         try {
             runner.applyPatch(zippedPatch, ContentVerificationPolicy.PRESERVE_ALL);
+            fail("Patch shouldn't be applied - ContentVerificationPolicy.PRESERVE_ALL");
         } catch (ContentConflictsException e) {
             assertPatchHasNotBeenApplied(e, patch, fileRemoved.getItem(), env);
 


### PR DESCRIPTION
RemoveModifiedFileTaskTestCase - safety checks for negative scenarios
https://issues.jboss.org/browse/WFCORE-3741

Separate PR suggested by Brian in https://github.com/wildfly/wildfly-core/pull/3204