### PR TITLE
[WFCORE-3907] Rename wildfly-component-matrix-builder to

### DIFF
--- a/component-matrix-builder/pom.xml
+++ b/component-matrix-builder/pom.xml
@@ -30,7 +30,7 @@
     </parent>
 
     <groupId>org.wildfly.core</groupId>
-    <artifactId>wildfly-component-matrix-builder</artifactId>
+    <artifactId>wildfly-core-component-matrix-builder</artifactId>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
wildfly-core-component-matrix-builder to be able to import it into
Eclipse

https://issues.jboss.org/browse/WFCORE-3907

@jmesnil could you please review?