### PR TITLE
[WFCORE-3915] Do not deploy testsuite modules

### DIFF
--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -28,9 +28,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- uses wildfly-core-parent parent as wildfly-core-testsuite-shared
-     is a dependency of wildfly-core-testsuite and can not be its child
-    -->
     <parent>
         <groupId>org.wildfly.core</groupId>
         <artifactId>wildfly-core-parent</artifactId>
@@ -42,12 +39,6 @@
     <packaging>jar</packaging>
 
     <name>WildFly Core Test Suite: Shared</name>
-
-    <properties>
-        <!-- Don't deploy the testsuite modules -->
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
     <build>
         <resources>
             <resource>


### PR DESCRIPTION
Revert change for wildfly-core-testsuite-shared as it is a dependency of
wildfly-testsuite-shared in WildFly Full codebase.

JIRA: https://issues.jboss.org/browse/WFCORE-3915