### PR TITLE
[WFCORE-3761] Deprecate unused OperationDefinition methods

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/OperationDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationDefinition.java
@@ -166,7 +166,10 @@ public abstract class OperationDefinition {
      *
      * @param operation model node of type {@link ModelType#OBJECT}, representing an operation request
      * @throws OperationFailedException if the value is not valid
+     *
+     * @deprecated Not used by the WildFly management kernel; will be removed in a future release
      */
+    @Deprecated
     public void validateOperation(final ModelNode operation) throws OperationFailedException {
         if (operation.hasDefined(ModelDescriptionConstants.OPERATION_NAME) && deprecationData != null && deprecationData.isNotificationUseful()) {
             ControllerLogger.DEPRECATED_LOGGER.operationDeprecated(getName(),
@@ -183,7 +186,11 @@ public abstract class OperationDefinition {
      * @param operationObject model node of type {@link ModelType#OBJECT}, typically representing an operation request
      * @param model           model node in which the value should be stored
      * @throws OperationFailedException if the value is not valid
+     *
+     * @deprecated Not used by the WildFly management kernel; will be removed in a future release
      */
+    @SuppressWarnings("deprecation")
+    @Deprecated
     public final void validateAndSet(ModelNode operationObject, final ModelNode model) throws OperationFailedException {
         validateOperation(operationObject);
         for (AttributeDefinition ad : this.parameters) {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3761

Minor. These methods are unused and there's no plan to use them.

I expect we'll at some point deprecate this maven module's OperationDefinition altogether as part of creating a new Extension API module, but this is just being proactive in case we don't or it takes a long time. 