### PR TITLE
[WFCORE-3822] Restore properties the CLI embedded server and host con…

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -178,7 +178,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
             }
         }
 
-        final EnvironmentRestorer restorer = new EnvironmentRestorer();
+        final EnvironmentRestorer restorer = new EnvironmentRestorer(JBOSS_DOMAIN_LOG_DIR);
         boolean ok = false;
         ThreadLocalContextSelector contextSelector = null;
         try {

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
@@ -157,7 +157,7 @@ class EmbedServerHandler extends CommandHandlerWithHelp {
             }
         }
 
-        final EnvironmentRestorer restorer = new EnvironmentRestorer();
+        final EnvironmentRestorer restorer = new EnvironmentRestorer(JBOSS_SERVER_LOG_DIR);
         boolean ok = false;
         ThreadLocalContextSelector contextSelector = null;
         try {


### PR DESCRIPTION
…troller explicitly set.
https://issues.jboss.org/browse/WFCORE-3822

The CLI embedded server and host controller explicitly set a few properties. These properties need to ensure to be restored to the correct values. Changed the `EnvironmentRestorer` to allow any properties to be restored to the previous value or cleared if not found.