### PR TITLE
[WFCORE-3999] Allow registering a custom HTTP handler for management interface

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/ManagementHttpServer.java
@@ -191,6 +191,19 @@ public class ManagementHttpServer {
         extensionHandlers.extensionPathHandler.addPrefixPath(context, readinessHandler);
     }
 
+    public void addManagementHandler(String contextName, HttpHandler managementHandler) {
+        Assert.checkNotNullParam("contextName", contextName);
+        Assert.checkNotNullParam("managementHandler", managementHandler);
+        String context = fixPath(contextName);
+        // Reject reserved contexts or duplicate extensions
+        if (extensionHandlers.reservedContexts.contains(context) || !extensionHandlers.extensionContexts.add(context)) {
+            throw new IllegalStateException();
+        }
+        HttpHandler readinessHandler = new RedirectReadinessHandler(extensionHandlers.readyFunction, managementHandler,
+                ErrorContextHandler.ERROR_CONTEXT);
+        extensionHandlers.extensionPathHandler.addPrefixPath(context, readinessHandler);
+    }
+
     public void addManagementGetRemapContext(String contextName, PathRemapper remapper) {
         Assert.checkNotNullParam("contextName", contextName);
         String context = fixPath(contextName);

--- a/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
@@ -21,6 +21,7 @@
 */
 package org.jboss.as.server.mgmt;
 
+import io.undertow.server.HttpHandler;
 import io.undertow.server.ListenerRegistry;
 import io.undertow.server.handlers.ChannelUpgradeHandler;
 
@@ -129,6 +130,12 @@ public class UndertowHttpManagementService implements Service<HttpManagement> {
                     return remapper.remapPath(originalPath);
                 }
             });
+        }
+
+        @Override
+        public void addManagementHandler(String contextName, HttpHandler managementHandler) {
+            Assert.assertNotNull(serverManagement);
+            serverManagement.addManagementHandler(contextName, managementHandler);
         }
 
         @Override

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/ExtensibleHttpManagement.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/ExtensibleHttpManagement.java
@@ -16,6 +16,7 @@ limitations under the License.
 
 package org.jboss.as.server.mgmt.domain;
 
+import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.resource.ResourceManager;
 
