### PR TITLE
Fix for WFCORE-3910, CLI remove dependency on jdk.jconsole

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -43,7 +43,6 @@
         <module name="java.prefs"/>
         <module name="java.security.sasl"/>
         <module name="java.xml"/>
-        <module name="jdk.jconsole"/>
 
         <!-- JAXP default dependencies. DO NOT REMOVE!!!
              These are loaded by the JAXP redirect facility in jboss-modules when this module is used


### PR DESCRIPTION
Fix for WFCORE-3910: https://issues.jboss.org/browse/WFCORE-3910
Has been introduced due to jdeps advertising jdk.jconsole as a dependency. But this dependency is only present in a jconsole context, outside jboss modules.