### PR TITLE
[WFCORE-3811] Upgrade to WildFly Galleon Plugins 1.0.0.Alpha20

### DIFF
--- a/core-galleon-pack/pom.xml
+++ b/core-galleon-pack/pom.xml
@@ -659,28 +659,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-artifacts</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>attach-artifact</goal>
-                        </goals>
-                        <configuration>
-                            <artifacts>
-                                <artifact>
-                                    <file>target/wildfly-core-galleon-pack-${project.version}.zip</file>
-                                    <type>zip</type>
-                                    <classifier>zip</classifier>
-                                </artifact>
-                            </artifacts>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/core-galleon-pack/wildfly-feature-pack-build.xml
+++ b/core-galleon-pack/wildfly-feature-pack-build.xml
@@ -32,8 +32,8 @@
     <config model="standalone">
         <props>
             <prop name="config.branch-is-batch" value="true"/>
-            <prop name="config.branch-per-spec" value="false"/>
             <prop name="config.merge-independent-branches" value="true"/>
+            <!-- <prop name="config.merge-same-deps-branches" value="true"/> -->
             <prop name="--admin-only" value=""/>
             <prop name="--internal-empty-config" value=""/>
             <prop name="--internal-remove-config" value=""/>
@@ -61,7 +61,6 @@
     <config model="domain">
         <props>
             <prop name="config.branch-is-batch" value="true"/>
-            <prop name="config.branch-per-spec" value="false"/>
             <prop name="config.merge-independent-branches" value="true"/>
             <prop name="--empty-domain-config" value=""/>
             <prop name="--remove-existing-domain-config" value=""/>
@@ -89,7 +88,6 @@
         </config-deps>
         <props>
             <prop name="config.branch-is-batch" value="true"/>
-            <prop name="config.branch-per-spec" value="false"/>
             <prop name="config.merge-independent-branches" value="true"/>
             <prop name="--domain-config" value="domain.xml"/>
             <prop name="--empty-host-config" value=""/>

--- a/pom.xml
+++ b/pom.xml
@@ -101,10 +101,10 @@
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
-        <version.org.jboss.galleon>1.0.0.Alpha11</version.org.jboss.galleon>
+        <version.org.jboss.galleon>1.0.0.Alpha12</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>1.0.0.Alpha19</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>1.0.0.Alpha20</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->


### PR DESCRIPTION
This change eliminates the need for the commit in WFCORE-3808.
Also removes properties from the configs that are matching the defaults, so not effective.