### PR TITLE
[WFCORE-3945] Remove the application-http-authentication http-authentication-factory from the default configuration.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/SecurityCommand.java
@@ -120,6 +120,7 @@ public class SecurityCommand implements GroupCommand<CLICommandInvocation, Comma
     public static final String OPT_SERVER_NAME = "server-name";
     public static final String OPT_NO_OVERRIDE_SECURITY_REALM = "no-override-security-realm";
     public static final String OPT_SECURITY_DOMAIN = "security-domain";
+    public static final String OPT_REFERENCED_SECURITY_DOMAIN = "referenced-security-domain";
 
     private final CommandContext ctx;
     private final AtomicReference<EmbeddedProcessLaunch> embeddedServerRef;
@@ -141,8 +142,8 @@ public class SecurityCommand implements GroupCommand<CLICommandInvocation, Comma
         commands.add(new ManagementEnableSASLCommand());
         commands.add(new ManagementEnableHTTPCommand());
         commands.add(new ManagementReorderSASLCommand());
-        commands.add(new HTTPServerEnableAuthCommand());
-        commands.add(new HTTPServerDisableAuthCommand());
+        commands.add(new HTTPServerEnableAuthCommand(ctx));
+        commands.add(new HTTPServerDisableAuthCommand(ctx));
         return commands;
     }
 
@@ -207,8 +208,7 @@ public class SecurityCommand implements GroupCommand<CLICommandInvocation, Comma
 
                 try {
                     return ElytronUtil.getMechanisms(completerInvocation.getCommandContext(),
-                            cmd.getFactorySpec(),
-                            cmd.getTargetedFactory(completerInvocation.getCommandContext()));
+                            cmd.getFactorySpec());
                 } catch (Exception ex) {
                     return Collections.emptyList();
                 }
@@ -271,6 +271,14 @@ public class SecurityCommand implements GroupCommand<CLICommandInvocation, Comma
             @Override
             protected List<String> getItems(CLICompleterInvocation completerInvocation) {
                 return Util.getUndertowSecurityDomains(completerInvocation.getCommandContext().getModelControllerClient());
+            }
+        }
+
+        public static class ReferencedSecurityDomainCompleter extends AbstractCompleter {
+
+            @Override
+            protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+                return ElytronUtil.getSecurityDomainNames(completerInvocation.getCommandContext().getModelControllerClient());
             }
         }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractDisableAuthenticationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractDisableAuthenticationCommand.java
@@ -26,7 +26,6 @@ import org.aesh.command.option.Option;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
-import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MECHANISM;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
 import org.jboss.dmr.ModelNode;
 import org.wildfly.core.cli.command.DMRCommand;
