### PR TITLE
[WFCORE-3868] Notify the suspend listener when timeout is 0

### DIFF
--- a/server/src/main/java/org/jboss/as/server/operations/ServerShutdownHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/ServerShutdownHandler.java
@@ -146,10 +146,6 @@ public class ServerShutdownHandler implements OperationStepHandler {
                             };
                             suspendController.addListener(listener);
                             suspendController.suspend(timeout > 0 ?  timeout * 1000 : timeout);
-                            if(timeout == 0) {
-                                shutdown.shutdown();
-                            }
-
                         }
                     }
                 });

--- a/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
+++ b/server/src/main/java/org/jboss/as/server/suspend/SuspendController.java
@@ -103,6 +103,8 @@ public class SuspendController implements Service<SuspendController> {
                         timeout();
                     }
                 }, timeoutMillis);
+            } else if (timeoutMillis == 0) {
+                timeout();
             }
         }
     }


### PR DESCRIPTION
If a ManagerExecutor is executing a task which is re-scheduling a new instance of itself just before exiting then the domain cannot be stopped when the timeout of stop operation is 0.
The problem is the listener is not notified when the user uses 0 as a timeout.

Since EE subsystem is not available in wildfly-core, I will add a test case in wildfly once this patch is merged and available from wildfly.

Jira issue: https://issues.jboss.org/browse/WFCORE-3868