### PR TITLE
[WFCORE-3785 + WFCORE-3800] Allow capability builders to declare additional galleon…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/capability/Capability.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/Capability.java
@@ -110,7 +110,7 @@ public interface Capability {
     boolean isDynamicallyNamed();
 
     /**
-     * Gets the full name of a capbility, including a dynamic element
+     * Gets the full name of a capability, including a dynamic element
      * @param dynamicNameElement the dynamic portion of the name. Cannot be {@code null}
      * @return the full capability name
      *
@@ -119,4 +119,39 @@ public interface Capability {
     String getDynamicName(String dynamicNameElement);
 
     String getDynamicName(PathAddress address);
+
+    /**
+     * Gets the names of any "additional" Galleon packages that must be installed in order
+     * for this capability to function. The purpose of providing this information is to
+     * make it available to the Galleon tooling that produces Galleon feature-specs,
+     * in order to allow the tooling to include the package information in the relevant
+     * spec.
+     * <p>
+     * A package is "additional" if it is not one of the "standard" packages that must be
+     * installed. The names of "standard" packages should not be returned. The "standard"
+     * packages are:
+     *
+     *  <ol>
+     *      <li>
+     *          The root package for the process type; i.e. the package that provides
+     *          the main module whose name is passed to JBoss Modules when the process
+     *          is launched.
+     *      </li>
+     *      <li>
+     *          If this capability is provided by an {@code Extension}, the package
+     *          that installs the module that provides the extension.
+     *      </li>
+     *      <li>
+     *          Any package that is listed as an additional required package by capability
+     *          upon which this capability has a {@link #getRequirements() requirement}.
+     *      </li>
+     *      <li>
+     *          Any package that is non-optionally required, either directly or transitively,
+     *          by one of the other types of standard packages.
+     *      </li>
+     *  </ol>
+     *
+     * @return the additional package names. Will not return {@code null} but may be empty
+     */
+    Set<String> getAdditionalRequiredPackages();
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadFeatureDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadFeatureDescriptionHandler.java
@@ -388,7 +388,7 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
                 featureParamMappings = Collections.emptyMap();
             }
         }
-        Set<String> capabilities = new HashSet<>();
+        Set<String> capabilities = new TreeSet<>();
         Set<String> additionalPackages = new TreeSet<>();
         for (RuntimeCapability<?> cap : registration.getCapabilities()) {
             String capabilityName = cap.getName();
@@ -400,8 +400,13 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
                 capabilityName = PROFILE_PREFIX + capabilityName;
             }
             capabilities.add(capabilityName);
-            feature.get(PROVIDES).add(capabilityName);
             additionalPackages.addAll(cap.getAdditionalRequiredPackages());
+        }
+        if (!capabilities.isEmpty()) {
+            ModelNode provide = feature.get(PROVIDES);
+            for (String cap : capabilities) {
+                provide.add(cap);
+            }
         }
         processComplexAttributes(feature, registration);
         addReferences(feature, registration);

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadFeatureDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadFeatureDescriptionHandler.java
@@ -75,6 +75,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
+import java.util.TreeSet;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.CapabilityReferenceRecorder;
@@ -210,7 +211,7 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
                 extensionParam.get(ModelDescriptionConstants.NAME).set(EXTENSION);
                 extensionParam.get(DEFAULT).set(extension);
                 feature.get(FEATURE).get(PARAMS).add(extensionParam);
-                ModelNode packages = feature.get(FEATURE).get(PACKAGES).setEmptyList();
+                ModelNode packages = feature.get(FEATURE).get(PACKAGES);
                 ModelNode packageNode = new ModelNode();
                 packageNode.get(PACKAGE).set(extension);
                 packages.add(packageNode);
@@ -388,6 +389,7 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
             }
         }
         Set<String> capabilities = new HashSet<>();
+        Set<String> additionalPackages = new TreeSet<>();
         for (RuntimeCapability<?> cap : registration.getCapabilities()) {
             String capabilityName = cap.getName();
             if (cap.isDynamicallyNamed()) {
@@ -399,11 +401,20 @@ public class ReadFeatureDescriptionHandler extends GlobalOperationHandlers.Abstr
             }
             capabilities.add(capabilityName);
             feature.get(PROVIDES).add(capabilityName);
+            additionalPackages.addAll(cap.getAdditionalRequiredPackages());
         }
         processComplexAttributes(feature, registration);
         addReferences(feature, registration);
         addRequiredCapabilities(feature, registration, requestProperties, capabilityScope, isProfile, capabilities,
                 featureParamMappings);
