### PR TITLE
Fix for WFCORE-3903, upgrade aesh 1.6, readline 1.9 and extensions 1.5

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CLICommandCompleter.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLICommandCompleter.java
@@ -73,7 +73,7 @@ public class CLICommandCompleter {
     protected void doComplete(CommandContext ctx, AeshCompleteOperation op, Completer completer) {
         String buffer = op.getBuffer();
         int cursor = op.getCursor();
-        if (buffer.isEmpty()) {
+        if (buffer.isEmpty() || cursor == 0) {
             completer.addAllCommandNames(ctx, op);
             return;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -140,9 +140,9 @@
         <version.javax.json.javax-json-api>1.1.2</version.javax.json.javax-json-api>
         <version.junit>4.12</version.junit>
         <version.log4j>1.2.17</version.log4j>
-        <version.org.aesh>1.5</version.org.aesh>
-        <version.org.aesh-extensions>1.4</version.org.aesh-extensions>
-        <version.org.aesh-readline>1.8</version.org.aesh-readline>
+        <version.org.aesh>1.6</version.org.aesh>
+        <version.org.aesh-extensions>1.5</version.org.aesh-extensions>
+        <version.org.aesh-readline>1.9</version.org.aesh-readline>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
         <!-- TODO Elytron - Bump to M17 -->
         <version.org.apache.httpcomponents.httpclient>4.5.2</version.org.apache.httpcomponents.httpclient>

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/MoreTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/MoreTestCase.java
@@ -153,16 +153,15 @@ public class MoreTestCase {
             checkWithRegex(window, morePattern);
             Assert.assertEquals(window, readlineConsole.getTerminalHeight(), countLines(window));
 
-            // Testing of key down is blocked by https://issues.jboss.org/browse/WFCORE-3545
-//            // it sends key down to the console what should return only one new line
-//            consoleWriter.print(Key.DOWN.getKeyValuesAsString());
-//            Assert.assertFalse(consoleWriter.checkError());
-//
-//            window = queue.poll(10, TimeUnit.SECONDS);
-//            Assert.assertNotNull(window);
-//            checkWithRegex(window, morePattern);
-//            // we expect 2 because on the second line there is --More(%)-- string
-//            Assert.assertEquals(window,2, countLines(window));
+            // it sends key down to the console what should return only one new line
+            consoleWriter.print(Key.DOWN.getKeyValuesAsString());
+            Assert.assertFalse(consoleWriter.checkError());
+
+            window = queue.poll(10, TimeUnit.SECONDS);
+            Assert.assertNotNull(window);
+            checkWithRegex(window, morePattern);
+            // we expect 2 because on the second line there is --More(%)-- string
+            Assert.assertEquals(window,2, countLines(window));
 
             consoleWriter.print("q");
             Assert.assertFalse(consoleWriter.checkError());


### PR DESCRIPTION
- Aesh upgrade.
- Includes fixes for WFCORE-3545, uncomment test with multiple chars
- Includes fixes for WFCORE-3904, NPE at Tab completion