### PR TITLE
[WFCORE-3981] Upgrade jboss-logging from 3.3.1.Final to 3.3.2.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <version.org.jboss.jboss-dmr>1.5.0.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-vfs>3.2.12.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.logging.commons-logging-jboss-logging>1.0.0.Final</version.org.jboss.logging.commons-logging-jboss-logging>
-        <version.org.jboss.logging.jboss-logging>3.3.1.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <version.org.jboss.logmanager.jboss-logmanager>2.1.4.Final</version.org.jboss.logmanager.jboss-logmanager>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3981

The only difference between 3.3.1.Final and 3.3.2.Final is the addition of the `Automatic-Module-Name` to the manifest.

https://github.com/jboss-logging/jboss-logging/compare/3.3.1.Final...3.3.2.Final