### PR TITLE
[WFCORE-2953] Add a socket-handler resource to the logging subsystem.

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
@@ -42,6 +42,7 @@
         <module name="org.apache.log4j"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.wildfly.security.elytron-private"/>
+        <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.msc"/>
@@ -50,5 +51,6 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.stdio"/>
         <module name="org.jboss.vfs"/>
+        <module name="org.wildfly.common"/>
     </dependencies>
 </module>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -110,6 +110,17 @@
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-network</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
             <exclusions>
                 <exclusion>

--- a/logging/src/main/java/org/jboss/as/logging/Attribute.java
+++ b/logging/src/main/java/org/jboss/as/logging/Attribute.java
@@ -32,6 +32,7 @@ import org.jboss.as.logging.handlers.AsyncHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.ConsoleHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.PeriodicHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.SizeRotatingHandlerResourceDefinition;
+import org.jboss.as.logging.handlers.SocketHandlerResourceDefinition;
 import org.jboss.as.logging.loggers.LoggerResourceDefinition;
 
 /**
@@ -43,6 +44,7 @@ public enum Attribute {
 
     APPEND(CommonAttributes.APPEND),
     AUTOFLUSH(CommonAttributes.AUTOFLUSH),
+    BLOCK_ON_RECONNECT(SocketHandlerResourceDefinition.BLOCK_ON_RECONNECT),
     CATEGORY(LoggerResourceDefinition.CATEGORY),
     CLASS(CommonAttributes.CLASS),
     COLOR_MAP(PatternFormatterResourceDefinition.COLOR_MAP),
@@ -55,6 +57,7 @@ public enum Attribute {
     MODULE(CommonAttributes.MODULE),
     NAME("name"),
     NEW_LEVEL(CommonAttributes.NEW_LEVEL),
+    OUTBOUND_SOCKET_BINDING_REF(SocketHandlerResourceDefinition.OUTBOUND_SOCKET_BINDING_REF),
     OVERFLOW_ACTION(AsyncHandlerResourceDefinition.OVERFLOW_ACTION),
     PATH(PathResourceDefinition.PATH),
     PATTERN(PatternFormatterResourceDefinition.PATTERN),
@@ -64,6 +67,7 @@ public enum Attribute {
     REPLACE_ALL(CommonAttributes.REPLACE_ALL),
     ROTATE_ON_BOOT(SizeRotatingHandlerResourceDefinition.ROTATE_ON_BOOT),
     ROTATE_SIZE(SizeRotatingHandlerResourceDefinition.ROTATE_SIZE),
+    SSL_CONTEXT(SocketHandlerResourceDefinition.SSL_CONTEXT),
     SUFFIX(PeriodicHandlerResourceDefinition.SUFFIX),
     SYSLOG_TYPE("syslog-type"),
     TARGET(ConsoleHandlerResourceDefinition.TARGET),

--- a/logging/src/main/java/org/jboss/as/logging/Element.java
+++ b/logging/src/main/java/org/jboss/as/logging/Element.java
@@ -38,6 +38,7 @@ import org.jboss.as.logging.handlers.FileHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.PeriodicHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.PeriodicSizeRotatingHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.SizeRotatingHandlerResourceDefinition;
+import org.jboss.as.logging.handlers.SocketHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.SyslogHandlerResourceDefinition;
 import org.jboss.as.logging.loggers.LoggerResourceDefinition;
 import org.jboss.as.logging.loggers.RootLoggerResourceDefinition;
@@ -88,6 +89,7 @@ enum Element {
     PORT(SyslogHandlerResourceDefinition.PORT),
     PROPERTIES(CommonAttributes.PROPERTIES),
     PROPERTY("property"),
+    PROTOCOL(SocketHandlerResourceDefinition.PROTOCOL),
     QUEUE_LENGTH(AsyncHandlerResourceDefinition.QUEUE_LENGTH),
     REPLACE(CommonAttributes.REPLACE),
     ROOT_LOGGER(RootLoggerResourceDefinition.NAME),
@@ -96,6 +98,7 @@ enum Element {
     SIZE_ROTATING_FILE_HANDLER(SizeRotatingHandlerResourceDefinition.NAME),
     SUBHANDLERS(AsyncHandlerResourceDefinition.SUBHANDLERS),
     SUFFIX(PeriodicHandlerResourceDefinition.SUFFIX),
+    SOCKET_HANDLER(SocketHandlerResourceDefinition.NAME),
     SYSLOG_FORMATTER(SyslogHandlerResourceDefinition.SYSLOG_FORMATTER),
     SYSLOG_HANDLER(SyslogHandlerResourceDefinition.NAME),
     TARGET(ConsoleHandlerResourceDefinition.TARGET),

--- a/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
+++ b/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
@@ -13,7 +13,8 @@ public enum KnownModelVersion {
     VERSION_3_0_0(ModelVersion.create(3, 0, 0), false),
     VERSION_4_0_0(ModelVersion.create(4, 0, 0), false),
     VERSION_5_0_0(ModelVersion.create(5, 0, 0), true),
-    VERSION_6_0_0(ModelVersion.create(6, 0, 0), false),
+    VERSION_6_0_0(ModelVersion.create(6, 0, 0), true),
+    VERSION_7_0_0(ModelVersion.create(7, 0, 0), false),
     ;
     private final ModelVersion modelVersion;
     private final boolean hasTransformers;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -97,7 +97,7 @@ public class LoggingExtension implements Extension {
 
     private static final GenericSubsystemDescribeHandler DESCRIBE_HANDLER = GenericSubsystemDescribeHandler.create(LoggingChildResourceComparator.INSTANCE);
 
-    private static final int MANAGEMENT_API_MAJOR_VERSION = 6;
+    private static final int MANAGEMENT_API_MAJOR_VERSION = 7;
     private static final int MANAGEMENT_API_MINOR_VERSION = 0;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
@@ -267,6 +267,7 @@ public class LoggingExtension implements Extension {
         setParser(context, Namespace.LOGGING_3_0, new LoggingSubsystemParser_3_0());
         setParser(context, Namespace.LOGGING_4_0, new LoggingSubsystemParser_4_0());
         setParser(context, Namespace.LOGGING_5_0, new LoggingSubsystemParser_5_0());
+        setParser(context, Namespace.LOGGING_6_0, new LoggingSubsystemParser_6_0());
 
         // Hack to ensure the Element and Attribute enums are loaded during this call which
         // is part of concurrent boot. These enums trigger a lot of classloading and static

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -67,6 +67,7 @@ import org.jboss.as.logging.handlers.FileHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.PeriodicHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.PeriodicSizeRotatingHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.SizeRotatingHandlerResourceDefinition;
+import org.jboss.as.logging.handlers.SocketHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.SyslogHandlerResourceDefinition;
 import org.jboss.as.logging.loggers.LoggerResourceDefinition;
 import org.jboss.as.logging.loggers.RootLoggerResourceDefinition;
@@ -331,6 +332,7 @@ public class LoggingExtension implements Extension {
         registration.registerSubModel(CustomFormatterResourceDefinition.INSTANCE);
         registration.registerSubModel(JsonFormatterResourceDefinition.INSTANCE);
         registration.registerSubModel(XmlFormatterResourceDefinition.INSTANCE);
+        registration.registerSubModel(SocketHandlerResourceDefinition.INSTANCE);
 
         if (registerTransformers) {
             registerTransformers(subsystem,
@@ -348,14 +350,16 @@ public class LoggingExtension implements Extension {
                     PatternFormatterResourceDefinition.INSTANCE,
                     CustomFormatterResourceDefinition.INSTANCE,
                     JsonFormatterResourceDefinition.INSTANCE,
-                    XmlFormatterResourceDefinition.INSTANCE);
+                    XmlFormatterResourceDefinition.INSTANCE,
+                    SocketHandlerResourceDefinition.INSTANCE);
         }
     }
 
     private void registerTransformers(final SubsystemRegistration registration, final TransformerResourceDefinition... defs) {
         ChainedTransformationDescriptionBuilder chainedBuilder = TransformationDescriptionBuilder.Factory.createChainedSubystemInstance(registration.getSubsystemVersion());
 
-        registerTransformers(chainedBuilder, registration.getSubsystemVersion(), KnownModelVersion.VERSION_5_0_0, defs);
+        registerTransformers(chainedBuilder, registration.getSubsystemVersion(), KnownModelVersion.VERSION_6_0_0, defs);
+        registerTransformers(chainedBuilder, KnownModelVersion.VERSION_6_0_0, KnownModelVersion.VERSION_5_0_0, defs);
         registerTransformers(chainedBuilder, KnownModelVersion.VERSION_5_0_0, KnownModelVersion.VERSION_2_0_0, defs);
         // Version 1.5.0 has the periodic-size-rotating-file-handler and the suffix attribute on the size-rotating-file-handler.
         // Neither of these are in 2.0.0 (WildFly 8.x). Mapping from 3.0.0 to 1.5.0 is required
@@ -363,12 +367,13 @@ public class LoggingExtension implements Extension {
 
         chainedBuilder.buildAndRegister(registration, new ModelVersion[] {
                 KnownModelVersion.VERSION_2_0_0.getModelVersion(),
-                KnownModelVersion.VERSION_5_0_0.getModelVersion(),
+                KnownModelVersion.VERSION_6_0_0.getModelVersion(),
         }, new ModelVersion[] {
                 KnownModelVersion.VERSION_1_5_0.getModelVersion(),
                 KnownModelVersion.VERSION_3_0_0.getModelVersion(),
                 KnownModelVersion.VERSION_4_0_0.getModelVersion(),
                 KnownModelVersion.VERSION_5_0_0.getModelVersion(),
+                KnownModelVersion.VERSION_6_0_0.getModelVersion(),
         });
     }
 

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
@@ -49,6 +49,7 @@ import org.jboss.as.logging.handlers.FileHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.PeriodicHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.PeriodicSizeRotatingHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.SizeRotatingHandlerResourceDefinition;
+import org.jboss.as.logging.handlers.SocketHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.SyslogHandlerResourceDefinition;
 import org.jboss.as.logging.loggers.LoggerResourceDefinition;
 import org.jboss.as.logging.loggers.RootLoggerResourceDefinition;
@@ -135,6 +136,7 @@ class LoggingSubsystemAdd extends AbstractAddStepHandler {
         subsystemHandlers.addAll(resource.getChildrenNames(PeriodicHandlerResourceDefinition.NAME));
         subsystemHandlers.addAll(resource.getChildrenNames(PeriodicSizeRotatingHandlerResourceDefinition.NAME));
         subsystemHandlers.addAll(resource.getChildrenNames(SizeRotatingHandlerResourceDefinition.NAME));
+        subsystemHandlers.addAll(resource.getChildrenNames(SocketHandlerResourceDefinition.NAME));
         subsystemHandlers.addAll(resource.getChildrenNames(SyslogHandlerResourceDefinition.NAME));
 
         // handlers

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_6_0.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_6_0.java
@@ -19,10 +19,330 @@
 
 package org.jboss.as.logging;
 
+import static org.jboss.as.controller.parsing.ParseUtils.duplicateNamedElement;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+import static org.jboss.as.logging.CommonAttributes.AUTOFLUSH;
+import static org.jboss.as.logging.CommonAttributes.ENABLED;
+import static org.jboss.as.logging.CommonAttributes.ENCODING;
+import static org.jboss.as.logging.CommonAttributes.FILTER_SPEC;
+import static org.jboss.as.logging.CommonAttributes.LEVEL;
+import static org.jboss.as.logging.CommonAttributes.LOGGING_PROFILE;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.logging.handlers.SocketHandlerResourceDefinition;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
 /**
  * Subsystem parser for 6.0 of the logging subsystem.
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 class LoggingSubsystemParser_6_0 extends LoggingSubsystemParser_5_0 {
+
+    @Override
+    public void readElement(final XMLExtendedStreamReader reader, final List<ModelNode> operations) throws XMLStreamException {
+        // No attributes
+        ParseUtils.requireNoAttributes(reader);
+
+        // Subsystem add operation
+        final ModelNode subsystemAddOp = Util.createAddOperation(SUBSYSTEM_ADDRESS);
+        operations.add(subsystemAddOp);
+
+        final List<ModelNode> loggerOperations = new ArrayList<>();
+        final List<ModelNode> asyncHandlerOperations = new ArrayList<>();
+        final List<ModelNode> handlerOperations = new ArrayList<>();
+        final List<ModelNode> formatterOperations = new ArrayList<>();
+
+        // Elements
+        final Set<String> loggerNames = new HashSet<>();
+        final Set<String> handlerNames = new HashSet<>();
+        final Set<String> formatterNames = new HashSet<>();
+        boolean rootDefined = false;
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case ADD_LOGGING_API_DEPENDENCIES: {
+                    final String value = ParseUtils.readStringAttributeElement(reader, Attribute.VALUE.getLocalName());
+                    LoggingResourceDefinition.ADD_LOGGING_API_DEPENDENCIES.parseAndSetParameter(value, subsystemAddOp, reader);
+                    break;
+                }
+                case USE_DEPLOYMENT_LOGGING_CONFIG: {
+                    final String value = ParseUtils.readStringAttributeElement(reader, Attribute.VALUE.getLocalName());
+                    LoggingResourceDefinition.USE_DEPLOYMENT_LOGGING_CONFIG.parseAndSetParameter(value, subsystemAddOp, reader);
+                    break;
+                }
+                case LOGGER: {
+                    parseLoggerElement(reader, SUBSYSTEM_ADDRESS, loggerOperations, loggerNames);
+                    break;
+                }
+                case ROOT_LOGGER: {
+                    if (rootDefined) {
+                        throw unexpectedElement(reader);
+                    }
+                    rootDefined = true;
+                    parseRootLoggerElement(reader, SUBSYSTEM_ADDRESS, loggerOperations);
+                    break;
+                }
+                case CONSOLE_HANDLER: {
+                    parseConsoleHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case FILE_HANDLER: {
+                    parseFileHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case CUSTOM_HANDLER: {
+                    parseCustomHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case PERIODIC_ROTATING_FILE_HANDLER: {
+                    parsePeriodicRotatingFileHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case PERIODIC_SIZE_ROTATING_FILE_HANDLER: {
+                    parsePeriodicSizeRotatingHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case SIZE_ROTATING_FILE_HANDLER: {
+                    parseSizeRotatingHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case SOCKET_HANDLER: {
+                    parseSocketHandlerElement(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case ASYNC_HANDLER: {
+                    parseAsyncHandlerElement(reader, SUBSYSTEM_ADDRESS, asyncHandlerOperations, handlerNames);
+                    break;
+                }
+                case SYSLOG_HANDLER: {
+                    parseSyslogHandler(reader, SUBSYSTEM_ADDRESS, handlerOperations, handlerNames);
+                    break;
+                }
+                case LOGGING_PROFILES: {
+                    parseLoggingProfilesElement(reader, operations);
+                }
+                break;
+                case FORMATTER: {
+                    parseFormatter(reader, SUBSYSTEM_ADDRESS, formatterOperations, formatterNames);
+                    break;
+                }
+                default: {
+                    reader.handleAny(operations);
+                    break;
+                }
+            }
+        }
+        operations.addAll(formatterOperations);
+        operations.addAll(handlerOperations);
+        operations.addAll(asyncHandlerOperations);
+        operations.addAll(loggerOperations);
+    }
+
+    @Override
+    void parseLoggingProfileElement(final XMLExtendedStreamReader reader, final List<ModelNode> operations, final Set<String> profileNames) throws XMLStreamException {
+        // Attributes
+        String name = null;
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME: {
+                    name = value;
+                    break;
+                }
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        if (!profileNames.add(name)) {
+            throw duplicateNamedElement(reader, name);
+        }
+        // Setup the address
+        final PathAddress profileAddress = SUBSYSTEM_ADDRESS.append(LOGGING_PROFILE, name);
+        operations.add(Util.createAddOperation(profileAddress));
+
+        final List<ModelNode> loggerOperations = new ArrayList<>();
+        final List<ModelNode> asyncHandlerOperations = new ArrayList<>();
+        final List<ModelNode> handlerOperations = new ArrayList<>();
+        final List<ModelNode> formatterOperations = new ArrayList<>();
+
+        final Set<String> loggerNames = new HashSet<>();
+        final Set<String> handlerNames = new HashSet<>();
+        final Set<String> formatterNames = new HashSet<>();
+        boolean gotRoot = false;
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case LOGGER: {
+                    parseLoggerElement(reader, profileAddress, loggerOperations, loggerNames);
+                    break;
+                }
+                case ROOT_LOGGER: {
+                    if (gotRoot) {
+                        throw unexpectedElement(reader);
+                    }
+                    gotRoot = true;
+                    parseRootLoggerElement(reader, profileAddress, loggerOperations);
+                    break;
+                }
+                case CONSOLE_HANDLER: {
+                    parseConsoleHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case FILE_HANDLER: {
+                    parseFileHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case CUSTOM_HANDLER: {
+                    parseCustomHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case PERIODIC_ROTATING_FILE_HANDLER: {
+                    parsePeriodicRotatingFileHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case PERIODIC_SIZE_ROTATING_FILE_HANDLER: {
+                    parsePeriodicSizeRotatingHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case SIZE_ROTATING_FILE_HANDLER: {
+                    parseSizeRotatingHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case SOCKET_HANDLER: {
+                    parseSocketHandlerElement(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case ASYNC_HANDLER: {
+                    parseAsyncHandlerElement(reader, profileAddress, asyncHandlerOperations, handlerNames);
+                    break;
+                }
+                case SYSLOG_HANDLER: {
+                    parseSyslogHandler(reader, profileAddress, handlerOperations, handlerNames);
+                    break;
+                }
+                case FORMATTER: {
+                    parseFormatter(reader, profileAddress, formatterOperations, formatterNames);
+                    break;
+                }
+                default: {
+                    reader.handleAny(operations);
+                    break;
+                }
+            }
+        }
+        operations.addAll(formatterOperations);
+        operations.addAll(handlerOperations);
+        operations.addAll(asyncHandlerOperations);
+        operations.addAll(loggerOperations);
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    void parseSocketHandlerElement(final XMLExtendedStreamReader reader, final PathAddress address, final List<ModelNode> operations, final Set<String> handlerNames) throws XMLStreamException {
+        final ModelNode operation = Util.createAddOperation();
+        // Attributes
+        String name = null;
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.NAME, Attribute.OUTBOUND_SOCKET_BINDING_REF);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case NAME: {
+                    name = value;
+                    break;
+                }
+                case AUTOFLUSH: {
+                    AUTOFLUSH.parseAndSetParameter(value, operation, reader);
+                    break;
+                }
+                case BLOCK_ON_RECONNECT: {
+                    SocketHandlerResourceDefinition.BLOCK_ON_RECONNECT.parseAndSetParameter(value, operation, reader);
+                    break;
+                }
+                case ENABLED: {
+                    ENABLED.parseAndSetParameter(value, operation, reader);
+                    break;
+                }
+                case OUTBOUND_SOCKET_BINDING_REF: {
+                    SocketHandlerResourceDefinition.OUTBOUND_SOCKET_BINDING_REF.parseAndSetParameter(value, operation, reader);
+                    break;
+                }
+                case SSL_CONTEXT: {
+                    SocketHandlerResourceDefinition.SSL_CONTEXT.parseAndSetParameter(value, operation, reader);
+                    break;
+                }
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        if (!handlerNames.add(name)) {
+            throw duplicateNamedElement(reader, name);
+        }
+
+        // Setup the operation address
+        addOperationAddress(operation, address, SocketHandlerResourceDefinition.NAME, name);
+
+        final EnumSet<Element> requiredElem = EnumSet.of(Element.NAMED_FORMATTER);
+        final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
+        while (reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            if (!encountered.add(element)) {
+                throw unexpectedElement(reader);
+            }
+            requiredElem.remove(element);
+            switch (element) {
+                case LEVEL: {
+                    LEVEL.parseAndSetParameter(readNameAttribute(reader), operation, reader);
+                    break;
+                }
+                case ENCODING: {
+                    ENCODING.parseAndSetParameter(readValueAttribute(reader), operation, reader);
+                    break;
+                }
+                case FILTER_SPEC: {
+                    FILTER_SPEC.parseAndSetParameter(readValueAttribute(reader), operation, reader);
+                    break;
+                }
+                case NAMED_FORMATTER: {
+                    SocketHandlerResourceDefinition.NAMED_FORMATTER.parseAndSetParameter(readNameAttribute(reader), operation, reader);
+                    break;
+                }
+                case PROTOCOL: {
+                    SocketHandlerResourceDefinition.PROTOCOL.parseAndSetParameter(readValueAttribute(reader), operation, reader);
+                    break;
+                }
+                default: {
+                    throw unexpectedElement(reader);
+                }
+            }
+        }
+        operations.add(operation);
+    }
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_6_0.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser_6_0.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging;
+
+/**
+ * Subsystem parser for 6.0 of the logging subsystem.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class LoggingSubsystemParser_6_0 extends LoggingSubsystemParser_5_0 {
+}

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
@@ -76,6 +76,7 @@ import org.jboss.as.logging.handlers.FileHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.PeriodicHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.PeriodicSizeRotatingHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.SizeRotatingHandlerResourceDefinition;
+import org.jboss.as.logging.handlers.SocketHandlerResourceDefinition;
 import org.jboss.as.logging.handlers.SyslogHandlerResourceDefinition;
 import org.jboss.as.logging.loggers.LoggerResourceDefinition;
 import org.jboss.as.logging.loggers.RootLoggerResourceDefinition;
@@ -197,6 +198,17 @@ public class LoggingSubsystemWriter implements XMLStreamConstants, XMLElementWri
                 }
             }
         }
+        if (model.hasDefined(SocketHandlerResourceDefinition.NAME)) {
+            final ModelNode handlers = model.get(SocketHandlerResourceDefinition.NAME);
+
+            for (Property handlerProp : handlers.asPropertyList()) {
+                final String name = handlerProp.getName();
+                final ModelNode handler = handlerProp.getValue();
+                if (handler.isDefined()) {
+                    writeSocketHandler(writer, handler, name);
+                }
+            }
+        }
         if (model.hasDefined(SyslogHandlerResourceDefinition.NAME)) {
             final ModelNode handlers = model.get(SyslogHandlerResourceDefinition.NAME);
 
@@ -315,6 +327,24 @@ public class LoggingSubsystemWriter implements XMLStreamConstants, XMLElementWri
         MAX_BACKUP_INDEX.marshallAsElement(model, writer);
         APPEND.marshallAsElement(model, writer);
         SizeRotatingHandlerResourceDefinition.SUFFIX.marshallAsElement(model, writer);
+
+        writer.writeEndElement();
+    }
+
+    private void writeSocketHandler(final XMLExtendedStreamWriter writer, final ModelNode model, final String name) throws XMLStreamException {
+        writer.writeStartElement(Element.SOCKET_HANDLER.getLocalName());
+        writer.writeAttribute(HANDLER_NAME.getXmlName(), name);
+        AUTOFLUSH.marshallAsAttribute(model, writer);
+        SocketHandlerResourceDefinition.BLOCK_ON_RECONNECT.marshallAsAttribute(model, false, writer);
+        ENABLED.marshallAsAttribute(model, false, writer);
+        SocketHandlerResourceDefinition.OUTBOUND_SOCKET_BINDING_REF.marshallAsAttribute(model, writer);
+        SocketHandlerResourceDefinition.SSL_CONTEXT.marshallAsAttribute(model, writer);
+
+        ENCODING.marshallAsElement(model, writer);
+        FILTER_SPEC.marshallAsElement(model, writer);
+        LEVEL.marshallAsElement(model, writer);
+        SocketHandlerResourceDefinition.NAMED_FORMATTER.marshallAsElement(model, writer);
+        SocketHandlerResourceDefinition.PROTOCOL.marshallAsElement(model, writer);
 
         writer.writeEndElement();
     }

--- a/logging/src/main/java/org/jboss/as/logging/Namespace.java
+++ b/logging/src/main/java/org/jboss/as/logging/Namespace.java
@@ -54,12 +54,14 @@ public enum Namespace {
     LOGGING_4_0("urn:jboss:domain:logging:4.0"),
 
     LOGGING_5_0("urn:jboss:domain:logging:5.0"),
+
+    LOGGING_6_0("urn:jboss:domain:logging:6.0"),
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = LOGGING_5_0;
+    public static final Namespace CURRENT = LOGGING_6_0;
 
     private final String name;
 

--- a/logging/src/main/java/org/jboss/as/logging/capabilities/Capabilities.java
+++ b/logging/src/main/java/org/jboss/as/logging/capabilities/Capabilities.java
@@ -19,6 +19,8 @@
 
 package org.jboss.as.logging.capabilities;
 
+import java.util.logging.Handler;
+
 import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.capability.RuntimeCapability;
 
@@ -35,6 +37,21 @@ public class Capabilities {
     public static final String PATH_CAPABILITY = "org.wildfly.management.path";
 
     /**
+     * Reference for an outbound socket.
+     */
+    public static final String OUTBOUND_SOCKET_BINDING_CAPABILITY = "org.wildfly.network.outbound-socket-binding";
+
+    /**
+     * Reference for a socket binding.
+     */
+    public static final String SOCKET_BINDING_MANAGER_CAPABILITY = "org.wildfly.management.socket-binding-manager";
+
+    /**
+     * Reference to an SSL context.
+     */
+    public static final String SSL_CONTEXT_CAPABILITY = "org.wildfly.security.ssl-context";
+
+    /**
      * A capability for logging formatters.
      */
     public static final RuntimeCapability<Void> FORMATTER_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.logging.formatter", true)