@@ -40,9 +39,6 @@ import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_NO_REL
  */
 @CommandDefinition(name = "abstract-auth-disable", description = "")
 public abstract class AbstractDisableAuthenticationCommand implements Command<CLICommandInvocation>, DMRCommand {
-    @Option(name = OPT_MECHANISM,
-            completer = SecurityCommand.OptionCompleters.MechanismDisableCompleter.class)
-    String mechanism;
 
     @Option(name = OPT_NO_RELOAD, hasValue = false)
     boolean noReload;
@@ -63,6 +59,8 @@ public abstract class AbstractDisableAuthenticationCommand implements Command<CL
 
     protected abstract String getSecuredEndpoint(CommandContext ctx);
 
+    protected abstract String getMechanism();
+
     @Override
     public CommandResult execute(CLICommandInvocation commandInvocation) throws CommandException, InterruptedException {
         CommandContext ctx = commandInvocation.getCommandContext();
@@ -75,7 +73,7 @@ public abstract class AbstractDisableAuthenticationCommand implements Command<CL
 
         SecurityCommand.execute(ctx, request, SecurityCommand.DEFAULT_FAILURE_CONSUMER, noReload);
         commandInvocation.getCommandContext().printLine("Command success.");
-        if (mechanism == null) {
+        if (getMechanism() == null) {
             commandInvocation.getCommandContext().printLine(factorySpec.getName()
                     + " authentication disabled for " + getSecuredEndpoint(commandInvocation.getCommandContext()));
         } else {
@@ -102,11 +100,11 @@ public abstract class AbstractDisableAuthenticationCommand implements Command<CL
         if (mn == null) {
             throw new CommandException("Invalid factory " + authFactory);
         }
-        if (mechanism == null) {
+        if (getMechanism() == null) {
             return disableFactory(context);
         }
         Set<String> set = new HashSet<>();
-        set.add(mechanism);
+        set.add(getMechanism());
         return ElytronUtil.removeMechanisms(context, mn, authFactory, factorySpec, set);
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractMgmtDisableAuthenticationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractMgmtDisableAuthenticationCommand.java
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MECHANISM;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "abstract-management-auth-disable", description = "")
+public abstract class AbstractMgmtDisableAuthenticationCommand extends AbstractDisableAuthenticationCommand {
+
+    @Option(name = OPT_MECHANISM,
+            completer = SecurityCommand.OptionCompleters.MechanismDisableCompleter.class)
+    String mechanism;
+
+    public AbstractMgmtDisableAuthenticationCommand(AuthFactorySpec factorySpec) {
+        super(factorySpec);
+    }
+
+    @Override
+    protected String getMechanism() {
+        return mechanism;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractMgmtEnableAuthenticationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/AbstractMgmtEnableAuthenticationCommand.java
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.auth;
+
+import org.aesh.command.CommandDefinition;
+import org.aesh.command.option.Option;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MECHANISM;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+@CommandDefinition(name = "abstract-management-auth-enable", description = "")
+public abstract class AbstractMgmtEnableAuthenticationCommand extends AbstractEnableAuthenticationCommand {
+
+    @Option(name = OPT_MECHANISM,
+            completer = SecurityCommand.OptionCompleters.MechanismCompleter.class)
+    String mechanism;
+
+    public AbstractMgmtEnableAuthenticationCommand(AuthFactorySpec factorySpec) {
+        super(factorySpec);
+    }
+
+    @Override
+    protected String getMechanism() {
+        return mechanism;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/HTTPServerDisableAuthCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/HTTPServerDisableAuthCommand.java
@@ -15,38 +15,118 @@ limitations under the License.
  */
 package org.jboss.as.cli.impl.aesh.cmd.security.auth;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
 import org.aesh.command.CommandDefinition;
+import org.aesh.command.impl.internal.ParsedCommand;
+import org.aesh.command.impl.internal.ParsedOption;
 import org.aesh.command.option.Option;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.impl.aesh.cmd.security.HttpServerCommandActivator;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MECHANISM;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_SECURITY_DOMAIN;
 import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters.MechanismDisableCompleter;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.HTTPServer;
+import org.jboss.as.cli.operation.OperationFormatException;
 import org.jboss.dmr.ModelNode;
+import org.wildfly.core.cli.command.aesh.CLICompleterInvocation;
+import org.wildfly.core.cli.command.aesh.activator.AbstractDependOptionActivator;
 
 /**
- * Disable authentication applied to an http-server security-domain.
+ * Disable authentication applied to an http-server security-domain. Complexity
+ * comes from the fact that an undertow application-security-domain can
+ * references a factory or a security domain.
  *
  * @author jdenise@redhat.com
  */
 @CommandDefinition(name = "disable-http-auth-http-server", description = "", activator = HttpServerCommandActivator.class)
 public class HTTPServerDisableAuthCommand extends AbstractDisableAuthenticationCommand {
 
+    public static class MechanismCompleter extends MechanismDisableCompleter {
+
+        @Override
+        protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+            HTTPServerDisableAuthCommand cmd = (HTTPServerDisableAuthCommand) completerInvocation.getCommand();
+            try {
+                if (!HTTPServer.hasAuthFactory(cmd.ctx, cmd.securityDomain)) {
+                    return Collections.emptyList();
+                }
+                return super.getItems(completerInvocation);
+            } catch (Exception ex) {
+                return Collections.emptyList();
+            }
+        }
+    }
+
+    public static class MechanismActivator extends AbstractDependOptionActivator {
+
+        public MechanismActivator() {
+            super(false, OPT_SECURITY_DOMAIN);
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand processedCommand) {
+            if (!super.isActivated(processedCommand)) {
+                return false;
+            }
+            HTTPServerDisableAuthCommand cmd = (HTTPServerDisableAuthCommand) processedCommand.command();
+            ParsedOption opt = processedCommand.findLongOptionNoActivatorCheck(OPT_SECURITY_DOMAIN);
+            if (opt != null && opt.value() != null) {
+                try {
+                    return HTTPServer.hasAuthFactory(cmd.ctx, opt.value());
+                } catch (IOException | OperationFormatException ex) {
+                    return false;
+                }
+            }
+            return false;
+        }
+    }
+
     @Option(name = OPT_SECURITY_DOMAIN, required = true, completer = OptionCompleters.SecurityDomainCompleter.class)
     String securityDomain;
 
-    public HTTPServerDisableAuthCommand() {
+    @Option(name = OPT_MECHANISM,
+            completer = MechanismCompleter.class, activator = MechanismActivator.class)
+    String factoryMechanism;
+
+    private final CommandContext ctx;
+
+    public HTTPServerDisableAuthCommand(CommandContext ctx) {
         super(AuthFactorySpec.HTTP);
+        this.ctx = ctx;
+    }
+
+    @Override
+    protected String getMechanism() {
+        return factoryMechanism;
+    }
+
+    @Override
+    public ModelNode buildSecurityRequest(CommandContext context) throws Exception {
+        if (HTTPServer.hasAuthFactory(ctx, securityDomain)) {
+            return super.buildSecurityRequest(context);
+        } else {
+            return disableFactory(context);
+        }
     }
 
     @Override
     public String getEnabledFactory(CommandContext ctx) throws Exception {
-        return HTTPServer.getSecurityDomainFactoryName(securityDomain, ctx);
+        // Special case for undertow security domain, can be a security-domain or a factory
+        if (HTTPServer.hasAuthFactory(ctx, securityDomain)) {
+            return HTTPServer.getSecurityDomainFactoryName(securityDomain, ctx);
+        } else {
+            return HTTPServer.getReferencedSecurityDomainName(securityDomain, ctx);
+        }
     }
 
     @Override
     protected ModelNode disableFactory(CommandContext context) throws Exception {
+        // In the undertow case, the undertow application-security-domain is simply removed.
+        // Whatever the fact that the domain references a factory or a domain.
         return HTTPServer.disableHTTPAuthentication(securityDomain, context);
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/HTTPServerEnableAuthCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/HTTPServerEnableAuthCommand.java
@@ -16,17 +16,30 @@ limitations under the License.
 package org.jboss.as.cli.impl.aesh.cmd.security.auth;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.aesh.command.CommandDefinition;
+import org.aesh.command.CommandException;
+import org.aesh.command.impl.internal.ParsedCommand;
 import org.aesh.command.option.Option;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.impl.aesh.cmd.security.HttpServerCommandActivator;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_MECHANISM;
+import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_REFERENCED_SECURITY_DOMAIN;
 import static org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OPT_SECURITY_DOMAIN;
 import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters.MechanismCompleter;
+import org.jboss.as.cli.impl.aesh.cmd.security.SecurityCommand.OptionCompleters.ReferencedSecurityDomainCompleter;
+import org.jboss.as.cli.impl.aesh.cmd.security.model.ApplicationSecurityDomain;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthFactorySpec;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.AuthSecurityBuilder;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.ElytronUtil;
 import org.jboss.as.cli.impl.aesh.cmd.security.model.HTTPServer;
 import org.jboss.as.cli.operation.OperationFormatException;
+import org.wildfly.core.cli.command.aesh.CLICompleterInvocation;
+import org.wildfly.core.cli.command.aesh.activator.AbstractDependRejectOptionActivator;
 
 /**
  * Enable authentication for a given http-server security domain.
@@ -36,18 +49,160 @@ import org.jboss.as.cli.operation.OperationFormatException;
 @CommandDefinition(name = "enable-http-auth-http-server", description = "", activator = HttpServerCommandActivator.class)
 public class HTTPServerEnableAuthCommand extends AbstractEnableAuthenticationCommand {
 
+    public static class FactoryMechanismCompleter extends MechanismCompleter {
+
+        @Override
+        protected List<String> getItems(CLICompleterInvocation completerInvocation) {
+            HTTPServerEnableAuthCommand cmd = (HTTPServerEnableAuthCommand) completerInvocation.getCommand();
+            try {
+                if (cmd.securityDomain != null) {
+                    ApplicationSecurityDomain secDomain = HTTPServer.getSecurityDomain(cmd.ctx, cmd.securityDomain);
+                    if (secDomain != null
+                            && secDomain.getFactory() == null) {
+                        return Collections.emptyList();
+                    }
+                    return super.getItems(completerInvocation);
+                } else {
+                    return Collections.emptyList();
+                }
+            } catch (Exception ex) {
+                return Collections.emptyList();
+            }
+        }
+    }
+
+    public static class ReferencedSecurityDomainActivator extends AbstractDependRejectOptionActivator {
+
+        private static final Set<String> EXPECTED = new HashSet<>();
+        private static final Set<String> REJECTED = new HashSet<>();
+
+        static {
+            REJECTED.add(OPT_MECHANISM);
+            EXPECTED.add(OPT_SECURITY_DOMAIN);
+        }
+
+        public ReferencedSecurityDomainActivator() {
+            super(false, EXPECTED, REJECTED);
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand pc) {
+            HTTPServerEnableAuthCommand cmd = (HTTPServerEnableAuthCommand) pc.command();
+            try {
+                if (!HTTPServer.isReferencedSecurityDomainSupported(cmd.ctx)) {
+                    return false;
+                }
+                if (cmd.securityDomain != null) {
+                    ApplicationSecurityDomain secDomain = HTTPServer.getSecurityDomain(cmd.ctx, cmd.securityDomain);
+                    if (secDomain != null && secDomain.getSecurityDomain() == null) {
+                        return false;
+                    }
+                }
+                return super.isActivated(pc);
+            } catch (OperationFormatException | IOException ex) {
+                return false;
+            }
+        }
+    }
+
+    public static class MechanismActivator extends AbstractDependRejectOptionActivator {
+
+        private static final Set<String> EXPECTED = new HashSet<>();
+        private static final Set<String> REJECTED = new HashSet<>();
+
+        static {
+            REJECTED.add(OPT_REFERENCED_SECURITY_DOMAIN);
+            EXPECTED.add(OPT_SECURITY_DOMAIN);
+        }
+
+        public MechanismActivator() {
+            super(false, EXPECTED, REJECTED);
+        }
+
+        @Override
+        public boolean isActivated(ParsedCommand processedCommand) {
+            if (!super.isActivated(processedCommand)) {
+                return false;
+            }
+            HTTPServerEnableAuthCommand cmd = (HTTPServerEnableAuthCommand) processedCommand.command();
+            try {
+                if (cmd.securityDomain != null) {
+                    ApplicationSecurityDomain secDomain = HTTPServer.getSecurityDomain(cmd.ctx, cmd.securityDomain);
+                    if (secDomain != null
+                            && secDomain.getFactory() == null) {
+                        return false;
+                    }
+                }
+            } catch (IOException | OperationFormatException ex) {
+                return false;
+            }
+            return super.isActivated(processedCommand);
+        }
+    }
+
     @Option(name = OPT_SECURITY_DOMAIN, required = true, completer = OptionCompleters.SecurityDomainCompleter.class)
     String securityDomain;
 
-    public HTTPServerEnableAuthCommand() {
+    @Option(name = OPT_MECHANISM,
+            completer = FactoryMechanismCompleter.class, activator = MechanismActivator.class)
+    String factoryMechanism;
+
+    @Option(name = OPT_REFERENCED_SECURITY_DOMAIN, completer = ReferencedSecurityDomainCompleter.class,
+            activator = ReferencedSecurityDomainActivator.class)
+    String referencedSecurityDomain;
+
+    private final CommandContext ctx;
+
+    public HTTPServerEnableAuthCommand(CommandContext ctx) {
         super(AuthFactorySpec.HTTP);
+        this.ctx = ctx;
+    }
+
+    @Override
+    protected String getMechanism() {
+        return factoryMechanism;
     }
 
     @Override
     protected void secure(CommandContext ctx, AuthSecurityBuilder builder) throws Exception {
-        if (getEnabledFactory(ctx) == null) {
+        ApplicationSecurityDomain secDomain = HTTPServer.getSecurityDomain(ctx, securityDomain);
+        if (secDomain != null) {
+            if (secDomain.getSecurityDomain() != null) {
+                if (!secDomain.getSecurityDomain().equals(builder.getReferencedSecurityDomain())) {
+                    // re-write the existing security domain
+                    HTTPServer.writeReferencedSecurityDomain(builder, securityDomain, ctx);
+                }
+            }
+        } else {
+            // add a new security domain resource
             HTTPServer.enableHTTPAuthentication(builder, securityDomain, ctx);
         }
+    }
+
+    @Override
+    protected AuthSecurityBuilder buildSecurityRequest(CommandContext context) throws Exception {
+        // No support for security-domain, fallback on legacy http authentication factory.
+        if (!HTTPServer.isReferencedSecurityDomainSupported(context)) {
+            return super.buildSecurityRequest(context);
+        }
+        AuthSecurityBuilder builder = null;
+        if (getMechanism() == null) {
+            if (referencedSecurityDomain == null) {
+                referencedSecurityDomain = getOOTBSecurityDomain(context);
+            }
+            if (!ElytronUtil.securityDomainExists(context, referencedSecurityDomain)) {
+                throw new CommandException("Can't enable HTTP Authentication, security domain "
+                        + referencedSecurityDomain + " doesn't exist");
+            }
+            builder = new AuthSecurityBuilder(referencedSecurityDomain);
+        } else {
+            if (referencedSecurityDomain != null) {
+                throw new CommandException("Can't mix mechanism and referenced security domain");
+            }
+            return super.buildSecurityRequest(context);
+        }
+        secure(context, builder);
+        return builder;
     }
 
     @Override
@@ -58,6 +213,10 @@ public class HTTPServerEnableAuthCommand extends AbstractEnableAuthenticationCom
     @Override
     protected String getOOTBFactory(CommandContext ctx) throws Exception {
         return ElytronUtil.OOTB_APPLICATION_HTTP_FACTORY;
+    }
+
+    protected String getOOTBSecurityDomain(CommandContext ctx) throws Exception {
+        return ElytronUtil.OOTB_APPLICATION_DOMAIN;
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementDisableHTTPCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementDisableHTTPCommand.java
@@ -29,7 +29,7 @@ import org.jboss.dmr.ModelNode;
  * @author jdenise@redhat.com
  */
 @CommandDefinition(name = "disable-http-auth-management", description = "", activator = SecurityCommandActivator.class)
-public class ManagementDisableHTTPCommand extends AbstractDisableAuthenticationCommand {
+public class ManagementDisableHTTPCommand extends AbstractMgmtDisableAuthenticationCommand {
 
     public ManagementDisableHTTPCommand() {
         super(AuthFactorySpec.HTTP);

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementDisableSASLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementDisableSASLCommand.java
@@ -32,7 +32,7 @@ import org.jboss.dmr.ModelNode;
  * @author jdenise@redhat.com
  */
 @CommandDefinition(name = "disable-sasl-management", description = "", activator = SecurityCommandActivator.class)
-public class ManagementDisableSASLCommand extends AbstractDisableAuthenticationCommand {
+public class ManagementDisableSASLCommand extends AbstractMgmtDisableAuthenticationCommand {
 
     @Option(name = OPT_MANAGEMENT_INTERFACE, hasValue = true,
             completer = OptionCompleters.ManagementInterfaceCompleter.class)

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementEnableHTTPCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementEnableHTTPCommand.java
@@ -32,7 +32,7 @@ import org.jboss.as.cli.operation.OperationFormatException;
  * @author jdenise@redhat.com
  */
 @CommandDefinition(name = "enable-http-auth-management", description = "", activator = SecurityCommandActivator.class)
-public class ManagementEnableHTTPCommand extends AbstractEnableAuthenticationCommand {
+public class ManagementEnableHTTPCommand extends AbstractMgmtEnableAuthenticationCommand {
 
     public ManagementEnableHTTPCommand() {
         super(AuthFactorySpec.HTTP);

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementEnableSASLCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/auth/ManagementEnableSASLCommand.java
@@ -35,7 +35,7 @@ import org.jboss.as.cli.operation.OperationFormatException;
  * @author jdenise@redhat.com
  */
 @CommandDefinition(name = "enable-sasl-management", description = "", activator = SecurityCommandActivator.class)
-public class ManagementEnableSASLCommand extends AbstractEnableAuthenticationCommand {
+public class ManagementEnableSASLCommand extends AbstractMgmtEnableAuthenticationCommand {
 
     @Option(name = OPT_MANAGEMENT_INTERFACE, activator = OptionActivators.DependsOnMechanism.class,
             completer = OptionCompleters.ManagementInterfaceCompleter.class)

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ApplicationSecurityDomain.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/ApplicationSecurityDomain.java
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+package org.jboss.as.cli.impl.aesh.cmd.security.model;
+
+/**
+ *
+ * @author jdenise@redhat.com
+ */
+public class ApplicationSecurityDomain {
+    private final String name;
+    private final String factory;
+    private final String secDomain;
+
+    ApplicationSecurityDomain(String name, String factory, String secDomain) {
+        this.name = name;
+        this.factory = factory;
+        this.secDomain = secDomain;
+    }
+
+    /**
+     * @return the name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return the factory
+     */
+    public String getFactory() {
+        return factory;
+    }
+
+    /**
+     * @return the secDomain
+     */
+    public String getSecurityDomain() {
+        return secDomain;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AuthSecurityBuilder.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/aesh/cmd/security/model/AuthSecurityBuilder.java
@@ -42,6 +42,7 @@ public class AuthSecurityBuilder {
     private final AuthFactory ootbFactory;
     private final List<String> order;
     private final AuthFactorySpec spec;
+    private final String securityDomain;
 
     public AuthSecurityBuilder(AuthMechanism mechanism, AuthFactorySpec spec) throws CommandException {
         Objects.requireNonNull(mechanism);
@@ -49,6 +50,7 @@ public class AuthSecurityBuilder {
         this.mechanism = mechanism;
         ootbFactory = null;
         order = null;
+        securityDomain = null;
         this.spec = spec;
         init();
     }
@@ -58,7 +60,18 @@ public class AuthSecurityBuilder {
         mechanism = null;
         this.ootbFactory = ootbFactory;
         order = null;
+        securityDomain = null;
         spec = ootbFactory.getSpec();
+        init();
+    }
+
+    public AuthSecurityBuilder(String securityDomain) throws CommandException {
+        Objects.requireNonNull(securityDomain);
+        this.securityDomain = securityDomain;
+        order = null;
+        mechanism = null;
+        ootbFactory = null;
+        spec = null;
         init();
     }
 
@@ -69,6 +82,7 @@ public class AuthSecurityBuilder {
         this.ootbFactory = null;
         init();
         spec = AuthFactorySpec.SASL;
+        securityDomain = null;
     }
 
     private void init() {
@@ -86,6 +100,10 @@ public class AuthSecurityBuilder {
 
     public AuthFactory getAuthFactory() {
         return ootbFactory == null ? authFactory : ootbFactory;
+    }
+
+    public String getReferencedSecurityDomain() {
+        return securityDomain;
     }
 
     public AuthSecurityBuilder setNewRealmName(String newRealmName) {
@@ -114,7 +132,7 @@ public class AuthSecurityBuilder {
 
     public void buildRequest(CommandContext ctx) throws Exception {
         // rely on existing resources, no request.
-        if (ootbFactory != null) {
+        if (ootbFactory != null || securityDomain != null) {
             return;
         }
 

--- a/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/auth/command_resources.properties
+++ b/cli/src/main/resources/org/jboss/as/cli/impl/aesh/cmd/security/auth/command_resources.properties
@@ -12,23 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-security.abstract-auth-disable.option.mechanism.description=\
+security.abstract-management-auth-disable.option.mechanism.description=\
 The authentication mechanism to disable. The option completer exposes all enabled mechanisms.
 
-security.abstract-auth-disable.option.mechanism.value=mechanism name
+security.abstract-management-auth-disable.option.mechanism.value=mechanism name
 
-security.abstract-auth-disable.option.no-reload.description=\
-Optional, by default the server is reloaded once the configuration changes have been applied. \
-In order to not reload the server, use this option.\n\
-NB: reload is done in start-mode=<the mode the current server is running>.
-
-security.abstract-auth-enable.option.mechanism.description=\
+security.abstract-management-auth-enable.option.mechanism.description=\
 The authentication mechanism to enable. The option completer exposes all supported \
  mechanisms that the CLI support.\n\
 NB: If the mechanism you want to configure is not present in the list, then \
 you must use elytron subsystem management operations to configure it.
 
-security.abstract-auth-enable.option.mechanism.value=mechanism name
+security.abstract-management-auth-enable.option.mechanism.value=mechanism name
+
+security.abstract-auth-disable.option.no-reload.description=\
+Optional, by default the server is reloaded once the configuration changes have been applied. \
+In order to not reload the server, use this option.\n\
+NB: reload is done in start-mode=<the mode the current server is running>.
 
 security.abstract-auth-enable.option.file-system-realm-name.description=\
 The elytron file-system-realm name.
@@ -132,8 +132,9 @@ In order to not reload the server, use this option.\n\
 NB: reload is done in start-mode=<the mode the current server is running>.
 
 security.disable-http-auth-http-server.description=\
-This command removes the security domain or a mechanism from the active HTTP factory. \
-Without a mechanism, the security domain is removed.\n\
+Without any mechanism specified, this command removes the http-server security domain. \
+If a mechanism is specified, the mechanism is removed from the http authentication factory \
+that this security domain references.\n\
 NB: Elytron existing resources are not removed from management model.\n\
 TIPS: Use 'echo-dmr security disable-http-auth-http-server <options>' in order to \
 visualize the composite request that would be sent to disable authentication.
@@ -144,16 +145,41 @@ Required, the undertow security domain name.
 security.disable-http-auth-http-server.option.security-domain.value=name
 
 security.enable-http-auth-http-server.description=\
-Associate an elytron HTTP Authentication factory to the security domain. \
+Associate an elytron security domain or HTTP Authentication factory to the http-server security domain. \
+If no elytron referenced security domain is provided nor mechanism, then the elytron Out of The Box Application \
+security domain is associated to the http-server security domain.\n\
+NB: If the server the CLI is connected to doesn't support "elytron referenced security \
+domain from http-server security domain", the elytron Out of The Box Application \
+HTTP Authentication factory is associated to the http-server security domain when no mechanism is provided.\n\
 In case a factory already exists for the passed security domain, the factory \
-is extended (or updated) with the selected mechanism. If no mechanism is provided, \
-the elytron Out of The Box Application HTTP Authentication factory is associated to \
-the security domain.\n\
+is extended (or updated) with the selected mechanism.
 NB: This command creates all the non existing resources required to configure \
 authentication. This command can be called multiple times to configure the \
 referenced HTTP Authentication factory.\n\
 TIPS: Use 'echo-dmr security enable-http-auth-http-server <options>' in order to \
 visualize the composite request that would be sent to enable authentication.
+
+security.disable-http-auth-http-server.option.mechanism.description=\
+The authentication mechanism to disable. The option completer exposes all enabled mechanisms.\n\
+NB: Only applies to security-domain that references an HTTP Authentication factory.
+
+security.disable-http-auth-http-server.option.mechanism.value=mechanism name
+
+security.enable-http-auth-http-server.option.mechanism.description=\
+The authentication mechanism to enable. The option completer exposes all supported \
+ mechanisms that the CLI support.\n\
+NB: If the mechanism you want to configure is not present in the list, then \
+you must use elytron subsystem management operations to configure it.\n\
+NB: This option can't be used when referencing an elytron security domain.
+
+security.enable-http-auth-http-server.option.mechanism.value=mechanism name
+
+security.enable-http-auth-http-server.option.referenced-security-domain.description=\
+An existing elytron security domain name. This option is only available if the server \
+the CLI is connected to support "elytron referenced security domain from http-server \
+security domain".
+
+security.enable-http-auth-http-server.option.referenced-security-domain.value=name
 
 security.enable-http-auth-http-server.option.security-domain.description=\
 Required, the undertow security domain name.

--- a/core-galleon-pack/src/main/resources/feature_groups/elytron-app.xml
+++ b/core-galleon-pack/src/main/resources/feature_groups/elytron-app.xml
@@ -19,10 +19,4 @@
         <param name="security-domain" value="ApplicationDomain"/>
         <param name="mechanism-configurations" value="[{mechanism-name=JBOSS-LOCAL-USER,realm-mapper=local},{mechanism-name=DIGEST-MD5,mechanism-realm-configurations=[{realm-name=ApplicationRealm}]}]"/>
     </feature>
-    <feature spec="subsystem.elytron.http-authentication-factory">
-        <param name="http-authentication-factory" value="application-http-authentication"/>
-        <param name="http-server-mechanism-factory" value="global"/>
-        <param name="security-domain" value="ApplicationDomain"/>
-        <param name="mechanism-configurations" value="[{mechanism-name=BASIC,mechanism-realm-configurations=[{realm-name=Application Realm}]},{mechanism-name=FORM}]"/>
-    </feature>
 </feature-group-spec>

--- a/core-galleon-pack/src/main/resources/packages/misc.common/pm/wildfly/tasks.xml
+++ b/core-galleon-pack/src/main/resources/packages/misc.common/pm/wildfly/tasks.xml
@@ -9,8 +9,13 @@
         <permission value="700">
             <filter pattern="*/tmp/auth" include="true"/>
         </permission>
+        <permission value="664">
+            <filter pattern="*.properties" include="true"/>
+        </permission>
         <permission value="600">
             <filter pattern="*-users.properties" include="true"/>
+            <filter pattern="*-roles.properties" include="true"/>
+            <filter pattern="*-groups.properties" include="true"/>
             <filter pattern="*/.installation" include="true"/>
         </permission>
     </file-permissions>

--- a/elytron/src/main/resources/subsystem-templates/elytron.xml
+++ b/elytron/src/main/resources/subsystem-templates/elytron.xml
@@ -108,16 +108,6 @@
                 <groups-properties path="application-roles.properties" relative-to="jboss.domain.config.dir" />
             </properties-realm>
         </replacement>
-        <replacement placeholder="HTTP_DEFINITIONS">
-            <http-authentication-factory name="application-http-authentication" security-domain="ApplicationDomain" http-server-mechanism-factory="global">
-                <mechanism-configuration>
-                    <mechanism mechanism-name="BASIC" >
-                        <mechanism-realm realm-name="Application Realm" />
-                    </mechanism>
-                    <mechanism mechanism-name="FORM" />
-                </mechanism-configuration>
-            </http-authentication-factory>
-        </replacement>
         <replacement placeholder="SASL_DEFINITIONS">
             <sasl-authentication-factory name="application-sasl-authentication" sasl-server-factory="configured" security-domain="ApplicationDomain">
                 <mechanism-configuration>
@@ -208,14 +198,6 @@
         </replacement>
 
         <replacement placeholder="HTTP_DEFINITIONS">
-            <http-authentication-factory name="application-http-authentication" security-domain="ApplicationDomain" http-server-mechanism-factory="global">
-                <mechanism-configuration>
-                    <mechanism mechanism-name="BASIC" >
-                        <mechanism-realm realm-name="Application Realm" />
-                    </mechanism>
-                    <mechanism mechanism-name="FORM" />
-                </mechanism-configuration>
-            </http-authentication-factory>
             <http-authentication-factory name="management-http-authentication" security-domain="ManagementDomain" http-server-mechanism-factory="global">
                 <mechanism-configuration>
                     <mechanism mechanism-name="DIGEST">

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTest.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogBootingSyslogTest.java
@@ -132,7 +132,7 @@ public class AuditLogBootingSyslogTest {
         final BlockingQueue<SyslogServerEventIF> queue = BlockedSyslogServerEventHandler.getQueue();
         queue.clear();
         container.start();
-        waitForExpectedQueueSize(18, queue);
+        waitForExpectedQueueSize(17, queue);
         queue.clear();
         makeOneLog();
         waitForExpectedQueueSize(1, queue);


### PR DESCRIPTION
This pull request is 2 of 3 and can be merged after https://github.com/wildfly/wildfly/pull/11400

https://issues.jboss.org/browse/WFCORE-3945

This pull request removes the application-http-authentication http-authentication-factory from the default configuration, it also contains updates to the JBoss CLI to use the new attribute added under https://github.com/wildfly/wildfly/pull/11400 and to no longer depend on the removed default configuration. 