### PR TITLE
[WFCORE-433]: git backend for loading/storing the configuration XML for wildfly

### DIFF
--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>vdx-wildfly</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
            <groupId>junit</groupId>
@@ -122,7 +127,6 @@
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3526,4 +3526,30 @@ public interface ControllerLogger extends BasicLogger {
             "to learn more about the deprecation.")
     String operationDeprecatedMessage(String name, String address);
 
+    @Message(id = 450, value = "Failed to clone the repository %s")
+    RuntimeException failedToCloneRepository(@Cause Exception cause, String repository);
+
+    /**
+     * Logs an error message indicating a failure to store the configuration file.
+     *
+     * @param cause the cause of the error.
+     * @param name  the name of the configuration.
+     * @return ConfigurationPersistenceException
+     */
+    @Message(id = 451, value = "Failed to publish configuration to %s because of %s")
+    ConfigurationPersistenceException failedToPublishConfiguration(@Cause Throwable cause, String name, String error);
+
+    @Message(id = 452, value = "Failed to persist configuration to %s because of %s")
+    ConfigurationPersistenceException failedToPersistConfiguration(@Cause Throwable cause, String name, String error);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 453, value = "Failed to delete configuration snapshot %s")
+    void failedToDeleteConfigurationSnapshot(@Cause Throwable cause, String name);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 454, value = "Failed to list configuration snapshots %s")
+    void failedToListConfigurationSnapshot(@Cause Throwable cause, String name);
+
+    @Message(id = 455, value = "Can't take snapshot %s because it already exists")
+    ConfigurationPersistenceException snapshotAlreadyExistError(String name);
 }

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/ConfigurationPublishHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/ConfigurationPublishHandler.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.controller.operations.common;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.access.AuthorizationResult;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
+import org.jboss.as.controller.persistence.ConfigurationPersister;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * Handler to publish configuration.
+ * Currently this is used only if git is used for persistence history.
+ * This will push the changes to a remote repository.
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class ConfigurationPublishHandler implements OperationStepHandler {
+
+    private static final String OPERATION_NAME = "publish-configuration";
+
+    private static final SimpleAttributeDefinition LOCATION = new SimpleAttributeDefinitionBuilder("location", ModelType.STRING)
+            .setRequired(false)
+            .build();
+
+    public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(OPERATION_NAME, ControllerResolver.getResolver("publish"))
+            .setParameters(LOCATION)
+            .setRuntimeOnly()
+            .withFlag(OperationEntry.Flag.MASTER_HOST_CONTROLLER_ONLY)
+            .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SNAPSHOTS)
+            .build();
+
+
+    private final ConfigurationPersister persister;
+
+    public ConfigurationPublishHandler(ConfigurationPersister persister) {
+        this.persister = persister;
+    }
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        AuthorizationResult authorizationResult = context.authorize(operation);
+        if (authorizationResult.getDecision() == AuthorizationResult.Decision.DENY) {
+            throw ControllerLogger.ROOT_LOGGER.unauthorized(operation.get(OP).asString(), context.getCurrentAddress(), authorizationResult.getExplanation());
+        }
+
+        String name = null;
+        if(operation.hasDefined(LOCATION.getName())) {
+            name = LOCATION.resolveModelAttribute(context, operation).asString();
+        }
+        try {
+            context.getResult().set(persister.publish(name));
+        } catch (ConfigurationPersistenceException e) {
+            throw new OperationFailedException(e);
+        }
+        context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+    }
+
+}

--- a/controller/src/main/java/org/jboss/as/controller/operations/common/SnapshotTakeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/common/SnapshotTakeHandler.java
@@ -18,12 +18,15 @@
  */
 package org.jboss.as.controller.operations.common;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.access.AuthorizationResult;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -45,7 +48,11 @@ public class SnapshotTakeHandler implements OperationStepHandler {
 
     private static final String OPERATION_NAME = "take-snapshot";
 
+    private static final AttributeDefinition COMMENT = SimpleAttributeDefinitionBuilder.create("comment", ModelType.STRING, true).setNullSignificant(true).build();
+    private static final AttributeDefinition SNAPSHOT_NAME = SimpleAttributeDefinitionBuilder.create(NAME, ModelType.STRING, true).setNullSignificant(true).build();
     public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(OPERATION_NAME, ControllerResolver.getResolver("snapshot"))
+            .addParameter(COMMENT)
+            .addParameter(SNAPSHOT_NAME)
             .setReplyType(ModelType.STRING)
             .setRuntimeOnly()
             .withFlag(OperationEntry.Flag.MASTER_HOST_CONTROLLER_ONLY)
@@ -64,9 +71,12 @@ public class SnapshotTakeHandler implements OperationStepHandler {
         if (authorizationResult.getDecision() == AuthorizationResult.Decision.DENY) {
             throw ControllerLogger.ROOT_LOGGER.unauthorized(operation.get(OP).asString(), context.getCurrentAddress(), authorizationResult.getExplanation());
         }
-
+        ModelNode commentNode = COMMENT.resolveModelAttribute(context, operation);
+        ModelNode snapshotNode = SNAPSHOT_NAME.resolveModelAttribute(context, operation);
+        String comment = commentNode.asStringOrNull();
+        String snapshot = snapshotNode.asStringOrNull();
         try {
-            String name = persister.snapshot();
+            String name = persister.snapshot(snapshot, comment);
             context.getResult().set(name);
         } catch (ConfigurationPersistenceException e) {
             throw new OperationFailedException(e);

--- a/controller/src/main/java/org/jboss/as/controller/persistence/AbstractConfigurationPersister.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/AbstractConfigurationPersister.java
@@ -118,11 +118,6 @@ public abstract class AbstractConfigurationPersister implements ExtensibleConfig
     }
 
     @Override
-    public String snapshot() throws ConfigurationPersistenceException{
-        return null;
-    }
-
-    @Override
     public SnapshotInfo listSnapshots() {
         return NULL_SNAPSHOT_INFO;
     }

--- a/controller/src/main/java/org/jboss/as/controller/persistence/AbstractFilePersistenceResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/AbstractFilePersistenceResource.java
@@ -21,7 +21,11 @@
 */
 package org.jboss.as.controller.persistence;
 
+import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
+
 import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.dmr.ModelNode;
@@ -55,7 +59,11 @@ public abstract class AbstractFilePersistenceResource implements ConfigurationPe
         if (marshalled == null) {
             throw ControllerLogger.ROOT_LOGGER.rollbackAlreadyInvoked();
         }
-        doCommit(marshalled);
+        try(InputStream in = getMarshalledInputStream()) {
+            doCommit(in);
+        } catch (IOException ioex) {
+            MGMT_OP_LOGGER.errorf(ioex, ioex.getMessage());
+        }
     }
 
     @Override
@@ -63,5 +71,9 @@ public abstract class AbstractFilePersistenceResource implements ConfigurationPe
         marshalled = null;
     }
 
-    protected abstract void doCommit(ExposedByteArrayOutputStream marshalled);
+    protected InputStream getMarshalledInputStream() {
+        return marshalled.getInputStream();
+    }
+
+    protected abstract void doCommit(InputStream marshalled);
 }

--- a/controller/src/main/java/org/jboss/as/controller/persistence/BackupXmlConfigurationPersister.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/BackupXmlConfigurationPersister.java
@@ -121,8 +121,8 @@ public class BackupXmlConfigurationPersister extends XmlConfigurationPersister {
     }
 
     @Override
