### PR TITLE
[WFCORE-4011] Upgrade WildFly Elytron to 1.5.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.5.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.5.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.0.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.2.2.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
This is a release containing the following bug fixes, some of which are required to fix issues identitfied in current RFEs

https://issues.jboss.org/browse/WFCORE-4011

Release Notes - WildFly Elytron - Version 1.5.2.Final

** Bug
    * [ELY-1616] - ldap-key-store requires attribute userPKCS12 on ldap entry, even if it should be mandatory
    * [ELY-1618] - TLS with BCJSSE Provider does not work
    * [ELY-1622] - BC FIPS with CLI: SunX509 KeyManagerFactory not available

** Task
    * [ELY-787] - SASL mechanisms are not IANA registered and specifications are not provided
    * [ELY-1625] - Fix ECPublicKey import in testsuite

** Release
    * [ELY-1628] - Release WildFly Elytron 1.5.2.Final
