### PR TITLE
WFCORE-3939 Add PersistentResourceXMLParser support for logical grouping of child resources

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -36,7 +36,7 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
  */
 public final class PersistentResourceXMLDescription implements ResourceParser, ResourceMarshaller {
 
-    protected final PathElement pathElement;
+    private final PathElement pathElement;
     private final String xmlElementName;
     private final String xmlWrapperElement;
     private final LinkedHashMap<String, LinkedHashMap<String, AttributeDefinition>> attributesByGroup;
@@ -125,13 +125,7 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         return this.pathElement;
     }
 
-    /**
-     * Parse xml from provided <code>reader</code> and add resulting operations to passed list
-     * @param reader xml reader to parse from
-     * @param parentAddress address of the parent, used as base for all child elements
-     * @param list list of operations where result will be put to.
-     * @throws XMLStreamException if any error occurs while parsing
-     */
+    @Override
     public void parse(final XMLExtendedStreamReader reader, PathAddress parentAddress, List<ModelNode> list) throws XMLStreamException {
         if (decoratorElement != null) {
             parseDecorator(reader, parentAddress, list);
@@ -327,12 +321,12 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         }
     }
 
-
+    @Override
     public void persist(XMLExtendedStreamWriter writer, ModelNode model) throws XMLStreamException {
         persist(writer, model, namespaceURI);
     }
 
