### PR TITLE
[WFCORE-3943] Use specific class loaders for embedded servers

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
@@ -37,6 +37,13 @@
         <module name="java.logging"/>
         <module name="java.management"/>
         <module name="java.xml"/>
+        <!--
+            org.jboss.as.controller module is used as module class loader for the operations executed by
+            the embedded server. We need to declare org.codehaus.woodstox as dependency here to use in the
+            embedded server the woodstox XMLStreamWriter implementation instead of the implementation coming
+            from the JDK.
+        -->
+        <module name="org.codehaus.woodstox" services="import"/>
         <module name="org.jboss.as.controller-client" export="true"/>
         <module name="org.jboss.as.core-security"/>
         <module name="org.jboss.as.protocol"/>

--- a/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedManagedProcess.java
+++ b/embedded/src/main/java/org/wildfly/core/embedded/EmbeddedManagedProcess.java
@@ -16,6 +16,9 @@ limitations under the License.
 
 package org.wildfly.core.embedded;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 import org.jboss.as.controller.client.ModelControllerClient;
 
 /**
@@ -44,4 +47,30 @@ public interface EmbeddedManagedProcess {
      * Stop the embedded process.
      */
     void stop();
+
+    static ClassLoader getTccl() {
+        if (System.getSecurityManager() == null) {
+            return Thread.currentThread().getContextClassLoader();
+        }
+        return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+            @Override
+            public ClassLoader run() {
+                return Thread.currentThread().getContextClassLoader();
+            }
+        });
+    }
+
+    static void setTccl(final ClassLoader cl) {
+        if (System.getSecurityManager() == null) {
+            Thread.currentThread().setContextClassLoader(cl);
+        } else {
+            AccessController.doPrivileged(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    Thread.currentThread().setContextClassLoader(cl);
+                    return null;
+                }
+            });
+        }
+    }
 }


### PR DESCRIPTION
It was found that the embedded server was not using a consistent class loader when it was invoked via Galleon, jboss-cli-client.jar or standard jboss-cli.sh. 
This patch sets a specific class loader when the embedded server starts/stops and when its operations are executed in order to have a consistent class loader across all uses.

Jira issue: https://issues.jboss.org/browse/WFCORE-3943