### PR TITLE
Fix for WFCORE-3672, Extend CLI security command with support for Authentication

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -80,9 +80,11 @@ public class Util {
     public static final String ALLOW_RESOURCE_SERVICE_RESTART = "allow-resource-service-restart";
     public static final String ALTERNATIVES = "alternatives";
     public static final String APPLICATION_REALM = "ApplicationRealm";
+    public static final String APPLICATION_SECURITY_DOMAIN = "application-security-domain";
     public static final String ARCHIVE = "archive";
     public static final String ATTACHED_STREAMS = "attached-streams";
     public static final String ATTRIBUTES = "attributes";
+    public static final String AVAILABLE_MECHANISMS = "available-mechanisms";
     public static final String AUTHENTICATION_OPTIONAL = "authentication-optional";
     public static final String BLOCKING_TIMEOUT = "blocking-timeout";
     public static final String BROWSE_CONTENT = "browse-content";
@@ -95,12 +97,16 @@ public class Util {
     public static final String COMBINED_DESCRIPTIONS = "combined-descriptions";
     public static final String COMPOSITE = "composite";
     public static final String CONCURRENT_GROUPS = "concurrent-groups";
+    public static final String CONFIGURED = "configured";
+    public static final String CONSTANT_REALM_MAPPER = "constant-realm-mapper";
+    public static final String CONSTANT_ROLE_MAPPER = "constant-role-mapper";
     public static final String CONTENT = "content";
     public static final String CORE_SERVICE = "core-service";
     public static final String CREDENTIAL_REFERENCE = "credential-reference";
     public static final String CIPHER_SUITE_FILTER = "cipher-suite-filter";
     public static final String DATASOURCES = "datasources";
     public static final String DEFAULT = "default";
+    public static final String DEFAULT_PERMISSION_MAPPER = "default-permission-mapper";
     public static final String DEPLOY = "deploy";
     public static final String DEPLOYMENT = "deployment";
     public static final String DEPLOYMENTS = "deployments";
@@ -108,6 +114,7 @@ public class Util {
     public static final String DEPLOYMENT_OVERLAY = "deployment-overlay";
     public static final String DEPTH = "depth";
     public static final String DESCRIPTION = "description";
+    public static final String DIGEST_REALM_NAME = "digest-realm-name";
     public static final String DISTINGUISHED_NAME = "distinguished-name";
     public static final String DOMAIN_FAILURE_DESCRIPTION = "domain-failure-description";
     public static final String DOMAIN_RESULTS = "domain-results";
@@ -121,6 +128,7 @@ public class Util {
     public static final String EXTENSION = "extension";
     public static final String FAILURE_DESCRIPTION = "failure-description";
     public static final String FILESYSTEM_PATH = "filesystem-path";
+    public static final String FILESYSTEM_REALM = "filesystem-realm";
     public static final String FINAL_PRINCIPAL_TRANSFORMER = "final-principal-transformer";
     public static final String POST_REALM_PRINCIPAL_TRANSFORMER = "post-realm-principal-transformer";
     public static final String PROVIDER_NAME = "provider-name";
@@ -129,12 +137,22 @@ public class Util {
     public static final String FALSE = "false";
     public static final String GENERATE_KEY_PAIR = "generate-key-pair";
     public static final String GENERATE_CERTIFICATE_SIGNING_REQUEST = "generate-certificate-signing-request";
+    public static final String GET_PROVIDER_POINTS = "get-provider-points";
+    public static final String GLOBAL = "global";
+    public static final String GROUPS = "groups";
+    public static final String GROUPS_ATTRIBUTE = "groups-attribute";
+    public static final String GROUPS_PROPERTIES = "groups-properties";
+    public static final String GROUPS_TO_ROLES = "groups-to-roles";
     public static final String HEAD_COMMENT_ALLOWED = "head-comment-allowed";
     public static final String HOST = "host";
+    public static final String HTTP_AUTHENTICATION_FACTORY = "http-authentication-factory";
     public static final String HTTP_INTERFACE = "http-interface";
+    public static final String HTTP_SERVER_MECHANISM_FACTORY = "http-server-mechanism-factory";
+    public static final String HTTP_UPGRADE = "http-upgrade";
     public static final String HTTPS = "https";
     public static final String HTTPS_LISTENER = "https-listener";
     public static final String ID = "id";
+    public static final String IDENTITY_REALM = "identity-realm";
     public static final String IMPORT_CERTIFICATE = "import-certificate";
     public static final String IN_SERIES = "in-series";
     public static final String INCLUDE_DEFAULTS = "include-defaults";
@@ -147,6 +165,7 @@ public class Util {
     public static final String KEY_SIZE = "key-size";
     public static final String KEY_STORE = "key-store";
     public static final String KEY_STORE_REALM = "key-store-realm";
+    public static final String LOCAL = "local";
     public static final String LOCAL_HOST_NAME = "local-host-name";
     public static final String MANAGEMENT = "management";
     public static final String MANAGEMENT_CLIENT_CONTENT = "management-client-content";
@@ -156,6 +175,9 @@ public class Util {
     public static final String MAX_FAILED_SERVERS = "max-failed-servers";
     public static final String MAX_FAILURE_PERCENTAGE = "max-failure-percentage";
     public static final String MAX_OCCURS = "max-occurs";
+    public static final String MECHANISM_CONFIGURATIONS = "mechanism-configurations";
+    public static final String MECHANISM_NAME = "mechanism-name";
+    public static final String MECHANISM_REALM_CONFIGURATIONS = "mechanism-realm-configurations";
     public static final String METRIC = "metric";
     public static final String MIN_OCCURS = "min-occurs";
     public static final String MODULE = "module";
@@ -171,11 +193,13 @@ public class Util {
     public static final String OUTCOME = "outcome";
     public static final String PATH = "path";
     public static final String PEM = "pem";
+    public static final String PERMISSION_MAPPER = "permission-mapper";
     public static final String PERSISTENT = "persistent";
     public static final String PROBLEM = "problem";
     public static final String PRODUCT_NAME = "product-name";
     public static final String PRODUCT_VERSION = "product-version";
     public static final String PROFILE = "profile";
+    public static final String PROPERTIES_REALM = "properties-realm";
     public static final String PROTOCOLS = "protocols";
     public static final String PROVIDERS = "providers";
     public static final String READ = "read";
@@ -189,6 +213,9 @@ public class Util {
     public static final String READ_WRITE = "read-write";
     public static final String READ_RESOURCE = "read-resource";
     public static final String READ_RESOURCE_DESCRIPTION = "read-resource-description";
+    public static final String REALMS = "realms";
+    public static final String REALM = "realm";
+    public static final String REALM_NAME = "realm-name";
     public static final String REALM_MAPPER = "realm-mapper";
     public static final String REDEPLOY = "redeploy";
     public static final String REDEPLOY_AFFECTED = "redeploy-affected";
@@ -207,6 +234,9 @@ public class Util {
     public static final String RESTART = "restart";
     public static final String RESTART_REQUIRED = "restart-required";
     public static final String RESULT = "result";
+    public static final String ROLES = "roles";
+    public static final String ROLE_DECODER = "role-decoder";
+    public static final String ROLE_MAPPER = "role-mapper";
     public static final String ROLLED_BACK = "rolled-back";
     public static final String ROLLBACK_ACROSS_GROUPS = "rollback-across-groups";
     public static final String ROLLBACK_FAILURE_DESCRIPTION = "rollback-failure-description";
@@ -216,6 +246,8 @@ public class Util {
     public static final String ROLLOUT_PLANS = "rollout-plans";
     public static final String RUNTIME_NAME = "runtime-name";
     public static final String RUNNING_MODE = "running-mode";
+    public static final String SASL_AUTHENTICATION_FACTORY = "sasl-authentication-factory";
+    public static final String SASL_SERVER_FACTORY = "sasl-server-factory";
     public static final String SECURE_SOCKET_BINDING = "secure-socket-binding";
     public static final String SECURITY_DOMAIN = "security-domain";
     public static final String SECURITY_REALM = "security-realm";
@@ -223,6 +255,7 @@ public class Util {
     public static final String SERVER_GROUP = "server-group";
     public static final String SERVER_SSL_CONTEXT = "server-ssl-context";
     public static final String SHUTDOWN = "shutdown";
+    public static final String SIMPLE_ROLE_DECODER = "simple-role-decoder";
     public static final String SOCKET_BINDING = "socket-binding";
     public static final String SOCKET_BINDING_GROUP = "socket-binding-group";
     public static final String SSL_CONTEXT = "ssl-context";
@@ -238,6 +271,7 @@ public class Util {
     public static final String SUBDEPLOYMENT = "subdeployment";
     public static final String SUBSYSTEM = "subsystem";
     public static final String SUCCESS = "success";
+    public static final String SUPER_USER_MAPPER = "super-user-mapper";
     public static final String TAIL_COMMENT_ALLOWED = "tail-comment-allowed";
     public static final String TIMEOUT = "timeout";
     public static final String TRIM_DESCRIPTIONS = "trim-descriptions";
@@ -250,6 +284,7 @@ public class Util {
     public static final String UNDERTOW = "undertow";
     public static final String UPLOAD_DEPLOYMENT_STREAM = "upload-deployment-stream";
     public static final String URL = "url";
+    public static final String USERS_PROPERTIES = "users-properties";
     public static final String USE_CIPHER_SUITES_ORDER = "use-cipher-suites-order";
     public static final String UUID = "uuid";
     public static final String VALID = "valid";
@@ -1666,5 +1701,29 @@ public class Util {
         } else {
             return null;
         }
+    }
+
+    public static List<String> getUndertowSecurityDomains(ModelControllerClient client) {
+
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_CHILDREN_NAMES);
+            builder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
+            builder.addProperty(Util.CHILD_TYPE, APPLICATION_SECURITY_DOMAIN);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = client.execute(request);
+            if (isSuccess(outcome)) {
+                return getList(outcome);
+            }
+        } catch (Exception e) {
+        }
+
+        return Collections.emptyList();
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractDisableAuthenticationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractDisableAuthenticationCommand.java
@@ -1,0 +1,121 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MECHANISM;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.cli.command.DMRCommand;
+import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_RELOAD;
+
+/**
+ * Base class for any command that disables Auth.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "abstract-auth-disable", description = "")
+public abstract class AbstractDisableAuthenticationCommand implements Command<CLICommandInvocation>, DMRCommand {
+    @Option(name = OPT_MECHANISM,
+            completer = SecurityCommand.OptionCompleters.MechanismDisableCompleter.class)
+    String mechanism;
+
+    @Option(name = OPT_NO_RELOAD, hasValue = false)
+    boolean noReload;
+
+    private final AuthFactorySpec factorySpec;
+
+    public AbstractDisableAuthenticationCommand(AuthFactorySpec factorySpec) {
+        this.factorySpec = factorySpec;
+    }
+
+    public AuthFactorySpec getFactorySpec() {
+        return factorySpec;
+    }
+
+    public abstract String getEnabledFactory(CommandContext ctx) throws Exception;
+
+    protected abstract ModelNode disableFactory(CommandContext context) throws Exception;
+
+    protected abstract String getSecuredEndpoint(CommandContext ctx);
+
+    @Override
+    public CommandResult execute(CLICommandInvocation commandInvocation) throws CommandException, InterruptedException {
+        CommandContext ctx = commandInvocation.getCommandContext();
+        ModelNode request;
+        try {
+            request = buildSecurityRequest(ctx);
+        } catch (Exception ex) {
+            throw new CommandException(ex.getLocalizedMessage());
+        }
+
+        SecurityCommand.execute(ctx, request, SecurityCommand.DEFAULT_FAILURE_CONSUMER, noReload);
+        commandInvocation.getCommandContext().printLine("Command success.");
+        if (mechanism == null) {
+            commandInvocation.getCommandContext().printLine(factorySpec.getName()
+                    + " authentication disabled for " + getSecuredEndpoint(commandInvocation.getCommandContext()));
+        } else {
+            commandInvocation.getCommandContext().printLine("Mechanism removed from " + factorySpec.getName()
+                    + " for " + getSecuredEndpoint(commandInvocation.getCommandContext()));
+        }
+
+        return CommandResult.SUCCESS;
+    }
+
+    @Override
+    public ModelNode buildRequest(CommandContext context) throws CommandFormatException {
+        try {
+            return buildSecurityRequest(context);
+        } catch (Exception ex) {
+            throw new CommandFormatException(ex.getLocalizedMessage() == null
+                    ? ex.toString() : ex.getLocalizedMessage());
+        }
+    }
+
+    public ModelNode buildSecurityRequest(CommandContext context) throws Exception {
+        String authFactory = validateOptions(context);
+        ModelNode mn = ElytronUtil.getAuthFactoryResource(authFactory, factorySpec, context);
+        if (mn == null) {
+            throw new CommandException("Invalid factory " + authFactory);
+        }
+        if (mechanism == null) {
+            return disableFactory(context);
+        }
+        Set<String> set = new HashSet<>();
+        set.add(mechanism);
+        return ElytronUtil.removeMechanisms(context, mn, authFactory, factorySpec, set);
+    }
+
+    private String validateOptions(CommandContext ctx) throws Exception {
+        String factory = getEnabledFactory(ctx);
+        if (factory == null) {
+            throw new CommandException(factorySpec.getName() + " authentication is not enabled.");
+        }
+        return factory;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractEnableAuthenticationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractEnableAuthenticationCommand.java
@@ -1,0 +1,342 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.impl.completer.FileOptionCompleter;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.FileSystemRealmConfiguration;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.LocalUserConfiguration;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.MechanismConfiguration;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.PropertiesRealmConfiguration;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthSecurityBuilder;
+import org.jboss.as.cli.impl.aesh.cmd.RelativeFile;
+import org.jboss.as.cli.impl.aesh.cmd.RelativeFilePathConverter;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_GROUP_PROPERTIES_FILE;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MECHANISM;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_AUTH_FACTORY_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_SECURITY_DOMAIN_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_RELOAD;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_RELATIVE_TO;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_SUPER_USER;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_USER_PROPERTIES_FILE;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_USER_ROLE_DECODER;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.formatOption;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactory;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthMechanism;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.EmptyConfiguration;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.KeyStoreConfiguration;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.cli.command.DMRCommand;
+import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NEW_SECURITY_REALM_NAME;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ExistingPropertiesRealmConfiguration;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_FILE_SYSTEM_REALM_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_PROPERTIES_REALM_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_EXPOSED_REALM;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_REALM_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_ROLES;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ExistingKeyStoreConfiguration;
+
+/**
+ * Base class for any command that enables Auth.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "abstract-auth-enable", description = "")
+public abstract class AbstractEnableAuthenticationCommand implements Command<CLICommandInvocation>, DMRCommand {
+
+    @Option(name = OPT_MECHANISM,
+            completer = SecurityCommand.OptionCompleters.MechanismCompleter.class)
+    String mechanism;
+
+    @Option(name = OPT_FILE_SYSTEM_REALM_NAME, activator = OptionActivators.FilesystemRealmActivator.class,
+            completer = SecurityCommand.OptionCompleters.FileSystemRealmCompleter.class)
+    String fileSystemRealmName;
+
+    @Option(name = OPT_PROPERTIES_REALM_NAME, activator = OptionActivators.PropertiesRealmActivator.class,
+            completer = SecurityCommand.OptionCompleters.PropertiesRealmCompleter.class)
+    String propertiesRealmName;
+
+    @Option(name = OPT_USER_ROLE_DECODER, activator = OptionActivators.FileSystemRoleDecoderActivator.class,
+            completer = SecurityCommand.OptionCompleters.SimpleDecoderCompleter.class)
+    String userRoleDecoder;
+
+    @Option(name = OPT_USER_PROPERTIES_FILE, activator = OptionActivators.PropertiesFileRealmActivator.class,
+            converter = RelativeFilePathConverter.class, completer = FileOptionCompleter.class)
+    RelativeFile userPropertiesFile;
+
+    @Option(name = OPT_GROUP_PROPERTIES_FILE, activator = OptionActivators.GroupPropertiesFileActivator.class,
+            converter = RelativeFilePathConverter.class, completer = FileOptionCompleter.class)
+    RelativeFile groupPropertiesFile;
+
+    @Option(name = OPT_EXPOSED_REALM, activator = OptionActivators.MechanismWithRealmActivator.class)
+    String exposedRealm;
+
+    @Option(name = OPT_RELATIVE_TO, activator = OptionActivators.RelativeToActivator.class)
+    String relativeTo;
+
+    @Option(name = OPT_NO_RELOAD, hasValue = false)
+    boolean noReload;
+
+    @Option(name = OPT_SUPER_USER, hasValue = false, activator = OptionActivators.SuperUserActivator.class)
+    boolean superUser;
+
+    @Option(name = OPT_NEW_SECURITY_DOMAIN_NAME, activator = OptionActivators.DependsOnMechanism.class)
+    String newSecurityDomain;
+
+    @Option(name = OPT_NEW_AUTH_FACTORY_NAME, activator = OptionActivators.DependsOnMechanism.class)
+    String newAuthFactoryName;
+
+    @Option(name = OPT_NEW_SECURITY_REALM_NAME, activator = OptionActivators.NewSecurityRealmActivator.class)
+    String newRealmName;
+
+    @Option(name = OPT_KEY_STORE_NAME, activator = OptionActivators.KeyStoreActivator.class,
+            completer = SecurityCommand.OptionCompleters.KeyStoreNameCompleter.class)
+    String keyStoreName;
+
+    @Option(name = OPT_KEY_STORE_REALM_NAME, activator = OptionActivators.KeyStoreRealmActivator.class,
+            completer = SecurityCommand.OptionCompleters.KeyStoreRealmCompleter.class)
+    String keyStoreRealmName;
+
+    @Option(name = OPT_ROLES, activator = OptionActivators.RolesActivator.class)
+    String roles;
+
+    private final AuthFactorySpec factorySpec;
+
+    protected AbstractEnableAuthenticationCommand(AuthFactorySpec factorySpec) {
+        this.factorySpec = factorySpec;
+    }
+
+    public AuthFactorySpec getFactorySpec() {
+        return factorySpec;
+    }
+
+    protected abstract void secure(CommandContext ctx, AuthSecurityBuilder builder) throws Exception;
+
+    protected abstract String getOOTBFactory(CommandContext ctx) throws Exception;
+
+    protected abstract String getSecuredEndpoint(CommandContext ctx);
+
+    protected abstract String getEnabledFactory(CommandContext ctx) throws Exception;
+
+    public String getTargetedFactory(CommandContext ctx) throws Exception {
+        String factory = getEnabledFactory(ctx);
+        if (factory == null) {
+            factory = getOOTBFactory(ctx);
+        }
+        return factory;
+    }
+
+    @Override
+    public CommandResult execute(CLICommandInvocation commandInvocation) throws CommandException, InterruptedException {
+        CommandContext ctx = commandInvocation.getCommandContext();
+        AuthSecurityBuilder builder;
+        try {
+            builder = buildSecurityRequest(ctx);
+        } catch (Exception ex) {
+            throw new CommandException(ex.getLocalizedMessage());
+        }
+        if (!builder.isEmpty()) {
+            SecurityCommand.execute(ctx, builder.getRequest(), SecurityCommand.DEFAULT_FAILURE_CONSUMER, !shouldReload());
+            commandInvocation.getCommandContext().printLine("Command success.");
+            commandInvocation.getCommandContext().printLine("Authentication configured for "
+                    + getSecuredEndpoint(commandInvocation.getCommandContext()));
+            commandInvocation.getCommandContext().printLine(factorySpec.getName()
+                    + " authentication-factory=" + builder.getAuthFactory().getName());
+            commandInvocation.getCommandContext().printLine("security-domain="
+                    + builder.getAuthFactory().getSecurityDomain().getName());
+        } else {
+            commandInvocation.getCommandContext().
+                    printLine("Authentication is already enabled for " + getSecuredEndpoint(commandInvocation.getCommandContext()));
+        }
+        return CommandResult.SUCCESS;
+    }
+
+    @Override
+    public ModelNode buildRequest(CommandContext context) throws CommandFormatException {
+        try {
+            return buildSecurityRequest(context).getRequest();
+        } catch (Exception ex) {
+            throw new CommandFormatException(ex.getLocalizedMessage() == null
+                    ? ex.toString() : ex.getLocalizedMessage());
+        }
+    }
+
+    private AuthSecurityBuilder buildSecurityRequest(CommandContext context) throws Exception {
+        AuthSecurityBuilder builder = buildSecurityBuilder(context);
+        //OOTB
+        if (builder == null) {
+            String factoryName = getOOTBFactory(context);
+            AuthFactory factory = ElytronUtil.getAuthFactory(factoryName, getFactorySpec(), context);
+            if (factory == null) {
+                throw new Exception("Can't enable " + factorySpec.getName() + " authentication, "
+                        + factoryName + " doesn't exist");
+            }
+            builder = new AuthSecurityBuilder(factory);
+        }
+        builder.buildRequest(context);
+        if (!builder.isFactoryAlreadySet()) {
+            secure(context, builder);
+        }
+        return builder;
+    }
+
+    private AuthSecurityBuilder buildSecurityBuilder(CommandContext context) throws Exception {
+        AuthMechanism mec = buildAuthMechanism(context);
+        if (mec != null) {
+            return buildSecurityBuilder(context, mec);
+        }
+        return null;
+    }
+
+    private AuthSecurityBuilder buildSecurityBuilder(CommandContext ctx, AuthMechanism mec) throws Exception {
+        String existingFactory = getEnabledFactory(ctx);
+        AuthSecurityBuilder builder = new AuthSecurityBuilder(mec, getFactorySpec());
+        builder.setActiveFactoryName(existingFactory);
+        configureBuilder(builder);
+        return builder;
+    }
+
+    protected MechanismConfiguration buildLocalUserConfiguration(CommandContext ctx,
+            boolean superUser) throws CommandException, IOException, OperationFormatException {
+        if (!ElytronUtil.localUserExists(ctx)) {
+            throw new CommandException("Can't configure 'local' user, no such identity.");
+        }
+        return new LocalUserConfiguration(superUser);
+    }
+
+    public static void throwInvalidOptions() throws CommandException {
+        throw new CommandException("You must only set a single mechanism.");
+    }
+
+    protected static MechanismConfiguration buildExternalConfiguration(CommandContext ctx,
+            String keyStore, String keyStoreRealmName, String roles) throws CommandException, IOException, OperationFormatException {
+        if (keyStore == null && keyStoreRealmName == null) {
+            throw new CommandException("A key-store name or key-store realm name must be set");
+        }
+        if (keyStore != null && keyStoreRealmName != null) {
+            throw new CommandException("Only one of a key-store name or key-store realm name must be set");
+        }
+
+        List<String> parsedRoles = null;
+        if (roles != null) {
+            String[] lst = roles.split(",");
+            parsedRoles = new ArrayList<>();
+            for (String r : lst) {
+                parsedRoles.add(r.trim());
+            }
+        }
+        if (keyStore != null) {
+            if (!ElytronUtil.keyStoreExists(ctx, keyStore)) {
+                throw new CommandException("Can't configure 'certificate' authentication, no key-store " + keyStore);
+            }
+            return new KeyStoreConfiguration(keyStore, parsedRoles);
+        } else {
+            return new ExistingKeyStoreConfiguration(keyStoreRealmName, parsedRoles);
+        }
+    }
+
+    protected static MechanismConfiguration buildUserPasswordConfiguration(RelativeFile userPropertiesFile,
+            String fileSystemRealm, String userRoleDecoder, String exposedRealmName, RelativeFile groupPropertiesFile, String propertiesRealmName, String relativeTo) throws CommandException, IOException {
+        if (userPropertiesFile == null && fileSystemRealm == null && propertiesRealmName == null) {
+            throw new CommandException("A properties file or propertie-realm name or a filesystem-realm name must be provided");
+        }
+        int num = 0;
+        if (userPropertiesFile != null) {
+            num += 1;
+        }
+        if (propertiesRealmName != null) {
+            num += 1;
+        }
+        if (fileSystemRealm != null) {
+            num += 1;
+        }
+        if (num > 1) {
+            throw new CommandException("Only one of properties file, propertie-realm name or filesystem-realm name must be provided");
+        }
+        if (userPropertiesFile != null) {
+            if (exposedRealmName == null) {
+                throw new CommandException(formatOption(OPT_EXPOSED_REALM) + " must be set when using a user properties file");
+            }
+            PropertiesRealmConfiguration config = new PropertiesRealmConfiguration(exposedRealmName,
+                    userPropertiesFile,
+                    groupPropertiesFile,
+                    relativeTo);
+            return config;
+        } else if (propertiesRealmName != null) {
+            if (exposedRealmName == null) {
+                throw new CommandException(formatOption(OPT_EXPOSED_REALM) + " must be set when using a properties file realm");
+            }
+            return new ExistingPropertiesRealmConfiguration(propertiesRealmName, exposedRealmName);
+        } else {
+            FileSystemRealmConfiguration config = new FileSystemRealmConfiguration(exposedRealmName, fileSystemRealm, userRoleDecoder);
+            return config;
+        }
+    }
+
+    private AuthMechanism buildAuthMechanism(CommandContext context)
+            throws Exception {
+        AuthMechanism mec = null;
+        if (mechanism == null) {
+            return null;
+        }
+        List<String> available = ElytronUtil.getAvailableMechanisms(context,
+                getFactorySpec(),
+                getTargetedFactory(context));
+        if (!available.contains(mechanism)) {
+            throw new CommandException("Unavialable mechanism " + mechanism);
+        }
+
+        if (ElytronUtil.getMechanismsWithRealm().contains(mechanism)) {
+            MechanismConfiguration config = buildUserPasswordConfiguration(userPropertiesFile,
+                    fileSystemRealmName, userRoleDecoder, exposedRealm,
+                    groupPropertiesFile, propertiesRealmName, relativeTo);
+            mec = new AuthMechanism(mechanism, config);
+        } else if (ElytronUtil.getMechanismsWithTrustStore().contains(mechanism)) {
+            MechanismConfiguration config = buildExternalConfiguration(context, keyStoreName, keyStoreRealmName, roles);
+            mec = new AuthMechanism(mechanism, config);
+        } else if (ElytronUtil.getMechanismsLocalUser().contains(mechanism)) {
+            MechanismConfiguration config = buildLocalUserConfiguration(context, superUser);
+            mec = new AuthMechanism(mechanism, config);
+        } else {
+            mec = new AuthMechanism(mechanism, new EmptyConfiguration());
+        }
+        return mec;
+    }
+
+    private boolean shouldReload() {
+        return !noReload;
+    }
+
+    private void configureBuilder(AuthSecurityBuilder builder) {
+        builder.setNewRealmName(newRealmName).
+                setAuthFactoryName(newAuthFactoryName).setSecurityDomainName(newSecurityDomain);
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractReorderSASLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractReorderSASLCommand.java
@@ -1,0 +1,98 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.aesh.command.Command;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.CommandResult;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MECHANISMS_ORDER;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthSecurityBuilder;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.core.cli.command.DMRCommand;
+import org.wildfly.core.cli.command.aesh.CLICommandInvocation;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_RELOAD;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+
+/**
+ * SASL mechanism re-ordering. SASL protocol use the first realm present in a
+ * factory. Order is of importance. NB: HTTP Auth is not subject to realm
+ * ordering, all realms are sent to the client.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "abstract-auth-sasl-re-order", description = "")
+public abstract class AbstractReorderSASLCommand implements Command<CLICommandInvocation>, DMRCommand {
+
+    @Option(name = OPT_MECHANISMS_ORDER, required = true,
+            completer = OptionCompleters.MechanismsCompleter.class)
+    String mechanismsOrder;
+
+    @Option(name = OPT_NO_RELOAD, hasValue = false)
+    boolean noReload;
+
+    public abstract String getSASLFactoryName(CommandContext ctx) throws IOException, OperationFormatException;
+
+    @Override
+    public CommandResult execute(CLICommandInvocation commandInvocation) throws CommandException, InterruptedException {
+        try {
+            SecurityCommand.execute(commandInvocation.getCommandContext(),
+                    buildRequest(commandInvocation.getCommandContext()), SecurityCommand.DEFAULT_FAILURE_CONSUMER, noReload);
+        } catch (CommandFormatException ex) {
+            throw new CommandException(ex.getLocalizedMessage());
+        }
+        return CommandResult.SUCCESS;
+    }
+
+    @Override
+    public ModelNode buildRequest(CommandContext context) throws CommandFormatException {
+        if (mechanismsOrder != null) {
+            String[] mecs = mechanismsOrder.split(",");
+            List<String> lst = new ArrayList<>();
+            for (String mec : mecs) {
+                lst.add(mec.trim());
+            }
+            try {
+                AuthSecurityBuilder builder = buildSecurityBuilder(context, lst);
+                builder.buildRequest(context);
+                return builder.getRequest();
+            } catch (Exception ex) {
+                throw new CommandFormatException(ex.getLocalizedMessage());
+            }
+        } else {
+            throw new CommandFormatException("Mechanism order must be provided.");
+        }
+    }
+
+    private AuthSecurityBuilder buildSecurityBuilder(CommandContext ctx, List<String> order) throws Exception {
+        String existingFactory = getSASLFactoryName(ctx);
+        if (existingFactory == null) {
+            throw new CommandFormatException("No SASL Factory to re-order.");
+        }
+        AuthSecurityBuilder builder = new AuthSecurityBuilder(order);
+        builder.setActiveFactoryName(existingFactory);
+        return builder;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/HTTPServerDisableAuthCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/HTTPServerDisableAuthCommand.java
@@ -1,0 +1,58 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.impl.aesh.cmd.security.HttpServerCommandActivator;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_SECURITY_DOMAIN;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.HTTPServer;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Disable authentication applied to an http-server security-domain.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "disable-http-auth-http-server", description = "", activator = HttpServerCommandActivator.class)
+public class HTTPServerDisableAuthCommand extends AbstractDisableAuthenticationCommand {
+
+    @Option(name = OPT_SECURITY_DOMAIN, required = true, completer = OptionCompleters.SecurityDomainCompleter.class)
+    String securityDomain;
+
+    public HTTPServerDisableAuthCommand() {
+        super(AuthFactorySpec.HTTP);
+    }
+
+    @Override
+    public String getEnabledFactory(CommandContext ctx) throws Exception {
+        return HTTPServer.getSecurityDomainFactoryName(securityDomain, ctx);
+    }
+
+    @Override
+    protected ModelNode disableFactory(CommandContext context) throws Exception {
+        return HTTPServer.disableHTTPAuthentication(securityDomain, context);
+    }
+
+    @Override
+    protected String getSecuredEndpoint(CommandContext ctx) {
+        return "security domain " + securityDomain;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/HTTPServerEnableAuthCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/HTTPServerEnableAuthCommand.java
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import java.io.IOException;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.impl.aesh.cmd.security.HttpServerCommandActivator;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_SECURITY_DOMAIN;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthSecurityBuilder;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.HTTPServer;
+import org.jboss.as.cli.operation.OperationFormatException;
+
+/**
+ * Enable authentication for a given http-server security domain.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "enable-http-auth-http-server", description = "", activator = HttpServerCommandActivator.class)
+public class HTTPServerEnableAuthCommand extends AbstractEnableAuthenticationCommand {
+
+    @Option(name = OPT_SECURITY_DOMAIN, required = true, completer = OptionCompleters.SecurityDomainCompleter.class)
+    String securityDomain;
+
+    public HTTPServerEnableAuthCommand() {
+        super(AuthFactorySpec.HTTP);
+    }
+
+    @Override
+    protected void secure(CommandContext ctx, AuthSecurityBuilder builder) throws Exception {
+        if (getEnabledFactory(ctx) == null) {
+            HTTPServer.enableHTTPAuthentication(builder, securityDomain, ctx);
+        }
+    }
+
+    @Override
+    protected String getEnabledFactory(CommandContext ctx) throws IOException, OperationFormatException {
+        return HTTPServer.getSecurityDomainFactoryName(securityDomain, ctx);
+    }
+
+    @Override
+    protected String getOOTBFactory(CommandContext ctx) throws Exception {
+        return ElytronUtil.OOTB_APPLICATION_HTTP_FACTORY;
+    }
+
+    @Override
+    protected String getSecuredEndpoint(CommandContext ctx) {
+        return "security domain " + securityDomain;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementDisableHTTPCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementDisableHTTPCommand.java
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
+import org.aesh.command.CommandDefinition;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommandActivator;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ManagementInterfaces;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Disable HTTP authentication applied to a management interface.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "disable-http-auth-management", description = "", activator = SecurityCommandActivator.class)
+public class ManagementDisableHTTPCommand extends AbstractDisableAuthenticationCommand {
+
+    public ManagementDisableHTTPCommand() {
+        super(AuthFactorySpec.HTTP);
+    }
+
+    @Override
+    public String getEnabledFactory(CommandContext ctx) throws Exception {
+        return ManagementInterfaces.getManagementInterfaceHTTPFactoryName(ctx);
+    }
+
+    @Override
+    protected ModelNode disableFactory(CommandContext context) throws Exception {
+        ModelNode request = ManagementInterfaces.disableHTTPAuth(context);
+        return request;
+    }
+
+    @Override
+    protected String getSecuredEndpoint(CommandContext ctx) {
+        return "management " + Util.HTTP_INTERFACE;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementDisableSASLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementDisableSASLCommand.java
@@ -1,0 +1,67 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MANAGEMENT_INTERFACE;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommandActivator;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.DefaultResourceNames;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ManagementInterfaces;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Disable SASL authentication applied to a management interface.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "disable-sasl-management", description = "", activator = SecurityCommandActivator.class)
+public class ManagementDisableSASLCommand extends AbstractDisableAuthenticationCommand {
+
+    @Option(name = OPT_MANAGEMENT_INTERFACE, hasValue = true,
+            completer = OptionCompleters.ManagementInterfaceCompleter.class)
+    String managementInterface;
+
+    public ManagementDisableSASLCommand() {
+        super(AuthFactorySpec.SASL);
+    }
+
+    @Override
+    public String getEnabledFactory(CommandContext ctx) throws Exception {
+        return ManagementInterfaces.getManagementInterfaceSaslFactoryName(managementInterface, ctx);
+    }
+
+    @Override
+    protected ModelNode disableFactory(CommandContext context) throws Exception {
+        if (managementInterface == null) {
+            managementInterface = DefaultResourceNames.getDefaultManagementInterfaceName(context);
+        }
+        ModelNode request = ManagementInterfaces.disableSASL(context, managementInterface);
+        return request;
+    }
+
+    @Override
+    protected String getSecuredEndpoint(CommandContext ctx) {
+        if (managementInterface == null) {
+            managementInterface = DefaultResourceNames.getDefaultManagementInterfaceName(ctx);
+        }
+        return "management " + managementInterface;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementEnableHTTPCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementEnableHTTPCommand.java
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import java.io.IOException;
+import org.aesh.command.CommandDefinition;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommandActivator;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthSecurityBuilder;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ManagementInterfaces;
+import org.jboss.as.cli.operation.OperationFormatException;
+
+/**
+ * Enable HTTP authentication for a management interface.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "enable-http-auth-management", description = "", activator = SecurityCommandActivator.class)
+public class ManagementEnableHTTPCommand extends AbstractEnableAuthenticationCommand {
+
+    public ManagementEnableHTTPCommand() {
+        super(AuthFactorySpec.HTTP);
+    }
+
+    @Override
+    protected void secure(CommandContext ctx, AuthSecurityBuilder builder) throws Exception {
+        ManagementInterfaces.enableHTTPAuthentication(builder, ctx);
+    }
+
+    @Override
+    protected String getEnabledFactory(CommandContext ctx) throws IOException, OperationFormatException {
+        return ManagementInterfaces.getManagementInterfaceHTTPFactoryName(ctx);
+    }
+
+    @Override
+    protected String getOOTBFactory(CommandContext ctx) throws Exception {
+        return ElytronUtil.OOTB_MANAGEMENT_HTTP_FACTORY;
+    }
+
+    @Override
+    protected String getSecuredEndpoint(CommandContext ctx) {
+        return "management " + Util.HTTP_INTERFACE;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementEnableSASLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementEnableSASLCommand.java
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import java.io.IOException;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MANAGEMENT_INTERFACE;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommandActivator;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthSecurityBuilder;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.DefaultResourceNames;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ManagementInterfaces;
+import org.jboss.as.cli.operation.OperationFormatException;
+
+/**
+ * Enable SASL authentication for a management interface.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "enable-sasl-management", description = "", activator = SecurityCommandActivator.class)
+public class ManagementEnableSASLCommand extends AbstractEnableAuthenticationCommand {
+
+    @Option(name = OPT_MANAGEMENT_INTERFACE, activator = OptionActivators.DependsOnMechanism.class,
+            completer = OptionCompleters.ManagementInterfaceCompleter.class)
+    String managementInterface;
+
+    public ManagementEnableSASLCommand() {
+        super(AuthFactorySpec.SASL);
+    }
+    @Override
+    protected void secure(CommandContext ctx, AuthSecurityBuilder builder) throws Exception {
+        ManagementInterfaces.enableSASL(managementInterface, builder, ctx);
+    }
+
+    @Override
+    protected String getEnabledFactory(CommandContext ctx) throws IOException, OperationFormatException {
+        return ManagementInterfaces.getManagementInterfaceSaslFactoryName(managementInterface, ctx);
+    }
+
+    @Override
+    protected String getOOTBFactory(CommandContext ctx) throws Exception {
+        return ElytronUtil.OOTB_MANAGEMENT_SASL_FACTORY;
+    }
+
+    @Override
+    protected String getSecuredEndpoint(CommandContext ctx) {
+        if (managementInterface == null) {
+            managementInterface = DefaultResourceNames.getDefaultManagementInterfaceName(ctx);
+        }
+        return "management " + managementInterface;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementReorderSASLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementReorderSASLCommand.java
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import java.io.IOException;
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.CommandContext;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MANAGEMENT_INTERFACE;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommandActivator;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ManagementInterfaces;
+import org.jboss.as.cli.operation.OperationFormatException;
+
+/**
+ * Reorder sasl mechanisms of a sasl factory attached to a management interface.
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "reorder-sasl-management", description = "", activator = SecurityCommandActivator.class)
+public class ManagementReorderSASLCommand extends AbstractReorderSASLCommand {
+
+    @Option(name = OPT_MANAGEMENT_INTERFACE, hasValue = true,
+            completer = OptionCompleters.ManagementInterfaceCompleter.class)
+    String managementInterface;
+
+    @Override
+    public String getSASLFactoryName(CommandContext ctx) throws IOException, OperationFormatException {
+        return ManagementInterfaces.getManagementInterfaceSaslFactoryName(managementInterface, ctx);
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/OptionActivators.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/OptionActivators.java
@@ -1,0 +1,258 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.aesh.command.activator.OptionActivator;
+import org.aesh.command.impl.internal.ParsedCommand;
+import org.aesh.command.impl.internal.ParsedOption;
+import org.wildfly.core.cli.command.aesh.activator.AbstractDependOptionActivator;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MECHANISM;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_USER_PROPERTIES_FILE;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_FILE_SYSTEM_REALM_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_KEY_STORE_REALM_NAME;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_PROPERTIES_REALM_NAME;
+import org.wildfly.core.cli.command.aesh.activator.AbstractDependRejectOptionActivator;
+
+/**
+ * Option activators used by all commands.
+ *
+ * @author jdenise@redhat.com
+ */
+public class OptionActivators {
+
+    public static class MechanismWithRealmActivator extends AbstractDependOptionActivator {
+
+        public MechanismWithRealmActivator() {
+            super(false, OPT_MECHANISM);
+        }
+        @Override
+        public boolean isActivated(ParsedCommand parsedCommand) {
+            if (!super.isActivated(parsedCommand)) {
+                return false;
+            }
+            ParsedOption opt = parsedCommand.findLongOptionNoActivatorCheck(OPT_MECHANISM);
+            return ElytronUtil.getMechanismsWithRealm().contains(opt.value());
+        }
+
+    }
+
+    public static class NewSecurityRealmActivator extends AbstractDependOptionActivator {
+
+        public NewSecurityRealmActivator() {
+            super(false, OPT_MECHANISM);
+        }
+        @Override
+        public boolean isActivated(ParsedCommand parsedCommand) {
+            if (!super.isActivated(parsedCommand)) {
+                return false;
+            }
+            ParsedOption mechOption = parsedCommand.findLongOptionNoActivatorCheck(OPT_MECHANISM);
+            if (ElytronUtil.getMechanismsLocalUser().contains(mechOption.value())) {
+                return false;
+            }
+            // Provide a name fpr realm tha twe are going to generate.
+            ParsedOption optProps = parsedCommand.findLongOptionNoActivatorCheck(OPT_USER_PROPERTIES_FILE);
+            if (optProps != null && optProps.value() != null) {
+                return true;
+            }
+            ParsedOption extCert = parsedCommand.findLongOptionNoActivatorCheck(OPT_KEY_STORE_NAME);
+            if (extCert != null && extCert.value() != null) {
+                return true;
+            }
+            return false;
+        }
+
+    }
+
+    public static class FilesystemRealmActivator extends AbstractDependRejectOptionActivator {
+
+        private static final Set<String> EXPECTED = new HashSet<>();
+        private static final Set<String> REJECTED = new HashSet<>();
+
+        static {
+            REJECTED.addAll(Arrays.asList(OPT_USER_PROPERTIES_FILE, OPT_PROPERTIES_REALM_NAME, OPT_KEY_STORE_NAME, OPT_KEY_STORE_REALM_NAME));
+            EXPECTED.add(OPT_MECHANISM);
+        }
+
+        public FilesystemRealmActivator() {
+            super(false, EXPECTED, REJECTED);
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand parsedCommand) {
+            if (!super.isActivated(parsedCommand)) {
+                return false;
+            }
+            ParsedOption opt = parsedCommand.findLongOptionNoActivatorCheck(OPT_MECHANISM);
+            return ElytronUtil.getMechanismsWithRealm().contains(opt.value());
+        }
+
+    }
+
+    public static class PropertiesRealmActivator extends AbstractDependRejectOptionActivator {
+
+        private static final Set<String> EXPECTED = new HashSet<>();
+        private static final Set<String> REJECTED = new HashSet<>();
+
+        static {
+            REJECTED.addAll(Arrays.asList(OPT_USER_PROPERTIES_FILE, OPT_FILE_SYSTEM_REALM_NAME, OPT_KEY_STORE_NAME, OPT_KEY_STORE_REALM_NAME));
+            EXPECTED.add(OPT_MECHANISM);
+        }
+        public PropertiesRealmActivator() {
+            super(false, EXPECTED, REJECTED);
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand parsedCommand) {
+            if (!super.isActivated(parsedCommand)) {
+                return false;
+            }
+            ParsedOption opt = parsedCommand.findLongOptionNoActivatorCheck(OPT_MECHANISM);
+            return ElytronUtil.getMechanismsWithRealm().contains(opt.value());
+        }
+
+    }
+
+    public static class PropertiesFileRealmActivator extends AbstractDependRejectOptionActivator {
+
+        private static final Set<String> EXPECTED = new HashSet<>();
+        private static final Set<String> REJECTED = new HashSet<>();
+
+        static {
+            REJECTED.addAll(Arrays.asList(OPT_FILE_SYSTEM_REALM_NAME, OPT_PROPERTIES_REALM_NAME, OPT_KEY_STORE_NAME, OPT_KEY_STORE_REALM_NAME));
+            EXPECTED.add(OPT_MECHANISM);
+        }
+        public PropertiesFileRealmActivator() {
+            super(false, EXPECTED, REJECTED);
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand parsedCommand) {
+            if (!super.isActivated(parsedCommand)) {
+                return false;
+            }
+            ParsedOption opt = parsedCommand.findLongOptionNoActivatorCheck(OPT_MECHANISM);
+            return ElytronUtil.getMechanismsWithRealm().contains(opt.value());
+        }
+
+    }
+
+    public static class KeyStoreRealmActivator extends AbstractDependRejectOptionActivator {
+
+        private static final Set<String> EXPECTED = new HashSet<>();
+        private static final Set<String> REJECTED = new HashSet<>();
+
+        static {
+            REJECTED.addAll(Arrays.asList(OPT_KEY_STORE_NAME, OPT_FILE_SYSTEM_REALM_NAME, OPT_PROPERTIES_REALM_NAME, OPT_USER_PROPERTIES_FILE));
+            EXPECTED.add(OPT_MECHANISM);
+        }
+        public KeyStoreRealmActivator() {
+            super(false, EXPECTED, REJECTED);
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand parsedCommand) {
+            if (!super.isActivated(parsedCommand)) {
+                return false;
+            }
+            ParsedOption opt = parsedCommand.findLongOptionNoActivatorCheck(OPT_MECHANISM);
+            return ElytronUtil.getMechanismsWithTrustStore().contains(opt.value());
+        }
+
+    }
+
+    public static class KeyStoreActivator extends AbstractDependRejectOptionActivator {
+
+        private static final Set<String> EXPECTED = new HashSet<>();
+        private static final Set<String> REJECTED = new HashSet<>();
+
+        static {
+            REJECTED.addAll(Arrays.asList(OPT_KEY_STORE_REALM_NAME, OPT_FILE_SYSTEM_REALM_NAME, OPT_PROPERTIES_REALM_NAME, OPT_USER_PROPERTIES_FILE));
+            EXPECTED.add(OPT_MECHANISM);
+        }
+        public KeyStoreActivator() {
+            super(false, EXPECTED, REJECTED);
+        }
+        @Override
+        public boolean isActivated(ParsedCommand parsedCommand) {
+            if (!super.isActivated(parsedCommand)) {
+                return false;
+            }
+            ParsedOption opt = parsedCommand.findLongOptionNoActivatorCheck(OPT_MECHANISM);
+            return ElytronUtil.getMechanismsWithTrustStore().contains(opt.value());
+        }
+
+    }
+
+    public static class RolesActivator extends AbstractDependOptionActivator {
+
+        public RolesActivator() {
+            super(false, OPT_MECHANISM);
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand parsedCommand) {
+            if (!super.isActivated(parsedCommand)) {
+                return false;
+            }
+            ParsedOption opt = parsedCommand.findLongOptionNoActivatorCheck(OPT_MECHANISM);
+            return ElytronUtil.getMechanismsWithTrustStore().contains(opt.value());
+        }
+
+    }
+
+    public static class DependsOnMechanism extends AbstractDependOptionActivator {
+
+        public DependsOnMechanism() {
+            super(false, OPT_MECHANISM);
+        }
+    }
+
+    public static class SuperUserActivator implements OptionActivator {
+
+        @Override
+        public boolean isActivated(ParsedCommand parsedCommand) {
+            ParsedOption opt = parsedCommand.findLongOptionNoActivatorCheck(OPT_MECHANISM);
+            return opt != null && opt.value() != null && ElytronUtil.getMechanismsLocalUser().contains(opt.value());
+        }
+    }
+
+    public static class GroupPropertiesFileActivator extends AbstractDependOptionActivator {
+
+        public GroupPropertiesFileActivator() {
+            super(false, OPT_USER_PROPERTIES_FILE);
+        }
+    }
+
+    public static class RelativeToActivator extends AbstractDependOptionActivator {
+
+        public RelativeToActivator() {
+            super(false, OPT_USER_PROPERTIES_FILE);
+        }
+    }
+
+    public static class FileSystemRoleDecoderActivator extends AbstractDependOptionActivator {
+
+        public FileSystemRoleDecoderActivator() {
+            super(false, OPT_FILE_SYSTEM_REALM_NAME);
+        }
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AbstractKeyStoreConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AbstractKeyStoreConfiguration.java
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.util.List;
+
+/**
+ * A command base class for trust-store based configuration.
+ *
+ * @author jdenise@redhat.com
+ */
+abstract class AbstractKeyStoreConfiguration implements MechanismConfiguration {
+
+    private String realmMapper;
+    private final List<String> roles;
+    private String roleMapper;
+
+    protected AbstractKeyStoreConfiguration(List<String> roles) {
+        this.roles = roles;
+    }
+
+    @Override
+    public void setRoleMapper(String roleMapper) {
+        this.roleMapper = roleMapper;
+    }
+
+    @Override
+    public String getRoleDecoder() {
+        return null;
+    }
+
+    @Override
+    public String getRoleMapper() {
+        return roleMapper;
+    }
+
+    @Override
+    public String getRealmMapper() {
+        return realmMapper;
+    }
+
+    @Override
+    public String getExposedRealmName() {
+        return null;
+    }
+
+    @Override
+    public void setRealmMapperName(String realmMapper) {
+        this.realmMapper = realmMapper;
+    }
+
+    @Override
+    public List<String> getRoles() {
+        return roles;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AuthFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AuthFactory.java
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Models an authentication factory.
+ *
+ * @author jdenise@redhat.com
+ */
+public class AuthFactory {
+
+    private final String name;
+    private final SecurityDomain domain;
+    private final List<AuthMechanism> mechanisms = new ArrayList<>();
+    private final AuthFactorySpec spec;
+
+    public AuthFactory(String name, SecurityDomain domain, AuthFactorySpec spec) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(domain);
+        Objects.requireNonNull(spec);
+        this.name = name;
+        this.domain = domain;
+        this.spec = spec;
+    }
+
+    public AuthFactorySpec getSpec() {
+        return spec;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the domain
+     */
+    public SecurityDomain getSecurityDomain() {
+        return domain;
+    }
+
+    public void addMechanism(AuthMechanism mec) {
+        Objects.requireNonNull(mec);
+        mechanisms.add(mec);
+    }
+
+    public List<AuthMechanism> getMechanisms() {
+        return Collections.unmodifiableList(mechanisms);
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AuthFactorySpec.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AuthFactorySpec.java
@@ -1,0 +1,81 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import org.jboss.as.cli.Util;
+
+/**
+ * A type of authentication factory that contains all specificities for the
+ * type. Currently SASL and HTTP.
+ *
+ * @author jdenise@redhat.com
+ */
+public class AuthFactorySpec {
+
+    public static final AuthFactorySpec SASL = new AuthFactorySpec(Util.SASL_AUTHENTICATION_FACTORY,
+            Util.SASL_SERVER_FACTORY, Util.CONFIGURED, "sasl", ElytronUtil.SASL_SERVER_CAPABILITY);
+    public static final AuthFactorySpec HTTP = new AuthFactorySpec(Util.HTTP_AUTHENTICATION_FACTORY,
+            Util.HTTP_SERVER_MECHANISM_FACTORY, Util.GLOBAL, "http", ElytronUtil.HTTP_SERVER_CAPABILITY);
+
+    private final String resourceType;
+    private final String serverType;
+    private final String serverValue;
+    private final String name;
+    private final String capability;
+
+    private AuthFactorySpec(String resourceType, String serverType, String serverValue, String name, String capability) {
+        this.resourceType = resourceType;
+        this.serverType = serverType;
+        this.serverValue = serverValue;
+        this.name = name;
+        this.capability = capability;
+    }
+
+    /**
+     * @return the resourceType
+     */
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    /**
+     * @return the serverType
+     */
+    public String getServerType() {
+        return serverType;
+    }
+
+    /**
+     * @return the serverValue
+     */
+    public String getServerValue() {
+        return serverValue;
+    }
+
+    /**
+     * @return the serverValue
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the serverValue
+     */
+    public String getCapability() {
+        return capability;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AuthMechanism.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AuthMechanism.java
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+/**
+ * An authentication mechanism eg: PLAIN, DIGEST-MD5, ...
+ *
+ * @author jdenise@redhat.com
+ */
+public class AuthMechanism {
+    private final String type;
+    private final MechanismConfiguration config;
+
+    public AuthMechanism(String type, MechanismConfiguration config) {
+        this.type = type;
+        this.config = config;
+    }
+
+    /**
+     * @return the type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @return the config
+     */
+    public MechanismConfiguration getConfig() {
+        return config;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AuthSecurityBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AuthSecurityBuilder.java
@@ -1,0 +1,279 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import org.aesh.command.CommandException;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Main class to build the requests to enable/disable authentication on any kind
+ * of interface/factory.
+ *
+ * @author jdenise@redhat.com
+ */
+public class AuthSecurityBuilder {
+
+    private String newSecurityDomain;
+    private String newFactoryName;
+    private String newRealmName;
+    private String activeFactoryName;
+    private final ModelNode composite = new ModelNode();
+    private final AuthMechanism mechanism;
+    private AuthFactory authFactory;
+    private final AuthFactory ootbFactory;
+    private final List<String> order;
+    private final AuthFactorySpec spec;
+
+    public AuthSecurityBuilder(AuthMechanism mechanism, AuthFactorySpec spec) throws CommandException {
+        Objects.requireNonNull(mechanism);
+        Objects.requireNonNull(spec);
+        this.mechanism = mechanism;
+        ootbFactory = null;
+        order = null;
+        this.spec = spec;
+        init();
+    }
+
+    public AuthSecurityBuilder(AuthFactory ootbFactory) throws CommandException {
+        Objects.requireNonNull(ootbFactory);
+        mechanism = null;
+        this.ootbFactory = ootbFactory;
+        order = null;
+        spec = ootbFactory.getSpec();
+        init();
+    }
+
+    public AuthSecurityBuilder(List<String> order) {
+        Objects.requireNonNull(order);
+        this.order = order;
+        mechanism = null;
+        this.ootbFactory = null;
+        init();
+        spec = AuthFactorySpec.SASL;
+    }
+
+    private void init() {
+        composite.get(Util.OPERATION).set(Util.COMPOSITE);
+        composite.get(Util.ADDRESS).setEmptyList();
+    }
+
+    public ModelNode getRequest() {
+        return composite;
+    }
+
+    public ModelNode getSteps() {
+        return composite.get(Util.STEPS);
+    }
+
+    public AuthFactory getAuthFactory() {
+        return ootbFactory == null ? authFactory : ootbFactory;
+    }
+
+    public AuthSecurityBuilder setNewRealmName(String newRealmName) {
+        this.newRealmName = newRealmName;
+        return this;
+    }
+
+    public AuthSecurityBuilder setSecurityDomainName(String securityDomain) {
+        this.newSecurityDomain = securityDomain;
+        return this;
+    }
+
+    public AuthSecurityBuilder setAuthFactoryName(String newFactoryName) {
+        this.newFactoryName = newFactoryName;
+        return this;
+    }
+
+    public AuthSecurityBuilder setActiveFactoryName(String activeFactoryName) {
+        this.activeFactoryName = activeFactoryName;
+        return this;
+    }
+
+    public boolean isFactoryAlreadySet() {
+        return activeFactoryName != null;
+    }
+
+    public void buildRequest(CommandContext ctx) throws Exception {
+        // rely on existing resources, no request.
+        if (ootbFactory != null) {
+            return;
+        }
+
+        if (order != null) {
+            if (activeFactoryName == null) {
+                throw new Exception("No SASL factory to re-order");
+            }
+            ModelNode request = ElytronUtil.reorderSASLFactory(ctx, order, activeFactoryName);
+            getSteps().add(request);
+            return;
+        }
+
+        Realm realm;
+        SecurityDomain securityDomain;
+        // First build the realm.
+        realm = buildRealm(ctx);
+
+        // If the configuration requires some constant roles, add a new constant-mapper.
+        if (realm != null) {
+            if (realm.getConfig().getRoles() != null) {
+                String roleMapper = ElytronUtil.findMatchingConstantRoleMapper(realm.getConfig().getRoles(), ctx);
+                if (roleMapper == null) {
+                    roleMapper = DefaultResourceNames.buildConstantRoleMapperName(realm, ctx);
+                    ModelNode request = ElytronUtil.buildConstantRoleMapper(realm.getConfig().getRoles(), roleMapper, ctx);
+                    getSteps().add(request);
+                }
+                // update the role mapper.
+                realm.getConfig().setRoleMapper(roleMapper);
+            }
+        }
+        // If we have an active Factory, the securityDomain is already present.
+        if (activeFactoryName == null) {
+            // In case no name has been provided. Lookup for a factory that would contain only this exact same mechanism/realm
+            // and reuse it.
+            if (newFactoryName == null) {
+                authFactory = ElytronUtil.findMatchingAuthFactory(mechanism, spec, ctx);
+            }
+            if (authFactory == null) {
+                // Add a new security domain (realm added to the new securityDomain)
+                securityDomain = buildSecurityDomain(ctx, realm);
+                // Finally the Factory;
+                authFactory = buildAuthFactory(ctx, securityDomain);
+            } else {
+                // We have a factory that contains the realm, need to add again the realm to the security-domain
+                // in case its configuration changed.
+                addRealm(ctx, authFactory.getSecurityDomain(), realm);
+            }
+        } else {
+            authFactory = ElytronUtil.getAuthFactory(activeFactoryName, spec, ctx);
+            if (authFactory == null) {
+                throw new Exception("Impossible to create factory");
+            }
+            // Add the realm to the existing security domain.
+            if (realm != null) {
+                addRealm(ctx, authFactory.getSecurityDomain(), realm);
+            }
+        }
+        if (authFactory == null) {
+            throw new Exception("Impossible to create factory");
+        }
+
+        //Add the mechanism to the factory
+        addAuthMechanism(ctx, authFactory, mechanism);
+    }
+
+    private Realm buildRealm(CommandContext ctx) throws Exception {
+        boolean existing = false;
+        String name;
+        if (mechanism.getConfig() instanceof PropertiesRealmConfiguration) {
+            PropertiesRealmConfiguration config = (PropertiesRealmConfiguration) mechanism.getConfig();
+            String rName = null;
+            // If a name is provided do not re-use existing realm.
+            if (newRealmName == null) {
+                rName = ElytronUtil.findMatchingUsersPropertiesRealm(ctx, config);
+            }
+            if (rName == null) {
+                if (newRealmName == null) {
+                    newRealmName = DefaultResourceNames.buildUserPropertiesDefaultRealmName(ctx, config);
+                }
+                ModelNode request = ElytronUtil.addUsersPropertiesRealm(ctx, newRealmName, config);
+                getSteps().add(request);
+                name = newRealmName;
+            } else {
+                existing = true;
+                name = rName;
+            }
+        } else if (mechanism.getConfig() instanceof KeyStoreConfiguration) {
+            KeyStoreConfiguration tsConfig = (KeyStoreConfiguration) mechanism.getConfig();
+            String ksRealmName = null;
+            // If a name is provided do not re-use existing realm.
+            if (newRealmName == null) {
+                ksRealmName = ElytronUtil.findKeyStoreRealm(ctx, tsConfig.getTrustStore());
+            }
+            if (ksRealmName == null) {
+                if (newRealmName == null) {
+                    ksRealmName = "ks-realm-" + tsConfig.getTrustStore();
+                } else {
+                    ksRealmName = newRealmName;
+                }
+                ModelNode request = ElytronUtil.addKeyStoreRealm(ctx, ksRealmName, tsConfig.getTrustStore());
+                getSteps().add(request);
+            } else {
+                existing = true;
+            }
+            name = ksRealmName;
+        } else {
+            // File system or existing properties realm.
+            existing = true;
+            name = mechanism.getConfig().getRealmName();
+        }
+
+        if (name == null) {
+            // No realm, not fully supported.
+            return null;
+        }
+
+        String constantMapper = ElytronUtil.findConstantRealmMapper(ctx, name);
+        if (constantMapper == null) {
+            getSteps().add(ElytronUtil.addConstantRealmMapper(ctx, name));
+            constantMapper = name;
+        }
+        mechanism.getConfig().setRealmMapperName(constantMapper);
+
+        return new Realm(name, constantMapper,
+                mechanism.getConfig(), existing);
+    }
+
+    private SecurityDomain buildSecurityDomain(CommandContext ctx, Realm realm) throws OperationFormatException, IOException {
+        if (newSecurityDomain == null) {
+            newSecurityDomain = DefaultResourceNames.buildDefaultSecurityDomainName(realm, ctx);
+        }
+        ModelNode request = ElytronUtil.addSecurityDomain(ctx, realm, newSecurityDomain);
+        getSteps().add(request);
+        SecurityDomain domain = new SecurityDomain(newSecurityDomain);
+        if (realm != null) {
+            domain.addRealm(realm);
+        }
+        return domain;
+    }
+
+    private AuthFactory buildAuthFactory(CommandContext ctx, SecurityDomain securityDomain) throws OperationFormatException, IOException {
+        if (newFactoryName == null) {
+            newFactoryName = DefaultResourceNames.buildDefaultAuthFactoryName(mechanism, spec, ctx);
+        }
+        ModelNode request = ElytronUtil.addAuthFactory(ctx, securityDomain, newFactoryName, spec);
+        getSteps().add(request);
+        AuthFactory factory = new AuthFactory(newFactoryName, securityDomain, spec);
+        return factory;
+    }
+
+    private void addAuthMechanism(CommandContext ctx, AuthFactory authFactory, AuthMechanism mechanism) throws OperationFormatException {
+        ElytronUtil.addAuthMechanism(ctx, authFactory, mechanism, getSteps());
+    }
+
+    private void addRealm(CommandContext ctx, SecurityDomain securityDomain, Realm realm) throws OperationFormatException {
+        ElytronUtil.addRealm(ctx, securityDomain, realm, getSteps());
+    }
+
+    public boolean isEmpty() {
+        return !getSteps().isDefined();
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/DefaultResourceNames.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/DefaultResourceNames.java
@@ -30,6 +30,10 @@ import org.jboss.as.cli.operation.OperationFormatException;
  */
 public class DefaultResourceNames {
 
+    private static final String SECURITY_DOMAIN_NAME = "security-domain";
+    public static final String ROLE_MAPPER_NAME = "role-mapper";
+    private static final String FACTORY_NAME = "factory";
+
     public static String buildDefaultKeyStoreName(String name, CommandContext ctx) throws OperationFormatException, IOException {
         int i = 1;
         String computedName = name;
@@ -94,5 +98,47 @@ public class DefaultResourceNames {
 
     static String getDefaultApplicationLegacyRealm() {
         return Util.APPLICATION_REALM;
+    }
+
+    public static String buildUserPropertiesDefaultRealmName(CommandContext ctx,
+            PropertiesRealmConfiguration config) throws OperationFormatException, IOException {
+        String name = new File(config.getUserPropertiesFile()).getName();
+        int i = 1;
+        String computedName = name;
+        while (ElytronUtil.serverPropertiesRealmExists(ctx, computedName)) {
+            computedName = name + "_" + i;
+            i += 1;
+        }
+        return computedName;
+    }
+
+    public static String buildDefaultSecurityDomainName(Realm realm, CommandContext ctx) throws OperationFormatException, IOException {
+        int i = 1;
+        String computedName = SECURITY_DOMAIN_NAME;
+        while (ElytronUtil.securityDomainExists(ctx, computedName)) {
+            computedName = SECURITY_DOMAIN_NAME + "_" + i;
+            i += 1;
+        }
+        return computedName;
+    }
+
+    public static String buildConstantRoleMapperName(Realm realm, CommandContext ctx) throws OperationFormatException, IOException {
+        int i = 1;
+        String computedName = ROLE_MAPPER_NAME;
+        while (ElytronUtil.constantRoleMapperExists(ctx, computedName)) {
+            computedName = ROLE_MAPPER_NAME + "_" + i;
+            i += 1;
+        }
+        return computedName;
+    }
+
+    public static String buildDefaultAuthFactoryName(AuthMechanism meca, AuthFactorySpec spec, CommandContext ctx) throws OperationFormatException, IOException {
+        int i = 1;
+        String computedName = spec.getName() + "-" + FACTORY_NAME;
+        while (ElytronUtil.factoryExists(ctx, computedName, spec)) {
+            computedName = spec.getName() + "-" + FACTORY_NAME + "_" + i;
+            i += 1;
+        }
+        return computedName;
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ElytronUtil.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ElytronUtil.java
@@ -19,7 +19,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.operation.OperationFormatException;
@@ -34,9 +37,73 @@ import org.jboss.dmr.ModelNode;
  */
 public abstract class ElytronUtil {
 
+    private static final String PLAIN_MECHANISM = "PLAIN";
+    private static final String DIGEST_MD5_MECHANISM = "DIGEST-MD5";
+    private static final String EXTERNAL_MECHANISM = "EXTERNAL";
+    private static final String JBOSS_LOCAL_USER_MECHANISM = "JBOSS-LOCAL-USER";
+
+    private static final String BASIC_MECHANISM = "BASIC";
+    private static final String DIGEST_MECHANISM = "DIGEST";
+    private static final String FORM_MECHANISM = "FORM";
+    private static final String CLIENT_CERT_MECHANISM = "CLIENT_CERT";
+
+    private static final String SCRAM_SHA_1 = "SCRAM-SHA-1";
+    private static final String SCRAM_SHA_1_PLUS = "SCRAM-SHA-1-PLUS";
+    private static final String SCRAM_SHA_256 = "SCRAM-SHA-256";
+    private static final String SCRAM_SHA_256_PLUS = "SCRAM-SHA-256-PLUS";
+    private static final String SCRAM_SHA_384 = "SCRAM-SHA-384";
+    private static final String SCRAM_SHA_384_PLUS = "SCRAM-SHA-384-PLUS";
+    private static final String SCRAM_SHA_512 = "SCRAM-SHA-512";
+    private static final String SCRAM_SHA_512_PLUS = "SCRAM-SHA-512-PLUS";
+
+    private static final String DIGEST_SHA = "DIGEST-SHA";
+    private static final String DIGEST_SHA_256 = "DIGEST-SHA-256";
+    private static final String DIGEST_SHA_384 = "DIGEST-SHA-384";
+    private static final String DIGEST_SHA_512 = "DIGEST-SHA-512";
+
     public static final String JKS = "JKS";
     public static final String PKCS12 = "PKCS12";
     public static final String TLS_V1_2 = "TLSv1.2";
+
+    public static String OOTB_MANAGEMENT_SASL_FACTORY = "management-sasl-authentication";
+    public static String OOTB_MANAGEMENT_HTTP_FACTORY = "management-http-authentication";
+    public static String OOTB_APPLICATION_HTTP_FACTORY = "application-http-authentication";
+
+    public static final String SASL_SERVER_CAPABILITY = "org.wildfly.security.sasl-server-factory";
+    public static final String HTTP_SERVER_CAPABILITY = "org.wildfly.security.http-server-mechanism-factory";
+
+    private static final Set<String> MECHANISMS_WITH_REALM = new HashSet<>();
+
+    private static final Set<String> MECHANISMS_WITH_TRUST_STORE = new HashSet<>();
+
+    private static final Set<String> MECHANISMS_LOCAL_USER = new HashSet<>();
+
+    static {
+        MECHANISMS_WITH_REALM.add(PLAIN_MECHANISM);
+        MECHANISMS_WITH_REALM.add(DIGEST_MD5_MECHANISM);
+        MECHANISMS_WITH_REALM.add(DIGEST_MECHANISM);
+        MECHANISMS_WITH_REALM.add(FORM_MECHANISM);
+        MECHANISMS_WITH_REALM.add(BASIC_MECHANISM);
+
+        MECHANISMS_WITH_REALM.add(SCRAM_SHA_1);
+        MECHANISMS_WITH_REALM.add(SCRAM_SHA_1_PLUS);
+        MECHANISMS_WITH_REALM.add(SCRAM_SHA_256);
+        MECHANISMS_WITH_REALM.add(SCRAM_SHA_256_PLUS);
+        MECHANISMS_WITH_REALM.add(SCRAM_SHA_384);
+        MECHANISMS_WITH_REALM.add(SCRAM_SHA_384_PLUS);
+        MECHANISMS_WITH_REALM.add(SCRAM_SHA_512);
+        MECHANISMS_WITH_REALM.add(SCRAM_SHA_512_PLUS);
+
+        MECHANISMS_WITH_REALM.add(DIGEST_SHA);
+        MECHANISMS_WITH_REALM.add(DIGEST_SHA_256);
+        MECHANISMS_WITH_REALM.add(DIGEST_SHA_384);
+        MECHANISMS_WITH_REALM.add(DIGEST_SHA_512);
+
+        MECHANISMS_WITH_TRUST_STORE.add(EXTERNAL_MECHANISM);
+        MECHANISMS_WITH_TRUST_STORE.add(CLIENT_CERT_MECHANISM);
+
+        MECHANISMS_LOCAL_USER.add(JBOSS_LOCAL_USER_MECHANISM);
+    }
 
     private ElytronUtil() {
     }
@@ -356,6 +423,10 @@ public abstract class ElytronUtil {
         return getNames(client, Util.KEY_STORE);
     }
 
+    public static List<String> getConstantRoleMappers(ModelControllerClient client) {
+        return getNames(client, Util.CONSTANT_ROLE_MAPPER);
+    }
+
     private static List<String> getNames(ModelControllerClient client, String type) {
         final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
         final ModelNode request;
@@ -448,4 +519,717 @@ public abstract class ElytronUtil {
         return Util.isSuccess(response);
     }
 
+    public static ModelNode getAuthFactoryResource(String authFactory, AuthFactorySpec spec, CommandContext ctx) {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_RESOURCE);
+            builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+            builder.addNode(spec.getResourceType(), authFactory);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+            if (Util.isSuccess(outcome)) {
+                return outcome.get(Util.RESULT);
+            }
+        } catch (Exception e) {
+        }
+        return null;
+    }
+
+    public static ModelNode reorderSASLFactory(CommandContext ctx, List<String> order, String factoryName) throws Exception {
+        ModelNode factory = getAuthFactoryResource(factoryName, AuthFactorySpec.SASL, ctx);
+        if (factory == null) {
+            throw new Exception("Invalid factory name " + factoryName);
+        }
+        if (factory.hasDefined(Util.MECHANISM_CONFIGURATIONS)) {
+            ModelNode mechanisms = factory.get(Util.MECHANISM_CONFIGURATIONS);
+            Set<String> seen = new HashSet<>();
+            List<ModelNode> newOrder = new ArrayList<>();
+            for (String o : order) {
+                for (ModelNode m : mechanisms.asList()) {
+                    String name = m.get(Util.MECHANISM_NAME).asString();
+                    if (o.equals(name)) {
+                        newOrder.add(m);
+                    }
+                    seen.add(name);
+                }
+            }
+            for (String r : order) {
+                if (!seen.contains(r)) {
+                    throw new Exception("Mechanism " + r
+                            + " is not contained in SASL factory " + factoryName);
+                }
+            }
+            if (!order.containsAll(seen)) {
+                throw new Exception("Mechanism list is not complete, existing mechanisms are:" + seen);
+            }
+
+            if (newOrder.isEmpty()) {
+                throw new Exception("Error: All mechanisms would be removed, this would fully disable access.");
+            }
+            ModelNode newValue = new ModelNode();
+            newValue.set(newOrder);
+            DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+            builder.setOperationName(Util.WRITE_ATTRIBUTE);
+            builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+            builder.addNode(AuthFactorySpec.SASL.getResourceType(), factoryName);
+            builder.addProperty(Util.NAME, Util.MECHANISM_CONFIGURATIONS);
+            builder.getModelNode().get(Util.VALUE).set(newValue);
+            return builder.buildRequest();
+        } else {
+            throw new Exception("No mechanism to re-order in Factory " + factoryName);
+        }
+    }
+
+    public static AuthFactory findMatchingAuthFactory(AuthMechanism newMechanism,
+            AuthFactorySpec spec, CommandContext ctx) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_CHILDREN_RESOURCES);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addProperty(Util.CHILD_TYPE, spec.getResourceType());
+        ModelNode request = builder.buildRequest();
+        ModelNode response = ctx.getModelControllerClient().execute(request);
+        AuthFactory factory = null;
+        if (Util.isSuccess(response)) {
+            if (response.hasDefined(Util.RESULT)) {
+                ModelNode res = response.get(Util.RESULT);
+                for (String ksName : res.keys()) {
+                    ModelNode ks = res.get(ksName);
+                    AuthFactory fact = getAuthFactory(ks, ksName, spec, ctx);
+                    List<AuthMechanism> mecs = fact.getMechanisms();
+                    if (mecs.isEmpty() || mecs.size() > 1) {
+                        continue;
+                    }
+                    AuthMechanism mec = mecs.get(0);
+                    // Only compare, type, realmName and realmMapper.
+                    if (newMechanism.getType().equals(mec.getType())) {
+                        if (newMechanism.getConfig().getRealmMapper() == null) {
+                            if (Objects.equals(newMechanism.getConfig().getRealmName(),
+                                    mec.getConfig().getRealmName())) {
+                                factory = fact;
+                                break;
+                            }
+                        } else if (Objects.equals(newMechanism.getConfig().getRealmMapper(),
+                                mec.getConfig().getRealmMapper())) {
+                            factory = fact;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return factory;
+    }
+
+    public static AuthFactory getAuthFactory(String authFactory, AuthFactorySpec spec, CommandContext ctx) {
+        ModelNode mn = getAuthFactoryResource(authFactory, spec, ctx);
+        return getAuthFactory(mn, authFactory, spec, ctx);
+    }
+
+    public static AuthFactory getAuthFactory(ModelNode mn, String authFactory, AuthFactorySpec spec, CommandContext ctx) {
+        AuthFactory factory = null;
+        if (mn != null) {
+            SecurityDomain sc = new SecurityDomain(mn.get(Util.SECURITY_DOMAIN).asString());
+            factory = new AuthFactory(authFactory, sc, spec);
+            if (mn.hasDefined(Util.MECHANISM_CONFIGURATIONS)) {
+                ModelNode lst = mn.get(Util.MECHANISM_CONFIGURATIONS);
+                for (ModelNode m : lst.asList()) {
+                    String name = m.get(Util.MECHANISM_NAME).asString();
+                    String realmMapper = null;
+                    String realmName = null;
+                    if (m.hasDefined(Util.REALM_MAPPER)) {
+                        realmMapper = m.get(Util.REALM_MAPPER).asString();
+                    }
+                    // XXX This could be evolved with new exposed attributes
+                    if (m.hasDefined(Util.MECHANISM_REALM_CONFIGURATIONS)) {
+                        ModelNode config = m.get(Util.MECHANISM_REALM_CONFIGURATIONS);
+                        for (ModelNode c : config.asList()) {
+                            if (c.hasDefined(Util.REALM_NAME)) {
+                                realmName = c.get(Util.REALM_NAME).asString();
+                                break;
+                            }
+                        }
+                    }
+                    String finalRealmName = realmName;
+                    String finalRealmMapper = realmMapper;
+                    AuthMechanism mec = new AuthMechanism(name, new MechanismConfiguration() {
+                        @Override
+                        public String getRealmName() {
+                            return finalRealmName;
+                        }
+
+                        @Override
+                        public String getRoleDecoder() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getRoleMapper() {
+                            return null;
+                        }
+
+                        @Override
+                        public String getRealmMapper() {
+                            return finalRealmMapper;
+                        }
+
+                        @Override
+                        public String getExposedRealmName() {
+                            return finalRealmName;
+                        }
+
+                        @Override
+                        public void setRealmMapperName(String constantMapper) {
+                            // NO-OP
+                        }
+                    });
+                    factory.addMechanism(mec);
+                }
+            }
+        }
+        return factory;
+    }
+
+    public static String findMatchingUsersPropertiesRealm(CommandContext ctx,
+            PropertiesRealmConfiguration config) throws Exception {
+        ModelNode resource = buildRealmResource(config);
+        List<String> names = findMatchingResources(ctx, Util.PROPERTIES_REALM, resource);
+        if (names.isEmpty()) {
+            return null;
+        }
+        return names.get(0);
+    }
+
+    private static ModelNode buildRealmResource(Realm realm) {
+        ModelNode mn = new ModelNode();
+        mn.get(Util.REALM).set(realm.getResourceName());
+        if (realm.getConfig().getRoleDecoder() != null) {
+            mn.get(Util.ROLE_DECODER).set(realm.getConfig().getRoleDecoder());
+        }
+        if (realm.getConfig().getRoleMapper() != null) {
+            mn.get(Util.ROLE_MAPPER).set(realm.getConfig().getRoleMapper());
+        }
+        return mn;
+    }
+
+    private static ModelNode buildRealmResource(PropertiesRealmConfiguration config) throws Exception {
+        ModelNode localRealm = new ModelNode();
+        localRealm.get(Util.GROUPS_ATTRIBUTE).set(Util.GROUPS);
+        if (config.getGroupPropertiesFile() != null) {
+            localRealm.get(Util.GROUPS_PROPERTIES).set(buildGroupsResource(config));
+        }
+        localRealm.get(Util.USERS_PROPERTIES).set(buildUsersResource(config));
+        return localRealm;
+    }
+
+    private static ModelNode buildGroupsResource(PropertiesRealmConfiguration config) throws IOException {
+        ModelNode mn = new ModelNode();
+        mn.get(Util.PATH).set(config.getGroupPropertiesFile());
+        if (config.getRelativeTo() != null) {
+            mn.get(Util.RELATIVE_TO).set(config.getRelativeTo());
+        }
+        return mn;
+    }
+
+    private static ModelNode buildUsersResource(PropertiesRealmConfiguration config) throws IOException {
+        ModelNode mn = new ModelNode();
+        mn.get(Util.PATH).set(config.getUserPropertiesFile());
+        if (config.getRelativeTo() != null) {
+            mn.get(Util.RELATIVE_TO).set(config.getRelativeTo());
+        }
+        mn.get(Util.DIGEST_REALM_NAME).set(config.getExposedRealmName());
+        return mn;
+    }
+
+    public static boolean serverPropertiesRealmExists(CommandContext ctx, String name) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.PROPERTIES_REALM, name);
+        return Util.isSuccess(ctx.getModelControllerClient().execute(builder.buildRequest()));
+    }
+
+    public static ModelNode addUsersPropertiesRealm(CommandContext ctx, String realmName,
+            PropertiesRealmConfiguration config) throws Exception {
+        ModelNode mn = buildRealmResource(config);
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.PROPERTIES_REALM, realmName);
+        for (String k : mn.keys()) {
+            builder.getModelNode().get(k).set(mn.get(k));
+        }
+        return builder.buildRequest();
+    }
+
+    public static String findKeyStoreRealm(CommandContext ctx, String trustStore) throws IOException, OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        String name = null;
+        builder.setOperationName(Util.READ_CHILDREN_RESOURCES);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addProperty(Util.CHILD_TYPE, Util.KEY_STORE_REALM);
+        ModelNode response = ctx.getModelControllerClient().execute(builder.buildRequest());
+        if (Util.isSuccess(response)) {
+            if (response.hasDefined(Util.RESULT)) {
+                ModelNode mn = response.get(Util.RESULT);
+                for (String key : mn.keys()) {
+                    ModelNode ksr = mn.get(key);
+                    if (ksr.hasDefined(Util.KEY_STORE)) {
+                        String ks = ksr.get(Util.KEY_STORE).asString();
+                        if (ks.equals(trustStore)) {
+                            name = key;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        return name;
+    }
+
+    public static ModelNode addKeyStoreRealm(CommandContext ctx, String ksRealmName, String keyStore) throws OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.KEY_STORE_REALM, ksRealmName);
+        builder.addProperty(Util.KEY_STORE, keyStore);
+        return builder.buildRequest();
+    }
+
+    public static String findConstantRealmMapper(CommandContext ctx, String realmName) throws IOException, OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_CHILDREN_RESOURCES);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addProperty(Util.CHILD_TYPE, Util.CONSTANT_REALM_MAPPER);
+        ModelNode request = builder.buildRequest();
+        ModelNode response = ctx.getModelControllerClient().execute(request);
+        if (Util.isSuccess(response)) {
+            if (response.hasDefined(Util.RESULT)) {
+                ModelNode res = response.get(Util.RESULT);
+                for (String csName : res.keys()) {
+                    ModelNode mn = res.get(csName);
+                    String constantName = mn.get(Util.REALM_NAME).asString();
+                    if (realmName.equals(constantName)) {
+                        return csName;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    public static ModelNode addConstantRealmMapper(CommandContext ctx, String realmName) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.CONSTANT_REALM_MAPPER, realmName);
+        builder.addProperty(Util.REALM_NAME, realmName);
+        return builder.buildRequest();
+    }
+
+    public static boolean securityDomainExists(CommandContext ctx, String name) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.SECURITY_DOMAIN, name);
+        return Util.isSuccess(ctx.getModelControllerClient().execute(builder.buildRequest()));
+    }
+
+    public static ModelNode addSecurityDomain(CommandContext ctx, Realm realm,
+            String newSecurityDomain) throws OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.SECURITY_DOMAIN, newSecurityDomain);
+        ModelNode mn = buildSecurityDomainResource(realm);
+        for (String k : mn.keys()) {
+            builder.getModelNode().get(k).set(mn.get(k));
+        }
+        return builder.buildRequest();
+    }
+
+    private static ModelNode buildSecurityDomainResource(Realm realm) {
+        ModelNode sd = new ModelNode();
+        if (realm != null) {
+            sd.get(Util.REALMS).add(buildRealmResource(realm));
+        }
+        sd.get(Util.PERMISSION_MAPPER).set(Util.DEFAULT_PERMISSION_MAPPER);
+
+        return sd;
+    }
+
+    public static boolean factoryExists(CommandContext ctx, String name, AuthFactorySpec spec) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(spec.getResourceType(), name);
+        return Util.isSuccess(ctx.getModelControllerClient().execute(builder.buildRequest()));
+    }
+
+    public static ModelNode addAuthFactory(CommandContext ctx, SecurityDomain securityDomain,
+            String newAuthFactoryName, AuthFactorySpec spec) throws OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(spec.getResourceType(), newAuthFactoryName);
+        ModelNode mn = buildAuthFactoryResource(securityDomain, spec);
+        for (String k : mn.keys()) {
+            builder.getModelNode().get(k).set(mn.get(k));
+        }
+        return builder.buildRequest();
+    }
+
+    private static ModelNode buildAuthFactoryResource(SecurityDomain domain, AuthFactorySpec spec) {
+        ModelNode sd = new ModelNode();
+        sd.get(spec.getServerType()).set(spec.getServerValue());
+        sd.get(Util.SECURITY_DOMAIN).set(domain.getName());
+        return sd;
+    }
+
+    public static void addAuthMechanism(CommandContext ctx, AuthFactory authFactory,
+            AuthMechanism mechanism, ModelNode steps) throws OperationFormatException {
+        ModelNode mechanisms = retrieveMechanisms(ctx, authFactory);
+        ModelNode newMechanism = buildMechanismResource(mechanism);
+        // check if a mechanism with the same name exists, replace it.
+        int index = 0;
+        boolean found = false;
+        for (ModelNode m : mechanisms.asList()) {
+            if (m.hasDefined(Util.MECHANISM_NAME)) {
+                String name = m.get(Util.MECHANISM_NAME).asString();
+                if (name.equals(mechanism.getType())) {
+                    // Already have the exact same mechanism, no need to add it.
+                    if (newMechanism.equals(m)) {
+                        return;
+                    }
+                    found = true;
+                    break;
+                }
+            }
+            index += 1;
+        }
+
+        if (found) {
+            mechanisms.remove(index);
+            mechanisms.insert(newMechanism, index);
+        } else {
+            mechanisms.add(newMechanism);
+        }
+
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.WRITE_ATTRIBUTE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(authFactory.getSpec().getResourceType(), authFactory.getName());
+        builder.getModelNode().get(Util.VALUE).set(mechanisms);
+        builder.getModelNode().get(Util.NAME).set(Util.MECHANISM_CONFIGURATIONS);
+        steps.add(builder.buildRequest());
+    }
+
+    private static ModelNode buildMechanismResource(AuthMechanism mechanism) {
+        ModelNode mn = new ModelNode();
+        mn.get(Util.MECHANISM_NAME).set(mechanism.getType());
+        if (mechanism.getConfig().getRealmMapper() != null) {
+            mn.get(Util.REALM_MAPPER).set(mechanism.getConfig().getRealmMapper());
+        }
+        if (mechanism.getConfig().getExposedRealmName() != null) {
+            ModelNode realmConfig = new ModelNode();
+            realmConfig.get(Util.REALM_NAME).set(mechanism.getConfig().getExposedRealmName());
+            mn.get(Util.MECHANISM_REALM_CONFIGURATIONS).add(realmConfig);
+        }
+        return mn;
+    }
+
+    public static void addRealm(CommandContext ctx, SecurityDomain securityDomain, Realm realm, ModelNode steps) throws OperationFormatException {
+        ModelNode realms = retrieveSecurityDomainRealms(ctx, securityDomain);
+        ModelNode newRealm = buildRealmResource(realm);
+        int index = 0;
+        boolean found = false;
+        for (ModelNode r : realms.asList()) {
+            if (r.hasDefined(Util.REALM)) {
+                String n = r.get(Util.REALM).asString();
+                // Already present, skip....
+                if (n.equals(realm.getResourceName())) {
+                    if (newRealm.equals(r)) {
+                        return;
+                    }
+                    // We need to replace it with the new one.
+                    found = true;
+                    break;
+                }
+            }
+            index += 1;
+        }
+        if (found) {
+            realms.remove(index);
+            realms.insert(newRealm, index);
+        } else {
+            realms.add(newRealm);
+        }
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.WRITE_ATTRIBUTE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.SECURITY_DOMAIN, securityDomain.getName());
+        builder.getModelNode().get(Util.VALUE).set(realms);
+        builder.getModelNode().get(Util.NAME).set(Util.REALMS);
+        steps.add(builder.buildRequest());
+    }
+
+    private static ModelNode retrieveSecurityDomainRealms(CommandContext ctx, SecurityDomain domain) {
+        ModelNode mn = getSecurityDomainResource(domain, ctx);
+        if (mn == null) {
+            return new ModelNode().setEmptyList();
+        } else if (mn.hasDefined(Util.REALMS)) {
+            return mn.get(Util.REALMS);
+        } else {
+            return new ModelNode().setEmptyList();
+        }
+    }
+
+    public static ModelNode getSecurityDomainResource(SecurityDomain domain, CommandContext ctx) {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_RESOURCE);
+            builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+            builder.addNode(Util.SECURITY_DOMAIN, domain.getName());
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+            if (Util.isSuccess(outcome)) {
+                return outcome.get(Util.RESULT);
+            }
+        } catch (Exception e) {
+        }
+        return null;
+    }
+
+    private static ModelNode retrieveMechanisms(CommandContext ctx, AuthFactory authFactory) {
+        ModelNode mn = getAuthFactoryResource(authFactory.getName(), authFactory.getSpec(), ctx);
+        if (mn == null) {
+            return new ModelNode().setEmptyList();
+        } else if (mn.hasDefined(Util.MECHANISM_CONFIGURATIONS)) {
+            return mn.get(Util.MECHANISM_CONFIGURATIONS);
+        } else {
+            return new ModelNode().setEmptyList();
+        }
+    }
+
+    public static final Set<String> getMechanismsWithRealm() {
+        return MECHANISMS_WITH_REALM;
+    }
+
+    public static final Set<String> getMechanismsWithTrustStore() {
+        return MECHANISMS_WITH_TRUST_STORE;
+    }
+
+    public static final Set<String> getMechanismsLocalUser() {
+        return MECHANISMS_LOCAL_USER;
+    }
+
+    private static boolean isMechanismSupported(String name) {
+        return getMechanismsWithRealm().contains(name) || getMechanismsWithTrustStore().contains(name) || getMechanismsLocalUser().contains(name);
+    }
+
+    public static List<String> getMechanisms(CommandContext ctx, AuthFactorySpec spec, String factory) throws OperationFormatException, IOException {
+        List<String> lst = new ArrayList<>();
+        for (String m : getAvailableMechanisms(ctx, spec, factory)) {
+            if (isMechanismSupported(m)) {
+                lst.add(m);
+            }
+        }
+        return lst;
+    }
+
+    public static List<String> getAvailableMechanisms(CommandContext ctx, AuthFactorySpec spec, String factory) throws OperationFormatException, IOException {
+        List<String> lst = new ArrayList<>();
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        builder.setOperationName(Util.READ_ATTRIBUTE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(spec.getResourceType(), factory);
+        builder.getModelNode().get(Util.NAME).set(spec.getServerType());
+        request = builder.buildRequest();
+        String mechanismFactory = null;
+        final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+        if (Util.isSuccess(outcome)) {
+            mechanismFactory = outcome.get(Util.RESULT).asString();
+        } else {
+            return Collections.emptyList();
+        }
+        ModelNode resource = getServerFactory(mechanismFactory, spec, ctx);
+        if (resource == null) {
+            return null;
+        }
+        for (ModelNode m : resource.get(Util.AVAILABLE_MECHANISMS).asList()) {
+            lst.add(m.asString());
+        }
+        return lst;
+    }
+
+    public static List<String> getFileSystemRealmNames(ModelControllerClient client) {
+        return getNames(client, Util.FILESYSTEM_REALM);
+    }
+
+    public static List<String> getPropertiesRealmNames(ModelControllerClient client) {
+        return getNames(client, Util.PROPERTIES_REALM);
+    }
+
+    public static List<String> getKeyStoreRealmNames(ModelControllerClient client) {
+        return getNames(client, Util.KEY_STORE_REALM);
+    }
+
+    private static ModelNode getServerFactory(String factory, AuthFactorySpec spec, CommandContext ctx) throws OperationFormatException, IOException {
+        for (ModelNode point : getServerFactoriesProviderPoints(ctx, spec)) {
+            ModelNode fact = getServerfactory(ctx, point.asString(), factory);
+            if (fact != null) {
+                return fact;
+            }
+        }
+        return null;
+    }
+
+    private static List<ModelNode> getServerFactoriesProviderPoints(CommandContext ctx, AuthFactorySpec spec) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.GET_PROVIDER_POINTS);
+        builder.addNode(Util.CORE_SERVICE, Util.CAPABILITY_REGISTRY);
+        builder.getModelNode().get(Util.NAME).set(spec.getCapability());
+        ModelNode response = ctx.getModelControllerClient().execute(builder.buildRequest());
+        if (Util.isSuccess(response)) {
+            return response.get(Util.RESULT).asList();
+        }
+        return null;
+    }
+
+    // Simplistic for now, the format is something like: /subsystem=elytron/aggregate-sasl-server-factory=*
+    private static ModelNode getServerfactory(CommandContext ctx, String point, String name) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        for (String p : point.split("/")) {
+            if (p.isEmpty()) {
+                continue;
+            }
+            String[] ps = p.split("=");
+            if (ps[1].equals("*")) {
+                ps[1] = name;
+            }
+            builder.addNode(ps[0], ps[1]);
+        }
+        builder.getModelNode().get(Util.INCLUDE_RUNTIME).set(true);
+        ModelNode response = ctx.getModelControllerClient().execute(builder.buildRequest());
+        if (Util.isSuccess(response)) {
+            return response.get(Util.RESULT);
+        }
+        return null;
+    }
+
+    public static List<String> getSimpleDecoderNames(ModelControllerClient client) {
+        return getNames(client, Util.SIMPLE_ROLE_DECODER);
+    }
+
+    public static boolean localUserExists(CommandContext ctx) throws IOException, OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.IDENTITY_REALM, Util.LOCAL);
+        return Util.isSuccess(ctx.getModelControllerClient().execute(builder.buildRequest()));
+    }
+
+    public static ModelNode removeMechanisms(CommandContext ctx, ModelNode factory,
+            String factoryName, AuthFactorySpec spec, Set<String> toRemove) throws Exception {
+        if (factory.hasDefined(Util.MECHANISM_CONFIGURATIONS)) {
+            List<ModelNode> remains = new ArrayList<>();
+            Set<String> seen = new HashSet<>();
+            ModelNode mechanisms = factory.get(Util.MECHANISM_CONFIGURATIONS);
+            for (ModelNode m : mechanisms.asList()) {
+                String name = m.get(Util.MECHANISM_NAME).asString();
+                if (!toRemove.contains(name)) {
+                    remains.add(m);
+                }
+                seen.add(name);
+            }
+            for (String r : toRemove) {
+                if (!seen.contains(r)) {
+                    throw new Exception("Mechanism " + r
+                            + " is not contained in factory " + factoryName);
+                }
+            }
+            if (remains.isEmpty()) {
+                throw new Exception("Error: All mechanisms would be removed, this would fully disable access. "
+                        + "To fully disable authentication, don't provide mechanism.");
+            }
+            ModelNode newValue = new ModelNode();
+            newValue.set(remains);
+            DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+            builder.setOperationName(Util.WRITE_ATTRIBUTE);
+            builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+            builder.addNode(spec.getResourceType(), factoryName);
+            builder.addProperty(Util.NAME, Util.MECHANISM_CONFIGURATIONS);
+            builder.getModelNode().get(Util.VALUE).set(newValue);
+            return builder.buildRequest();
+        } else {
+            throw new Exception("No mechanism to remove in Factory " + factoryName);
+        }
+    }
+
+    public static List<String> getMechanisms(CommandContext ctx, String factoryName, AuthFactorySpec spec) throws Exception {
+        ModelNode factory = getAuthFactoryResource(factoryName, spec, ctx);
+        if (factory == null) {
+            throw new Exception("Invalid factory name " + factoryName);
+        }
+        List<String> lst = new ArrayList<>();
+        if (factory.hasDefined(Util.MECHANISM_CONFIGURATIONS)) {
+            ModelNode mechanisms = factory.get(Util.MECHANISM_CONFIGURATIONS);
+            for (ModelNode m : mechanisms.asList()) {
+                String name = m.get(Util.MECHANISM_NAME).asString();
+                lst.add(name);
+            }
+        } else {
+            throw new Exception("No mechanism in Factory " + factoryName);
+        }
+        return lst;
+    }
+
+    static String findMatchingConstantRoleMapper(List<String> roles,
+            CommandContext ctx) throws OperationFormatException, IOException {
+        ModelNode resource = buildConstantRoleMapperResource(roles);
+        List<String> names = findMatchingResources(ctx, Util.CONSTANT_ROLE_MAPPER, resource);
+        if (names.isEmpty()) {
+            return null;
+        }
+        return names.get(0);
+    }
+
+    private static ModelNode buildConstantRoleMapperResource(List<String> roles) {
+        ModelNode mn = new ModelNode();
+        ModelNode r = mn.get(Util.ROLES);
+        for (String role : roles) {
+            r.add(role);
+        }
+        return mn;
+    }
+
+    static ModelNode buildConstantRoleMapper(List<String> roles, String mapperName, CommandContext ctx) throws OperationFormatException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.ADD);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.CONSTANT_ROLE_MAPPER, mapperName);
+        builder.getModelNode().get(Util.ROLES).set(buildConstantRoleMapperResource(roles).get(Util.ROLES));
+        return builder.buildRequest();
+    }
+
+    public static boolean constantRoleMapperExists(CommandContext ctx, String name) throws OperationFormatException, IOException {
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.setOperationName(Util.READ_RESOURCE);
+        builder.addNode(Util.SUBSYSTEM, Util.ELYTRON);
+        builder.addNode(Util.CONSTANT_ROLE_MAPPER, name);
+        return Util.isSuccess(ctx.getModelControllerClient().execute(builder.buildRequest()));
+    }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/EmptyConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/EmptyConfiguration.java
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+/**
+ * An empty mechanism configuration
+ *
+ * @author jdenise@redhat.com
+ */
+public class EmptyConfiguration implements MechanismConfiguration {
+
+    @Override
+    public String getRealmName() {
+        return null;
+    }
+
+    @Override
+    public String getRoleDecoder() {
+        return null;
+    }
+
+    @Override
+    public String getRoleMapper() {
+        return null;
+    }
+
+    @Override
+    public String getRealmMapper() {
+        return null;
+    }
+
+    @Override
+    public String getExposedRealmName() {
+        return null;
+    }
+
+    @Override
+    public void setRealmMapperName(String constantMapper) {
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ExistingKeyStoreConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ExistingKeyStoreConfiguration.java
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.util.List;
+
+/**
+ * A configuration for an existing key-store-realm
+ *
+ * @author jdenise@redhat.com
+ */
+public class ExistingKeyStoreConfiguration extends AbstractKeyStoreConfiguration {
+
+    private final String realmName;
+
+    public ExistingKeyStoreConfiguration(String realmName, List<String> roles) {
+        super(roles);
+        this.realmName = realmName;
+    }
+
+    @Override
+    public String getRealmName() {
+        return realmName;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ExistingPropertiesRealmConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ExistingPropertiesRealmConfiguration.java
@@ -1,0 +1,65 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import org.jboss.as.cli.Util;
+
+/**
+ * A configuration for an existing properties-realm
+ *
+ * @author jdenise@redhat.com
+ */
+public class ExistingPropertiesRealmConfiguration implements MechanismConfiguration {
+
+    private final String name;
+    private final String exposedRealmName;
+    private String realmMapper;
+    public ExistingPropertiesRealmConfiguration(String name, String exposedRealmName) {
+        this.name = name;
+        this.exposedRealmName = exposedRealmName;
+    }
+
+    @Override
+    public String getRealmName() {
+        return name;
+    }
+
+    @Override
+    public String getRoleDecoder() {
+        return Util.GROUPS_TO_ROLES;
+    }
+
+    @Override
+    public String getRoleMapper() {
+        return null;
+    }
+
+    @Override
+    public String getRealmMapper() {
+        return realmMapper;
+    }
+
+    @Override
+    public String getExposedRealmName() {
+        return exposedRealmName;
+    }
+
+    @Override
+    public void setRealmMapperName(String constantMapper) {
+        this.realmMapper = constantMapper;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/FileSystemRealmConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/FileSystemRealmConfiguration.java
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+/**
+ * A configuration for an existing file-system realm.
+ *
+ * @author jdenise@redhat.com
+ */
+public class FileSystemRealmConfiguration implements MechanismConfiguration {
+    private final String realmName;
+    private final String roleDecoder;
+    private final String exposedRealmName;
+    private String realmMapper;
+    public FileSystemRealmConfiguration(String exposedRealmName, String realmName, String roleDecoder) {
+        this.realmName = realmName;
+        this.roleDecoder = roleDecoder;
+        this.exposedRealmName = exposedRealmName;
+    }
+
+    /**
+     * @return the realmName
+     */
+    @Override
+    public String getRealmName() {
+        return realmName;
+    }
+
+    /**
+     * @return the roleDecoder
+     */
+    @Override
+    public String getRoleDecoder() {
+        return roleDecoder;
+    }
+
+    @Override
+    public String getRealmMapper() {
+        return realmMapper;
+    }
+
+    @Override
+    public String getRoleMapper() {
+        return null;
+    }
+
+    @Override
+    public String getExposedRealmName() {
+        return exposedRealmName;
+    }
+
+    @Override
+    public void setRealmMapperName(String realmMapper) {
+        this.realmMapper = realmMapper;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/HTTPServer.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/HTTPServer.java
@@ -138,4 +138,40 @@ public class HTTPServer {
         return Util.isSuccess(response);
     }
 
+    public static void enableHTTPAuthentication(AuthSecurityBuilder builder, String securityDomain, CommandContext ctx) throws Exception {
+        final DefaultOperationRequestBuilder reqBuilder = new DefaultOperationRequestBuilder();
+        reqBuilder.setOperationName(Util.ADD);
+        reqBuilder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
+        reqBuilder.addNode(Util.APPLICATION_SECURITY_DOMAIN, securityDomain);
+        reqBuilder.addProperty(Util.HTTP_AUTHENTICATION_FACTORY, builder.getAuthFactory().getName());
+        builder.getSteps().add(reqBuilder.buildRequest());
+    }
+
+    public static ModelNode disableHTTPAuthentication(String securityDomain, CommandContext ctx) throws Exception {
+        final DefaultOperationRequestBuilder reqBuilder = new DefaultOperationRequestBuilder();
+        reqBuilder.setOperationName(Util.REMOVE);
+        reqBuilder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
+        reqBuilder.addNode(Util.APPLICATION_SECURITY_DOMAIN, securityDomain);
+        return reqBuilder.buildRequest();
+    }
+
+    public static String getSecurityDomainFactoryName(String securityDomain, CommandContext ctx) throws IOException, OperationFormatException {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        builder.setOperationName(Util.READ_ATTRIBUTE);
+        builder.addNode(Util.SUBSYSTEM, Util.UNDERTOW);
+        builder.addNode(Util.APPLICATION_SECURITY_DOMAIN, securityDomain);
+        builder.addProperty(Util.NAME, Util.HTTP_AUTHENTICATION_FACTORY);
+        request = builder.buildRequest();
+
+        final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+        if (isSuccess(outcome)) {
+            if (outcome.hasDefined(Util.RESULT)) {
+                return outcome.get(Util.RESULT).asString();
+            }
+        }
+
+        return null;
+    }
+
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/KeyStoreConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/KeyStoreConfiguration.java
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.util.List;
+
+/**
+ * A configuration for an existing key-store
+ *
+ * @author jdenise@redhat.com
+ */
+public class KeyStoreConfiguration extends AbstractKeyStoreConfiguration {
+
+    private final String trustStore;
+
+    public KeyStoreConfiguration(String trustStore, List<String> roles) {
+        super(roles);
+        this.trustStore = trustStore;
+    }
+
+    public String getTrustStore() {
+        return trustStore;
+    }
+
+    @Override
+    public String getRealmName() {
+        return null;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/LocalUserConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/LocalUserConfiguration.java
@@ -1,0 +1,63 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import org.jboss.as.cli.Util;
+
+/**
+ * A configuration for local mechanism.
+ *
+ * @author jdenise@redhat.com
+ */
+public class LocalUserConfiguration implements MechanismConfiguration {
+
+    private final boolean superUser;
+    private String realmMapper;
+
+    public LocalUserConfiguration(boolean superUser) {
+        this.superUser = superUser;
+    }
+    @Override
+    public String getRealmName() {
+        return Util.LOCAL;
+    }
+
+    @Override
+    public String getRoleDecoder() {
+        return null;
+    }
+
+    @Override
+    public String getRoleMapper() {
+        return superUser ? Util.SUPER_USER_MAPPER : null;
+    }
+
+    @Override
+    public String getRealmMapper() {
+        return realmMapper;
+    }
+
+    @Override
+    public String getExposedRealmName() {
+        return null;
+    }
+
+    @Override
+    public void setRealmMapperName(String realmMapper) {
+        this.realmMapper = realmMapper;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ManagementInterfaces.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ManagementInterfaces.java
@@ -136,4 +136,103 @@ public class ManagementInterfaces {
 
         return null;
     }
+
+    public static String getManagementInterfaceSaslFactoryName(String managementInterface, CommandContext ctx) throws IOException, OperationFormatException {
+        if (managementInterface == null) {
+            managementInterface = DefaultResourceNames.getDefaultManagementInterfaceName(ctx);
+        }
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_ATTRIBUTE);
+            builder.addNode(Util.CORE_SERVICE, Util.MANAGEMENT);
+            builder.addNode(Util.MANAGEMENT_INTERFACE, managementInterface);
+            String attributeName = Util.SASL_AUTHENTICATION_FACTORY;
+            if (Util.HTTP_INTERFACE.equals(managementInterface)) {
+                attributeName = Util.HTTP_UPGRADE + "." + Util.SASL_AUTHENTICATION_FACTORY;
+            }
+            builder.addProperty(Util.NAME, attributeName);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+            if (Util.isSuccess(outcome)) {
+                ModelNode mn = outcome.get(Util.RESULT);
+                if (mn.isDefined()) {
+                    return outcome.get(Util.RESULT).asString();
+                } else {
+                    return null;
+                }
+            }
+        } catch (Exception e) {
+        }
+
+        return null;
+    }
+
+    public static String getManagementInterfaceHTTPFactoryName(CommandContext ctx) throws IOException, OperationFormatException {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        try {
+            builder.setOperationName(Util.READ_ATTRIBUTE);
+            builder.addNode(Util.CORE_SERVICE, Util.MANAGEMENT);
+            builder.addNode(Util.MANAGEMENT_INTERFACE, Util.HTTP_INTERFACE);
+            builder.addProperty(Util.NAME, Util.HTTP_AUTHENTICATION_FACTORY);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        try {
+            final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+            if (Util.isSuccess(outcome)) {
+                ModelNode mn = outcome.get(Util.RESULT);
+                if (mn.isDefined()) {
+                    return outcome.get(Util.RESULT).asString();
+                } else {
+                    return null;
+                }
+            }
+        } catch (Exception e) {
+        }
+
+        return null;
+    }
+
+    public static void enableHTTPAuthentication(AuthSecurityBuilder http, CommandContext ctx) throws IOException, OperationFormatException {
+        final ModelNode request = writeInterfaceAttribute(Util.HTTP_INTERFACE, Util.HTTP_AUTHENTICATION_FACTORY, http.getAuthFactory().getName());
+        http.getSteps().add(request);
+    }
+
+    public static void enableSASL(String managementInterface, AuthSecurityBuilder sasl, CommandContext ctx) throws IOException, OperationFormatException {
+        if (managementInterface == null) {
+            managementInterface = DefaultResourceNames.getDefaultManagementInterfaceName(ctx);
+        }
+        String attributeName = Util.SASL_AUTHENTICATION_FACTORY;
+        if (Util.HTTP_INTERFACE.equals(managementInterface)) {
+            attributeName = Util.HTTP_UPGRADE + "." + Util.SASL_AUTHENTICATION_FACTORY;
+        }
+        final ModelNode request = writeInterfaceAttribute(managementInterface, attributeName, sasl.getAuthFactory().getName());
+        sasl.getSteps().add(request);
+    }
+
+    public static ModelNode disableSASL(CommandContext context, String managementInterface)
+            throws IOException, OperationFormatException {
+        if (managementInterface == null) {
+            managementInterface = DefaultResourceNames.getDefaultManagementInterfaceName(context);
+        }
+        String attributeName = Util.SASL_AUTHENTICATION_FACTORY;
+        if (Util.HTTP_INTERFACE.equals(managementInterface)) {
+            attributeName = Util.HTTP_UPGRADE + "." + Util.SASL_AUTHENTICATION_FACTORY;
+        }
+        return writeInterfaceAttribute(managementInterface, attributeName, null);
+    }
+
+    public static ModelNode disableHTTPAuth(CommandContext context)
+            throws IOException, OperationFormatException {
+        return writeInterfaceAttribute(Util.HTTP_INTERFACE, Util.HTTP_AUTHENTICATION_FACTORY, null);
+    }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/MechanismConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/MechanismConfiguration.java
@@ -1,0 +1,45 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.util.List;
+
+/**
+ * The set of attributes exposed by a mechanism configuration.
+ *
+ * @author jdenise@redhat.com
+ */
+public interface MechanismConfiguration {
+
+    String getRealmName();
+
+    String getRoleDecoder();
+
+    String getRoleMapper();
+
+    default List<String> getRoles() {
+        return null;
+    }
+
+    default void setRoleMapper(String roleMapper) {
+    }
+
+    String getRealmMapper();
+
+    String getExposedRealmName();
+
+    void setRealmMapperName(String constantMapper);
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/PropertiesRealmConfiguration.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/PropertiesRealmConfiguration.java
@@ -1,0 +1,105 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.io.IOException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.aesh.cmd.RelativeFile;
+
+/**
+ * A configuration for a new properties realm.
+ *
+ * @author jdenise@redhat.com
+ */
+public class PropertiesRealmConfiguration implements MechanismConfiguration {
+    private String realmName;
+    private final String relativeTo;
+    private final String userPropertiesFile;
+    private final String groupPropertiesFile;
+    private final String exposedRealmName;
+    private String realmMapper;
+
+    public PropertiesRealmConfiguration(String exposedRealmName, RelativeFile userPropertiesFile, RelativeFile groupPropertiesFile, String relativeTo) throws IOException {
+        this.exposedRealmName = exposedRealmName;
+        this.userPropertiesFile = relativeTo != null ? userPropertiesFile.getOriginalPath() : userPropertiesFile.getCanonicalPath();
+        this.groupPropertiesFile = groupPropertiesFile == null ? null : relativeTo != null ? groupPropertiesFile.getOriginalPath() : groupPropertiesFile.getCanonicalPath();
+        this.relativeTo = relativeTo;
+    }
+
+    public PropertiesRealmConfiguration(String name) throws IOException {
+        this(null, null, null, null);
+    }
+
+
+    /**
+     * @return the realmName
+     */
+    @Override
+    public String getExposedRealmName() {
+        return exposedRealmName;
+    }
+
+    /**
+     * @return the realmName
+     */
+    @Override
+    public String getRealmName() {
+        return realmName;
+    }
+
+    /**
+     * @return the relativeTo
+     */
+    public String getRelativeTo() {
+        return relativeTo;
+    }
+
+    /**
+     * @return the userPropertiesFile
+     * @throws java.io.IOException
+     */
+    public String getUserPropertiesFile() throws IOException {
+        return userPropertiesFile;
+    }
+
+    /**
+     * @return the groupPropertiesFile
+     * @throws java.io.IOException
+     */
+    public String getGroupPropertiesFile() throws IOException {
+        return groupPropertiesFile;
+    }
+
+    @Override
+    public String getRoleDecoder() {
+        return Util.GROUPS_TO_ROLES;
+    }
+
+    @Override
+    public String getRealmMapper() {
+        return realmMapper;
+    }
+
+    @Override
+    public String getRoleMapper() {
+        return null;
+    }
+
+    @Override
+    public void setRealmMapperName(String realmMapper) {
+        this.realmMapper = realmMapper;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/Realm.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/Realm.java
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+/**
+ * Realm model.
+ *
+ * @author jdenise@redhat.com
+ */
+public class Realm {
+    private final boolean exists;
+    private final MechanismConfiguration config;
+    private final String constantMapper;
+    private final String resourceName;
+
+    Realm(String resourceName, String constantMapper, MechanismConfiguration config, boolean exists) {
+        this.resourceName = resourceName;
+        this.constantMapper = constantMapper;
+        this.config = config;
+        this.exists = exists;
+    }
+
+    public String getConstantMapper() {
+        return constantMapper;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    /**
+     * @return the exists
+     */
+    public boolean exists() {
+        return exists;
+    }
+
+    /**
+     * @return the config
+     */
+    public MechanismConfiguration getConfig() {
+        return config;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/SecurityDomain.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/SecurityDomain.java
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Security Domain model.
+ *
+ * @author jdenise@redhat.com
+ */
+public class SecurityDomain {
+    private final String name;
+    private final List<Realm> realms = new ArrayList<>();
+    public SecurityDomain(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    void addRealm(Realm realm) {
+        Objects.requireNonNull(realm);
+        realms.add(realm);
+    }
+
+    List<Realm> getRealms() {
+        return Collections.unmodifiableList(realms);
+    }
+
+}

--- a/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/auth/command_resources.properties
+++ b/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/auth/command_resources.properties
@@ -1,0 +1,218 @@
+# Copyright 2018 Red Hat, Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#  http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+security.abstract-auth-disable.option.mechanism.description=\
+The authentication mechanism to disable. The option completer exposes all enabled mechanisms.
+
+security.abstract-auth-disable.option.mechanism.value=mechanism name
+
+security.abstract-auth-disable.option.no-reload.description=\
+Optional, by default the server is reloaded once the configuration changes have been applied. \
+In order to not reload the server, use this option.\n\
+NB: reload is done in start-mode=<the mode the current server is running>.
+
+security.abstract-auth-enable.option.mechanism.description=\
+The authentication mechanism to enable. The option completer exposes all supported \
+ mechanisms that the CLI support.\n\
+NB: If the mechanism you want to configure is not present in the list, then \
+you must use elytron subsystem management operations to configure it.
+
+security.abstract-auth-enable.option.mechanism.value=mechanism name
+
+security.abstract-auth-enable.option.file-system-realm-name.description=\
+The elytron file-system-realm name.
+
+security.abstract-auth-enable.option.file-system-realm-name.value=realm name
+
+security.abstract-auth-enable.option.user-role-decoder.description=\
+Usable only if --file-system-realm is in use. This is the name of the role decoder \
+to extract the roles from the users repository.
+
+security.abstract-auth-enable.option.user-role-decoder.value=role-decoder name
+
+security.abstract-auth-enable.option.properties-realm-name.description=\
+The name of an existing properties realm.
+
+security.abstract-auth-enable.option.properties-realm-name.value=realm name
+
+security.abstract-auth-enable.option.roles.description=\
+Optional, a comma separated list of roles associated to the current identity. \
+If no existing constant role mapper exists for this list of roles, a constant role mapper will be generated. \
+Apply only to EXTERNAL (SASL) or CLIENT_CERT (HTTP Auth) mechanisms.
+
+security.abstract-auth-enable.option.roles.value=list of roles
+
+security.abstract-auth-enable.option.user-properties-file.description=\
+A path to the properties file that contains users.
+
+security.abstract-auth-enable.option.user-properties-file.value=file path
+
+security.abstract-auth-enable.option.group-properties-file.description=\
+A path to the properties file that contains groups (management) or roles (http-server).
+
+security.abstract-auth-enable.option.group-properties-file.value=file path
+
+security.abstract-auth-enable.option.exposed-realm.description=\
+The Realm exposed to the client. If a properties realm is used, this value MUST \
+be the same as the 'realm-name' value located inside users properties file.\n\
+NB: It must be set when --user-properties-file or --properties-realm is used. For other \
+kinds of realm it is optional.
+
+security.abstract-auth-enable.option.exposed-realm.value=exposed realm
+
+security.abstract-auth-enable.option.relative-to.description=\
+Optional, to be used with the --group-properties-file and --user-properties-file options. \
+Makes the provided paths relative to a system property (eg:jboss.server.config.dir).
+
+security.abstract-auth-enable.option.relative-to.value=system property
+
+security.abstract-auth-enable.option.no-reload.description=\
+Optional, by default the server is reloaded once the configuration changes have been applied. \
+In order to not reload the server, use this option.\n\
+NB: reload is done in start-mode=<the mode the current server is running>.
+
+security.abstract-auth-enable.option.super-user.description=\
+In order to configure local user with super-user permissions. Usable with JBOSS-LOCAL-USER \
+mechanism.
+
+security.abstract-auth-enable.option.new-security-domain-name.description=\
+Optional, used to name the security domain with the specified value, by default \
+a name is computed.
+
+security.abstract-auth-enable.option.new-security-domain-name.value=name
+
+security.abstract-auth-enable.option.new-auth-factory-name.description=\
+Optional, used to name the factory with the specified value, by default \
+a name is computed.
+
+security.abstract-auth-enable.option.new-auth-factory-name.value=name
+
+security.abstract-auth-enable.option.new-realm-name.description=\
+Optional, used to name the properties file realm resource with the specified value, by default \
+a name is computed.
+
+security.abstract-auth-enable.option.new-realm-name.value=name
+
+security.abstract-auth-enable.option.key-store-name.description=\
+Must be specified when the mechanism is EXTERNAL (SASL) or CLIENT_CERT (HTTP Auth), \
+this is the name of the trust-store. \
+Option completer proposes the existing key-stores.\n\
+NB: You can instead use an existing key-store-realm (--key-store-realm-name) option.
+
+security.abstract-auth-enable.option.key-store-name.value=key-store name
+
+security.abstract-auth-enable.option.key-store-realm-name.description=\
+Must be specified when the mechanism is EXTERNAL (SASL) or CLIENT_CERT (HTTP Auth), \
+this is the name of the trust-store. \
+Option completer proposes the existing key-store-realms.\n\
+NB: You can instead use an existing key-store (--key-store-name) option.
+
+security.abstract-auth-enable.option.key-store-realm-name.vale=realm name
+
+security.abstract-auth-sasl-re-order.option.mechanisms-order.description=\
+Comma separated list of mechanisms names. Completer for this option proposes the \
+mechanisms present in the targeted factory.
+
+security.abstract-auth-sasl-re-order.option.mechanisms-order.value=list of mechanisms
+
+security.abstract-auth-sasl-re-order.option.no-reload.description=\
+Optional, by default the server is reloaded once the configuration changes have been applied. \
+In order to not reload the server, use this option.\n\
+NB: reload is done in start-mode=<the mode the current server is running>.
+
+security.disable-http-auth-http-server.description=\
+This command removes the security domain or a mechanism from the active HTTP factory. \
+Without a mechanism, the security domain is removed.\n\
+NB: Elytron existing resources are not removed from management model.\n\
+TIPS: Use 'echo-dmr security disable-http-auth-http-server <options>' in order to \
+visualize the composite request that would be sent to disable authentication.
+
+security.disable-http-auth-http-server.option.security-domain.description=\
+Required, the undertow security domain name.
+
+security.disable-http-auth-http-server.option.security-domain.value=name
+
+security.enable-http-auth-http-server.description=\
+Associate an elytron HTTP Authentication factory to the security domain. \
+In case a factory already exists for the passed security domain, the factory \
+is extended (or updated) with the selected mechanism. If no mechanism is provided, \
+the elytron Out of The Box Application HTTP Authentication factory is associated to \
+the security domain.\n\
+NB: This command creates all the non existing resources required to configure \
+authentication. This command can be called multiple times to configure the \
+referenced HTTP Authentication factory.\n\
+TIPS: Use 'echo-dmr security enable-http-auth-http-server <options>' in order to \
+visualize the composite request that would be sent to enable authentication.
+
+security.enable-http-auth-http-server.option.security-domain.description=\
+Required, the undertow security domain name.
+
+security.enable-http-auth-http-server.option.security-domain.value=name
+
+security.disable-http-auth-management.description=\
+This command removes the active HTTP Authentication factory or a mechanism from \
+the active HTTP Authentication factory. Without any mechanism provided, this \
+command erases the factory from the interface.\n\
+NB: Elytron existing resources are not removed from management model.\n\
+TIPS: Use 'echo-dmr security disable-http-auth-management <options>' in order to \
+visualize the composite request that would be sent to disable authentication.
+
+security.disable-sasl-management.description=\
+This command removes the active SASL Authentication factory or a mechanism from \
+the active SASL Authentication factory. Without any mechanism provided, this \
+command erases the factory from the http or native interfaces.\n\
+NB: Elytron existing resources are not removed from management model.\n\
+TIPS: Use 'echo-dmr security disable-sasl-management <options>' in order to \
+visualize the composite request that would be sent to disable authentication.
+
+security.disable-sasl-management.option.management-interface.description=\
+The management interface to configure, by default this is the http-interface.
+
+security.disable-sasl-management.option.management-interface.value=name
+
+security.enable-http-auth-management.description=\
+Associate an elytron HTTP Authentication factory to the management interface. \
+In case an HTTP Authentication factory already exists, the factory is extended \
+(or updated) with the selected mechanism. If no mechanism is provided, \
+the elytron Out of the Box HTTP Authentication factory is associated to the management \
+interface. This command creates all the non existing resources required to configure \
+authentication. This command can be called multiple times to configure the \
+referenced HTTP Authentication factory.\n\
+NB: This command targets only the management http-interface.\n\
+TIPS: Use 'echo-dmr security enable-http-auth-management <options>' in order to \
+visualize the composite request that would be sent to enable authentication.
+
+security.enable-sasl-management.description=\
+Associate an elytron SASL Authentication factory to the management interface. \
+In case a SASL Authentication factory already exists, the factory is extended (or updated) \
+with the selected mechanism. If no mechanism is provided, the elytron Out of the Box SASL \
+Authentication factory is associated to the management interface. \
+This command creates all the non existing resources required to configure authentication. \
+This command can be called multiple times to configure the referenced SASL Authentication factory.\n\
+TIPS: Use 'echo-dmr security enable-sasl-management <options>' in order to \
+visualize the composite request that would be sent to enable authentication.
+
+security.enable-sasl-management.option.management-interface.description=\
+The management interface to configure, by default this is the http-interface.
+
+security.enable-sasl-management.option.management-interface.value=name
+
+security.reorder-sasl-management.description=\
+Re-order the SASL mechanisms present is the SASL Authentication factory attached \
+to the targeted management interface. \
+
+security.reorder-sasl-management.option.management-interface.description=\
+The management interface to configure, by default this is the http-interface.
+
+security.reorder-sasl-management.option.management-interface.value=name

--- a/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/ssl/command_resources.properties
+++ b/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/ssl/command_resources.properties
@@ -125,7 +125,7 @@ Once SSL has been disabled, CLI reloads the server (start-mode=<the mode the cur
 server is running>) and attempts to reconnect.\n\
 \n\
 TIPS: Use 'echo-dmr security ssl-disable-management <options>' in order to \
-visualize the composite request that would be sent to enable SSL.
+visualize the composite request that would be sent to disable SSL.
 
 security.disable-ssl-management.option.no-reload.description=\
 Optional, by default the server is reloaded once the configuration changes have been applied. \
@@ -194,7 +194,7 @@ file (--key-store-path option)\n\
 This command tries to limit the set of created resources by identifying existing resources \
 that can be reused to full-fill the security requirements.\n\
 \n\
-TIPS: Use 'echo-dmr security ssl-enable-https-server [<options>]' in order to \
+TIPS: Use 'echo-dmr security ssl-enable-http-server [<options>]' in order to \
 visualize the composite request that would be sent to enable SSL.
 
 security.enable-ssl-http-server.option.server-name.description=\
@@ -211,8 +211,8 @@ Disable https for the undertow http server. This command is only available if th
 is present. By default the 'default-server' is the target of \
 this command. Other server name can be specified thanks to the --server-name option.\
 \n\
-TIPS: Use 'echo-dmr security ssl-disable-https-server <options>' in order to \
-visualize the composite request that would be sent to enable SSL.
+TIPS: Use 'echo-dmr security ssl-disable-http-server <options>' in order to \
+visualize the composite request that would be sent to disable SSL.
 
 security.disable-ssl-http-server.option.no-reload.description=\
 Optional, by default the server is reloaded once the configuration changes have been applied. \

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIAuthenticationTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIAuthenticationTestCase.java
@@ -1,0 +1,299 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.test.manualmode.management.cli;
+
+import java.net.Authenticator;
+import java.net.HttpURLConnection;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import javax.inject.Inject;
+import org.jboss.as.test.integration.management.cli.CliProcessWrapper;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class CLIAuthenticationTestCase {
+
+    private static final String FS_REALM_NAME = "fs-test-realm";
+    private static final String USER = "user1";
+    private static final String PASSWORD = "mypassword";
+
+    private static class TestAuthenticator extends Authenticator {
+
+        @Override
+        protected PasswordAuthentication getPasswordAuthentication() {
+            return new PasswordAuthentication(USER, PASSWORD.toCharArray());
+        }
+
+        public String getRealm() {
+            return super.getRequestingPrompt();
+        }
+    }
+    @Inject
+    private static ServerController container;
+
+    @ClassRule
+    public static final TemporaryFolder temporaryDir = new TemporaryFolder();
+
+    @BeforeClass
+    public static void initServer() throws Exception {
+        container.start();
+        ReloadRedirectTestCase.setupNativeInterface(container);
+        ModelNode addFS = createOpNode("subsystem=elytron/filesystem-realm=" + FS_REALM_NAME,
+                "add");
+        addFS.get("path").set(temporaryDir.newFolder("identities").getAbsolutePath());
+        container.getClient().executeForResult(addFS);
+
+        ModelNode addIdentity = createOpNode("subsystem=elytron/filesystem-realm=" + FS_REALM_NAME,
+                "add-identity");
+        addIdentity.get("identity").set(USER);
+        container.getClient().executeForResult(addIdentity);
+
+        ModelNode setPassword = createOpNode("subsystem=elytron/filesystem-realm=" + FS_REALM_NAME,
+                "set-password");
+        setPassword.get("identity").set(USER);
+        ModelNode clear = setPassword.get("clear");
+        clear.get("password").set(PASSWORD);
+        container.getClient().executeForResult(setPassword);
+
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        try {
+            // Even though we don't reuse this server, the next test uses the config so we
+            // need to revert the config changes the test made
+            ManagementClient client = ReloadRedirectTestCase.getCleanupClient();
+            cleanConfig(client);
+            ReloadRedirectTestCase.removeNativeInterface(client);
+        } finally {
+            container.stop();
+        }
+    }
+
+    private static void eraseAllFactories(ManagementClient client) throws Exception {
+        Exception e = null;
+        try {
+            ModelNode eraseHttp = createOpNode("core-service=management/management-interface=http-interface",
+                    "write-attribute");
+            eraseHttp.get("name").set("http-authentication-factory");
+            client.executeForResult(eraseHttp);
+        } catch (Exception ex) {
+            if (e == null) {
+                e = ex;
+            }
+        } finally {
+            try {
+                ModelNode eraseSasl = createOpNode("core-service=management/management-interface=http-interface",
+                        "write-attribute");
+                eraseSasl.get("name").set("http-upgrade.sasl-authentication-factory");
+                client.executeForResult(eraseSasl);
+            } catch (Exception ex) {
+                if (e == null) {
+                    e = ex;
+                }
+            }
+        }
+        if (e != null) {
+            throw e;
+        }
+    }
+
+    private static void cleanConfig(ManagementClient client) throws UnsuccessfulOperationException {
+        ModelNode removeFS = createOpNode("subsystem=elytron/filesystem-realm=" + FS_REALM_NAME,
+                "remove");
+        client.executeForResult(removeFS);
+    }
+
+    private static void cleanTest(ManagementClient client, String factory, String domain) throws Exception {
+        Exception e = null;
+        try {
+            eraseAllFactories(client);
+        } catch (Exception ex) {
+            if (e == null) {
+                e = ex;
+            }
+        } finally {
+            try {
+                ModelNode removeFactory = createOpNode("subsystem=elytron/" + factory,
+                        "remove");
+                client.executeForResult(removeFactory);
+            } catch (Exception ex) {
+                if (e == null) {
+                    e = ex;
+                }
+            } finally {
+                try {
+                    ModelNode removeDomain = createOpNode("subsystem=elytron/security-domain=" + domain,
+                            "remove");
+                    client.executeForResult(removeDomain);
+                } catch (Exception ex) {
+                    if (e == null) {
+                        e = ex;
+                    }
+                } finally {
+                    try {
+                        ModelNode removeMapper = createOpNode("subsystem=elytron/constant-realm-mapper=" + FS_REALM_NAME,
+                                "remove");
+                        client.executeForResult(removeMapper);
+                    } catch (Exception ex) {
+                        if (e == null) {
+                            e = ex;
+                        }
+                    }
+                }
+            }
+        }
+        if (e != null) {
+            throw e;
+        }
+    }
+
+    @Test
+    public void testHttpAuth() throws Throwable {
+        CliProcessWrapper cliProc = new CliProcessWrapper()
+                .addCliArgument("--connect")
+                .addCliArgument("--controller="
+                        + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort());
+        Throwable exception = null;
+        try {
+            cliProc.executeInteractive();
+            cliProc.clearOutput();
+            Assert.assertTrue(cliProc.pushLineAndWaitForResults("security enable-http-auth-management"
+                    + " --mechanism=BASIC"
+                    + " --exposed-realm=FOO"
+                    + " --file-system-realm-name=" + FS_REALM_NAME
+                    + " --new-auth-factory-name=test-http-auth-factory"
+                    + " --new-security-domain-name=test-http-auth-security-domain", "[standalone@"));
+            Assert.assertTrue(cliProc.getOutput(), cliProc.getOutput().contains("Command success."));
+            {
+                URL url = new URL("http://" + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort() + "/management");
+                HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                Assert.assertEquals(401, connection.getResponseCode());
+            }
+            {
+                TestAuthenticator myAuth = new TestAuthenticator();
+                Authenticator.setDefault(myAuth);
+                try {
+                    URL url = new URL("http://" + TestSuiteEnvironment.getServerAddress() + ":"
+                            + TestSuiteEnvironment.getServerPort() + "/management");
+                    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+                    Assert.assertEquals(200, connection.getResponseCode());
+                    Assert.assertEquals("FOO", myAuth.getRealm());
+                } finally {
+                    Authenticator.setDefault(null);
+                }
+            }
+            Assert.assertTrue(cliProc.getOutput(),
+                    cliProc.pushLineAndWaitForResults("security disable-http-auth-management",
+                            "[standalone@"));
+        } catch (Throwable ex) {
+            exception = ex;
+        } finally {
+            try {
+                cleanTest(ReloadRedirectTestCase.getCleanupClient(),
+                        "http-authentication-factory=test-http-auth-factory",
+                        "test-http-auth-security-domain");
+            } catch (Throwable ex) {
+                if (exception == null) {
+                    exception = ex;
+                }
+            } finally {
+                try {
+                    cliProc.ctrlCAndWaitForClose();
+                } catch (Throwable ex) {
+                    if (exception == null) {
+                        exception = ex;
+                    }
+                }
+            }
+        }
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
+    @Test
+    public void testSaslAuth() throws Throwable {
+        CliProcessWrapper cliProc = new CliProcessWrapper()
+                .addCliArgument("--connect")
+                .addCliArgument("--controller="
+                        + TestSuiteEnvironment.getServerAddress() + ":"
+                        + TestSuiteEnvironment.getServerPort());
+        Throwable exception = null;
+        try {
+            cliProc.executeInteractive();
+            cliProc.clearOutput();
+            Assert.assertTrue(cliProc.pushLineAndWaitForResults("security enable-sasl-management"
+                    + " --mechanism=DIGEST-MD5"
+                    + " --exposed-realm=FOO"
+                    + " --file-system-realm-name=" + FS_REALM_NAME
+                    + " --new-auth-factory-name=test-sasl-factory"
+                    + " --new-security-domain-name=test-sasl-security-domain", "Username:"));
+            Assert.assertTrue(cliProc.getOutput(), cliProc.getOutput().contains("Authenticating against security realm: FOO"));
+            cliProc.clearOutput();
+            Assert.assertTrue(
+                    cliProc.pushLineAndWaitForResults(USER, "Password:"));
+            cliProc.clearOutput();
+            Assert.assertTrue(
+                    cliProc.pushLineAndWaitForResults(PASSWORD, "[standalone@"));
+            Assert.assertTrue(cliProc.getOutput(), cliProc.getOutput().contains("Command success."));
+            Assert.assertTrue(cliProc.pushLineAndWaitForResults("security disable-sasl-management",
+                    "[standalone@"));
+        } catch (Throwable ex) {
+            exception = ex;
+        } finally {
+            try {
+                cleanTest(ReloadRedirectTestCase.getCleanupClient(), "sasl-authentication-factory=test-sasl-factory", "test-sasl-security-domain");
+            } catch (Throwable ex) {
+                if (exception == null) {
+                    exception = ex;
+                }
+            } finally {
+                try {
+                    cliProc.ctrlCAndWaitForClose();
+                } catch (Throwable ex) {
+                    if (exception == null) {
+                        exception = ex;
+                    }
+                }
+            }
+        }
+        if (exception != null) {
+            throw new Exception(cliProc.getOutput(), exception);
+        }
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityAuthCommandsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityAuthCommandsTestCase.java
@@ -1,0 +1,966 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContextFactory;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.impl.CommandContextConfiguration;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.DefaultResourceNames;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
+import static org.jboss.as.test.integration.management.cli.SecurityCommandsTestCase.disableNative;
+import static org.jboss.as.test.integration.management.cli.SecurityCommandsTestCase.enableNative;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@RunWith(WildflyTestRunner.class)
+public class SecurityAuthCommandsTestCase {
+
+    private static final ByteArrayOutputStream consoleOutput = new ByteArrayOutputStream();
+
+    private static CommandContext ctx;
+
+    @ClassRule
+    public static final TemporaryFolder temporaryUserHome = new TemporaryFolder();
+
+    private static ManagementClient client;
+
+    private static final String TEST_DOMAIN = "test-domain";
+    private static final String TEST_SASL_FACTORY = "test-sasl-factory";
+    private static final String TEST_HTTP_FACTORY = "test-http-factory";
+    private static final String TEST_USERS_REALM = "test-users-realm";
+    private static final String TEST_KS_REALM = "test-ks-realm";
+    private static final String TEST_FS_REALM = "test-fs-realm";
+    private static final String TEST_KS = "test-ks";
+
+    private static List<ModelNode> originalPropertiesRealms;
+    private static List<ModelNode> originalKSRealms;
+    private static List<ModelNode> originalSaslFactories;
+    private static List<ModelNode> originalHttpFactories;
+    private static List<ModelNode> originalSecurityDomains;
+    private static List<ModelNode> originalFSRealms;
+    private static List<ModelNode> originalConstantMappers;
+    private static List<ModelNode> originalConstantRoleMappers;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Create ctx, used to setup the test and do the final reload.
+        CommandContextConfiguration.Builder configBuilder = new CommandContextConfiguration.Builder();
+        configBuilder.setConsoleOutput(consoleOutput).
+                setController("remote+http://" + TestSuiteEnvironment.getServerAddress()
+                        + ":" + TestSuiteEnvironment.getServerPort());
+        ctx = CommandContextFactory.getInstance().newCommandContext(configBuilder.build());
+        ctx.connectController();
+        client = new ManagementClient(ctx.getModelControllerClient(), null, -1, null);
+
+        // filesystem realm.
+        addFSRealm();
+
+        originalFSRealms = getFileSystemRealms();
+        originalPropertiesRealms = getPropertiesRealm();
+        originalSaslFactories = getSaslFactories();
+        originalHttpFactories = getHttpFactories();
+        originalSecurityDomains = getSecurityDomains();
+        originalConstantMappers = getConstantRealmMappers();
+        originalConstantRoleMappers = getConstantRoleMappers();
+        originalKSRealms = getKSRealms();
+    }
+
+    private static void addFSRealm() throws Exception {
+        ctx.handle("/subsystem=elytron/filesystem-realm=" + TEST_FS_REALM + ":add(path="
+                + CliCompletionTestCase.escapePath(temporaryUserHome.newFolder("identities").getAbsolutePath()));
+        ctx.handle("/subsystem=elytron/filesystem-realm=" + TEST_FS_REALM + ":add-identity(identity=user1");
+        ctx.handle("/subsystem=elytron/filesystem-realm=" + TEST_FS_REALM + ":set-password(identity=user1,clear={password=mypassword})");
+    }
+
+    private static List<ModelNode> getPropertiesRealm() throws UnsuccessfulOperationException {
+        ModelNode props = createOpNode("subsystem=elytron",
+                "read-children-names");
+        props.get("child-type").set("properties-realm");
+        List<ModelNode> res = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(props).asList()) {
+            ModelNode prop = createOpNode("subsystem=elytron/properties-realm=" + mn.asString(), "read-resource");
+            prop.get("recursive").set(Boolean.TRUE);
+            prop.get("recursive-depth").set(100);
+            res.add(client.executeForResult(prop));
+        }
+        return res;
+    }
+
+    private static List<ModelNode> getKSRealms() throws UnsuccessfulOperationException {
+        ModelNode props = createOpNode("subsystem=elytron",
+                "read-children-names");
+        props.get("child-type").set("key-store-realm");
+        List<ModelNode> res = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(props).asList()) {
+            ModelNode prop = createOpNode("subsystem=elytron/key-store-realm=" + mn.asString(), "read-resource");
+            prop.get("recursive").set(Boolean.TRUE);
+            prop.get("recursive-depth").set(100);
+            res.add(client.executeForResult(prop));
+        }
+        return res;
+    }
+
+    private static ModelNode getConstantRoleMapper(String name) throws UnsuccessfulOperationException {
+        ModelNode prop = createOpNode("subsystem=elytron/constant-role-mapper=" + name, "read-resource");
+        prop.get("recursive").set(Boolean.TRUE);
+        prop.get("recursive-depth").set(100);
+        return client.executeForResult(prop);
+    }
+
+    private static List<ModelNode> getFileSystemRealms() throws UnsuccessfulOperationException {
+        ModelNode props = createOpNode("subsystem=elytron",
+                "read-children-names");
+        props.get("child-type").set("filesystem-realm");
+        List<ModelNode> res = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(props).asList()) {
+            ModelNode prop = createOpNode("subsystem=elytron/filesystem-realm=" + mn.asString(), "read-resource");
+            prop.get("recursive").set(Boolean.TRUE);
+            prop.get("recursive-depth").set(100);
+            res.add(client.executeForResult(prop));
+        }
+        return res;
+    }
+
+    private static List<ModelNode> getSaslFactories() throws UnsuccessfulOperationException {
+        ModelNode props = createOpNode("subsystem=elytron",
+                "read-children-names");
+        props.get("child-type").set("sasl-authentication-factory");
+        List<ModelNode> res = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(props).asList()) {
+            ModelNode prop = createOpNode("subsystem=elytron/sasl-authentication-factory=" + mn.asString(), "read-resource");
+            prop.get("recursive").set(Boolean.TRUE);
+            prop.get("recursive-depth").set(100);
+            res.add(client.executeForResult(prop));
+        }
+        return res;
+    }
+
+    private static List<String> getNames(String childrenType) throws UnsuccessfulOperationException {
+        ModelNode props = createOpNode("subsystem=elytron",
+                "read-children-names");
+        props.get("child-type").set(childrenType);
+        List<String> res = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(props).asList()) {
+            res.add(mn.asString());
+        }
+        return res;
+    }
+
+    private static List<ModelNode> getHttpFactories() throws UnsuccessfulOperationException {
+        ModelNode props = createOpNode("subsystem=elytron",
+                "read-children-names");
+        props.get("child-type").set("http-authentication-factory");
+        List<ModelNode> res = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(props).asList()) {
+            ModelNode prop = createOpNode("subsystem=elytron/http-authentication-factory=" + mn.asString(), "read-resource");
+            prop.get("recursive").set(Boolean.TRUE);
+            prop.get("recursive-depth").set(100);
+            res.add(client.executeForResult(prop));
+        }
+        return res;
+    }
+
+    private static List<ModelNode> getSecurityDomains() throws UnsuccessfulOperationException {
+        ModelNode props = createOpNode("subsystem=elytron",
+                "read-children-names");
+        props.get("child-type").set("security-domain");
+        List<ModelNode> res = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(props).asList()) {
+            ModelNode prop = createOpNode("subsystem=elytron/security-domain=" + mn.asString(), "read-resource");
+            prop.get("recursive").set(Boolean.TRUE);
+            prop.get("recursive-depth").set(100);
+            res.add(client.executeForResult(prop));
+        }
+        return res;
+    }
+
+    private static List<ModelNode> getConstantRoleMappers() throws UnsuccessfulOperationException {
+        ModelNode props = createOpNode("subsystem=elytron",
+                "read-children-names");
+        props.get("child-type").set("constant-role-mapper");
+        List<ModelNode> res = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(props).asList()) {
+            ModelNode prop = createOpNode("subsystem=elytron/constant-role-mapper=" + mn.asString(), "read-resource");
+            prop.get("recursive").set(Boolean.TRUE);
+            prop.get("recursive-depth").set(100);
+            res.add(client.executeForResult(prop));
+        }
+        return res;
+    }
+
+    private static List<ModelNode> getConstantRealmMappers() throws UnsuccessfulOperationException {
+        ModelNode props = createOpNode("subsystem=elytron",
+                "read-children-names");
+        props.get("child-type").set("constant-realm-mapper");
+        List<ModelNode> res = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(props).asList()) {
+            ModelNode prop = createOpNode("subsystem=elytron/constant-realm-mapper=" + mn.asString(), "read-resource");
+            prop.get("recursive").set(Boolean.TRUE);
+            prop.get("recursive-depth").set(100);
+            res.add(client.executeForResult(prop));
+        }
+        return res;
+    }
+
+    private static void checkState() throws Exception {
+        Assert.assertEquals(originalConstantMappers, getConstantRealmMappers());
+        Assert.assertEquals(originalFSRealms, getFileSystemRealms());
+        Assert.assertEquals(originalHttpFactories, getHttpFactories());
+        Assert.assertEquals(originalPropertiesRealms, getPropertiesRealm());
+        Assert.assertEquals(originalKSRealms, getKSRealms());
+        Assert.assertEquals(originalSaslFactories, getSaslFactories());
+        Assert.assertEquals(originalSecurityDomains, getSecurityDomains());
+        Assert.assertEquals(originalConstantRoleMappers, getConstantRoleMappers());
+    }
+
+    @After
+    public void cleanupTest() throws Exception {
+        try {
+            eraseAllFactories(client);
+            eraseAuth();
+            checkState();
+        } finally {
+            ctx.handle("reload");
+        }
+    }
+
+    private void eraseAuth() throws Exception {
+        // Clean everything tests could have created or not created.
+        try {
+            ModelNode op = createOpNode("subsystem=elytron/sasl-authentication-factory=" + TEST_SASL_FACTORY,
+                    "remove");
+            client.executeForResult(op);
+        } catch (Exception ex) {
+            // OK,
+        }
+
+        try {
+            ModelNode op = createOpNode("subsystem=elytron/http-authentication-factory=" + TEST_HTTP_FACTORY,
+                    "remove");
+            client.executeForResult(op);
+        } catch (Exception ex) {
+            // OK,
+        }
+
+        try {
+            ModelNode op = createOpNode("subsystem=elytron/security-domain=" + TEST_DOMAIN,
+                    "remove");
+            client.executeForResult(op);
+        } catch (Exception ex) {
+            // OK,
+        }
+
+        try {
+            ModelNode op = createOpNode("subsystem=elytron/properties-realm=" + TEST_USERS_REALM,
+                    "remove");
+            client.executeForResult(op);
+        } catch (Exception ex) {
+            // OK,
+        }
+
+        try {
+            ModelNode op = createOpNode("subsystem=elytron/key-store-realm=" + TEST_KS_REALM,
+                    "remove");
+            client.executeForResult(op);
+        } catch (Exception ex) {
+            // OK,
+        }
+
+        try {
+            ModelNode removeMapper = createOpNode("subsystem=elytron/constant-realm-mapper=" + TEST_USERS_REALM,
+                    "remove");
+            client.executeForResult(removeMapper);
+        } catch (Exception ex) {
+            // OK,
+        }
+        try {
+            ModelNode removeMapper = createOpNode("subsystem=elytron/constant-realm-mapper=" + TEST_FS_REALM,
+                    "remove");
+            client.executeForResult(removeMapper);
+        } catch (Exception ex) {
+            // OK,
+        }
+
+        try {
+            ModelNode removeMapper = createOpNode("subsystem=elytron/constant-realm-mapper=" + TEST_KS_REALM,
+                    "remove");
+            client.executeForResult(removeMapper);
+        } catch (Exception ex) {
+            // OK,
+        }
+
+        try {
+            ModelNode removeMapper = createOpNode("subsystem=elytron/constant-role-mapper="
+                    + DefaultResourceNames.ROLE_MAPPER_NAME,
+                    "remove");
+            client.executeForResult(removeMapper);
+        } catch (Exception ex) {
+            // OK,
+        }
+
+        try {
+            ModelNode removeMapper = createOpNode("subsystem=elytron/constant-realm-mapper=ManagementRealm",
+                    "remove");
+            client.executeForResult(removeMapper);
+        } catch (Exception ex) {
+            // OK,
+        }
+
+        try {
+            ModelNode op = createOpNode("subsystem=elytron/key-store=" + TEST_KS,
+                    "remove");
+            client.executeForResult(op);
+        } catch (Exception ex) {
+            // OK,
+        }
+    }
+
+    private static void eraseAllFactories(ManagementClient client) throws Exception {
+        Exception e = null;
+        try {
+            ModelNode eraseHttp = createOpNode("core-service=management/management-interface=http-interface",
+                    "write-attribute");
+            eraseHttp.get("name").set("http-authentication-factory");
+            client.executeForResult(eraseHttp);
+        } catch (Exception ex) {
+            if (e == null) {
+                e = ex;
+            }
+        } finally {
+            try {
+                ModelNode eraseSasl = createOpNode("core-service=management/management-interface=http-interface",
+                        "write-attribute");
+                eraseSasl.get("name").set("http-upgrade.sasl-authentication-factory");
+                client.executeForResult(eraseSasl);
+            } catch (Exception ex) {
+                if (e == null) {
+                    e = ex;
+                }
+            }
+        }
+        if (e != null) {
+            throw e;
+        }
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        Exception e = null;
+        if (ctx != null) {
+            try {
+                ctx.handle("/subsystem=elytron/filesystem-realm=" + TEST_FS_REALM + ":remove");
+            } catch (Exception ex) {
+                if (e == null) {
+                    e = ex;
+                }
+            } finally {
+                try {
+                    ctx.handle("reload");
+                } finally {
+                    ctx.terminateSession();
+                }
+            }
+        }
+        if (e != null) {
+            throw e;
+        }
+    }
+
+    @Test
+    public void testOOBSASLManagement() throws Exception {
+        ctx.handle("security enable-sasl-management --no-reload");
+        Assert.assertEquals(ElytronUtil.OOTB_MANAGEMENT_SASL_FACTORY, getManagementInterfaceAuthFactory(ctx, null, true));
+        ctx.handle("security disable-sasl-management --no-reload");
+        Assert.assertNull(getManagementInterfaceAuthFactory(ctx, null, true));
+    }
+
+    @Test
+    public void testOOBSASLManagementItf() throws Exception {
+        ctx.handle("security enable-sasl-management --no-reload --management-interface=" + Util.HTTP_INTERFACE);
+        Assert.assertEquals(ElytronUtil.OOTB_MANAGEMENT_SASL_FACTORY, getManagementInterfaceAuthFactory(ctx, Util.HTTP_INTERFACE, true));
+        ctx.handle("security disable-sasl-management --no-reload --management-interface=" + Util.HTTP_INTERFACE);
+        Assert.assertNull(getManagementInterfaceAuthFactory(ctx, Util.HTTP_INTERFACE, true));
+    }
+
+    @Test
+    public void testOOBSASLManagementNative() throws Exception {
+        enableNative(ctx);
+        try {
+            ctx.handle("security enable-sasl-management --no-reload --management-interface=" + Util.NATIVE_INTERFACE);
+            Assert.assertEquals(ElytronUtil.OOTB_MANAGEMENT_SASL_FACTORY, getManagementInterfaceAuthFactory(ctx, Util.NATIVE_INTERFACE, true));
+            ctx.handle("security disable-sasl-management --no-reload --management-interface=" + Util.NATIVE_INTERFACE);
+            Assert.assertNull(getManagementInterfaceAuthFactory(ctx, Util.NATIVE_INTERFACE, true));
+        } finally {
+            disableNative(ctx);
+        }
+    }
+
+    @Test
+    public void testOOBSASLManagement2() throws Exception {
+        // New factory but reuse OOB ManagementRealm properties realm.
+        // side effect is to create a constant realm mapper for ManagementRealm.
+        ctx.handle("security enable-sasl-management --no-reload --mechanism=DIGEST-MD5 "
+                + "--user-properties-file=mgmt-users.properties --group-properties-file=mgmt-groups.properties  "
+                + "--relative-to=jboss.server.config.dir --exposed-realm=ManagementRealm --new-security-domain-name=" + TEST_DOMAIN
+                + " --new-auth-factory-name=" + TEST_SASL_FACTORY);
+        Assert.assertEquals(TEST_SASL_FACTORY, getManagementInterfaceAuthFactory(ctx, null, true));
+
+        // Check Realm.
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(true, "DIGEST-MD5"));
+        Assert.assertEquals("ManagementRealm", getMechanismRealmMapper(true, "DIGEST-MD5"));
+        getNames(Util.CONSTANT_REALM_MAPPER).contains("ManagementRealm");
+
+        // Replace with file system realm.
+        ctx.handle("security enable-sasl-management --no-reload --mechanism=DIGEST-MD5 "
+                + "--file-system-realm-name=" + TEST_FS_REALM);
+
+        Assert.assertEquals(TEST_FS_REALM, getMechanismRealmMapper(true, "DIGEST-MD5"));
+        getNames(Util.CONSTANT_REALM_MAPPER).contains(TEST_FS_REALM);
+
+        // check that domain has both realms.
+        List<String> realms = getDomainRealms(TEST_DOMAIN);
+        Assert.assertTrue(realms.contains("ManagementRealm"));
+        Assert.assertTrue(realms.contains(TEST_FS_REALM));
+    }
+
+    @Test
+    public void testOOBHTTPManagement() throws Exception {
+        ctx.handle("security enable-http-auth-management --no-reload");
+        Assert.assertEquals(ElytronUtil.OOTB_MANAGEMENT_HTTP_FACTORY, getManagementInterfaceAuthFactory(ctx, null, false));
+        ctx.handle("security disable-http-auth-management --no-reload");
+        Assert.assertNull(getManagementInterfaceAuthFactory(ctx, null, true));
+    }
+
+    @Test
+    public void testOOBHTTPManagement2() throws Exception {
+        // New factory but reuse OOB ManagementRealm properties realm.
+        // side effect is to create a constant realm mapper for ManagementRealm.
+        ctx.handle("security enable-http-auth-management --no-reload --mechanism=BASIC "
+                + "--user-properties-file=mgmt-users.properties --group-properties-file=mgmt-groups.properties  "
+                + "--relative-to=jboss.server.config.dir --exposed-realm=ManagementRealm --new-security-domain-name=" + TEST_DOMAIN
+                + " --new-auth-factory-name=" + TEST_HTTP_FACTORY);
+        Assert.assertEquals(TEST_HTTP_FACTORY, getManagementInterfaceAuthFactory(ctx, null, false));
+
+        // Check Realm.
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(false, "BASIC"));
+        Assert.assertEquals("ManagementRealm", getMechanismRealmMapper(false, "BASIC"));
+        getNames(Util.CONSTANT_REALM_MAPPER).contains("ManagementRealm");
+
+        // Replace with file system realm.
+        ctx.handle("security enable-http-auth-management --no-reload --mechanism=BASIC "
+                + "--file-system-realm-name=" + TEST_FS_REALM);
+
+        Assert.assertEquals(TEST_FS_REALM, getMechanismRealmMapper(false, "BASIC"));
+        getNames(Util.CONSTANT_REALM_MAPPER).contains(TEST_FS_REALM);
+
+        // check that domain has both realms.
+        List<String> realms = getDomainRealms(TEST_DOMAIN);
+        Assert.assertTrue(realms.contains("ManagementRealm"));
+        Assert.assertTrue(realms.contains(TEST_FS_REALM));
+    }
+
+    @Test
+    public void testSASLManagement() throws Exception {
+        String cmd = "security enable-sasl-management --no-reload --mechanism=DIGEST-MD5"
+                + " --user-properties-file=mgmt-users.properties --group-properties-file=mgmt-groups.properties"
+                + " --relative-to=jboss.server.config.dir --new-security-domain-name=" + TEST_DOMAIN
+                + " --new-auth-factory-name=" + TEST_SASL_FACTORY + " --new-realm-name=" + TEST_USERS_REALM;
+        {
+            // Must use --exposed-realm-name=
+            boolean failed = false;
+            try {
+                ctx.handle(cmd);
+            } catch (Exception ex) {
+                // XXX OK.
+                failed = true;
+            }
+            if (!failed) {
+                throw new Exception("--exposed-realm-name= must be set");
+            }
+        }
+        cmd += " --exposed-realm=ManagementRealm";
+        // Enable and add mechanisms.
+        ctx.handle("security enable-sasl-management --no-reload --mechanism=JBOSS-LOCAL-USER --new-security-domain-name=" + TEST_DOMAIN
+                + " --new-auth-factory-name=" + TEST_SASL_FACTORY);
+
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains("local"));
+
+        Assert.assertTrue(getNames(Util.SASL_AUTHENTICATION_FACTORY).contains(TEST_SASL_FACTORY));
+        Assert.assertTrue(getNames(Util.SECURITY_DOMAIN).contains(TEST_DOMAIN));
+
+        Assert.assertEquals(Arrays.asList("JBOSS-LOCAL-USER"), getMechanisms(true));
+        Assert.assertNull(getRoleMapper(true, "local"));
+        ctx.handle("security enable-sasl-management --no-reload --mechanism=JBOSS-LOCAL-USER --super-user");
+        Assert.assertEquals(Arrays.asList("JBOSS-LOCAL-USER"), getMechanisms(true));
+        Assert.assertEquals("super-user-mapper", getRoleMapper(true, "local"));
+
+        // Add DIGEST + properties file realm.
+        ctx.handle(cmd);
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains("local"));
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_USERS_REALM));
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(true, "DIGEST-MD5"));
+        Assert.assertEquals(TEST_USERS_REALM, getMechanismRealmMapper(true, "DIGEST-MD5"));
+
+        // capture the state.
+        List<ModelNode> factories = getSaslFactories();
+        List<ModelNode> domains = getSecurityDomains();
+        List<ModelNode> mappers = getConstantRealmMappers();
+        List<ModelNode> userRealms = getPropertiesRealm();
+
+        List<String> expected1 = Arrays.asList("JBOSS-LOCAL-USER", "DIGEST-MD5");
+        Assert.assertEquals(expected1, getMechanisms(true));
+
+        Assert.assertTrue(getNames(Util.PROPERTIES_REALM).contains(TEST_USERS_REALM));
+
+        // Reverse order of mechanisms.
+        ctx.handle("security reorder-sasl-management --mechanisms-order=DIGEST-MD5,JBOSS-LOCAL-USER, --no-reload");
+        List<String> expected2 = Arrays.asList("DIGEST-MD5", "JBOSS-LOCAL-USER");
+        Assert.assertEquals(expected2, getMechanisms(true));
+        ctx.handle("security reorder-sasl-management --mechanisms-order=JBOSS-LOCAL-USER,DIGEST-MD5 --no-reload");
+        Assert.assertEquals(expected1, getMechanisms(true));
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(true, "DIGEST-MD5"));
+        Assert.assertEquals(TEST_USERS_REALM, getMechanismRealmMapper(true, "DIGEST-MD5"));
+
+        // Disable local mechanism
+        ctx.handle("security disable-sasl-management --no-reload --mechanism=JBOSS-LOCAL-USER");
+        Assert.assertEquals(domains, getSecurityDomains());
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains("local"));
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_USERS_REALM));
+        //still secured
+        Assert.assertEquals(TEST_SASL_FACTORY, getManagementInterfaceAuthFactory(ctx, null, true));
+        Assert.assertEquals(Arrays.asList("DIGEST-MD5"), getMechanisms(true));
+
+        // Re-order a single mechanism
+        ctx.handle("security reorder-sasl-management --mechanisms-order=DIGEST-MD5 --no-reload");
+        Assert.assertEquals(Arrays.asList("DIGEST-MD5"), getMechanisms(true));
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(true, "DIGEST-MD5"));
+        Assert.assertEquals(TEST_USERS_REALM, getMechanismRealmMapper(true, "DIGEST-MD5"));
+        {
+            // Disable the last mechanism is forbidden
+            boolean failed = false;
+            try {
+                ctx.handle("security disable-sasl-management --no-reload --mechanism=DIGEST-MD5");
+            } catch (Exception ex) {
+                // XXX OK.
+                failed = true;
+            }
+            if (!failed) {
+                throw new Exception("Disabling the last mechanism should have failed");
+            }
+        }
+
+        // Re-enable the mechanism and re-order as original state.
+        ctx.handle("security enable-sasl-management --no-reload --mechanism=JBOSS-LOCAL-USER --super-user");
+        Assert.assertEquals(domains, getSecurityDomains());
+        Assert.assertEquals(mappers, getConstantRealmMappers());
+        Assert.assertEquals(expected2, getMechanisms(true));
+        Assert.assertEquals("super-user-mapper", getRoleMapper(true, "local"));
+        ctx.handle("security reorder-sasl-management --mechanisms-order=JBOSS-LOCAL-USER,DIGEST-MD5 --no-reload");
+        Assert.assertEquals(expected1, getMechanisms(true));
+        Assert.assertEquals(factories, getSaslFactories());
+
+        // Disable DIGEST-MD5 and re-enable it. No new resource created because re-using same realm.
+        ctx.handle("security disable-sasl-management --no-reload --mechanism=DIGEST-MD5");
+        Assert.assertEquals(Arrays.asList("JBOSS-LOCAL-USER"), getMechanisms(true));
+        Assert.assertEquals(domains, getSecurityDomains());
+        Assert.assertEquals(userRealms, getPropertiesRealm());
+        // Re-enable MD5 re-using the existing realm
+        ctx.handle("security enable-sasl-management --no-reload --mechanism=DIGEST-MD5 --properties-realm-name="
+                + TEST_USERS_REALM + " --exposed-realm=ManagementRealm");
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(true, "DIGEST-MD5"));
+        Assert.assertEquals(TEST_USERS_REALM, getMechanismRealmMapper(true, "DIGEST-MD5"));
+        Assert.assertEquals(factories, getSaslFactories());
+        Assert.assertEquals(domains, getSecurityDomains());
+        Assert.assertEquals(mappers, getConstantRealmMappers());
+        Assert.assertEquals(userRealms, getPropertiesRealm());
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains("local"));
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_USERS_REALM));
+    }
+
+    @Test
+    public void testHTTPManagement() throws Exception {
+
+        // Enable and add mechanisms.
+        ctx.handle("security enable-http-auth-management --no-reload --mechanism=BASIC"
+                + " --user-properties-file=mgmt-users.properties --group-properties-file=mgmt-groups.properties"
+                + " --relative-to=jboss.server.config.dir --new-security-domain-name=" + TEST_DOMAIN
+                + " --new-auth-factory-name=" + TEST_HTTP_FACTORY + " --new-realm-name="
+                + TEST_USERS_REALM + " --exposed-realm=ManagementRealm");
+
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_USERS_REALM));
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(false, "BASIC"));
+        Assert.assertEquals(TEST_USERS_REALM, getMechanismRealmMapper(false, "BASIC"));
+        Assert.assertTrue(getNames(Util.HTTP_AUTHENTICATION_FACTORY).contains(TEST_HTTP_FACTORY));
+        Assert.assertTrue(getNames(Util.SECURITY_DOMAIN).contains(TEST_DOMAIN));
+
+        Assert.assertEquals(Arrays.asList("BASIC"), getMechanisms(false));
+
+        // Add DIGEST.
+        ctx.handle("security enable-http-auth-management --no-reload --mechanism=DIGEST"
+                + " --properties-realm-name=" + TEST_USERS_REALM + " --exposed-realm=ManagementRealm");
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(false, "BASIC"));
+        Assert.assertEquals(TEST_USERS_REALM, getMechanismRealmMapper(false, "BASIC"));
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).size() == 1);
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_USERS_REALM));
+        // capture the state.
+        List<ModelNode> factories = getHttpFactories();
+        List<ModelNode> domains = getSecurityDomains();
+        List<ModelNode> mappers = getConstantRealmMappers();
+        List<ModelNode> userRealms = getPropertiesRealm();
+
+        List<String> expected1 = Arrays.asList("BASIC", "DIGEST");
+        Assert.assertEquals(expected1, getMechanisms(false));
+
+        Assert.assertTrue(getNames(Util.PROPERTIES_REALM).contains(TEST_USERS_REALM));
+
+        // Disable digest mechanism
+        ctx.handle("security disable-http-auth-management --no-reload --mechanism=DIGEST");
+
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).size() == 1);
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_USERS_REALM));
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(false, "BASIC"));
+        Assert.assertEquals(TEST_USERS_REALM, getMechanismRealmMapper(false, "BASIC"));
+        Assert.assertEquals(domains, getSecurityDomains());
+        //still secured
+        Assert.assertEquals(TEST_HTTP_FACTORY, getManagementInterfaceAuthFactory(ctx, null, false));
+        Assert.assertEquals(Arrays.asList("BASIC"), getMechanisms(false));
+
+        {
+            // Disable the last mechanism is forbidden
+            boolean failed = false;
+            try {
+                ctx.handle("security disable-http-auth-management --no-reload --mechanism=BASIC");
+            } catch (Exception ex) {
+                // XXX OK.
+                failed = true;
+            }
+            if (!failed) {
+                throw new Exception("Disabling the last mechanism should have failed");
+            }
+        }
+
+        // Re-enable the mechanism
+        ctx.handle("security enable-http-auth-management --no-reload --mechanism=DIGEST"
+                + " --properties-realm-name=" + TEST_USERS_REALM + " --exposed-realm=ManagementRealm");
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(false, "BASIC"));
+        Assert.assertEquals(TEST_USERS_REALM, getMechanismRealmMapper(false, "BASIC"));
+        Assert.assertEquals("ManagementRealm", getExposedRealmName(false, "DIGEST"));
+        Assert.assertEquals(TEST_USERS_REALM, getMechanismRealmMapper(false, "DIGEST"));
+        Assert.assertEquals(expected1, getMechanisms(false));
+        Assert.assertEquals(factories, getHttpFactories());
+        Assert.assertEquals(domains, getSecurityDomains());
+        Assert.assertEquals(mappers, getConstantRealmMappers());
+        Assert.assertEquals(userRealms, getPropertiesRealm());
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).size() == 1);
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_USERS_REALM));
+    }
+
+    @Test
+    public void testDisableAuthManagement() throws Exception {
+        {
+            boolean failed = false;
+            try {
+                ctx.handle("security disable-http-auth-management --no-reload");
+            } catch (Exception ex) {
+                // XXX OK.
+                failed = true;
+            }
+            if (!failed) {
+                throw new Exception("Should have fail");
+            }
+        }
+        {
+            boolean failed = false;
+            try {
+                ctx.handle("security disable-sasl-management --no-reload");
+            } catch (Exception ex) {
+                // XXX OK.
+                failed = true;
+            }
+            if (!failed) {
+                throw new Exception("Should have fail");
+            }
+        }
+    }
+
+    @Test
+    public void testSASLEmbedded() throws Exception {
+        testEmbedded("enable-sasl-management", "disable-sasl-management");
+    }
+
+    @Test
+    public void testHTTPEmbedded() throws Exception {
+        testEmbedded("enable-http-auth-management", "disable-http-auth-management");
+    }
+
+    @Test
+    public void testSASLCertificate() throws Exception {
+        ctx.handle("/subsystem=elytron/key-store=" + TEST_KS + ":add(type=JKS, credential-reference={clear-text=pass})");
+        ctx.handle("security enable-sasl-management --no-reload --mechanism=EXTERNAL"
+                + " --key-store-name=" + TEST_KS + " --new-security-domain-name=" + TEST_DOMAIN
+                + " --new-auth-factory-name=" + TEST_SASL_FACTORY + " --new-realm-name=" + TEST_KS_REALM);
+        Assert.assertEquals(TEST_KS_REALM, getMechanismRealmMapper(true, "EXTERNAL"));
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_KS_REALM));
+
+        // capture the state.
+        List<ModelNode> factories = getSaslFactories();
+        List<ModelNode> domains = getSecurityDomains();
+        List<ModelNode> mappers = getConstantRealmMappers();
+        List<ModelNode> ksRealms = getKSRealms();
+
+        // Re-enable simply by re-using same key-store-realm, no changes expected.
+        ctx.handle("security enable-sasl-management --no-reload --mechanism=EXTERNAL"
+                + " --key-store-realm-name=" + TEST_KS_REALM);
+        Assert.assertEquals(TEST_KS_REALM, getMechanismRealmMapper(true, "EXTERNAL"));
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_KS_REALM));
+
+        Assert.assertEquals(factories, getSaslFactories());
+        Assert.assertEquals(domains, getSecurityDomains());
+        Assert.assertEquals(mappers, getConstantRealmMappers());
+        Assert.assertEquals(ksRealms, getKSRealms());
+
+        ctx.handle("security disable-sasl-management --no-reload");
+
+        // Re-enable simply by re-using same key-store-realm with roles, no changes expected other than roles.
+        ctx.handle("security enable-sasl-management --no-reload --mechanism=EXTERNAL"
+                + " --key-store-realm-name=" + TEST_KS_REALM + " --roles=FOO,BAR");
+
+        Assert.assertEquals(factories, getSaslFactories());
+        Assert.assertEquals(mappers, getConstantRealmMappers());
+        Assert.assertEquals(ksRealms, getKSRealms());
+
+        Assert.assertEquals(DefaultResourceNames.ROLE_MAPPER_NAME, getRoleMapper(TEST_KS_REALM, TEST_DOMAIN));
+        Assert.assertTrue(getNames(Util.CONSTANT_ROLE_MAPPER).contains(DefaultResourceNames.ROLE_MAPPER_NAME));
+        ModelNode roleMapper = getConstantRoleMapper(DefaultResourceNames.ROLE_MAPPER_NAME);
+        List<ModelNode> lst = roleMapper.get(Util.ROLES).asList();
+        Assert.assertTrue(lst.size() == 2);
+        for (ModelNode r : lst) {
+            if (!r.asString().equals("FOO") && !r.asString().equals("BAR")) {
+                throw new Exception("Invalid roles in " + lst);
+            }
+        }
+    }
+
+    @Test
+    public void testHTTPCertificate() throws Exception {
+        ctx.handle("/subsystem=elytron/key-store=" + TEST_KS + ":add(type=JKS, credential-reference={clear-text=pass})");
+        ctx.handle("security enable-http-auth-management --no-reload --mechanism=CLIENT_CERT"
+                + " --key-store-name=" + TEST_KS + " --new-security-domain-name=" + TEST_DOMAIN
+                + " --new-auth-factory-name=" + TEST_HTTP_FACTORY + " --new-realm-name=" + TEST_KS_REALM);
+        Assert.assertEquals(TEST_KS_REALM, getMechanismRealmMapper(false, "CLIENT_CERT"));
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_KS_REALM));
+
+        // capture the state.
+        List<ModelNode> factories = getHttpFactories();
+        List<ModelNode> domains = getSecurityDomains();
+        List<ModelNode> mappers = getConstantRealmMappers();
+        List<ModelNode> ksRealms = getKSRealms();
+
+        // Re-enable simply by re-using same key-store-realm, no changes expected.
+        ctx.handle("security enable-http-auth-management --no-reload --mechanism=CLIENT_CERT"
+                + " --key-store-realm-name=" + TEST_KS_REALM);
+        Assert.assertEquals(TEST_KS_REALM, getMechanismRealmMapper(false, "CLIENT_CERT"));
+        Assert.assertTrue(getDomainRealms(TEST_DOMAIN).contains(TEST_KS_REALM));
+
+        Assert.assertEquals(factories, getHttpFactories());
+        Assert.assertEquals(domains, getSecurityDomains());
+        Assert.assertEquals(mappers, getConstantRealmMappers());
+        Assert.assertEquals(ksRealms, getKSRealms());
+
+        ctx.handle("security disable-http-auth-management --no-reload");
+
+        // Re-enable simply by re-using same key-store-realm with roles, no changes expected other than roles.
+        ctx.handle("security enable-http-auth-management --no-reload --mechanism=CLIENT_CERT"
+                + " --key-store-realm-name=" + TEST_KS_REALM + " --roles=FOO,BAR");
+
+        Assert.assertEquals(factories, getHttpFactories());
+        Assert.assertEquals(mappers, getConstantRealmMappers());
+        Assert.assertEquals(ksRealms, getKSRealms());
+
+        Assert.assertEquals(DefaultResourceNames.ROLE_MAPPER_NAME, getRoleMapper(TEST_KS_REALM, TEST_DOMAIN));
+        List<String> names = getNames(Util.CONSTANT_ROLE_MAPPER);
+        Assert.assertTrue(names.toString(), names.contains(DefaultResourceNames.ROLE_MAPPER_NAME));
+        ModelNode roleMapper = getConstantRoleMapper(DefaultResourceNames.ROLE_MAPPER_NAME);
+        List<ModelNode> lst = roleMapper.get(Util.ROLES).asList();
+        Assert.assertTrue(lst.size() == 2);
+        for (ModelNode r : lst) {
+            if (!r.asString().equals("FOO") && !r.asString().equals("BAR")) {
+                throw new Exception("Invalid roles in " + lst);
+            }
+        }
+    }
+
+    private static void testEmbedded(String enable, String disable) throws Exception {
+        CliProcessWrapper cli = new CliProcessWrapper()
+                .addJavaOption("-Duser.home=" + temporaryUserHome.getRoot().toPath().toString());
+        try {
+            cli.executeInteractive();
+            cli.clearOutput();
+            String prompt = "[standalone@embedded /]";
+            Assert.assertTrue(cli.getOutput(), cli.pushLineAndWaitForResults("embed-server --std-out=echo", prompt));
+            Assert.assertTrue(cli.getOutput(), cli.pushLineAndWaitForResults("security " + enable + " --no-reload", prompt));
+
+            // Disable sasl
+            Assert.assertTrue(cli.getOutput(), cli.pushLineAndWaitForResults("security " + disable + " --no-reload", prompt));
+
+            // Re-enable
+            Assert.assertTrue(cli.getOutput(), cli.pushLineAndWaitForResults("security " + enable + " --no-reload", prompt));
+
+            //  Disable sasl
+            Assert.assertTrue(cli.getOutput(), cli.pushLineAndWaitForResults("security " + disable + " --no-reload", prompt));
+        } finally {
+            cli.destroyProcess();
+        }
+    }
+
+    private static String getRoleMapper(boolean sasl, String realm) throws Exception {
+        String factory = getManagementInterfaceAuthFactory(ctx, null, sasl);
+        ModelNode secDomain = createOpNode("subsystem=elytron/" + (sasl ? "sasl-authentication-factory=" : "http-authentication-factory=") + factory,
+                "read-attribute");
+        secDomain.get("name").set("security-domain");
+        String domain = client.executeForResult(secDomain).asString();
+
+        ModelNode realms = createOpNode("subsystem=elytron/security-domain=" + domain,
+                "read-attribute");
+        realms.get("name").set("realms");
+        for (ModelNode mn : client.executeForResult(realms).asList()) {
+            if (mn.get("realm").asString().equals(realm)) {
+                return mn.hasDefined("role-mapper") ? mn.get("role-mapper").asString() : null;
+            }
+        }
+        return null;
+    }
+
+    private static List<String> getMechanisms(boolean sasl) throws Exception {
+        String factory = getManagementInterfaceAuthFactory(ctx, null, sasl);
+        ModelNode mecs = createOpNode("subsystem=elytron/" + (sasl ? "sasl-authentication-factory=" : "http-authentication-factory=") + factory,
+                "read-attribute");
+        mecs.get("name").set("mechanism-configurations");
+        List<String> res = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(mecs).asList()) {
+            res.add(mn.get("mechanism-name").asString());
+        }
+        return res;
+    }
+
+    private static String getExposedRealmName(boolean sasl, String mec) throws Exception {
+        String factory = getManagementInterfaceAuthFactory(ctx, null, sasl);
+        ModelNode mecs = createOpNode("subsystem=elytron/" + (sasl ? "sasl-authentication-factory=" : "http-authentication-factory=") + factory,
+                "read-attribute");
+        mecs.get("name").set("mechanism-configurations");
+        for (ModelNode mn : client.executeForResult(mecs).asList()) {
+            if (mn.get("mechanism-name").asString().equals(mec)) {
+                return mn.get("mechanism-realm-configurations").asList().get(0).get("realm-name").asString();
+            }
+        }
+        return null;
+    }
+
+    private static String getMechanismRealmMapper(boolean sasl, String mec) throws Exception {
+        String factory = getManagementInterfaceAuthFactory(ctx, null, sasl);
+        ModelNode mecs = createOpNode("subsystem=elytron/" + (sasl ? "sasl-authentication-factory=" : "http-authentication-factory=") + factory,
+                "read-attribute");
+        mecs.get("name").set("mechanism-configurations");
+        for (ModelNode mn : client.executeForResult(mecs).asList()) {
+            if (mn.get("mechanism-name").asString().equals(mec)) {
+                return mn.get("realm-mapper").asString();
+            }
+        }
+        return null;
+    }
+
+    private static String getRoleMapper(String realm, String securityDomain) throws Exception {
+        ModelNode mecs = createOpNode("subsystem=elytron/security-domain=" + securityDomain,
+                "read-attribute");
+        mecs.get("name").set("realms");
+        for (ModelNode mn : client.executeForResult(mecs).asList()) {
+            if (mn.get("realm").asString().equals(realm)) {
+                return mn.get("role-mapper").asString();
+            }
+        }
+        return null;
+    }
+
+    private static List<String> getDomainRealms(String domain) throws Exception {
+        ModelNode realms = createOpNode("subsystem=elytron/security-domain=" + domain,
+                "read-attribute");
+        realms.get("name").set("realms");
+        List<String> lst = new ArrayList<>();
+        for (ModelNode mn : client.executeForResult(realms).asList()) {
+            lst.add(mn.get("realm").asString());
+        }
+        return lst;
+    }
+
+    private static String getManagementInterfaceAuthFactory(CommandContext ctx, String interfaceName, boolean sasl) throws Exception {
+        final DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        final ModelNode request;
+        String attribute = Util.HTTP_AUTHENTICATION_FACTORY;
+        if (sasl) {
+            if (interfaceName == null || interfaceName.equals(Util.HTTP_INTERFACE)) {
+                attribute = Util.HTTP_UPGRADE + "." + Util.SASL_AUTHENTICATION_FACTORY;
+            } else {
+                attribute = Util.SASL_AUTHENTICATION_FACTORY;
+            }
+        }
+        try {
+            builder.setOperationName(Util.READ_ATTRIBUTE);
+            builder.addNode(Util.CORE_SERVICE, Util.MANAGEMENT);
+            builder.addNode(Util.MANAGEMENT_INTERFACE, interfaceName == null ? Util.HTTP_INTERFACE : interfaceName);
+            builder.addProperty(Util.NAME, attribute);
+            request = builder.buildRequest();
+        } catch (OperationFormatException e) {
+            throw new IllegalStateException("Failed to build operation", e);
+        }
+
+        final ModelNode outcome = ctx.getModelControllerClient().execute(request);
+        if (Util.isSuccess(outcome)) {
+            boolean hasResult = outcome.has(Util.RESULT);
+            if (hasResult) {
+                if (outcome.get(Util.RESULT).isDefined()) {
+                    return outcome.get(Util.RESULT).asString();
+                } else {
+                    return null;
+                }
+            }
+        }
+
+        throw new Exception("Error retrieving Auth factory " + outcome);
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
@@ -392,11 +392,11 @@ public class SecurityCommandsTestCase {
 
     @Test
     public void testEnableSSLNative() throws Exception {
-        enableNative();
+        enableNative(ctx);
         try {
             testEnableSSL("native-interface");
         } finally {
-            disableNative();
+            disableNative(ctx);
         }
     }
 
@@ -478,11 +478,11 @@ public class SecurityCommandsTestCase {
 
     @Test
     public void testEnableSSLInteractiveConfirmNative() throws Exception {
-        enableNative();
+        enableNative(ctx);
         try {
             testEnableSSLInteractiveConfirm("native-interface");
         } finally {
-            disableNative();
+            disableNative(ctx);
         }
     }
 
@@ -672,12 +672,12 @@ public class SecurityCommandsTestCase {
         ctx.handle("security disable-ssl-management --no-reload");
     }
 
-    private static void enableNative() throws CommandLineException {
+    public static void enableNative(CommandContext ctx) throws CommandLineException {
         ctx.handle("/socket-binding-group=standard-sockets/socket-binding=management-native:add(port=9999,interface=management)");
         ctx.handle("/core-service=management/management-interface=native-interface:add(security-realm=ManagementRealm, socket-binding=management-native)");
     }
 
-    private static void disableNative() throws CommandLineException {
+    public static void disableNative(CommandContext ctx) throws CommandLineException {
         ctx.handle("/core-service=management/management-interface=native-interface:remove()");
         ctx.handle("/socket-binding-group=standard-sockets/socket-binding=management-native:remove()");
     }


### PR DESCRIPTION
- EAP Feature: EAP7-943
- WF-CORE: WFCORE-3672
Management and http-server auth commands.
Tests of feature and completion.

- Analysis doc: https://github.com/wildfly/wildfly-proposals/pull/32

Community doc has been written and will have to be merged in WF. Branch is: https://github.com/jfdenise/wildfly/tree/auth-command

WARNING: Once this one is merged, a PR will have to be open in Full to merge tests specific to http-server. Branch is: https://github.com/jfdenise/wildfly/tree/auth-command

A running experimental job showing that the http-server tests are passing: https://ci.wildfly.org/viewLog.html?buildId=98335&tab=buildResultsDiv&buildTypeId=WF_WildFlyCoreIntegrationExperiments
