### PR TITLE
Fix for WFCORE-3973, Upgrade CLI to use aesh-extensions 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <version.junit>4.12</version.junit>
         <version.log4j>1.2.17</version.log4j>
         <version.org.aesh>1.7</version.org.aesh>
-        <version.org.aesh-extensions>1.5</version.org.aesh-extensions>
+        <version.org.aesh-extensions>1.6</version.org.aesh-extensions>
         <version.org.aesh-readline>1.10</version.org.aesh-readline>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
         <!-- TODO Elytron - Bump to M17 -->


### PR DESCRIPTION
Upgrade required to remove javafx dependency introduced by aesh-extensions