### PR TITLE
Fix for WFCORE-3789, CLI, powershell option handling

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
@@ -10,10 +10,10 @@ $scripts = (Get-ChildItem $MyInvocation.MyCommand.Path).Directory.FullName;
 $SERVER_OPTS = Process-Script-Parameters -Params $ARGS
 
 # Override ibm JRE behavior
-$SERVER_OPTS += "-Dcom.ibm.jsse2.overrideDefaultTLS=true"
+$IBM_TLS_OPT = "-Dcom.ibm.jsse2.overrideDefaultTLS=true"
 
 $PROG_ARGS = Get-Java-Arguments -entryModule "org.jboss.as.cli" -serverOpts $SERVER_OPTS -logFileProperties "$JBOSS_HOME/bin/jboss-cli-logging.properties"
 
-& $JAVA $PROG_ARGS
+& $JAVA $IBM_TLS_OPT $PROG_ARGS
 
 Env-Clean-Up


### PR DESCRIPTION
Introduce a new variable to contain IBM specific option. Manual testing on windows platform.