### PR TITLE
[WFCORE-323] Allow multistep op handling to defer resolution of the O…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -22,6 +22,7 @@
 package org.jboss.as.controller.operations.global;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_CONTROL;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
@@ -36,6 +37,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
@@ -43,6 +45,7 @@ import static org.jboss.as.controller.operations.global.GlobalOperationAttribute
 import static org.jboss.as.controller.operations.global.GlobalOperationAttributes.RECURSIVE_DEPTH;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -86,19 +89,42 @@ import org.jboss.dmr.ModelType;
  */
 public class GlobalOperationHandlers {
 
+    public static final Set<String> STD_WRITE_OPS = Collections.unmodifiableSet(new HashSet<>(
+            Arrays.asList(
+                    ADD,
+                    REMOVE,
+                    WriteAttributeHandler.DEFINITION.getName(),
+                    UndefineAttributeHandler.DEFINITION.getName(),
+                    MapOperations.MAP_PUT_DEFINITION.getName(),
+                    MapOperations.MAP_CLEAR_DEFINITION.getName(),
+                    MapOperations.MAP_REMOVE_DEFINITION.getName(),
+                    ListOperations.LIST_ADD_DEFINITION.getName(),
+                    ListOperations.LIST_CLEAR_DEFINITION.getName(),
+                    ListOperations.LIST_REMOVE_DEFINITION.getName())));
+
+    public static final Set<String> STD_READ_OPS = Collections.unmodifiableSet(new HashSet<>(
+            Arrays.asList(
+                    ReadResourceHandler.DEFINITION.getName(),
+                    ReadAttributeHandler.DEFINITION.getName(),
+                    ReadAttributeGroupHandler.DEFINITION.getName(),
+                    ReadResourceDescriptionHandler.DEFINITION.getName(),
+                    ReadAttributeGroupNamesHandler.DEFINITION.getName(),
+                    ReadChildrenNamesHandler.DEFINITION.getName(),
+                    ReadChildrenTypesHandler.DEFINITION.getName(),
+                    ReadChildrenResourcesHandler.DEFINITION.getName(),
+                    ReadOperationNamesHandler.DEFINITION.getName(),
+                    QueryOperationHandler.DEFINITION.getName(),
+                    MapOperations.MAP_GET_DEFINITION.getName(),
+                    ListOperations.LIST_GET_DEFINITION.getName())));
 
     public static void registerGlobalOperations(ManagementResourceRegistration root, ProcessType processType) {
         if( processType.isHostController()) {
-            root.registerOperationHandler(org.jboss.as.controller.operations.global.ReadResourceHandler.DEFINITION,
-                    org.jboss.as.controller.operations.global.ReadResourceHandler.INSTANCE, true);
-            root.registerOperationHandler(org.jboss.as.controller.operations.global.ReadAttributeHandler.DEFINITION,
-                    org.jboss.as.controller.operations.global.ReadAttributeHandler.INSTANCE, true);
+            root.registerOperationHandler(ReadResourceHandler.DEFINITION, ReadResourceHandler.INSTANCE, true);
+            root.registerOperationHandler(ReadAttributeHandler.DEFINITION, ReadAttributeHandler.INSTANCE, true);
             root.registerOperationHandler(ReadAttributeGroupHandler.DEFINITION, ReadAttributeGroupHandler.INSTANCE, true);
         }else{
-            root.registerOperationHandler(org.jboss.as.controller.operations.global.ReadResourceHandler.RESOLVE_DEFINITION,
-                    org.jboss.as.controller.operations.global.ReadResourceHandler.RESOLVE_INSTANCE, true);
-            root.registerOperationHandler(org.jboss.as.controller.operations.global.ReadAttributeHandler.RESOLVE_DEFINITION,
-                    org.jboss.as.controller.operations.global.ReadAttributeHandler.RESOLVE_INSTANCE, true);
+            root.registerOperationHandler(ReadResourceHandler.RESOLVE_DEFINITION, ReadResourceHandler.RESOLVE_INSTANCE, true);
+            root.registerOperationHandler(ReadAttributeHandler.RESOLVE_DEFINITION, ReadAttributeHandler.RESOLVE_INSTANCE, true);
             root.registerOperationHandler(ReadAttributeGroupHandler.RESOLVE_DEFINITION, ReadAttributeGroupHandler.RESOLVE_INSTANCE, true);
         }
 
@@ -137,10 +163,8 @@ public class GlobalOperationHandlers {
             }
         }, true);
 
