### PR TITLE
[WFCORE-3984] --add-modules java.se for modular.jdk.args

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1575,6 +1575,7 @@
             </activation>
             <properties>
                 <modular.jdk.args>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+                    --add-modules=java.se
                     --illegal-access=permit</modular.jdk.args>
                 <!-- [WFCORE-1494] remove JUL workaround -->
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true -Djdk.attach.allowAttachSelf=true</modular.jdk.props>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -278,6 +278,7 @@
                             </scripts>
                             <jboss-home>${project.build.directory}/wildfly-core</jboss-home>
                             <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                            <java-opts>${modular.jdk.args}</java-opts>
                             <system-properties>
                                 <maven.repo.local>${settings.localRepository}</maven.repo.local>
                                 <module.path>${jboss.dist}/modules</module.path>

--- a/testsuite/elytron/pom.xml
+++ b/testsuite/elytron/pom.xml
@@ -179,6 +179,7 @@
                              </scripts>
                              <jboss-home>${project.build.directory}/wildfly-core</jboss-home>
                              <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                             <java-opts>${modular.jdk.args}</java-opts>
                              <system-properties>
                                  <maven.repo.local>${settings.localRepository}</maven.repo.local>
                                  <module.path>${jboss.dist}/modules</module.path>

--- a/testsuite/manualmode/pom.xml
+++ b/testsuite/manualmode/pom.xml
@@ -320,6 +320,7 @@
                             </scripts>
                             <jboss-home>${project.build.directory}/wildfly-core</jboss-home>
                             <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                            <java-opts>${modular.jdk.args}</java-opts>
                             <system-properties>
                                 <maven.repo.local>${settings.localRepository}</maven.repo.local>
                                 <module.path>${jboss.dist}/modules</module.path>

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -200,6 +200,7 @@
                              </scripts>
                              <jboss-home>${project.build.directory}/${server.output.dir.prefix}</jboss-home>
                              <stdout>${project.build.directory}/wildfly-plugin.log</stdout>
+                             <java-opts>${modular.jdk.args}</java-opts>
                              <system-properties>
                                  <maven.repo.local>${settings.localRepository}</maven.repo.local>
                                  <module.path>${jboss.dist}/modules</module.path>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3984

--add-modules java.se for modular.jdk.args for Java 11 ea improvements 