### PR TITLE
[WFCORE-3819][WFCORE-3877] added custom-security-event-listener into Elytron

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuditLoggingParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuditLoggingParser.java
@@ -57,9 +57,16 @@ class AuditLoggingParser {
             .setUseElementsForGroups(false)
             .addAttributes(AuditResourceDefinitions.SERVER_ADDRESS, AuditResourceDefinitions.PORT, AuditResourceDefinitions.TRANSPORT, AuditResourceDefinitions.HOST_NAME, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.SSL_CONTEXT)
             .build();
+
     private final PersistentResourceXMLDescription aggregateSecurityEventParser = builder(PathElement.pathElement(AGGREGATE_SECURITY_EVENT_LISTENER), null)
             .addAttribute(AuditResourceDefinitions.REFERENCES, new AttributeParsers.NamedStringListParser(SECURITY_EVENT_LISTENER), new AttributeMarshallers.NamedStringListMarshaller(SECURITY_EVENT_LISTENER))
             .build();
+
+    private final PersistentResourceXMLDescription customSecurityEventParser = builder(PathElement.pathElement(ElytronDescriptionConstants.CUSTOM_SECURITY_EVENT_LISTENER), null)
+            .addAttributes(CustomComponentDefinition.ATTRIBUTES)
+            .setUseElementsForGroups(false)
+            .build();
+
     final PersistentResourceXMLDescription parser = decorator(ElytronDescriptionConstants.AUDIT_LOGGING)
             .addChild(aggregateSecurityEventParser)
             .addChild(fileAuditLogParser)
@@ -68,5 +75,13 @@ class AuditLoggingParser {
             .addChild(syslogAuditLogParser)
             .build();
 
+    final PersistentResourceXMLDescription parser4_0 = decorator(ElytronDescriptionConstants.AUDIT_LOGGING)
+            .addChild(aggregateSecurityEventParser)
+            .addChild(customSecurityEventParser) // new
+            .addChild(fileAuditLogParser)
+            .addChild(periodicRotatingFileAuditLogParser)
+            .addChild(sizeRotatingFileAuditLogParser)
+            .addChild(syslogAuditLogParser)
+            .build();
 
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/Configurable.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/Configurable.java
@@ -25,8 +25,11 @@ import java.util.Map;
  * Where custom components implement this interface they can be dynamically be configured by the subsystem with
  * a {@link Map<String, String>}.
  *
+ * @deprecated it is sufficient to implement {@code initialize(Map&lt;String, String&gt;)} method in custom component
+ *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
+@Deprecated
 public interface Configurable {
 
     /**

--- a/elytron/src/main/java/org/wildfly/extension/elytron/CustomComponentDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CustomComponentDefinition.java
@@ -20,7 +20,7 @@ package org.wildfly.extension.elytron;
 
 import static org.wildfly.extension.elytron.ClassLoadingAttributeDefinitions.CLASS_NAME;
 import static org.wildfly.extension.elytron.ClassLoadingAttributeDefinitions.resolveClassLoader;
-import static org.wildfly.extension.elytron.ElytronDefinition.commonDependencies;
+import static org.wildfly.extension.elytron.ElytronDefinition.commonRequirements;
 import static org.wildfly.extension.elytron.SecurityActions.doPrivileged;
 import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
 
@@ -30,6 +30,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
@@ -58,7 +59,7 @@ import org.jboss.msc.service.StartException;
  *
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
-class CustomComponentDefinition<T> extends SimpleResourceDefinition {
+class CustomComponentDefinition<C, T> extends SimpleResourceDefinition {
 
     static final SimpleAttributeDefinition MODULE = new SimpleAttributeDefinitionBuilder(ClassLoadingAttributeDefinitions.MODULE)
         .setRequired(true)
@@ -70,25 +71,17 @@ class CustomComponentDefinition<T> extends SimpleResourceDefinition {
         .setRestartAllServices()
         .build();
 
-    private final Class<T> serviceType;
-    private final RuntimeCapability<?>[] runtimeCapabilities;
-    private final String pathKey;
-
     static final AttributeDefinition[] ATTRIBUTES = {MODULE, CLASS_NAME, CONFIGURATION};
 
-    CustomComponentDefinition(Class<T> serviceType, String pathKey, @SuppressWarnings("rawtypes") RuntimeCapability ... runtimeCapabilities) {
+    CustomComponentDefinition(Class<C> serviceType, Function<C, T> wrapper, String pathKey, @SuppressWarnings("rawtypes") RuntimeCapability ... runtimeCapabilities) {
         super(addAddRemoveHandlers(new Parameters(PathElement.pathElement(pathKey), ElytronExtension.getResourceDescriptionResolver(pathKey))
             .setAddRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
             .setRemoveRestartLevel(OperationEntry.Flag.RESTART_RESOURCE_SERVICES)
-            .setCapabilities(runtimeCapabilities), serviceType, runtimeCapabilities));
-
-        this.serviceType = serviceType;
-        this.runtimeCapabilities = runtimeCapabilities;
-        this.pathKey = pathKey;
+            .setCapabilities(runtimeCapabilities), serviceType, wrapper, runtimeCapabilities));
     }
 
-    private static <T> Parameters addAddRemoveHandlers(Parameters parameters, Class<T> serviceType, RuntimeCapability<?> ... runtimeCapabilities) {
-        AbstractAddStepHandler add = new ComponentAddHandler<T>(serviceType, runtimeCapabilities);
+    private static <C, T> Parameters addAddRemoveHandlers(Parameters parameters, Class<C> serviceType, Function<C, T> wrapper, RuntimeCapability<?> ... runtimeCapabilities) {
+        AbstractAddStepHandler add = new ComponentAddHandler<>(serviceType, wrapper, runtimeCapabilities);
         OperationStepHandler remove = new TrivialCapabilityServiceRemoveHandler(add, runtimeCapabilities);
 
         parameters.setAddHandler(add);
@@ -105,15 +98,17 @@ class CustomComponentDefinition<T> extends SimpleResourceDefinition {
         }
     }
 
-    private static class ComponentAddHandler<T> extends BaseAddHandler {
+    private static class ComponentAddHandler<C, T> extends BaseAddHandler {
 
         private final RuntimeCapability<?>[] runtimeCapabilities;
-        private final Class<T> serviceType;
+        private final Class<C> serviceType;
+        private final Function<C, T> wrapper;
 
-        private ComponentAddHandler(Class<T> serviceType, RuntimeCapability<?> ... runtimeCapabilities) {
-            super( new HashSet<RuntimeCapability>(Arrays.asList(runtimeCapabilities)), ATTRIBUTES);
+        private ComponentAddHandler(Class<C> serviceType, Function<C, T> wrapper, RuntimeCapability<?> ... runtimeCapabilities) {
+            super(new HashSet<>(Arrays.asList(runtimeCapabilities)), ATTRIBUTES);
             this.runtimeCapabilities = runtimeCapabilities;
             this.serviceType = serviceType;
+            this.wrapper = wrapper;
         }
 
         @Override
@@ -131,14 +126,13 @@ class CustomComponentDefinition<T> extends SimpleResourceDefinition {
             final Map<String, String> configurationMap;
             configurationMap = CONFIGURATION.unwrap(context, model);
 
-            TrivialService<T> customComponentService = new TrivialService<T>(() -> createValue(module, className, configurationMap));
-
-            ServiceBuilder<T> serviceBuilder = serviceTarget.addService(primaryServiceName, customComponentService);
-            for (int i=1;i<runtimeCapabilities.length;i++) {
+            ServiceBuilder<?> serviceBuilder = serviceTarget.addService(primaryServiceName);
+            for (int i = 1; i < runtimeCapabilities.length; i++) {
                 serviceBuilder.addAliases(toServiceName(runtimeCapabilities[i], address));
             }
 
-            commonDependencies(serviceBuilder)
+            commonRequirements(serviceBuilder)
+                .setInstance(new TrivialService<>(() -> createValue(module, className, configurationMap)))
                 .setInitialMode(Mode.ACTIVE)
                 .install();
         }
@@ -152,9 +146,9 @@ class CustomComponentDefinition<T> extends SimpleResourceDefinition {
             try {
                 classLoader = doPrivileged((PrivilegedExceptionAction<ClassLoader>) () -> resolveClassLoader(module));
 
-                Class<? extends T> typeClazz = classLoader.loadClass(className).asSubclass(serviceType);
+                Class<? extends C> typeClazz = classLoader.loadClass(className).asSubclass(serviceType);
 
-                T component = typeClazz.getDeclaredConstructor().newInstance();
+                C component = typeClazz.getDeclaredConstructor().newInstance();
 
                 if (configuration != null && !configuration.isEmpty()) {
                     try {
@@ -165,7 +159,7 @@ class CustomComponentDefinition<T> extends SimpleResourceDefinition {
                     }
                 }
 
-                return component;
+                return wrapper.apply(component);
             } catch (PrivilegedActionException e) {
                 throw new StartException(e.getCause());
             } catch (Exception e) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -18,7 +18,6 @@
 
 package org.wildfly.extension.elytron;
 
-import static org.wildfly.extension.elytron.ElytronExtension.isServerOrHostController;
 import static org.wildfly.extension.elytron.Capabilities.AUTHENTICATION_CONTEXT_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.ELYTRON_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.MODIFIABLE_SECURITY_REALM_RUNTIME_CAPABILITY;
@@ -29,12 +28,16 @@ import static org.wildfly.extension.elytron.Capabilities.PROVIDERS_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.REALM_MAPPER_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.ROLE_DECODER_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.ROLE_MAPPER_RUNTIME_CAPABILITY;
+import static org.wildfly.extension.elytron.Capabilities.SECURITY_EVENT_LISTENER_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.SECURITY_FACTORY_CREDENTIAL_RUNTIME_CAPABILITY;
 import static org.wildfly.extension.elytron.Capabilities.SECURITY_REALM_RUNTIME_CAPABILITY;
+import static org.wildfly.extension.elytron.ElytronExtension.isServerOrHostController;
 
 import java.security.Provider;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.AttributeMarshaller;
@@ -72,6 +75,7 @@ import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.extension.elytron.capabilities.CredentialSecurityFactory;
 import org.wildfly.extension.elytron.capabilities.PrincipalTransformer;
+import org.wildfly.extension.elytron.capabilities._private.SecurityEventListener;
 import org.wildfly.security.Version;
 import org.wildfly.security.auth.server.ModifiableSecurityRealm;
 import org.wildfly.security.auth.server.PrincipalDecoder;
@@ -140,6 +144,8 @@ class ElytronDefinition extends SimpleResourceDefinition {
 
         // Audit
         resourceRegistration.registerSubModel(AuditResourceDefinitions.getAggregateSecurityEventListenerDefinition());
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(Consumer.class, SecurityEventListener::from,
+                ElytronDescriptionConstants.CUSTOM_SECURITY_EVENT_LISTENER, SECURITY_EVENT_LISTENER_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(AuditResourceDefinitions.getFileAuditLogResourceDefinition());
         resourceRegistration.registerSubModel(AuditResourceDefinitions.getPeriodicRotatingFileAuditLogResourceDefinition());
         resourceRegistration.registerSubModel(AuditResourceDefinitions.getSizeRotatingFileAuditLogResourceDefinition());
@@ -154,9 +160,9 @@ class ElytronDefinition extends SimpleResourceDefinition {
 
         // Security Realms
         resourceRegistration.registerSubModel(new AggregateRealmDefinition());
-        resourceRegistration.registerSubModel(new CustomComponentDefinition<SecurityRealm>(SecurityRealm.class, ElytronDescriptionConstants.CUSTOM_REALM, SECURITY_REALM_RUNTIME_CAPABILITY));
-        resourceRegistration.registerSubModel(ModifiableRealmDecorator.wrap(new CustomComponentDefinition<ModifiableSecurityRealm>(
-                ModifiableSecurityRealm.class, ElytronDescriptionConstants.CUSTOM_MODIFIABLE_REALM,
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(SecurityRealm.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_REALM, SECURITY_REALM_RUNTIME_CAPABILITY));
+        resourceRegistration.registerSubModel(ModifiableRealmDecorator.wrap(new CustomComponentDefinition<>(
+                ModifiableSecurityRealm.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_MODIFIABLE_REALM,
                 MODIFIABLE_SECURITY_REALM_RUNTIME_CAPABILITY, SECURITY_REALM_RUNTIME_CAPABILITY)));
         resourceRegistration.registerSubModel(RealmDefinitions.getIdentityRealmDefinition());
         resourceRegistration.registerSubModel(new JdbcRealmDefinition());
@@ -168,11 +174,11 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(new CachingRealmDefinition());
 
         // Security Factories
-        resourceRegistration.registerSubModel(new CustomComponentDefinition<CredentialSecurityFactory>(CredentialSecurityFactory.class, ElytronDescriptionConstants.CUSTOM_CREDENTIAL_SECURITY_FACTORY, SECURITY_FACTORY_CREDENTIAL_RUNTIME_CAPABILITY));
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(CredentialSecurityFactory.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_CREDENTIAL_SECURITY_FACTORY, SECURITY_FACTORY_CREDENTIAL_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(KerberosSecurityFactoryDefinition.getKerberosSecurityFactoryDefinition());
 
         // Permission Mappers
-        resourceRegistration.registerSubModel(new CustomComponentDefinition<PermissionMapper>(PermissionMapper.class, ElytronDescriptionConstants.CUSTOM_PERMISSION_MAPPER, PERMISSION_MAPPER_RUNTIME_CAPABILITY));
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(PermissionMapper.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_PERMISSION_MAPPER, PERMISSION_MAPPER_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(PermissionMapperDefinitions.getLogicalPermissionMapper());
         resourceRegistration.registerSubModel(PermissionMapperDefinitions.getSimplePermissionMapper());
         resourceRegistration.registerSubModel(PermissionMapperDefinitions.getConstantPermissionMapper());
@@ -184,25 +190,25 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(PrincipalDecoderDefinitions.getAggregatePrincipalDecoderDefinition());
         resourceRegistration.registerSubModel(PrincipalDecoderDefinitions.getConcatenatingPrincipalDecoder());
         resourceRegistration.registerSubModel(PrincipalDecoderDefinitions.getConstantPrincipalDecoder());
-        resourceRegistration.registerSubModel(new CustomComponentDefinition<PrincipalDecoder>(PrincipalDecoder.class, ElytronDescriptionConstants.CUSTOM_PRINCIPAL_DECODER, PRINCIPAL_DECODER_RUNTIME_CAPABILITY));
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(PrincipalDecoder.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_PRINCIPAL_DECODER, PRINCIPAL_DECODER_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(PrincipalDecoderDefinitions.getX500AttributePrincipalDecoder());
 
         // Principal Transformers
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getAggregatePrincipalTransformerDefinition());
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getChainedPrincipalTransformerDefinition());
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getConstantPrincipalTransformerDefinition());
-        resourceRegistration.registerSubModel(new CustomComponentDefinition<PrincipalTransformer>(PrincipalTransformer.class, ElytronDescriptionConstants.CUSTOM_PRINCIPAL_TRANSFORMER, PRINCIPAL_TRANSFORMER_RUNTIME_CAPABILITY));
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(PrincipalTransformer.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_PRINCIPAL_TRANSFORMER, PRINCIPAL_TRANSFORMER_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getRegexPrincipalTransformerDefinition());
         resourceRegistration.registerSubModel(PrincipalTransformerDefinitions.getRegexValidatingPrincipalTransformerDefinition());
 
         // Realm Mappers
         resourceRegistration.registerSubModel(RealmMapperDefinitions.getConstantRealmMapper());
-        resourceRegistration.registerSubModel(new CustomComponentDefinition<RealmMapper>(RealmMapper.class, ElytronDescriptionConstants.CUSTOM_REALM_MAPPER, REALM_MAPPER_RUNTIME_CAPABILITY));
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(RealmMapper.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_REALM_MAPPER, REALM_MAPPER_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(RealmMapperDefinitions.getMappedRegexRealmMapper());
         resourceRegistration.registerSubModel(RealmMapperDefinitions.getSimpleRegexRealmMapperDefinition());
 
         // Role Decoders
-        resourceRegistration.registerSubModel(new CustomComponentDefinition<RoleDecoder>(RoleDecoder.class, ElytronDescriptionConstants.CUSTOM_ROLE_DECODER, ROLE_DECODER_RUNTIME_CAPABILITY));
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(RoleDecoder.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_ROLE_DECODER, ROLE_DECODER_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(RoleDecoderDefinitions.getSimpleRoleDecoderDefinition());
 
         // Role Mappers
@@ -210,7 +216,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(RoleMapperDefinitions.getAddPrefixRoleMapperDefinition());
         resourceRegistration.registerSubModel(RoleMapperDefinitions.getAggregateRoleMapperDefinition());
         resourceRegistration.registerSubModel(RoleMapperDefinitions.getConstantRoleMapperDefinition());
-        resourceRegistration.registerSubModel(new CustomComponentDefinition<RoleMapper>(RoleMapper.class, ElytronDescriptionConstants.CUSTOM_ROLE_MAPPER, ROLE_MAPPER_RUNTIME_CAPABILITY));
+        resourceRegistration.registerSubModel(new CustomComponentDefinition<>(RoleMapper.class, Function.identity(), ElytronDescriptionConstants.CUSTOM_ROLE_MAPPER, ROLE_MAPPER_RUNTIME_CAPABILITY));
         resourceRegistration.registerSubModel(RoleMapperDefinitions.getLogicalRoleMapperDefinition());
         resourceRegistration.registerSubModel(RoleMapperDefinitions.getMappedRoleMapperDefinition());
 
@@ -278,14 +284,25 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerReadWriteAttribute(SECURITY_PROPERTIES, null, new SecurityPropertiesWriteHandler(SECURITY_PROPERTIES));
     }
 
-
+    @Deprecated
     static <T> ServiceBuilder<T>  commonDependencies(ServiceBuilder<T> serviceBuilder) {
         return commonDependencies(serviceBuilder, true, true);
     }
 
+    @Deprecated
     static <T> ServiceBuilder<T>  commonDependencies(ServiceBuilder<T> serviceBuilder, boolean dependOnProperties, boolean dependOnProviderRegistration) {
         if (dependOnProperties) serviceBuilder.addDependencies(SecurityPropertyService.SERVICE_NAME);
         if (dependOnProviderRegistration) serviceBuilder.addDependencies(ProviderRegistrationService.SERVICE_NAME);
+        return serviceBuilder;
+    }
+
+    static <T> ServiceBuilder<T>  commonRequirements(ServiceBuilder<T> serviceBuilder) {
+        return commonRequirements(serviceBuilder, true, true);
+    }
+
+    static <T> ServiceBuilder<T>  commonRequirements(ServiceBuilder<T> serviceBuilder, boolean dependOnProperties, boolean dependOnProviderRegistration) {
+        if (dependOnProperties) serviceBuilder.requires(SecurityPropertyService.SERVICE_NAME);
+        if (dependOnProviderRegistration) serviceBuilder.requires(ProviderRegistrationService.SERVICE_NAME);
         return serviceBuilder;
     }
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -122,6 +122,7 @@ interface ElytronDescriptionConstants {
     String CREDENTIAL_STORES = "credential-stores";
     String CREDENTIALS = "credentials";
     String CRITICAL = "critical";
+
     String CUSTOM_CREDENTIAL_SECURITY_FACTORY = "custom-credential-security-factory";
     String CUSTOM_PERMISSION_MAPPER = "custom-permission-mapper";
     String CUSTOM_POLICY = "custom-policy";
@@ -132,6 +133,7 @@ interface ElytronDescriptionConstants {
     String CUSTOM_REALM_MAPPER = "custom-realm-mapper";
     String CUSTOM_ROLE_DECODER = "custom-role-decoder";
     String CUSTOM_ROLE_MAPPER = "custom-role-mapper";
+    String CUSTOM_SECURITY_EVENT_LISTENER = "custom-security-event-listener";
 
     String DATA_SOURCE = "data-source";
     String DEBUG = "debug";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser3_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser3_0.java
@@ -61,7 +61,7 @@ class ElytronSubsystemParser3_0 extends ElytronSubsystemParser2_0 {
                 .addChild(getRealmParser())
                 .addChild(getCredentialSecurityFactoryParser())
                 .addChild(getMapperParser())
-                .addChild(getPermissionSetParser())
+                .addChild(getPermissionSetParser()) // new
                 .addChild(getHttpParser())
                 .addChild(getSaslParser())
                 .addChild(getTlsParser())

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser4_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser4_0.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.extension.elytron;
 
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+
 /**
  * The subsystem parser, which uses stax to read and write to and from xml.
  *
@@ -29,6 +31,11 @@ public class ElytronSubsystemParser4_0 extends ElytronSubsystemParser3_0 {
     @Override
     String getNameSpace() {
         return ElytronExtension.NAMESPACE_4_0;
+    }
+
+    @Override
+    PersistentResourceXMLDescription getAuditLoggingParser() {
+        return new AuditLoggingParser().parser4_0;
     }
 
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -89,6 +89,7 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
                 ), PRINCIPAL_QUERIES)
                 .end();
         builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.MAPPED_ROLE_MAPPER));
+        builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.CUSTOM_SECURITY_EVENT_LISTENER));
     }
 
     private static void from3(ChainedTransformationDescriptionBuilder chainedBuilder) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -42,7 +42,6 @@ import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceController.State;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
-import org.wildfly.extension.elytron.Configurable;
 import org.wildfly.security.auth.server.SecurityRealm;
 
 /**
@@ -180,13 +179,13 @@ public interface ElytronSubsystemMessages extends BasicLogger {
 
     /**
      * A {@link StartException} where a custom component has been defined with configuration but does not implement
-     * the {@link Configurable} interface.
+     * the {@code initialize(Map<String, String>)} method.
      *
      * @param className the class name of the custom component implementation being loaded.
      * @return The {@link StartException} for the error.
      */
-    @Message(id = 15, value = "The custom component implementation '%s' doe not implement 'org.wildfly.extension.elytron.Configurable' however configuration has been supplied.")
-    StartException componentNotConfigurable(final String className);
+    @Message(id = 15, value = "The custom component implementation '%s' doe not implement method initialize(Map<String, String>), however configuration has been supplied.")
+    StartException componentNotConfigurable(final String className, @Cause Exception cause);
 
     /**
      * An {@link OperationFailedException} where validation of a specified regular expression has failed.

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -107,6 +107,15 @@ elytron.aggregate-security-event-listener.remove=The remove operation for the ag
 # Attributes
 elytron.aggregate-security-event-listener.security-event-listeners=The referenced security event listener resources to aggregate.
 
+elytron.custom-security-event-listener=A custom security event listener. (Audit logger for example.)
+# Operations
+elytron.custom-security-event-listener.add=The add operation for the listener.
+elytron.custom-security-event-listener.remove=The remove operation for the listener.
+# Attributes
+elytron.custom-security-event-listener.module=The module to use to load the custom security event listener.
+elytron.custom-security-event-listener.class-name=The class name of the implementation of the custom security event listener.
+elytron.custom-security-event-listener.configuration=The optional key/value configuration for the custom security event listener.
+
 elytron.file-audit-log=An audit logger that logs to a local file.
 # Operations
 elytron.file-audit-log.add=Add the audit logger resource.

--- a/elytron/src/main/resources/schema/wildfly-elytron_4_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_4_0.xsd
@@ -1002,7 +1002,7 @@
 		                    <xs:documentation>
 		                        The configuration to apply to the SecurityRealm implementation.
 
-		                        Note: If configuration is supplied the realm MUST implement the Configurable interface.
+		                        Note: If configuration is supplied the realm MUST implement initialize(Map&lt;String, String&gt;) method.
 		                    </xs:documentation>
 		                </xs:annotation>
 		            </xs:element>
@@ -2068,7 +2068,7 @@
                             <xs:documentation>
                                 The configuration to apply to the SecurityFactory implementation.
 
-                                Note: If configuration is supplied the SecurityFactory MUST implement the Configurable interface.
+                                Note: If configuration is supplied the SecurityFactory MUST implement initialize(Map&lt;String, String&gt;) method.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>
@@ -2282,7 +2282,7 @@
                             <xs:documentation>
                                 The configuration to apply to the PermissionMapper implementation.
 
-                                Note: If configuration is supplied the PermissionMapper MUST implement the Configurable interface.
+                                Note: If configuration is supplied the PermissionMapper MUST implement initialize(Map&lt;String, String&gt;) method.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>
@@ -2533,7 +2533,7 @@
                             <xs:documentation>
                                 The configuration to apply to the PrincipalDecoder implementation.
 
-                                Note: If configuration is supplied the PrincipalDecoder MUST implement the Configurable interface.
+                                Note: If configuration is supplied the PrincipalDecoder MUST implement initialize(Map&lt;String, String&gt;) method.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>
@@ -2799,7 +2799,7 @@
                             <xs:documentation>
                                 The configuration to apply to the PrincipalTransformer implementation.
 
-                                Note: If configuration is supplied the PrincipalTransformer MUST implement the Configurable interface.
+                                Note: If configuration is supplied the PrincipalTransformer MUST implement initialize(Map&lt;String, String&gt;) method.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>
@@ -2883,7 +2883,7 @@
                             <xs:documentation>
                                 The configuration to apply to the RealmMapper implementation.
 
-                                Note: If configuration is supplied the RealmMapper MUST implement the Configurable interface.
+                                Note: If configuration is supplied the RealmMapper MUST implement initialize(Map&lt;String, String&gt;) method.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>
@@ -3021,7 +3021,7 @@
                             <xs:documentation>
                                 The configuration to apply to the RoleDecoder implementation.
 
-                                Note: If configuration is supplied the RoleDecoder MUST implement the Configurable interface.
+                                Note: If configuration is supplied the RoleDecoder MUST implement initialize(Map&lt;String, String&gt;) method.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>
@@ -3134,7 +3134,7 @@
                             <xs:documentation>
                                 The configuration to apply to the RoleMapper implementation.
 
-                                Note: If configuration is supplied the RoleMapper MUST implement the Configurable interface.
+                                Note: If configuration is supplied the RoleMapper MUST implement initialize(Map&lt;String, String&gt;) method.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>

--- a/elytron/src/main/resources/schema/wildfly-elytron_4_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_4_0.xsd
@@ -497,7 +497,8 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element name="aggregate-security-event-listener" type="aggregateSecurityEventListener" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="aggregate-security-event-listener" type="aggregateSecurityEventListenerType" minOccurs="0" maxOccurs="unbounded" />
+            <xs:element name="custom-security-event-listener" type="customSecurityEventListenerType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="file-audit-log" type="fileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="periodic-rotating-file-audit-log" type="periodicRotatingFileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
             <xs:element name="size-rotating-file-audit-log" type="sizeRotatingFileAuditLogType" minOccurs="0" maxOccurs="unbounded" />
@@ -545,7 +546,7 @@
         </xs:attribute>
     </xs:complexType>
 
-    <xs:complexType name="aggregateSecurityEventListener">
+    <xs:complexType name="aggregateSecurityEventListenerType">
         <xs:annotation>
             <xs:documentation>
                 A security event listener definition that is actually an aggregation of other security event listeners.
@@ -724,6 +725,31 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customSecurityEventListenerType">
+        <xs:annotation>
+            <xs:documentation>
+                A security event listener definition for a custom security event listener implementation.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="auditLogType">
+                <xs:sequence>
+                    <xs:element name="configuration"
+                                type="customComponentConfiguration" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The configuration to apply to the security event listener implementation.
+
+                                Note: If configuration is supplied the listener MUST implement a void initialize(Map&lt;String, String&gt;) method.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                </xs:sequence>
+                <xs:attributeGroup ref="customComponentAttributes" />
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -123,6 +123,9 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
                 .addFailedAttribute(subsystemAddress.append(PathElement.pathElement(ElytronDescriptionConstants.MAPPED_ROLE_MAPPER, "DisallowedMappedRoleMapper")),
                         FailedOperationTransformationConfig.REJECTED_RESOURCE
                 )
+                .addFailedAttribute(subsystemAddress.append(PathElement.pathElement(ElytronDescriptionConstants.CUSTOM_SECURITY_EVENT_LISTENER)),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE
+                )
         );
         /*ModelTestUtils.checkFailedTransformedBootOperations(mainServices, elytronVersion, ops, new FailedOperationTransformationConfig()
                ...

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
@@ -7,6 +7,7 @@
             <security-event-listener name="local-file"/>
             <security-event-listener name="remote-syslog"/>
         </aggregate-security-event-listener>
+        <custom-security-event-listener name="a" module="b" class-name="c.D"/>
         <file-audit-log name="local-file" path="audit.log" relative-to="jboss.home.dir" synchronized="false" format="JSON" />
         <periodic-rotating-file-audit-log name="periodic-rotating" path="audit.log" relative-to="jboss.server.log.dir" format="JSON" suffix="y-M-d"/>
         <size-rotating-file-audit-log name="size-rotating" path="audit.log" relative-to="jboss.server.log.dir" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d"/>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-1.2-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-1.2-reject.xml
@@ -19,4 +19,7 @@
             <role-mapping from="a" to="b c"/>
         </mapped-role-mapper>
     </mappers>
+    <audit-logging>
+        <custom-security-event-listener name="a" module="b" class-name="c.D"/>
+    </audit-logging>
 </subsystem>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3819 (custom audit, https://issues.jboss.org/browse/EAP7-1007, analysis: https://github.com/wildfly/wildfly-proposals/pull/68)
https://issues.jboss.org/browse/WFCORE-3877 (Configurable optional, https://issues.jboss.org/browse/EAP7-1005, analysis: https://github.com/wildfly/wildfly-proposals/pull/69)

test + doc of this: https://github.com/wildfly/wildfly/pull/11367 (https://issues.jboss.org/browse/WFLY-10611)

* added custom-security-event-listener
* reworked CustomComponentDefinition to allow passing wrapper (to allow custom-security-event-listener to implement Consumer<SecurityEvent> and not to depend on subsystem-specific SecurityEventListener)
* as requested by @darranl, removed need to implement Configurable interface requirement - method initialize(Map) sufficient
* in reworked component removed dependencies on deprecated ServiceBuilder methods