### PR TITLE
WFCORE-3939 Add PersistentResourceXMLParser support for logical grouping of child resources

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -36,7 +36,7 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
  */
 public final class PersistentResourceXMLDescription implements ResourceParser, ResourceMarshaller {
 
-    protected final PathElement pathElement;
+    private final PathElement pathElement;
     private final String xmlElementName;
     private final String xmlWrapperElement;
     private final LinkedHashMap<String, LinkedHashMap<String, AttributeDefinition>> attributesByGroup;
@@ -125,13 +125,7 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         return this.pathElement;
     }
 
-    /**
-     * Parse xml from provided <code>reader</code> and add resulting operations to passed list
-     * @param reader xml reader to parse from
-     * @param parentAddress address of the parent, used as base for all child elements
-     * @param list list of operations where result will be put to.
-     * @throws XMLStreamException if any error occurs while parsing
-     */
+    @Override
     public void parse(final XMLExtendedStreamReader reader, PathAddress parentAddress, List<ModelNode> list) throws XMLStreamException {
         if (decoratorElement != null) {
             parseDecorator(reader, parentAddress, list);
@@ -327,12 +321,12 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         }
     }
 
-
+    @Override
     public void persist(XMLExtendedStreamWriter writer, ModelNode model) throws XMLStreamException {
         persist(writer, model, namespaceURI);
     }
 
