### PR TITLE
[WFCORE-3986] Upgrade WildFly Elytron to 1.5.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.5.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.5.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.2.2.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3986



Release Notes - WildFly Elytron - Version 1.5.1.Final

** Bug
    * [ELY-1618] - TLS with BCJSSE Provider does not work
** Release
    * [ELY-1619] - Release WildFly Elytron 1.5.1.Final