### PR TITLE
WFCORE-3944 NPE in SyncServerStateOperationHandler when group is not …

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncServerStateOperationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/SyncServerStateOperationHandler.java
@@ -351,7 +351,9 @@ class SyncServerStateOperationHandler implements OperationStepHandler {
 
             final Set<String> servers = new HashSet<>();
             for (String group : affectedGroups) {
-                servers.addAll(serversByGroup.get(group));
+                if (serversByGroup.containsKey(group)) {
+                    servers.addAll(serversByGroup.get(group));
+                }
             }
             return servers;
         }


### PR DESCRIPTION
…present on host

The SyncServerStateOperationHandler throws a NPE when the synchronizing a deployment that is deployed on a server group which doesn't has any server on current host.

https://issues.jboss.org/browse/WFCORE-3944
https://issues.jboss.org/browse/JBEAP-14817