### PR TITLE
Fix for WFCORE-3732, aesh 1.4 upgrade, terminal in raw mode by default

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/ReadlineConsole.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ReadlineConsole.java
@@ -445,6 +445,17 @@ public class ReadlineConsole {
             Attributes attr = connection.getAttributes();
             attr.setLocalFlag(Attributes.LocalFlag.ECHOCTL, false);
             connection.setAttributes(attr);
+            /**
+             * On some terminal (Mac terminal), when the terminal switches to
+             * the original mode (the mode in place prior readline is called
+             * with echo ON) when executing a command, then, if there are still
+             * some characters to read in the buffer (eg: large copy/paste of
+             * commands) these characters are displayed by the terminal. It has
+             * been observed on some platforms (eg: Mac OS). By entering the raw
+             * mode we are not impacted by this behavior. That is tracked by
+             * AESH-463.
+             */
+            connection.enterRawMode();
         }
     }
 

--- a/component-matrix/pom.xml
+++ b/component-matrix/pom.xml
@@ -64,9 +64,9 @@
         <version.javax.json.javax-json-api>1.1.2</version.javax.json.javax-json-api>
         <version.junit>4.12</version.junit>
         <version.log4j>1.2.17</version.log4j>
-        <version.org.aesh>1.1</version.org.aesh>
-        <version.org.aesh-extensions>1.1</version.org.aesh-extensions>
-        <version.org.aesh-readline>1.6</version.org.aesh-readline>
+        <version.org.aesh>1.4</version.org.aesh>
+        <version.org.aesh-extensions>1.3</version.org.aesh-extensions>
+        <version.org.aesh-readline>1.7</version.org.aesh-readline>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
         <!-- TODO Elytron - Bump to M17 -->
         <version.org.apache.httpcomponents.httpclient>4.5.2</version.org.apache.httpcomponents.httpclient>


### PR DESCRIPTION
Upgrade aesh dependencies:
aesh 1.4,
aesh-extensions 1.3
aesh-realine 1.7
Workaround AESH-463 by entering in raw mode during the whole CLI process life time.