@@ -53,6 +54,17 @@ public interface ExtensibleHttpManagement extends HttpManagement {
      *                               added via this interface or otherwise
      */
     void addManagementGetRemapContext(String contextName, PathRemapper remapper);
+
+    /**
+     * Add a context for a HTTP management handler.
+     * @param contextName the name of the context. Cannot be {@code null} or empty
+     * @param managementHandler HTTP management handler. Cannot be {@code null}
+     *
+     * @throws IllegalArgumentException if either parameter is invalid
+     * @throws IllegalStateException if there is already a context present named the same as {@code contextName}, either
+     *                               added via this interface or otherwise
+     */
+    void addManagementHandler(String contextName, HttpHandler managementHandler);
 
     /**
      * Remove a previously added context

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/customcontext/testbase/CustomManagementContextTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/customcontext/testbase/CustomManagementContextTestBase.java
@@ -30,12 +30,13 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.http.Header;
-import org.apache.http.HttpResponse;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -141,14 +142,22 @@ public abstract class CustomManagementContextTestBase {
         final String staticUrlDirectory = urlBase + "static/";
         final String badStaticUrl = urlBase + "static/bad.txt";
         final String errorUrl = urlBase + "error/index.html";
+        final String dynamicUrl = urlBase + "dynamic/";
 
         // Sanity check
 
         try (CloseableHttpClient client = HttpClients.createDefault()) {
-            HttpResponse resp = client.execute(new HttpGet(remapUrl));
+            CloseableHttpResponse resp = client.execute(new HttpGet(remapUrl));
             assertEquals(404, resp.getStatusLine().getStatusCode());
+            resp.close();
+
             resp = client.execute(new HttpGet(staticUrl));
             assertEquals(404, resp.getStatusLine().getStatusCode());
+            resp.close();
+
+            resp = client.execute(new HttpGet(staticUrl));
+            assertEquals(404, resp.getStatusLine().getStatusCode());
+            resp.close();
         }
 
         // Add extension and subsystem
@@ -159,22 +168,28 @@ public abstract class CustomManagementContextTestBase {
         // Unauthenticated check
 
         try (CloseableHttpClient client = HttpClients.createDefault()) {
-            HttpResponse resp = client.execute(new HttpGet(remapUrl));
+            CloseableHttpResponse resp = client.execute(new HttpGet(remapUrl));
             assertEquals(401, resp.getStatusLine().getStatusCode());
+            resp.close();
             resp = client.execute(new HttpGet(staticUrl));
             assertEquals(200, resp.getStatusLine().getStatusCode());
+            resp.close();
+            resp = client.execute(new HttpGet(dynamicUrl));
+            assertEquals(200, resp.getStatusLine().getStatusCode());
+            resp.close();
         }
 
         try (CloseableHttpClient client = createAuthenticatingClient(managementClient)) {
 
             // Authenticated check
 
-            HttpResponse resp = client.execute(new HttpGet(remapUrl));
+            CloseableHttpResponse resp = client.execute(new HttpGet(remapUrl));
             assertEquals(200, resp.getStatusLine().getStatusCode());
             ModelNode respNode = ModelNode.fromJSONString(EntityUtils.toString(resp.getEntity()));
             assertEquals(respNode.toString(), CustomContextExtension.EXTENSION_NAME, respNode.get("module").asString());
             assertTrue(respNode.toString(), respNode.hasDefined("subsystem"));
             assertTrue(respNode.toString(), respNode.get("subsystem").has(CustomContextExtension.SUBSYSTEM_NAME));
+            resp.close();
 
             resp = client.execute(new HttpGet(staticUrl));
             assertEquals(200, resp.getStatusLine().getStatusCode());
@@ -194,23 +209,41 @@ public abstract class CustomManagementContextTestBase {
                     headersMap.getOrDefault("X-Frame-Options", "").contains("SAMEORIGIN"));
             Assert.assertTrue("Cache-Control header with max-age=2678400 is expected,",
                     headersMap.getOrDefault("Cache-Control", "").contains("max-age=2678400"));
+            resp.close();
 
             // directory listing is not allowed
             resp = client.execute(new HttpGet(staticUrlDirectory));
             assertEquals(404, resp.getStatusLine().getStatusCode());
+            resp.close();
 
             // POST check
             resp = client.execute(new HttpPost(remapUrl));
             assertEquals(405, resp.getStatusLine().getStatusCode());
+            resp.close();
             resp = client.execute(new HttpPost(staticUrl));
             assertEquals(200, resp.getStatusLine().getStatusCode());
+            resp.close();
+
+            // POST check for dynamic URL
+            final String newValue = "MY NEW VALUE";
+            final HttpPost postDynamic = new HttpPost(dynamicUrl);
+            postDynamic.setEntity(new StringEntity(newValue));
+            resp = client.execute(postDynamic);
+            assertEquals(204, resp.getStatusLine().getStatusCode());
+            resp.close();
+            resp = client.execute(new HttpGet(dynamicUrl));
+            assertEquals(200, resp.getStatusLine().getStatusCode());
+            text = EntityUtils.toString(resp.getEntity());
+            assertEquals(newValue, text);
 
             // Bad URL check
 
             resp = client.execute(new HttpGet(badRemapUrl));
             assertEquals(404, resp.getStatusLine().getStatusCode());
+            resp.close();
             resp = client.execute(new HttpGet(badStaticUrl));
             assertEquals(404, resp.getStatusLine().getStatusCode());
+            resp.close();
 
             // Remove subsystem
 
@@ -220,8 +253,10 @@ public abstract class CustomManagementContextTestBase {
 
             resp = client.execute(new HttpGet(remapUrl));
             assertEquals(404, resp.getStatusLine().getStatusCode());
+            resp.close();
             resp = client.execute(new HttpGet(staticUrl));
             assertEquals(404, resp.getStatusLine().getStatusCode());
+            resp.close();
 
             // Error Context
             resp = client.execute(new HttpGet(errorUrl));
@@ -234,6 +269,7 @@ public abstract class CustomManagementContextTestBase {
             }
             Assert.assertTrue("'X-Frame-Options: SAMEORIGIN' error context header is expected as well",
                               errorContextHeadersMap.getOrDefault("X-Frame-Options", "").contains("SAMEORIGIN"));
+            resp.close();
         }
     }
 


### PR DESCRIPTION
* add `addManagementHandler(String, HttpHandler)` method to the
  ExtensibleHttpManagement API

JIRA: https://issues.jboss.org/browse/WFCORE-3999