### PR TITLE
[WFCORE-3999] Allow registering a custom HTTP handler for management interface

### DIFF
--- a/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/UndertowHttpManagementService.java
@@ -21,6 +21,7 @@
 */
 package org.jboss.as.server.mgmt;
 
+import io.undertow.server.HttpHandler;
 import io.undertow.server.ListenerRegistry;
 import io.undertow.server.handlers.ChannelUpgradeHandler;
 
@@ -129,6 +130,12 @@ public class UndertowHttpManagementService implements Service<HttpManagement> {
                     return remapper.remapPath(originalPath);
                 }
             });
+        }
+
+        @Override
+        public void addManagementHandler(String contextName, boolean requiresSecurity, HttpHandler managementHandler) {
+            Assert.assertNotNull(serverManagement);
+            serverManagement.addManagementHandler(contextName, requiresSecurity, managementHandler);
         }
 
         @Override

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/ExtensibleHttpManagement.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/ExtensibleHttpManagement.java
@@ -16,6 +16,7 @@ limitations under the License.
 
 package org.jboss.as.server.mgmt.domain;
 
+import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.resource.ResourceManager;
 
@@ -53,6 +54,18 @@ public interface ExtensibleHttpManagement extends HttpManagement {
      *                               added via this interface or otherwise
      */
     void addManagementGetRemapContext(String contextName, PathRemapper remapper);
+
+    /**
+     * Add a context for a HTTP management handler.
+     * @param contextName the name of the context. Cannot be {@code null} or empty
+     * @param requiresSecurity {@code true} if the management handler requires a security realm.
+     * @param managementHandler HTTP management handler. Cannot be {@code null}
+     *
+     * @throws IllegalArgumentException if either parameter is invalid
+     * @throws IllegalStateException if there is already a context present named the same as {@code contextName}, either
+     *                               added via this interface or otherwise
+     */
+    void addManagementHandler(String contextName, boolean requiresSecurity, HttpHandler managementHandler);
 
     /**
      * Remove a previously added context


### PR DESCRIPTION
* add addManagementHandler(String, boolean, HttpHandler) method to the
  ExtensibleHttpManagement API

JIRA: https://issues.jboss.org/browse/WFCORE-3999
Proposal: https://github.com/wildfly/wildfly-proposals/pull/117