### PR TITLE
[WFCORE-3841] Upgrade to Galleon 1.0.0.CR2 and Galleon Plugins 1.0.0.CR3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,10 +101,10 @@
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
-        <version.org.jboss.galleon>1.0.0.CR1</version.org.jboss.galleon>
+        <version.org.jboss.galleon>1.0.0.CR2</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>1.0.0.CR2</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>1.0.0.CR3</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3841

Galleon 1.0.0.CR2 fixes an issue of adding features with list-add operation with the setting config.branch-per-spec disabled, which is the default now.
Galleon Plugins 1.0.0.CR3 fixes an issue when jboss-modules might not be able to resolve artifacts with hardcoded versions in module.xml during feature spec generation.