### PR TITLE
[WFCORE-3951] Upgrade jboss-logmanager from 2.1.2.Final to 2.1.3.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
         <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
-        <version.org.jboss.logmanager.jboss-logmanager>2.1.2.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.1.3.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.4.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.5.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.8.5.Final</version.org.jboss.modules.jboss-modules>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3951