+        if (additionalPackages.size() > 0) {
+            ModelNode packages = feature.get(PACKAGES);
+            for (String pkg : additionalPackages) {
+                ModelNode pkgNode = new ModelNode();
+                pkgNode.get(PACKAGE).set(pkg);
+                packages.add(pkgNode);
+            }
+        }
         return result;
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadFeatureDescriptionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadFeatureDescriptionTestCase.java
@@ -86,6 +86,7 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
     private static final String NON_FEATURE_RESOURCE = "non-feature-resource";
     private static final String TEST = "test";
     private static final String MAIN_RESOURCE_CAPABILITY_NAME = "main-resource-capability";
+    private static final String MAIN_RESOURCE_PACKAGE_NAME = "main-resource-package";
     private static final String ROOT_CAPABILITY_NAME = "root-capability";
 
     private static final OperationStepHandler WRITE_HANDLER = new ModelOnlyWriteAttributeHandler();
@@ -235,6 +236,11 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
         // requires `root-capability` because `optional-attr` references it
         Assert.assertEquals(ROOT_CAPABILITY_NAME, requires.asList().get(0).require(NAME).asString());
         Assert.assertTrue(requires.asList().get(0).require(OPTIONAL).asBoolean());
+
+        // packages
+        ModelNode packages = feature.require(PACKAGES);
+        Assert.assertEquals(1, packages.asList().size());
+        Assert.assertEquals(MAIN_RESOURCE_PACKAGE_NAME, packages.asList().get(0).get(PACKAGE).asString());
     }
 
     /**
@@ -542,7 +548,9 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
     private static class MainResourceDefinition extends SimpleResourceDefinition {
 
         private static final RuntimeCapability MAIN_RESOURCE_CAPABILITY =
-                RuntimeCapability.Builder.of(MAIN_RESOURCE_CAPABILITY_NAME, true).build();
+                RuntimeCapability.Builder.of(MAIN_RESOURCE_CAPABILITY_NAME, true)
+                        .addAdditionalRequiredPackages(MAIN_RESOURCE_PACKAGE_NAME)
+                        .build();
 
         private static final AttributeDefinition OPTIONAL_ATTRIBUTE =
                 new SimpleAttributeDefinitionBuilder("optional-attr", ModelType.INT, true)

--- a/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
@@ -73,7 +73,9 @@ import org.xnio.XnioWorker;
 public class UndertowHttpManagementService implements Service<HttpManagement> {
 
     public static final RuntimeCapability<Void> EXTENSIBLE_HTTP_MANAGEMENT_CAPABILITY =
-            RuntimeCapability.Builder.of("org.wildfly.management.http.extensible", ExtensibleHttpManagement.class).build();
+            RuntimeCapability.Builder.of("org.wildfly.management.http.extensible", ExtensibleHttpManagement.class)
+                    .addAdditionalRequiredPackages("org.jboss.as.domain-http-error-content")
+                    .build();
     public static final ServiceName SERVICE_NAME = EXTENSIBLE_HTTP_MANAGEMENT_CAPABILITY.getCapabilityServiceName();
 
     public static final String SERVER_NAME = "wildfly-managment";


### PR DESCRIPTION
… packages required by the cap; expose this data via read-feature-description

https://issues.jboss.org/browse/WFCORE-3785

@aloubyansky @ehsavoie Is this useful?

```
[standalone@embedded /] /core-service=management/management-interface=http-interface:read-feature-description
{
    "outcome" => "success",
    "result" => {"feature" => {
        "name" => "core-service.management.management-interface.http-interface",
        "annotation" => {
            . . .
        },
        "params" => [
            . . .
        ],
        "provides" => [
            . . .
        ],
        "children" => {
            . . .
        },
        "refs" => [{"feature" => "core-service.management"}],
        "requires" => [
            . . .
        ],
        "packages" => ["org.jboss.as.domain-http-error-content"]
    }}
}
```