-    public String snapshot() throws ConfigurationPersistenceException {
-        return configurationFile.snapshot();
+    public String snapshot(String name, String comment) throws ConfigurationPersistenceException {
+        return configurationFile.snapshot(name, comment);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFilePersistenceResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationFilePersistenceResource.java
@@ -25,6 +25,7 @@ package org.jboss.as.controller.persistence;
 import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
 
 import java.io.File;
+import java.io.InputStream;
 
 import org.jboss.dmr.ModelNode;
 
@@ -48,7 +49,7 @@ public class ConfigurationFilePersistenceResource extends AbstractFilePersistenc
     }
 
     @Override
-    public void doCommit(ExposedByteArrayOutputStream marshalled) {
+    protected void doCommit(InputStream in) {
         final File tempFileName;
 
         if ( FilePersistenceUtils.isParentFolderWritable(fileName) ){
@@ -59,7 +60,7 @@ public class ConfigurationFilePersistenceResource extends AbstractFilePersistenc
 
         try {
             try {
-                FilePersistenceUtils.writeToTempFile(marshalled, tempFileName, fileName);
+                FilePersistenceUtils.writeToTempFile(in, tempFileName, fileName);
             } catch (Exception e) {
                 MGMT_OP_LOGGER.failedToStoreConfiguration(e, fileName.getName());
                 return;

--- a/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationPersister.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/ConfigurationPersister.java
@@ -76,6 +76,7 @@ public interface ConfigurationPersister {
      *
      * @return callback to use to control whether the stored model should be flushed to permanent storage. Will not be
      *          {@code null}
+     * @throws org.jboss.as.controller.persistence.ConfigurationPersistenceException
      */
     PersistenceResource store(ModelNode model, Set<PathAddress> affectedAddresses) throws ConfigurationPersistenceException;
 
@@ -91,6 +92,8 @@ public interface ConfigurationPersister {
     /**
      * Load the configuration model, returning it as a list of updates to be
      * executed by the controller.
+     * @return the configuration model as a list of updates to be executed by the controller.
+     * @throws org.jboss.as.controller.persistence.ConfigurationPersistenceException
      */
     List<ModelNode> load() throws ConfigurationPersistenceException;
 
@@ -99,6 +102,7 @@ public interface ConfigurationPersister {
      * and all services have started successfully.
      *
      * @see #isPersisting()
+     * @throws org.jboss.as.controller.persistence.ConfigurationPersistenceException
      */
     void successfulBoot() throws ConfigurationPersistenceException;
 
@@ -107,8 +111,33 @@ public interface ConfigurationPersister {
      *
      * @return the file location of the snapshot
      * @throws ConfigurationPersistenceException if a problem happened when creating the snapshot
+     * @deprecated use #snapshot(String name, String message) instead.
      */
-    String snapshot() throws ConfigurationPersistenceException;
+    @Deprecated
+    default String snapshot() throws ConfigurationPersistenceException {
+         return snapshot(null, "");
+    }
+
+    /**
+     * Take a snapshot of the current configuration.
+     *
+     * @param message optionnal message
+     * @return the file location of the snapshot
+     * @throws ConfigurationPersistenceException if a problem happened when creating the snapshot
+     */
+    default String snapshot(String name, String message) throws ConfigurationPersistenceException {
+         return "";
+    }
+
+    /**
+     * Publish the current configuration
+     * @param target the target destination of the publication.
+     * @return the location of the published configuraiotn
+     * @throws ConfigurationPersistenceException if a problem happened when publishing
+     */
+    default String publish(String target) throws ConfigurationPersistenceException {
+         return null;
+    }
 
     /**
      * Gets the names of the snapshots in the snapshots directory

--- a/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceResource.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceResource.java
@@ -25,6 +25,7 @@ package org.jboss.as.controller.persistence;
 import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
 
 import java.io.File;
+import java.io.InputStream;
 
 import org.jboss.dmr.ModelNode;
 
@@ -43,12 +44,11 @@ public class FilePersistenceResource extends AbstractFilePersistenceResource {
 
     }
 
-
     @Override
-    protected void doCommit(ExposedByteArrayOutputStream marshalled) {
+    protected void doCommit(InputStream in) {
         final File tempFileName = FilePersistenceUtils.createTempFile(fileName);
         try {
-            FilePersistenceUtils.writeToTempFile(marshalled, tempFileName, fileName);
+            FilePersistenceUtils.writeToTempFile(in, tempFileName, fileName);
             FilePersistenceUtils.moveTempFileToMain(tempFileName, fileName);
         } catch (Exception e) {
             MGMT_OP_LOGGER.failedToStoreConfiguration(e, fileName.getName());

--- a/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/FilePersistenceUtils.java
@@ -37,6 +37,7 @@ import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -50,6 +51,29 @@ import org.xnio.IoUtils;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 class FilePersistenceUtils {
+    static final int[] ILLEGAL_CHARS = {34, 60, 62, 124, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 58, 42, 63, 92, 47};
+    static {
+        Arrays.sort(ILLEGAL_CHARS);
+    }
+
+    static String sanitizeFileName(String name) {
+        if(name == null || name.isEmpty()) {
+            return "";
+        }
+        StringBuilder cleanName = new StringBuilder();
+        int len = name.codePointCount(0, name.length());
+        for (int i = 0; i < len; i++) {
+            int c = name.codePointAt(i);
+            if (Arrays.binarySearch(ILLEGAL_CHARS, c) < 0) {
+                cleanName.appendCodePoint(c);
+            }
+        }
+        try {
+            return new File(cleanName.toString()).getCanonicalFile().getName();
+        } catch (IOException ex) {
+            return "";
+        }
+    }
 
     static File createTempFile(File fileName) {
         return createTempFile(fileName.getParentFile(), fileName.getName());
@@ -98,7 +122,7 @@ class FilePersistenceUtils {
         }
     }
 
-    static File writeToTempFile(ExposedByteArrayOutputStream marshalled, File tempFileName, File fileName) throws IOException {
+    static File writeToTempFile(InputStream is, File tempFileName, File fileName) throws IOException {
         Path targetPath = tempFileName.toPath();
         deleteFile(tempFileName);
         try {
@@ -106,9 +130,7 @@ class FilePersistenceUtils {
         } catch (IOException ioex) {
             ControllerLogger.ROOT_LOGGER.error(ioex.getLocalizedMessage(), ioex);
         }
-        try (InputStream is = marshalled.getInputStream()) {
-            Files.copy(is, targetPath, StandardCopyOption.REPLACE_EXISTING);
-        }
+        Files.copy(is, targetPath, StandardCopyOption.REPLACE_EXISTING);
         return tempFileName;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/persistence/XmlConfigurationPersister.java
+++ b/controller/src/main/java/org/jboss/as/controller/persistence/XmlConfigurationPersister.java
@@ -166,8 +166,4 @@ public class XmlConfigurationPersister extends AbstractConfigurationPersister {
 
     }
 
-    @Override
-    public String snapshot() throws ConfigurationPersistenceException {
-        return "";
-    }
 }

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -623,6 +623,9 @@ read-config-as-xml=Reads the current configuration and returns it in XML format.
 read-config-as-xml.response=The XML form of the persistent configuration.
 add-deployer-chains=Adds deployer chain
 
+#Publish
+publish.publish-configuration=Publish the configuration to some external location.
+publish.publish-configuration.location=The location where the configuration is going to be published. This should be a valid remote git repository (either URL or alias).
 
 #Snapshots
 snapshot.delete-snapshot=Deletes a snapshot from the snapshots directory
@@ -631,6 +634,8 @@ snapshot.list-snapshots=Lists the snapshots
 snapshot.list-snapshots.directory=The directory where the snapshots are stored
 snapshot.list-snapshots.names=The names of the snapshots within the snapshots directory
 snapshot.take-snapshot=Takes a snapshot of the current configuration
+snapshot.take-snapshot.name=The name of the snapshot being taken.
+snapshot.take-snapshot.comment=Comment on the snapshot being taken.
 snapshot.take-snapshot.reply=The location of the file on the machine the configuration belongs
 
 # Misc

--- a/controller/src/test/java/org/jboss/as/controller/persistence/FilePersistenceUtilsTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/FilePersistenceUtilsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.controller.persistence;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2018 Red Hat, inc.
+ */
+public class FilePersistenceUtilsTest {
+
+    @Test
+    public void testSanitizeFileName() {
+        String name = "name.é";
+        Assert.assertEquals("name.é", FilePersistenceUtils.sanitizeFileName(name));
+        name = "/name.é";
+        Assert.assertEquals("name.é",FilePersistenceUtils.sanitizeFileName(name));
+        name = "name.é\\";
+        Assert.assertEquals("name.é",FilePersistenceUtils.sanitizeFileName(name));
+        name = "\\name.txt";
+        Assert.assertEquals("name.txt", FilePersistenceUtils.sanitizeFileName(name));
+        name = "../name.txt";
+        Assert.assertEquals("..name.txt",FilePersistenceUtils.sanitizeFileName(name));
+        name = "~/name.txt";
+        Assert.assertEquals("~name.txt",FilePersistenceUtils.sanitizeFileName(name));
+        name = "name.txt\r\n";
+        Assert.assertEquals("name.txt",FilePersistenceUtils.sanitizeFileName(name));
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistanceResourceTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistanceResourceTestCase.java
@@ -787,7 +787,7 @@ public class PersistanceResourceTestCase {
         checkFiles(null, "One", "std", "std", "One", "std");
 
         //Make sure that a reset to a snapshot loads that file
-        configurationFile.snapshot();
+        configurationFile.snapshot(null, null);
         ConfigurationPersister.SnapshotInfo snapshotInfo = configurationFile.listSnapshots();
         Assert.assertEquals(1, snapshotInfo.names().size());
         store(persister, "Two");
@@ -834,7 +834,7 @@ public class PersistanceResourceTestCase {
         checkFiles(null, "std", "std", "std", "One", "std");
 
         //Make sure that a reset to a snapshot loads that file
-        configurationFile.snapshot();
+        configurationFile.snapshot(null, null);
         ConfigurationPersister.SnapshotInfo snapshotInfo = configurationFile.listSnapshots();
         Assert.assertEquals(1, snapshotInfo.names().size());
         store(persister, "Two");

--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -307,6 +307,46 @@
             <artifactId>wildfly-openssl-solaris-x86_64</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jzlib</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.googlecode.javaewah</groupId>
+            <artifactId>JavaEWAH</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-codec</artifactId>
+                    <groupId>commons-codec</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+
         <!-- Add this dependency to make sure that the core model is tested before we build the server -->
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/core-feature-pack/src/license/core-feature-pack-licenses.xml
+++ b/core-feature-pack/src/license/core-feature-pack-licenses.xml
@@ -24,6 +24,39 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>com.googlecode.javaewah</groupId>
+      <artifactId>JavaEWAH</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jsch</artifactId>
+      <licenses>
+        <license>
+          <name>BSD style licence</name>
+          <url>http://www.jcraft.com/jsch/LICENSE.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>com.jcraft</groupId>
+      <artifactId>jzlib</artifactId>
+      <licenses>
+        <license>
+          <name>BSD style licence</name>
+          <url>http://www.jcraft.com/jzlib/LICENSE.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-core</artifactId>
       <licenses>
@@ -51,12 +84,50 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+        <license>
+          <name>Creative Commons Attribution 2.5</name>
+          <url>http://creativecommons.org/licenses/by/2.5/legalcode</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>stax2-api</artifactId>
       <licenses>
         <license>
           <name>The BSD License</name>
           <url>http://repository.jboss.org/licenses/bsd.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
+        <groupId>org.eclipse.jgit</groupId>
+        <artifactId>org.eclipse.jgit</artifactId>
+        <licenses>
+        <license>
+          <name>Eclipse Distribution License - v 1.0</name>
+          <url>http://repository.jboss.org/licenses/edl-1.0.txt</url>
           <distribution>repo</distribution>
         </license>
       </licenses>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/com/googlecode/javaewah/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/com/googlecode/javaewah/main/module.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="com.googlecode.javaewah">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${com.googlecode.javaewah:JavaEWAH}" />
+    </resources>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/com/jcraft/jsch/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/com/jcraft/jsch/main/module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.8" name="com.jcraft.jsch">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${com.jcraft:jsch}"/>
+    </resources>
+
+    <dependencies>
+        <module name="com.jcraft.jzlib"/>
+    </dependencies>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/com/jcraft/jzlib/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/com/jcraft/jzlib/main/module.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="com.jcraft.jzlib">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${com.jcraft:jzlib}"/>
+    </resources>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/core/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/core/main/module.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.8" name="org.apache.httpcomponents.core">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.apache.httpcomponents:httpclient}"/>
+        <artifact name="${org.apache.httpcomponents:httpcore}"/>
+    </resources>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/jgit/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/jgit/main/module.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2010, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<module xmlns="urn:jboss:module:1.8" name="org.eclipse.jgit">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.eclipse.jgit:org.eclipse.jgit}"/>
+    </resources>
+
+    <dependencies>
+        <module name="org.slf4j" />
+        <module name="org.slf4j.impl" />
+        <module name="javax.api"/>
+        <module name="com.jcraft.jsch"/>
+        <module name="com.jcraft.jzlib"/>
+        <module name="com.googlecode.javaewah"/>
+        <module name="org.apache.httpcomponents.core"/>
+    </dependencies>
+</module>

--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
@@ -58,5 +58,6 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.threads"/>
         <module name="org.projectodd.vdx"/>
+        <module name="org.eclipse.jgit" export="true"/>
     </dependencies>
 </module>

--- a/core-galleon-pack/pom.xml
+++ b/core-galleon-pack/pom.xml
@@ -260,6 +260,46 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jzlib</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.googlecode.javaewah</groupId>
+            <artifactId>JavaEWAH</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>commons-codec</artifactId>
+                    <groupId>commons-codec</groupId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>

--- a/deployment-repository/pom.xml
+++ b/deployment-repository/pom.xml
@@ -103,6 +103,10 @@
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-protocol</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepository.java
@@ -159,6 +159,9 @@ public interface ContentRepository {
     default void readOnly() {
     }
 
+    default void flush(boolean success) {
+    }
+
     /**
      * Clean content that is not referenced from the repository.
      *

--- a/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepositoryImpl.java
+++ b/deployment-repository/src/main/java/org/jboss/as/repository/ContentRepositoryImpl.java
@@ -198,7 +198,7 @@ public class ContentRepositoryImpl implements ContentRepository {
         return getDeploymentContentFile(deploymentHash, false);
     }
 
-    private Path getDeploymentContentFile(byte[] deploymentHash, boolean validate) {
+    protected Path getDeploymentContentFile(byte[] deploymentHash, boolean validate) {
         return getDeploymentHashDir(deploymentHash, validate).resolve(CONTENT);
     }
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerConfigurationPersister.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerConfigurationPersister.java
@@ -220,7 +220,7 @@ public class HostControllerConfigurationPersister implements ExtensibleConfigura
     }
 
     @Override
-    public String snapshot() throws ConfigurationPersistenceException {
+    public String snapshot(String name, String comment) throws ConfigurationPersistenceException {
         throw new UnsupportedOperationException();
     }
 
@@ -253,7 +253,7 @@ public class HostControllerConfigurationPersister implements ExtensibleConfigura
         final String defaultDomainConfig = WildFlySecurityManager.getPropertyPrivileged(HostControllerEnvironment.JBOSS_DOMAIN_DEFAULT_CONFIG, "domain.xml");
         final String initialDomainConfig = environment.getInitialDomainConfig();
         return new ConfigurationFile(environment.getDomainConfigurationDir(), defaultDomainConfig,
-                initialDomainConfig == null ? environment.getDomainConfig() : initialDomainConfig, environment.getDomainConfigurationFileInteractionPolicy());
+                initialDomainConfig == null ? environment.getDomainConfig() : initialDomainConfig, environment.getDomainConfigurationFileInteractionPolicy(), false);
     }
 
     private ConfigurationFile getBackupDomainConfigurationFile() {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -380,10 +380,6 @@ public class HostControllerEnvironment extends ProcessEnvironment {
         this.domainConfigurationDir = tmp;
         WildFlySecurityManager.setPropertyPrivileged(DOMAIN_CONFIG_DIR, this.domainConfigurationDir.getAbsolutePath());
 
-        final String defaultHostConfig = WildFlySecurityManager.getPropertyPrivileged(JBOSS_HOST_DEFAULT_CONFIG, "host.xml");
-
-        hostConfigurationFile = new ConfigurationFile(domainConfigurationDir, defaultHostConfig, initialHostConfig == null ? hostConfig : initialHostConfig, hostConfigInteractionPolicy);
-
         this.domainConfig = domainConfig;
         this.initialDomainConfig = initialDomainConfig;
 
@@ -474,6 +470,11 @@ public class HostControllerEnvironment extends ProcessEnvironment {
         } else {
             this.defaultJVM = null;
         }
+
+        final String defaultHostConfig = WildFlySecurityManager.getPropertyPrivileged(JBOSS_HOST_DEFAULT_CONFIG, "host.xml");
+
+        hostConfigurationFile = new ConfigurationFile(domainConfigurationDir, defaultHostConfig, initialHostConfig == null ? hostConfig : initialHostConfig, hostConfigInteractionPolicy, false);
+
         final Path filePath = this.domainDataDir.toPath().resolve(KERNEL_DIR).resolve(UUID_FILE);
         UUID uuid;
         try {

--- a/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
+++ b/launcher/src/main/java/org/wildfly/core/launcher/StandaloneCommandBuilder.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.core.launcher;
 
+import static org.wildfly.core.launcher.logger.LauncherMessages.MESSAGES;
+
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -399,6 +401,21 @@ public class StandaloneCommandBuilder extends AbstractCommandBuilder<StandaloneC
      */
     public StandaloneCommandBuilder addSecurityProperties(final Map<String, String> properties) {
         securityProperties.putAll(properties);
+        return this;
+    }
+
+    public StandaloneCommandBuilder setGitRepository(final String gitRepository, final String gitBranch, final String gitAuthentication) {
+        if(gitRepository == null) {
+            throw MESSAGES.nullParam("git-repo");
+        }
+        addServerArg("--git-repo", gitRepository);
+        if (gitBranch != null) {
+            addServerArg("--git-branch", gitBranch);
+        }
+        if (gitAuthentication != null) {
+            addServerArg("--git-auth", gitAuthentication);
+        }
+
         return this;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,10 @@
          -->
         <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
         <version.com.fasterxml.jackson.core.jackson-databind>2.9.2</version.com.fasterxml.jackson.core.jackson-databind>
+        <version.com.googlecode.javaewah>1.1.6</version.com.googlecode.javaewah>
         <version.com.io7m.xom>1.2.10</version.com.io7m.xom>
+        <version.com.jcraft.jsch>0.1.54</version.com.jcraft.jsch>
+        <version.com.jcraft.jzlib>1.1.1</version.com.jcraft.jzlib>
         <version.commons-io>2.5</version.commons-io>
         <version.commons-lang>2.6</version.commons-lang>
         <version.io.undertow>2.0.10.Final</version.io.undertow>
@@ -154,6 +157,7 @@
         <version.org.codehaus.plexus.plexus-utils>3.1.0</version.org.codehaus.plexus.plexus-utils>
         <version.org.codehaus.woodstox.stax2-api>3.1.4</version.org.codehaus.woodstox.stax2-api>
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
+        <version.org.eclipse.jgit>5.0.2.201807311906-r</version.org.eclipse.jgit>
         <version.org.fusesource.jansi>1.16</version.org.fusesource.jansi>
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
         <version.org.jboss.byteman>4.0.4</version.org.jboss.byteman>
@@ -1053,6 +1057,38 @@
                 <artifactId>slf4j-ext</artifactId>
                 <version>${version.org.slf4j}</version>
             </dependency>
+            <!-- git persistence -->
+           <dependency>
+                <groupId>org.eclipse.jgit</groupId>
+                <artifactId>org.eclipse.jgit</artifactId>
+                <version>${version.org.eclipse.jgit}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jsch</artifactId>
+                <version>${version.com.jcraft.jsch}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.jcraft</groupId>
+                <artifactId>jzlib</artifactId>
+                <version>${version.com.jcraft.jzlib}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.googlecode.javaewah</groupId>
+                <artifactId>JavaEWAH</artifactId>
+                <version>${version.com.googlecode.javaewah}</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.wildfly.build</groupId>
                 <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
@@ -1604,6 +1640,7 @@
             <layout>default</layout>
         </repository>
     </repositories>
+
 
     <pluginRepositories>
         <pluginRepository>

--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
@@ -72,6 +72,11 @@ public class CommandLineConstants {
     public static final String HELP = "--help";
     public static final String SHORT_HELP = "-h";
 
+    /** Passed in to a SERVER to configure the git repository used for configuration history. */
+    public static final String GIT_REPO = "--git-repo";
+    public static final String GIT_BRANCH = "--git-branch";
+    public static final String GIT_AUTH = "--git-auth";
+
     /** Passed in to a DC to choose the domain.xml file. The location must be relative to the domain configuration directory */
     public static final String OLD_DOMAIN_CONFIG = "-domain-config";
     public static final String DOMAIN_CONFIG = "--domain-config";

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -145,6 +145,10 @@
             <groupId>org.wildfly.common</groupId>
             <artifactId>wildfly-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+        </dependency>
         <!--
         <dependency>
             <groupId>org.picketbox</groupId>
@@ -170,6 +174,16 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.slf4j</groupId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ApplicationServerService.java
@@ -36,6 +36,7 @@ import java.util.TreeSet;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.repository.ContentRepository;
+import org.jboss.as.server.controller.git.GitContentRepository;
 import org.jboss.as.server.deployment.ContentCleanerService;
 import org.jboss.as.server.deployment.DeploymentMountProvider;
 import org.jboss.as.server.logging.ServerLogger;
@@ -141,7 +142,11 @@ final class ApplicationServerService implements Service<AsyncFuture<ServiceConta
         // Install either a local or remote content repository
         if(standalone) {
             if ( ! selfContained ) {
-                ContentRepository.Factory.addService(serviceTarget, serverEnvironment.getServerContentDir(), serverEnvironment.getServerTempDir());
+                if(serverEnvironment.useGit()) {
+                    GitContentRepository.addService(serviceTarget, serverEnvironment.getGitRepository(), serverEnvironment.getServerContentDir(), serverEnvironment.getServerTempDir());
+                } else {
+                    ContentRepository.Factory.addService(serviceTarget, serverEnvironment.getServerContentDir(), serverEnvironment.getServerTempDir());
+                }
             }
         } else {
             RemoteFileRepositoryService.addService(serviceTarget, serverEnvironment.getServerContentDir(), serverEnvironment.getServerTempDir());

--- a/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
+++ b/server/src/main/java/org/jboss/as/server/CommandLineArgumentUsageImpl.java
@@ -77,6 +77,14 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
         addArguments(CommandLineConstants.START_MODE);
         instructions.add(ServerLogger.ROOT_LOGGER.argStartMode());
 
+        addArguments(CommandLineConstants.GIT_REPO + " <repo_url>", CommandLineConstants.GIT_REPO + "=<repo_url>");
+        instructions.add(ServerLogger.ROOT_LOGGER.argGitRepo());
+
+        addArguments(CommandLineConstants.GIT_BRANCH + " <branch>", CommandLineConstants.GIT_BRANCH + "=<branch>");
+        instructions.add(ServerLogger.ROOT_LOGGER.argGitBranch());
+
+        addArguments(CommandLineConstants.GIT_AUTH + " <auth_config>", CommandLineConstants.GIT_AUTH + "=<auth_config>");
+        instructions.add(ServerLogger.ROOT_LOGGER.argGitAuth());
     }
 
     public static void printUsage(final PrintStream out) {

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -26,8 +26,10 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
+import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -44,11 +46,13 @@ import org.jboss.as.controller.interfaces.InetAddressUtil;
 import org.jboss.as.controller.operations.common.ProcessEnvironment;
 import org.jboss.as.controller.persistence.ConfigurationFile;
 import org.jboss.as.network.NetworkUtils;
+import org.jboss.as.server.controller.git.GitRepository;
+import org.jboss.as.server.controller.git.GitRepositoryConfiguration;
 import org.jboss.as.server.logging.ServerLogger;
 import org.jboss.as.version.ProductConfig;
 import org.jboss.modules.Module;
-import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
+import org.wildfly.client.config.ConfigXMLParseException;
 import org.wildfly.common.cpu.ProcessorInfo;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -323,30 +327,33 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
     private final UUID serverUUID;
     private final long startTime;
     private final boolean startSuspended;
+    private GitRepository repository;
 
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
                              final RunningMode initialRunningMode, ProductConfig productConfig, boolean startSuspended) {
         this(hostControllerName, props, env, serverConfig, configInteractionPolicy, launchType, initialRunningMode, productConfig,
-                System.currentTimeMillis(), startSuspended);
+                System.currentTimeMillis(), startSuspended, null, null, null);
     }
 
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
                              final RunningMode initialRunningMode, ProductConfig productConfig) {
         this(hostControllerName, props, env, serverConfig, configInteractionPolicy, launchType, initialRunningMode, productConfig,
-                System.currentTimeMillis(), false);
+                System.currentTimeMillis(), false, null, null, null);
     }
 
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
-                             final RunningMode initialRunningMode, ProductConfig productConfig, long startTime) {
-        this(hostControllerName, props, env, serverConfig, configInteractionPolicy, launchType, initialRunningMode, productConfig, startTime, false);
+                             final RunningMode initialRunningMode, ProductConfig productConfig, long startTime, String gitRepository, String gitBranch, String gitAuthConfiguration) {
+        this(hostControllerName, props, env, serverConfig, configInteractionPolicy, launchType, initialRunningMode, productConfig,
+                startTime, false, gitRepository, gitBranch, gitAuthConfiguration);
     }
 
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
-                             final RunningMode initialRunningMode, ProductConfig productConfig, long startTime, boolean startSuspended) {
+                             final RunningMode initialRunningMode, ProductConfig productConfig, long startTime, boolean startSuspended,
+                             String gitRepository, String gitBranch, String gitAuthConfiguration) {
         this.startSuspended = startSuspended;
         assert props != null;
 
@@ -390,6 +397,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
             controllerTempDir = serverTempDir;
             domainBaseDir = null;
             domainConfigurationDir = null;
+            repository = null;
             WildFlySecurityManager.setPropertyPrivileged(ServerEnvironment.JBOSS_PERSIST_SERVER_CONFIG, "false");
         } else {
 
@@ -449,13 +457,6 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
             if (standalone && (!serverConfigurationDir.exists() || !serverConfigurationDir.isDirectory())) {
                 throw ServerLogger.ROOT_LOGGER.configDirectoryDoesNotExist(serverConfigurationDir);
             }
-
-            String defaultServerConfig = WildFlySecurityManager.getPropertyPrivileged(JBOSS_SERVER_DEFAULT_CONFIG, "standalone.xml");
-            serverConfigurationFile = standalone ? new ConfigurationFile(serverConfigurationDir, defaultServerConfig, serverConfig, configInteractionPolicy) : null;
-            // Adds a system property to indicate whether or not the server configuration should be persisted
-            @SuppressWarnings("deprecation")
-            final String propertyKey = JBOSS_PERSIST_SERVER_CONFIG;
-            WildFlySecurityManager.setPropertyPrivileged(propertyKey, Boolean.toString(configInteractionPolicy == null || !configInteractionPolicy.isReadOnly()));
 
             tmp = getFileFromProperty(SERVER_DATA_DIR, props);
             if (tmp == null) {
@@ -525,6 +526,29 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
                 throw ServerLogger.ROOT_LOGGER.couldNotCreateControllerTempDirectory(tmp);
             }
             controllerTempDir = tmp;
+            String defaultServerConfig = WildFlySecurityManager.getPropertyPrivileged(JBOSS_SERVER_DEFAULT_CONFIG, "standalone.xml");
+            GitRepositoryConfiguration gitConfiguration = GitRepositoryConfiguration.Builder.getInstance()
+                    .setBasePath(serverBaseDir.toPath())
+                    .setAuthenticationConfig(gitAuthConfiguration)
+                    .setBranch(gitBranch)
+                    .setRepository(gitRepository)
+                    .setIgnored(listIgnoredFiles(defaultServerConfig))
+                    .build();
+            if (gitConfiguration != null ) {
+                try {
+                    repository = new GitRepository(gitConfiguration);
+                } catch(IllegalArgumentException | IOException | ConfigXMLParseException | GeneralSecurityException ex) {
+                    repository = null;
+                    ServerLogger.ROOT_LOGGER.errorUsingGit(ex, ex.getMessage());
+                }
+            } else {
+                repository = null;
+            }
+            serverConfigurationFile = standalone ? new ConfigurationFile(serverConfigurationDir, defaultServerConfig, serverConfig, configInteractionPolicy, repository != null) : null;
+            // Adds a system property to indicate whether or not the server configuration should be persisted
+            @SuppressWarnings("deprecation")
+            final String propertyKey = JBOSS_PERSIST_SERVER_CONFIG;
+            WildFlySecurityManager.setPropertyPrivileged(propertyKey, Boolean.toString(configInteractionPolicy == null || !configInteractionPolicy.isReadOnly()));
 
             // Optional paths for the domain mode
             tmp = getFileFromProperty(DOMAIN_BASE_DIR, props);
@@ -602,10 +626,46 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
         // Register the vfs module as URLStreamHandlerFactory
         try {
             ModuleLoader bootLoader = Module.getBootModuleLoader();
-            Module vfsModule = bootLoader.loadModule(ModuleIdentifier.create(VFS_MODULE_IDENTIFIER));
+            Module vfsModule = bootLoader.loadModule(VFS_MODULE_IDENTIFIER);
             Module.registerURLStreamHandlerFactoryModule(vfsModule);
         } catch (Exception ex) {
             ServerLogger.ROOT_LOGGER.cannotAddURLStreamHandlerFactory(ex, VFS_MODULE_IDENTIFIER);
+        }
+    }
+
+    private Set<String> listIgnoredFiles(String defaultServerConfig) {
+        Set<String> ignored = new LinkedHashSet<>();
+        setIgnored(ignored, serverDataDir.toPath(), true, false);
+        setUnignored(ignored, serverDataDir.toPath(), false);
+        setUnignored(ignored, serverContentDir.toPath(), true);
+        setIgnored(ignored, serverConfigurationDir.toPath().resolve("logging.properties"), false, true);
+        setIgnored(ignored, serverBaseDir.toPath().resolve("deployments"), false, false);
+        setIgnored(ignored, serverLogDir.toPath(), false, false);
+        setIgnored(ignored, serverTempDir.toPath(), false, false);
+        setIgnored(ignored, serverConfigurationDir.toPath().resolve(defaultServerConfig.replace('.', '_') + "_history"), false, false);
+        return ignored;
+    }
+
+    private void setIgnored(Set<String> ignored, Path path, boolean wilcard, boolean isFile) {
+        final Path serverBasePath = serverBaseDir.toPath();
+        if (path.startsWith(serverBasePath)) {
+            String ignoredBasePath = serverBasePath.relativize(path).toString().replace('\\', '/');
+            if (wilcard) {
+                ignored.add(ignoredBasePath + "/*");
+            } else {
+                if (isFile) {
+                    ignored.add(ignoredBasePath);
+                } else {
+                    ignored.add(ignoredBasePath + '/');
+                }
+            }
+        }
+    }
+
+    private void setUnignored(Set<String> ignored, Path path, boolean dir) {
+        final Path serverBasePath = serverBaseDir.toPath();
+        if(path.startsWith(serverBasePath)) {
+            ignored.add("!" + serverBasePath.relativize(path).toString().replace('\\', '/'));
         }
     }
 
@@ -1030,6 +1090,14 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
      */
     public long getStartTime() {
         return startTime;
+    }
+
+    public boolean useGit() {
+        return this.repository != null;
+    }
+
+    public GitRepository getGitRepository() {
+        return repository;
     }
 
     /**

--- a/server/src/main/java/org/jboss/as/server/ServerStartTask.java
+++ b/server/src/main/java/org/jboss/as/server/ServerStartTask.java
@@ -131,7 +131,7 @@ public final class ServerStartTask implements ServerTask, Serializable, ObjectIn
         // Create server environment on the server, so that the system properties are getting initialized on the right side
         final ServerEnvironment providedEnvironment = new ServerEnvironment(hostControllerName, properties,
                 WildFlySecurityManager.getSystemEnvironmentPrivileged(), null, null, ServerEnvironment.LaunchType.DOMAIN,
-                RunningMode.NORMAL, productConfig, Module.getStartTime(), suspend);
+                RunningMode.NORMAL, productConfig, Module.getStartTime(), suspend, null, null, null);
         DomainServerCommunicationServices.updateOperationID(initialOperationID);
 
         // TODO perhaps have ConfigurationPersisterFactory as a Service

--- a/server/src/main/java/org/jboss/as/server/controller/git/ElytronClientCredentialsProvider.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/ElytronClientCredentialsProvider.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.server.controller.git;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.AccessController;
+import java.security.GeneralSecurityException;
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.auth.callback.UnsupportedCallbackException;
+import org.eclipse.jgit.errors.UnsupportedCredentialItem;
+import org.eclipse.jgit.transport.CredentialItem;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.URIish;
+import org.wildfly.client.config.ConfigXMLParseException;
+import org.wildfly.security.auth.client.AuthenticationConfiguration;
+import org.wildfly.security.auth.client.AuthenticationContext;
+import org.wildfly.security.auth.client.AuthenticationContextConfigurationClient;
+import org.wildfly.security.auth.client.ElytronXmlParser;
+
+/**
+ * Credential provider for JGIt using Elytron.
+ * Currently only login/password is supported.
+ * @author Emmanuel Hugonnet (c) 2018 Red Hat, inc.
+ */
+public class ElytronClientCredentialsProvider extends CredentialsProvider {
+
+    private static AuthenticationContextConfigurationClient CLIENT = AccessController.doPrivileged(AuthenticationContextConfigurationClient.ACTION);
+    private final AuthenticationContext context;
+
+    public ElytronClientCredentialsProvider(URI authenticationConfig) throws ConfigXMLParseException, GeneralSecurityException {
+        context =  ElytronXmlParser.parseAuthenticationClientConfiguration(authenticationConfig).create();
+    }
+
+    @Override
+    public boolean isInteractive() {
+        return false;
+    }
+
+    @Override
+    public boolean supports(CredentialItem... items) {
+        for (CredentialItem i : items) {
+            if (!(i instanceof CredentialItem.Username) && !(i instanceof CredentialItem.Password)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean get(URIish uri, CredentialItem... items) throws UnsupportedCredentialItem {
+        try {
+            AuthenticationConfiguration config = CLIENT.getAuthenticationConfiguration(new URI(uri.toString()), context);
+            for (CredentialItem i : items) {
+                if (i instanceof CredentialItem.Username) {
+                    NameCallback callback = new NameCallback("git username");
+                    Callback[] callbacks = {callback};
+                    CLIENT.getCallbackHandler(config).handle(callbacks);
+                    ((CredentialItem.Username) i).setValue(callback.getName());
+                    continue;
+                }
+                if (i instanceof CredentialItem.Password) {
+                    PasswordCallback callback = new PasswordCallback("git username", false);
+                    Callback[] callbacks = {callback};
+                    CLIENT.getCallbackHandler(config).handle(callbacks);
+                    ((CredentialItem.Password) i).setValue(callback.getPassword());
+                    continue;
+                }
+                if (i instanceof CredentialItem.StringType) {
+                    if (i.getPromptText().equals("Password: ")) { //$NON-NLS-1$
+                        PasswordCallback callback = new PasswordCallback("git username", false);
+                        Callback[] callbacks = {callback};
+                        CLIENT.getCallbackHandler(config).handle(callbacks);
+                        ((CredentialItem.StringType) i).setValue(new String(callback.getPassword()));
+                        continue;
+                    }
+                }
+                throw new UnsupportedCredentialItem(uri, i.getClass().getName()
+                        + ":" + i.getPromptText()); //$NON-NLS-1$
+            }
+        } catch (IOException  | UnsupportedCallbackException | URISyntaxException ex) {
+            throw new UnsupportedCredentialItem(uri, ex.getMessage());
+        }
+
+        return true;
+    }
+
+}

--- a/server/src/main/java/org/jboss/as/server/controller/git/GitConfigurationPersistenceResource.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/GitConfigurationPersistenceResource.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.server.controller.git;
+
+import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ResetCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Constants;
+import org.jboss.as.controller.persistence.AbstractConfigurationPersister;
+import org.jboss.as.controller.persistence.AbstractFilePersistenceResource;
+import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *{@link ConfigurationPersister.PersistenceResource} that persists to a configuration file upon commit, also
+ * ensuring a git commit is made.
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class GitConfigurationPersistenceResource extends AbstractFilePersistenceResource {
+
+    protected final File file;
+    private final GitRepository repository;
+
+    public GitConfigurationPersistenceResource(final ModelNode model, final File fileName, final GitRepository repository,
+            final AbstractConfigurationPersister persister) throws ConfigurationPersistenceException {
+       super(model, persister);
+        this.file = fileName;
+        this.repository = repository;
+    }
+
+    @Override
+    public void rollback() {
+        super.rollback();
+        try (Git git = repository.getGit()) {
+            git.reset().setMode(ResetCommand.ResetType.HARD).setRef(Constants.HEAD).call();
+        } catch (GitAPIException ex) {
+            MGMT_OP_LOGGER.failedToStoreConfiguration(ex, file.getName());
+        }
+    }
+
+    protected void gitCommit(String msg) {
+        try (Git git = repository.getGit()) {
+            if(!git.status().call().isClean()) {
+                git.commit().setMessage(msg).setAll(true).setNoVerify(true).call();
+            }
+        } catch (GitAPIException e) {
+            MGMT_OP_LOGGER.failedToStoreConfiguration(e, file.getName());
+        }
+    }
+
+    @Override
+    protected void doCommit(InputStream in) {
+        try {
+            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            gitCommit("Storing configuration");
+        } catch (IOException ex) {
+            MGMT_OP_LOGGER.failedToStoreConfiguration(ex, file.getName());
+        }
+    }
+
+}

--- a/server/src/main/java/org/jboss/as/server/controller/git/GitConfigurationPersister.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/GitConfigurationPersister.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.server.controller.git;
+
+import static org.eclipse.jgit.lib.Constants.R_TAGS;
+import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.xml.namespace.QName;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.IncorrectObjectTypeException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.revwalk.RevSort;
+import org.eclipse.jgit.revwalk.RevTag;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.transport.PushResult;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.RemoteRefUpdate;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.persistence.ConfigurationFile;
+import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
+import org.jboss.as.controller.persistence.ConfigurationPersister.PersistenceResource;
+import org.jboss.as.controller.persistence.ConfigurationPersister.SnapshotInfo;
+import org.jboss.as.controller.persistence.ModelMarshallingContext;
+import org.jboss.as.controller.persistence.XmlConfigurationPersister;
+import org.jboss.as.server.logging.ServerLogger;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+
+/**
+ * A configuration persister which uses an XML file for backing storage and Git for history support.
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2015 Red Hat, inc.
+ */
+public class GitConfigurationPersister extends XmlConfigurationPersister {
+    private final AtomicBoolean successfulBoot = new AtomicBoolean();
+    private GitRepository gitRepository;
+    private final Path root;
+    private final File mainFile;
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmssSSS");
+    private static final String SNAPSHOT_PREFIX = "Snapshot-";
+
+    public GitConfigurationPersister(GitRepository gitRepository, ConfigurationFile file, QName rootElement, XMLElementReader<List<ModelNode>> rootParser,
+            XMLElementWriter<ModelMarshallingContext> rootDeparser, boolean suppressLoad) {
+        super(file.getBootFile(), rootElement, rootParser, rootDeparser, suppressLoad);
+        root = file.getConfigurationDir().getParentFile().toPath();
+        mainFile = file.getMainFile();
+        this.gitRepository = gitRepository;
+        File baseDir = root.toFile();
+        try {
+            File gitDir = new File(baseDir, Constants.DOT_GIT);
+            if(!gitDir.exists()) {
+                gitDir.mkdir();
+            }
+            if (gitRepository.isBare()) {
+                Git.init().setDirectory(baseDir).setGitDir(gitDir).call();
+                ServerLogger.ROOT_LOGGER.gitRespositoryInitialized(baseDir.getAbsolutePath());
+            }
+        } catch (IllegalStateException | GitAPIException e) {
+            ControllerLogger.ROOT_LOGGER.error(e);
+        }
+    }
+
+    public GitConfigurationPersister(GitRepository gitRepository, ConfigurationFile file, QName rootElement, XMLElementReader<List<ModelNode>> rootParser,
+            XMLElementWriter<ModelMarshallingContext> rootDeparser) {
+        this(gitRepository, file, rootElement, rootParser, rootDeparser, false);
+    }
+
+    @Override
+    public void successfulBoot() throws ConfigurationPersistenceException {
+        successfulBoot.compareAndSet(false, true);
+    }
+
+    @Override
+    public PersistenceResource store(final ModelNode model, Set<PathAddress> affectedAddresses) throws ConfigurationPersistenceException {
+        if(!successfulBoot.get()) {
+            return new PersistenceResource() {
+                @Override
+                public void commit() {
+                }
+
+                @Override
+                public void rollback() {
+                }
+            };
+        }
+        return new GitConfigurationPersistenceResource(model, mainFile, gitRepository, this);
+    }
+
+    @Override
+    public String snapshot(String name, String comment) throws ConfigurationPersistenceException {
+        boolean noComment = (comment ==null || comment.isEmpty());
+        String message = noComment ? SNAPSHOT_PREFIX + FORMATTER.format(LocalDateTime.now()) : comment;
+        String tagName = (name ==null || name.isEmpty()) ? SNAPSHOT_PREFIX + FORMATTER.format(LocalDateTime.now()) : name;
+        try (Git git = gitRepository.getGit()) {
+            Status status = git.status().call();
+            List<Ref> tags = git.tagList().call();
+            String refTagName = R_TAGS + tagName;
+            for(Ref tag : tags) {
+                if(refTagName.equals(tag.getName())) {
+                   throw MGMT_OP_LOGGER.snapshotAlreadyExistError(tagName);
+                }
+            }
+            //if comment is not null
+            if(status.hasUncommittedChanges() || !noComment) {
+                git.commit().setMessage(message).setAll(true).setNoVerify(true).call();
+            }
+            git.tag().setName(tagName).setMessage(message).call();
+        } catch (GitAPIException ex) {
+            throw MGMT_OP_LOGGER.failedToPersistConfiguration(ex, message, ex.getMessage());
+        }
+        return message;
+    }
+
+    @Override
+    public String publish(String name) throws ConfigurationPersistenceException {
+        StringBuilder message = new StringBuilder();
+        String remoteName = gitRepository.getRemoteName(name);
+        if (remoteName != null && gitRepository.isValidRemoteName(remoteName)) {
+            try (Git git = gitRepository.getGit()) {
+                Iterable<PushResult> result = git.push().setRemote(remoteName)
+                        .setRefSpecs(new RefSpec(gitRepository.getBranch() + ':' + gitRepository.getBranch()))
+                        .setPushTags().call();
+                for (PushResult pushResult : result) {
+                    for (RemoteRefUpdate refUpdate : pushResult.getRemoteUpdates()) {
+                        message.append(refUpdate.getMessage()).append(" ").append(refUpdate.getNewObjectId().name()).append('\n');
+                    }
+                }
+            } catch (GitAPIException ex) {
+                throw MGMT_OP_LOGGER.failedToPublishConfiguration(ex, name, ex.getMessage());
+            }
+        }
+        return message.toString();
+    }
+
+    @Override
+    public void deleteSnapshot(String name) {
+         try (Git git = gitRepository.getGit()) {
+             git.tagDelete().setTags(name).call();
+        } catch (GitAPIException ex) {
+            MGMT_OP_LOGGER.failedToDeleteConfigurationSnapshot(ex,name);
+        }
+    }
+
+    @Override
+    public SnapshotInfo listSnapshots() {
+        try (Git git = gitRepository.getGit()) {
+            final List<String> snapshots = new ArrayList<>();
+            for(Ref ref : git.tagList().call()) {
+                RevWalk revWalk = new RevWalk(git.getRepository());
+                revWalk.sort(RevSort.COMMIT_TIME_DESC, true);
+                try {
+                    RevTag annotatedTag = revWalk.parseTag(ref.getObjectId());
+                    snapshots.add(annotatedTag.getTagName() + " : " + annotatedTag.getFullMessage());
+                } catch (IncorrectObjectTypeException ex) {
+                   snapshots.add(ref.getName());
+                }
+                snapshots.add(ref.getName());
+            }
+            return new SnapshotInfo() {
+                @Override
+                public String getSnapshotDirectory() {
+                    return "";
+                }
+
+                @Override
+                public List<String> names() {
+                    return snapshots;
+                }
+            };
+        } catch (GitAPIException ex) {
+            MGMT_OP_LOGGER.failedToListConfigurationSnapshot(ex, mainFile.getName());
+        } catch (IOException ex) {
+            MGMT_OP_LOGGER.failedToListConfigurationSnapshot(ex, mainFile.getName());
+        }
+        return NULL_SNAPSHOT_INFO;
+    }
+
+}

--- a/server/src/main/java/org/jboss/as/server/controller/git/GitContentRepository.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/GitContentRepository.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.server.controller.git;
+
+import static org.eclipse.jgit.lib.Constants.HEAD;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.jgit.api.AddCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.RmCommand;
+import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.RevisionSyntaxException;
+import org.jboss.as.repository.ContentReference;
+import org.jboss.as.repository.ContentRepository;
+import org.jboss.as.repository.ContentRepositoryImpl;
+import org.jboss.as.repository.ExplodedContent;
+import org.jboss.as.repository.ExplodedContentException;
+import org.jboss.msc.service.ServiceTarget;
+
+/**
+ * Content repository implementation that integrates with git for history.
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class GitContentRepository extends ContentRepositoryImpl {
+
+    private final GitRepository gitRepository;
+
+    protected GitContentRepository(GitRepository gitRepository, File repoRoot, File tmpRoot, long obsolescenceTimeout, long lockTimeout) {
+        super(repoRoot, tmpRoot, obsolescenceTimeout, lockTimeout);
+        this.gitRepository = gitRepository;
+    }
+
+    @Override
+    public byte[] removeContentFromExploded(byte[] deploymentHash, List<String> paths) throws ExplodedContentException {
+        byte[] result = super.removeContentFromExploded(deploymentHash, paths);
+        if (!Arrays.equals(deploymentHash, result)) {
+            final Path realFile = getDeploymentContentFile(result, true);
+            try (Git git = gitRepository.getGit()) {
+                git.add().addFilepattern(gitRepository.getPattern(realFile)).call();
+            } catch (GitAPIException ex) {
+                throw new ExplodedContentException(ex.getMessage(), ex);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public byte[] addContentToExploded(byte[] deploymentHash, List<ExplodedContent> addFiles, boolean overwrite) throws ExplodedContentException {
+        byte[] result = super.addContentToExploded(deploymentHash, addFiles, overwrite);
+        if (!Arrays.equals(deploymentHash, result)) {
+            final Path realFile = getDeploymentContentFile(result, true);
+            try (Git git = gitRepository.getGit()) {
+                git.add().addFilepattern(gitRepository.getPattern(realFile)).call();
+            } catch (GitAPIException ex) {
+                throw new ExplodedContentException(ex.getMessage(), ex);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public byte[] explodeSubContent(byte[] deploymentHash, String relativePath) throws ExplodedContentException {
+        byte[] result = super.explodeSubContent(deploymentHash, relativePath);
+        if (!Arrays.equals(deploymentHash, result)) {
+            final Path realFile = getDeploymentContentFile(result, true);
+            try (Git git = gitRepository.getGit()) {
+                git.add().addFilepattern(gitRepository.getPattern(realFile)).call();
+            } catch (GitAPIException ex) {
+                throw new ExplodedContentException(ex.getMessage(), ex);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public byte[] explodeContent(byte[] deploymentHash) throws ExplodedContentException {
+        byte[] result = super.explodeContent(deploymentHash);
+        if (!Arrays.equals(deploymentHash, result)) {
+            final Path realFile = getDeploymentContentFile(result, true);
+            try (Git git = gitRepository.getGit()) {
+                git.add().addFilepattern(gitRepository.getPattern(realFile)).call();
+            } catch (GitAPIException ex) {
+                throw new ExplodedContentException(ex.getMessage(), ex);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void removeContent(ContentReference reference) {
+        final Path realFile = getDeploymentContentFile(reference.getHash());
+        super.removeContent(reference);
+        if (!Files.exists(realFile)) {
+            try (Git git = gitRepository.getGit()) {
+                Set<String> deletedFiles = git.status().call().getMissing();
+                RmCommand rmCommand = git.rm();
+                for (String file : deletedFiles) {
+                    rmCommand.addFilepattern(file);
+                }
+                rmCommand.addFilepattern(gitRepository.getPattern(realFile)).call();
+            } catch (GitAPIException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    @Override
+    public byte[] addContent(InputStream stream) throws IOException {
+        byte[] result = super.addContent(stream);
+        final Path realFile = getDeploymentContentFile(result, true);
+        try (Git git = gitRepository.getGit()) {
+            git.add().addFilepattern(gitRepository.getPattern(realFile)).call();
+        } catch (GitAPIException ex) {
+            throw new IOException(ex);
+        }
+        return result;
+    }
+
+    @Override
+    public void flush(boolean success) {
+        if (success) {
+            try (Git git = gitRepository.getGit()) {
+                Status status = git.status().call();
+                if (!status.isClean()) {
+                    String message = git.getRepository().parseCommit(git.getRepository().resolve(HEAD)).getFullMessage();
+                    if(! status.getUntracked().isEmpty() || ! status.getUntrackedFolders().isEmpty()) {
+                        AddCommand addCommand = git.add();
+                        for(String untracked : status.getUntrackedFolders()) {
+                            addCommand = addCommand.addFilepattern(untracked);
+                        }
+                        for(String untracked : status.getUntracked()) {
+                            addCommand = addCommand.addFilepattern(untracked);
+                        }
+                        addCommand.call();
+                    }
+                    git.commit().setMessage(message).setAmend(true).setAll(true).setNoVerify(true).call();
+                }
+            } catch (RevisionSyntaxException | IOException | GitAPIException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    public static void addService(final ServiceTarget serviceTarget, final GitRepository gitRepository, final File repoRoot, final File tmpRoot) {
+        ContentRepository.Factory.addService(serviceTarget, new GitContentRepository(gitRepository, repoRoot, tmpRoot, OBSOLETE_CONTENT_TIMEOUT, LOCK_TIMEOUT));
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/controller/git/GitRepository.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/GitRepository.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.server.controller.git;
+
+import static org.eclipse.jgit.lib.Constants.DEFAULT_REMOTE_NAME;
+import static org.eclipse.jgit.lib.Constants.DOT_GIT_IGNORE;
+import static org.eclipse.jgit.lib.Constants.DOT_GIT;
+import static org.eclipse.jgit.lib.Constants.HEAD;
+import static org.eclipse.jgit.lib.Constants.MASTER;
+import static org.eclipse.jgit.lib.Constants.R_HEADS;
+import static org.eclipse.jgit.lib.Constants.R_REMOTES;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.eclipse.jgit.api.AddCommand;
+import org.eclipse.jgit.api.CheckoutCommand;
+import org.eclipse.jgit.api.CheckoutResult;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.PullResult;
+import org.eclipse.jgit.api.ResetCommand;
+import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.merge.MergeStrategy;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.jboss.as.server.logging.ServerLogger;
+import org.wildfly.client.config.ConfigXMLParseException;
+
+/**
+ * Abstraction over a git repository.
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class GitRepository implements Closeable {
+
+    private final Set<String> ignored;
+    private final Repository repository;
+    private final Path basePath;
+    private final String defaultRemoteRepository;
+    private final String branch;
+
+    public GitRepository(GitRepositoryConfiguration gitConfig)
+            throws IllegalArgumentException, IOException, ConfigXMLParseException, GeneralSecurityException {
+        this.basePath = gitConfig.getBasePath();
+        this.branch = gitConfig.getBranch();
+        this.ignored = gitConfig.getIgnored();
+        this.defaultRemoteRepository = gitConfig.getRepository();
+        File baseDir = basePath.toFile();
+        File gitDir = new File(baseDir, DOT_GIT);
+        if (gitConfig.getAuthenticationConfig() != null) {
+            CredentialsProvider.setDefault(new ElytronClientCredentialsProvider(gitConfig.getAuthenticationConfig()));
+        }
+        if (gitDir.exists()) {
+            try {
+                repository = new FileRepositoryBuilder().setWorkTree(baseDir).setGitDir(gitDir).setup().build();
+            } catch (IOException ex) {
+                throw ServerLogger.ROOT_LOGGER.failedToPullRepository(ex, gitConfig.getRepository());
+            }
+            try (Git git = Git.wrap(repository)) {
+                git.clean();
+                if (!isLocalGitRepository(gitConfig.getRepository())) {
+                    String remote = getRemoteName(gitConfig.getRepository());
+                    checkoutToSelectedBranch(git);
+                    PullResult result = git.pull().setRemote(remote).setRemoteBranchName(branch).setStrategy(MergeStrategy.RESOLVE).call();
+                    if (!result.isSuccessful()) {
+                        throw ServerLogger.ROOT_LOGGER.failedToPullRepository(null, gitConfig.getRepository());
+                    }
+                } else {
+                    if (!this.branch.equals(repository.getBranch())) {
+                        CheckoutCommand checkout = git.checkout().setName(branch);
+                        checkout.call();
+                        if (checkout.getResult().getStatus() == CheckoutResult.Status.ERROR) {
+                            throw ServerLogger.ROOT_LOGGER.failedToPullRepository(null, gitConfig.getRepository());
+                        }
+                    }
+                }
+            } catch (GitAPIException ex) {
+                throw ServerLogger.ROOT_LOGGER.failedToPullRepository(ex, gitConfig.getRepository());
+            }
+        } else {
+            if (isLocalGitRepository(gitConfig.getRepository())) {
+                try (Git git = Git.init().setDirectory(baseDir).call()) {
+                    final AddCommand addCommand = git.add();
+                    addCommand.addFilepattern("data/content/");
+                    Path configurationDir = basePath.resolve("configuration");
+                    try (Stream<Path> files = Files.list(configurationDir)) {
+                        files.filter(configFile -> !"logging.properties".equals(configFile.getFileName().toString()) && Files.isRegularFile(configFile))
+                                .forEach(configFile -> addCommand.addFilepattern(getPattern(configFile)));
+                    }
+                    addCommand.call();
+                    createGitIgnore(git, basePath);
+                    git.commit().setMessage(ServerLogger.ROOT_LOGGER.repositoryInitialized()).call();
+                } catch (GitAPIException | IOException ex) {
+                    throw ServerLogger.ROOT_LOGGER.failedToInitRepository(ex, gitConfig.getRepository());
+                }
+            } else {
+                clearExistingFiles(basePath, gitConfig.getRepository());
+                try (Git git = Git.init().setDirectory(baseDir).call()) {
+                    String remoteName = UUID.randomUUID().toString();
+                    StoredConfig config = git.getRepository().getConfig();
+                    config.setString("remote", remoteName, "url", gitConfig.getRepository());
+                    config.setString("remote", remoteName, "fetch", "+" + R_HEADS + "*:" + R_REMOTES + remoteName + "/*");
+                    config.save();
+                    git.clean();
+                    git.pull().setRemote(remoteName).setRemoteBranchName(branch).setStrategy(MergeStrategy.RESOLVE).call();
+                    checkoutToSelectedBranch(git);
+                    if (createGitIgnore(git, basePath)) {
+                        git.commit().setMessage(ServerLogger.ROOT_LOGGER.addingIgnored()).call();
+                    }
+                } catch (GitAPIException ex) {
+                    throw ServerLogger.ROOT_LOGGER.failedToInitRepository(ex, gitConfig.getRepository());
+                }
+            }
+            repository = new FileRepositoryBuilder().setWorkTree(baseDir).setGitDir(gitDir).setup().build();
+        }
+        ServerLogger.ROOT_LOGGER.usingGit();
+    }
+
+    private void checkoutToSelectedBranch(final Git git) throws IOException, GitAPIException {
+        boolean createBranch = !ObjectId.isId(branch);
+        if (createBranch) {
+            Ref ref = git.getRepository().exactRef(R_HEADS + branch);
+            if (ref != null) {
+                createBranch = false;
+            }
+        }
+        CheckoutCommand checkout = git.checkout().setCreateBranch(createBranch).setName(branch);
+        checkout.call();
+        if (checkout.getResult().getStatus() == CheckoutResult.Status.ERROR) {
+            throw ServerLogger.ROOT_LOGGER.failedToPullRepository(null, defaultRemoteRepository);
+        }
+    }
+
+    public GitRepository(Repository repository) {
+        this.repository = repository;
+        this.ignored = Collections.emptySet();
+        this.defaultRemoteRepository = DEFAULT_REMOTE_NAME;
+        this.branch = MASTER;
+        if (repository.isBare()) {
+            this.basePath = repository.getDirectory().toPath();
+        } else {
+            this.basePath = repository.getDirectory().toPath().getParent();
+        }
+        ServerLogger.ROOT_LOGGER.usingGit();
+    }
+
+    private void clearExistingFiles(Path root, String gitRepository) {
+        try {
+            Files.walkFileTree(root, new FileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    if (!ignored.contains(dir.getFileName().toString() + '/')) {
+                    return FileVisitResult.CONTINUE;
+                    }
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    try {
+                        ServerLogger.ROOT_LOGGER.deletingFile(file);
+                        Files.delete(file);
+                    } catch (IOException ioex) {
+                        ServerLogger.ROOT_LOGGER.debug(ioex.getMessage(), ioex);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    if (exc != null) {
+                        throw exc;
+                    }
+                    return FileVisitResult.TERMINATE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    if (exc != null) {
+                        throw exc;
+                    }
+                    try {
+                        ServerLogger.ROOT_LOGGER.deletingFile(dir);
+                        Files.delete(dir);
+                    } catch (IOException ioex) {
+                        ServerLogger.ROOT_LOGGER.debug(ioex.getMessage(), ioex);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+            });
+        } catch (IOException ex) {
+            throw ServerLogger.ROOT_LOGGER.failedToInitRepository(ex, gitRepository);
+        }
+    }
+
+    private boolean createGitIgnore(Git git, Path root) throws IOException, GitAPIException {
+        Path gitIgnore = root.resolve(DOT_GIT_IGNORE);
+        if (Files.notExists(gitIgnore)) {
+            Files.write(gitIgnore, ignored);
+            git.add().addFilepattern(DOT_GIT_IGNORE).call();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean isLocalGitRepository(String gitRepository) {
+        return "local".equals(gitRepository);
+    }
+
+    public Git getGit() {
+        return Git.wrap(repository);
+    }
+
+    public File getDirectory() {
+        return repository.getDirectory();
+    }
+
+    public boolean isBare() {
+        return repository.isBare();
+    }
+
+    @Override
+    public void close() {
+        this.repository.close();
+    }
+
+    public String getPattern(File file) {
+        return getPattern(file.toPath());
+    }
+
+    public String getPattern(Path file) {
+        return basePath.toAbsolutePath().relativize(file.toAbsolutePath()).toString().replace('\\', '/');
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public final boolean isValidRemoteName(String remoteName) {
+        return repository.getRemoteNames().contains(remoteName);
+    }
+
+    public final String getRemoteName(String gitRepository) {
+        return findRemoteName(gitRepository == null || gitRepository.isEmpty() ? defaultRemoteRepository : gitRepository);
+    }
+
+    private String findRemoteName(String gitRepository) {
+        if (isValidRemoteName(gitRepository)) {
+            return gitRepository;
+        }
+        StoredConfig config = repository.getConfig();
+        for (String remoteName : repository.getRemoteNames()) {
+            if (gitRepository.equals(config.getString("remote", remoteName, "url"))) {
+                return remoteName;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Reset hard on HEAD.
+     *
+     * @throws GitAPIException
+     */
+    public void rollback() throws GitAPIException {
+        try (Git git = getGit()) {
+            git.reset().setMode(ResetCommand.ResetType.HARD).setRef(HEAD).call();
+        }
+    }
+
+    /**
+     * Commit all changes if there are uncommitted changes.
+     *
+     * @param msg the commit message.
+     * @throws GitAPIException
+     */
+    public void commit(String msg) throws GitAPIException {
+        try (Git git = getGit()) {
+            Status status = git.status().call();
+            if (!status.isClean()) {
+                git.commit().setMessage(msg).setAll(true).setNoVerify(true).call();
+            }
+        }
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/controller/git/GitRepositoryConfiguration.java
+++ b/server/src/main/java/org/jboss/as/server/controller/git/GitRepositoryConfiguration.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.server.controller.git;
+
+import static org.eclipse.jgit.lib.Constants.MASTER;
+import static org.eclipse.jgit.lib.Constants.DOT_GIT;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+import org.jboss.as.server.logging.ServerLogger;
+
+/**
+ * Encapsulate the git configuration used for configuration history.
+ * @author Emmanuel Hugonnet (c) 2018 Red Hat, inc.
+ */
+public class GitRepositoryConfiguration {
+    private final Path basePath;
+    private final String repository;
+    private final String branch;
+    private final URI authenticationConfig;
+    private final Set<String> ignored;
+
+
+    private GitRepositoryConfiguration(Path basePath, String repository, String branch, URI authenticationConfig, Set<String> ignored) {
+        this.basePath = basePath;
+        this.repository = repository;
+        this.branch = branch;
+        this.authenticationConfig = authenticationConfig;
+        this.ignored = ignored;
+    }
+
+    public Path getBasePath() {
+        return basePath;
+    }
+
+    public String getRepository() {
+        return repository;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public URI getAuthenticationConfig() {
+        return authenticationConfig;
+    }
+
+    public Set<String> getIgnored() {
+        return ignored;
+    }
+
+    public boolean isLocal() {
+        return "local".equals(repository);
+    }
+
+    public static class Builder {
+
+        private Path basePath;
+        private String repository;
+        private String branch = MASTER;
+        private URI authenticationConfig;
+        private Set<String> ignored;
+
+        private Builder() {
+        }
+
+        public static Builder getInstance() {
+            return new Builder();
+        }
+
+        public Builder setBasePath(Path basePath) {
+            this.basePath = basePath;
+            return this;
+        }
+
+        public Builder setRepository(String repository) {
+            this.repository = repository;
+            return this;
+        }
+
+        public Builder setBranch(String branch) {
+            if(branch != null) {
+                this.branch = branch;
+            }
+            return this;
+        }
+
+        public Builder setAuthenticationConfig(URI authenticationConfig) {
+            this.authenticationConfig = authenticationConfig;
+            return this;
+        }
+
+        public Builder setAuthenticationConfig(String authConfiguration) {
+            if (authConfiguration != null) {
+                try {
+                    authenticationConfig = new URI(authConfiguration);
+                } catch (URISyntaxException ex) {
+                    ServerLogger.ROOT_LOGGER.errorUsingGit(ex, ex.getMessage());
+                }
+            }
+            return this;
+        }
+
+        public Builder setIgnored(Set<String> ignored) {
+            this.ignored = ignored;
+            return this;
+        }
+
+        public GitRepositoryConfiguration build() {
+            if (repository == null || repository.isEmpty()) {
+                if (Files.exists(basePath.resolve(DOT_GIT))) {
+                    this.repository = "local";
+                } else {
+                    return null;
+                }
+            }
+            if(this.ignored == null) {
+                this.ignored =  Collections.emptySet();
+            }
+            return new GitRepositoryConfiguration(basePath, repository, branch, authenticationConfig, ignored);
+        }
+    }
+    }

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -48,6 +48,7 @@ import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistryType;
 import org.jboss.as.controller.extension.ExtensionResourceDefinition;
 import org.jboss.as.controller.extension.MutableRootResourceRegistrationProvider;
+import org.jboss.as.controller.operations.common.ConfigurationPublishHandler;
 import org.jboss.as.controller.operations.common.NamespaceAddHandler;
 import org.jboss.as.controller.operations.common.NamespaceRemoveHandler;
 import org.jboss.as.controller.operations.common.ProcessStateAttributeHandler;
@@ -315,6 +316,10 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerOperationHandler(DeploymentAttributes.FULL_REPLACE_DEPLOYMENT_DEFINITION, DeploymentFullReplaceHandler.create(contentRepository, vaultReader));
 
         if (!isDomain) {
+            if(serverEnvironment.useGit()) {
+                resourceRegistration.registerOperationHandler(ConfigurationPublishHandler.DEFINITION,
+                        new ConfigurationPublishHandler(extensibleConfigurationPersister));
+            }
             SnapshotDeleteHandler snapshotDelete = new SnapshotDeleteHandler(extensibleConfigurationPersister);
             resourceRegistration.registerOperationHandler(SnapshotDeleteHandler.DEFINITION, snapshotDelete);
             SnapshotListHandler snapshotList = new SnapshotListHandler(extensibleConfigurationPersister);

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentAddHandler.java
@@ -32,6 +32,7 @@ import static org.jboss.as.server.controller.resources.DeploymentAttributes.OWNE
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.PERSISTENT;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.SERVER_ADD_ATTRIBUTES;
+import static org.jboss.as.server.deployment.DeploymentHandlerUtils.addFlushHandler;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.asString;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.getInputStream;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.hasValidContentAdditionParameterDefined;
@@ -150,7 +151,7 @@ public class DeploymentAddHandler implements OperationStepHandler {
 
         if (contentItem.getHash() != null) {
             final byte[] contentHash = contentItem.getHash();
-            context.completeStep(new OperationContext.ResultHandler() {
+            addFlushHandler(context, contentRepository,new OperationContext.ResultHandler() {
                 @Override
                 public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
                     if (resultAction == ResultAction.KEEP) {

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentExplodeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentExplodeHandler.java
@@ -19,6 +19,7 @@ package org.jboss.as.server.deployment;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_ARCHIVE;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_HASH;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENABLED;
+import static org.jboss.as.server.deployment.DeploymentHandlerUtils.addFlushHandler;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.getContentItem;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.isArchive;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.isManaged;
@@ -91,7 +92,7 @@ public class DeploymentExplodeHandler implements OperationStepHandler {
         contentItem.get(CONTENT_HASH.getName()).set(newHash);
         contentItem.get(CONTENT_ARCHIVE.getName()).set(false);
 
-        context.completeStep(new OperationContext.ResultHandler() {
+        addFlushHandler(context, contentRepository, new OperationContext.ResultHandler() {
             @Override
             public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
                 if (resultAction == OperationContext.ResultAction.KEEP) {

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
@@ -29,6 +29,7 @@ import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENAB
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.OWNER;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.PERSISTENT;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
+import static org.jboss.as.server.deployment.DeploymentHandlerUtils.addFlushHandler;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.asString;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.createFailureException;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.getInputStream;
@@ -173,7 +174,7 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
             DeploymentHandlerUtil.undeploy(context, operation, name, runtimeName, vaultReader);
         }
 
-        context.completeStep(new OperationContext.ResultHandler() {
+        addFlushHandler(context, contentRepository, new OperationContext.ResultHandler() {
             @Override
             public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
                 if (resultAction == ResultAction.KEEP) {

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentRemoveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentRemoveHandler.java
@@ -23,6 +23,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REM
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_RESOURCE_ALL;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENABLED;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
+import static org.jboss.as.server.deployment.DeploymentHandlerUtils.addFlushHandler;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.getContents;
 
 import java.util.Collections;
@@ -84,7 +85,7 @@ public class DeploymentRemoveHandler implements OperationStepHandler {
                         runtimeName = null;
                     }
                     final ModelNode contentNode = CONTENT_RESOURCE_ALL.resolveModelAttribute(context, model);
-                    context.completeStep(new OperationContext.ResultHandler() {
+                    addFlushHandler(context, contentRepository, new OperationContext.ResultHandler() {
                         @Override
                         public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
                             final String managementName = context.getCurrentAddressValue();

--- a/server/src/main/java/org/jboss/as/server/deployment/ExplodedDeploymentAddContentHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/ExplodedDeploymentAddContentHandler.java
@@ -24,6 +24,7 @@ import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENAB
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_PARAM_ALL_EXPLODED;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.OVERWRITE;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.TARGET_PATH;
+import static org.jboss.as.server.deployment.DeploymentHandlerUtils.addFlushHandler;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.getContentItem;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.isArchive;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.isManaged;
@@ -145,7 +146,7 @@ public class ExplodedDeploymentAddContentHandler implements OperationStepHandler
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep(new OperationContext.ResultHandler() {
+        addFlushHandler(context, contentRepository, new OperationContext.ResultHandler() {
             @Override
             public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
                 if (resultAction == ResultAction.KEEP) {

--- a/server/src/main/java/org/jboss/as/server/deployment/ExplodedDeploymentRemoveContentHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/ExplodedDeploymentRemoveContentHandler.java
@@ -21,6 +21,7 @@ import static org.jboss.as.server.Services.JBOSS_SERVER_EXECUTOR;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_HASH;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENABLED;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.REMOVED_PATHS;
+import static org.jboss.as.server.deployment.DeploymentHandlerUtils.addFlushHandler;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.getContentItem;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.isArchive;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtil.isManaged;
@@ -114,7 +115,7 @@ public class ExplodedDeploymentRemoveContentHandler implements OperationStepHand
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.completeStep(new OperationContext.ResultHandler() {
+        addFlushHandler(context, contentRepository, new OperationContext.ResultHandler() {
             @Override
             public void handleResult(ResultAction resultAction, OperationContext context, ModelNode operation) {
                 if (resultAction == ResultAction.KEEP) {

--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -573,6 +573,30 @@ public interface ServerLogger extends BasicLogger {
     String argStartMode();
 
     /**
+     * Instructions for the {@link CommandLineConstants#GIT_REPO} command line argument.
+     *
+     * @return the message
+     */
+    @Message(id = Message.NONE, value = "The git repository to clone to get the server configuration.")
+    String argGitRepo();
+
+    /**
+     * Instructions for the {@link CommandLineConstants#GIT_BRANCH} command line argument.
+     *
+     * @return the message
+     */
+    @Message(id = Message.NONE, value = "The git branch to use to get the server configuration. Default is 'master'")
+    String argGitBranch();
+
+    /**
+     * Instructions for the {@link CommandLineConstants#GIT_AUTH} command line argument.
+     *
+     * @return the message
+     */
+    @Message(id = Message.NONE, value = "The elytron configuration file for managing git credentials. Default is 'null'")
+    String argGitAuth();
+
+    /**
      * Creates an error message indicating a value was expected for the given command line option.
      *
      * @param option the name of the command line option
@@ -1281,6 +1305,25 @@ public interface ServerLogger extends BasicLogger {
     @Message(id = 267, value = "Cannot mount resource root '%s', is it really an archive?")
     XMLStreamException archiveMountFailed(String path, @Cause ZipException cause);
 
+    @Message(id = 268, value = "Failed to pull the repository %s")
+    RuntimeException failedToPullRepository(@Cause Exception cause, String repository);
+
+    @Message(id = 269, value = "Failed to initialize the repository %s")
+    RuntimeException failedToInitRepository(@Cause Exception cause, String repository);
+    /**
+     * Logs an error message indicating a failure to store the configuration file.
+     *
+     * @param cause the cause of the error.
+     * @param name  the name of the configuration.
+     */
+    @LogMessage(level = ERROR)
+    @Message(id = 270, value = "Failed to publish configuration to %s")
+    void failedToPublishConfiguration(@Cause Throwable cause, String name);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 271, value = "Git error: %s")
+    void errorUsingGit(@Cause Throwable cause, String message);
+
     ////////////////////////////////////////////////
     //Messages without IDs
 
@@ -1289,4 +1332,23 @@ public interface ServerLogger extends BasicLogger {
 
     @Message(id = Message.NONE, value = "The attribute '%s' has changed from '%s' to '%s'")
     String jmxAttributeChange(String name, String oldState, String stateString);
+
+    @LogMessage(level = INFO)
+    @Message(id = Message.NONE, value = "The configuration history is managed through Git")
+    void usingGit();
+
+    @Message(id = Message.NONE, value = "Repository initialized")
+    String repositoryInitialized();
+
+    @Message(id = Message.NONE, value = "Adding .gitignore")
+    String addingIgnored();
+
+    @LogMessage(level = INFO)
+    @Message(id = Message.NONE, value = "Git initialized in %s")
+    void gitRespositoryInitialized(String name);
+
+    @LogMessage(level = DEBUG)
+    @Message(id = Message.NONE, value = "Deleting file %s")
+    void deletingFile(Path name);
+
 }

--- a/server/src/test/java/org/jboss/as/controller/persistence/AbstractGitPersistenceResourceTestCase.java
+++ b/server/src/test/java/org/jboss/as/controller/persistence/AbstractGitPersistenceResourceTestCase.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.controller.persistence;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.IncorrectObjectTypeException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevSort;
+import org.eclipse.jgit.revwalk.RevTag;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.server.controller.git.GitConfigurationPersistenceResource;
+import org.jboss.as.server.controller.git.GitConfigurationPersister;
+import org.jboss.as.server.controller.git.GitRepository;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class AbstractGitPersistenceResourceTestCase {
+
+    protected Path root;
+    protected Repository repository;
+
+    protected void checkFiles(String mainFileName, String content) throws Exception {
+        assertFileContents(root.resolve(mainFileName + ".xml"), content);
+    }
+
+    protected Path createFile(Path dir, String name, String contents) throws IOException {
+        Files.createDirectories(dir);
+        Path file = dir.resolve(name);
+        if (contents != null) {
+            return Files.write(dir.resolve(name), contents.getBytes(StandardCharsets.UTF_8));
+        }
+        return file;
+    }
+
+    protected void delete(File file) {
+        if (file.isDirectory()) {
+            for (String name : file.list()) {
+                delete(new File(file, name));
+            }
+        }
+        if (!file.delete() && file.exists()) {
+            Assert.fail("Could not delete " + file);
+        }
+    }
+
+    protected void assertFileContents(Path file, String expectedContents) throws Exception {
+        Assert.assertTrue(file + " does not exist", Files.exists(file));
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader in = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            String s = in.readLine();
+            while (s != null) {
+                sb.append(s);
+                s = in.readLine();
+            }
+        }
+        Assert.assertEquals(expectedContents, sb.toString());
+    }
+
+    protected void store(TestConfigurationFilePersister persister, String s) throws Exception {
+        persister.store(new ModelNode(s), Collections.<PathAddress>emptySet()).commit();
+    }
+
+    protected List<String> listCommits(Repository repository) throws IOException, GitAPIException {
+        try (Git git = new Git(repository)) {
+            return listCommits(git, Constants.MASTER);
+        }
+    }
+
+    private List<String> listCommits(Git git, String branchName) throws IOException, GitAPIException {
+        List<String> commits = new ArrayList<>();
+        for(RevCommit commit : git.log().add(git.getRepository().resolve(branchName)).call()) {
+            commits.add(commit.getFullMessage());
+        }
+        return commits;
+    }
+
+    protected List<String> listTags(Repository repository) throws IOException, GitAPIException {
+        try (Git git = new Git(repository)) {
+            return listTags(git);
+        }
+    }
+
+    private List<String> listTags(Git git) throws IOException, GitAPIException {
+        List<String> tags = new ArrayList<>();
+        for (Ref tag : git.tagList().call()) {
+            RevWalk revWalk = new RevWalk(git.getRepository());
+            revWalk.sort(RevSort.COMMIT_TIME_DESC, true);
+            try {
+                RevTag annotatedTag = revWalk.parseTag(tag.getObjectId());
+                tags.add(annotatedTag.getTagName() + " : " + annotatedTag.getFullMessage());
+            } catch (IncorrectObjectTypeException ex) {
+                tags.add(tag.getName().substring("refs/tags/".length()));
+            }
+        }
+        return tags;
+    }
+
+    protected class TestConfigurationFilePersister extends GitConfigurationPersister {
+
+    private final File configurationFile;
+    private final GitRepository repository;
+
+    public TestConfigurationFilePersister(ConfigurationFile file, GitRepository repository) {
+        super(repository, file, null, null, null);
+        this.configurationFile = file.getBootFile();
+        this.repository = repository;
+    }
+
+    ConfigurationPersister.PersistenceResource create(ModelNode model) throws ConfigurationPersistenceException {
+        return new GitConfigurationPersistenceResource(model, configurationFile, repository, this);
+    }
+
+    @Override
+    public List<ModelNode> load() throws ConfigurationPersistenceException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void marshallAsXml(ModelNode model, OutputStream output) throws ConfigurationPersistenceException {
+        try {
+            output.write(model.asString().getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new ConfigurationPersistenceException(e);
+        }
+    }
+}
+
+}

--- a/server/src/test/java/org/jboss/as/controller/persistence/GitPersistenceResourceTestCase.java
+++ b/server/src/test/java/org/jboss/as/controller/persistence/GitPersistenceResourceTestCase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.controller.persistence;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.util.FileUtils;
+import org.jboss.as.controller.persistence.ConfigurationPersister.SnapshotInfo;
+import org.jboss.as.server.controller.git.GitRepository;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class GitPersistenceResourceTestCase extends AbstractGitPersistenceResourceTestCase {
+
+    @Before
+    public void createDirectoriesAndFiles() throws Exception {
+        root = new File("target", "standalone").toPath();
+        Files.createDirectories(root);
+        File baseDir = root.toAbsolutePath().toFile();
+        File gitDir = new File(baseDir, Constants.DOT_GIT);
+        if (!gitDir.exists()) {
+            try (Git git = Git.init().setDirectory(baseDir).setGitDir(gitDir).call()) {
+                git.commit().setMessage("Repository initialized").call();
+            }
+        }
+        repository = new FileRepositoryBuilder().setWorkTree(baseDir).setGitDir(gitDir).setup().build();
+    }
+
+    @After
+    public void deleteDirectoriesAndFiles() throws Exception {
+        if (repository != null) {
+            repository.close();
+        }
+        FileUtils.delete(root.toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+    }
+
+    @Test
+    public void testDefaultPersistentConfigurationFile() throws Exception {
+        List<String> commits = listCommits(repository);
+        Assert.assertEquals(1, commits.size());
+        Assert.assertEquals("Repository initialized", commits.get(0));
+        Assert.assertTrue(Files.exists(root));
+        Path standard = createFile(root, "standard.xml", "std");
+        ConfigurationFile configurationFile = new ConfigurationFile(root.toFile(), "standard.xml", null, ConfigurationFile.InteractionPolicy.STANDARD, true);
+        Assert.assertEquals(standard.toAbsolutePath().toString(), configurationFile.getBootFile().getAbsolutePath());
+        TestConfigurationFilePersister persister = new TestConfigurationFilePersister(configurationFile, new GitRepository(repository));
+        persister.successfulBoot();
+        checkFiles("standard", "std");
+        commits = listCommits(repository);
+        Assert.assertEquals(1, commits.size());
+        Assert.assertEquals("Repository initialized", commits.get(0));
+        store(persister, "One");
+        commits = listCommits(repository);
+        Assert.assertEquals(2, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        Assert.assertEquals("Repository initialized", commits.get(1));
+        checkFiles("standard", "One");
+        SnapshotInfo infos = persister.listSnapshots();
+        Assert.assertTrue(infos.names().isEmpty());
+        store(persister, "Two");
+        commits = listCommits(repository);
+        Assert.assertEquals(3, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        Assert.assertEquals("Storing configuration", commits.get(1));
+        Assert.assertEquals("Repository initialized", commits.get(2));
+        List<String> tags = listTags(repository);
+        Assert.assertEquals(0, tags.size());
+        persister.snapshot("test_snapshot", "1st snapshot");
+        tags = listTags(repository);
+        Assert.assertEquals(1, tags.size());
+        Assert.assertEquals("test_snapshot : 1st snapshot", tags.get(0));
+    }
+
+}

--- a/server/src/test/java/org/jboss/as/controller/persistence/RemoteGitPersistenceResourceTestCase.java
+++ b/server/src/test/java/org/jboss/as/controller/persistence/RemoteGitPersistenceResourceTestCase.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.controller.persistence;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.jboss.as.controller.persistence.ConfigurationPersister.SnapshotInfo;
+import org.jboss.as.server.controller.git.GitRepository;
+import org.jboss.as.server.controller.git.GitRepositoryConfiguration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class RemoteGitPersistenceResourceTestCase extends AbstractGitPersistenceResourceTestCase {
+
+    private Path remoteRoot;
+    private Repository remoteRepository;
+
+    @Before
+    public void createDirectoriesAndFiles() throws Exception {
+        root = new File("target", "standalone").toPath();
+        remoteRoot = new File("target", "remote").toPath().resolve("standalone");
+        Files.createDirectories(remoteRoot);
+        File baseDir = remoteRoot.toAbsolutePath().toFile();
+        createFile(remoteRoot, "standard.xml", "std");
+        File gitDir = new File(baseDir, Constants.DOT_GIT);
+        if (!gitDir.exists()) {
+            try (Git git = Git.init().setDirectory(baseDir).call()) {
+                git.add().addFilepattern("standard.xml").call();
+                git.commit().setMessage("Repository initialized").call();
+            }
+        }
+        remoteRepository = new FileRepositoryBuilder().setWorkTree(baseDir).setGitDir(gitDir).setup().build();
+        repository = new FileRepositoryBuilder().setWorkTree(root.toAbsolutePath().toFile()).setGitDir(new File(root.toAbsolutePath().toFile(), Constants.DOT_GIT)).setup().build();
+    }
+
+    @After
+    public void deleteDirectoriesAndFiles() throws Exception {
+        if (remoteRepository != null) {
+            remoteRepository.close();
+        }
+        if (repository != null) {
+            repository.close();
+        }
+        delete(remoteRoot.toFile());
+        delete(root.toFile());
+    }
+
+    @Test
+    public void testDefaultPersistentConfigurationFile() throws Exception {
+        Path standard = createFile(root, "standard.xml", "std");
+        ConfigurationFile configurationFile = new ConfigurationFile(root.toFile(), "standard.xml", null, ConfigurationFile.InteractionPolicy.STANDARD, true);
+        Assert.assertEquals(standard.toAbsolutePath().toString(), configurationFile.getBootFile().getAbsolutePath());
+        GitRepositoryConfiguration.Builder.getInstance()
+                .setBasePath(root)
+                .setRepository(remoteRoot.resolve(Constants.DOT_GIT).toAbsolutePath().toString())
+                .build();
+        try (GitRepository gitRepository = new GitRepository(GitRepositoryConfiguration.Builder.getInstance()
+                .setBasePath(root)
+                .setRepository(remoteRoot.resolve(Constants.DOT_GIT).toAbsolutePath().toString())
+                .build())) {
+            List<String> commits = listCommits(repository);
+            Assert.assertEquals(2, commits.size());
+            Assert.assertEquals("Adding .gitignore", commits.get(0));
+            Assert.assertEquals("Repository initialized", commits.get(1));
+            Assert.assertTrue(Files.exists(root));
+            commits = listCommits(remoteRepository);
+            Assert.assertEquals(1, commits.size());
+            Assert.assertEquals("Repository initialized", commits.get(0));
+            TestConfigurationFilePersister persister = new TestConfigurationFilePersister(configurationFile, gitRepository);
+            persister.successfulBoot();
+            checkFiles("standard", "std");
+            commits = listCommits(repository);
+            Assert.assertEquals(2, commits.size());
+            Assert.assertEquals("Adding .gitignore", commits.get(0));
+            Assert.assertEquals("Repository initialized", commits.get(1));
+            store(persister, "One");
+            commits = listCommits(repository);
+            Assert.assertEquals(3, commits.size());
+            Assert.assertEquals("Storing configuration", commits.get(0));
+            Assert.assertEquals("Adding .gitignore", commits.get(1));
+            Assert.assertEquals("Repository initialized", commits.get(2));
+            checkFiles("standard", "One");
+            SnapshotInfo infos = persister.listSnapshots();
+            Assert.assertTrue(infos.names().isEmpty());
+            store(persister, "Two");
+            commits = listCommits(repository);
+            Assert.assertEquals(4, commits.size());
+            Assert.assertEquals("Storing configuration", commits.get(0));
+            Assert.assertEquals("Storing configuration", commits.get(1));
+            Assert.assertEquals("Adding .gitignore", commits.get(2));
+            Assert.assertEquals("Repository initialized", commits.get(3));
+            List<String> tags = listTags(repository);
+            Assert.assertEquals(0, tags.size());
+            persister.snapshot("test_snapshot", "1st snapshot");
+            commits = listCommits(repository);
+            Assert.assertEquals(5, commits.size());
+            Assert.assertEquals("1st snapshot", commits.get(0));
+            Assert.assertEquals("Storing configuration", commits.get(1));
+            Assert.assertEquals("Storing configuration", commits.get(2));
+            Assert.assertEquals("Adding .gitignore", commits.get(3));
+            Assert.assertEquals("Repository initialized", commits.get(4));
+            tags = listTags(repository);
+            Assert.assertEquals(1, tags.size());
+            Assert.assertEquals("test_snapshot : 1st snapshot", tags.get(0));
+            commits = listCommits(remoteRepository);
+            Assert.assertEquals(1, commits.size());
+            Assert.assertEquals("Repository initialized", commits.get(0));
+            persister.publish(null);
+            commits = listCommits(remoteRepository);
+            Assert.assertEquals(5, commits.size());
+            Assert.assertEquals("1st snapshot", commits.get(0));
+            Assert.assertEquals("Storing configuration", commits.get(1));
+            Assert.assertEquals("Storing configuration", commits.get(2));
+            Assert.assertEquals("Adding .gitignore", commits.get(3));
+            Assert.assertEquals("Repository initialized", commits.get(4));
+            tags = listTags(remoteRepository);
+            Assert.assertEquals(1, tags.size());
+            Assert.assertEquals("test_snapshot : 1st snapshot", tags.get(0));
+        }
+    }
+
+
+}

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>syslog4j</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.byteman</groupId>
             <artifactId>byteman</artifactId>
             <scope>test</scope>

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/AbstractGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/AbstractGitRepositoryTestCase.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.manualmode.management.persistence;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.errors.IncorrectObjectTypeException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTag;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.util.FileUtils;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+
+/**
+ *
+ * @author Emmanuel Hugonnet (c) 2017 Red Hat, inc.
+ */
+public class AbstractGitRepositoryTestCase {
+
+    private final Path jbossServerBaseDir = new File(System.getProperty("jboss.home", System.getenv("JBOSS_HOME"))).toPath().resolve("standalone");
+    private static final String TEST_DEPLOYMENT_RUNTIME_NAME = "test.jar";
+    private static final ModelNode TEST_SYSTEM_PROPERTY_ADDRESS = new ModelNode().add("system-property", "git-history-property");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmm");
+    protected Repository emptyRemoteRepository;
+    protected Repository repository;
+    private Path emptyRemoteRoot;
+
+    static {
+        TEST_SYSTEM_PROPERTY_ADDRESS.protect();
+    }
+
+    @Inject
+    protected ServerController container;
+
+    @Before
+    public void prepareEmptyRemoteRepository() throws Exception {
+        emptyRemoteRoot = new File("target", "empty-remote").toPath();
+        Files.createDirectories(emptyRemoteRoot);
+        File gitDir = new File(emptyRemoteRoot.toFile(), Constants.DOT_GIT);
+        if (!gitDir.exists()) {
+            try (Git git = Git.init().setDirectory(emptyRemoteRoot.toFile()).call()) {
+            }
+        }
+        Assert.assertTrue(gitDir.exists());
+        emptyRemoteRepository = new FileRepositoryBuilder().setWorkTree(emptyRemoteRoot.toFile()).setGitDir(gitDir).setup().build();
+    }
+
+    protected void closeEmptyRemoteRepository() throws Exception {
+        if (emptyRemoteRepository != null) {
+            emptyRemoteRepository.close();
+        }
+        FileUtils.delete(emptyRemoteRoot.toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+    }
+
+    protected Repository createRepository() throws IOException {
+        Repository repo = new FileRepositoryBuilder().setWorkTree(getJbossServerBaseDir().toFile())
+                .setGitDir(getDotGitDir().toFile())
+                .setup().build();
+        StoredConfig config = repo.getConfig();
+        config.setString("remote", "empty", "url", "file://" + emptyRemoteRoot.resolve(Constants.DOT_GIT).toAbsolutePath().toString());
+        config.save();
+        return repo;
+    }
+
+    protected void closeRepository() throws Exception{
+        if (repository != null) {
+            repository.close();
+        }
+        if (Files.exists(getDotGitDir())) {
+            FileUtils.delete(getDotGitDir().toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+        }
+        if(Files.exists(getDotGitIgnore())) {
+            FileUtils.delete(getDotGitIgnore().toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+        }
+    }
+
+    protected List<String> listCommits(Repository repository) throws IOException, GitAPIException {
+        try (Git git = new Git(repository)) {
+            return listCommits(git, Constants.MASTER);
+        }
+    }
+
+    private List<String> listCommits(Git git, String branchName) throws IOException, GitAPIException {
+        List<String> commits = new ArrayList<>();
+        for (RevCommit commit : git.log().add(git.getRepository().resolve(branchName)).call()) {
+            commits.add(commit.getFullMessage());
+        }
+        return commits;
+    }
+
+    protected List<String> listTags(Repository repository) throws IOException, GitAPIException {
+        List<String> tags = new ArrayList<>();
+        try (Git git = new Git(repository)) {
+            for (Ref tag : git.tagList().call()) {
+                RevWalk revWalk = new RevWalk(repository);
+                try {
+                    RevTag annotatedTag = revWalk.parseTag(tag.getObjectId());
+                    tags.add(annotatedTag.getTagName());
+                } catch (IncorrectObjectTypeException ex) {
+                    tags.add(tag.getName().substring("refs/tags/".length()));
+                }
+            }
+        }
+        return tags;
+    }
+
+    protected List<String> listFilesInCommit(Repository repository) throws IOException, GitAPIException {
+        List<String> result = new ArrayList<>();
+        try (Git git = new Git(repository)) {
+            RevCommit commit = git.log().add(git.getRepository().resolve(Constants.MASTER)).call().iterator().next();
+            if (commit.getParentCount() > 0) {
+                try (TreeWalk treeWalk = new TreeWalk(repository)) {
+                    treeWalk.addTree(commit.getParent(0).getTree());
+                    treeWalk.addTree(commit.getTree());
+                    treeWalk.setRecursive(true);
+                    List<DiffEntry> diff = DiffEntry.scan(treeWalk, false, null);
+                    for (DiffEntry diffEntry : diff) {
+                        if(diffEntry.getChangeType() == DiffEntry.ChangeType.DELETE) {
+                            result.add("-" + diffEntry.getOldPath());
+                        } else {
+                            result.add(diffEntry.getNewPath());
+                        }
+                    }
+                }
+            }
+        }
+        Collections.sort(result);
+        return result;
+    }
+
+    protected void addSystemProperty() throws UnsuccessfulOperationException {
+        ModelNode op = Operations.createAddOperation(TEST_SYSTEM_PROPERTY_ADDRESS);
+        op.get("value").set("git-history-property-value");
+
+        ManagementClient client = container.getClient();
+        client.executeForResult(op);
+    }
+
+    protected void removeSystemProperty() throws IOException {
+        ModelNode op = Operations.createRemoveOperation(TEST_SYSTEM_PROPERTY_ADDRESS);
+        container.getClient().getControllerClient().execute(op);
+    }
+
+    protected void deployEmptyDeployment() throws ServerDeploymentHelper.ServerDeploymentException {
+        container.deploy(ShrinkWrap.create(JavaArchive.class).add(EmptyAsset.INSTANCE, "file"), TEST_DEPLOYMENT_RUNTIME_NAME);
+    }
+
+    protected void removeDeployment() throws ServerDeploymentHelper.ServerDeploymentException {
+        container.undeploy(TEST_DEPLOYMENT_RUNTIME_NAME);
+    }
+
+    protected void undeployDeployment() throws UnsuccessfulOperationException {
+        ModelNode op = Operations.createOperation("undeploy",
+                new ModelNode().add("deployment", TEST_DEPLOYMENT_RUNTIME_NAME));
+        ManagementClient client = container.getClient();
+        client.executeForResult(op);
+    }
+
+    protected void explodeDeployment() throws UnsuccessfulOperationException {
+        ModelNode op = Operations.createOperation("explode",
+                new ModelNode().add("deployment", TEST_DEPLOYMENT_RUNTIME_NAME));
+
+        ManagementClient client = container.getClient();
+        client.executeForResult(op);
+    }
+
+    protected void addContentToDeployment() throws UnsuccessfulOperationException {
+        ModelNode content = new ModelNode();
+        content.get("bytes").set(RemoteGitRepositoryTestCase.class.getName().getBytes());
+        content.get("target-path").set("test.properties");
+
+        ModelNode op = Operations.createOperation("add-content",
+                new ModelNode().add("deployment", TEST_DEPLOYMENT_RUNTIME_NAME));
+        op.get("content").setEmptyList();
+        op.get("content").add(content);
+
+        ManagementClient client = container.getClient();
+        client.executeForResult(op);
+    }
+
+    protected void removeContentFromDeployment() throws UnsuccessfulOperationException {
+        ModelNode op = Operations.createOperation("remove-content",
+                new ModelNode().add("deployment", TEST_DEPLOYMENT_RUNTIME_NAME));
+        op.get("paths").setEmptyList();
+        op.get("paths").add("test.properties");
+        ManagementClient client = container.getClient();
+        client.executeForResult(op);
+    }
+
+    protected void takeSnapshot(String name, String description) throws UnsuccessfulOperationException {
+        ModelNode op = Operations.createOperation("take-snapshot");
+        if (name != null) {
+            op.get("name").set(name);
+        }
+        if (description != null) {
+            op.get("comment").set(description);
+        }
+
+        container.getClient().executeForResult(op);
+    }
+
+    protected void publish(String location) throws UnsuccessfulOperationException {
+        ModelNode op = Operations.createOperation("publish-configuration");
+        if (location != null) {
+            op.get("location").set(location);
+        }
+        container.getClient().executeForResult(op);
+    }
+
+    protected void verifyDefaultSnapshotString(String string) {
+        String timestamp = FORMATTER.format(LocalDateTime.now());
+        Assert.assertTrue(string, string.startsWith("Snapshot-" + timestamp));
+    }
+
+    protected Path getDotGitDir() {
+        return jbossServerBaseDir.resolve(".git");
+    }
+
+    protected Path getDotGitIgnore() {
+        return jbossServerBaseDir.resolve(".gitignore");
+    }
+
+    protected Path getJbossServerBaseDir() {
+        return jbossServerBaseDir;
+    }
+
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/GitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/GitRepositoryTestCase.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.manualmode.management.persistence;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class GitRepositoryTestCase extends AbstractGitRepositoryTestCase {
+
+    @After
+    public void after() throws Exception {
+        if (container.isStarted()) {
+            try {
+                removeDeployment();
+            } catch (Exception sde) {
+                // ignore error undeploying, might not exist
+            }
+            removeSystemProperty();
+            container.stop();
+        }
+        closeRepository();
+        closeEmptyRemoteRepository();
+    }
+
+    /**
+     * Start server (no parameter)
+     */
+    @Test
+    public void startDefaultTest() throws Exception {
+        // start default (no parameters, no .git in jboss.server.base.dir)
+        container.start();
+        Assert.assertTrue(Files.notExists(getDotGitDir()));
+        Assert.assertTrue(Files.notExists(getDotGitIgnore()));
+        container.stop();
+
+        // start with local repository (--git-repo=local) to initialize the local repo
+        container.startGitBackedConfiguration("local", null, null);
+        Assert.assertTrue("Directory not found " + getDotGitDir(), Files.exists(getDotGitDir()));
+        Assert.assertTrue("File not found " + getDotGitIgnore(), Files.exists(getDotGitIgnore()));
+        container.stop();
+
+        // start with default (no parameters), but with initialized empty repository in jboss.server.base.dir
+        container.start();
+        repository = createRepository();
+        addSystemProperty();
+        int expectedNumberOfCommits = 2;
+        List<String> commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        Assert.assertEquals("Repository initialized", commits.get(1));
+        container.stop();
+
+        // start with default (no parameters), local git repository already contains configuration from last run
+        container.start();
+        try {
+            addSystemProperty();
+            Assert.fail("Operation should have failed");
+        } catch (UnsuccessfulOperationException uoe) {
+            Assert.assertTrue(uoe.getMessage().contains("WFLYCTL0212"));
+        }
+        removeSystemProperty();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+    }
+
+    /**
+     * Start server with parameter --git-repo=local
+     */
+    @Test
+    public void startGitRepoLocalTest() throws Exception {
+        // start with local repository and branch (--git-repo=local --git-branch=my_branch)
+        container.startGitBackedConfiguration("local", "my_branch", null);
+        Assert.assertTrue("Directory not found " + getDotGitDir(), Files.exists(getDotGitDir()));
+        Assert.assertTrue("File not found " + getDotGitIgnore(), Files.exists(getDotGitIgnore()));
+        repository = createRepository();
+        addSystemProperty();
+        int expectedNumberOfCommits = 2;
+        List<String> commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        Assert.assertEquals("Repository initialized", commits.get(1));
+        container.stop();
+
+        // create tag in local repo and change master for next test
+        container.startGitBackedConfiguration("local", null, null);
+        takeSnapshot("my_tag", null);
+        Assert.assertEquals(1, listTags(repository).size());
+        removeSystemProperty();
+        container.stop();
+
+        // start with local repository (where repository already exists) and branch where branch is actually tag
+        // (--git-repo=local --git-branch=my_tag)
+        container.startGitBackedConfiguration("local", "my_tag", null);
+        try {
+            addSystemProperty();
+            Assert.fail("Operation should have failed");
+        } catch (UnsuccessfulOperationException uoe) {
+            Assert.assertTrue(uoe.getMessage().contains("WFLYCTL0212"));
+        }
+    }
+
+    /**
+     * Start server with parameter --git-repo=local and make changes in config and deployment
+     */
+    @Test
+    public void historyAndManagementOperationsTest() throws Exception {
+        container.startGitBackedConfiguration("local", null, null);
+        Assert.assertTrue("Directory not found " + getDotGitDir(), Files.exists(getDotGitDir()));
+        Assert.assertTrue("File not found " + getDotGitIgnore(), Files.exists(getDotGitIgnore()));
+
+        repository = createRepository();
+        int expectedNumberOfCommits = 1;
+
+        // start => initial commit
+        List<String> commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Repository initialized", commits.get(0));
+        List<String> paths = listFilesInCommit(repository);
+
+        // change configuration => commit
+        addSystemProperty();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(1, paths.size());
+        Assert.assertEquals("configuration/standalone.xml", paths.get(0));
+
+        // deploy deployment => commit
+        deployEmptyDeployment();
+        listUntracked(repository).forEach(l-> System.out.println(l));
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 2, paths.size());
+        Assert.assertEquals("configuration/standalone.xml", paths.get(0));
+        String contentPath = paths.get(1);
+        Assert.assertTrue(contentPath.startsWith("data/content/") && contentPath.endsWith("/content"));
+
+        // undeploy deployment (/deployment=name:undeploy) => commited
+        undeployDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 1, paths.size());
+        Assert.assertEquals("configuration/standalone.xml", paths.get(0));
+
+        // exploded deployment => commited
+        explodeDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(Arrays.toString(commits.toArray()), expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 3, paths.size());
+        Assert.assertEquals("-" + contentPath, paths.get(0));
+        Assert.assertEquals("configuration/standalone.xml", paths.get(1));
+        String contentFile = paths.get(2);
+        Assert.assertNotEquals(contentPath, contentFile);
+        Assert.assertTrue(contentFile.startsWith("data/content/") && contentFile.endsWith("/content/file"));
+
+        // exploded deployment - add content => commited
+        addContentToDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 4, paths.size());
+        Assert.assertEquals("configuration/standalone.xml", paths.get(1));
+        Assert.assertEquals("-" + contentFile, paths.get(0));
+        contentFile = paths.get(2);
+        String contentProperties = paths.get(3);
+        Assert.assertNotEquals(contentPath, contentFile);
+        Assert.assertNotEquals(contentPath, contentProperties);
+        Assert.assertTrue(contentFile.startsWith("data/content/") && contentFile.endsWith("/content/file"));
+        Assert.assertTrue(contentProperties.startsWith("data/content/") && contentProperties.endsWith("/content/test.properties"));
+
+        // exploded deployment - remove content => commited
+        removeContentFromDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 4, paths.size());
+        Assert.assertEquals("-" + contentFile, paths.get(0));
+        Assert.assertEquals("-" + contentProperties, paths.get(1));
+        Assert.assertEquals("configuration/standalone.xml", paths.get(2));
+        contentFile = paths.get(3);
+        Assert.assertTrue(contentFile.startsWith("data/content/") && contentFile.endsWith("/content/file"));
+
+        // :clean-obsolete-content
+        // remove deployment => commit
+        removeDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 2, paths.size());
+        Assert.assertEquals( "-" + contentFile, paths.get(0));
+        Assert.assertEquals("configuration/standalone.xml", paths.get(1));
+        // :clean-obsolete-content
+        // deployment-overlay
+
+        // there are no tags
+        List<String> tags = listTags(repository);
+        Assert.assertEquals(0, tags.size());
+
+        // :take-snapshot => tag = timestamp
+        takeSnapshot(null, null);
+        tags = listTags(repository);
+        Assert.assertEquals(1, tags.size());
+        verifyDefaultSnapshotString(tags.get(0));
+        // this snapshot is not expected to have commit, as there is no uncommited remove of content data
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+
+        // :take-snapshot(name=foo) => success, tag=foo
+        takeSnapshot("foo", null);
+        tags = listTags(repository);
+        Assert.assertEquals(2, tags.size());
+        // there should be two tags, from this and previous snapshot
+        Assert.assertEquals("foo", tags.get(1));
+        // this should be the same commit as with previous snapshot
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+
+        // :take-snapshot(name=foo) => fail, tag already exists
+        try {
+            takeSnapshot("foo", null);
+            Assert.fail("Operation should have failed");
+        } catch (UnsuccessfulOperationException uoe) {
+            // good
+            Assert.assertTrue(uoe.getMessage().contains("WFLYCTL0455"));
+        }
+
+        // :take-snapshot(description=bar) => tag = timestamp, commit msg=bar
+        takeSnapshot(null, "bar");
+        expectedNumberOfCommits++;
+        tags = listTags(repository);
+        Assert.assertEquals(3, tags.size());
+        // tags are ordered alphabetically, so we want second with default name
+        verifyDefaultSnapshotString(tags.get(1));
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("bar", commits.get(0));
+
+        // :take-snapshot(name=fooo, description=barbar) => success, tag=fooo, commit msg=bar
+        takeSnapshot("fooo", "bar");
+        expectedNumberOfCommits++;
+        tags = listTags(repository);
+        Assert.assertEquals(4, tags.size());
+        // fooo is alphabetically last
+        Assert.assertEquals("fooo", tags.get(3));
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("bar", commits.get(0));
+
+        // :take-snapshot(name=fooo, description=bar) => fail
+        try {
+            takeSnapshot("fooo", "bar");
+            Assert.fail("Operation should have failed");
+        } catch (UnsuccessfulOperationException uoe) {
+            // good
+            Assert.assertTrue(uoe.getMessage().contains("WFLYCTL0455"));
+        }
+
+        // :publish-configuration => push to origin
+        publish(null);
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("bar", commits.get(0));
+
+        // :publish-configuration(location=empty) => push to empty)
+        publish("empty");
+        tags = listTags(emptyRemoteRepository);
+        Assert.assertEquals(4, tags.size());
+        Assert.assertEquals("fooo", tags.get(3));
+        commits = listCommits(emptyRemoteRepository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("bar", commits.get(0));
+    }
+
+     protected List<String> listUntracked(Repository repository) throws IOException, GitAPIException {
+         List<String> result = new ArrayList<>();
+         result.add("Untracked:");
+        try (Git git = new Git(repository)) {
+            Status status = git.status().call();
+            result.addAll(status.getUntrackedFolders());
+            result.addAll(status.getUntracked());
+            return result;
+        }
+    }
+}

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteGitRepositoryTestCase.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.test.manualmode.management.persistence;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.util.FileUtils;
+import org.jboss.as.repository.PathUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ServerControl;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+@RunWith(WildflyTestRunner.class)
+@ServerControl(manual = true)
+public class RemoteGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
+
+    private Path remoteRoot;
+    private Repository remoteRepository;
+
+    @Before
+    public void prepareTest() throws Exception {
+        remoteRoot = new File("target", "remote").toPath();
+        Path repoConfigDir = remoteRoot.resolve("configuration");
+        Files.createDirectories(repoConfigDir);
+        File baseDir = remoteRoot.toAbsolutePath().toFile();
+        PathUtil.copyRecursively(getJbossServerBaseDir().resolve("configuration"), repoConfigDir, true);
+        File gitDir = new File(baseDir, Constants.DOT_GIT);
+        if (!gitDir.exists()) {
+            try (Git git = Git.init().setDirectory(baseDir).call()) {
+                git.add().addFilepattern("configuration").call();
+                git.commit().setMessage("Repository initialized").call();
+            }
+        }
+        remoteRepository = new FileRepositoryBuilder().setWorkTree(baseDir).setGitDir(gitDir).setup().build();
+    }
+
+    @After
+    public void after() throws Exception {
+        if (container.isStarted()) {
+            try {
+                removeDeployment();
+            } catch (Exception sde) {
+                // ignore error undeploying, might not exist
+            }
+            removeSystemProperty();
+            container.stop();
+        }
+        closeRepository();
+        closeEmptyRemoteRepository();
+        closeRemoteRepository();
+    }
+
+    private void closeRemoteRepository() throws Exception{
+        if (remoteRepository != null) {
+            remoteRepository.close();
+        }
+        FileUtils.delete(remoteRoot.toFile(), FileUtils.RECURSIVE | FileUtils.RETRY);
+    }
+
+    /**
+     * Start server with parameter --git-repo=file:///my_repo/test/.git
+     */
+    @Test
+    public void startGitRepoRemoteTest() throws Exception {
+        // start with remote repository containing configuration (--git-repo=file:///my_repo/test/.git)
+        container.startGitBackedConfiguration("file://" + remoteRoot.resolve(Constants.DOT_GIT).toAbsolutePath().toString(), Constants.MASTER, null);
+        Assert.assertTrue("Directory not found " + getDotGitDir(), Files.exists(getDotGitDir()));
+        Assert.assertTrue("File not found " + getDotGitIgnore(), Files.exists(getDotGitIgnore()));
+        List<String> commits = listCommits(remoteRepository);
+        Assert.assertEquals(1, commits.size());
+        addSystemProperty();
+        publish(null);
+        commits = listCommits(remoteRepository);
+        Assert.assertEquals(3, commits.size());
+
+        // create branch in remote repo and change master for next test
+        try(Git git = new Git(remoteRepository)) {
+            git.checkout().setName("my_branch").setCreateBranch(true).call();
+        }
+        removeSystemProperty();
+        publish(null);
+        container.stop();
+        closeRepository();
+
+        // start with remote repository and branch containing configuration
+        // (--git-repo=file:///my_repo/test/.git --git-branch=my_branch)
+        container.startGitBackedConfiguration("file://" + remoteRoot.resolve(Constants.DOT_GIT).toAbsolutePath().toString(), "my_branch", null);
+        Assert.assertTrue("Directory not found " + getDotGitDir(), Files.exists(getDotGitDir()));
+        Assert.assertTrue("File not found " + getDotGitIgnore(), Files.exists(getDotGitIgnore()));
+        try {
+            addSystemProperty();
+            Assert.fail("Operation should have failed");
+        } catch (UnsuccessfulOperationException uoe) {
+            Assert.assertTrue(uoe.getMessage().contains("WFLYCTL0212"));
+        }
+    }
+
+    /**
+     * Start server with parameter --git-repo=file:///my_repo/test/.git
+     */
+    @Test
+    public void historyAndManagementOperationsTest() throws Exception {
+        container.startGitBackedConfiguration("file://" + remoteRoot.resolve(Constants.DOT_GIT).toAbsolutePath().toString(), Constants.MASTER, null);
+        Assert.assertTrue("Directory not found " + getDotGitDir(), Files.exists(getDotGitDir()));
+        Assert.assertTrue("File not found " + getDotGitIgnore(), Files.exists(getDotGitIgnore()));
+        repository = createRepository();
+
+        int expectedNumberOfCommits = 2;
+
+        // start => initial commit
+        List<String> commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Adding .gitignore", commits.get(0));
+        Assert.assertEquals("Repository initialized", commits.get(1));
+        List<String> paths = listFilesInCommit(repository);
+
+        // change configuration => commit
+        addSystemProperty();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(1, paths.size());
+        Assert.assertEquals("configuration/standalone.xml", paths.get(0));
+
+        // deploy deployment => commit
+        deployEmptyDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 2, paths.size());
+        Assert.assertEquals("configuration/standalone.xml", paths.get(0));
+        String contentPath = paths.get(1);
+        Assert.assertTrue(contentPath.startsWith("data/content/") && contentPath.endsWith("/content"));
+
+        // undeploy deployment (/deployment=name:undeploy) => commited
+        undeployDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 1, paths.size());
+        Assert.assertEquals("configuration/standalone.xml", paths.get(0));
+
+        // exploded deployment => commited
+        explodeDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(Arrays.toString(commits.toArray()), expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 3, paths.size());
+        Assert.assertEquals("-" + contentPath, paths.get(0));
+        Assert.assertEquals("configuration/standalone.xml", paths.get(1));
+        String contentFile = paths.get(2);
+        Assert.assertNotEquals(contentPath, contentFile);
+        Assert.assertTrue(contentFile.startsWith("data/content/") && contentFile.endsWith("/content/file"));
+
+        // exploded deployment - add content => commited
+        addContentToDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 4, paths.size());
+        Assert.assertEquals("configuration/standalone.xml", paths.get(1));
+        Assert.assertEquals("-" + contentFile, paths.get(0));
+        contentFile = paths.get(2);
+        String contentProperties = paths.get(3);
+        Assert.assertNotEquals(contentPath, contentFile);
+        Assert.assertNotEquals(contentPath, contentProperties);
+        Assert.assertTrue(contentFile.startsWith("data/content/") && contentFile.endsWith("/content/file"));
+        Assert.assertTrue(contentProperties.startsWith("data/content/") && contentProperties.endsWith("/content/test.properties"));
+
+        // exploded deployment - remove content => commited
+        removeContentFromDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 4, paths.size());
+        Assert.assertEquals("-" + contentFile, paths.get(0));
+        Assert.assertEquals("-" + contentProperties, paths.get(1));
+        Assert.assertEquals("configuration/standalone.xml", paths.get(2));
+        contentFile = paths.get(3);
+        Assert.assertTrue(contentFile.startsWith("data/content/") && contentFile.endsWith("/content/file"));
+
+        // :clean-obsolete-content
+        // remove deployment => commit
+        removeDeployment();
+        expectedNumberOfCommits++;
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+        paths = listFilesInCommit(repository);
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 2, paths.size());
+        Assert.assertEquals( "-" + contentFile, paths.get(0));
+        Assert.assertEquals("configuration/standalone.xml", paths.get(1));
+        // :clean-obsolete-content
+        // deployment-overlay
+
+        // there are no tags
+        List<String> tags = listTags(repository);
+        Assert.assertEquals(0, tags.size());
+
+        // :take-snapshot => tag = timestamp
+        takeSnapshot(null, null);
+        tags = listTags(repository);
+        Assert.assertEquals(1, tags.size());
+        verifyDefaultSnapshotString(tags.get(0));
+        // this snapshot is not expected to have commit, as there is no uncommited remove of content data
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("Storing configuration", commits.get(0));
+
+        // :take-snapshot(name=foo) => success, tag=foo
+        takeSnapshot("foo", null);
+        tags = listTags(repository);
+        Assert.assertEquals(2, tags.size());
+        // there should be two tags, from this and previous snapshot
+        Assert.assertEquals("foo", tags.get(1));
+        // this should be the same commit as with previous snapshot
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+
+        // :take-snapshot(name=foo) => fail, tag already exists
+        try {
+            takeSnapshot("foo", null);
+            Assert.fail("Operation should have failed");
+        } catch (UnsuccessfulOperationException uoe) {
+            // good
+            Assert.assertTrue(uoe.getMessage().contains("WFLYCTL0455"));
+        }
+
+        // :take-snapshot(description=bar) => tag = timestamp, commit msg=bar
+        takeSnapshot(null, "bar");
+        expectedNumberOfCommits++;
+        tags = listTags(repository);
+        Assert.assertEquals(3, tags.size());
+        // tags are ordered alphabetically, so we want second with default name
+        verifyDefaultSnapshotString(tags.get(1));
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("bar", commits.get(0));
+
+        // :take-snapshot(name=fooo, description=barbar) => success, tag=fooo, commit msg=bar
+        takeSnapshot("fooo", "bar");
+        expectedNumberOfCommits++;
+        tags = listTags(repository);
+        Assert.assertEquals(4, tags.size());
+        // fooo is alphabetically last
+        Assert.assertEquals("fooo", tags.get(3));
+        commits = listCommits(repository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("bar", commits.get(0));
+
+        // :take-snapshot(name=fooo, description=bar) => fail
+        try {
+            takeSnapshot("fooo", "bar");
+            Assert.fail("Operation should have failed");
+        } catch (UnsuccessfulOperationException uoe) {
+            // good
+            Assert.assertTrue(uoe.getMessage().contains("WFLYCTL0455"));
+        }
+
+
+        // :publish-configuration => push to origin
+        commits = listCommits(remoteRepository);
+        Assert.assertEquals(1, commits.size());
+        Assert.assertEquals("Repository initialized", commits.get(0));
+        publish(null);
+        commits = listCommits(remoteRepository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("bar", commits.get(0));
+
+        // :publish-configuration(location=empty) => push to empty)
+        publish("empty");
+        tags = listTags(emptyRemoteRepository);
+        Assert.assertEquals(4, tags.size());
+        Assert.assertEquals("fooo", tags.get(3));
+        commits = listCommits(emptyRemoteRepository);
+        Assert.assertEquals(expectedNumberOfCommits, commits.size());
+        Assert.assertEquals("bar", commits.get(0));
+    }
+
+}

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/Server.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -73,6 +74,11 @@ public class Server {
     private final URI authConfigUri;
     private final boolean readOnly;
 
+    // git backed configuration
+    private String gitRepository;
+    private String gitBranch;
+    private String gitAuthConfiguration;
+
     public Server() {
         this(null, false);
     }
@@ -127,6 +133,21 @@ public class Server {
         this.startMode = startMode;
     }
 
+    /**
+     * Enable git backed configuration repository
+     *
+     * @param gitRepository
+     * @param gitBranch
+     * @param gitAuthConfig
+     */
+    public void setGitRepository(final String gitRepository, final String gitBranch, final String gitAuthConfig) {
+        Objects.requireNonNull(gitRepository);
+
+        this.gitRepository = gitRepository;
+        this.gitBranch = gitBranch;
+        this.gitAuthConfiguration = gitAuthConfig;
+    }
+
     protected void start() {
         start(System.out);
     }
@@ -162,6 +183,10 @@ public class Server {
                 commandBuilder.setServerReadOnlyConfiguration(serverConfig);
             } else {
                 commandBuilder.setServerConfiguration(serverConfig);
+            }
+
+            if (gitRepository != null) {
+                commandBuilder.setGitRepository(gitRepository, gitBranch, gitAuthConfiguration);
             }
 
             //we are testing, of course we want assertions and set-up some other defaults

--- a/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ServerController.java
+++ b/testsuite/test-runner/src/main/java/org/wildfly/core/testrunner/ServerController.java
@@ -71,10 +71,34 @@ public class ServerController {
      * @param readOnly
      */
     public void start(final String serverConfig, final URI authConfigUri, Server.StartMode startMode, PrintStream out, boolean readOnly) {
+     start(serverConfig, authConfigUri, startMode, out, readOnly, null, null, null);
+    }
+
+    /**
+     * Stats the server.
+     * <p>
+     * If the {@code authConfigUri} is not {@code null} the resource will be used for authentication of the
+     * {@link org.jboss.as.controller.client.ModelControllerClient}.
+     * </p>
+     *
+     * @param serverConfig  the configuration file to use or {@code null} to use the default
+     * @param authConfigUri the path to the {@code wildfly-config.xml} or {@code null}
+     * @param startMode     the mode to start the server in
+     * @param out           the print stream used to consume the {@code stdout} and {@code stderr} streams
+     * @param readOnly
+     * @param gitRepository the git repository to clone to get the server configuration.
+     * @param gitBranch     the git branch to use to get the server configuration
+     * @param gitAuthConfig the path
+     */
+    public void start(final String serverConfig, final URI authConfigUri, Server.StartMode startMode, PrintStream out,
+                      boolean readOnly, final String gitRepository, final String gitBranch, final String gitAuthConfig) {
         if (started.compareAndSet(false, true)) {
             server = new Server(authConfigUri, readOnly);
             if (serverConfig != null) {
                 server.setServerConfig(serverConfig);
+            }
+            if (gitRepository != null) {
+                server.setGitRepository(gitRepository, gitBranch, gitAuthConfig);
             }
             server.setStartMode(startMode);
             try {
@@ -106,6 +130,10 @@ public class ServerController {
 
     public void startSuspended() {
         start(null, Server.StartMode.SUSPEND);
+    }
+
+    public void startGitBackedConfiguration(final String gitRepository, final String gitBranch, final String gitAuthConfig) {
+        start(null, null, Server.StartMode.NORMAL, System.out, false, gitRepository, gitBranch, gitAuthConfig);
     }
 
     public void stop() {


### PR DESCRIPTION
Having it working properly in standalone.
Deleting content of the configuration directory before cloning so we have the logging.properties on boot.
Fixing too many commits on boot
Allowing for git repository creation with the special repo 'local'.
Snapshots can take a comment that will be used as commit comment.
Adding support for managed content.
Removing domain support
Using tags for snapshot management
Integrating Elytron

Jira: https://issues.jboss.org/browse/WFCORE-433
JBEAP: https://issues.jboss.org/browse/EAP7-728
Proposal PR: https://github.com/wildfly/wildfly-proposals/pull/80
Documentation PR: https://github.com/wildfly/wildfly/pull/11492