### PR TITLE
[WFCORE-3990] Upgrade to Byteman version 4.0.4 for better JDK9+ support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <version.org.codehaus.woodstox.woodstox-core>5.0.3</version.org.codehaus.woodstox.woodstox-core>
         <version.org.fusesource.jansi>1.16</version.org.fusesource.jansi>
         <version.org.glassfish.javax.json>1.1.2</version.org.glassfish.javax.json>
-        <version.org.jboss.byteman>3.0.9</version.org.jboss.byteman>
+        <version.org.jboss.byteman>4.0.4</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.2.3.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.invocation>1.5.1.Final</version.org.jboss.invocation>
         <version.org.jboss.jandex>2.0.5.Final</version.org.jboss.jandex>
@@ -1630,7 +1630,6 @@
                     --illegal-access=permit</modular.jdk.args>
                 <!-- [WFCORE-1494] remove JUL workaround -->
                 <modular.jdk.props>-Dsun.util.logging.disableCallerCheck=true -Djdk.attach.allowAttachSelf=true</modular.jdk.props>
-                <version.org.jboss.byteman>4.0.0-BETA5</version.org.jboss.byteman>
             </properties>
         </profile>
         <!--


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3990

This is the root cause of at least these issues:
 * https://issues.jboss.org/browse/WFCORE-3869
 * https://issues.jboss.org/browse/WFCORE-3874
 * https://issues.jboss.org/browse/WFCORE-3875