@@ -43,8 +60,12 @@ public class Capabilities {
 
     /**
      * A capability for logging handlers.
+     * <p>
+     * Note that while this capability can expose a {@linkplain Handler handler} it's not required. It's only used in
+     * cases where a handler might need to register a service. This is not needed in most cases.
+     * </p>
      */
-    public static final RuntimeCapability<Void> HANDLER_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.logging.handler", true)
+    public static final RuntimeCapability<Void> HANDLER_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.logging.handler", true, Handler.class)
             .setDynamicNameMapper(LoggingProfileNameMapper.INSTANCE)
             .build();
 

--- a/logging/src/main/java/org/jboss/as/logging/handlers/HandlerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/HandlerOperations.java
@@ -403,15 +403,7 @@ final class HandlerOperations {
         }
     }
 
-    /**
-     * A step handler to remove a handler
-     */
-    static final OperationStepHandler CHANGE_LEVEL = new HandlerUpdateOperationStepHandler(PropertySorter.NO_OP, LEVEL);
-
-    /**
-     * A step handler to remove a handler
-     */
-    static final OperationStepHandler REMOVE_HANDLER = new LoggingOperations.LoggingRemoveOperationStepHandler() {
+    static class LogHandlerRemoveHandler extends LoggingOperations.LoggingRemoveOperationStepHandler {
 
         @Override
         public void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
@@ -462,7 +454,17 @@ final class HandlerOperations {
                 logContextConfiguration.removePojoConfiguration(name);
             }
         }
-    };
+    }
+
+    /**
+     * A step handler to remove a handler
+     */
+    static final OperationStepHandler CHANGE_LEVEL = new HandlerUpdateOperationStepHandler(PropertySorter.NO_OP, LEVEL);
+
+    /**
+     * A step handler to remove a handler
+     */
+    static final OperationStepHandler REMOVE_HANDLER = new LogHandlerRemoveHandler();
 
     /**
      * The handler for adding a subhandler to an {@link org.jboss.logmanager.handlers.AsyncHandler}.

--- a/logging/src/main/java/org/jboss/as/logging/handlers/SocketHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/SocketHandlerResourceDefinition.java
@@ -1,0 +1,472 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.logging.handlers;
+
+import static org.jboss.as.logging.CommonAttributes.AUTOFLUSH;
+import static org.jboss.as.logging.CommonAttributes.ENABLED;
+import static org.jboss.as.logging.CommonAttributes.ENCODING;
+import static org.jboss.as.logging.CommonAttributes.FILTER_SPEC;
+import static org.jboss.as.logging.CommonAttributes.LEVEL;
+import static org.jboss.as.logging.Logging.createOperationFailure;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.security.NoSuchAlgorithmException;
+import java.util.function.Supplier;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import javax.net.ssl.SSLContext;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationContext.Stage;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.as.logging.ElementAttributeMarshaller;
+import org.jboss.as.logging.KnownModelVersion;
+import org.jboss.as.logging.Logging;
+import org.jboss.as.logging.LoggingExtension;
+import org.jboss.as.logging.LoggingOperations;
+import org.jboss.as.logging.LoggingOperations.LoggingAddOperationStepHandler;
+import org.jboss.as.logging.TransformerResourceDefinition;
+import org.jboss.as.logging.capabilities.Capabilities;
+import org.jboss.as.logging.logging.LoggingLogger;
+import org.jboss.as.network.OutboundSocketBinding;
+import org.jboss.as.network.SocketBindingManager;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.logmanager.config.HandlerConfiguration;
+import org.jboss.logmanager.config.LogContextConfiguration;
+import org.jboss.logmanager.handlers.ClientSocketFactory;
+import org.jboss.logmanager.handlers.DelayedHandler;
+import org.jboss.logmanager.handlers.SocketHandler;
+import org.jboss.msc.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+import org.wildfly.common.function.Functions;
+
+/**
+ * Represents a {@link SocketHandler}. The handler will be wrapped with a {@link DelayedHandler} for booting from the
+ * {@code logging.properties} file.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("Convert2Lambda")
+public class SocketHandlerResourceDefinition extends TransformerResourceDefinition {
+    public static final String NAME = "socket-handler";
+    private static final PathElement PATH = PathElement.pathElement(NAME);
+
+    public static final SimpleAttributeDefinition BLOCK_ON_RECONNECT = SimpleAttributeDefinitionBuilder.create("block-on-reconnect", ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(false))
+            .build();
+
+    public static final SimpleAttributeDefinition NAMED_FORMATTER = SimpleAttributeDefinitionBuilder.create(AbstractHandlerDefinition.NAMED_FORMATTER)
+            .setAttributeMarshaller(ElementAttributeMarshaller.NAME_ATTRIBUTE_MARSHALLER)
+            .setAlternatives(new String[0])
+            .setRequired(true)
+            .build();
+
+    public static final SimpleAttributeDefinition OUTBOUND_SOCKET_BINDING_REF = SimpleAttributeDefinitionBuilder.create("outbound-socket-binding-ref", ModelType.STRING, false)
+            .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
+            .setAllowExpression(true)
+            .setCapabilityReference(Capabilities.OUTBOUND_SOCKET_BINDING_CAPABILITY)
+            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .build();
+
+    public static final SimpleAttributeDefinition PROTOCOL = SimpleAttributeDefinitionBuilder.create("protocol", ModelType.STRING, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(SocketHandler.Protocol.TCP.name()))
+            .setAttributeMarshaller(ElementAttributeMarshaller.VALUE_ATTRIBUTE_MARSHALLER)
+            .setValidator(new EnumValidator<>(SocketHandler.Protocol.class, SocketHandler.Protocol.values()))
+            .build();
+
+    public static final SimpleAttributeDefinition SSL_CONTEXT = SimpleAttributeDefinitionBuilder.create("ssl-context", ModelType.STRING, true)
+            .addFlag(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SSL_REF)
+            .setAllowExpression(true)
+            .setCapabilityReference(Capabilities.SSL_CONTEXT_CAPABILITY)
+            .build();
+
+    private static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {
+            AUTOFLUSH,
+            BLOCK_ON_RECONNECT,
+            LEVEL,
+            ENABLED,
+            ENCODING,
+            NAMED_FORMATTER,
+            FILTER_SPEC,
+            PROTOCOL,
+            OUTBOUND_SOCKET_BINDING_REF,
+            SSL_CONTEXT,
+    };
+
+    private static final LoggingAddOperationStepHandler ADD_HANDLER = new LoggingAddOperationStepHandler(ATTRIBUTES) {
+
+        @Override
+        protected OperationStepHandler additionalModelStep(final LogContextConfiguration logContextConfiguration) {
+            return new OperationStepHandler() {
+                @Override
+                public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+                    // If we don't require runtime steps to be executed we need to discard records on the delayed handler
+                    if (!requiresRuntime(context)) {
+                        HandlerConfiguration configuration = logContextConfiguration.getHandlerConfiguration(context.getCurrentAddressValue());
+                        if (configuration != null) {
+                            if (!(configuration.getInstance() instanceof DelayedHandler)) {
+                                throw LoggingLogger.ROOT_LOGGER.invalidType(DelayedHandler.class, configuration.getInstance().getClass());
+                            }
+                            final DelayedHandler delayedHandler = (DelayedHandler) configuration.getInstance();
+                            // Clear any previous handlers and close them, then add the new handler
+                            final Handler[] current = delayedHandler.setHandlers(new Handler[] {new DiscardingHandler()});
+                            if (current != null) {
+                                for (Handler handler : current) {
+                                    handler.close();
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        @Override
+        public void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
+            final String name = context.getCurrentAddressValue();
+            HandlerConfiguration configuration = logContextConfiguration.getHandlerConfiguration(name);
+            if (configuration == null) {
+                configuration = logContextConfiguration.addHandlerConfiguration(null, DelayedHandler.class.getName(), name);
+            } else {
+                if (!(configuration.getInstance() instanceof DelayedHandler)) {
+                    throw LoggingLogger.ROOT_LOGGER.invalidType(DelayedHandler.class, configuration.getInstance().getClass());
+                }
+            }
+            ENABLED.setPropertyValue(context, model, configuration);
+            final ModelNode filter = FILTER_SPEC.resolveModelAttribute(context, model);
+            if (filter.isDefined()) {
+                configuration.setFilter(filter.asString());
+            }
+            configuration.setLevel(LEVEL.resolvePropertyValue(context, model));
+            configuration.setFormatterName(NAMED_FORMATTER.resolveModelAttribute(context, model).asString());
+        }
+
+        @Override
+        protected OperationStepHandler afterCommit(final LogContextConfiguration logContextConfiguration, final ModelNode model) {
+            return new OperationStepHandler() {
+                @Override
+                public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+                    final String name = context.getCurrentAddressValue();
+                    final HandlerConfiguration configuration = logContextConfiguration.getHandlerConfiguration(name);
+
+                    final SocketHandler.Protocol protocol = SocketHandler.Protocol.valueOf(PROTOCOL.resolveModelAttribute(context, model).asString());
+                    final boolean autoflush = AUTOFLUSH.resolveModelAttribute(context, model).asBoolean();
+                    final boolean blockOnReconnect = BLOCK_ON_RECONNECT.resolveModelAttribute(context, model).asBoolean();
+                    final boolean enabled = ENABLED.resolveModelAttribute(context, model).asBoolean();
+
+                    final DelayedHandler delayedHandler = (DelayedHandler) configuration.getInstance();
+                    final String socketBindingName = OUTBOUND_SOCKET_BINDING_REF.resolveModelAttribute(context, model).asString();
+                    final ModelNode sslContextRef = SSL_CONTEXT.resolveModelAttribute(context, model);
+
+                    final ServiceName serviceName = Capabilities.HANDLER_CAPABILITY.getCapabilityServiceName(
+                            Capabilities.HANDLER_CAPABILITY.getDynamicName(context.getCurrentAddress()));
+                    final ServiceBuilder<?> serviceBuilder = context.getServiceTarget().addService(serviceName);
+
+                    final Supplier<OutboundSocketBinding> outboundSocketBinding = serviceBuilder.requires(
+                            context.getCapabilityServiceName(Capabilities.OUTBOUND_SOCKET_BINDING_CAPABILITY, socketBindingName,
+                                    OutboundSocketBinding.class)
+                    );
+                    final Supplier<SocketBindingManager> socketBindingManager = serviceBuilder.requires(
+                            context.getCapabilityServiceName(Capabilities.SOCKET_BINDING_MANAGER_CAPABILITY, SocketBindingManager.class)
+                    );
+                    final Supplier<SSLContext> sslContext;
+                    if (sslContextRef.isDefined()) {
+                        sslContext = serviceBuilder.requires(
+                                context.getCapabilityServiceName(Capabilities.SSL_CONTEXT_CAPABILITY, sslContextRef.asString(), SSLContext.class));
+                    } else {
+                        if (protocol == SocketHandler.Protocol.SSL_TCP) {
+                            // Attempt to use the default SSL context if a context reference was not set, but we're
+                            // using the SSL_TCP protocol
+                            try {
+                                sslContext = Functions.constantSupplier(SSLContext.getDefault());
+                            } catch (NoSuchAlgorithmException e) {
+                                throw LoggingLogger.ROOT_LOGGER.failedToConfigureSslContext(e, NAME, context.getCurrentAddressValue());
+                            }
+                        } else {
+                            // Not using SSL_TCP use a null value to be ignored in the WildFlyClientSocketFactory
+                            sslContext = Functions.constantSupplier(null);
+                        }
+                    }
+
+                    // A service needs to be used to ensure the dependent services are installed
+                    serviceBuilder.setInstance(new Service() {
+
+                        @Override
+                        public synchronized void start(final StartContext context) {
+                            final ClientSocketFactory clientSocketFactory = new WildFlyClientSocketFactory(socketBindingManager.get(),
+                                    outboundSocketBinding.get(), sslContext.get(), name);
+                            delayedHandler.setCloseChildren(true);
+                            final SocketHandler socketHandler = new SocketHandler(clientSocketFactory, protocol);
+                            socketHandler.setAutoFlush(autoflush);
+                            socketHandler.setBlockOnReconnect(blockOnReconnect);
+                            socketHandler.setEnabled(enabled);
+                            // Get the filter, formatter and level from the DelayedHandler.
+                            socketHandler.setFilter(delayedHandler.getFilter());
+                            socketHandler.setFormatter(delayedHandler.getFormatter());
+                            socketHandler.setLevel(delayedHandler.getLevel());
+                            // Clear any previous handlers and close them, then add the new handler
+                            final Handler[] current = delayedHandler.setHandlers(new Handler[] {socketHandler});
+                            if (current != null) {
+                                for (Handler handler : current) {
+                                    handler.close();
+                                }
+                            }
+                        }
+
+                        @Override
+                        public void stop(final StopContext context) {
+                            // Nothing to do on stop
+                        }
+                    }).install();
+                }
+            };
+        }
+    };
+
+    private static final OperationStepHandler REMOVE_HANDLER = new HandlerOperations.LogHandlerRemoveHandler() {
+        @Override
+        public void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
+            super.performRuntime(context, operation, model, logContextConfiguration);
+            context.addStep(new OperationStepHandler() {
+                @Override
+                public void execute(final OperationContext context, final ModelNode operation) {
+                    final ServiceName serviceName = Capabilities.HANDLER_CAPABILITY.getCapabilityServiceName(
+                            Capabilities.HANDLER_CAPABILITY.getDynamicName(context.getCurrentAddress()));
+                    context.removeService(serviceName);
+                }
+            }, Stage.RUNTIME);
+        }
+
+        @Override
+        protected void revertRuntime(final OperationContext context, final ModelNode operation, final ModelNode model, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
+            ADD_HANDLER.performRuntime(context, operation, model, logContextConfiguration);
+        }
+    };
+
+    public static final SocketHandlerResourceDefinition INSTANCE = new SocketHandlerResourceDefinition();
+
+    private SocketHandlerResourceDefinition() {
+        super(new Parameters(PATH, LoggingExtension.getResourceDescriptionResolver(NAME))
+                .setAddHandler(ADD_HANDLER)
+                .setRemoveHandler(REMOVE_HANDLER)
+                .setCapabilities(Capabilities.HANDLER_CAPABILITY)
+        );
+
+    }
+
+    @Override
+    public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
+        for (AttributeDefinition attribute : ATTRIBUTES) {
+            resourceRegistration.registerReadWriteAttribute(attribute, null, WriteAttributeHandler.INSTANCE);
+        }
+    }
+
+    @Override
+    public void registerTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder rootResourceBuilder,
+                                     final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+        switch (modelVersion) {
+            case VERSION_6_0_0:
+                rootResourceBuilder.rejectChildResource(getPathElement());
+                loggingProfileBuilder.rejectChildResource(getPathElement());
+                break;
+        }
+    }
+
+    private static class WriteAttributeHandler extends LoggingOperations.LoggingWriteAttributeHandler {
+        static final WriteAttributeHandler INSTANCE = new WriteAttributeHandler();
+
+        WriteAttributeHandler() {
+            super(ATTRIBUTES);
+        }
+
+        @SuppressWarnings("deprecation")
+        @Override
+        protected boolean applyUpdate(final OperationContext context, final String attributeName, final String addressName,
+                                      final ModelNode value, final LogContextConfiguration logContextConfiguration) throws OperationFailedException {
+
+            // First get the handler configuration.
+            final HandlerConfiguration configuration = logContextConfiguration.getHandlerConfiguration(addressName);
+            if (configuration == null) {
+                throw createOperationFailure(LoggingLogger.ROOT_LOGGER.handlerConfigurationNotFound(addressName));
+            }
+            // Handle writing the attribute
+            if (LEVEL.getName().equals(attributeName)) {
+                configuration.setLevel(value.asString());
+            } else if (NAMED_FORMATTER.getName().equals(attributeName)) {
+                if (value.isDefined()) {
+                    configuration.setFormatterName(value.asString());
+                } else {
+                    configuration.setFormatterName(null);
+                }
+            } else if (FILTER_SPEC.getName().equals(attributeName)) {
+                if (value.isDefined()) {
+                    configuration.setFilter(value.asString());
+                } else {
+                    configuration.setFilter(null);
+                }
+            }
+            return Logging.requiresReload(getAttributeDefinition(attributeName).getFlags());
+
+        }
+
+        @Override
+        protected OperationStepHandler afterCommit(final LogContextConfiguration logContextConfiguration,
+                                                   final String attributeName, final ModelNode resolvedValue, final ModelNode currentValue) {
+            return new OperationStepHandler() {
+                @Override
+                public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+                    final String addressName = context.getCurrentAddressValue();
+
+                    // First get the handler configuration.
+                    final HandlerConfiguration configuration = logContextConfiguration.getHandlerConfiguration(addressName);
+                    if (configuration == null) {
+                        throw createOperationFailure(LoggingLogger.ROOT_LOGGER.handlerConfigurationNotFound(addressName));
+                    }
+                    // Should always be a DelayedHandler
+                    Handler instance = configuration.getInstance();
+                    if (!(instance instanceof DelayedHandler)) {
+                        throw LoggingLogger.ROOT_LOGGER.invalidType(DelayedHandler.class, instance.getClass());
+                    }
+                    final DelayedHandler delayedHandler = (DelayedHandler) instance;
+
+                    // Should only contain a single handler which should be a socket handler
+                    final Handler[] children = delayedHandler.getHandlers();
+                    if (children == null || children.length == 0) {
+                        throw LoggingLogger.ROOT_LOGGER.invalidType(SocketHandler.class, null);
+                    }
+                    instance = children[0];
+                    if (!(instance instanceof SocketHandler)) {
+                        throw LoggingLogger.ROOT_LOGGER.invalidType(SocketHandler.class, instance.getClass());
+                    }
+                    final SocketHandler socketHandler = (SocketHandler) instance;
+
+                    // Only configure the socket-handler instance if the results are okay to keep
+                    context.completeStep(new OperationContext.ResultHandler() {
+                        @Override
+                        public void handleResult(final OperationContext.ResultAction resultAction, final OperationContext context, final ModelNode operation) {
+                            if (resultAction == OperationContext.ResultAction.KEEP) {
+                                // Handle writing the attribute
+                                if (LEVEL.getName().equals(attributeName)) {
+                                    socketHandler.setLevel(delayedHandler.getLevel());
+                                } else if (NAMED_FORMATTER.getName().equals(attributeName)) {
+                                    socketHandler.setFormatter(delayedHandler.getFormatter());
+                                } else if (FILTER_SPEC.getName().equals(attributeName)) {
+                                    socketHandler.setFilter(delayedHandler.getFilter());
+                                } else if (AUTOFLUSH.getName().equals(attributeName)) {
+                                    socketHandler.setAutoFlush(resolvedValue.asBoolean());
+                                } else if (BLOCK_ON_RECONNECT.getName().equals(attributeName)) {
+                                    socketHandler.setBlockOnReconnect(resolvedValue.asBoolean());
+                                } else if (ENABLED.getName().equals(attributeName)) {
+                                    socketHandler.setEnabled(resolvedValue.asBoolean());
+                                } else if (PROTOCOL.getName().equals(attributeName)) {
+                                    socketHandler.setProtocol(SocketHandler.Protocol.valueOf(resolvedValue.asString()));
+                                }
+                            }
+                        }
+                    });
+                }
+            };
+        }
+    }
+
+    private static class WildFlyClientSocketFactory implements ClientSocketFactory {
+        private final SocketBindingManager socketBinding;
+        private final OutboundSocketBinding outboundSocketBinding;
+        private final String name;
+        private final SSLContext sslContext;
+
+        private WildFlyClientSocketFactory(final SocketBindingManager socketBinding,
+                                           final OutboundSocketBinding outboundSocketBinding, final SSLContext sslContext,
+                                           final String name) {
+            this.socketBinding = socketBinding;
+            this.outboundSocketBinding = outboundSocketBinding;
+            this.sslContext = sslContext;
+            this.name = name;
+        }
+
+        @Override
+        public DatagramSocket createDatagramSocket() throws SocketException {
+            return socketBinding.createDatagramSocket(name);
+        }
+
+        @Override
+        public Socket createSocket() throws IOException {
+            if (sslContext != null) {
+                return sslContext.getSocketFactory().createSocket(getAddress(), getPort());
+            }
+            return outboundSocketBinding.connect();
+        }
+
+        @Override
+        public InetAddress getAddress() {
+            try {
+                return outboundSocketBinding.getResolvedDestinationAddress();
+            } catch (UnknownHostException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public int getPort() {
+            return outboundSocketBinding.getDestinationPort();
+        }
+    }
+
+    private static class DiscardingHandler extends Handler {
+
+        @Override
+        public void publish(final LogRecord record) {
+            // Do nothing
+        }
+
+        @Override
+        public void flush() {
+            // Do nothing
+        }
+
+        @Override
+        public void close() throws SecurityException {
+            // Do nothing
+        }
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/logging/LoggingLogger.java
@@ -953,4 +953,27 @@ public interface LoggingLogger extends BasicLogger {
      */
     @Message(id = 91, value = "Exception output type %s is invalid.")
     OperationFailedException invalidExceptionOutputType(String value);
