### PR TITLE
[WFCORE-3955] Upgrade WildFly Elytron to 1.4.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.3.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.4.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web.undertow-server>1.1.0.Final</version.org.wildfly.security.elytron-web.undertow-server>
         <version.org.wildfly.security.elytron.tool>1.2.2.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3955


This pull request contains three feature requests.

    * [ELY-1418] - CLIENT_CERT without users certificates database

The proposal for this one can be found at https://developer.jboss.org/wiki/AnalysisDesign-CLIENTCERTWithoutUsersCertificatesDatabase
Community documentation and corresponding PR can be found at https://issues.jboss.org/browse/WFLY-10553

    * [ELY-1582] - Support hex encoding in jdbc-realm for elytron

QE have agreed this one is Ok to merge into WildFly Elytron as without subsystem changes it is not exposed as a new feature.

    * [ELY-1591] - Provide Elytron alternative to RoleMappingLoginModule

This one is not exposed by this pull request and is covered by it's own PR with subsystem and test changes.





Release Notes - WildFly Elytron - Version 1.4.0.Final

** Enhancement
    * [ELY-657] - Wrong error message in OAuth2Client
    * [ELY-1583] - Unsufficient TRACE messages in Keystore realm + properties realm
    * [ELY-1588] - Unhandled ignored usage of "clear-text" in credential-store-reference

** Feature Request
    * [ELY-1418] - CLIENT_CERT without users certificates database
    * [ELY-1582] - Support hex encoding in jdbc-realm for elytron
    * [ELY-1591] - Provide Elytron alternative to RoleMappingLoginModule

** Bug
    * [ELY-1444] - Jdbc-realm with simple digest mapper
    * [ELY-1480] - Coverity, Explicit null dereferenced in FileSystemSecurityRealm
    * [ELY-1529] - OAuth2SaslClientV10Test or OAuth2SaslClientV11Test intermittently fails during MockWebServer binding
    * [ELY-1536] - DigestSaslClient parse but ignore "stale" param
    * [ELY-1540] - Build fails on Java 9.0.4
    * [ELY-1547] - SPNEGO: missing negstat field in the first reply for expired token
    * [ELY-1549] - IBM JDK, SPNEGO + FORM; with invalid ticket 401 status code is returned
    * [ELY-1554] - Upgrade Apache DS in Elytron tests
    * [ELY-1564] - In PasswordKeyMapper an exception is logged with a wrong algorithm name.
    * [ELY-1570] - WildFlyElytronProvider fails Java Mission Control and JDK 10
    * [ELY-1572] - japicmp force source compatibility, but only binary compatibility is required
    * [ELY-1587] - X500 principal [CN=client] was not decoded - no values of attribute [2.5.4.3]
    * [ELY-1603] - WildFly Elytron currently supports two HTTP mechanisms not registered with the WildFlyElytronProvider

** Task
    * [ELY-1459] - Move byte and codepoint iterators to WildFly Common
    * [ELY-1532] - Deprecate AuthConf setHost, setProtocol, setPort properties
    * [ELY-1565] - local-kerberos can be removed/deprecated from authentication client
    * [ELY-1586] - Update the testsuite to make use of the utilities for certificate generation instead of using pre-generated CAs and certs 
    * [ELY-1602] - Temporarily add a Pem.generatePemX509Certificate() method that takes the ByteStringBuilder from Elytron as a parameter

** Release
    * [ELY-1606] - Release WildFly Elytron 1.4.0.Final
