### PR TITLE
WFCORE-3857 Upgrade to WildFly Galleon plugins 1.0.0.CR6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <version.org.jboss.galleon>1.0.0.CR3</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>1.0.0.CR5</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>1.0.0.CR6</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3857

This upgrade contains support for colon as a separator between module name and slot in module.xml module dependencies. It still supports the legacy way of specifying the slot using an attribute.