-    private void writeStartElement(XMLExtendedStreamWriter writer, String namespaceURI, String localName) throws XMLStreamException {
+    private static void writeStartElement(XMLExtendedStreamWriter writer, String namespaceURI, String localName) throws XMLStreamException {
         if (namespaceURI != null) {
             writer.writeStartElement(namespaceURI, localName);
         } else {
@@ -340,7 +334,7 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         }
     }
 
-    private void startSubsystemElement(XMLExtendedStreamWriter writer, String namespaceURI, boolean empty) throws XMLStreamException {
+    private static void startSubsystemElement(XMLExtendedStreamWriter writer, String namespaceURI, boolean empty) throws XMLStreamException {
         if (writer.getNamespaceContext().getPrefix(namespaceURI) == null) {
             // Unknown namespace; it becomes default
             writer.setDefaultNamespace(namespaceURI);

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/NonResolvingResourceDescriptionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/NonResolvingResourceDescriptionResolver.java
@@ -34,7 +34,7 @@ import java.util.ResourceBundle;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public class NonResolvingResourceDescriptionResolver extends StandardResourceDescriptionResolver {
-    public static NonResolvingResourceDescriptionResolver INSTANCE = new NonResolvingResourceDescriptionResolver();
+    public static final NonResolvingResourceDescriptionResolver INSTANCE = new NonResolvingResourceDescriptionResolver();
 
     public NonResolvingResourceDescriptionResolver() {
         super("", "", NonResolvingResourceDescriptionResolver.class.getClassLoader());

--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
@@ -670,7 +670,7 @@ public class PersistentResourceXMLParserTestCase {
                 .build();
 
 
-        static final PersistentResourceDefinition RESOURCE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("resource"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition RESOURCE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("resource"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -689,7 +689,7 @@ public class PersistentResourceXMLParserTestCase {
             }
         };
 
-        static final PersistentResourceDefinition BUFFER_CACHE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("buffer-cache"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition BUFFER_CACHE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("buffer-cache"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -702,7 +702,7 @@ public class PersistentResourceXMLParserTestCase {
             }
         };
 
-        static final PersistentResourceDefinition OBJECT_TYPE_TEST = new PersistentResourceDefinition(PathElement.pathElement("object-type-test"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition OBJECT_TYPE_TEST = new PersistentResourceDefinition(PathElement.pathElement("object-type-test"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -712,7 +712,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        static final PersistentResourceDefinition SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("server"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("server"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -732,7 +732,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        static final PersistentResourceDefinition CUSTOM_SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("custom"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition CUSTOM_SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("custom"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -749,7 +749,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        static final PersistentResourceDefinition SESSION_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("mail-session"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition SESSION_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("mail-session"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -765,7 +765,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        PersistentResourceDefinition SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(SUBSYSTEM_PATH, new NonResolvingResourceDescriptionResolver()) {
+        PersistentResourceDefinition SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(SUBSYSTEM_PATH, NonResolvingResourceDescriptionResolver.INSTANCE) {
 
             @Override
             public Collection<AttributeDefinition> getAttributes() {
@@ -1189,7 +1189,7 @@ public class PersistentResourceXMLParserTestCase {
         static final IIOPRootDefinition INSTANCE = new IIOPRootDefinition();
 
         private IIOPRootDefinition() {
-            super(PathElement.pathElement("subsystem", "orb"), new NonResolvingResourceDescriptionResolver());
+            super(PathElement.pathElement("subsystem", "orb"), NonResolvingResourceDescriptionResolver.INSTANCE);
         }
 
         @Override
@@ -1395,7 +1395,7 @@ public class PersistentResourceXMLParserTestCase {
                     .build();
         }
 
-    static final PersistentResourceDefinition SERVICE_PROCESS_RESOURCE = new PersistentResourceDefinition(PathElement.pathElement("service"), new NonResolvingResourceDescriptionResolver()) {
+    static final PersistentResourceDefinition SERVICE_PROCESS_RESOURCE = new PersistentResourceDefinition(PathElement.pathElement("service"), NonResolvingResourceDescriptionResolver.INSTANCE) {
         @Override
         public Collection<AttributeDefinition> getAttributes() {
             Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -1409,7 +1409,7 @@ public class PersistentResourceXMLParserTestCase {
 
     protected static final PathElement PROCESS_SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "process");
 
-    PersistentResourceDefinition PROCESS_SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(PROCESS_SUBSYSTEM_PATH, new NonResolvingResourceDescriptionResolver()) {
+    PersistentResourceDefinition PROCESS_SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(PROCESS_SUBSYSTEM_PATH, NonResolvingResourceDescriptionResolver.INSTANCE) {
 
               @Override
               public Collection<AttributeDefinition> getAttributes() {

--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
@@ -466,6 +466,31 @@ public class PersistentResourceXMLParserTestCase {
         Assert.assertEquals(normalizeXML(xml), normalizeXML(out));
     }
 
+    @Test
+    public void testChildGroups() throws Exception {
+        PersistentResourceXMLParser parser = new ChildGroupParser();
+
+        String xml = readResource("child-groups-subsystem.xml");
+        StringReader strReader = new StringReader(xml);
+
+        XMLMapper mapper = XMLMapper.Factory.create();
+        mapper.registerRootElement(new QName(ChildGroupParser.NAMESPACE, "subsystem"), parser);
+
+        XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(new StreamSource(strReader));
+        List<ModelNode> operations = new ArrayList<>();
+        mapper.parseDocument(operations, reader);
+
+        Assert.assertEquals(operations.toString(), 5, operations.size());
+        ModelNode subsystem = opsToModel(operations);
+
+        StringWriter stringWriter = new StringWriter();
+        XMLExtendedStreamWriter xmlStreamWriter = createXMLStreamWriter(XMLOutputFactory.newInstance().createXMLStreamWriter(stringWriter));
+        SubsystemMarshallingContext context = new SubsystemMarshallingContext(subsystem, xmlStreamWriter);
+        mapper.deparseDocument(parser, context, xmlStreamWriter);
+        String out = stringWriter.toString();
+        Assert.assertEquals(normalizeXML(xml), normalizeXML(out));
+    }
+
     private ModelNode opsToModel(List<ModelNode> operations) {
         ModelNode subsystem = new ModelNode();
 
@@ -1435,6 +1460,40 @@ public class PersistentResourceXMLParserTestCase {
                             .addAttribute(PROCESS_STATE_LISTENERS)
                             .addAttribute(UNWRAPPED_LISTENER, AttributeParsers.UNWRAPPED_OBJECT_LIST_PARSER, AttributeMarshaller.UNWRAPPED_OBJECT_LIST_MARSHALLER)
                             .addAttribute(OBJECT_DEFINITION))
+                    .build();
+        }
+    }
+
+    static class ChildGroupParser extends PersistentResourceXMLParser {
+        static final String NAMESPACE = "urn:jboss:domain:jgroups:1.0";
+        private static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "jgroups");
+        private static final PathElement CHANNEL_PATH = PathElement.pathElement("channel");
+        private static final PathElement STACK_PATH = PathElement.pathElement("stack");
+
+        static final AttributeDefinition DEFAULT_CHANNEL = new SimpleAttributeDefinitionBuilder("default-channel", ModelType.STRING)
+                .setRequired(true)
+                .setXmlName("default")
+                .setAttributeGroup("channels")
+                .build();
+
+        static final AttributeDefinition DEFAULT_STACK = new SimpleAttributeDefinitionBuilder("default-stack", ModelType.STRING)
+                .setRequired(true)
+                .setXmlName("default")
+                .setAttributeGroup("stacks")
+                .build();
+
+        static final AttributeDefinition STACK = new SimpleAttributeDefinitionBuilder("stack", ModelType.STRING)
+                .setRequired(true)
+                .build();
+
+        @Override
+        public PersistentResourceXMLDescription getParserDescription() {
+            return builder(SUBSYSTEM_PATH, NAMESPACE)
+                    .addAttribute(DEFAULT_CHANNEL)
+                    .addAttribute(DEFAULT_STACK)
+                    .setUseElementsForGroups(true)
+                    .addChild(DEFAULT_CHANNEL, builder(CHANNEL_PATH).addAttribute(STACK))
+                    .addChild(DEFAULT_STACK, builder(STACK_PATH))
                     .build();
         }
     }

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/child-groups-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/child-groups-subsystem.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:jgroups:1.0">
+    <channels default="ee">
+        <channel name="ee" stack="tcp"/>
+        <channel name="foo"/>
+    </channels>
+    <stacks default="udp">
+        <stack name="udp"/>
+        <stack name="tcp"/>
+    </stacks>
+</subsystem>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3939

Enables usage of PersistentResourceXMLParser in subsystems where child resources are logically grouped (e.g. clustering subsystems).