### PR TITLE
[WFCORE-3837] / [WFCORE-3838] WildFly Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
         <version.org.wildfly.security.elytron>1.3.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web.undertow-server>1.1.0.Final</version.org.wildfly.security.elytron-web.undertow-server>
-        <version.org.wildfly.security.elytron.tool>1.1.4.Final</version.org.wildfly.security.elytron.tool>
+        <version.org.wildfly.security.elytron.tool>1.2.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
-        <version.org.wildfly.security.elytron>1.3.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.3.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web.undertow-server>1.1.0.Final</version.org.wildfly.security.elytron-web.undertow-server>
         <version.org.wildfly.security.elytron.tool>1.1.4.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
These component updates are just to synchronize the latest fixes from the maintenance branches.

The tool is also required as it includes the WildFly Elytron classes.  Although the tool has had a minor version increment this is just to leave the 1.1.x release stream free should WildFly 12 require a further release.

https://issues.jboss.org/browse/WFCORE-3837
https://issues.jboss.org/browse/WFCORE-3838