### PR TITLE
[WFCORE-3970] Add a management operation to allow an Elytron trust-manager to be re-initialized

### DIFF
--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1156,6 +1156,7 @@ elytron.trust-manager=A trust manager definition for creating the TrustManager[]
 #operations
 elytron.trust-manager.add=Add the new trust manager definition.
 elytron.trust-manager.remove=Remove the trust manager definition.
+elytron.trust-manager.init=Reinitialize trust manager.
 # Attributes
 elytron.trust-manager.algorithm=The name of the algorithm to use to create the underlying TrustManagerFactory.
 elytron.trust-manager.providers=Reference to obtain the Provider[] to use when creating the underlying TrustManagerFactory.


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3970
https://issues.jboss.org/browse/EAP7-1052

Analysis Document: https://github.com/wildfly/wildfly-proposals/pull/115

Documentation PR: https://github.com/wildfly/wildfly/pull/11496