### PR TITLE
[WFCORE-3762] Actually create the response warning; the previous fix …

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
+++ b/controller/src/test/java/org/jboss/as/controller/TestModelControllerService.java
@@ -109,8 +109,11 @@ public abstract class TestModelControllerService extends AbstractControllerServi
         return capabilityRegistry;
     }
 
-    protected static OperationDefinition getOD(String name) {
-        return new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver())
-                .build();
+    static OperationDefinition getOD(String name) {
+        return getODBuilder(name).build();
+    }
+
+    static SimpleOperationDefinitionBuilder getODBuilder(String name) {
+        return new SimpleOperationDefinitionBuilder(name, new NonResolvingResourceDescriptionResolver());
     }
 }


### PR DESCRIPTION
…would never actually do that.

Make the level WARNING not INFO as by default INFO is not sent to the user, making this pointless.

Also, avoid repeated response warnings from different steps for the same end user op.

Second shot at https://issues.jboss.org/browse/WFCORE-3762