### PR TITLE
WFCORE-3751 DefaultCapabilityReferenceRecorder generates wrong dependent name if corresponding RuntimeCapability uses a dynamic name mapper

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAddStepHandler.java
@@ -72,7 +72,9 @@ public class AbstractAddStepHandler implements OperationStepHandler {
      * @param capability capability to register in {@link #recordCapabilitiesAndRequirements(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
      *                     {@code null} is allowed
      * @param attributes attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}.attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
+     * @deprecated Use {@link #AbstractAddStepHandler(Collection) instead. {@link RuntimeCapability} should be registered with {@link ManagementResourceRegistration}
      */
+    @Deprecated
     public AbstractAddStepHandler(RuntimeCapability capability, Collection<? extends AttributeDefinition> attributes) {
         this(capability == null ? NULL_CAPABILITIES : Collections.singleton(capability), attributes );
     }
@@ -83,7 +85,9 @@ public class AbstractAddStepHandler implements OperationStepHandler {
      * @param capabilities capabilities to register in {@link #recordCapabilitiesAndRequirements(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
      *                     {@code null} is allowed
      * @param attributes   attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
+     * @deprecated Use {@link #AbstractAddStepHandler(Collection) instead. {@link RuntimeCapability} should be registered with {@link ManagementResourceRegistration}
      */
+    @Deprecated
     public AbstractAddStepHandler(Set<RuntimeCapability> capabilities, Collection<? extends AttributeDefinition> attributes) {
         //Please don't add more constructors, instead use the Parameters variety
         this.attributes = attributes == null ? NULL_ATTRIBUTES : attributes;
@@ -96,7 +100,9 @@ public class AbstractAddStepHandler implements OperationStepHandler {
      * @param capability capability to register in {@link #recordCapabilitiesAndRequirements(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
      *                     {@code null} is allowed
      * @param attributes attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
+     * @deprecated Use {@link #AbstractAddStepHandler(AttributeDefinition...) instead. {@link RuntimeCapability} should be registered with {@link ManagementResourceRegistration}
      */
+    @Deprecated
     public AbstractAddStepHandler(RuntimeCapability capability, AttributeDefinition... attributes) {
         this(capability == null ? NULL_CAPABILITIES : Collections.singleton(capability), attributes);
     }
@@ -116,7 +122,9 @@ public class AbstractAddStepHandler implements OperationStepHandler {
      * @param capabilities capabilities to register in {@link #recordCapabilitiesAndRequirements(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
      *                     {@code null} is allowed
      * @param attributes attributes to use in {@link #populateModel(OperationContext, org.jboss.dmr.ModelNode, org.jboss.as.controller.registry.Resource)}
+     * @deprecated Use {@link #AbstractAddStepHandler(AttributeDefinition...) instead. {@link RuntimeCapability} should be registered with {@link ManagementResourceRegistration}
      */
+    @Deprecated
     public AbstractAddStepHandler(Set<RuntimeCapability> capabilities, AttributeDefinition... attributes) {
         this(capabilities, attributes.length > 0 ? Arrays.asList(attributes) : NULL_ATTRIBUTES);
     }
@@ -472,6 +480,7 @@ public class AbstractAddStepHandler implements OperationStepHandler {
         public Parameters() {
         }
 
+        @Deprecated
         public Parameters addRuntimeCapability(RuntimeCapability...capabilities) {
             Set<RuntimeCapability> capabilitySet = getOrCreateCapabilities();
             for (RuntimeCapability capability : capabilities) {
@@ -480,6 +489,7 @@ public class AbstractAddStepHandler implements OperationStepHandler {
             return this;
         }
 
+        @Deprecated
         public Parameters addRuntimeCapability(Set<RuntimeCapability> capabilities) {
             getOrCreateCapabilities().addAll(capabilities);
             return this;

--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -852,7 +852,7 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
      * @see AttributeDefinition#removeCapabilityRequirements(OperationContext, org.jboss.as.controller.registry.Resource, ModelNode)
      */
     public BUILDER setCapabilityReference(String referencedCapability, RuntimeCapability<?> dependentCapability) {
-        return setCapabilityReference(referencedCapability, dependentCapability.getName(), dependentCapability.isDynamicallyNamed());
+        return setCapabilityReference(referencedCapability, dependentCapability.getName());
     }
 
     /**
@@ -948,12 +948,34 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
      *                             portion of which comes from the name of the resource with which
      *                             the attribute is associated
      * @return the builder
-     * @see AttributeDefinition#addCapabilityRequirements(OperationContext, org.jboss.as.controller.registry.Resource, ModelNode)
-     * @see AttributeDefinition#removeCapabilityRequirements(OperationContext, org.jboss.as.controller.registry.Resource, ModelNode)
+     * @deprecated Use {@link #setCapabilityReference(String, String)} instead.
      */
+    @Deprecated
     public BUILDER setCapabilityReference(String referencedCapability, String dependentCapability, boolean dynamicDependent) {
         //noinspection deprecation
         referenceRecorder = new CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder(referencedCapability, dependentCapability, dynamicDependent);
+        return (BUILDER) this;
+    }
+
+    /**
+     * Records that this attribute's value represents a reference to an instance of a
+     * {@link org.jboss.as.controller.capability.RuntimeCapability#isDynamicallyNamed() dynamic capability}.
+     * <p>
+     * This method is a convenience method equivalent to calling
+     * {@link #setCapabilityReference(CapabilityReferenceRecorder)}
+     * passing in a {@link org.jboss.as.controller.CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder}
+     * constructed using the parameters passed to this method.
+     *
+     * @param referencedCapability the name of the dynamic capability the dynamic portion of whose name is
+     *                             represented by the attribute's value
+     * @param dependentCapability  the name of the capability that depends on {@code referencedCapability}
+     * @return the builder
+     * @see AttributeDefinition#addCapabilityRequirements(OperationContext, org.jboss.as.controller.registry.Resource, ModelNode)
+     * @see AttributeDefinition#removeCapabilityRequirements(OperationContext, org.jboss.as.controller.registry.Resource, ModelNode)
+     */
+    public BUILDER setCapabilityReference(String referencedCapability, String dependentCapability) {
+        //noinspection deprecation
+        referenceRecorder = new CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder(referencedCapability, dependentCapability);
         return (BUILDER) this;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/AbstractBoottimeAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractBoottimeAddStepHandler.java
@@ -66,6 +66,7 @@ public abstract class AbstractBoottimeAddStepHandler extends AbstractAddStepHand
     /**
      * {@inheritDoc}
      */
+    @Deprecated
     protected AbstractBoottimeAddStepHandler(RuntimeCapability capability, Collection<? extends AttributeDefinition> attributes) {
         super(capability, attributes);
     }
@@ -73,6 +74,7 @@ public abstract class AbstractBoottimeAddStepHandler extends AbstractAddStepHand
     /**
      * {@inheritDoc}
      */
+    @Deprecated
     protected AbstractBoottimeAddStepHandler(Set<RuntimeCapability> capabilities, Collection<? extends AttributeDefinition> attributes) {
         super(capabilities, attributes);
     }
@@ -80,6 +82,7 @@ public abstract class AbstractBoottimeAddStepHandler extends AbstractAddStepHand
     /**
      * {@inheritDoc}
      */
+    @Deprecated
     protected AbstractBoottimeAddStepHandler(RuntimeCapability capability, AttributeDefinition... attributes) {
         super(capability, attributes);
     }
@@ -94,6 +97,7 @@ public abstract class AbstractBoottimeAddStepHandler extends AbstractAddStepHand
     /**
      * {@inheritDoc}
      */
+    @Deprecated
     protected AbstractBoottimeAddStepHandler(Set<RuntimeCapability> capabilities, AttributeDefinition... attributes) {
         super(capabilities, attributes);
     }

--- a/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractRemoveStepHandler.java
@@ -51,13 +51,15 @@ public abstract class AbstractRemoveStepHandler implements OperationStepHandler 
     private final Set<RuntimeCapability> capabilities;
 
     protected AbstractRemoveStepHandler() {
-        this(AbstractAddStepHandler.NULL_CAPABILITIES);
+        this.capabilities = AbstractAddStepHandler.NULL_CAPABILITIES;
     }
 
+    @Deprecated
     protected AbstractRemoveStepHandler(RuntimeCapability... capabilities) {
         this(capabilities.length == 0 ? AbstractAddStepHandler.NULL_CAPABILITIES : new HashSet<RuntimeCapability>(Arrays.asList(capabilities)));
     }
 
+    @Deprecated
     protected AbstractRemoveStepHandler(Set<RuntimeCapability> capabilities) {
         this.capabilities = capabilities == null ? AbstractAddStepHandler.NULL_CAPABILITIES : capabilities;
     }

--- a/controller/src/main/java/org/jboss/as/controller/ReloadRequiredAddStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReloadRequiredAddStepHandler.java
@@ -54,10 +54,13 @@ public class ReloadRequiredAddStepHandler extends AbstractAddStepHandler {
     public ReloadRequiredAddStepHandler(Collection<AttributeDefinition> attributes) {
         super(attributes);
     }
+
+    @Deprecated
     public ReloadRequiredAddStepHandler(RuntimeCapability capability, AttributeDefinition... attributes) {
         super(capability, attributes);
     }
 
+    @Deprecated
     public ReloadRequiredAddStepHandler(Set<RuntimeCapability> capabilities, Collection<AttributeDefinition> attributes) {
         super(capabilities, attributes);
     }

--- a/controller/src/main/java/org/jboss/as/controller/ReloadRequiredRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReloadRequiredRemoveStepHandler.java
@@ -41,6 +41,7 @@ public class ReloadRequiredRemoveStepHandler extends AbstractRemoveStepHandler {
      *
      * @param unavailableCapabilities capabilities to deregister
      */
+    @Deprecated
     public ReloadRequiredRemoveStepHandler(RuntimeCapability... unavailableCapabilities) {
         super(unavailableCapabilities);
     }

--- a/controller/src/main/java/org/jboss/as/controller/ServiceRemoveStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ServiceRemoveStepHandler.java
@@ -52,6 +52,7 @@ public class ServiceRemoveStepHandler extends AbstractRemoveStepHandler {
      * @param unavailableCapabilities capabilities that will no longer be available once the remove occurs. Any services
      *          {@link RuntimeCapability#getCapabilityServiceValueType() exposed by the capabilities} will also be removed
      */
+    @Deprecated
     public ServiceRemoveStepHandler(final ServiceName baseServiceName, final AbstractAddStepHandler addOperation, final RuntimeCapability ... unavailableCapabilities) {
         super(unavailableCapabilities);
         this.baseServiceName = baseServiceName;
@@ -75,6 +76,7 @@ public class ServiceRemoveStepHandler extends AbstractRemoveStepHandler {
      *          {@link RuntimeCapability#getCapabilityServiceValueType() exposed by the capabilities} will also be removed.
      *          Cannot be {@code null} or empty.
      */
+    @Deprecated
     public ServiceRemoveStepHandler(final AbstractAddStepHandler addOperation, final RuntimeCapability ... unavailableCapabilities) {
         this(null, addOperation, unavailableCapabilities);
     }

--- a/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/resource/AbstractSocketBindingResourceDefinition.java
@@ -65,7 +65,7 @@ public abstract class AbstractSocketBindingResourceDefinition extends SimpleReso
             .setExpressionsDeprecated()
             .setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, true, true))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setCapabilityReference("org.wildfly.network.interface", SOCKET_BINDING_CAPABILITY_NAME, true)
+            .setCapabilityReference("org.wildfly.network.interface", SOCKET_BINDING_CAPABILITY_NAME)
             .build();
 
     public static final SimpleAttributeDefinition PORT = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.PORT, ModelType.INT, true)

--- a/controller/src/test/java/org/jboss/as/controller/CapabilityReferenceRecorderTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/CapabilityReferenceRecorderTest.java
@@ -27,7 +27,7 @@ public class CapabilityReferenceRecorderTest {
 
     @Test
     public void testDefaultRequirementPatternElements() {
-        CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder recorder = new CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder("org.wildfly.requirement", "org.wildfly.dependent", true);
+        CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder recorder = new CapabilityReferenceRecorder.DefaultCapabilityReferenceRecorder("org.wildfly.requirement", "org.wildfly.dependent");
         String[] result = recorder.getRequirementPatternSegments("test", null);
         Assert.assertTrue(result != null);
         Assert.assertEquals(1, result.length);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessIdentityResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessIdentityResourceDefinition.java
@@ -73,7 +73,7 @@ public class AccessIdentityResourceDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SECURITY_DOMAIN, ModelType.STRING, false)
             .setMinSize(1)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, MANAGEMENT_IDENTITY_CAPABILITY, false)
+            .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, MANAGEMENT_IDENTITY_CAPABILITY)
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.ELYTRON_SECURITY_DOMAIN_REF)
             .build();
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessIdentityResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/AccessIdentityResourceDefinition.java
@@ -82,9 +82,10 @@ public class AccessIdentityResourceDefinition extends SimpleResourceDefinition {
     private AccessIdentityResourceDefinition(AbstractAddStepHandler add) {
         super(new Parameters(PATH_ELEMENT, DomainManagementResolver.getResolver("core.identity"))
                 .setAddHandler(add)
-                .setRemoveHandler(new ReloadRequiredRemoveStepHandler(MANAGEMENT_IDENTITY_RUNTIME_CAPABILITY))
+                .setRemoveHandler(ReloadRequiredRemoveStepHandler.INSTANCE)
                 .setAddRestartLevel(OperationEntry.Flag.RESTART_NONE)
                 .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
+                .setCapabilities(MANAGEMENT_IDENTITY_RUNTIME_CAPABILITY)
                 .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.ACCESS_CONTROL));
     }
 
@@ -105,7 +106,7 @@ public class AccessIdentityResourceDefinition extends SimpleResourceDefinition {
         private final ManagementSecurityIdentitySupplier securityIdentitySupplier;
 
         AccessIdentityAddHandler(ManagementSecurityIdentitySupplier securityIdentitySupplier) {
-            super(MANAGEMENT_IDENTITY_RUNTIME_CAPABILITY, ATTRIBUTES);
+            super(ATTRIBUTES);
             this.securityIdentitySupplier = securityIdentitySupplier;
         }
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/AggregateComponentDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AggregateComponentDefinition.java
@@ -86,7 +86,7 @@ class AggregateComponentDefinition<T> extends SimpleResourceDefinition {
         StringListAttributeDefinition aggregateReferences = new StringListAttributeDefinition.Builder(referencesName)
             .setMinSize(2)
             .setRequired(true)
-            .setCapabilityReference(capabilityName, capabilityName, true)//todo this is ultra fishy
+            .setCapabilityReference(capabilityName, capabilityName)//todo this is ultra fishy
             .setRestartAllServices()
             .build();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/AggregateRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AggregateRealmDefinition.java
@@ -57,13 +57,13 @@ class AggregateRealmDefinition extends SimpleResourceDefinition {
 
     static final SimpleAttributeDefinition AUTHENTICATION_REALM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.AUTHENTICATION_REALM, ModelType.STRING, false)
         .setMinSize(1)
-        .setCapabilityReference(SECURITY_REALM_CAPABILITY, SECURITY_REALM_CAPABILITY, true)
+        .setCapabilityReference(SECURITY_REALM_CAPABILITY, SECURITY_REALM_CAPABILITY)
         .setRestartAllServices()
         .build();
 
     static final SimpleAttributeDefinition AUTHORIZATION_REALM = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.AUTHORIZATION_REALM, ModelType.STRING, false)
         .setMinSize(1)
-        .setCapabilityReference(SECURITY_REALM_CAPABILITY, SECURITY_REALM_CAPABILITY, true)
+        .setCapabilityReference(SECURITY_REALM_CAPABILITY, SECURITY_REALM_CAPABILITY)
         .setRestartAllServices()
         .build();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuditResourceDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuditResourceDefinitions.java
@@ -157,7 +157,7 @@ class AuditResourceDefinitions {
     static final SimpleAttributeDefinition SSL_CONTEXT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SSL_CONTEXT, ModelType.STRING, true)
             .setAllowExpression(false)
             .setRestartAllServices()
-            .setCapabilityReference(SSL_CONTEXT_CAPABILITY, SECURITY_EVENT_LISTENER_CAPABILITY, true)
+            .setCapabilityReference(SSL_CONTEXT_CAPABILITY, SECURITY_EVENT_LISTENER_CAPABILITY)
             .build();
 
     private static final AggregateComponentDefinition<SecurityEventListener> AGGREGATE_SECURITY_EVENT_LISTENER = AggregateComponentDefinition.create(SecurityEventListener.class,

--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuthenticationFactoryDefinitions.java
@@ -105,13 +105,13 @@ class AuthenticationFactoryDefinitions {
     static final SimpleAttributeDefinition HTTP_SERVER_MECHANISM_FACTORY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.HTTP_SERVER_MECHANISM_FACTORY, ModelType.STRING, false)
             .setMinSize(1)
             .setRestartAllServices()
-            .setCapabilityReference(HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY, HTTP_AUTHENTICATION_FACTORY_CAPABILITY, true)
+            .setCapabilityReference(HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY, HTTP_AUTHENTICATION_FACTORY_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition SASL_SERVER_FACTORY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SASL_SERVER_FACTORY, ModelType.STRING, false)
             .setMinSize(1)
             .setRestartAllServices()
-            .setCapabilityReference(SASL_SERVER_FACTORY_CAPABILITY, SASL_AUTHENTICATION_FACTORY_CAPABILITY, true)
+            .setCapabilityReference(SASL_SERVER_FACTORY_CAPABILITY, SASL_AUTHENTICATION_FACTORY_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition MECHANISM_NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.MECHANISM_NAME, ModelType.STRING, true)
@@ -168,16 +168,16 @@ class AuthenticationFactoryDefinitions {
 
     static AttributeDefinition getMechanismConfiguration(String forCapability) {
         SimpleAttributeDefinition preRealmPrincipalTransformerAttribute = new SimpleAttributeDefinitionBuilder(BASE_PRE_REALM_PRINCIPAL_TRANSFORMER)
-                .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, forCapability, true)
+                .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, forCapability)
                 .build();
         SimpleAttributeDefinition postRealmPrincipalTransformerAttribute = new SimpleAttributeDefinitionBuilder(BASE_POST_REALM_PRINCIPAL_TRANSFORMER)
-                .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, forCapability, true)
+                .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, forCapability)
                 .build();
         SimpleAttributeDefinition finalprincipalTransformerAttribute = new SimpleAttributeDefinitionBuilder(BASE_FINAL_PRINCIPAL_TRANSFORMER)
-                .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, forCapability, true)
+                .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, forCapability)
                 .build();
         SimpleAttributeDefinition realmMapperAttribute = new SimpleAttributeDefinitionBuilder(BASE_REALM_MAPPER)
-                .setCapabilityReference(REALM_MAPPER_CAPABILITY, forCapability, true)
+                .setCapabilityReference(REALM_MAPPER_CAPABILITY, forCapability)
                 .build();
 
         ObjectTypeAttributeDefinition mechanismRealmConfiguration = new ObjectTypeAttributeDefinition.Builder(ElytronDescriptionConstants.MECHANISM_REALM_CONFIGURATION, REALM_NAME, preRealmPrincipalTransformerAttribute, postRealmPrincipalTransformerAttribute, finalprincipalTransformerAttribute, realmMapperAttribute)
@@ -195,7 +195,7 @@ class AuthenticationFactoryDefinitions {
                 .build();
 
         SimpleAttributeDefinition credentialSecurityFactoryAttribute = new SimpleAttributeDefinitionBuilder(BASE_CREDENTIAL_SECURITY_FACTORY)
-                .setCapabilityReference(SECURITY_FACTORY_CREDENTIAL_CAPABILITY, forCapability, true)
+                .setCapabilityReference(SECURITY_FACTORY_CREDENTIAL_CAPABILITY, forCapability)
                 .build();
 
         ObjectTypeAttributeDefinition mechanismConfiguration = new ObjectTypeAttributeDefinition.Builder(ElytronDescriptionConstants.MECHANISM_CONFIGURATION, MECHANISM_NAME, HOST_NAME, PROTOCOL,
@@ -364,7 +364,7 @@ class AuthenticationFactoryDefinitions {
     static ResourceDefinition getHttpAuthenticationFactory() {
 
         SimpleAttributeDefinition securityDomainAttribute = new SimpleAttributeDefinitionBuilder(BASE_SECURITY_DOMAIN_REF)
-                .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, HTTP_AUTHENTICATION_FACTORY_CAPABILITY, true)
+                .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, HTTP_AUTHENTICATION_FACTORY_CAPABILITY)
                 .setRestartAllServices()
                 .build();
 
@@ -448,7 +448,7 @@ class AuthenticationFactoryDefinitions {
 
     static ResourceDefinition getSaslAuthenticationFactory() {
         SimpleAttributeDefinition securityDomainAttribute = new SimpleAttributeDefinitionBuilder(BASE_SECURITY_DOMAIN_REF)
-                .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SASL_AUTHENTICATION_FACTORY_CAPABILITY, true)
+                .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SASL_AUTHENTICATION_FACTORY_CAPABILITY)
                 .setRestartAllServices()
                 .build();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CredentialStoreResourceDefinition.java
@@ -145,7 +145,7 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
             .setAllowExpression(false)
             .setMinSize(1)
             .setRestartAllServices()
-            .setCapabilityReference(PROVIDERS_CAPABILITY, CREDENTIAL_STORE_CAPABILITY, true)
+            .setCapabilityReference(PROVIDERS_CAPABILITY, CREDENTIAL_STORE_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition OTHER_PROVIDERS = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.OTHER_PROVIDERS, ModelType.STRING, true)
@@ -153,7 +153,7 @@ final class CredentialStoreResourceDefinition extends SimpleResourceDefinition {
             .setAllowExpression(false)
             .setMinSize(1)
             .setRestartAllServices()
-            .setCapabilityReference(PROVIDERS_CAPABILITY, CREDENTIAL_STORE_CAPABILITY, true)
+            .setCapabilityReference(PROVIDERS_CAPABILITY, CREDENTIAL_STORE_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition RELATIVE_TO = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.RELATIVE_TO, ModelType.STRING, true)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DirContextDefinition.java
@@ -113,14 +113,14 @@ class DirContextDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition AUTHENTICATION_CONTEXT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.AUTHENTICATION_CONTEXT, ModelType.STRING, true)
             .setAllowExpression(false)
             .setRestartAllServices()
-            .setCapabilityReference(AUTHENTICATION_CONTEXT_CAPABILITY, DIR_CONTEXT_CAPABILITY, true)
+            .setCapabilityReference(AUTHENTICATION_CONTEXT_CAPABILITY, DIR_CONTEXT_CAPABILITY)
             .setAlternatives(CredentialReference.CREDENTIAL_REFERENCE, ElytronDescriptionConstants.SSL_CONTEXT,ElytronDescriptionConstants.PRINCIPAL)
             .build();
 
     static final SimpleAttributeDefinition SSL_CONTEXT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SSL_CONTEXT, ModelType.STRING, true)
             .setAllowExpression(false)
             .setRestartAllServices()
-            .setCapabilityReference(SSL_CONTEXT_CAPABILITY, DIR_CONTEXT_CAPABILITY, true)
+            .setCapabilityReference(SSL_CONTEXT_CAPABILITY, DIR_CONTEXT_CAPABILITY)
             .setAlternatives(ElytronDescriptionConstants.AUTHENTICATION_CONTEXT)
             .build();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/DomainDefinition.java
@@ -114,53 +114,53 @@ class DomainDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition PRE_REALM_PRINCIPAL_TRANSFORMER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PRE_REALM_PRINCIPAL_TRANSFORMER, ModelType.STRING, true)
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-        .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+        .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition POST_REALM_PRINCIPAL_TRANSFORMER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.POST_REALM_PRINCIPAL_TRANSFORMER, ModelType.STRING, true)
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-        .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+        .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition PRINCIPAL_DECODER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PRINCIPAL_DECODER, ModelType.STRING, true)
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-        .setCapabilityReference(PRINCIPAL_DECODER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+        .setCapabilityReference(PRINCIPAL_DECODER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition PERMISSION_MAPPER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PERMISSION_MAPPER, ModelType.STRING, true)
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-        .setCapabilityReference(PERMISSION_MAPPER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+        .setCapabilityReference(PERMISSION_MAPPER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition REALM_MAPPER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.REALM_MAPPER, ModelType.STRING, true)
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-        .setCapabilityReference(REALM_MAPPER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+        .setCapabilityReference(REALM_MAPPER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition ROLE_MAPPER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ROLE_MAPPER, ModelType.STRING, true)
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-        .setCapabilityReference(ROLE_MAPPER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+        .setCapabilityReference(ROLE_MAPPER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition REALM_NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.REALM, ModelType.STRING, false)
         .setXmlName(ElytronDescriptionConstants.NAME)
         .setMinSize(1)
-        .setCapabilityReference(SECURITY_REALM_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+        .setCapabilityReference(SECURITY_REALM_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition REALM_PRINCIPAL_TRANSFORMER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PRINCIPAL_TRANSFORMER, ModelType.STRING, true)
         .setMinSize(1)
-        .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+        .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition REALM_ROLE_DECODER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ROLE_DECODER, ModelType.STRING, true)
         .setMinSize(1)
-        .setCapabilityReference(ROLE_DECODER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+        .setCapabilityReference(ROLE_DECODER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
         .build();
 
     static final ObjectTypeAttributeDefinition REALM = new ObjectTypeAttributeDefinition.Builder(ElytronDescriptionConstants.REALM, REALM_NAME, REALM_PRINCIPAL_TRANSFORMER, REALM_ROLE_DECODER, ROLE_MAPPER)
@@ -178,7 +178,7 @@ class DomainDefinition extends SimpleResourceDefinition {
             .setRequired(false)
             .setMinSize(1)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+            .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition OUTFLOW_ANONYMOUS = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.OUTFLOW_ANONYMOUS, ModelType.BOOLEAN, true)
@@ -193,12 +193,12 @@ class DomainDefinition extends SimpleResourceDefinition {
             .setRequired(false)
             .setMinSize(1)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+            .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition SECURITY_EVENT_LISTENER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SECURITY_EVENT_LISTENER, ModelType.STRING, true)
             .setAllowExpression(false)
-            .setCapabilityReference(SECURITY_EVENT_LISTENER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY, true)
+            .setCapabilityReference(SECURITY_EVENT_LISTENER_CAPABILITY, SECURITY_DOMAIN_CAPABILITY)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/FilteringKeyStoreDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/FilteringKeyStoreDefinition.java
@@ -63,7 +63,7 @@ class FilteringKeyStoreDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition KEY_STORE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.KEY_STORE, ModelType.STRING, false)
             .setAllowExpression(false)
             .setRestartAllServices()
-            .setCapabilityReference(KEY_STORE_CAPABILITY, KEY_STORE_CAPABILITY, true)
+            .setCapabilityReference(KEY_STORE_CAPABILITY, KEY_STORE_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition ALIAS_FILTER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ALIAS_FILTER, ModelType.STRING, false)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/HttpServerDefinitions.java
@@ -81,13 +81,13 @@ class HttpServerDefinitions {
     static final SimpleAttributeDefinition HTTP_SERVER_FACTORY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.HTTP_SERVER_MECHANISM_FACTORY, ModelType.STRING, false)
         .setMinSize(1)
         .setRestartAllServices()
-        .setCapabilityReference(HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY, HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY, true)
+        .setCapabilityReference(HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY, HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition PROVIDERS = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PROVIDERS, ModelType.STRING, true)
         .setMinSize(1)
         .setRestartAllServices()
-        .setCapabilityReference(PROVIDERS_CAPABILITY, HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY, true)
+        .setCapabilityReference(PROVIDERS_CAPABILITY, HTTP_SERVER_MECHANISM_FACTORY_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition PATTERN_FILTER = new SimpleAttributeDefinitionBuilder(RegexAttributeDefinitions.PATTERN)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/JdbcRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/JdbcRealmDefinition.java
@@ -422,7 +422,7 @@ class JdbcRealmDefinition extends SimpleResourceDefinition {
         static final SimpleAttributeDefinition DATA_SOURCE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.DATA_SOURCE, ModelType.STRING, false)
                 .setMinSize(1)
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-                .setCapabilityReference(Capabilities.DATA_SOURCE_CAPABILITY_NAME, Capabilities.SECURITY_REALM_CAPABILITY, true)
+                .setCapabilityReference(Capabilities.DATA_SOURCE_CAPABILITY_NAME, Capabilities.SECURITY_REALM_CAPABILITY)
                 .build();
 
         static final ObjectListAttributeDefinition ATTRIBUTE_MAPPINGS = new ObjectListAttributeDefinition.Builder(ElytronDescriptionConstants.ATTRIBUTE_MAPPING, AttributeMappingObjectDefinition.OBJECT_DEFINITION)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreDefinition.java
@@ -100,7 +100,7 @@ final class KeyStoreDefinition extends SimpleResourceDefinition {
         .setAttributeGroup(ElytronDescriptionConstants.IMPLEMENTATION)
         .setMinSize(1)
         .setRestartAllServices()
-        .setCapabilityReference(PROVIDERS_CAPABILITY, KEY_STORE_CAPABILITY, true)
+        .setCapabilityReference(PROVIDERS_CAPABILITY, KEY_STORE_CAPABILITY)
         .build();
 
     static final ObjectTypeAttributeDefinition CREDENTIAL_REFERENCE = CredentialReference.getAttributeDefinition(true);

--- a/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/KeyStoreRealmDefinition.java
@@ -61,7 +61,7 @@ class KeyStoreRealmDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition KEYSTORE = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.KEY_STORE, ModelType.STRING, false)
         .setMinSize(1)
         .setRestartAllServices()
-        .setCapabilityReference(KEY_STORE_CAPABILITY, SECURITY_REALM_CAPABILITY, true)
+        .setCapabilityReference(KEY_STORE_CAPABILITY, SECURITY_REALM_CAPABILITY)
         .build();
 
     private static final AbstractAddStepHandler ADD = new RealmAddHandler();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/LdapKeyStoreDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/LdapKeyStoreDefinition.java
@@ -80,7 +80,7 @@ final class LdapKeyStoreDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition DIR_CONTEXT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.DIR_CONTEXT, ModelType.STRING, false)
             .setAllowExpression(false)
             .setRestartAllServices()
-            .setCapabilityReference(DIR_CONTEXT_CAPABILITY, KEY_STORE_CAPABILITY, true)
+            .setCapabilityReference(DIR_CONTEXT_CAPABILITY, KEY_STORE_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition SEARCH_PATH = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SEARCH_PATH, ModelType.STRING, false)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/LdapRealmDefinition.java
@@ -377,7 +377,7 @@ class LdapRealmDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition DIR_CONTEXT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.DIR_CONTEXT, ModelType.STRING, false)
             .setAllowExpression(false)
             .setRestartAllServices()
-            .setCapabilityReference(DIR_CONTEXT_CAPABILITY, SECURITY_REALM_CAPABILITY, true)
+            .setCapabilityReference(DIR_CONTEXT_CAPABILITY, SECURITY_REALM_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition DIRECT_VERIFICATION = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.DIRECT_VERIFICATION, ModelType.BOOLEAN, true)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PermissionMapperDefinitions.java
@@ -78,13 +78,13 @@ class PermissionMapperDefinitions {
     static final SimpleAttributeDefinition LEFT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.LEFT, ModelType.STRING, false)
             .setMinSize(1)
             .setRestartAllServices()
-            .setCapabilityReference(PERMISSION_MAPPER_CAPABILITY, PERMISSION_MAPPER_CAPABILITY, true)
+            .setCapabilityReference(PERMISSION_MAPPER_CAPABILITY, PERMISSION_MAPPER_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition RIGHT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.RIGHT, ModelType.STRING, false)
             .setMinSize(1)
             .setRestartAllServices()
-            .setCapabilityReference(PERMISSION_MAPPER_CAPABILITY, PERMISSION_MAPPER_CAPABILITY, true)
+            .setCapabilityReference(PERMISSION_MAPPER_CAPABILITY, PERMISSION_MAPPER_CAPABILITY)
             .build();
 
     static final SimpleAttributeDefinition LOGICAL_OPERATION = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.LOGICAL_OPERATION, ModelType.STRING, false)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/PrincipalDecoderDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/PrincipalDecoderDefinitions.java
@@ -131,7 +131,7 @@ class PrincipalDecoderDefinitions {
     static final StringListAttributeDefinition PRINCIPAL_DECODERS = new StringListAttributeDefinition.Builder(ElytronDescriptionConstants.PRINCIPAL_DECODERS)
         .setMinSize(2)
         .setRequired(true)
-        .setCapabilityReference(PRINCIPAL_DECODER_RUNTIME_CAPABILITY.getName(), PRINCIPAL_DECODER_RUNTIME_CAPABILITY.getName(), true)
+        .setCapabilityReference(PRINCIPAL_DECODER_RUNTIME_CAPABILITY.getName(), PRINCIPAL_DECODER_RUNTIME_CAPABILITY.getName())
             .setAttributeParser(AttributeParsers.STRING_LIST_NAMED_ELEMENT)
             .setAttributeMarshaller(AttributeMarshallers.STRING_LIST_NAMED_ELEMENT)
             .setXmlName(ElytronDescriptionConstants.PRINCIPAL_DECODER)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/RealmMapperDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/RealmMapperDefinitions.java
@@ -64,7 +64,7 @@ class RealmMapperDefinitions {
     static final SimpleAttributeDefinition DELEGATE_REALM_MAPPER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.DELEGATE_REALM_MAPPER, ModelType.STRING, true)
         .setMinSize(1)
         .setRestartAllServices()
-        .setCapabilityReference(REALM_MAPPER_CAPABILITY, REALM_MAPPER_CAPABILITY, true)
+        .setCapabilityReference(REALM_MAPPER_CAPABILITY, REALM_MAPPER_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition REALM_NAME = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.REALM_NAME, ModelType.STRING, false)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/RoleMapperDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/RoleMapperDefinitions.java
@@ -77,13 +77,13 @@ class RoleMapperDefinitions {
     static final SimpleAttributeDefinition LEFT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.LEFT, ModelType.STRING, true)
         .setMinSize(1)
         .setRestartAllServices()
-        .setCapabilityReference(ROLE_MAPPER_CAPABILITY, ROLE_MAPPER_CAPABILITY, true)
+        .setCapabilityReference(ROLE_MAPPER_CAPABILITY, ROLE_MAPPER_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition RIGHT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.RIGHT, ModelType.STRING, true)
         .setMinSize(1)
         .setRestartAllServices()
-        .setCapabilityReference(ROLE_MAPPER_CAPABILITY, ROLE_MAPPER_CAPABILITY, true)
+        .setCapabilityReference(ROLE_MAPPER_CAPABILITY, ROLE_MAPPER_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition LOGICAL_OPERATION = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.LOGICAL_OPERATION, ModelType.STRING, false)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -164,31 +164,31 @@ class SSLDefinitions {
 
     static final SimpleAttributeDefinition SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SECURITY_DOMAIN, ModelType.STRING, true)
             .setMinSize(1)
-            .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SSL_CONTEXT_CAPABILITY, true)
+            .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SSL_CONTEXT_CAPABILITY)
             .setRestartAllServices()
             .build();
 
     static final SimpleAttributeDefinition PRE_REALM_PRINCIPAL_TRANSFORMER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PRE_REALM_PRINCIPAL_TRANSFORMER, ModelType.STRING, true)
             .setMinSize(1)
-            .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SSL_CONTEXT_CAPABILITY, true)
+            .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SSL_CONTEXT_CAPABILITY)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
     static final SimpleAttributeDefinition POST_REALM_PRINCIPAL_TRANSFORMER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.POST_REALM_PRINCIPAL_TRANSFORMER, ModelType.STRING, true)
             .setMinSize(1)
-            .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SSL_CONTEXT_CAPABILITY, true)
+            .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SSL_CONTEXT_CAPABILITY)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
     static final SimpleAttributeDefinition FINAL_PRINCIPAL_TRANSFORMER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.FINAL_PRINCIPAL_TRANSFORMER, ModelType.STRING, true)
             .setMinSize(1)
-            .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SSL_CONTEXT_CAPABILITY, true)
+            .setCapabilityReference(PRINCIPAL_TRANSFORMER_CAPABILITY, SSL_CONTEXT_CAPABILITY)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
     static final SimpleAttributeDefinition REALM_MAPPER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.REALM_MAPPER, ModelType.STRING, true)
             .setMinSize(1)
-            .setCapabilityReference(REALM_MAPPER_CAPABILITY, SSL_CONTEXT_CAPABILITY, true)
+            .setCapabilityReference(REALM_MAPPER_CAPABILITY, SSL_CONTEXT_CAPABILITY)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .build();
 
@@ -261,14 +261,14 @@ class SSLDefinitions {
 
     static final SimpleAttributeDefinition KEY_MANAGER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.KEY_MANAGER, ModelType.STRING, true)
             .setMinSize(1)
-            .setCapabilityReference(KEY_MANAGER_CAPABILITY, SSL_CONTEXT_CAPABILITY, true)
+            .setCapabilityReference(KEY_MANAGER_CAPABILITY, SSL_CONTEXT_CAPABILITY)
             .setRestartAllServices()
             .setAllowExpression(false)
             .build();
 
     static final SimpleAttributeDefinition TRUST_MANAGER = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.TRUST_MANAGER, ModelType.STRING, true)
             .setMinSize(1)
-            .setCapabilityReference(TRUST_MANAGER_CAPABILITY, SSL_CONTEXT_CAPABILITY, true)
+            .setCapabilityReference(TRUST_MANAGER_CAPABILITY, SSL_CONTEXT_CAPABILITY)
             .setRestartAllServices()
             .setAllowExpression(false)
             .build();
@@ -351,13 +351,13 @@ class SSLDefinitions {
         final StandardResourceDescriptionResolver RESOURCE_RESOLVER = ElytronExtension.getResourceDescriptionResolver(ElytronDescriptionConstants.KEY_MANAGER);
 
         final SimpleAttributeDefinition providersDefinition = new SimpleAttributeDefinitionBuilder(PROVIDERS)
-                .setCapabilityReference(PROVIDERS_CAPABILITY, KEY_MANAGER_CAPABILITY, true)
+                .setCapabilityReference(PROVIDERS_CAPABILITY, KEY_MANAGER_CAPABILITY)
                 .setAllowExpression(false)
                 .setRestartAllServices()
                 .build();
 
         final SimpleAttributeDefinition keystoreDefinition = new SimpleAttributeDefinitionBuilder(KEYSTORE)
-                .setCapabilityReference(KEY_STORE_CAPABILITY, KEY_MANAGER_CAPABILITY, true)
+                .setCapabilityReference(KEY_STORE_CAPABILITY, KEY_MANAGER_CAPABILITY)
                 .setAllowExpression(false)
                 .setRestartAllServices()
                 .build();
@@ -494,13 +494,13 @@ class SSLDefinitions {
     static ResourceDefinition getTrustManagerDefinition() {
 
         final SimpleAttributeDefinition providersDefinition = new SimpleAttributeDefinitionBuilder(PROVIDERS)
-                .setCapabilityReference(PROVIDERS_CAPABILITY, TRUST_MANAGER_CAPABILITY, true)
+                .setCapabilityReference(PROVIDERS_CAPABILITY, TRUST_MANAGER_CAPABILITY)
                 .setAllowExpression(false)
                 .setRestartAllServices()
                 .build();
 
         final SimpleAttributeDefinition keystoreDefinition = new SimpleAttributeDefinitionBuilder(KEYSTORE)
-                .setCapabilityReference(KEY_STORE_CAPABILITY, TRUST_MANAGER_CAPABILITY, true)
+                .setCapabilityReference(KEY_STORE_CAPABILITY, TRUST_MANAGER_CAPABILITY)
                 .setAllowExpression(false)
                 .setRestartAllServices()
                 .build();
@@ -818,7 +818,7 @@ class SSLDefinitions {
     static ResourceDefinition getServerSSLContextDefinition(boolean serverOrHostController) {
 
         final SimpleAttributeDefinition providersDefinition = new SimpleAttributeDefinitionBuilder(PROVIDERS)
-                .setCapabilityReference(PROVIDERS_CAPABILITY, SSL_CONTEXT_CAPABILITY, true)
+                .setCapabilityReference(PROVIDERS_CAPABILITY, SSL_CONTEXT_CAPABILITY)
                 .setAllowExpression(false)
                 .setRestartAllServices()
                 .build();
@@ -949,7 +949,7 @@ class SSLDefinitions {
     static ResourceDefinition getClientSSLContextDefinition(boolean serverOrHostController) {
 
         final SimpleAttributeDefinition providersDefinition = new SimpleAttributeDefinitionBuilder(PROVIDERS)
-                .setCapabilityReference(PROVIDERS_CAPABILITY, SSL_CONTEXT_CAPABILITY, true)
+                .setCapabilityReference(PROVIDERS_CAPABILITY, SSL_CONTEXT_CAPABILITY)
                 .setAllowExpression(false)
                 .setRestartAllServices()
                 .build();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SaslServerDefinitions.java
@@ -108,19 +108,19 @@ class SaslServerDefinitions {
     static final SimpleAttributeDefinition SECURITY_DOMAIN = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SECURITY_DOMAIN, ModelType.STRING, false)
         .setMinSize(1)
         .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-        .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SASL_AUTHENTICATION_FACTORY_CAPABILITY, true)
+        .setCapabilityReference(SECURITY_DOMAIN_CAPABILITY, SASL_AUTHENTICATION_FACTORY_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition SASL_SERVER_FACTORY = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SASL_SERVER_FACTORY, ModelType.STRING, false)
         .setMinSize(1)
         .setRestartAllServices()
-        .setCapabilityReference(SASL_SERVER_FACTORY_CAPABILITY, SASL_SERVER_FACTORY_CAPABILITY, true)
+        .setCapabilityReference(SASL_SERVER_FACTORY_CAPABILITY, SASL_SERVER_FACTORY_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition PROVIDERS = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.PROVIDERS, ModelType.STRING, true)
         .setMinSize(1)
         .setRestartAllServices()
-        .setCapabilityReference(PROVIDERS_CAPABILITY, SASL_SERVER_FACTORY_CAPABILITY, true)
+        .setCapabilityReference(PROVIDERS_CAPABILITY, SASL_SERVER_FACTORY_CAPABILITY)
         .build();
 
     static final SimpleAttributeDefinition ENABLING = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.ENABLING, ModelType.BOOLEAN, true)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TokenRealmDefinition.java
@@ -116,7 +116,7 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                 .setAlternatives(ElytronDescriptionConstants.PUBLIC_KEY)
                 .setRequires(ElytronDescriptionConstants.CERTIFICATE)
                 .setMinSize(1)
-                .setCapabilityReference(KEY_STORE_CAPABILITY, SECURITY_REALM_CAPABILITY, true)
+                .setCapabilityReference(KEY_STORE_CAPABILITY, SECURITY_REALM_CAPABILITY)
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                 .setAllowExpression(false)
                 .build();
@@ -159,7 +159,7 @@ class TokenRealmDefinition extends SimpleResourceDefinition {
                 .build();
 
         protected static final SimpleAttributeDefinition SSL_CONTEXT = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.CLIENT_SSL_CONTEXT, ModelType.STRING, true)
-                .setCapabilityReference(SSL_CONTEXT_CAPABILITY, SECURITY_REALM_CAPABILITY, true)
+                .setCapabilityReference(SSL_CONTEXT_CAPABILITY, SECURITY_REALM_CAPABILITY)
                 .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                 .setValidator(new StringLengthValidator(1))
                 .build();

--- a/host-controller/pom.xml
+++ b/host-controller/pom.xml
@@ -120,6 +120,11 @@
            <artifactId>junit</artifactId>
            <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SocketBindingGroupResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SocketBindingGroupResourceDefinition.java
@@ -79,7 +79,7 @@ public class SocketBindingGroupResourceDefinition extends AbstractSocketBindingG
                     }
                 }
             })
-            .setCapabilityReference(SOCKET_BINDING_GROUP_CAPABILITY_NAME, SOCKET_BINDING_GROUP_CAPABILITY_NAME, true)
+            .setCapabilityReference(SOCKET_BINDING_GROUP_CAPABILITY_NAME, SOCKET_BINDING_GROUP_CAPABILITY_NAME)
             .build();
 
     public static SocketBindingGroupResourceDefinition INSTANCE = new SocketBindingGroupResourceDefinition();

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ProfileResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ProfileResourceDefinition.java
@@ -80,7 +80,7 @@ public class ProfileResourceDefinition extends SimpleResourceDefinition {
     public static final ListAttributeDefinition INCLUDES = new StringListAttributeDefinition.Builder(ModelDescriptionConstants.INCLUDES)
             .setRequired(false)
             .setElementValidator(new StringLengthValidator(1, true))
-            .setCapabilityReference(PROFILE_CAPABILITY_NAME, PROFILE_CAPABILITY_NAME, true)
+            .setCapabilityReference(PROFILE_CAPABILITY_NAME, PROFILE_CAPABILITY_NAME)
             .build();
 
     public static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {INCLUDES};

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/ServerGroupResourceDefinition.java
@@ -66,21 +66,20 @@ import org.jboss.dmr.ModelType;
 public class ServerGroupResourceDefinition extends SimpleResourceDefinition {
 
     public static final String SERVER_GROUP_CAPABILITY_NAME = "org.wildfly.domain.server-group";
-    public static final RuntimeCapability SERVER_GROUP_CAPABILITY = RuntimeCapability.Builder.of(SERVER_GROUP_CAPABILITY_NAME, true)
-            .build();
+    public static final RuntimeCapability<Void> SERVER_GROUP_CAPABILITY = RuntimeCapability.Builder.of(SERVER_GROUP_CAPABILITY_NAME, true).build();
 
     public static final PathElement PATH = PathElement.pathElement(SERVER_GROUP);
 
     public static final SimpleAttributeDefinition PROFILE = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.PROFILE, ModelType.STRING)
             .setValidator(new StringLengthValidator(1))
-            .setCapabilityReference(ProfileResourceDefinition.PROFILE_CAPABILITY_NAME, SERVER_GROUP_CAPABILITY_NAME, true)
+            .setCapabilityReference(ProfileResourceDefinition.PROFILE_CAPABILITY_NAME, SERVER_GROUP_CAPABILITY_NAME)
             .addArbitraryDescriptor(FEATURE_REFERENCE, new ModelNode(true))
             .build();
 
     public static final SimpleAttributeDefinition SOCKET_BINDING_GROUP = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SOCKET_BINDING_GROUP, ModelType.STRING, false)
             .setXmlName(Attribute.REF.getLocalName())
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
-            .setCapabilityReference(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY_NAME, SERVER_GROUP_CAPABILITY_NAME, true)
+            .setCapabilityReference(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY_NAME, SERVER_GROUP_CAPABILITY_NAME)
             .addArbitraryDescriptor(FEATURE_REFERENCE, new ModelNode(true))
             .build();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/DomainControllerWriteAttributeHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/DomainControllerWriteAttributeHandler.java
@@ -68,7 +68,7 @@ public abstract class DomainControllerWriteAttributeHandler extends ReloadRequir
                     .build();
     public static final SimpleAttributeDefinition AUTHENTICATION_CONTEXT =
             new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.AUTHENTICATION_CONTEXT,  ModelType.STRING,  true)
-                    .setCapabilityReference("org.wildfly.security.authentication-context", "org.wildfly.host.controller", false)
+                    .setCapabilityReference("org.wildfly.security.authentication-context", "org.wildfly.host.controller")
                     .setAlternatives(ModelDescriptionConstants.SECURITY_REALM, ModelDescriptionConstants.USERNAME)
                     .build();
     public static final SimpleAttributeDefinition PORT =

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/RemoteDomainControllerAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/RemoteDomainControllerAddHandler.java
@@ -83,7 +83,7 @@ public class RemoteDomainControllerAddHandler implements OperationStepHandler {
 
     public static final SimpleAttributeDefinition AUTHENTICATION_CONTEXT =
             new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.AUTHENTICATION_CONTEXT,  ModelType.STRING,  true)
-                    .setCapabilityReference("org.wildfly.security.authentication-context", "org.wildfly.host.controller", false)
+                    .setCapabilityReference("org.wildfly.security.authentication-context", "org.wildfly.host.controller")
                     .setAlternatives(ModelDescriptionConstants.SECURITY_REALM, ModelDescriptionConstants.USERNAME)
                     .build();
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/resources/ServerConfigResourceDefinition.java
@@ -95,7 +95,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
             .setDefaultValue(new ModelNode(false)).build();
 
     public static final SimpleAttributeDefinition SOCKET_BINDING_GROUP = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.SOCKET_BINDING_GROUP, ModelType.STRING, true)
-            .setCapabilityReference(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY_NAME, SERVER_CONFIG_CAPABILITY_NAME, true)
+            .setCapabilityReference(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY_NAME, SERVER_CONFIG_CAPABILITY_NAME)
             .build();
 
     public static final SimpleAttributeDefinition SOCKET_BINDING_DEFAULT_INTERFACE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOCKET_BINDING_DEFAULT_INTERFACE, ModelType.STRING, true)
@@ -113,7 +113,7 @@ public class ServerConfigResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     public static final SimpleAttributeDefinition GROUP = SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.GROUP, ModelType.STRING)
-            .setCapabilityReference(ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY_NAME, SERVER_CONFIG_CAPABILITY_NAME, true)
+            .setCapabilityReference(ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY_NAME, SERVER_CONFIG_CAPABILITY_NAME)
             .build();
 
     public static final SimpleAttributeDefinition STATUS = SimpleAttributeDefinitionBuilder.create(ServerStatusHandler.ATTRIBUTE_NAME, ModelType.STRING)

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -42,6 +42,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -54,13 +58,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
-import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.BlockingTimeout;
-import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.CapabilityServiceTarget;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.NoopOperationStepHandler;
-import org.jboss.as.controller.NotificationDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
@@ -69,7 +69,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ProxyController;
-import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.access.Action.ActionEffect;
@@ -77,22 +76,13 @@ import org.jboss.as.controller.access.AuthorizationResult;
 import org.jboss.as.controller.access.Caller;
 import org.jboss.as.controller.access.Environment;
 import org.jboss.as.controller.access.ResourceAuthorization;
-import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.MessageSeverity;
-import org.jboss.as.controller.client.OperationAttachments;
-import org.jboss.as.controller.client.OperationMessageHandler;
-import org.jboss.as.controller.descriptions.DescriptionProvider;
-import org.jboss.as.controller.descriptions.OverrideDescriptionProvider;
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.notification.Notification;
-import org.jboss.as.controller.registry.AliasEntry;
-import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.NotificationEntry;
-import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.access.AccessAuthorizationResourceDefinition;
@@ -134,6 +124,7 @@ public abstract class AbstractOperationTestCase {
         Resource root;
         private final boolean booting;
         final PathAddress operationAddress;
+        final ManagementResourceRegistration registration;
         private Set<PathAddress> expectedSteps = new HashSet<PathAddress>();
         private final Map<AttachmentKey<?>, Object> valueAttachments = new HashMap<AttachmentKey<?>, Object>();
         private final ModelNode result = new ModelNode();
@@ -146,6 +137,7 @@ public abstract class AbstractOperationTestCase {
             this.booting = booting;
             this.operationAddress = operationAddress;
             this.failOnUnexpected = failOnUnexpected;
+            this.registration = createManagementResourceRegistration(operationAddress);
         }
 
         protected MockOperationContext(final Resource root, final boolean booting, final PathAddress operationAddress) {
@@ -373,7 +365,7 @@ public abstract class AbstractOperationTestCase {
 
         @Override
         public ManagementResourceRegistration getResourceRegistrationForUpdate() {
-            return RESOURCE_REGISTRATION;
+            return this.registration;
         }
 
         @Override
@@ -787,281 +779,21 @@ public abstract class AbstractOperationTestCase {
         }
     }
 
-
-    static final ManagementResourceRegistration RESOURCE_REGISTRATION = new ManagementResourceRegistration() {
-        @Override
-        public ManagementResourceRegistration getOverrideModel(String name) {
-            return null;
-        }
-
-        @Override
-        public ProcessType getProcessType() {
-            return ProcessType.HOST_CONTROLLER;
-        }
-
-        @Override
-        public ManagementResourceRegistration getSubModel(PathAddress address) {
-            return this;
-        }
-
-        @Override
-        public List<AccessConstraintDefinition> getAccessConstraints() {
-            return Collections.emptyList();
-        }
-
-        public ManagementResourceRegistration registerSubModel(PathElement address, DescriptionProvider descriptionProvider) {
-            return null;
-        }
-
-        @Override
-        public ManagementResourceRegistration registerSubModel(ResourceDefinition resourceDefinition) {
-            return null;
-        }
-
-        @Override
-        public void unregisterSubModel(PathElement address) {
-        }
-
-        @Override
-        public boolean isAllowsOverride() {
-            return false;
-        }
-
-        @Override
-        public void setRuntimeOnly(boolean runtimeOnly) {
-
-        }
-
-        @Override
-        public ManagementResourceRegistration registerOverrideModel(String name, OverrideDescriptionProvider descriptionProvider) {
-            return null;
-        }
-
-        @Override
-        public void unregisterOverrideModel(String name) {
-        }
-
-        @Override
-        public void registerCapability(RuntimeCapability capability) {
-
-        }
-
-        @Override
-        public void registerIncorporatingCapabilities(Set<RuntimeCapability> capabilities) {
-
-        }
-
-        @Override
-        public void registerRequirements(Set<CapabilityReferenceRecorder> requirements) {
-
-        }
-
-        @Override
-        public void registerOperationHandler(OperationDefinition definition, OperationStepHandler handler) {
-
-        }
-
-        @Override
-        public void registerOperationHandler(OperationDefinition definition, OperationStepHandler handler, boolean inherited) {
-
-        }
-
-        @Override
-        public void unregisterOperationHandler(String operationName) {
-
-        }
-
-        @Override
-        public void registerReadWriteAttribute(AttributeDefinition definition, OperationStepHandler readHandler, OperationStepHandler writeHandler) {
-
-        }
-
-        public void registerReadOnlyAttribute(String attributeName, OperationStepHandler readHandler, AttributeAccess.Storage storage) {
-
-        }
-
-        @Override
-        public void registerReadOnlyAttribute(AttributeDefinition definition, OperationStepHandler readHandler) {
-
-        }
-
-        @Override
-        public void registerMetric(AttributeDefinition definition, OperationStepHandler metricHandler) {
-
-        }
-
-        @Override
-        public void unregisterAttribute(String attributeName) {
-
-        }
-
-        @Override
-        public void registerNotification(NotificationDefinition notification, boolean inherited) {
-
-        }
-
-        @Override
-        public void registerNotification(NotificationDefinition notification) {
-
-        }
-
-        @Override
-        public void unregisterNotification(String notificationType) {
-
-        }
-
-        @Override
-        public boolean isOrderedChildResource() {
-            return false;
-        }
-
-        @Override
-        public Set<String> getOrderedChildTypes() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public void registerProxyController(PathElement address, ProxyController proxyController) {
-
-        }
-
-        @Override
-        public void unregisterProxyController(PathElement address) {
-
-        }
-
-        @Override
-        public PathAddress getPathAddress() {
-            return PathAddress.EMPTY_ADDRESS;
-        }
-
-        @Override
-        public ImmutableManagementResourceRegistration getParent() {
-            return null;
-        }
-
-        @Override
-        public boolean isRuntimeOnly() {
-            return false;
-        }
-
-        @Override
-        public boolean isRemote() {
-            return false;
-        }
-
-        @Override
-        public Set<RuntimeCapability> getCapabilities() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<RuntimeCapability> getIncorporatingCapabilities() {
-            return null;
-        }
-
-        @Override
-        public Set<CapabilityReferenceRecorder> getRequirements() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public OperationStepHandler getOperationHandler(PathAddress address, String operationName) {
-            return NoopOperationStepHandler.WITHOUT_RESULT;
-        }
-
-        @Override
-        public DescriptionProvider getOperationDescription(PathAddress address, String operationName) {
-            return null;
-        }
-
-        @Override
-        public Set<OperationEntry.Flag> getOperationFlags(PathAddress address, String operationName) {
-            return null;
-        }
-
-        @Override
-        public OperationEntry getOperationEntry(PathAddress address, String operationName) {
-            return null;
-        }
-
-        @Override
-        public Set<String> getAttributeNames(PathAddress address) {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public AttributeAccess getAttributeAccess(PathAddress address, String attributeName) {
-            return null;
-        }
-
-        @Override
-        public Map<String, AttributeAccess> getAttributes(PathAddress address) {
-            return Collections.emptyMap();
-        }
-
-        @Override
-        public Set<String> getChildNames(PathAddress address) {
-            return null;
-        }
-
-        @Override
-        public Set<PathElement> getChildAddresses(PathAddress address) {
-            return null;
-        }
-
-        @Override
-        public DescriptionProvider getModelDescription(PathAddress address) {
-            return null;
-        }
-
-        @Override
-        public Map<String, OperationEntry> getOperationDescriptions(PathAddress address, boolean inherited) {
-            return null;
-        }
-
-        @Override
-        public AliasEntry getAliasEntry() {
-            return null;
-        }
-
-        @Override
-        public Map<String, NotificationEntry> getNotificationDescriptions(PathAddress address, boolean inherited) {
-            return null;
-        }
-
-        @Override
-        public ProxyController getProxyController(PathAddress address) {
-            if (address.getLastElement().getKey().equals(SERVER) && !address.getLastElement().getValue().equals("server-two")) {
-                return new ProxyController() {
-                    @Override
-                    public PathAddress getProxyNodeAddress() {
-                        return null;
-                    }
-
-                    public void execute(ModelNode operation, OperationMessageHandler handler, ProxyOperationControl control, OperationAttachments attachments, BlockingTimeout blockingTimeout) {
-                    }
-                };
-            }
-            return null;
-        }
-
-        @Override
-        public Set<ProxyController> getProxyControllers(PathAddress address) {
-            return null;
-        }
-
-        @Override
-        public void registerAlias(PathElement address, AliasEntry alias) {
-        }
-
-        @Override
-        public void unregisterAlias(PathElement address) {
-        }
-
-        @Override
-        public boolean isAlias() {
-            return false;
-        }
-    };
+    static final ManagementResourceRegistration createManagementResourceRegistration(PathAddress address) {
+        ManagementResourceRegistration registration = mock(ManagementResourceRegistration.class);
+        ProxyController proxyController = mock(ProxyController.class);
+        when(registration.getAccessConstraints()).thenReturn(Collections.emptyList());
+        when(registration.getAttributeNames(any())).thenReturn(Collections.emptySet());
+        when(registration.getAttributes(any())).thenReturn(Collections.emptyMap());
+        when(registration.getCapabilities()).thenReturn(Collections.emptySet());
+        when(registration.getChildAddresses(any())).thenReturn(Collections.emptySet());
+        when(registration.getChildNames(any())).thenReturn(Collections.emptySet());
+        when(registration.getOperationHandler(any(), anyString())).thenReturn(NoopOperationStepHandler.WITHOUT_RESULT);
+        when(registration.getOrderedChildTypes()).thenReturn(Collections.emptySet());
+        when(registration.getPathAddress()).thenReturn(address);
+        when(registration.getProcessType()).thenReturn(ProcessType.HOST_CONTROLLER);
+        when(registration.getProxyController(any())).thenReturn(proxyController);
+        when(registration.getSubModel(any())).thenReturn(registration);
+        return registration;
+    }
 }

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ProfileIncludesHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ProfileIncludesHandlerTestCase.java
@@ -25,6 +25,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -290,6 +293,7 @@ public class ProfileIncludesHandlerTestCase extends AbstractOperationTestCase {
         protected MockOperationContext(final Resource root, final boolean booting, final PathAddress operationAddress, final boolean rollback) {
             super(root, booting, operationAddress);
             this.rollback = rollback;
+            when(this.registration.getCapabilities()).thenReturn(Collections.singleton(ProfileResourceDefinition.PROFILE_CAPABILITY));
         }
 
         public void completeStep(ResultHandler resultHandler) {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReloadRequiredServerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ReloadRequiredServerTestCase.java
@@ -34,8 +34,10 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -46,6 +48,7 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProxyController;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.registry.Resource;
@@ -53,6 +56,7 @@ import org.jboss.as.domain.controller.ServerIdentity;
 import org.jboss.as.domain.controller.operations.coordination.ServerOperationResolver;
 import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
 import org.jboss.as.host.controller.operations.ServerRestartRequiredServerConfigWriteAttributeHandler;
+import org.jboss.as.host.controller.resources.ServerConfigResourceDefinition;
 import org.jboss.as.server.operations.ServerProcessStateHandler;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
@@ -518,6 +522,10 @@ public class ReloadRequiredServerTestCase extends AbstractOperationTestCase {
         private OperationStepHandler nextStep;
         protected MockOperationContext(final Resource root, final boolean booting, final PathAddress operationAddress) {
             super(root, booting, operationAddress);
+            Set<RuntimeCapability> capabilities = new HashSet<>();
+            capabilities.add(ServerConfigResourceDefinition.SERVER_CONFIG_CAPABILITY);
+            capabilities.add(ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY);
+            when(this.registration.getCapabilities()).thenReturn(capabilities);
         }
 
         void executeStep(OperationStepHandler handler, ModelNode operation) throws OperationFailedException {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerConfigOperationsTestCase.java
@@ -34,10 +34,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -62,6 +64,7 @@ import org.jboss.as.host.controller.discovery.DiscoveryOption;
 import org.jboss.as.host.controller.operations.ServerAddHandler;
 import org.jboss.as.host.controller.operations.ServerRemoveHandler;
 import org.jboss.as.host.controller.operations.ServerRestartRequiredServerConfigWriteAttributeHandler;
+import org.jboss.as.host.controller.resources.ServerConfigResourceDefinition;
 import org.jboss.as.process.ProcessInfo;
 import org.jboss.as.process.ProcessMessageHandler;
 import org.jboss.as.protocol.mgmt.ManagementChannelHandler;
@@ -696,6 +699,7 @@ public class ServerGroupAffectedResourceServerConfigOperationsTestCase extends A
         protected MockOperationContext(final Resource root, final boolean booting, final PathAddress operationAddress, final boolean rollback) {
             super(root, booting, operationAddress);
             this.rollback = rollback;
+            when(this.registration.getCapabilities()).thenReturn(Collections.singleton(ServerConfigResourceDefinition.SERVER_CONFIG_CAPABILITY));
         }
 
         void executeStep(OperationStepHandler handler, ModelNode operation) throws OperationFailedException {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ServerGroupAffectedResourceServerGroupOperationsTestCase.java
@@ -31,6 +31,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -360,6 +363,7 @@ public class ServerGroupAffectedResourceServerGroupOperationsTestCase extends Ab
         protected MockOperationContext(final Resource root, final boolean booting, final PathAddress operationAddress, final boolean rollback) {
             super(root, booting, operationAddress);
             this.rollback = rollback;
+            when(this.registration.getCapabilities()).thenReturn(Collections.singleton(ServerGroupResourceDefinition.SERVER_GROUP_CAPABILITY));
         }
 
         void executeStep(OperationStepHandler handler, ModelNode operation) throws OperationFailedException {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SocketBindingGroupIncludesHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/SocketBindingGroupIncludesHandlerTestCase.java
@@ -28,12 +28,17 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import org.jboss.as.controller.ModelOnlyRemoveStepHandler;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.resources.ProfileResourceDefinition;
@@ -299,6 +304,10 @@ public class SocketBindingGroupIncludesHandlerTestCase extends AbstractOperation
         protected MockOperationContext(final Resource root, final boolean booting, final PathAddress operationAddress, final boolean rollback) {
             super(root, booting, operationAddress);
             this.rollback = rollback;
+            Set<RuntimeCapability> capabilities = new HashSet<>();
+            capabilities.add(SocketBindingGroupResourceDefinition.SOCKET_BINDING_GROUP_CAPABILITY);
+            capabilities.add(ProfileResourceDefinition.PROFILE_CAPABILITY);
+            when(this.registration.getCapabilities()).thenReturn(capabilities);
         }
 
         public void completeStep(ResultHandler resultHandler) {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
@@ -82,7 +82,7 @@ class RemoteOutboundConnectionResourceDefinition extends AbstractOutboundConnect
             .build();
 
     public static final SimpleAttributeDefinition AUTHENTICATION_CONTEXT = new SimpleAttributeDefinitionBuilder(CommonAttributes.AUTHENTICATION_CONTEXT, ModelType.STRING, true)
-            .setCapabilityReference(AUTHENTICATION_CONTEXT_CAPABILITY, OUTBOUND_CONNECTION_CAPABILITY_NAME, true)
+            .setCapabilityReference(AUTHENTICATION_CONTEXT_CAPABILITY, OUTBOUND_CONNECTION_CAPABILITY_NAME)
             .setAlternatives(CommonAttributes.USERNAME, CommonAttributes.SECURITY_REALM, CommonAttributes.PROTOCOL)
             .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.AUTHENTICATION_CLIENT_REF)
             .build();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestHostCapableExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestHostCapableExtension.java
@@ -104,7 +104,7 @@ public class TestHostCapableExtension implements Extension {
         private static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder("name", ModelType.STRING, false).build();
         private static final SimpleAttributeDefinition SOCKET_BINDING =
                 new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.SOCKET_BINDING, ModelType.STRING, true)
-                .setCapabilityReference(SOCKET_CAPABILITY_NAME, TEST_CAPABILITY_NAME, true)
+                .setCapabilityReference(SOCKET_CAPABILITY_NAME, TEST_CAPABILITY_NAME)
                 .build();
         private static final OperationDefinition TEST_OP = new SimpleOperationDefinitionBuilder("test-op", new NonResolvingResourceDescriptionResolver()).build();
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestHostCapableExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestHostCapableExtension.java
@@ -134,6 +134,11 @@ public class TestHostCapableExtension implements Extension {
             });
         }
 
+        @Override
+        public void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+            resourceRegistration.registerCapability(TEST_CAPABILITY);
+        }
+
         private static ServiceName createServiceName(PathAddress address) {
             ServiceName name = ServiceName.JBOSS;
             name = name.append("test");
@@ -146,7 +151,7 @@ public class TestHostCapableExtension implements Extension {
         private static class AddSubsystemHandler extends AbstractAddStepHandler {
 
             AddSubsystemHandler() {
-                super(TEST_CAPABILITY, NAME, SOCKET_BINDING);
+                super(NAME, SOCKET_BINDING);
             }
 
             @Override
@@ -166,10 +171,6 @@ public class TestHostCapableExtension implements Extension {
 
 
         private static class RemoveSubsystemHandler extends AbstractRemoveStepHandler {
-
-            RemoveSubsystemHandler(){
-                super(TEST_CAPABILITY);
-            }
 
             @Override
             protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model)


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3751