-    private void writeStartElement(XMLExtendedStreamWriter writer, String namespaceURI, String localName) throws XMLStreamException {
+    private static void writeStartElement(XMLExtendedStreamWriter writer, String namespaceURI, String localName) throws XMLStreamException {
         if (namespaceURI != null) {
             writer.writeStartElement(namespaceURI, localName);
         } else {
@@ -340,7 +334,7 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         }
     }
 
-    private void startSubsystemElement(XMLExtendedStreamWriter writer, String namespaceURI, boolean empty) throws XMLStreamException {
+    private static void startSubsystemElement(XMLExtendedStreamWriter writer, String namespaceURI, boolean empty) throws XMLStreamException {
         if (writer.getNamespaceContext().getPrefix(namespaceURI) == null) {
             // Unknown namespace; it becomes default
             writer.setDefaultNamespace(namespaceURI);

--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -40,14 +40,14 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
     private final PathElement pathElement;
     private final String xmlElementName;
     private final String xmlWrapperElement;
-    private final LinkedHashMap<String, LinkedHashMap<String, AttributeDefinition>> attributesByGroup;
-    private final List<PersistentResourceXMLDescription> children;
-    private final List<ResourceMarshaller> marshallers;
+    private final Map<String, Map<String, AttributeDefinition>> attributesByGroup;
+    private final Map<String, List<PersistentResourceXMLDescription>> childrenByGroup = new HashMap<>();
+    private final Map<String, List<ResourceMarshaller>> marshallersByGroup = new HashMap<>();
     private final Map<String, AttributeDefinition> attributeElements = new HashMap<>();
     private final boolean useValueAsElementName;
     private final boolean noAddOperation;
     private final AdditionalOperationsGenerator additionalOperationsGenerator;
-    private final LinkedHashMap<String, ResourceParser> customChildParsers;
+    private final Map<String, ResourceParser> customChildParsers;
     private final String decoratorElement;
     private boolean flushRequired = true;
     private boolean childAlreadyRead = false;
@@ -76,7 +76,7 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
             // Segregate attributes by group
             for (AttributeDefinition ad : builder.attributeList) {
                 String adGroup = ad.getAttributeGroup();
-                LinkedHashMap<String, AttributeDefinition> forGroup = this.attributesByGroup.get(adGroup);
+                Map<String, AttributeDefinition> forGroup = this.attributesByGroup.get(adGroup);
                 if (forGroup == null) {
                     forGroup = new LinkedHashMap<>();
                     this.attributesByGroup.put(adGroup, forGroup);
@@ -102,14 +102,27 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
             // Ignore attribute-group, treat all as if they are in the default group
             this.attributesByGroup.put(null, attrs);
         }
-        this.children = new ArrayList<>();
-        this.marshallers = builder.marshallers;
-        for (PersistentResourceXMLBuilder b : builder.childrenBuilders) {
-            PersistentResourceXMLDescription child = b.build();
-            this.children.add(child);
-            this.marshallers.add(child);
+        this.childrenByGroup.put(null, builder.children);
+        this.marshallersByGroup.put(null, builder.marshallers);
+        for (Map.Entry<String, List<PersistentResourceXMLBuilder>> entry : builder.childrenBuilders.entrySet()) {
+            String group = entry.getKey();
+            List<PersistentResourceXMLBuilder> childBuilders = entry.getValue();
+            List<PersistentResourceXMLDescription> children = this.childrenByGroup.get(group);
+            if (children == null) {
+                children = new ArrayList<>(childBuilders.size());
+                this.childrenByGroup.put(group, children);
+            }
+            List<ResourceMarshaller> marshallers = this.marshallersByGroup.get(group);
+            if (marshallers == null) {
+                marshallers = new ArrayList<>(childBuilders.size());
+                this.marshallersByGroup.put(group, marshallers);
+            }
+            for (PersistentResourceXMLBuilder childBuilder : childBuilders) {
+                PersistentResourceXMLDescription child = childBuilder.build();
+                children.add(child);
+                marshallers.add(child);
+            }
         }
-        this.children.addAll(builder.children);
         this.useValueAsElementName = builder.useValueAsElementName;
         this.noAddOperation = builder.noAddOperation;
         this.additionalOperationsGenerator = builder.additionalOperationsGenerator;
@@ -152,7 +165,7 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
             throw unexpectedElement(reader, Collections.singleton(decoratorElement));
         }
         if (!reader.isEndElement()) { //only parse children if we are not on end of tag already
-            parseChildren(reader, parentAddress, list, new ModelNode());
+            parseChildren(reader, parentAddress, list, new ModelNode(), null);
         }
     }
 
@@ -162,7 +175,7 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
             additionalOperationsGenerator.additionalOperations(PathAddress.pathAddress(op.get(OP_ADDR)), op, list);
         }
         if (!reader.isEndElement()) { //only parse children if we are not on end of tag already
-            parseChildren(reader, list, op);
+            parseChildren(reader, list, op, null);
         }
     }
 
@@ -180,13 +193,13 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
                         ad.getParser().parseElement(ad, reader, op);
                         final String newLocalName = reader.getLocalName();
                         if (attributeGroups.contains(newLocalName)) {
-                            parseGroup(reader, op);
-                        } else if (reader.isEndElement() && !attributeGroups.contains(newLocalName) && !attributeElements.containsKey(newLocalName)) {
+                            parseGroup(reader, list, op);
+                        } else if (reader.isEndElement() && !attributeElements.containsKey(newLocalName)) {
                             childAlreadyRead = true;
                             break;
                         }
                     } else {
-                        parseGroup(reader, op);
+                        parseGroup(reader, list, op);
                     }
 
                 } else {
@@ -200,8 +213,9 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         return op;
     }
 
