### PR TITLE
Remove comment from jmx subsystem template for domain

### DIFF
--- a/jmx/src/main/resources/subsystem-templates/jmx.xml
+++ b/jmx/src/main/resources/subsystem-templates/jmx.xml
@@ -16,7 +16,6 @@
    </supplement>   
    <supplement name="domain">
       <replacement placeholder="REMOTING-CONNECTOR">
-         <!--<remoting-connector use-management-endpoint="false"/>-->
       </replacement>   
    </supplement>
    


### PR DESCRIPTION
Further removal of comments from our standard config files.