### PR TITLE
[WFCORE-3784] Add missing subsystems to WildFly Core domain.xml profile

### DIFF
--- a/core-feature-pack/src/main/resources/configuration/domain/subsystems.xml
+++ b/core-feature-pack/src/main/resources/configuration/domain/subsystems.xml
@@ -4,8 +4,10 @@
    <subsystems name="default">
       <subsystem>logging.xml</subsystem>
       <subsystem>core-management.xml</subsystem>
+      <subsystem>discovery.xml</subsystem>
       <subsystem supplement="domain">elytron.xml</subsystem>
       <subsystem>jmx.xml</subsystem>
       <subsystem>request-controller.xml</subsystem>
+      <subsystem>security-manager.xml</subsystem>
    </subsystems>
 </config>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3784