+
+    /**
+     * Creates an exception indicating the types is invalid.
+     *
+     * @param expected the expected type
+     * @param found    the found type
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 92, value = "Invalid type found. Expected %s but found %s.")
+    OperationFailedException invalidType(Class<?> expected, Class<?> found);
+
+    /**
+     * Creates an exception indicating a failure to configure the SSL context.
+     *
+     * @param cause         the cause of the error
+     * @param resourceName  the name of the resource
+     * @param resourceValue the resource value
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 93, value = "Failed to configure SSL context for %s %s.")
+    OperationFailedException failedToConfigureSslContext(@Cause Throwable cause, String resourceName, String resourceValue);
 }

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -566,6 +566,30 @@ logging.custom-handler.filter.pattern=The pattern to match
 logging.custom-handler.filter.replacement=The string replacement
 logging.custom-handler.filter.replace-all=True if all occurrences should be replaced; false if only the first occurrence
 
+# Socket handler definitions
+logging.socket-handler=Defines a handler which writes to a socket. Note that a socket-handler will queue messages \
+  during the boot process. These messages will be drained to the socket once the resource is fully configured. If the \
+  server is in admin-only state messages will be discarded.
+# Operations
+logging.socket-handler.add=Add a new socket handler.
+logging.socket-handler.remove=Removes the socket handler.
+# Attributes
+logging.socket-handler.autoflush=Automatically flush after each write.
+logging.socket-handler.block-on-reconnect=If set to true the write methods will block when attempting to reconnect. This \
+  is only advisable to be set to true if using an asynchronous handler.
+logging.socket-handler.enabled=If set to true the handler is enabled and functioning as normal, if set to false the \
+  handler is ignored when processing log messages.
+logging.socket-handler.encoding=The character encoding used by this Handler.
+logging.socket-handler.filter-spec=A filter expression value to define a filter. Example for a filter that does not \
+  match a pattern: not(match("JBAS.*"))
+logging.socket-handler.level=The log level specifying which message levels will be logged by this logger. Message \
+  levels lower than this value will be discarded.
+logging.socket-handler.named-formatter=The name of the defined formatter to be used on the handler.
+logging.socket-handler.outbound-socket-binding-ref=Outbound socket reference for the socket connection.
+logging.socket-handler.protocol=The protocol the socket should communicate over.
+logging.socket-handler.ssl-context=The reference to the defined SSL context. This is only used if the protocol is set \
+  to SSL_TCP.
+
 # Syslog handler definitions
 logging.syslog-handler=Defines a syslog handler.
 # Operations

--- a/logging/src/main/resources/schema/jboss-as-logging_6_0.xsd
+++ b/logging/src/main/resources/schema/jboss-as-logging_6_0.xsd
@@ -1,0 +1,789 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:logging:6.0"
+           xmlns="urn:jboss:domain:logging:6.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="6.0">
+
+    <!-- The logging subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the logging subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="logger" type="loggerType"/>
+            <xs:element name="root-logger" type="rootLoggerType"/>
+            <xs:element name="console-handler" type="consoleHandlerType"/>
+            <xs:element name="file-handler" type="fileHandlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
+            <xs:element name="periodic-size-rotating-file-handler" type="periodicSizeFileHandlerType"/>
+            <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="async-handler" type="asyncHandlerType"/>
+            <xs:element name="custom-handler" type="customHandlerType"/>
+            <xs:element name="syslog-handler" type="syslogHandlerType"/>
+            <xs:element name="formatter" type="formatterType"/>
+            <xs:element name="add-logging-api-dependencies" type="booleanTrueValueType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Determines whether or not the default logging dependencies should be added to deployments during the deployment process.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="use-deployment-logging-config" type="booleanTrueValueType">
+                <xs:annotation>
+                    <xs:documentation>
+                        Determines whether or not deployments should be scanned for configuration files. If set to
+                        true and a configuration file is found the log manager will be configured based on the
+                        configuration file.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="logging-profiles" type="logging-profilesType" minOccurs="0" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="logging-profilesType">
+        <xs:annotation>
+            <xs:documentation>
+                Contains a list of profiles available for use in deployments
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="logging-profile" type="logging-profileType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="logging-profileType">
+        <xs:annotation>
+            <xs:documentation>
+                A logging profile that can be used in a deployment for a custom logging configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="logger" type="loggerType"/>
+            <xs:element name="root-logger" type="rootLoggerType"/>
+            <xs:element name="console-handler" type="consoleHandlerType"/>
+            <xs:element name="file-handler" type="fileHandlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
+            <xs:element name="periodic-size-rotating-file-handler" type="periodicSizeFileHandlerType"/>
+            <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="async-handler" type="asyncHandlerType"/>
+            <xs:element name="custom-handler" type="customHandlerType"/>
+            <xs:element name="syslog-handler" type="syslogHandlerType"/>
+            <xs:element name="formatter" type="formatterType"/>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of free-form properties.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="value" type="xs:string" use="optional"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="refType">
+        <xs:annotation>
+            <xs:documentation>
+                A named reference to another object.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlersType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of handlers to apply to the enclosing object.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="handler" type="refType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="rootLoggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines the root logger for this log context.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all minOccurs="1" maxOccurs="1">
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="handlers" type="handlersType" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="loggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a logger category.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="rootLoggerType">
+                <xs:attribute name="use-parent-handlers" type="xs:boolean" use="optional" default="true"/>
+                <xs:attribute name="category" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="consoleHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to the console.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="target" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="name" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="System.out"/>
+                                <xs:enumeration value="System.err"/>
+                                <xs:enumeration value="console"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="fileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType" minOccurs="1"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="periodicFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after a time period derived from the given
+                suffix string, which should be in a format understood by java.text.SimpleDateFormat.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="suffix" type="valueType"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="periodicSizeFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after the size of the file grows beyond a
+                certain point or the time period derived from the given suffix string and keeping a fixed number of
+                backups. The suffix should be in a format understood by java.text.SimpleDateFormat.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
+            <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
+            <xs:element name="suffix" type="valueType"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="rotate-on-boot" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="sizeFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after the size of the file grows beyond a
+                certain point and keeping a fixed number of backups.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
+            <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
+            <xs:element name="suffix" type="valueType" minOccurs="0"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="rotate-on-boot" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="asyncHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to the sub-handlers in an asynchronous thread. Used for handlers which
+                introduce a substantial amount of lag.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="queue-length" type="queueLengthType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="overflow-action" type="overflowActionType" minOccurs="0"/>
+            <xs:element name="subhandlers" type="handlersType"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="customHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a custom handler.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="module" type="xs:string" use="required"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="syslogHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a syslog handler for UNIX/Linux based operating systems.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="server-address" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The address of the syslog server. The default is localhost.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hostname" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the host the messages are being sent from. For example the name of the host the
+                        application server is running on.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="port" type="positiveIntType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The port the syslog server is listening on. The default is 514.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="app-name" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The app name used when formatting the message in RFC5424 format. By default the app name is
+                        &quot;java&quot;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="formatter" type="syslogFormatterType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="facility" type="facilityType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="queueLengthType">
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:positiveInteger">
+                    <xs:minExclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="overflowActionType">
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="block"/>
+                    <xs:enumeration value="discard"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="positiveIntType">
+        <xs:attribute name="value" use="required" type="xs:positiveInteger"/>
+    </xs:complexType>
+
+    <xs:complexType name="booleanValueType">
+        <xs:attribute name="value" use="required" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="booleanTrueValueType">
+        <xs:attribute name="value" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="valueType">
+        <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="pathType">
+        <xs:attribute name="relative-to" use="optional" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="sizeType">
+        <xs:attribute name="value">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <!-- XSD doesn't allow ^ or $ so ^[0-9]+[bkmgtp]?$ is invalid -->
+                    <xs:pattern value="[0-9]+[bkmgtp]"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="facilityType">
+        <xs:annotation>
+            <xs:documentation>
+                Facility as defined by RFC-5424 (http://tools.ietf.org/html/rfc5424)and RFC-3164
+                (http://tools.ietf.org/html/rfc3164).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="kernel"/>
+                    <xs:enumeration value="user-level"/>
+                    <xs:enumeration value="mail-system"/>
+                    <xs:enumeration value="system-daemons"/>
+                    <xs:enumeration value="security"/>
+                    <xs:enumeration value="syslogd"/>
+                    <xs:enumeration value="line-printer"/>
+                    <xs:enumeration value="network-news"/>
+                    <xs:enumeration value="uucp"/>
+                    <xs:enumeration value="clock-daemon"/>
+                    <xs:enumeration value="security2"/>
+                    <xs:enumeration value="ftp-daemon"/>
+                    <xs:enumeration value="ntp"/>
+                    <xs:enumeration value="log-audit"/>
+                    <xs:enumeration value="log-alert"/>
+                    <xs:enumeration value="clock-daemon2"/>
+                    <xs:enumeration value="local-use-0"/>
+                    <xs:enumeration value="local-use-1"/>
+                    <xs:enumeration value="local-use-2"/>
+                    <xs:enumeration value="local-use-3"/>
+                    <xs:enumeration value="local-use-4"/>
+                    <xs:enumeration value="local-use-5"/>
+                    <xs:enumeration value="local-use-6"/>
+                    <xs:enumeration value="local-use-7"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!-- Formatters -->
+
+    <xs:complexType name="formatterType">
+        <xs:annotation>
+            <xs:documentation>
+                A formatter that can be assigned to a handler.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="pattern-formatter" type="patternFormatterType" maxOccurs="1"/>
+            <xs:element name="custom-formatter" type="customFormatterType" maxOccurs="1"/>
+            <xs:element name="json-formatter" type="structuredFormatterType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Defines a JSON formatter to be used to format log messages.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="xml-formatter" type="xmlFormatterType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Defines a XML formatter to be used to format log messages.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlerFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a formatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="pattern-formatter" type="handlerPatternFormatterType" maxOccurs="1"/>
+            <xs:element name="named-formatter" type="namedFormatterType" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="handlerPatternFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a pattern formatter. See the documentation for
+                org.jboss.logmanager.formatters.FormatStringParser
+                for more information about the format string.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="patternFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a pattern formatter. See the documentation for
+                org.jboss.logmanager.formatters.FormatStringParser
+                for more information about the format string.
+
+                The color-map attribute allows for a comma delimited list of colors to be used for different levels. The
+                format is level-name:color-name.
+
+                Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest
+
+                Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred,
+                brightgreen,
+                brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The format pattern as defined in org.jboss.logmanager.formatters.FormatStringParser.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="color-map" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The color-map attribute allows for a comma delimited list of colors to be used for different levels.
+                    The
+                    format is level-name:color-name.
+
+                    Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest
+
+                    Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred,
+                    brightgreen,
+                    brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="structuredFormatterType">
+        <xs:all>
+            <xs:element name="exception-output-type" type="exceptionOutputType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Indicates how the cause of the logged message, if one is available, will be added to the output.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="record-delimiter" type="valueType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The value to be used to indicate the end of a record. If set to null no delimiter will be used
+                        at the end of the record. The default value is a line feed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="key-overrides" type="keyOverrideType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Allows the names of the keys or elements for the properties to be overridden.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="meta-data" type="propertiesType" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the meta data to use in the structured format. Properties will be added to each log message.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="date-format" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The date/time format pattern. The pattern must be a valid
+                    java.time.format.DateTimeFormatter.ofPattern() pattern.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="pretty-print" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Indicates whether or not pretty printing should be used when formatting.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="print-details" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets whether or not details should be printed. Printing the details can be expensive as the values
+                    are retrieved from the caller. The details include the source class name, source file name, source
+                    method name and source line number.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="zone-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The zone ID for formatting the date and time. The system default is used if left undefined.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="xmlFormatterType">
+        <xs:complexContent>
+            <xs:extension base="structuredFormatterType">
+                <xs:attribute name="namespace-uri" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Allows the namespace to be overridden. If not defined a default will be used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="print-namespace" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Indicates whether or no the namespace should be added to each record element.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="customFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                Defines a formatter to be used to format log messages.
+
+                Note that most log records are formatted in the printf format. Formatters may require invocation of org.jboss.logmanager.ExtLogRecord#getFormattedMessage() for the message to be properly formatted.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="module" type="xs:string" use="required"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="namedFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                The name of a defined formatter that will be used to format the log message.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="exceptionOutputType">
+        <xs:annotation>
+            <xs:documentation>
+                Set the output type for exceptions. The default is detailed.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="detailed">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cause, if present, will be an array of stack trace elements. This will include
+                                suppressed exceptions and the cause of the exception.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="formatted">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cause, if present, will be a string representation of the stack trace in a
+                                stackTrace property. The property value is a string created by
+                                Throwable.printStackTrace().
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="detailed-and-formatted">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cause, if present, will be a string representation of the stack trace in a
+                                stackTrace property. The property value is a string created by
+                                Throwable.printStackTrace().
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="keyOverrideType">
+        <xs:attribute name="exception" type="xs:string"/>
+        <xs:attribute name="exception-caused-by" type="xs:string"/>
+        <xs:attribute name="exception-circular-reference" type="xs:string"/>
+        <xs:attribute name="exception-frame" type="xs:string"/>
+        <xs:attribute name="exception-frame-class" type="xs:string"/>
+        <xs:attribute name="exception-frame-line" type="xs:string"/>
+        <xs:attribute name="exception-frame-method" type="xs:string"/>
+        <xs:attribute name="exception-frames" type="xs:string"/>
+        <xs:attribute name="exception-message" type="xs:string"/>
+        <xs:attribute name="exception-reference-id" type="xs:string"/>
+        <xs:attribute name="exception-suppressed" type="xs:string"/>
+        <xs:attribute name="exception-type" type="xs:string"/>
+        <xs:attribute name="host-name" type="xs:string"/>
+        <xs:attribute name="level" type="xs:string"/>
+        <xs:attribute name="logger-class-name" type="xs:string"/>
+        <xs:attribute name="logger-name" type="xs:string"/>
+        <xs:attribute name="mdc" type="xs:string"/>
+        <xs:attribute name="message" type="xs:string"/>
+        <xs:attribute name="ndc" type="xs:string"/>
+        <xs:attribute name="process-id" type="xs:string"/>
+        <xs:attribute name="process-name" type="xs:string"/>
+        <xs:attribute name="record" type="xs:string"/>
+        <xs:attribute name="sequence" type="xs:string"/>
+        <xs:attribute name="source-class-name" type="xs:string"/>
+        <xs:attribute name="source-file-name" type="xs:string"/>
+        <xs:attribute name="source-line-number" type="xs:string"/>
+        <xs:attribute name="source-method-name" type="xs:string"/>
+        <xs:attribute name="source-module-name" type="xs:string"/>
+        <xs:attribute name="source-module-version" type="xs:string"/>
+        <xs:attribute name="stack-trace" type="xs:string"/>
+        <xs:attribute name="thread-id" type="xs:string"/>
+        <xs:attribute name="thread-name" type="xs:string"/>
+        <xs:attribute name="timestamp" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="syslogFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a formatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="syslog-format" type="syslogFormatType" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="syslogFormatType">
+        <xs:annotation>
+            <xs:documentation>
+                Formats the log message according to the RFC specification.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="syslog-type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="RFC5424">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Formats the message according the the RFC-5424 specification
+                                (http://tools.ietf.org/html/rfc5424#section-6)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="RFC3164">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Formats the message according the the RFC-3164 specification
+                                (http://tools.ietf.org/html/rfc3164#section-4.1)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/logging/src/main/resources/schema/jboss-as-logging_6_0.xsd
+++ b/logging/src/main/resources/schema/jboss-as-logging_6_0.xsd
@@ -45,6 +45,7 @@
             <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
             <xs:element name="periodic-size-rotating-file-handler" type="periodicSizeFileHandlerType"/>
             <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="socket-handler" type="socketHandlerType"/>
             <xs:element name="async-handler" type="asyncHandlerType"/>
             <xs:element name="custom-handler" type="customHandlerType"/>
             <xs:element name="syslog-handler" type="syslogHandlerType"/>
@@ -96,6 +97,7 @@
             <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
             <xs:element name="periodic-size-rotating-file-handler" type="periodicSizeFileHandlerType"/>
             <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="socket-handler" type="socketHandlerType"/>
             <xs:element name="async-handler" type="asyncHandlerType"/>
             <xs:element name="custom-handler" type="customHandlerType"/>
             <xs:element name="syslog-handler" type="syslogHandlerType"/>
@@ -321,6 +323,39 @@
         <xs:attribute name="module" type="xs:string" use="required"/>
         <xs:attribute name="class" type="xs:string" use="required"/>
         <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="socketHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a socket.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="named-formatter" type="namedFormatterType"/>
+            <xs:element name="protocol" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="value" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="SSL_TCP"/>
+                                <xs:enumeration value="TCP"/>
+                                <xs:enumeration value="UDP"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" default="true"/>
+        <xs:attribute name="block-on-reconnect" type="xs:boolean" default="false"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" default="true"/>
+        <xs:attribute name="outbound-socket-binding-ref" type="xs:string" use="required"/>
+        <xs:attribute name="ssl-context" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="syslogHandlerType">

--- a/logging/src/main/resources/subsystem-templates/logging.xml
+++ b/logging/src/main/resources/subsystem-templates/logging.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
    <extension-module>org.jboss.as.logging</extension-module>
-   <subsystem xmlns="urn:jboss:domain:logging:5.0">
+   <subsystem xmlns="urn:jboss:domain:logging:6.0">
        <?HANDLERS?>
        <periodic-rotating-file-handler name="FILE" autoflush="true">
            <formatter>

--- a/logging/src/test/java/org/jboss/as/logging/AbstractOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/AbstractOperationsTestCase.java
@@ -55,11 +55,11 @@ public abstract class AbstractOperationsTestCase extends AbstractLoggingSubsyste
 
     @After
     @Override
-    public void clearLogContext() {
+    public void clearLogContext() throws Exception {
         super.clearLogContext();
         final LoggingProfileContextSelector contextSelector = LoggingProfileContextSelector.getInstance();
         if (contextSelector.exists(PROFILE)) {
-            clearLogContext(contextSelector.get(PROFILE));
+            contextSelector.get(PROFILE).close();
             contextSelector.remove(PROFILE);
         }
     }

--- a/logging/src/test/java/org/jboss/as/logging/FormatterOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/FormatterOperationsTestCase.java
@@ -61,11 +61,11 @@ public class FormatterOperationsTestCase extends AbstractOperationsTestCase {
 
     @After
     @Override
-    public void clearLogContext() {
+    public void clearLogContext() throws Exception {
         super.clearLogContext();
         final LoggingProfileContextSelector contextSelector = LoggingProfileContextSelector.getInstance();
         if (contextSelector.exists(PROFILE)) {
-            clearLogContext(contextSelector.get(PROFILE));
+            contextSelector.get(PROFILE).close();
             contextSelector.remove(PROFILE);
         }
     }

--- a/logging/src/test/java/org/jboss/as/logging/LoggingOperationsSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingOperationsSubsystemTestCase.java
@@ -86,11 +86,11 @@ public class LoggingOperationsSubsystemTestCase extends AbstractLoggingSubsystem
 
     @After
     @Override
-    public void clearLogContext() {
+    public void clearLogContext() throws Exception {
         super.clearLogContext();
         final LoggingProfileContextSelector contextSelector = LoggingProfileContextSelector.getInstance();
         if (contextSelector.exists(PROFILE)) {
-            clearLogContext(contextSelector.get(PROFILE));
+            contextSelector.get(PROFILE).close();
             contextSelector.remove(PROFILE);
         }
     }

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemRollbackTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemRollbackTestCase.java
@@ -61,11 +61,11 @@ public class LoggingSubsystemRollbackTestCase extends AbstractLoggingSubsystemTe
 
     @After
     @Override
-    public void clearLogContext() {
+    public void clearLogContext() throws Exception {
         super.clearLogContext();
         final LoggingProfileContextSelector contextSelector = LoggingProfileContextSelector.getInstance();
         if (contextSelector.exists(PROFILE_NAME)) {
-            clearLogContext(contextSelector.get(PROFILE_NAME));
+            contextSelector.get(PROFILE_NAME).close();
             contextSelector.remove(PROFILE_NAME);
         }
     }

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -158,6 +158,10 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append("json-formatter"),
                                 FailedOperationTransformationConfig.REJECTED_RESOURCE)
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append("xml-formatter"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append("socket-handler"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(loggingProfileAddress.append("socket-handler"),
                                 FailedOperationTransformationConfig.REJECTED_RESOURCE));
     }
 
@@ -177,6 +181,10 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append("json-formatter"),
                                 FailedOperationTransformationConfig.REJECTED_RESOURCE)
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append("xml-formatter"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append("socket-handler"),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS.append(CommonAttributes.LOGGING_PROFILE).append("socket-handler"),
                                 FailedOperationTransformationConfig.REJECTED_RESOURCE));
     }
 
@@ -188,7 +196,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         builder.createLegacyKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance(), controllerVersion, legacyModelVersion)
                 .addMavenResourceURL(controllerVersion.getCoreMavenGroupId() + ":wildfly-logging:" + controllerVersion.getCoreVersion())
                 .dontPersistXml()
-                .addSingleChildFirstClass(LoggingTestEnvironment.class, LoggingTestEnvironment.LoggingInitializer.class)
+                .addSingleChildFirstClass(LoggingTestEnvironment.class)
                 .configureReverseControllerCheck(LoggingTestEnvironment.getManagementInstance(), null);
 
         KernelServices mainServices = builder.build();
@@ -208,7 +216,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         builder.createLegacyKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance(), controllerVersion, legacyModelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-logging:" + controllerVersion.getMavenGavVersion())
                 .dontPersistXml()
-                .addSingleChildFirstClass(LoggingTestEnvironment.class, LoggingTestEnvironment.LoggingInitializer.class)
+                .addSingleChildFirstClass(LoggingTestEnvironment.class)
                 .configureReverseControllerCheck(LoggingTestEnvironment.getManagementInstance(), null);
 
         KernelServices mainServices = builder.build();
@@ -226,7 +234,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         builder.createLegacyKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance(), controllerVersion, legacyModelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-logging:" + controllerVersion.getMavenGavVersion())
                 .dontPersistXml()
-                .addSingleChildFirstClass(LoggingTestEnvironment.class, LoggingTestEnvironment.LoggingInitializer.class)
+                .addSingleChildFirstClass(LoggingTestEnvironment.class)
                 .configureReverseControllerCheck(LoggingTestEnvironment.getManagementInstance(), null);
 
 
@@ -248,7 +256,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         builder.createLegacyKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance(), controllerVersion, legacyModelVersion)
                 .addMavenResourceURL(controllerVersion.getCoreMavenGroupId() + ":wildfly-logging:" + controllerVersion.getCoreVersion())
                 .dontPersistXml()
-                .addSingleChildFirstClass(LoggingTestEnvironment.class, LoggingTestEnvironment.LoggingInitializer.class)
+                .addSingleChildFirstClass(LoggingTestEnvironment.class)
                 .configureReverseControllerCheck(LoggingTestEnvironment.getManagementInstance(), null);
 
 

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -71,7 +71,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/jboss-as-logging_5_0.xsd";
+        return "schema/jboss-as-logging_6_0.xsd";
     }
 
     @Test

--- a/logging/src/test/resources/default-subsystem.xml
+++ b/logging/src/test/resources/default-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:5.0">
+<subsystem xmlns="urn:jboss:domain:logging:6.0">
     <console-handler name="CONSOLE">
         <level name="INFO"/>
         <formatter>

--- a/logging/src/test/resources/empty-subsystem.xml
+++ b/logging/src/test/resources/empty-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:5.0">
+<subsystem xmlns="urn:jboss:domain:logging:6.0">
 
     <!-- Set-up a default logging profile -->
     <logging-profiles>

--- a/logging/src/test/resources/expressions.xml
+++ b/logging/src/test/resources/expressions.xml
@@ -89,6 +89,15 @@
         <suffix value="${test.file.suffix:.yyyy-MM-dd'T'HH:mm:ssZ}"/>
     </size-rotating-file-handler>
 
+    <socket-handler name="socket-handler" autoflush="${test.autoflush:true}" block-on-reconnect="${test.reconnect:true}"
+                    enabled="${test.enableddd:true}" outbound-socket-binding-ref="${test.socket-binding:true}">
+        <encoding value="${test.encoding:UTF-8}"/>
+        <filter-spec value="${test.pattern:match(&quot;.*&quot;)}"/>
+        <level name="${test.file.level:INFO}"/>
+        <named-formatter name="PATTERN"/>
+        <protocol value="${test.protocol:UDP}"/>
+    </socket-handler>
+
     <syslog-handler name="syslog" enabled="${test.syslog.enabled:false}">
         <level name="${test.default.level:INFO}"/>
         <server-address value="${test.syslog.server-address:127.0.0.1}"/>
@@ -198,6 +207,15 @@
                 <append value="${test.file.append:false}"/>
                 <suffix value="${test.file.suffix:.yyyy-MM-dd'T'HH:mm:ssZ}"/>
             </size-rotating-file-handler>
+
+            <socket-handler name="socket-handler" autoflush="${test.autoflush:true}" block-on-reconnect="${test.reconnect:true}"
+                            enabled="${test.enableddd:true}" outbound-socket-binding-ref="${test.socket-binding:true}">
+                <encoding value="${test.encoding:UTF-8}"/>
+                <filter-spec value="${test.pattern:match(&quot;.*&quot;)}"/>
+                <level name="${test.file.level:INFO}"/>
+                <named-formatter name="PATTERN"/>
+                <protocol value="${test.protocol:UDP}"/>
+            </socket-handler>
 
             <syslog-handler name="syslog" enabled="${test.syslog.enabled:false}">
                 <level name="${test.default.level:INFO}"/>

--- a/logging/src/test/resources/expressions_5_0.xml
+++ b/logging/src/test/resources/expressions_5_0.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:6.0">
+<subsystem xmlns="urn:jboss:domain:logging:5.0">
     <add-logging-api-dependencies value="${test.add.deps:true}"/>
     <use-deployment-logging-config value="${test.use.dep.config:true}"/>
 

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -113,6 +113,14 @@
         <suffix value=".yyyy-MM-dd'T'HH:mm:ssZ"/>
     </size-rotating-file-handler>
 
+    <socket-handler name="socket-handler" autoflush="false" block-on-reconnect="true" enabled="false" outbound-socket-binding-ref="log-server">
+        <encoding value="UTF-8"/>
+        <filter-spec value="not(match(&quot;TEST&quot;))"/>
+        <level name="INFO"/>
+        <named-formatter name="PATTERN"/>
+        <protocol value="UDP"/>
+    </socket-handler>
+
     <syslog-handler name="syslog" enabled="false">
         <level name="INFO"/>
         <server-address value="127.0.0.1"/>
@@ -223,6 +231,14 @@
                 <append value="false"/>
                 <suffix value=".yyyy-MM-dd'T'HH:mm:ssZ"/>
             </size-rotating-file-handler>
+
+            <socket-handler name="socket-handler" autoflush="false" block-on-reconnect="true" enabled="false" outbound-socket-binding-ref="log-server">
+                <encoding value="UTF-8"/>
+                <filter-spec value="not(match(&quot;TEST&quot;))"/>
+                <level name="INFO"/>
+                <named-formatter name="PATTERN"/>
+                <protocol value="UDP"/>
+            </socket-handler>
 
             <syslog-handler name="syslog">
                 <level name="WARN"/>

--- a/logging/src/test/resources/logging_5_0.xml
+++ b/logging/src/test/resources/logging_5_0.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:6.0">
+<subsystem xmlns="urn:jboss:domain:logging:5.0">
     <add-logging-api-dependencies value="false"/>
     <use-deployment-logging-config value="false"/>
 

--- a/logging/src/test/resources/operations.xml
+++ b/logging/src/test/resources/operations.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:logging:5.0">
+<subsystem xmlns="urn:jboss:domain:logging:6.0">
     <console-handler name="CONSOLE">
         <level name="INFO"/>
         <formatter>

--- a/logging/src/test/resources/rollback-logging.xml
+++ b/logging/src/test/resources/rollback-logging.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:5.0">
+<subsystem xmlns="urn:jboss:domain:logging:6.0">
 
     <console-handler name="CONSOLE">
         <level name="INFO"/>

--- a/logging/src/test/resources/simple-subsystem.xml
+++ b/logging/src/test/resources/simple-subsystem.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:logging:5.0">
+<subsystem xmlns="urn:jboss:domain:logging:6.0">
 
     <file-handler name="FILE" autoflush="true">
         <formatter>

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ControllerInitializer.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ControllerInitializer.java
@@ -300,7 +300,7 @@ public class ControllerInitializer {
      * @param ops the operations list to add our ops to
      */
     protected void initializeSocketBindingsOperations(List<ModelNode> ops) {
-        if (socketBindings.size() == 0) {
+        if (socketBindings.isEmpty() && outboundSocketBindings.isEmpty()) {
             return;
         }
 

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/JsonLogServer.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/JsonLogServer.java
@@ -1,0 +1,355 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.logging;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.net.ServerSocketFactory;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLServerSocketFactory;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+
+/**
+ * A simple log server that assumes JSON messages are being sent with a separator of {@code \n}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public abstract class JsonLogServer implements Runnable, AutoCloseable {
+
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final ExecutorService service;
+    private final BlockingQueue<JsonObject> queue;
+    private final CountDownLatch latch;
+
+    private JsonLogServer() {
+        service = Executors.newSingleThreadExecutor(r -> {
+            final Thread thread = new Thread(r);
+            thread.setDaemon(true);
+            return thread;
+        });
+        queue = new LinkedBlockingQueue<>();
+        latch = new CountDownLatch(1);
+    }
+
+    /**
+     * Creates a new TCP listening log server.
+     *
+     * @param port the port to listen on
+     *
+     * @return the log server
+     */
+    public static JsonLogServer createTcpServer(final int port) {
+        return new TcpServer(ServerSocketFactory.getDefault(), port);
+    }
+
+    /**
+     * Creates a new SSL TCP listening log server.
+     * <p>
+     * This uses the {@link SSLServerSocketFactory#getDefault()} to get an SSL server socket.
+     * </p>
+     *
+     * @param port the port to listen on
+     *
+     * @return the log server
+     */
+    public static JsonLogServer createTlsServer(final int port, final Path keystorePath, final String keystorePassword) throws Exception {
+        KeyManager[] keyManagers;
+        final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        try (InputStream in = Files.newInputStream(keystorePath)) {
+            final KeyStore ks = KeyStore.getInstance("JKS");
+            ks.load(in, keystorePassword.toCharArray());
+            kmf.init(ks, keystorePassword.toCharArray());
+            keyManagers = kmf.getKeyManagers();
+        }
+
+        final SSLContext context = SSLContext.getInstance("TLS");
+        context.init(keyManagers, null, null);
+        return new TcpServer(context.getServerSocketFactory(), port);
+    }
+
+    /**
+     * Creates a new UDP listening log server.
+     *
+     * @param port the port to listen on
+     *
+     * @return the log server
+     */
+    public static JsonLogServer createUdpServer(final int port) {
+        return new UdpServer(port);
+    }
+
+    /**
+     * Starts the log server.
+     *
+     * @param timeout the timeout
+     */
+    public void start(final long timeout) throws InterruptedException {
+        if (started.compareAndSet(false, true)) {
+            service.submit(this);
+            if (!latch.await(timeout, TimeUnit.MILLISECONDS)) {
+                stop();
+                throw new RuntimeException(String.format("Failed to start server within %d milliseconds", timeout));
+            }
+        }
+    }
+
+    /**
+     * Stops the log server.
+     */
+    public void stop() {
+        started.set(false);
+        queue.clear();
+    }
+
+    /**
+     * Indicates whether or not the log server is running.
+     *
+     * @return {@code true} if the log server is running, otherwise {@code false}
+     */
+    @SuppressWarnings("WeakerAccess")
+    public boolean isRunning() {
+        return started.get();
+    }
+
+    /**
+     * Gets the next log message that was logged. This can be invoked until {@code null} is returned, however
+     * {@code null} won't be returned until the timeout is reached. It is best to invoke this a known number of times
+     * to not stall testing.
+     *
+     * @param timeout the timeout to wait for the log message to be completely logged
+     *
+     * @return the next log message found or {@code null} if the timeout occurred before the log message was received
+     *
+     * @throws InterruptedException if waiting for the log message was interrupted
+     */
+    public JsonObject getLogMessage(final long timeout) throws InterruptedException {
+        return queue.poll(timeout, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            stop();
+        } finally {
+            service.shutdown();
+            service.awaitTermination(TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+        }
+    }
+
+    private static class TcpServer extends JsonLogServer {
+        private final ExecutorService executor;
+        private final ServerSocketFactory serverSocketFactory;
+        private final int port;
+        private final AtomicInteger clientCount = new AtomicInteger();
+        private final Deque<EchoClient> clients = new ArrayDeque<>();
+        // Guarded by this
+        private ServerSocket serverSocket;
+
+        private TcpServer(final ServerSocketFactory serverSocketFactory, final int port) {
+            executor = Executors.newCachedThreadPool(r -> {
+                final Thread thread = new Thread(r);
+                thread.setDaemon(true);
+                thread.setName("Echo Client-" + clientCount.incrementAndGet());
+                return thread;
+            });
+            this.serverSocketFactory = serverSocketFactory;
+            this.port = port;
+        }
+
+        @Override
+        public void run() {
+            try {
+                synchronized (this) {
+                    serverSocket = serverSocketFactory.createServerSocket(port);
+                    super.latch.countDown();
+                }
+                while (isRunning()) {
+                    final EchoClient client = new EchoClient(serverSocket.accept(), super.queue);
+                    synchronized (clients) {
+                        clients.addLast(client);
+                    }
+                    executor.submit(client);
+                }
+            } catch (IOException e) {
+                stop();
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void stop() {
+            try {
+                synchronized (this) {
+                    uncheckedClose(serverSocket);
+                    serverSocket = null;
+                    clientCount.set(0);
+                }
+                synchronized (clients) {
+                    EchoClient client;
+                    while ((client = clients.pollFirst()) != null) {
+                        uncheckedClose(client);
+                    }
+                }
+            } finally {
+                super.stop();
+            }
+        }
+    }
+
+    private static class UdpServer extends JsonLogServer {
+        private final int port;
+        // Guarded by this
+        private DatagramSocket socket;
+
+        private UdpServer(final int port) {
+            this.port = port;
+        }
+
+        @Override
+        public void run() {
+            synchronized (this) {
+                try {
+                    socket = new DatagramSocket(port);
+                    super.latch.countDown();
+                } catch (SocketException e) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+            try {
+                while (isRunning()) {
+                    final DatagramPacket packet = new DatagramPacket(new byte[2048], 2048);
+                    socket.receive(packet);
+                    try (JsonReader reader = Json.createReader(new ByteArrayInputStream(packet.getData()))) {
+                        super.queue.offer(reader.readObject());
+                    }
+                }
+            } catch (IOException e) {
+                if (isRunning()) {
+                    throw new UncheckedIOException(e);
+                }
+            }
+        }
+
+        @Override
+        public void stop() {
+            try {
+                synchronized (this) {
+                    uncheckedClose(socket);
+                    socket = null;
+                }
+            } finally {
+                super.stop();
+            }
+        }
+    }
+
+    private static void uncheckedClose(final Closeable... closeables) {
+        UncheckedIOException cause = null;
+        for (Closeable closeable : closeables) {
+            if (closeable != null) try {
+                closeable.close();
+            } catch (IOException e) {
+                if (cause == null) {
+                    cause = new UncheckedIOException(e);
+                } else {
+                    cause.addSuppressed(e);
+                }
+            }
+        }
+        if (cause != null) {
+            throw cause;
+        }
+    }
+
+    private static class EchoClient implements Closeable, Runnable {
+        private final Socket socket;
+        private final BlockingQueue<JsonObject> queue;
+        private volatile boolean closed = false;
+
+        private EchoClient(final Socket socket, final BlockingQueue<JsonObject> queue) {
+            this.socket = socket;
+            this.queue = queue;
+        }
+
+        @Override
+        public void run() {
+            try {
+                InputStream in = socket.getInputStream();
+                while (!closed) {
+                    final byte[] buffer = new byte[512];
+                    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    int len;
+                    while ((len = in.read(buffer)) != -1) {
+                        for (int i = 0; i < len; i++) {
+                            final byte b = buffer[i];
+                            if (b == '\n') {
+                                // This should indicate the end of the record so we can assume we have a full JSON message
+                                try (JsonReader reader = Json.createReader(new ByteArrayInputStream(out.toByteArray()))) {
+                                    queue.add(reader.readObject());
+                                    out.reset();
+                                }
+                            } else {
+                                out.write(b);
+                            }
+                        }
+                    }
+                    close();
+                }
+            } catch (IOException e) {
+                uncheckedClose(this);
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            uncheckedClose(socket);
+        }
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/handlers/SocketHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/handlers/SocketHandlerTestCase.java
@@ -1,0 +1,514 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.test.integration.logging.handlers;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.json.JsonObject;
+import javax.security.auth.x500.X500Principal;
+
+import org.apache.http.HttpStatus;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.as.test.integration.logging.AbstractLoggingTestCase;
+import org.jboss.as.test.integration.logging.JsonLogServer;
+import org.jboss.as.test.integration.logging.LoggingServiceActivator;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.jboss.logging.Logger;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.security.x500.cert.SelfSignedX509CertificateAndSigningKey;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+// https://github.com/justinmcook/wildfly-core/blob/caea7f7170c24598244558c6a82404e8417c6335/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogHandlerBootEnabledTestCase.java
+@RunWith(WildflyTestRunner.class)
+@ServerSetup(SocketHandlerTestCase.ConfigureSubsystem.class)
+public class SocketHandlerTestCase extends AbstractLoggingTestCase {
+
+    private static final String HOSTNAME = TestSuiteEnvironment.getServerAddress();
+    private static final int PORT = 10514;
+    private static final int ALT_PORT = 11514;
+    private static final int DFT_TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(System.getProperty("org.jboss.as.logging.timeout", "3")) * 1000);
+    private static final String SOCKET_BINDING_NAME = "log-server";
+    private static final String FORMATTER_NAME = "json";
+    private static final ModelNode LOGGER_ADDRESS = SUBSYSTEM_ADDRESS.append("logger", LoggingServiceActivator.LOGGER.getName()).toModelNode();
+    private static final Path TEMP_DIR = createTempDir();
+
+    // TLS Configuration
+    private static final String TEST_PASSWORD = "changeit";
+    private static final char[] KEYSTORE_CREATION_PASSWORD = TEST_PASSWORD.toCharArray();
+    private static final String ALIAS = "selfsigned";
+    private static final String SERVER_DNS_STRING = "CN=localhost, OU=Unknown, L=Unknown, ST=Unknown, C=Unknown";
+
+    private final Deque<ModelNode> resourcesToRemove = new ArrayDeque<>();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        deploy(createDeployment(), DEPLOYMENT_NAME);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        undeploy(DEPLOYMENT_NAME);
+        // Clear the temporary directory and delete it
+        Files.walkFileTree(TEMP_DIR, new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(final Path dir, final IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        Files.deleteIfExists(TEMP_DIR);
+    }
+
+    @After
+    public void cleanUp() throws Exception {
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        ModelNode address;
+        while ((address = resourcesToRemove.pollFirst()) != null) {
+            final ModelNode op = Operations.createOperation("remove-handler", LOGGER_ADDRESS);
+            op.get("name").set(getName(address));
+            builder.addStep(op);
+            builder.addStep(Operations.createRemoveOperation(address));
+        }
+        executeOperation(builder.build());
+    }
+
+    @Test
+    public void testTcpSocket() throws Exception {
+        // Create a TCP server and start it
+        try (JsonLogServer server = JsonLogServer.createTcpServer(PORT)) {
+            server.start(DFT_TIMEOUT);
+
+            // Add the socket handler and test all levels
+            final ModelNode socketHandlerAddress = addSocketHandler("test-log-server", null, null);
+            checkLevelsLogged(server, EnumSet.allOf(Logger.Level.class), "Test TCP all levels.");
+
+            // Change to only allowing INFO and higher messages
+            executeOperation(Operations.createWriteAttributeOperation(socketHandlerAddress, "level", "INFO"));
+            checkLevelsLogged(server, EnumSet.of(Logger.Level.INFO, Logger.Level.WARN, Logger.Level.ERROR, Logger.Level.FATAL), "Test TCP INFO and higher.");
+        }
+    }
+
+    @Test
+    public void testTlsSocket() throws Exception {
+        final KeyStore clientTrustStore = loadKeyStore();
+        final KeyStore serverKeyStore = loadKeyStore();
+
+        createKeyStoreTrustStore(serverKeyStore, clientTrustStore);
+        final Path clientTrustFile = createTemporaryKeyStoreFile(clientTrustStore, "client-trust-store.jks");
+        final Path serverCertFile = createTemporaryKeyStoreFile(serverKeyStore, "server-cert-store.jks");
+        // Create a TCP server and start it
+        try (JsonLogServer server = JsonLogServer.createTlsServer(PORT, serverCertFile, TEST_PASSWORD)) {
+            server.start(DFT_TIMEOUT);
+
+            // Add the socket handler and test all levels
+            final ModelNode socketHandlerAddress = addSocketHandler("test-log-server", null, "SSL_TCP", clientTrustFile);
+            checkLevelsLogged(server, EnumSet.allOf(Logger.Level.class), "Test SSL_TCP all levels.");
+
+            // Change to only allowing INFO and higher messages
+            executeOperation(Operations.createWriteAttributeOperation(socketHandlerAddress, "level", "INFO"));
+            checkLevelsLogged(server, EnumSet.of(Logger.Level.INFO, Logger.Level.WARN, Logger.Level.ERROR, Logger.Level.FATAL), "Test SSL_TCP INFO and higher.");
+        }
+    }
+
+    @Test
+    public void testUdpSocket() throws Exception {
+        // Create a UDP server and start it
+        try (JsonLogServer server = JsonLogServer.createUdpServer(PORT)) {
+            server.start(DFT_TIMEOUT);
+            final ModelNode socketHandlerAddress = addSocketHandler("test-log-server", null, "UDP");
+            checkLevelsLogged(server, EnumSet.allOf(Logger.Level.class), "Test UPD all levels.");
+
+            // Change to only allowing INFO and higher messages
+            executeOperation(Operations.createWriteAttributeOperation(socketHandlerAddress, "level", "INFO"));
+            checkLevelsLogged(server, EnumSet.of(Logger.Level.INFO, Logger.Level.WARN, Logger.Level.ERROR, Logger.Level.FATAL), "Test UDP INFO and higher.");
+        }
+    }
+
+    @Test
+    public void testLevelChange() throws Exception {
+        // Create a TCP server and start it
+        try (JsonLogServer server = JsonLogServer.createTcpServer(PORT)) {
+            server.start(DFT_TIMEOUT);
+
+            // Add the socket handler and test all levels
+            final ModelNode socketHandlerAddress = addSocketHandler("test-log-server", "WARN", null);
+            checkLevelsLogged(server, EnumSet.of(Logger.Level.WARN, Logger.Level.ERROR, Logger.Level.FATAL), "Test TCP WARN and greater levels.");
+
+            // Change to allow INFO and higher messages
+            executeOperation(Operations.createWriteAttributeOperation(socketHandlerAddress, "level", "INFO"));
+            checkLevelsLogged(server, EnumSet.of(Logger.Level.INFO, Logger.Level.WARN, Logger.Level.ERROR, Logger.Level.FATAL), "Test TCP INFO and higher.");
+        }
+    }
+
+    @Test
+    public void testWithFilter() throws Exception {
+        // Create a TCP server and start it
+        try (JsonLogServer server = JsonLogServer.createTcpServer(PORT)) {
+            server.start(DFT_TIMEOUT);
+
+            final ModelNode address = addSocketHandler("test-log-server", "INFO", "TCP");
+            executeOperation(Operations.createWriteAttributeOperation(address, "filter-spec", "substituteAll(\"\\\\s\", \"_\")"));
+            // We should end up with only 3 messages that should have the spaces removed and replaced with an underscore
+            final List<JsonObject> foundMessages = executeRequest("test message",
+                    Collections.singletonMap(LoggingServiceActivator.LOG_LEVELS_KEY, "INFO,WARN,ERROR"), server, 3);
+            // Process the JSON messages
+            for (JsonObject foundMessage : foundMessages) {
+                final String msg = foundMessage.getString("message");
+                Assert.assertEquals(String.format("Expected test_message but found %s for level %s.",
+                        msg, foundMessage.getString("level")), "test_message", msg);
+            }
+        }
+    }
+
+    @Test
+    public void testProtocolChange() throws Exception {
+        final ModelNode address = addSocketHandler("test-log-server", "INFO", "TCP");
+        // Create a TCP server and start it
+        try (JsonLogServer server = JsonLogServer.createTcpServer(PORT)) {
+            server.start(DFT_TIMEOUT);
+            // We should end up with a single log INFO log message
+            final JsonObject foundMessage = executeRequest("Test TCP message",
+                    Collections.singletonMap(LoggingServiceActivator.LOG_LEVELS_KEY, "INFO"), server);
+            Assert.assertEquals("Test TCP message", foundMessage.getString("message"));
+            server.stop();
+        }
+
+        // Create a new UDP server
+        try (JsonLogServer server = JsonLogServer.createUdpServer(PORT)) {
+            server.start(DFT_TIMEOUT);
+
+            // Change the protocol and ensure we can connect
+            executeOperation(Operations.createWriteAttributeOperation(address, "protocol", "UDP"));
+            final JsonObject foundMessage = executeRequest("Test UDP message",
+                    Collections.singletonMap(LoggingServiceActivator.LOG_LEVELS_KEY, "INFO"), server);
+            Assert.assertEquals("Test UDP message", foundMessage.getString("message"));
+        }
+    }
+
+    @Test
+    public void testOutboundSocketBindingChange() throws Exception {
+        // Add a new outbound-socket-binding
+        final String altName = "alt-log-server";
+        final ModelNode outboundSocketBindingAddress = Operations.createAddress("socket-binding-group", "standard-sockets",
+                "remote-destination-outbound-socket-binding", altName);
+        ModelNode op = Operations.createAddOperation(outboundSocketBindingAddress);
+        op.get("host").set(HOSTNAME);
+        op.get("port").set(ALT_PORT);
+        executeOperation(op);
+        resourcesToRemove.addLast(outboundSocketBindingAddress);
+
+        // Create the server, plus a new server listening on the alternate port
+        try (JsonLogServer server = JsonLogServer.createTcpServer(PORT);
+             JsonLogServer altServer = JsonLogServer.createTcpServer(ALT_PORT)
+        ) {
+            server.start(DFT_TIMEOUT);
+            altServer.start(DFT_TIMEOUT);
+            final ModelNode altAddress = addSocketHandler("test-log-server-alt", null, null);
+
+            // Log a single message to the current log server and validate
+            JsonObject foundMessage = executeRequest("Test first message",
+                    Collections.singletonMap(LoggingServiceActivator.LOG_LEVELS_KEY, "INFO"), server);
+            Assert.assertEquals("Test first message", foundMessage.getString("message"));
+
+            // Change the outbound-socket-binding-ref, which should require a reload
+            op = Operations.createWriteAttributeOperation(altAddress, "outbound-socket-binding-ref", altName);
+            executeOperation(op);
+            ServerReload.executeReloadAndWaitForCompletion(client.getControllerClient());
+
+            // Log a single message to the alternate log server and validate
+            foundMessage = executeRequest("Test alternate message",
+                    Collections.singletonMap(LoggingServiceActivator.LOG_LEVELS_KEY, "INFO"), altServer);
+            Assert.assertEquals("Test alternate message", foundMessage.getString("message"));
+        }
+    }
+
+    private void checkLevelsLogged(final JsonLogServer server, final Set<Logger.Level> expectedLevels, final String msg) throws IOException, InterruptedException {
+        executeRequest(msg, Collections.singletonMap("includeLevel", "true"));
+        final List<JsonObject> foundMessages = new ArrayList<>();
+        for (int i = 0; i < expectedLevels.size(); i++) {
+            final JsonObject foundMessage = server.getLogMessage(DFT_TIMEOUT);
+            if (foundMessage == null) {
+                final String failureMessage = "A log messages was not received within " + DFT_TIMEOUT + " milliseconds." +
+                        System.lineSeparator() +
+                        "Found the following messages: " + foundMessages +
+                        System.lineSeparator() +
+                        "Expected the following levels to be logged: " + expectedLevels;
+                Assert.fail(failureMessage);
+
+            }
+            foundMessages.add(foundMessage);
+        }
+        Assert.assertEquals(expectedLevels.size(), foundMessages.size());
+
+        // Check that we have all the expected levels
+        final Collection<String> levels = expectedLevels.stream()
+                .map(Enum::name)
+                .collect(Collectors.toList());
+        final Iterator<JsonObject> iter = foundMessages.iterator();
+        while (iter.hasNext()) {
+            final JsonObject foundMessage = iter.next();
+            final String foundLevel = foundMessage.getString("level");
+            Assert.assertNotNull("Expected a level on " + foundMessage, foundLevel);
+            Assert.assertTrue(String.format("Level %s was logged, but not expected.", foundLevel), levels.remove(foundLevel));
+            iter.remove();
+        }
+
+        // The string levels should be empty, if not we're missing an expected level
+        Assert.assertTrue("Found levels that did not appear to be logged: " + levels, levels.isEmpty());
+    }
+
+    private ModelNode addSocketHandler(final String name, final String level, final String protocol) throws IOException {
+        return addSocketHandler(name, level, protocol, null);
+    }
+
+    private ModelNode addSocketHandler(final String name, final String level, final String protocol, final Path keyStore) throws IOException {
+        final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+        // Add a socket handler
+        final ModelNode address = SUBSYSTEM_ADDRESS.append("socket-handler", name).toModelNode();
+        ModelNode op = Operations.createAddOperation(address);
+        op.get("named-formatter").set(FORMATTER_NAME);
+        op.get("outbound-socket-binding-ref").set(SOCKET_BINDING_NAME);
+        if (level != null) {
+            op.get("level").set(level);
+        }
+        if (protocol != null) {
+            op.get("protocol").set(protocol);
+        }
+        if (keyStore != null) {
+            // We need to add the SSL context to Elytron
+            final ModelNode keyStoreAddress = Operations.createAddress("subsystem", "elytron", "key-store", "log-test-ks");
+            resourcesToRemove.addFirst(keyStoreAddress);
+            final ModelNode keyStoreAddOp = Operations.createAddOperation(keyStoreAddress);
+            keyStoreAddOp.get("path").set(keyStore.toAbsolutePath().toString());
+            keyStoreAddOp.get("type").set("JKS");
+            final ModelNode creds = keyStoreAddOp.get("credential-reference").setEmptyObject();
+            creds.get("clear-text").set(TEST_PASSWORD);
+            builder.addStep(keyStoreAddOp);
+
+            final ModelNode keyManagerAddress = Operations.createAddress("subsystem", "elytron", "trust-manager", "log-test-tm");
+            resourcesToRemove.addLast(keyManagerAddress);
+            final ModelNode keyManagerAddOp = Operations.createAddOperation(keyManagerAddress);
+            keyManagerAddOp.get("key-store").set("log-test-ks");
+            builder.addStep(keyManagerAddOp);
+
+            final ModelNode sslContextAddress = Operations.createAddress("subsystem", "elytron", "client-ssl-context", "log-test-ssl-context");
+            resourcesToRemove.addLast(sslContextAddress);
+            final ModelNode sslContextAddOp = Operations.createAddOperation(sslContextAddress);
+            sslContextAddOp.get("trust-manager").set("log-test-tm");
+            sslContextAddOp.get("protocols").setEmptyList().add("TLSv1.2");
+            builder.addStep(sslContextAddOp);
+
+            op.get("ssl-context").set("log-test-ssl-context");
+        }
+        builder.addStep(op);
+        resourcesToRemove.addFirst(address);
+
+        // Add the handler to the logger
+        op = Operations.createOperation("add-handler", LOGGER_ADDRESS);
+        op.get("name").set(name);
+        builder.addStep(op);
+        executeOperation(builder.build());
+        return address;
+    }
+
+    private static void executeRequest(final String msg, final Map<String, String> params) throws IOException {
+        final int statusCode = getResponse(msg, params);
+        Assert.assertEquals("Invalid response statusCode: " + statusCode, HttpStatus.SC_OK, statusCode);
+    }
+
+    private static JsonObject executeRequest(final String msg, final Map<String, String> params,
+                                             final JsonLogServer server) throws IOException, InterruptedException {
+        return executeRequest(msg, params, server, 1).get(0);
+    }
+
+    private static List<JsonObject> executeRequest(final String msg, final Map<String, String> params,
+                                                   final JsonLogServer server, final int expectedMessages) throws IOException, InterruptedException {
+        executeRequest(msg, params);
+        final List<JsonObject> messages = new ArrayList<>(expectedMessages);
+        for (int i = 0; i < expectedMessages; i++) {
+            final JsonObject foundMessage = server.getLogMessage(DFT_TIMEOUT);
+            if (foundMessage == null) {
+                final String failureMessage = "A log messages was not received within " + DFT_TIMEOUT + " milliseconds." +
+                        System.lineSeparator() +
+                        "Found the following messages: " + messages;
+                Assert.fail(failureMessage);
+
+            }
+            messages.add(foundMessage);
+        }
+        return messages;
+    }
+
+    private static String getName(final ModelNode address) {
+        Assert.assertEquals(ModelType.LIST, address.getType());
+        String name = "";
+        for (Property property : address.asPropertyList()) {
+            name = property.getValue().asString();
+        }
+        return name;
+    }
+
+    private static void createKeyStoreTrustStore(final KeyStore keyStore, final KeyStore trustStore) throws KeyStoreException {
+        final X500Principal principal = new X500Principal(SERVER_DNS_STRING);
+
+        final SelfSignedX509CertificateAndSigningKey selfSignedX509CertificateAndSigningKey = SelfSignedX509CertificateAndSigningKey.builder()
+                .setKeyAlgorithmName("RSA")
+                .setSignatureAlgorithmName("SHA1withRSA")
+                .setDn(principal)
+                .setKeySize(1024)
+                .build();
+        final X509Certificate certificate = selfSignedX509CertificateAndSigningKey.getSelfSignedCertificate();
+
+        keyStore.setKeyEntry(ALIAS, selfSignedX509CertificateAndSigningKey.getSigningKey(), KEYSTORE_CREATION_PASSWORD, new X509Certificate[] {certificate});
+        trustStore.setCertificateEntry(ALIAS, certificate);
+    }
+
+    private static KeyStore loadKeyStore() throws Exception {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        ks.load(null, null);
+        return ks;
+    }
+
+    private static Path createTemporaryKeyStoreFile(final KeyStore keyStore, final String fileName) throws Exception {
+        final Path file = TEMP_DIR.resolve(fileName);
+        try (OutputStream fos = Files.newOutputStream(file)) {
+            keyStore.store(fos, KEYSTORE_CREATION_PASSWORD);
+        }
+        return file;
+    }
+
+    private static Path createTempDir() {
+        try {
+            return Files.createTempDirectory("wf-test");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public static class ConfigureSubsystem implements ServerSetupTask {
+        private ModelNode describeResult;
+
+        @Override
+        public void setup(final ManagementClient managementClient) throws Exception {
+            // Describe the current subsystem to restore in the tearDown
+            final ModelNode describeOp = Operations.createOperation("describe", SUBSYSTEM_ADDRESS.toModelNode());
+            describeResult = executeOperation(managementClient, describeOp);
+
+            final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+
+            final ModelNode outboundSocketBindingAddress = Operations.createAddress("socket-binding-group", "standard-sockets",
+                    "remote-destination-outbound-socket-binding", SOCKET_BINDING_NAME);
+            ModelNode op = Operations.createAddOperation(outboundSocketBindingAddress);
+            op.get("host").set(HOSTNAME);
+            op.get("port").set(PORT);
+            builder.addStep(op);
+
+            final ModelNode formatterAddress = SUBSYSTEM_ADDRESS.append("json-formatter", FORMATTER_NAME).toModelNode();
+            builder.addStep(Operations.createAddOperation(formatterAddress));
+
+            builder.addStep(Operations.createAddOperation(LOGGER_ADDRESS));
+
+            executeOperation(managementClient, builder.build());
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient) throws Exception {
+            try {
+                if (describeResult != null) {
+                    final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
+                    // First remove the subsystem, then read add based on the describe op.
+                    builder.addStep(Operations.createRemoveOperation(SUBSYSTEM_ADDRESS.toModelNode()));
+                    for (ModelNode addOp : describeResult.asList()) {
+                        builder.addStep(addOp);
+                    }
+                    executeOperation(managementClient, builder.build());
+                }
+            } finally {
+                // Reload if required
+                final ModelNode op = Operations.createReadAttributeOperation(new ModelNode().setEmptyList(), "server-state");
+                ModelNode result = executeOperation(managementClient, op);
+                if (ClientConstants.CONTROLLER_PROCESS_STATE_RELOAD_REQUIRED.equals(result.asString())) {
+                    ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+                }
+            }
+        }
+
+        private ModelNode executeOperation(final ManagementClient managementClient, final ModelNode op) throws IOException {
+            final ModelNode result = managementClient.getControllerClient().execute(op);
+            if (!Operations.isSuccessfulOutcome(result)) {
+                throw new RuntimeException(Operations.getFailureDescription(result).toString());
+            }
+            return Operations.readResult(result);
+        }
+
+        private void executeOperation(final ManagementClient managementClient, final Operation op) throws IOException {
+            final ModelNode result = managementClient.getControllerClient().execute(op);
+            if (!Operations.isSuccessfulOutcome(result)) {
+                throw new RuntimeException(Operations.getFailureDescription(result).toString());
+            }
+        }
+
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/AbstractLoggingOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/AbstractLoggingOperationsTestCase.java
@@ -58,11 +58,15 @@ public abstract class AbstractLoggingOperationsTestCase extends AbstractLoggingT
     }
 
     protected ModelNode testWrite(final ModelNode address, final String attribute, final String value) throws IOException {
+        return testWrite(address, attribute, value, true);
+    }
+
+    protected ModelNode testWrite(final ModelNode address, final String attribute, final String value, final boolean reloadIfRequired) throws IOException {
         final CompositeOperationBuilder builder = CompositeOperationBuilder.create();
         builder.addStep(Operations.createWriteAttributeOperation(address, attribute, value));
         // Create the read operation
         builder.addStep(Operations.createReadAttributeOperation(address, attribute));
-        final ModelNode result = executeOperation(builder.build());
+        final ModelNode result = executeOperation(builder.build(), reloadIfRequired);
         assertEquals(value, Operations.readResult(Operations.readResult(result).get("step-2")).asString());
         return result;
     }

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
@@ -74,8 +74,6 @@ public class CustomHandlerOperationsTestCase extends AbstractLoggingOperationsTe
         testWrite(address, "encoding", "utf-8");
         testWrite(address, "formatter", "[test] %d{HH:mm:ss,SSS} %-5p [%c] %s%E%n");
         testWrite(address, "filter-spec", "deny");
-        testWrite(address, "class", QueueHandler.class.getName());
-        testWrite(address, "module", "org.jboss.logmanager");
         // Create a properties value
         final ModelNode properties = new ModelNode().setEmptyObject();
         properties.get("autoFlush").set(true);
@@ -89,6 +87,10 @@ public class CustomHandlerOperationsTestCase extends AbstractLoggingOperationsTe
         testUndefine(address, "formatter");
         testUndefine(address, "filter-spec");
         testUndefine(address, "properties");
+
+        // Writing either of these requires a reload, but we want to skip the reload
+        testWrite(address, "class", QueueHandler.class.getName(), false);
+        testWrite(address, "module", "org.jboss.logmanager", false);
 
         // Clean-up
         executeOperation(Operations.createRemoveOperation(address));

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/logging/syslog/SyslogHandlerTestCase.java
@@ -122,8 +122,8 @@ public class SyslogHandlerTestCase extends AbstractLoggingTestCase {
         executeOperation(Operations.createWriteAttributeOperation(SYSLOG_HANDLER_ADDR, "level", "ERROR"));
         queue.clear();
         makeLogs();
-        testLog(queue, Level.ERROR);
         testLog(queue, Level.FATAL);
+        testLog(queue, Level.ERROR);
         Assert.assertTrue("No other message was expected in syslog.", queue.isEmpty());
     }
 


### PR DESCRIPTION
Associated JIRA's:
https://issues.jboss.org/browse/WFCORE-2953 - `socket-handler`
https://issues.jboss.org/browse/WFCORE-3927 - logging subsystem schema bump
https://issues.jboss.org/browse/WFCORE-3946 - test fix

Design Document: https://github.com/wildfly/wildfly-proposals/pull/103

Community documentation is coming.

This adds a `socket-handler` resource to the logging subsystem. An `/socket-binding=*/*-destination-outbound-socket-binding` is required the connections. This allows a standard socket binding resource to be used rather than require the `socket-binding` resource to handle it's own connections.

