### PR TITLE
[WFCORE-3765] Explicitly list all dependencies, organizing them by ho…

### DIFF
--- a/embedded/pom.xml
+++ b/embedded/pom.xml
@@ -36,26 +36,149 @@
     <name>WildFly: Embedded</name>
 
     <dependencies>
+        <!--
+             All dependencies must be strictly controlled so it is clear what is needed
+             by the embedding app. This means for nearly all dependencies we exclude all
+             transitive deps, forcing them to be explicitly declared.
+
+             Please keep dependencies organized by how they are used.
+        -->
+
+        <!-- Compile time dependencies that must be available at runtime
+             via the embedding app's classloader -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.modules</groupId>
+            <artifactId>jboss-modules</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.stdio</groupId>
+            <artifactId>jboss-stdio</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Runtime only dependencies that must be on the embedding app's classpath -->
+        <dependency>
+            <groupId>org.jboss</groupId>
+            <artifactId>jboss-dmr</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.threads</groupId>
+            <artifactId>jboss-threads</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Compile time dependencies that at runtime are loaded
+             by the embedded process' modular classloader from its
+             module path. These do not need to be visible to the
+             embedding app's classloader and are thus treated as 'provided' -->
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-controller</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-host-controller</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-elytron</artifactId>
+            <groupId>org.jboss.msc</groupId>
+            <artifactId>jboss-msc</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
         </dependency>
+
+        <!-- Compile time only dependencies not needed at runtime -->
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <optional>true</optional>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
             <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
                   projects that depend on this project.-->
             <scope>provided</scope>
@@ -64,28 +187,45 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
+            <exclusions>
+                <!-- Here we don't blanket exclude because we need jdeparser and it's not part
+                     of the wildfy-core bom, i.e. we need it via a transitive dep -->
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                </exclusion>
+            </exclusions>
             <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
                   projects that depend on this project.-->
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>jboss-logmanager</artifactId>
-            <optional>true</optional>
+            <!-- As far as embedded is concerned, this is compile time only as it's just used
+                 to import a single constant. At runtime the module is used transitively, but not
+                 directly by the code in this maven module. -->
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-process-controller</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.modules</groupId>
-            <artifactId>jboss-modules</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.stdio</groupId>
-            <artifactId>jboss-stdio</artifactId>
-        </dependency>
+
+        <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <!-- Here we don't blanket exclude because we need are ok with transitive test deps -->
             <scope>test</scope>
         </dependency>
+
     </dependencies>
 </project>

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedStandaloneServerFactory.java
@@ -53,7 +53,6 @@ import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.value.Value;
 import org.jboss.stdio.StdioContext;
-import org.wildfly.common.Assert;
 import org.wildfly.core.embedded.logging.EmbeddedLogger;
 
 /**
@@ -87,11 +86,16 @@ public class EmbeddedStandaloneServerFactory {
     }
 
     public static StandaloneServer create(final File jbossHomeDir, final ModuleLoader moduleLoader, final Properties systemProps, final Map<String, String> systemEnv, final String[] cmdargs) {
-        Assert.checkNotNullParam("jbossHomeDir", jbossHomeDir);
-        Assert.checkNotNullParam("moduleLoader", moduleLoader);
-        Assert.checkNotNullParam("systemProps", systemProps);
-        Assert.checkNotNullParam("systemEnv", systemEnv);
-        Assert.checkNotNullParam("cmdargs", cmdargs);
+        if (jbossHomeDir == null)
+            throw EmbeddedLogger.ROOT_LOGGER.nullVar("jbossHomeDir");
+        if (moduleLoader == null)
+            throw EmbeddedLogger.ROOT_LOGGER.nullVar("moduleLoader");
+        if (systemProps == null)
+            throw EmbeddedLogger.ROOT_LOGGER.nullVar("systemProps");
+        if (systemEnv == null)
+            throw EmbeddedLogger.ROOT_LOGGER.nullVar("systemEnv");
+        if (cmdargs == null)
+            throw EmbeddedLogger.ROOT_LOGGER.nullVar("cmdargs");
 
         setupCleanDirectories(jbossHomeDir.toPath(), systemProps);
 

--- a/embedded/src/main/java/org/wildfly/core/embedded/SecurityActions.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/SecurityActions.java
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.wildfly.core.embedded;
+
+import static java.lang.System.getProperty;
+import static java.lang.System.getSecurityManager;
+import static java.lang.System.setProperty;
+import static java.security.AccessController.doPrivileged;
+
+import java.security.PrivilegedAction;
+
+/**
+ * Privileged actions used by more than one class in this module.
+ *
+ * @author Brian Stansberry
+ */
+final class SecurityActions {
+
+    static String getPropertyPrivileged(final String name, final String def) {
+        final SecurityManager sm = getSecurityManager();
+        if (sm == null) {
+            return getProperty(name, def);
+        }
+        return doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                return getProperty(name, def);
+            }
+        });
+    }
+
+    static void setPropertyPrivileged(final String name, final String value) {
+        final SecurityManager sm = getSecurityManager();
+        if (sm == null) {
+            setProperty(name, value);
+        } else {
+            doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    setProperty(name, value);
+                    return null;
+                }
+            });
+        }
+    }
+}

--- a/embedded/src/main/java/org/wildfly/core/embedded/logging/EmbeddedLogger.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/logging/EmbeddedLogger.java
@@ -150,7 +150,11 @@ public interface EmbeddedLogger extends BasicLogger {
     @Message(id = 14, value = "Cannot load module %s from: %s")
     RuntimeException moduleLoaderError(@Cause Throwable cause, String msg, ModuleLoader moduleLoader);
 
-    // id = 15; redundant parameter null check message
+    /**
+     * Creates an exception indicating the variable, represented by the {@code name} parameter, is {@code null}.
+     */
+    @Message(id = 15, value = "%s is null")
+    IllegalArgumentException nullVar(String name);
 
     /**
 //     * Creates an exception indicating the system property could not be found.


### PR DESCRIPTION
…w they are used. Use 'provided' scope for dependencies that are not required to be visible to the embedding app's classloader at runtime.

Also, drop use of WildFlySecurityManager to avoid the requirement for elytron on the embedding app's classpath.

Also, drop use of wildfly-common Assert, even though it's only required on the modular classloader side, just to cut the pom footprint and help avoid it leaking to the embedded app side.

https://issues.jboss.org/browse/WFCORE-3765

This will conflict with #3202. I planned to wait on this and fix conflicts when #3202 is merged. But if there are going to be delays on #3202, which is a Feature, then this can go first.