-    private void parseGroup(XMLExtendedStreamReader reader, ModelNode op) throws XMLStreamException {
-        Map<String, AttributeDefinition> groupAttrs = attributesByGroup.get(reader.getLocalName());
+    private void parseGroup(XMLExtendedStreamReader reader, List<ModelNode> list, ModelNode op) throws XMLStreamException {
+        String group = reader.getLocalName();
+        Map<String, AttributeDefinition> groupAttrs = attributesByGroup.get(group);
         for (AttributeDefinition attrGroup : groupAttrs.values()) {
             if (op.hasDefined(attrGroup.getName())) {
                 throw ParseUtils.unexpectedElement(reader);
@@ -214,6 +228,12 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
             if (ad != null) {
                 ad.getParser().parseElement(ad, reader, op);
             } else {
+                if (this.childrenByGroup.containsKey(group)) {
+                    this.childAlreadyRead = true;
+                    this.parseChildren(reader, list, op, group);
+                    this.childAlreadyRead = false;
+                    break;
+                }
                 throw ParseUtils.unexpectedElement(reader);
             }
         }
@@ -257,11 +277,10 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
                         AttributeParser parser = attributeParsers.getOrDefault(ad.getXmlName(), ad.getParser());
                         parser.parseElement(ad, reader, op);
                     } else {
-                        childAlreadyRead = true;
                         break;  //this means we only have children left, return so child handling logic can take over
                     }
-                    childAlreadyRead = true;
                 } while (!reader.getLocalName().equals(originalStartElement) && reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT);
+                childAlreadyRead = true;
             }
         }
     }
@@ -280,9 +299,9 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         return this.pathElement;
     }
 
