### PR TITLE
WFCORE-2780 - Improve buffer-pool model description

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemTransformers.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemTransformers.java
@@ -24,11 +24,13 @@ import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.transform.ExtensionTransformerRegistration;
 import org.jboss.as.controller.transform.SubsystemTransformerRegistration;
+import org.jboss.as.controller.transform.TransformerRegistry;
 import org.jboss.as.controller.transform.description.AttributeConverter;
 import org.jboss.as.controller.transform.description.ChainedTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.controller.transform.description.TransformationDescription;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
 
 /**
@@ -74,9 +76,15 @@ public class IOSubsystemTransformers implements ExtensionTransformerRegistration
                         WorkerResourceDefinition.WORKER_IO_THREADS,
                         WorkerResourceDefinition.WORKER_TASK_KEEPALIVE,
                         WorkerResourceDefinition.WORKER_TASK_MAX_THREADS
-                );
-
-
-
+                )
+        ;
+        final ResourceTransformationDescriptionBuilder bufferPoolResourceBuilder = builder
+                .addChildResource(BufferPoolResourceDefinition.INSTANCE.getPathElement());
+        bufferPoolResourceBuilder.getAttributeBuilder()
+                .addRename("slice-size", BufferPoolResourceDefinition.BUFFER_SIZE.getName()).end();
+        bufferPoolResourceBuilder.getAttributeBuilder()
+                .addRename("slices-per-buffer", BufferPoolResourceDefinition.BUFFER_PER_SLICE.getName()).end();
+        TransformationDescription.Tools.register(bufferPoolResourceBuilder.build(), TransformerRegistry.Factory.create()
+                .getServerRegistration(ModelVersion.create(2)));
     }
 }


### PR DESCRIPTION
Issue: [JBEAP-9140](https://issues.jboss.org/browse/JBEAP-9140)
Upstream Issue: [WFCORE-2780](https://issues.jboss.org/browse/WFCORE-2780)

(no downstream required)

Please don't merge! It's not working (yet) and I'm using this PR to ask for help.

@bstansberry as you recommended me (on [PR2400](https://github.com/wildfly/wildfly-core/pull/2400)), I've took a look at the transformer API. It seems to me that I have everything in place for this to work, but it does not. It compile, build but when I look at the buffer pool attributes, the renamed one are still missing.

Could you take a (brief) look and see if you spot the mistake? (I expect it to be obvious for anyone more familiar than me with the API)