### PR TITLE
[WFCORE-3500] Upgrade javax.json from 1.0.4 to 1.1.2.

### DIFF
--- a/component-matrix/pom.xml
+++ b/component-matrix/pom.xml
@@ -61,6 +61,7 @@
         <version.commons-lang>2.6</version.commons-lang>
         <version.io.undertow>2.0.4.Final</version.io.undertow>
         <version.javax.inject.javax.inject>1</version.javax.inject.javax.inject>
+        <version.javax.json.javax-json-api>1.1.2</version.javax.json.javax-json-api>
         <version.junit>4.12</version.junit>
         <version.log4j>1.2.17</version.log4j>
         <version.org.aesh>1.1</version.org.aesh>
@@ -77,7 +78,7 @@
         <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.fusesource.jansi>1.16</version.org.fusesource.jansi>
-        <version.org.glassfish.javax.json>1.0.4</version.org.glassfish.javax.json>
+        <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
         <version.org.jboss.byteman>3.0.9</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.2.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.1.Final</version.org.jboss.invocation>
@@ -215,6 +216,11 @@
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>${version.javax.inject.javax.inject}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.json</groupId>
+                <artifactId>javax.json-api</artifactId>
+                <version>${version.javax.json.javax-json-api}</version>
             </dependency>
             <dependency>
                 <groupId>org.aesh</groupId>

--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -44,6 +44,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectodd.vdx</groupId>
             <artifactId>vdx-core</artifactId>
         </dependency>

--- a/core-feature-pack/src/license/core-feature-pack-licenses.xml
+++ b/core-feature-pack/src/license/core-feature-pack-licenses.xml
@@ -35,6 +35,22 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+      <licenses>
+        <license>
+          <name>Common Development and Distribution License 1.1</name>
+          <url>https://javaee.github.io/glassfish/LICENSE</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>GNU General Public License v2.0 only</name>
+          <url>http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>stax2-api</artifactId>
       <licenses>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
@@ -28,15 +28,7 @@
         <property name="jboss.api" value="public"/>
     </properties>
 
-    <dependencies>
-        <module name="org.glassfish.javax.json" export="false">
-            <exports>
-                <include-set>
-                    <path name="javax/json"/>
-                    <path name="javax/json/spi"/>
-                    <path name="javax/json/stream"/>
-                </include-set>
-            </exports>
-        </module>
-    </dependencies>
+    <resources>
+        <artifact name="${javax.json:javax.json-api}"/>
+    </resources>
 </module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
@@ -29,6 +29,7 @@
     </properties>
 
     <dependencies>
+        <module name="javax.json.api" />
     </dependencies>
     <resources>
         <artifact name="${org.glassfish:javax.json}"/>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/javax/json/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/javax/json/main/module.xml
@@ -26,6 +26,9 @@
     </properties>
 
     <resources>
+        <!-- Add both the API and the implementation as we need a separate module for core until WildFly is Java EE
+             compliant -->
+        <artifact name="${javax.json:javax.json-api}"/>
         <artifact name="${org.glassfish:javax.json}"/>
     </resources>
 </module>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -164,8 +164,8 @@
 
         <!-- Required for the json-formatter -->
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
         </dependency>
 
         <!-- Test dependencies -->
@@ -186,6 +186,12 @@
         <dependency>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3500

Java EE 8 requires `javax.json:javax.json-api` upgrade to 1.1. This was already done in WildFly https://github.com/wildfly/wildfly/pull/10872. This just upgrades core to the new version as before we move to full Java EE 8 compatibility this will be required. There should not be backwards compatibility issues and this will allow core to be tested with the newer version.

There is also a possible issue where the wrong version of the temporary `org.wildfly.javax.json` module could be overridden in Galleon from the version in full.