### PR TITLE
[WFCORE-3985] The DeploymentOverlayTestCase is part of the CLITestSui…

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
@@ -101,7 +101,7 @@ public class DeploymentOverlayTestCase {
 
     @BeforeClass
     public static void setupDomain() throws Exception {
-        testSupport = DomainTestSuite.createSupport(DeploymentOverlayTestCase.class.getSimpleName());
+        testSupport = CLITestSuite.createSupport(DeploymentOverlayTestCase.class.getSimpleName());
         masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
         slaveClient = testSupport.getDomainSlaveLifecycleUtil().getDomainClient();
         properties.clear();
@@ -118,7 +118,7 @@ public class DeploymentOverlayTestCase {
         masterClient = null;
         slaveClient.close();
         slaveClient = null;
-        DomainTestSuite.stopSupport();
+        CLITestSuite.stopSupport();
     }
 
     @After


### PR DESCRIPTION
…te and should use the static methods from that suite instead of the DomainTestSuite.

https://issues.jboss.org/browse/WFCORE-3985