### PR TITLE
Fix for WFCORE-3829, ReloadRedirectTestCase failing with ibm jdk

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadRedirectTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ReloadRedirectTestCase.java
@@ -55,6 +55,7 @@ import org.wildfly.core.testrunner.WildflyTestRunner;
 @ServerControl(manual = true)
 public class ReloadRedirectTestCase {
 
+    private static final String IBM_OVERRIDE_DEFAULT_TLS = "-Dcom.ibm.jsse2.overrideDefaultTLS=true";
     public static final int MANAGEMENT_NATIVE_PORT = 9999;
 
     @Inject
@@ -239,6 +240,7 @@ public class ReloadRedirectTestCase {
     @Test
     public void testReloadwithRedirect() throws Exception {
         CliProcessWrapper cliProc = new CliProcessWrapper()
+                .addJavaOption(IBM_OVERRIDE_DEFAULT_TLS)
                 .addCliArgument("--connect")
                 .addCliArgument("--controller="
                         + TestSuiteEnvironment.getServerAddress() + ":"
@@ -257,6 +259,7 @@ public class ReloadRedirectTestCase {
     @Test
     public void testRedirectWithSecurityCommands() throws Throwable {
         CliProcessWrapper cliProc = new CliProcessWrapper()
+                .addJavaOption(IBM_OVERRIDE_DEFAULT_TLS)
                 .addCliArgument("--connect")
                 .addCliArgument("--no-color-output")
                 .addCliArgument("--controller="


### PR DESCRIPTION
The root cause of the reported problem is tha tthe property com.ibm.jsse2.overrideDefaultTLS=true is missing.
I ran into other cases when the :reload operation is canceled although the operation is not yet done. Fixed this case too.