-        root.registerOperationHandler(org.jboss.as.controller.operations.global.WriteAttributeHandler.DEFINITION,
-                org.jboss.as.controller.operations.global.WriteAttributeHandler.INSTANCE, true);
-        root.registerOperationHandler(org.jboss.as.controller.operations.global.UndefineAttributeHandler.DEFINITION,
-                org.jboss.as.controller.operations.global.UndefineAttributeHandler.INSTANCE, true);
+        root.registerOperationHandler(WriteAttributeHandler.DEFINITION, WriteAttributeHandler.INSTANCE, true);
+        root.registerOperationHandler(UndefineAttributeHandler.DEFINITION, UndefineAttributeHandler.INSTANCE, true);
     }
 
     public static final String CHECK_DEFAULT_RESOURCE_ACCESS = "check-default-resource-access";

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationRouting.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/OperationRouting.java
@@ -29,6 +29,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.operations.global.GlobalOperationHandlers.STD_READ_OPS;
+import static org.jboss.as.controller.operations.global.GlobalOperationHandlers.STD_WRITE_OPS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -43,6 +46,7 @@ import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.domain.controller.logging.DomainControllerLogger;
+import org.jboss.as.host.controller.logging.HostControllerLogger;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -55,19 +59,22 @@ class OperationRouting {
     static OperationRouting determineRouting(OperationContext context, ModelNode operation,
                                              final LocalHostControllerInfo localHostControllerInfo, Set<String> hostNames) throws OperationFailedException {
         final ImmutableManagementResourceRegistration rootRegistration = context.getRootResourceRegistration();
-        return determineRouting(operation, localHostControllerInfo, rootRegistration, hostNames);
+        return determineRouting(operation, localHostControllerInfo, rootRegistration, hostNames, false);
     }
 
     private static OperationRouting determineRouting(final ModelNode operation, final LocalHostControllerInfo localHostControllerInfo,
-                                                     final ImmutableManagementResourceRegistration rootRegistration, Set<String> hostNames) throws OperationFailedException {
+                                                     final ImmutableManagementResourceRegistration rootRegistration,
+                                                     final Set<String> hostNames, final boolean compositeStep) throws OperationFailedException {
+        HostControllerLogger.ROOT_LOGGER.tracef("Determining routing for %s", operation);
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
         final String operationName = operation.require(OP).asString();
-        final Set<OperationEntry.Flag> operationFlags = resolveOperationFlags(address, operationName, rootRegistration);
+        final Set<OperationEntry.Flag> operationFlags = resolveOperationFlags(address, operationName, rootRegistration, compositeStep);
         return determineRouting(operation, address, operationName, operationFlags, localHostControllerInfo, rootRegistration, hostNames);
     }
 
     private static Set<OperationEntry.Flag> resolveOperationFlags(final PathAddress address, final String operationName,
-                                                         final ImmutableManagementResourceRegistration rootRegistration) throws OperationFailedException {
+                                                                  final ImmutableManagementResourceRegistration rootRegistration,
+                                                                  final boolean compositeStep) throws OperationFailedException {
         Set<OperationEntry.Flag> result = null;
         boolean validAddress = false;
 
@@ -81,6 +88,25 @@ class OperationRouting {
             validAddress = true;
             OperationEntry opE = targetReg.getOperationEntry(PathAddress.EMPTY_ADDRESS, operationName);
             result = opE == null ? null : opE.getFlags();
+        } else if (compositeStep) {
+            // WFCORE-323. This could be a subsystem step in a composite where an earlier step adds
+            // the extension. So the registration of the subsystem would not be done yet.
+            // See if we can figure out flags usable for routing.
+            PathAddress subsystemRoot = findSubsystemRootAddress(address);
+            if (subsystemRoot != null // else this isn't for a subsystem
+                    // Only bother if the subsystem root is not registered.
+                    // If the root is registered then the was already added
+                    && (address.equals(subsystemRoot) || rootRegistration.getSubModel(subsystemRoot) == null)) {
+
+                if (STD_READ_OPS.contains(operationName)) {
+                    // One of the global read ops
+                    result = Collections.singleton(OperationEntry.Flag.READ_ONLY);
+                } else if (STD_WRITE_OPS.contains(operationName)) {
+                    // One of the global write ops, or 'add' or 'remove'.
+                    // Not read only and not allowed t
+                    result = Collections.emptySet();
+                } // else we don't know what this op does so we can't provide a routing.
+            }
         }
 
         if (result == null) {
@@ -94,6 +120,23 @@ class OperationRouting {
             }
         }
 
+        return result;
+    }
+
+    private static PathAddress findSubsystemRootAddress(PathAddress address) {
+        PathAddress result = null;
+        int size = address.size();
+        if (size > 1) {
+            int subsystemKey = Integer.MAX_VALUE;
+            String firstKey = address.getElement(0).getKey();
+            if (HOST.equals(firstKey) || PROFILE.equals(firstKey)) {
+                subsystemKey = 1;
+            }
+            if (size > subsystemKey
+                    && SUBSYSTEM.equals(address.getElement(subsystemKey).getKey())) {
+                result = subsystemKey == size - 1 ? address : address.subAddress(0, subsystemKey + 1);
+            }
+        }
         return result;
     }
 
@@ -116,8 +159,7 @@ class OperationRouting {
             if (HOST.equals(first.getKey())) {
                 if (first.isMultiTarget()) {
                     if (first.isWildcard()) {
-                        targetHost = new HashSet<>();
-                        targetHost.addAll(hostNames);
+                        targetHost = new HashSet<>(hostNames);
                         targetHost.add(localHostControllerInfo.getLocalHostName());
                     } else {
                         targetHost = new HashSet<>();
@@ -147,6 +189,9 @@ class OperationRouting {
                     // even if the request is for a write op. A write-op to a server
                     // is illegal anyway, so there is no reason to handle it two-phase
                     routing =  new OperationRouting(targetHost, false);
+                } else if (!ServerOperationResolver.isHostChildAddressMultiphase(address)) {
+                    // Address does not result in changes to child processes
+                    routing =  new OperationRouting(targetHost, false);
                 }
             }
             if (routing == null) {
@@ -167,7 +212,7 @@ class OperationRouting {
                 boolean fwdToAllHosts = false;
                 boolean twoStep = false;
                 for (ModelNode step : operation.get(STEPS).asList()) {
-                    OperationRouting stepRouting = determineRouting(step, localHostControllerInfo, rootRegistration, hostNames);
+                    OperationRouting stepRouting = determineRouting(step, localHostControllerInfo, rootRegistration, hostNames, true);
                     if (stepRouting.isMultiphase()) {
                         twoStep = true;
                         // Make sure we don't loose the information that we have to execute the operation on all hosts

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationResolver.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationResolver.java
@@ -113,6 +113,25 @@ public class ServerOperationResolver {
     private static final AttachmentKey<ModelNode> DOMAIN_MODEL_ATTACHMENT = AttachmentKey.create(ModelNode.class);
     private static final AttachmentKey<ModelNode> ORIGINAL_DOMAIN_MODEL_ATTACHMENT = AttachmentKey.create(ModelNode.class);
 
+    /**
+     * Gets whether the given address requires multiphase handling
+     * @param address an address, which most be 2 or more elements long with 'host' as the key of the first element
+     * @return {@code true} if the address requires multiphase handling; {@code} false if it can be handled
+     *         directly on the target host
+     */
+    static boolean isHostChildAddressMultiphase(PathAddress address) {
+        assert address.size() > 1 : "address size must be greater than 1";
+        assert ModelDescriptionConstants.HOST.equals(address.getElement(0).getKey()) : "Only host addresses allowed";
+        switch (address.getElement(1).getKey()) {
+            case ModelDescriptionConstants.EXTENSION:
+            case ModelDescriptionConstants.SUBSYSTEM:
+            case ModelDescriptionConstants.SERVER:
+            case SOCKET_BINDING_GROUP:
+                return false;
+            default:
+                return true;
+        }
+    }
     private enum DomainKey {
 
         UNKNOWN(null),

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/ServerOperationsResolverHandler.java
@@ -162,7 +162,8 @@ public class ServerOperationsResolverHandler implements OperationStepHandler {
         final PathAddress relativeAddress = domainOpAddress.subAddress(originalAddress.size());
         if(! pushToServers) {
             Set<OperationEntry.Flag> flags = originalRegistration.getOperationFlags(relativeAddress, domainOp.require(OP).asString());
-            if (flags.contains(OperationEntry.Flag.READ_ONLY)
+            if (flags != null
+                    && flags.contains(OperationEntry.Flag.READ_ONLY)
                     && !flags.contains(OperationEntry.Flag.DOMAIN_PUSH_TO_SERVERS)
                     && !flags.contains(OperationEntry.Flag.RUNTIME_ONLY)) {
                 result = Collections.emptyMap();

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/optypes/OpTypesExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/optypes/OpTypesExtension.java
@@ -138,7 +138,7 @@ public class OpTypesExtension implements Extension {
         public void registerOperations(ManagementResourceRegistration resourceRegistration) {
             super.registerOperations(resourceRegistration);
 
-            resourceRegistration.registerOperationHandler(PUBLIC, NoopOperationStepHandler.WITH_RESULT);
+            resourceRegistration.registerOperationHandler(PUBLIC, ((context, operation) -> context.getResult().set(true)));
             resourceRegistration.registerOperationHandler(HIDDEN, NoopOperationStepHandler.WITH_RESULT);
             resourceRegistration.registerOperationHandler(PRIVATE, NoopOperationStepHandler.WITH_RESULT);
             resourceRegistration.registerOperationHandler(RUNTIME_ONLY, RuntimeOnlyHandler.INSTANCE);

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/ExtensionSubsystemCompositeTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/ExtensionSubsystemCompositeTestCase.java
@@ -1,0 +1,170 @@
+/*
+Copyright 2019 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.wildfly.core.test.standalone.mgmt;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+import org.jboss.as.test.integration.management.extension.ExtensionUtils;
+import org.jboss.as.test.integration.management.extension.optypes.OpTypesExtension;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests adding and removing extensions and subsystems in a composite op.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(WildflyTestRunner.class)
+public class ExtensionSubsystemCompositeTestCase {
+
+    private static final PathAddress EXT = PathAddress.pathAddress("extension", OpTypesExtension.EXTENSION_NAME);
+    private static final PathAddress SUBSYSTEM = PathAddress.pathAddress("subsystem", OpTypesExtension.SUBSYSTEM_NAME);
+
+    @Inject
+    private static ManagementClient managementClient;
+
+    @Before
+    public void installExtensionModule() throws IOException {
+        // We use OpTypesExtension for this test because it's convenient. Doesn't do anything crazy
+        // and exposes an op ('public') that we can call to check the subsystem is added and functions
+        ExtensionUtils.createExtensionModule(OpTypesExtension.EXTENSION_NAME, OpTypesExtension.class,
+                EmptySubsystemParser.class.getPackage());
+    }
+
+    @After
+    public void removeExtensionModule() {
+
+        try {
+            executeOp(Util.createRemoveOperation(SUBSYSTEM), SUCCESS);
+        } catch (Throwable ignored) {
+            // assume subsystem wasn't there
+        } finally {
+            try {
+                executeOp(Util.createRemoveOperation(EXT), SUCCESS);
+            } catch (Throwable t) {
+                // assume extension wasn't there
+            } finally {
+                ExtensionUtils.deleteExtensionModule(OpTypesExtension.EXTENSION_NAME);
+            }
+        }
+    }
+
+    @Test
+    public void test() throws IOException {
+
+        // 1) Sanity check -- subsystem not there
+        ModelNode invokePublic = Util.createEmptyOperation("public", SUBSYSTEM);
+        testBadOp(invokePublic);
+
+        // 2) sanity check -- subsystem add w/o extension -- fail
+        ModelNode subAdd = Util.createAddOperation(SUBSYSTEM);
+        testBadOp(subAdd);
+
+        // 3) ext add + sub add + sub other in composite
+        ModelNode extAdd = Util.createAddOperation(EXT);
+        ModelNode goodAdd = buildComposite(extAdd, subAdd, invokePublic);
+        testGoodComposite(goodAdd);
+
+        // 4) Sanity check -- try invokePublic again outside the composite
+        ModelNode response = executeOp(invokePublic, "success");
+        assertTrue(response.toString(), response.has("result"));
+        assertTrue(response.toString(), response.get("result").asBoolean());
+
+        // 5) sub remove + ext remove + sub add in composite -- fail
+        ModelNode subRemove = Util.createRemoveOperation(SUBSYSTEM);
+        ModelNode extRemove = Util.createRemoveOperation(EXT);
+        ModelNode badRemove = buildComposite(invokePublic, subRemove, extRemove, subAdd);
+        response = testBadOp(badRemove);
+        // But the 'public' op should have worked
+        validateInvokePublicStep(response, 1, true);
+
+        // 6) sub remove + ext remove in composite
+        ModelNode goodRemove = buildComposite(invokePublic, subRemove, extRemove);
+        response = executeOp(goodRemove, "success");
+        validateInvokePublicStep(response, 1, false);
+
+        // 7) confirm ext add + sub add + sub other still works
+        testGoodComposite(goodAdd);
+
+        // 8) Sanity check -- try invokePublic again outside the composite
+        response = executeOp(invokePublic, "success");
+        assertTrue(response.toString(), response.has("result"));
+        assertTrue(response.toString(), response.get("result").asBoolean());
+    }
+
+    private ModelNode executeOp(ModelNode op, String outcome) throws IOException {
+        ModelNode response = managementClient.getControllerClient().execute(op);
+        assertTrue(response.toString(), response.hasDefined(OUTCOME));
+        assertEquals(response.toString(), outcome, response.get(OUTCOME).asString());
+        return response;
+    }
+
+    private void testGoodComposite(ModelNode composite) throws IOException {
+        ModelNode result = executeOp(composite, "success");
+        validateInvokePublicStep(result, 3, false);
+    }
+
+    private ModelNode testBadOp(ModelNode badOp) throws IOException {
+        ModelNode response = executeOp(badOp, "failed");
+        String msg = response.toString();
+        assertTrue(msg, response.has("failure-description"));
+        ModelNode failure = response.get("failure-description");
+        assertTrue(msg, failure.asString().contains("WFLYCTL0030"));
+        return response;
+    }
+
+    private static ModelNode buildComposite(ModelNode... steps) {
+        ModelNode result = Util.createEmptyOperation("composite", PathAddress.EMPTY_ADDRESS);
+        ModelNode stepsParam = result.get("steps");
+        for (ModelNode step : steps) {
+            stepsParam.add(step);
+        }
+        return result;
+    }
+
+    private static void validateInvokePublicStep(ModelNode response, int step, boolean expectRollback) {
+        String msg = response.toString();
+        assertTrue(msg, response.has("result"));
+        ModelNode result = response.get("result");
+        assertTrue(msg, result.isDefined());
+        String stepKey = "step-"+step;
+        assertEquals(msg, expectRollback ? "failed" : "success", result.get(stepKey, "outcome").asString());
+        assertTrue(msg, result.has(stepKey, "result"));
+        assertTrue(msg, result.get(stepKey, "result").asBoolean());
+        if (expectRollback) {
+            assertTrue(msg, result.has(stepKey, "rolled-back"));
+            assertTrue(msg, result.get(stepKey, "rolled-back").asBoolean());
+        } else {
+            assertFalse(msg, result.has(stepKey, "rolled-back"));
+        }
+    }
+
+}


### PR DESCRIPTION
…perationEntry until it's time to execute the step

https://issues.jboss.org/browse/WFCORE-323

I bumped the priority on this as it can be useful to tools like galleon by removing the need to segregate extension add ops associated with a feature from the related subsystem ops.

The basic point here is to allow an extension=foo:add and a subsystem=foo:add op to both be in the same composite, without the latter failing because initially the MRR for the subsystem doesn't exist.

The way this works is via the util that registers op steps for composites tracking. If a step has added or removed an extension, for subsequent subsystem ops instead of the util requiring resolution of the handler for the op and using that for the step, it can use a handler that when it executes will try at that point to resolve the handler. This means the resolution is deferred until after the extension add/remove has executed.