### PR TITLE
[WFCORE-3683] Add the WildFly11.0, WildFly12.0 and EAP7.1 versions to…

### DIFF
--- a/server/src/main/resources/schema/wildfly-config_7_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_7_0.xsd
@@ -4858,6 +4858,33 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:enumeration>
+                    <xs:enumeration value="WildFly11.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 5.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="EAP7.1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 5.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="WildFly12.0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[
+                                   A shorthand identifier for kernel management API version 6.0.x
+                                ]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>


### PR DESCRIPTION
… the schema

https://issues.jboss.org/browse/WFCORE-3863

Blocks https://github.com/wildfly/wildfly/pull/11247

@jmesnil This is something to look out for in any PR that adds more items to the HostExcludeResourceDefinition.KnownRelease enum.