### PR TITLE
Fix for WFCORE-3968, Upgrade CLI to use aesh 1.7 and aesh-readline 1.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,9 +140,9 @@
         <version.javax.json.javax-json-api>1.1.2</version.javax.json.javax-json-api>
         <version.junit>4.12</version.junit>
         <version.log4j>1.2.17</version.log4j>
-        <version.org.aesh>1.6</version.org.aesh>
+        <version.org.aesh>1.7</version.org.aesh>
         <version.org.aesh-extensions>1.5</version.org.aesh-extensions>
-        <version.org.aesh-readline>1.9</version.org.aesh-readline>
+        <version.org.aesh-readline>1.10</version.org.aesh-readline>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
         <!-- TODO Elytron - Bump to M17 -->
         <version.org.apache.httpcomponents.httpclient>4.5.2</version.org.apache.httpcomponents.httpclient>


### PR DESCRIPTION
- aesh upgrade required by installer.
