### PR TITLE
[WFCORE-3765] Remove org.jboss.msc from the modular system class path

### DIFF
--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedProcessFactory.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedProcessFactory.java
@@ -298,7 +298,7 @@ public class EmbeddedProcessFactory {
             clearPropertyPrivileged(SYSPROP_KEY_CLASS_PATH);
             SecurityActions.setPropertyPrivileged(SYSPROP_KEY_MODULE_PATH, modulePath);
 
-            StringBuilder packages = new StringBuilder("org.jboss.modules,org.jboss.msc,org.jboss.dmr,org.jboss.threads,org.jboss.as.controller.client");
+            StringBuilder packages = new StringBuilder("org.jboss.modules,org.jboss.dmr,org.jboss.threads,org.jboss.as.controller.client");
             if (systemPackages != null) {
                 for (String packageName : systemPackages) {
                     packages.append(",");


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3765

Follows up on #3229 to declare remove `org.jboss.msc` from the modular system class path. 