### PR TITLE
[WFCORE-4013] Upgrade Elytron Web to 1.2.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.5.1.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.2.0.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.2.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.2.2.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>


### PR DESCRIPTION
This release is a bug fix release only.

https://issues.jboss.org/browse/WFCORE-4013

Release Notes - Elytron Web - Version 1.2.1.Final

** Bug
    * [ELYWEB-6] - Coverity, Dereference null return value ElytronHttpServletExchange
    * [ELYWEB-8] - constraint drive authentication method in undertow doesn't work with elytron

** Release
    * [ELYWEB-10] - Release Elytron Web 1.2.1.Final
