### PR TITLE
[WFLY-10394] Workaround wrong TCCL issue in naming subsystem by restoring lost (otherwise unused) dependency

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
@@ -38,6 +38,8 @@
     </resources>
 
     <dependencies>
+        <!-- This is a workaround for WFLY-10394 -->
+        <module name="java.naming"/>
         <module name="java.management"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-10394