-    private Map<String, PersistentResourceXMLDescription> getChildrenMap() {
+    private Map<String, PersistentResourceXMLDescription> getChildrenMap(String group) {
         Map<String, PersistentResourceXMLDescription> res = new HashMap<>();
-        for (PersistentResourceXMLDescription child : children) {
+        for (PersistentResourceXMLDescription child : childrenByGroup.get(group)) {
             if (child.xmlWrapperElement != null) {
                 res.put(child.xmlWrapperElement, child);
             } else {
@@ -292,12 +311,12 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         return res;
     }
 
-    private void parseChildren(final XMLExtendedStreamReader reader, List<ModelNode> list, ModelNode op) throws XMLStreamException {
-        this.parseChildren(reader, PathAddress.pathAddress(op.get(OP_ADDR)), list, op);
+    private void parseChildren(final XMLExtendedStreamReader reader, List<ModelNode> list, ModelNode op, String group) throws XMLStreamException {
+        this.parseChildren(reader, PathAddress.pathAddress(op.get(OP_ADDR)), list, op, group);
     }
 
-    private void parseChildren(final XMLExtendedStreamReader reader, PathAddress parentAddress, List<ModelNode> list, ModelNode op) throws XMLStreamException {
-        if (children.size() == 0) {
+    private void parseChildren(final XMLExtendedStreamReader reader, PathAddress parentAddress, List<ModelNode> list, ModelNode op, String group) throws XMLStreamException {
+        if (childrenByGroup.get(group).isEmpty()) {
             if (flushRequired && attributeGroups.isEmpty() && attributeElements.isEmpty()) {
                 ParseUtils.requireNoContent(reader);
             }
@@ -305,7 +324,7 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
                 throw ParseUtils.unexpectedElement(reader);
             }
         } else {
-            Map<String, PersistentResourceXMLDescription> children = getChildrenMap();
+            Map<String, PersistentResourceXMLDescription> children = getChildrenMap(group);
             if (childAlreadyRead) {
                 PersistentResourceXMLDescription decoratorChild = children.get(reader.getLocalName());
                 if (decoratorChild != null && decoratorChild.decoratorElement != null) {
@@ -370,7 +389,7 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
     private void persistDecorator(XMLExtendedStreamWriter writer, ModelNode model) throws XMLStreamException {
        if (shouldWriteDecoratorAndElements(model)) {
            writer.writeStartElement(decoratorElement);
-           persistChildren(writer, model);
+           persistChildren(writer, model, null);
            writer.writeEndElement();
        }
     }
@@ -379,10 +398,10 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
      * @return true if any of children are defined in the model
      */
     private boolean shouldWriteDecoratorAndElements(ModelNode model) {
-        for (PersistentResourceXMLDescription child : children) {
+        for (PersistentResourceXMLDescription child : childrenByGroup.get(null)) {
             //if we have child decorator, than we check its children, we only handle one level of nesting
             if (child.decoratorElement != null) {
-                for (PersistentResourceXMLDescription decoratedChild : child.children) {
+                for (PersistentResourceXMLDescription decoratedChild : child.childrenByGroup.get(null)) {
                     if (definedInModel(model, decoratedChild)) {
                         return true;
                     }
@@ -432,11 +451,11 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
                     writer.writeAttribute(nameAttributeName, name);
                 }
                 persistAttributes(writer, subModel);
-                persistChildren(writer, subModel);
+                persistChildren(writer, subModel, null);
                 writer.writeEndElement();
             }
         } else {
-            final boolean empty = attributeGroups.isEmpty() && children.isEmpty();
+            final boolean empty = attributeGroups.isEmpty() && childrenByGroup.get(null).isEmpty();
             if (useValueAsElementName) {
                 writeStartElement(writer, namespaceURI, getPathElement().getValue());
             } else if (isSubsystem) {
@@ -446,7 +465,7 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
             }
 
             persistAttributes(writer, model);
-            persistChildren(writer, model);
+            persistChildren(writer, model, null);
 
             // Do not attempt to write end element if the <subsystem/> has no elements!
             if (!isSubsystem || !empty) {
@@ -462,11 +481,11 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
     private void persistAttributes(XMLExtendedStreamWriter writer, ModelNode model) throws XMLStreamException {
         marshallAttributes(writer, model, attributesByGroup.get(null).values(), null);
         if (useElementsForGroups) {
-            for (Map.Entry<String, LinkedHashMap<String, AttributeDefinition>> entry : attributesByGroup.entrySet()) {
-                if (entry.getKey() == null) {
-                    continue;
+            for (Map.Entry<String, Map<String, AttributeDefinition>> entry : attributesByGroup.entrySet()) {
+                String group = entry.getKey();
+                if (group != null) {
+                    marshallAttributes(writer, model, entry.getValue().values(), group);
                 }
-                marshallAttributes(writer, model, entry.getValue().values(), entry.getKey());
             }
         }
     }
@@ -491,28 +510,36 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
             sortedAds.addAll(elementAds);
         }
 
+        boolean hasChildren = (group != null) && this.marshallersByGroup.containsKey(group);
+        boolean hasNestedElements = elementAds != null || hasChildren;
+
         for (AttributeDefinition ad : sortedAds) {
             AttributeMarshaller marshaller = attributeMarshallers.getOrDefault(ad.getXmlName(), ad.getMarshaller());
-            if (marshaller.isMarshallable(ad, model, marshallDefaultValues)) {
+            boolean marshallable = marshaller.isMarshallable(ad, model, marshallDefaultValues);
+            if (marshallable || hasChildren) {
                 if (!started && group != null) {
-                    if (elementAds != null) {
+                    if (hasNestedElements) {
                         writer.writeStartElement(group);
                     } else {
                         writer.writeEmptyElement(group);
                     }
                     started = true;
                 }
-                marshaller.marshall(ad, model, marshallDefaultValues, writer);
+                if (marshallable) {
+                    marshaller.marshall(ad, model, marshallDefaultValues, writer);
+                }
             }
-
         }
-        if (elementAds != null && started) {
+        if (hasChildren) {
+            this.persistChildren(writer, model, group);
+        }
+        if (hasNestedElements && started) {
             writer.writeEndElement();
         }
     }
 
-    public void persistChildren(XMLExtendedStreamWriter writer, ModelNode model) throws XMLStreamException {
-        for (ResourceMarshaller child : marshallers) {
+    public void persistChildren(XMLExtendedStreamWriter writer, ModelNode model, String group) throws XMLStreamException {
+        for (ResourceMarshaller child : marshallersByGroup.get(group)) {
             child.persist(writer, model);
         }
     }
@@ -593,12 +620,12 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         private boolean useValueAsElementName;
         private boolean noAddOperation;
         private AdditionalOperationsGenerator additionalOperationsGenerator;
-        private final LinkedList<AttributeDefinition> attributeList = new LinkedList<>();
-        private final List<PersistentResourceXMLBuilder> childrenBuilders = new ArrayList<>();
-        private final List<PersistentResourceXMLDescription> children = new ArrayList<>();
-        private final LinkedHashMap<String, AttributeParser> attributeParsers = new LinkedHashMap<>();
-        private final LinkedHashMap<String, AttributeMarshaller> attributeMarshallers = new LinkedHashMap<>();
-        private final LinkedHashMap<String, ResourceParser> customChildParsers = new LinkedHashMap<>();
+        private final List<AttributeDefinition> attributeList = new LinkedList<>();
+        private final Map<String, List<PersistentResourceXMLBuilder>> childrenBuilders = new HashMap<>();
+        private final List<PersistentResourceXMLDescription> children = new LinkedList<>();
+        private final Map<String, AttributeParser> attributeParsers = new LinkedHashMap<>();
+        private final Map<String, AttributeMarshaller> attributeMarshallers = new LinkedHashMap<>();
+        private final Map<String, ResourceParser> customChildParsers = new LinkedHashMap<>();
         private final LinkedList<ResourceMarshaller> marshallers = new LinkedList<>();
         private boolean useElementsForGroups = true;
         private String forcedName;
@@ -607,19 +634,28 @@ public final class PersistentResourceXMLDescription implements ResourceParser, R
         private String decoratorElement = null;
 
         private PersistentResourceXMLBuilder(final PathElement pathElement) {
-            this.pathElement = pathElement;
-            this.namespaceURI = null;
-            this.xmlElementName = pathElement.isWildcard() ? pathElement.getKey() : pathElement.getValue();
+            this(pathElement, null);
         }
 
         private PersistentResourceXMLBuilder(final PathElement pathElement, String namespaceURI) {
             this.pathElement = pathElement;
             this.namespaceURI = namespaceURI;
             this.xmlElementName = pathElement.isWildcard() ? pathElement.getKey() : pathElement.getValue();
+            this.childrenBuilders.put(null, new LinkedList<>());
         }
 
         public PersistentResourceXMLBuilder addChild(PersistentResourceXMLBuilder builder) {
-            this.childrenBuilders.add(builder);
+            return this.addChild(null, builder);
+        }
+
+        public PersistentResourceXMLBuilder addChild(AttributeDefinition parentAttribute, PersistentResourceXMLBuilder builder) {
+            String group = (parentAttribute != null) ? parentAttribute.getAttributeGroup() : null;
+            List<PersistentResourceXMLBuilder> children = this.childrenBuilders.get(group);
+            if (children == null) {
+                children = new LinkedList<>();
+                this.childrenBuilders.put(group, children);
+            }
+            children.add(builder);
             return this;
         }
 

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/NonResolvingResourceDescriptionResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/NonResolvingResourceDescriptionResolver.java
@@ -34,7 +34,7 @@ import java.util.ResourceBundle;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public class NonResolvingResourceDescriptionResolver extends StandardResourceDescriptionResolver {
-    public static NonResolvingResourceDescriptionResolver INSTANCE = new NonResolvingResourceDescriptionResolver();
+    public static final NonResolvingResourceDescriptionResolver INSTANCE = new NonResolvingResourceDescriptionResolver();
 
     public NonResolvingResourceDescriptionResolver() {
         super("", "", NonResolvingResourceDescriptionResolver.class.getClassLoader());

--- a/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/persistence/PersistentResourceXMLParserTestCase.java
@@ -670,7 +670,7 @@ public class PersistentResourceXMLParserTestCase {
                 .build();
 
 
-        static final PersistentResourceDefinition RESOURCE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("resource"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition RESOURCE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("resource"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -689,7 +689,7 @@ public class PersistentResourceXMLParserTestCase {
             }
         };
 
-        static final PersistentResourceDefinition BUFFER_CACHE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("buffer-cache"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition BUFFER_CACHE_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("buffer-cache"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -702,7 +702,7 @@ public class PersistentResourceXMLParserTestCase {
             }
         };
 
-        static final PersistentResourceDefinition OBJECT_TYPE_TEST = new PersistentResourceDefinition(PathElement.pathElement("object-type-test"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition OBJECT_TYPE_TEST = new PersistentResourceDefinition(PathElement.pathElement("object-type-test"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -712,7 +712,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        static final PersistentResourceDefinition SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("server"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("server"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -732,7 +732,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        static final PersistentResourceDefinition CUSTOM_SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("custom"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition CUSTOM_SERVER_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("custom"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -749,7 +749,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        static final PersistentResourceDefinition SESSION_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("mail-session"), new NonResolvingResourceDescriptionResolver()) {
+        static final PersistentResourceDefinition SESSION_INSTANCE = new PersistentResourceDefinition(PathElement.pathElement("mail-session"), NonResolvingResourceDescriptionResolver.INSTANCE) {
             @Override
             public Collection<AttributeDefinition> getAttributes() {
                 Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -765,7 +765,7 @@ public class PersistentResourceXMLParserTestCase {
         };
 
 
-        PersistentResourceDefinition SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(SUBSYSTEM_PATH, new NonResolvingResourceDescriptionResolver()) {
+        PersistentResourceDefinition SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(SUBSYSTEM_PATH, NonResolvingResourceDescriptionResolver.INSTANCE) {
 
             @Override
             public Collection<AttributeDefinition> getAttributes() {
@@ -1189,7 +1189,7 @@ public class PersistentResourceXMLParserTestCase {
         static final IIOPRootDefinition INSTANCE = new IIOPRootDefinition();
 
         private IIOPRootDefinition() {
-            super(PathElement.pathElement("subsystem", "orb"), new NonResolvingResourceDescriptionResolver());
+            super(PathElement.pathElement("subsystem", "orb"), NonResolvingResourceDescriptionResolver.INSTANCE);
         }
 
         @Override
@@ -1395,7 +1395,7 @@ public class PersistentResourceXMLParserTestCase {
                     .build();
         }
 
-    static final PersistentResourceDefinition SERVICE_PROCESS_RESOURCE = new PersistentResourceDefinition(PathElement.pathElement("service"), new NonResolvingResourceDescriptionResolver()) {
+    static final PersistentResourceDefinition SERVICE_PROCESS_RESOURCE = new PersistentResourceDefinition(PathElement.pathElement("service"), NonResolvingResourceDescriptionResolver.INSTANCE) {
         @Override
         public Collection<AttributeDefinition> getAttributes() {
             Collection<AttributeDefinition> attributes = new ArrayList<>();
@@ -1409,7 +1409,7 @@ public class PersistentResourceXMLParserTestCase {
 
     protected static final PathElement PROCESS_SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "process");
 
-    PersistentResourceDefinition PROCESS_SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(PROCESS_SUBSYSTEM_PATH, new NonResolvingResourceDescriptionResolver()) {
+    PersistentResourceDefinition PROCESS_SUBSYSTEM_ROOT_INSTANCE = new PersistentResourceDefinition(PROCESS_SUBSYSTEM_PATH, NonResolvingResourceDescriptionResolver.INSTANCE) {
 
               @Override
               public Collection<AttributeDefinition> getAttributes() {

--- a/controller/src/test/resources/org/jboss/as/controller/persistence/child-groups-subsystem.xml
+++ b/controller/src/test/resources/org/jboss/as/controller/persistence/child-groups-subsystem.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ JBoss, Home of Professional Open Source
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors as indicated
+  ~ by the @authors tag.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:jgroups:1.0">
+    <channels default="ee">
+        <channel name="ee" stack="tcp"/>
+        <channel name="foo"/>
+    </channels>
+    <stacks>
+        <stack name="udp"/>
+        <stack name="tcp"/>
+    </stacks>
+    <post-group/>
+</subsystem>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3939

Enables usage of PersistentResourceXMLParser in subsystems where child resources are logically grouped (e.g. clustering subsystems).