### PR TITLE
[WFCORE-3902] Support Maven staged repositories

### DIFF
--- a/model-test/src/main/java/org/jboss/as/model/test/MavenUtil.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/MavenUtil.java
@@ -254,6 +254,14 @@ class MavenUtil {
                 repository.setProxy(httpProxy);
             }
             remoteRepositories.add(repository.build());
+            // add the jboss staging repository only if the system property exists
+            if (System.getProperty("jboss.staging.repository.group") != null) {
+                RemoteRepository.Builder stagingRepository = new RemoteRepository.Builder("jboss-staging-repository-group", "default", "https://repository.jboss.org/nexus/content/groups/staging/");
+                if (httpProxy != null) {
+                    stagingRepository.setProxy(httpProxy);
+                }
+                remoteRepositories.add(stagingRepository.build());
+            }
             //add repos from users settings.xml
             List<String> remoteRepositories1 = mavenSettings.getRemoteRepositories();
             for (int i = 0; i < remoteRepositories1.size(); i++) {


### PR DESCRIPTION
* add staging repository to MavenUtil

If the jboss.staging.repository.group System property is present, adds
JBoss staging repository to the remote repositories used to download
artifacts from MavenUtil.

JIRA: https://issues.jboss.org/browse/WFCORE-3902