### PR TITLE
[WFCORE-3901] Remove wildfly-openssl-solaris-sparcv9 lincense

### DIFF
--- a/core-feature-pack/src/license/core-feature-pack-licenses.xml
+++ b/core-feature-pack/src/license/core-feature-pack-licenses.xml
@@ -1056,17 +1056,6 @@
     </dependency>
     <dependency>
       <groupId>org.wildfly.openssl</groupId>
-      <artifactId>wildfly-openssl-solaris-sparcv9</artifactId>
-      <licenses>
-        <license>
-          <name>Apache License 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>org.wildfly.openssl</groupId>
       <artifactId>wildfly-openssl-solaris-x86_64</artifactId>
       <licenses>
         <license>


### PR DESCRIPTION
This PR follows up https://github.com/wildfly/wildfly-core/pull/3208

From the point of view of distribution created by the feature pack, the wildfly-openssl-solaris-sparcv9 is not included in the final license, but since the library was removed, it looks like it makes sense remove the license as well.

Jira issue: https://issues.jboss.org/browse/WFCORE-3901