### PR TITLE
[WFCORE-3798] Upgrade WildFly Elytron to 1.3.1.Final

### DIFF
--- a/component-matrix/pom.xml
+++ b/component-matrix/pom.xml
@@ -127,7 +127,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
-        <version.org.wildfly.security.elytron>1.3.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.3.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web.undertow-server>1.1.0.Final</version.org.wildfly.security.elytron-web.undertow-server>
         <version.org.wildfly.security.elytron.tool>1.1.4.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3798

Release Notes - WildFly Elytron - Version 1.3.1.Final

** Bug
    * [ELY-1480] - Coverity, Explicit null dereferenced in FileSystemSecurityRealm
    * [ELY-1536] - DigestSaslClient parse but ignore "stale" param
    * [ELY-1547] - SPNEGO: missing negstat field in the first reply for expired token
    * [ELY-1549] - IBM JDK, SPNEGO + FORM; with invalid ticket 401 status code is returned
    * [ELY-1564] - In PasswordKeyMapper an exception is logged with a wrong algorithm name.
** Task
    * [ELY-1532] - Deprecate AuthConf setHost, setProtocol, setPort properties
** Release
    * [ELY-1575] - Release WildFly Elytron 1.3.1.Final