### PR TITLE
[WFCORE-3884] / [WFCORE-3889]  Ensure correct ClassLoader is used when dynamically loading classes and add dependency on 'jdk.security.auth' for the domain-management module.

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
@@ -41,6 +41,7 @@
         <!-- This is a workaround for WFLY-10394 -->
         <module name="java.naming"/>
         <module name="java.management"/>
+        <module name="jdk.security.auth"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.server"/>

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/KeytabService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/KeytabService.java
@@ -54,6 +54,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * A service used for loading Kerberos keytabs.
@@ -206,8 +207,13 @@ public class KeytabService implements Service<KeytabService> {
         final Subject theSubject = new Subject();
 
         final LoginContext lc = new LoginContext("KDC", theSubject, NO_CALLBACK_HANDLER, isClient ? clientConfiguration : serverConfiguration);
-        lc.login();
 
+        final ClassLoader old = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(KeytabService.class);
+        try {
+            lc.login();
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(old);
+        }
 
         return new SubjectIdentity() {
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3884

This pull request ensures the Thread's context ClassLoader is set when interacting with LDAP.

Tomorrow @mchoma will be looking at this as well as Martin has the test that originally discovered the regression, I am submitting in the meantime for review and CI.