### PR TITLE
[WFCORE-37] Don't throw an exception if a handler is added via the ad…

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
+++ b/logging/src/main/java/org/jboss/as/logging/CommonAttributes.java
@@ -122,6 +122,7 @@ public interface CommonAttributes {
             .build();
 
     LogHandlerListAttributeDefinition HANDLERS = LogHandlerListAttributeDefinition.Builder.of("handlers")
+            .setAllowDuplicates(false)
             .setAllowExpression(false)
             .setCapabilityReference(Capabilities.LOGGER_HANDLER_REFERENCE_RECORDER)
             .setRequired(false)

--- a/logging/src/main/java/org/jboss/as/logging/handlers/AsyncHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/handlers/AsyncHandlerResourceDefinition.java
@@ -92,6 +92,7 @@ public class AsyncHandlerResourceDefinition extends AbstractHandlerDefinition {
             .build();
 
     public static final LogHandlerListAttributeDefinition SUBHANDLERS = LogHandlerListAttributeDefinition.Builder.of("subhandlers")
+            .setAllowDuplicates(false)
             .setAllowExpression(false)
             .setCapabilityReference(Capabilities.HANDLER_REFERENCE_RECORDER)
             .setRequired(false)


### PR DESCRIPTION
…d-handler operation. Also fix the model validation to keep the handler names unique when associated with a logger or async-handler.

https://issues.jboss.org/browse/WFCORE-37

If adding a handler and then adding it to a logger or async-handler in a composite operation via the `add-handler` operation a failure would occur because the `add` operation already adds the handler as it's found in the model already. This just ignores the error and logs a trace message instead. The `add-handler` operation shouldn't fail if the handler is already assigned.