### PR TITLE
Fix for WFCORE-3935, CLI, revisit modular context detection

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedHostControllerHandler.java
@@ -260,6 +260,7 @@ class EmbedHostControllerHandler extends CommandHandlerWithHelp {
                         .setCommandArguments(cmds);
             } else {
                 configBuilder = Configuration.Builder.of(jbossHome.getAbsoluteFile())
+                        .addSystemPackages(EmbeddedControllerHandlerRegistrar.EXTENDED_SYSTEM_PKGS)
                         .setCommandArguments(cmds);
             }
             // Disables the logging subsystem from registering an embedded log context if the subsystem is present

--- a/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/embedded/EmbedServerHandler.java
@@ -234,6 +234,7 @@ class EmbedServerHandler extends CommandHandlerWithHelp {
                         .setCommandArguments(cmds);
             } else {
                 configBuilder = Configuration.Builder.of(jbossHome.getAbsoluteFile())
+                        .addSystemPackages(EmbeddedControllerHandlerRegistrar.EXTENDED_SYSTEM_PKGS)
                         .setCommandArguments(cmds);
             }
             // Disables the logging subsystem from registering an embedded log context if the subsystem is present

--- a/cli/src/main/java/org/jboss/as/cli/impl/SecurityActions.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/SecurityActions.java
@@ -82,6 +82,11 @@ class SecurityActions {
         return iface.cast(clazz.newInstance());
     }
 
+    /**
+     * WARNING: Calling this method in non modular context has the side effect to load the Module class.
+     * This is problematic, the system packages required to properly execute an embedded-server will not
+     * be correct.
+     */
     static <T> T loadAndInstantiateFromModule(final String moduleId, final Class<T> iface, final String name) throws Exception {
         if (!WildFlySecurityManager.isChecking()) {
             return internalLoadAndInstantiateFromModule(moduleId, iface, name);


### PR DESCRIPTION
This is an attempt to simplify modular context detection. @bstansberry @jamezp this is a follow-up for WFCORE-3866.
