### PR TITLE
[WFCORE-3816] ExtensionIndexService throws NPE while reading extensions on the IBM jdk

### DIFF
--- a/server/src/main/java/org/jboss/as/server/moduleservice/ExtensionIndexService.java
+++ b/server/src/main/java/org/jboss/as/server/moduleservice/ExtensionIndexService.java
@@ -91,6 +91,10 @@ public final class ExtensionIndexService implements Service<ExtensionIndex>, Ext
                         final JarFile jarFile = new JarFile(jar);
                         try {
                             final Manifest manifest = jarFile.getManifest();
+                            if (manifest == null) {
+                                // jar lacks manifest file
+                                continue;
+                            }
                             final Attributes mainAttributes = manifest.getMainAttributes();
                             final String extensionName = mainAttributes.getValue(Attributes.Name.EXTENSION_NAME);
                             if (extensionName == null) {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3816 ExtensionIndexService throws NPE while reading extensions on the IBM jdk   
   
IBM jdk contains 
```
ibm-java-8.0-5.11/jre/lib/ext/traceformat.jar: java.lang.NullPointerException
ibm-java-8.0-5.11/jre/lib/ext/dtfj.jar: java.lang.NullPointerException
ibm-java-8.0-5.11/jre/lib/ext/dtfjview.jar: java.lang.NullPointerException
``` 
where `manifest.getMainAttributes();` throws NPE.
   
causes ->
https://issues.jboss.org/browse/WFLY-10349 WeldBundledLibraryDeployment Test cases fail on IBM jdk