### PR TITLE
[WFCORE-3764] Upgrade WildFly Elytron to 1.3.0.Final

### DIFF
--- a/component-matrix/pom.xml
+++ b/component-matrix/pom.xml
@@ -127,7 +127,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
-        <version.org.wildfly.security.elytron>1.2.4.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.3.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web.undertow-server>1.1.0.Final</version.org.wildfly.security.elytron-web.undertow-server>
         <version.org.wildfly.security.elytron.tool>1.1.4.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION

https://issues.jboss.org/browse/WFCORE-3764


Release Notes - WildFly Elytron - Version 1.3.0.Final

** Enhancement
    * [ELY-1067] - Add support to use default GSSCredential CredentalSource with AuthenticationConfiguration from XML

** Bug
    * [ELY-534] - Some tests fail with ExceptionInInitializerError with JMockit 1.22 for IBM JDK
    * [ELY-1436] - Log jdbc-realm key-mapper processing
    * [ELY-1503] - SPNEGO fails on <distributable/> deployment
    * [ELY-1521] - Coverity, SpnegoContext is Serializable; consider declaring a serialVersionUID
    * [ELY-1550] - Performance issue in audit endpoints
    * [ELY-1552] - Coverity, Reliance on default encoding in DigestAuthenticationMechanism.
    * [ELY-1553] - ElytronXmlParser.parseAuthenticationClientConfiguration() requires additional Permission when runs with Security Manager
    * [ELY-1557] - ElytronXMLParser use == comparison for strings
    * [ELY-1558] - WildFlyElytronProvider is not initialized with appropriate privileges
    * [ELY-1561] - TCCL not set around LoginContext ctor call in GSSCredentialSecurityFactory.Builder#createGSSCredential

** Task
    * [ELY-1515] - Update JAPICMP plug in to compare against 1.2.0.Final
    * [ELY-1518] - Eliminate stream and lambda from SPNEGO authentication mechanism.
    * [ELY-1523] - Update the JAPICMP settings so that we only detect changes that break API compatibility
    * [ELY-1533] - Prevent SNAPSHOT versions of json-smart from being downloaded when building Elytron

** Release
    * [ELY-1566] - Release WildFly Elytron 1.3.0.Final