### PR TITLE
[WFCORE-3776] Deprecate attribute 'show-model' in jmx subsystem

### DIFF
--- a/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemRootResource.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JMXSubsystemRootResource.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 import javax.management.MBeanServer;
 
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationContext.Stage;
 import org.jboss.as.controller.OperationFailedException;
@@ -65,6 +66,7 @@ public class JMXSubsystemRootResource extends SimpleResourceDefinition {
 
     private static final SimpleAttributeDefinition SHOW_MODEL_ALIAS = SimpleAttributeDefinitionBuilder.create(CommonAttributes.SHOW_MODEL, ModelType.BOOLEAN, true)
             .addFlag(AttributeAccess.Flag.ALIAS)
+            .setDeprecated(ModelVersion.create(7,0,0))
             .build();
 
     public static final SimpleAttributeDefinition CORE_MBEAN_SENSITIVITY = new SimpleAttributeDefinitionBuilder(CommonAttributes.NON_CORE_MBEAN_SENSITIVITY, ModelType.BOOLEAN, true)

--- a/jmx/src/main/resources/org/jboss/as/jmx/LocalDescriptions.properties
+++ b/jmx/src/main/resources/org/jboss/as/jmx/LocalDescriptions.properties
@@ -2,6 +2,7 @@ jmx=The configuration of the JMX subsystem.
 jmx.add=Adds the JMX subsystem.
 jmx.remove=Removes the JMX subsystem.
 jmx.show-model=Alias for the existence of the 'resolved' model controller jmx facade. When writing, if set to 'true' it will add the 'resolved' model controller jmx facade resource with the default domain name.
+jmx.show-model.deprecated=The show-model configuration is deprecated and may be removed or moved in future versions.
 jmx.non-core-mbean-sensitivity=Whether or not core MBeans, i.e. mbeans not coming from the model controller, should be considered sensitive.
 jmx.expose-model=Expose the model controller in the MBeanServer. The recommended is the 'expression' child.
 jmx.connector=Connectors for the JMX subsystem.


### PR DESCRIPTION
This is the first step in order to remove the `show-model` attribute from jmx subsystem.

Jira issue: https://issues.jboss.org/browse/WFCORE-3776

CC @kabir 