### PR TITLE
[WFCORE-3991] read-config-as-features management operation

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -322,6 +322,7 @@ public class ModelDescriptionConstants {
     public static final String NATIVE = "native";
     public static final String NATIVE_INTERFACE = "native-interface";
     public static final String NATIVE_REMOTING_INTERFACE = "native-remoting-interface";
+    public static final String NESTED = "nested";
     public static final String NETWORK = "network";
     public static final String NILLABLE = "nillable";
     public static final String NIL_SIGNIFICANT = "nil-significant";
@@ -393,6 +394,7 @@ public class ModelDescriptionConstants {
     public static final String READ_CHILDREN_NAMES_OPERATION = "read-children-names";
     public static final String READ_CHILDREN_TYPES_OPERATION = "read-children-types";
     public static final String READ_CHILDREN_RESOURCES_OPERATION = "read-children-resources";
+    public static final String READ_CONFIG_AS_FEATURES_OPERATION = "read-config-as-features";
     public static final String READ_CONFIG_AS_XML_OPERATION = "read-config-as-xml";
     public static final String READ_CONTENT = "read-content";
     public static final String READ_FEATURE_DESCRIPTION_OPERATION = "read-feature-description";
@@ -515,6 +517,7 @@ public class ModelDescriptionConstants {
     public static final String SOCKET_BINDING_REF = "socket-binding-ref";
     public static final String SOURCE_INTERFACE = "source-interface";
     public static final String SOURCE_PORT = "source-port";
+    public static final String SPEC = "spec";
     public static final String SSL = "ssl";
     public static final String SSL_CONTEXT = "ssl-context";
     public static final String STANDARD_ROLE_NAMES = "standard-role-names";

--- a/controller/src/main/java/org/jboss/as/controller/operations/PathAddressFilter.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/PathAddressFilter.java
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.domain.controller.operations;
+package org.jboss.as.controller.operations;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -33,17 +33,17 @@ import org.jboss.as.controller.PathElement;
 /**
  * @author Emanuel Muckenhuber
  */
-class PathAddressFilter {
+public final class PathAddressFilter {
 
-    static final OperationContext.AttachmentKey<PathAddressFilter> KEY = OperationContext.AttachmentKey.create(PathAddressFilter.class);
+    public static final OperationContext.AttachmentKey<PathAddressFilter> KEY = OperationContext.AttachmentKey.create(PathAddressFilter.class);
 
     private final boolean accept;
     private final Node node = new Node(null);
-    protected PathAddressFilter(boolean accept) {
+    public PathAddressFilter(boolean accept) {
         this.accept = accept;
     }
 
-    boolean accepts(PathAddress address) {
+    public boolean accepts(PathAddress address) {
         final Iterator<PathElement> i = address.iterator();
         Node node = this.node;
         while (i.hasNext()) {
@@ -66,7 +66,7 @@ class PathAddressFilter {
         return accept;
     }
 
-    void addReject(final PathAddress address) {
+    public void addReject(final PathAddress address) {
         final Iterator<PathElement> i = address.iterator();
         Node node = this.node;
         while (i.hasNext()) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadConfigAsFeaturesOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadConfigAsFeaturesOperationHandler.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.controller.operations.global;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NESTED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PARAMS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CONFIG_AS_FEATURES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SPEC;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ObjectTypeAttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.operations.PathAddressFilter;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.AttributeAccess.AccessType;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class ReadConfigAsFeaturesOperationHandler implements OperationStepHandler {
+
+    private static final String ID = "id";
+
+    public static final SimpleOperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(READ_CONFIG_AS_FEATURES_OPERATION, ControllerResolver.getResolver(SUBSYSTEM))
+            .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.READ_WHOLE_CONFIG)
+            .setReadOnly()
+            .withFlag(OperationEntry.Flag.HIDDEN)
+            .setReplyType(ModelType.LIST)
+            .setReplyValueType(ModelType.OBJECT)
+            .addParameter(SimpleAttributeDefinitionBuilder.create(NESTED, ModelType.BOOLEAN)
+                    .setRequired(false)
+                    .setDefaultValue(new ModelNode(true))
+                    .build())
+            .build();
+
+    private final String operationName;
+    private final PathAddressFilter addressFilter;
+
+    public ReadConfigAsFeaturesOperationHandler() {
+        this(null);
+    }
+
+    public ReadConfigAsFeaturesOperationHandler(PathAddressFilter addressFilter) {
+        this.operationName = READ_CONFIG_AS_FEATURES_OPERATION;
+        this.addressFilter = addressFilter;
+    }
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        final PathAddress address = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
+        if (addressFilter != null && !addressFilter.accepts(address)) {
+            return;
+        }
+        final ImmutableManagementResourceRegistration registration = context.getResourceRegistration();
+        if (registration.isAlias() || registration.isRemote() || registration.isRuntimeOnly()) {
+            return;
+        }
+        final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS, false);
+        if (resource.isProxy() || resource.isRuntime()) {
+            return;
+        }
+
+        final ModelNode result = context.getResult();
+        result.setEmptyList();
+        final ModelNode results = new ModelNode().setEmptyList();
+        final AtomicReference<ModelNode> failureRef = new AtomicReference<>();
+
+        final boolean nest = operation.hasDefined(NESTED) ? operation.get(NESTED).asBoolean() : true;
+        final ModelNode feature = registration.isFeature() ? readAsFeature(resource, registration, operation, address, context, results, nest) : null;
+
+        // Step to handle failed operations
+        context.addStep(new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                boolean failed = false;
+                if (failureRef.get() != null) {
+                    // One of our subsystems failed
+                    context.getFailureDescription().set(failureRef.get());
+                    failed = true;
+                }
+                if (!failed) {
+                    final List<ModelNode> children = results.asList();
+                    if (feature == null) {
+                        for (ModelNode child : children) {
+                            result.add(child);
+                        }
+                    } else if (nest) {
+                        if (!children.isEmpty()) {
+                            final ModelNode nested = feature.get(ModelDescriptionConstants.CHILDREN).setEmptyList();
+                            for (final ModelNode childRsp : children) {
+                                nested.add(childRsp);
+                            }
+                        }
+                        result.add(feature);
+                    } else {
+                        result.add(feature);
+                        if (!children.isEmpty()) {
+                            for (final ModelNode childRsp : children) {
+                                result.add(childRsp);
+                            }
+                        }
+                    }
+                    context.getResult().set(result);
+                }
+            }
+        }, OperationContext.Stage.MODEL, true);
+
+        describeChildren(resource, registration, address, context, failureRef, results, operation, nest);
+    }
+
+    private void describeChildren(final Resource resource, final ImmutableManagementResourceRegistration registration,
+            final PathAddress address, OperationContext context,
+            final AtomicReference<ModelNode> failureRef, final ModelNode results, ModelNode operation, Boolean nest) {
+        for(String childType : resource.getChildTypes()) {
+            for(Resource.ResourceEntry entry : resource.getChildren(childType)) {
+                if(addressFilter != null && !addressFilter.accepts(address.append(entry.getPathElement()))) {
+                    continue;
+                }
+                final ImmutableManagementResourceRegistration childRegistration = registration.getSubModel(PathAddress.EMPTY_ADDRESS.append(entry.getPathElement()));
+                if(childRegistration == null) {
+                    ControllerLogger.ROOT_LOGGER.debugf("Couldn't find a registration for %s at %s for resource %s at %s", entry.getPathElement().toString(), registration.getPathAddress().toCLIStyleString(), resource, address.toCLIStyleString());
+                    continue;
+                }
+                if(childRegistration.isRuntimeOnly() || childRegistration.isRemote() || childRegistration.isAlias()) {
+                    continue;
+                }
+                describeChildResource(entry, registration, address, context, failureRef, results, operation, nest);
+            }
+        }
+    }
+
+    private ModelNode readAsFeature(final Resource resource,
+            final ImmutableManagementResourceRegistration registration, ModelNode operation, final PathAddress address,
+            OperationContext context, ModelNode results, boolean nest) throws OperationFailedException {
+            ImmutableManagementResourceRegistration registry = context.getRootResourceRegistration().getSubModel(address);
+
+            final ModelNode featureNode = new ModelNode();
+            featureNode.get(SPEC).set(registry.getFeature());
+
+            final ModelNode idParams = featureNode.get(ID);
+            final Set<String> idParamNames;
+            final int addrSize = address.size();
+            if (addrSize > 0) {
+                idParamNames = new HashSet<>(addrSize);
+                if(addrSize > 1) {
+                    int i = 0;
+                    while (i < addrSize - 1) {
+                        final PathElement elt = address.getElement(i++);
+                        final String paramName = elt.getKey();
+                        idParamNames.add(paramName);
+                        if(!nest) {
+                            idParams.get(paramName).set(elt.getValue());
+                        }
+                    }
+                }
+                final PathElement lastElt = address.getLastElement();
+                final String paramName = lastElt.getKey();
+                idParams.get(paramName).set(lastElt.getValue());
+                idParamNames.add(paramName);
+            } else {
+                idParamNames = Collections.emptySet();
+            }
+
+            final DescriptionProvider addDescr = registration.getOperationDescription(PathAddress.EMPTY_ADDRESS, ModelDescriptionConstants.ADD);
+            final ModelNode addProps = addDescr == null ? null : addDescr.getModelDescription(null).get(ModelDescriptionConstants.REQUEST_PROPERTIES);
+
+            List<ModelNode> children = Collections.emptyList();
+            ModelNode params = null;
+            final ModelNode model = resource.getModel();
+            try(Stream<String> attrs = registration.getAttributeNames(PathAddress.EMPTY_ADDRESS).stream()) {
+                final Iterator<String> i = attrs.iterator();
+                while(i.hasNext()) {
+                    final String attrName = i.next();
+                    if(!model.hasDefined(attrName)) {
+                        continue;
+                    }
+                    final AttributeAccess attrAccess = registration.getAttributeAccess(PathAddress.EMPTY_ADDRESS, attrName);
+                    if(attrAccess.getStorageType() != AttributeAccess.Storage.CONFIGURATION ||
+                            !(attrAccess.getAccessType().equals(AccessType.READ_WRITE) ||
+                            addProps != null && addProps.has(attrName))) {
+                        continue;
+                    }
+                    final AttributeDefinition attrDef = attrAccess.getAttributeDefinition();
+                    if (!attrDef.isRequired() || !(addProps != null && addProps.hasDefined(attrName))) {
+                        final ModelType attrType = attrDef.getType();
+                        if (attrType.equals(ModelType.OBJECT)
+                                && ObjectTypeAttributeDefinition.class.isAssignableFrom(attrDef.getClass())) {
+                            final ModelNode child = readObjectAttributeAsFeature(registration, (ObjectTypeAttributeDefinition) attrDef,
+                                    idParams, idParamNames, model.get(attrName), nest);
+                            if (children.isEmpty()) {
+                                children = Collections.singletonList(child);
+                                continue;
+                            }
+                            if (children.size() == 1) {
+                                final List<ModelNode> tmp = children;
+                                children = new ArrayList<>(2);
+                                children.add(tmp.get(0));
+                            }
+                            children.add(child);
+                            continue;
+                        }
+                        /* NOTE: the commented out code allows to split the list as an atomic value into a list of item features
+                         * the reason it's commented out is that currently list items have no IDs and so can't be compared and merged
+                        if(attrType.equals(ModelType.LIST) && ObjectListAttributeDefinition.class.isAssignableFrom(attrAccess.getAttributeDefinition().getClass())) {
+                            final List<ModelNode> features = getListAttributeFeature(registration,
+                                (ObjectListAttributeDefinition) attrAccess.getAttributeDefinition(), idParams, idParamNames,
+                                model.get(attrName).asList());
+                            if(children.isEmpty()) {
+                                children = features;
+                                continue;
+                            }
+                            children.addAll(features);
+                             continue;
+                         }
+                         */
+                    }
+                    String paramName = attrName;
+                    if (idParamNames.contains(attrName) || ((PROFILE.equals(attrName) || HOST.equals(attrName)) && isSubsystem(address))) {
+                        paramName = attrName + "-feature";
+                    }
+                    if(params == null) {
+                        params = featureNode.get(PARAMS);
+                    }
+                    params.get(paramName).set(model.get(attrName));
+                }
+            }
+
+            if(!children.isEmpty()) {
+                for(ModelNode child : children) {
+                    results.add(child);
+                }
+            }
+            return featureNode;
+    }
+
+    private ModelNode readObjectAttributeAsFeature(final ImmutableManagementResourceRegistration registration, ObjectTypeAttributeDefinition attrDef,
+            ModelNode idParams, Set<String> idParamNames, ModelNode objectValue, boolean nest) {
+        final ModelNode featureNode = new ModelNode();
+        featureNode.get(SPEC).set(registration.getFeature() + '.' + attrDef.getName());
+
+        if(!nest) {
+            featureNode.get(ID).set(idParams.clone());
+        }
+
+        final ModelNode params = featureNode.get(PARAMS);
+        final AttributeDefinition[] attrs = attrDef.getValueTypes();
+        for(AttributeDefinition attr : attrs) {
+            String attrName = attr.getName();
+            if(!objectValue.hasDefined(attrName)) {
+                continue;
+            }
+            final ModelNode attrValue = objectValue.get(attrName);
+            if(idParamNames.contains(attrName)) {
+                attrName += "-feature";
+            }
+            params.get(attrName).set(attrValue);
+        }
+        return featureNode;
+    }
+
+/* This method breaks a list of objects into a list of features.
+ * But given that the result of this method is used for generating config diffs and we can't establish an identity for the list items,
+ * this method is not used and complex lists are handled as atomic attribute values.
+    private List<ModelNode> getListAttributeFeature(final ImmutableManagementResourceRegistration registration, ObjectListAttributeDefinition attrDef,
+            ModelNode idParams, Set<String> idParamNames, List<ModelNode> list) {
+        final ObjectTypeAttributeDefinition itemType = attrDef.getValueType();
+        final AttributeDefinition[] attrs = itemType.getValueTypes();
+
+        List<ModelNode> features = new ArrayList<>(list.size());
+        for(ModelNode item : list) {
+            final ModelNode featureNode = new ModelNode();
+            featureNode.get("spec").set(registration.getFeature() + '.' + attrDef.getName());
+
+            final ModelNode params = featureNode.get(PARAMS);
+            for(Property param : idParams.asPropertyList()) {
+                params.get(param.getName()).set(param.getValue());
+            }
+
+            for(AttributeDefinition attr : attrs) {
+                String attrName = attr.getName();
+                if(!item.hasDefined(attrName)) {
+                    continue;
+                }
+                final ModelNode attrValue = item.get(attrName);
+                if(idParamNames.contains(attrName)) {
+                    attrName += "-feature";
+                }
+                params.get(attrName).set(attrValue);
+            }
+            features.add(featureNode);
+        }
+        return features;
+    }
+*/
+    private static boolean isSubsystem(PathAddress address) {
+        for(PathElement elt : address) {
+            if(SUBSYSTEM.equals(elt.getKey())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void describeChildResource(final Resource.ResourceEntry entry,
+            final ImmutableManagementResourceRegistration registration, final PathAddress address,
+            OperationContext context, final AtomicReference<ModelNode> failureRef,
+            final ModelNode results, ModelNode operation, Boolean nest) {
+        final ModelNode childRsp = new ModelNode();
+        context.addStep(new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                if (failureRef.get() == null) {
+                    if (childRsp.hasDefined(FAILURE_DESCRIPTION)) {
+                        failureRef.set(childRsp.get(FAILURE_DESCRIPTION));
+                    } else if (childRsp.hasDefined(RESULT)) {
+                        addChildOperation(address, childRsp.require(RESULT).asList(), results);
+                    }
+                }
+            }
+        }, OperationContext.Stage.MODEL, true);
+        final ModelNode childOperation = operation.clone();
+        childOperation.get(ModelDescriptionConstants.OP).set(operationName);
+        if(nest != null) {
+            childOperation.get(NESTED).set(nest);
+        }
+        final PathElement childPE = entry.getPathElement();
+        childOperation.get(ModelDescriptionConstants.OP_ADDR).set(address.append(childPE).toModelNode());
+        final ImmutableManagementResourceRegistration childRegistration = registration.getSubModel(PathAddress.EMPTY_ADDRESS.append(childPE));
+        final OperationStepHandler stepHandler = childRegistration.getOperationHandler(PathAddress.EMPTY_ADDRESS, operationName);
+        context.addStep(childRsp, childOperation, stepHandler, OperationContext.Stage.MODEL, true);
+    }
+
+    protected void addChildOperation(final PathAddress parent, final List<ModelNode> operations, ModelNode results) {
+        for (final ModelNode operation : operations) {
+            results.add(operation);
+        }
+    }
+}

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -467,6 +467,8 @@ local-destination-outbound-socket-binding.fixed-source-port=Whether the port val
 
 # Subsystem
 subsystem.describe=Outputs the subsystem as a list of operations that can be executed to create the original model
+subsystem.read-config-as-features=Translates current state of the management model to configured provisioning features
+subsystem.read-config-as-features.nested=Whether child features should be nested in their parents
 
 # Global operations
 global.read-attribute=Gets the value of an attribute for the selected resource

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadConfigAsFeaturesTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadConfigAsFeaturesTestCase.java
@@ -1,0 +1,274 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller.test;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NESTED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CONFIG_AS_FEATURES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PARAMS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SPEC;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.junit.Assert.assertEquals;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ManagementModel;
+import org.jboss.as.controller.ModelOnlyAddStepHandler;
+import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
+import org.jboss.as.controller.ObjectListAttributeDefinition;
+import org.jboss.as.controller.ObjectTypeAttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PrimitiveListAttributeDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.global.GlobalNotifications;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.operations.global.ReadConfigAsFeaturesOperationHandler;
+import org.jboss.as.controller.operations.global.ReadFeatureDescriptionHandler;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.Test;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+public class ReadConfigAsFeaturesTestCase extends AbstractControllerTestBase {
+
+    private static final String NON_FEATURE = "non-feature";
+    private static final String RESOURCE = "resource";
+    private static final String RT_RESOURCE = "rt-resource";
+    private static final String TEST = "test";
+
+    private static final String ATTR_HOST = "host";
+    private static final String ATTR_PROFILE = "profile";
+    private static final String ATTR_STR = "attr-str";
+    private static final String ATTR_RT_ONLY = "attr-rt-only";
+    private static final String ATTR_LIST_STR = "attr-list-str";
+    private static final String ATTR_LIST_OBJ = "attr-list-obj";
+    private static final String ATTR_OBJ = "attr-obj";
+    private static final String ATTR_OBJ_REQUIRED = "attr-obj-required";
+
+    private static final AttributeDefinition ATTR_HOST_DEF = TestUtils.createAttribute(ATTR_HOST, ModelType.STRING);
+    private static final AttributeDefinition ATTR_PROFILE_DEF = TestUtils.createAttribute(ATTR_PROFILE, ModelType.STRING);
+    private static final AttributeDefinition ATTR_STR_DEF = TestUtils.createAttribute(ATTR_STR, ModelType.STRING);
+    private static final AttributeDefinition ATTR_RT_ONLY_DEF = TestUtils.createAttribute(ATTR_RT_ONLY, ModelType.STRING, true);
+    private static final PrimitiveListAttributeDefinition ATTR_LIST_STR_DEF = new PrimitiveListAttributeDefinition.Builder(ATTR_LIST_STR, ModelType.STRING).build();
+    private static final ObjectTypeAttributeDefinition ATTR_OBJ_DEF = new ObjectTypeAttributeDefinition.Builder(ATTR_OBJ, ATTR_STR_DEF, ATTR_LIST_STR_DEF).build();
+    private static final ObjectListAttributeDefinition ATTR_LIST_OBJ_DEF = new ObjectListAttributeDefinition.Builder(ATTR_LIST_OBJ, ATTR_OBJ_DEF).build();
+    private static final ObjectTypeAttributeDefinition ATTR_OBJ_REQUIRED_DEF = new ObjectTypeAttributeDefinition.Builder(ATTR_OBJ_REQUIRED, ATTR_STR_DEF, ATTR_LIST_STR_DEF)
+            .setRequired(true)
+            .build();
+    private static final AttributeDefinition ATTR_SUBSYSTEM_DEF = TestUtils.createAttribute(SUBSYSTEM, ModelType.STRING);
+
+    private static final OperationStepHandler WRITE_HANDLER = new ModelOnlyWriteAttributeHandler();
+
+    private ManagementResourceRegistration registration;
+
+    @Override
+    public void setupController() throws InterruptedException {
+        super.setupController();
+        // register read-feature op
+        // can't do this in #initModel() because `capabilityRegistry` is not available at that stage
+        registration.registerOperationHandler(ReadFeatureDescriptionHandler.DEFINITION,
+                ReadFeatureDescriptionHandler.getInstance(capabilityRegistry), true);
+    }
+
+    @Test
+    public void testNested() throws Exception {
+/*
+        ModelNode op = new ModelNode();
+        op.get("operation").set("read-feature-description");
+        op.get("recursive").set(true);
+        op.get("address").setEmptyList().add(SUBSYSTEM, TEST);
+        System.out.println(executeForResult(op));
+*/
+        final ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(OP).set(READ_CONFIG_AS_FEATURES_OPERATION);
+        final ModelNode subsystemFeature = getSubsystemFeature();
+        final ModelNode children = subsystemFeature.get("children");
+        children.add(getAttrObjFeature(true));
+        children.add(getTestResourceFeature(true));
+        final ModelNode rootFeature = getRootFeature();
+        rootFeature.get("children").add(subsystemFeature);
+
+        assertEquals(new ModelNode().add(rootFeature), executeForResult(operation));
+    }
+
+    @Test
+    public void testNestedFalse() throws Exception {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).setEmptyList();
+        operation.get(OP).set(READ_CONFIG_AS_FEATURES_OPERATION);
+        operation.get(NESTED).set(false);
+        assertEquals(new ModelNode().add(getRootFeature()).add(getSubsystemFeature()).add(getAttrObjFeature(false)).add(getTestResourceFeature(false)), executeForResult(operation));
+    }
+
+    private static ModelNode getRootFeature() {
+        final ModelNode result = new ModelNode();
+        result.get(SPEC).set("server-root");
+        result.get("id");
+        return result;
+    }
+
+    private static ModelNode getSubsystemFeature() {
+        final ModelNode result = new ModelNode();
+        result.get(SPEC).set(SUBSYSTEM + "." + TEST);
+        result.get("id").get(SUBSYSTEM).set(TEST);
+
+        final ModelNode params = result.get(PARAMS);
+        params.get(ATTR_STR).set("one");
+        params.get("host-feature").set("test-host");
+        params.get("profile-feature").set("test-profile");
+        params.get(ATTR_LIST_STR).set(new ModelNode().add("a").add("b").add("c"));
+
+        final ModelNode obj = new ModelNode();
+        obj.get(ATTR_STR).set("1");
+        obj.get(ATTR_LIST_STR).set(new ModelNode().add("d").add("e"));
+
+        params.get(ATTR_LIST_OBJ).add(obj);
+        params.get(ATTR_OBJ_REQUIRED).set(obj);
+
+        return result;
+    }
+
+    private static ModelNode getAttrObjFeature(boolean nested) {
+        final ModelNode result = new ModelNode();
+        result.get(SPEC).set(SUBSYSTEM + "." + TEST + "." + ATTR_OBJ);
+        if(!nested) {
+            result.get("id").get(SUBSYSTEM).set(TEST);
+        }
+        final ModelNode params = result.get(PARAMS);
+        params.get(ATTR_STR).set("1");
+        params.get(ATTR_LIST_STR).set(new ModelNode().add("d").add("e"));
+        return result;
+    }
+
+    private static ModelNode getTestResourceFeature(boolean nested) {
+        final ModelNode result = new ModelNode();
+        result.get(SPEC).set(SUBSYSTEM + "." + TEST + "." + RESOURCE);
+        ModelNode id = result.get("id");
+        if(!nested) {
+            id.get(SUBSYSTEM).set(TEST);
+        }
+        id.get(RESOURCE).set(TEST);
+
+        final ModelNode params = result.get(PARAMS);
+        params.get(ATTR_STR).set("one");
+        params.get(ATTR_LIST_STR).set(new ModelNode().add("d").add("e"));
+        params.get(SUBSYSTEM + "-feature").set("one");
+        return result;
+    }
+
+    @Override
+    protected void initModel(ManagementModel managementModel) {
+
+        final ModelNode model = new ModelNode();
+        model.get(SUBSYSTEM, TEST, ATTR_HOST).set("test-host");
+        model.get(SUBSYSTEM, TEST, ATTR_PROFILE).set("test-profile");
+        model.get(SUBSYSTEM, TEST, ATTR_STR).set("one");
+        model.get(SUBSYSTEM, TEST, ATTR_RT_ONLY).set("value");
+
+        model.get(SUBSYSTEM, TEST, ATTR_LIST_STR).set(new ModelNode().add("a").add("b").add("c"));
+
+        ModelNode value = new ModelNode();
+        value.get(ATTR_STR).set("1");
+        value.get(ATTR_LIST_STR).add("d").add("e");
+
+        model.get(SUBSYSTEM, TEST, ATTR_OBJ).set(value);
+        model.get(SUBSYSTEM, TEST, ATTR_OBJ_REQUIRED).set(value);
+
+        model.get(SUBSYSTEM, TEST, ATTR_LIST_OBJ).set(new ModelNode().add(value));
+
+        model.get(SUBSYSTEM, TEST, RESOURCE, TEST, ATTR_STR).set("one");
+        model.get(SUBSYSTEM, TEST, RESOURCE, TEST, ATTR_RT_ONLY).set("value");
+        model.get(SUBSYSTEM, TEST, RESOURCE, TEST, ATTR_LIST_STR).set(new ModelNode().add("d").add("e"));
+        model.get(SUBSYSTEM, TEST, RESOURCE, TEST, SUBSYSTEM).set("one");
+
+        model.get(SUBSYSTEM, TEST, RT_RESOURCE, TEST, ATTR_STR).set("one");
+        model.get(SUBSYSTEM, TEST, NON_FEATURE, TEST, ATTR_STR).set("one");
+
+        final ManagementResourceRegistration registration = managementModel.getRootResourceRegistration();
+        this.registration = registration;
+        GlobalOperationHandlers.registerGlobalOperations(registration, processType);
+
+        registration.registerOperationHandler(new SimpleOperationDefinitionBuilder("setup", new NonResolvingResourceDescriptionResolver())
+                .setPrivateEntry()
+                .build()
+                , new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                createModel(context, model);
+            }
+        });
+
+
+        GlobalNotifications.registerGlobalNotifications(registration, processType);
+
+        registration.registerOperationHandler(ReadConfigAsFeaturesOperationHandler.DEFINITION, new ReadConfigAsFeaturesOperationHandler(), true);
+
+        final ManagementResourceRegistration subsystem =
+                registration.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement(SUBSYSTEM, TEST),
+                                NonResolvingResourceDescriptionResolver.INSTANCE));
+        subsystem.registerReadWriteAttribute(ATTR_HOST_DEF, null, WRITE_HANDLER);
+        subsystem.registerReadWriteAttribute(ATTR_PROFILE_DEF, null, WRITE_HANDLER);
+        subsystem.registerReadWriteAttribute(ATTR_STR_DEF, null, WRITE_HANDLER);
+        subsystem.registerReadWriteAttribute(ATTR_RT_ONLY_DEF, null, WRITE_HANDLER);
+        subsystem.registerReadWriteAttribute(ATTR_LIST_STR_DEF, null, WRITE_HANDLER);
+        subsystem.registerReadWriteAttribute(ATTR_OBJ_DEF, null, WRITE_HANDLER);
+        subsystem.registerReadWriteAttribute(ATTR_OBJ_REQUIRED_DEF, null, WRITE_HANDLER);
+        subsystem.registerReadWriteAttribute(ATTR_LIST_OBJ_DEF, null, WRITE_HANDLER);
+
+        AttributeDefinition[] attrDefs = new AttributeDefinition[] {ATTR_HOST_DEF, ATTR_PROFILE_DEF, ATTR_STR_DEF, ATTR_RT_ONLY_DEF, ATTR_LIST_STR_DEF, ATTR_OBJ_DEF, ATTR_OBJ_REQUIRED_DEF, ATTR_LIST_OBJ_DEF};
+        subsystem.registerOperationHandler(TestUtils.createOperationDefinition("add", attrDefs), new ModelOnlyAddStepHandler(attrDefs));
+
+        final ManagementResourceRegistration resource = subsystem.registerSubModel(new SimpleResourceDefinition(PathElement.pathElement(RESOURCE, "*"),
+                NonResolvingResourceDescriptionResolver.INSTANCE));
+        resource.registerReadWriteAttribute(ATTR_STR_DEF, null, WRITE_HANDLER);
+        resource.registerReadWriteAttribute(ATTR_RT_ONLY_DEF, null, WRITE_HANDLER);
+        resource.registerReadWriteAttribute(ATTR_LIST_STR_DEF, null, WRITE_HANDLER);
+        resource.registerReadWriteAttribute(ATTR_SUBSYSTEM_DEF, null, WRITE_HANDLER);
+        attrDefs = new AttributeDefinition[] {ATTR_STR_DEF, ATTR_RT_ONLY_DEF, ATTR_LIST_STR_DEF, ATTR_SUBSYSTEM_DEF};
+        resource.registerOperationHandler(TestUtils.createOperationDefinition("add", attrDefs), new ModelOnlyAddStepHandler(attrDefs));
+
+        final ManagementResourceRegistration rt = subsystem.registerSubModel(new SimpleResourceDefinition(
+                new SimpleResourceDefinition.Parameters(PathElement.pathElement(RT_RESOURCE, TEST),
+                        NonResolvingResourceDescriptionResolver.INSTANCE)
+                        .setRuntime()));
+        rt.registerReadWriteAttribute(ATTR_STR_DEF, null, WRITE_HANDLER);
+        rt.registerOperationHandler(TestUtils.createOperationDefinition("add", new AttributeDefinition[] {ATTR_STR_DEF}), new ModelOnlyAddStepHandler(attrDefs));
+
+        final ManagementResourceRegistration nonFeature = subsystem.registerSubModel(new SimpleResourceDefinition(
+                new SimpleResourceDefinition.Parameters(PathElement.pathElement(NON_FEATURE, TEST),
+                        NonResolvingResourceDescriptionResolver.INSTANCE)
+                        .setFeature(false)));
+        nonFeature.registerReadWriteAttribute(ATTR_STR_DEF, null, WRITE_HANDLER);
+        nonFeature.registerOperationHandler(TestUtils.createOperationDefinition("add", new AttributeDefinition[] {ATTR_STR_DEF}), new ModelOnlyAddStepHandler(attrDefs));
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/GenericModelDescribeOperationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/GenericModelDescribeOperationHandler.java
@@ -48,6 +48,7 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.controller.operations.PathAddressFilter;
 import org.jboss.as.controller.operations.common.OrderedChildTypesAttachment;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainOperationsHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainOperationsHandler.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
+import org.jboss.as.controller.operations.PathAddressFilter;
 import org.jboss.as.controller.operations.common.OrderedChildTypesAttachment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/DomainRootDefinition.java
@@ -42,6 +42,7 @@ import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
@@ -57,6 +58,7 @@ import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistryType;
 import org.jboss.as.controller.extension.ExtensionResourceDefinition;
 import org.jboss.as.controller.extension.MutableRootResourceRegistrationProvider;
+import org.jboss.as.controller.operations.PathAddressFilter;
 import org.jboss.as.controller.operations.common.NamespaceAddHandler;
 import org.jboss.as.controller.operations.common.NamespaceRemoveHandler;
 import org.jboss.as.controller.operations.common.SchemaLocationAddHandler;
@@ -67,6 +69,7 @@ import org.jboss.as.controller.operations.common.SnapshotTakeHandler;
 import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
 import org.jboss.as.controller.operations.common.XmlMarshallingHandler;
 import org.jboss.as.controller.operations.global.GlobalInstallationReportHandler;
+import org.jboss.as.controller.operations.global.ReadConfigAsFeaturesOperationHandler;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
@@ -272,6 +275,11 @@ public class DomainRootDefinition extends SimpleResourceDefinition {
                 GlobalInstallationReportHandler.createDomainOperation(), false);
 
         resourceRegistration.registerOperationHandler(GenericModelDescribeOperationHandler.DEFINITION, GenericModelDescribeOperationHandler.INSTANCE, true);
+
+        final PathAddressFilter hostFilter = new PathAddressFilter(true);
+        hostFilter.addReject(PathAddress.pathAddress(PathElement.pathElement(ModelDescriptionConstants.HOST)));
+        resourceRegistration.registerOperationHandler(ReadConfigAsFeaturesOperationHandler.DEFINITION, new ReadConfigAsFeaturesOperationHandler(hostFilter), true);
+
         if (isMaster) {
             DeploymentUploadURLHandler.registerMaster(resourceRegistration, contentRepo);
             DeploymentUploadStreamAttachmentHandler.registerMaster(resourceRegistration, contentRepo);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/HostResourceDefinition.java
@@ -64,6 +64,7 @@ import org.jboss.as.controller.operations.common.ValidateOperationHandler;
 import org.jboss.as.controller.operations.common.XmlMarshallingHandler;
 import org.jboss.as.controller.operations.global.GlobalInstallationReportHandler;
 import org.jboss.as.controller.operations.global.ReadAttributeHandler;
+import org.jboss.as.controller.operations.global.ReadConfigAsFeaturesOperationHandler;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -346,6 +347,7 @@ public class HostResourceDefinition extends SimpleResourceDefinition {
         hostRegistration.registerOperationHandler(GlobalInstallationReportHandler.DEFINITION, GlobalInstallationReportHandler.INSTANCE, false);
         hostRegistration.registerOperationHandler(InstallationReportHandler.DEFINITION, InstallationReportHandler.createOperation(environment), false);
 
+        hostRegistration.registerOperationHandler(ReadConfigAsFeaturesOperationHandler.DEFINITION, new ReadConfigAsFeaturesOperationHandler(), true);
 
         hostRegistration.registerOperationHandler(ValidateAddressOperationHandler.DEFINITION, ValidateAddressOperationHandler.INSTANCE);
 

--- a/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
+++ b/server/src/main/java/org/jboss/as/server/controller/resources/ServerRootResourceDefinition.java
@@ -64,6 +64,7 @@ import org.jboss.as.controller.operations.common.XmlMarshallingHandler;
 import org.jboss.as.controller.operations.global.GlobalInstallationReportHandler;
 import org.jboss.as.controller.operations.global.GlobalNotifications;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.operations.global.ReadConfigAsFeaturesOperationHandler;
 import org.jboss.as.controller.operations.global.ReadFeatureDescriptionHandler;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
@@ -294,6 +295,7 @@ public class ServerRootResourceDefinition extends SimpleResourceDefinition {
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         GlobalOperationHandlers.registerGlobalOperations(resourceRegistration, ProcessType.STANDALONE_SERVER);
         resourceRegistration.registerOperationHandler(ReadFeatureDescriptionHandler.DEFINITION, ReadFeatureDescriptionHandler.getInstance(capabilityRegistry), true);
+        resourceRegistration.registerOperationHandler(ReadConfigAsFeaturesOperationHandler.DEFINITION, new ReadConfigAsFeaturesOperationHandler(), true);
 
         resourceRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION, ValidateOperationHandler.INSTANCE);
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3991

This is a read-only and hidden operation which reads the management model and represents it in terms of provisioning features. This operation is used by Galleon provisioning plugins to generate configuration diffs.