### PR TITLE
[WFCORE-3915] Do not deploy testsuite modules

### DIFF
--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -28,6 +28,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <!-- uses wildfly-core-parent parent as wildfly-core-testsuite-shared
+     is a dependency of wildfly-core-testsuite and can not be its child
+    -->
     <parent>
         <groupId>org.wildfly.core</groupId>
         <artifactId>wildfly-core-parent</artifactId>
@@ -39,6 +42,12 @@
     <packaging>jar</packaging>
 
     <name>WildFly Core Test Suite: Shared</name>
+
+    <properties>
+        <!-- Don't deploy the testsuite modules -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <build>
         <resources>
             <resource>

--- a/testsuite/test-runner/pom.xml
+++ b/testsuite/test-runner/pom.xml
@@ -26,6 +26,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <!-- uses wildfly-core-parent parent as wildfly-core-testsuite-shared
+         is a dependency of wildfly-core-testsuite and can not be its child
+    -->
     <parent>
         <groupId>org.wildfly.core</groupId>
         <artifactId>wildfly-core-parent</artifactId>
@@ -37,6 +40,11 @@
     <name>WildFly: Test Runner</name>
     <description>A test runner used for running management integration tests.
         Arquillian is not used to avoid a circular dependency.</description>
+
+    <properties>
+        <!-- Don't deploy the testsuite modules -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/testsuite/vault-test-feature-pack/pom.xml
+++ b/testsuite/vault-test-feature-pack/pom.xml
@@ -43,6 +43,12 @@
         module solely for WildFly Core testsuite use in testing its security vault functionality
     </description>
 
+
+    <properties>
+        <!-- Don't deploy the testsuite modules -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
 
         <!-- feature pack dependencies -->


### PR DESCRIPTION
Some testsuite do not use wildfly-core-testsuite as their parent.
Flag those to skip Maven deployments (testsuite modules are not part of
a release).

JIRA: https://issues.jboss.org/browse/WFCORE-3915