### PR TITLE
[WFCORE-3854] Upgrade WildFly Elytron Tool to 1.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.3.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web.undertow-server>1.1.0.Final</version.org.wildfly.security.elytron-web.undertow-server>
-        <version.org.wildfly.security.elytron.tool>1.2.0.Final</version.org.wildfly.security.elytron.tool>
+        <version.org.wildfly.security.elytron.tool>1.2.1.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>
 


### PR DESCRIPTION
This latest component upgrade is just pulling in a set of recent bug fixes.

https://issues.jboss.org/browse/WFCORE-3854