### PR TITLE
[WFCORE-3991] Test coverage for read-config-as-features

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -240,6 +240,7 @@ public class ModelDescriptionConstants {
     public static final String HTTP_UPGRADE = "http-upgrade";
     public static final String HTTP_UPGRADE_ENABLED = "http-upgrade-enabled";
     public static final String HTTP_INTERFACE = "http-interface";
+    public static final String ID = "id";
     public static final String IDENTITY = "identity";
     public static final String IGNORED = "ignored-by-unaffected-host-controller";
     public static final String IGNORED_RESOURCES = "ignored-resources";
@@ -275,6 +276,7 @@ public class ModelDescriptionConstants {
     public static final String LEVEL = "level";
     public static final String LDAP = "ldap";
     public static final String LDAP_CONNECTION = "ldap-connection";
+    public static final String LIST_SNAPSHOTS_OPERATION = "list-snapshots";
     public static final String LOCAL = "local";
     public static final String LOCAL_DESTINATION_OUTBOUND_SOCKET_BINDING = "local-destination-outbound-socket-binding";
     public static final String LOCAL_HOST_NAME = "local-host-name";
@@ -358,10 +360,10 @@ public class ModelDescriptionConstants {
     public static final String PASSWORD = "password";
     public static final String PATH = "path";
     public static final String PATHS = "paths";
+    public static final String PATTERN = "pattern";
     public static final String PERIODIC_ROTATING_FILE_HANDLER = "periodic-rotating-file-handler";
     public static final String PERMISSION_COMBINATION_POLICY = "permission-combination-policy";
     public static final String PERSIST_NAME = "persist-name";
-    public static final String PATTERN = "pattern";
     public static final String PERSISTENT = "persistent";
     public static final String PLAIN_TEXT = "plain-text";
     public static final String PLATFORM_MBEAN = "platform-mbean";
@@ -546,6 +548,7 @@ public class ModelDescriptionConstants {
      */
     public static final String SYNC_REMOVED_FOR_READD = "sync-dropped-for-readd";
     public static final String TAIL_COMMENT_ALLOWED = "tail-comment-allowed";
+    public static final String TAKE_SNAPSHOT_OPERATION = "take-snapshot";
     public static final String TARGET_PATH = "target-path";
     public static final String TCP = "tcp";
     public static final String TIMEOUT = "timeout";

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ReadConfigAsFeaturesDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/ReadConfigAsFeaturesDomainTestCase.java
@@ -1,0 +1,211 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.domain.management;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.management.api.ReadConfigAsFeaturesTestBase;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+
+/**
+ * Tests {@code read-config-as-features} operation in domain mode.
+ *
+ * @author <a href="mailto:rjanik@redhat.com">Richard Janík</a>
+ */
+public class ReadConfigAsFeaturesDomainTestCase extends ReadConfigAsFeaturesTestBase {
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainMasterLifecycleUtil;
+
+    private String defaultDomainConfig;
+    private String defaultHostConfig;
+    private ModelNode defaultDomainConfigAsFeatures;
+    private ModelNode defaultHostConfigAsFeatures;
+
+    @BeforeClass
+    public static void setupDomain() {
+        testSupport = DomainTestSupport.createAndStartSupport(DomainTestSupport.Configuration.create(ReadConfigAsFeaturesDomainTestCase.class.getSimpleName(),
+                "domain-configs/domain-standard.xml", "host-configs/host-master.xml", "host-configs/host-slave.xml"));
+        domainMasterLifecycleUtil = testSupport.getDomainMasterLifecycleUtil();
+    }
+
+    @AfterClass
+    public static void tearDownDomain() {
+        testSupport.stop();
+        testSupport = null;
+        domainMasterLifecycleUtil = null;
+    }
+
+    @Test
+    public void domainSystemPropertyTest() {
+        ModelNode redefineProperty = Util.getWriteAttributeOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, "jboss.domain.test.property.one"), VALUE, "SIX");
+        ModelNode addProperty = Util.createAddOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, "customProp"));
+        addProperty.get(BOOT_TIME).set(false);
+        addProperty.get(VALUE).set("customPropVal");
+
+        ModelNode expectedDomainConfigAsFeatures = defaultDomainConfigAsFeatures.clone();
+
+        // modify the existing property
+        ModelNode propertyId = new ModelNode();
+        propertyId.get(SYSTEM_PROPERTY).set("jboss.domain.test.property.one");
+        ModelNode existingProperty = getListElement(expectedDomainConfigAsFeatures, "domain.system-property", propertyId);
+        existingProperty.get(PARAMS).get(VALUE).set("SIX");
+
+        // add the new property
+        ModelNode newPropertyId = new ModelNode();
+        ModelNode newPropertyParams = new ModelNode();
+        ModelNode newProperty = new ModelNode();
+        newPropertyId.get(SYSTEM_PROPERTY).set("customProp");
+        newPropertyParams.get(BOOT_TIME).set(false);
+        newPropertyParams.get(VALUE).set("customPropVal");
+        newProperty.get(SPEC).set("domain.system-property");
+        newProperty.get(ID).set(newPropertyId);
+        newProperty.get(PARAMS).set(newPropertyParams);
+        // insert the new property as a first property
+        int newPropertyIndex = getListElementIndex(expectedDomainConfigAsFeatures, "domain.system-property"); // finds the first one
+        expectedDomainConfigAsFeatures.insert(newProperty, newPropertyIndex);
+
+        doTest(Arrays.asList(redefineProperty, addProperty), expectedDomainConfigAsFeatures, PathAddress.EMPTY_ADDRESS);
+    }
+
+    @Test
+    public void domainProfileTest() {
+        ModelNode redefineProfileAttribute = Util.getWriteAttributeOperation(
+                PathAddress.pathAddress(PROFILE, DEFAULT).append(SUBSYSTEM, "io").append("buffer-pool", "default"),
+                "buffer-size", 500);
+        ModelNode removeSubsystemFromProfile = Util.createRemoveOperation(PathAddress.pathAddress(PROFILE, DEFAULT).append(SUBSYSTEM, "request-controller"));
+
+        ModelNode expectedDomainConfigAsFeatures = defaultDomainConfigAsFeatures.clone();
+
+        // remove the request controller subsystem
+        ModelNode defaultProfileId = new ModelNode();
+        defaultProfileId.get(PROFILE).set(DEFAULT);
+        ModelNode defaultProfile = getListElement(expectedDomainConfigAsFeatures, PROFILE, defaultProfileId);
+        int requestControllerSubsystemIndex = getFeatureNodeChildIndex(defaultProfile, "profile.subsystem.request-controller");
+        defaultProfile.get(CHILDREN).remove(requestControllerSubsystemIndex);
+
+        // rewrite the buffer-pool attribute
+        ModelNode ioSubsystem = getFeatureNodeChild(defaultProfile, "profile.subsystem.io");
+        ModelNode bufferPool = getFeatureNodeChild(ioSubsystem, "profile.subsystem.io.buffer-pool");
+        ModelNode bufferPoolParams = new ModelNode();
+        bufferPoolParams.get("buffer-size").set(500);
+        bufferPool.get(PARAMS).set(bufferPoolParams);
+
+        doTest(Arrays.asList(redefineProfileAttribute, removeSubsystemFromProfile), expectedDomainConfigAsFeatures, PathAddress.EMPTY_ADDRESS);
+    }
+
+    @Test
+    public void hostInterfaceTest() {
+        ModelNode redefineInterface = Util.getWriteAttributeOperation(PathAddress.pathAddress(HOST, MASTER).append(INTERFACE, "management"), INET_ADDRESS, "10.10.10.10");
+
+        ModelNode expectedHostConfigAsFeatures = defaultHostConfigAsFeatures.clone();
+
+        ModelNode managementInterfaceId = new ModelNode();
+        managementInterfaceId.get(INTERFACE).set("management");
+        ModelNode managementInterface = getFeatureNodeChild(expectedHostConfigAsFeatures.get(0), "host.interface", managementInterfaceId);
+        ModelNode managementInterfaceParams = new ModelNode();
+        managementInterfaceParams.get(INET_ADDRESS).set("10.10.10.10");
+        managementInterface.get(PARAMS).set(managementInterfaceParams);
+
+        doTest(Collections.singletonList(redefineInterface), expectedHostConfigAsFeatures, PathAddress.pathAddress(HOST, MASTER));
+    }
+
+    @Test
+    public void hostSubsystemTest() {
+        ModelNode redefineJmxAttribute = Util.getWriteAttributeOperation(
+                PathAddress.pathAddress(HOST, MASTER).append(SUBSYSTEM, "jmx").append("expose-model", "resolved"),
+                "domain-name", "customDomainName");
+
+        ModelNode expectedHostConfigAsFeatures = defaultHostConfigAsFeatures.clone();
+
+        ModelNode jmxSubsystem = getFeatureNodeChild(expectedHostConfigAsFeatures.get(0), "host.subsystem.jmx");
+        ModelNode exposeModelResolved = getFeatureNodeChild(jmxSubsystem, "host.subsystem.jmx.expose-model.resolved");
+        ModelNode exposeModelResolvedParams = new ModelNode();
+        exposeModelResolvedParams.get("domain-name").set("customDomainName");
+        exposeModelResolved.get(PARAMS).set(exposeModelResolvedParams);
+
+        doTest(Collections.singletonList(redefineJmxAttribute), expectedHostConfigAsFeatures, PathAddress.pathAddress(HOST, MASTER));
+    }
+
+    private void doTest(List<ModelNode> operations, ModelNode expectedConfigAsFeatures, PathAddress domainOrHostPath) {
+        for (ModelNode operation : operations) {
+            domainMasterLifecycleUtil.executeForResult(operation);
+        }
+        if (!expectedConfigAsFeatures.equals(getConfigAsFeatures(domainOrHostPath))) {
+            // Assert.assertEquals() barfs the whole models to the console, we don't want that
+            System.out.println("Actual:\n" + getConfigAsFeatures(domainOrHostPath).toJSONString(false) + "\nExpected:\n" + expectedConfigAsFeatures.toJSONString(false));
+            Assert.fail("There are differences between the expected and the actual model, see the test output for details");
+        }
+    }
+
+    @Override
+    protected void saveDefaultConfig() {
+        if (defaultDomainConfig == null || defaultHostConfig == null) {
+            ModelNode takeSnapshotOnDomain = Util.createEmptyOperation(TAKE_SNAPSHOT_OPERATION, PathAddress.EMPTY_ADDRESS);
+            ModelNode takeSnapshotOnHost = Util.createEmptyOperation(TAKE_SNAPSHOT_OPERATION, PathAddress.pathAddress(HOST, MASTER));
+            domainMasterLifecycleUtil.executeForResult(takeSnapshotOnDomain);
+            domainMasterLifecycleUtil.executeForResult(takeSnapshotOnHost);
+            ModelNode listDomainSnapshots = Util.createEmptyOperation(LIST_SNAPSHOTS_OPERATION, PathAddress.EMPTY_ADDRESS);
+            ModelNode listHostSnapshots = Util.createEmptyOperation(LIST_SNAPSHOTS_OPERATION, PathAddress.pathAddress(HOST, MASTER));
+            ModelNode domainSnapshots = domainMasterLifecycleUtil.executeForResult(listDomainSnapshots);
+            ModelNode hostSnapshots = domainMasterLifecycleUtil.executeForResult(listHostSnapshots);
+
+            defaultDomainConfig = domainSnapshots.get("names").get(0).asString();
+            defaultHostConfig = hostSnapshots.get("names").get(0).asString();
+        }
+    }
+
+    @Override
+    protected void saveDefaultResult() {
+        if (defaultDomainConfigAsFeatures == null || defaultHostConfigAsFeatures == null) {
+            defaultDomainConfigAsFeatures = getConfigAsFeatures(PathAddress.EMPTY_ADDRESS);
+            defaultHostConfigAsFeatures = getConfigAsFeatures(PathAddress.pathAddress(HOST, MASTER));
+        }
+    }
+
+    @Override
+    protected void restoreDefaultConfig() throws TimeoutException, InterruptedException {
+        ModelNode reloadWithSnapshots = Util.createEmptyOperation(RELOAD, PathAddress.pathAddress(HOST, MASTER));
+        reloadWithSnapshots.get(DOMAIN_CONFIG).set(defaultDomainConfig);
+        reloadWithSnapshots.get(HOST_CONFIG).set(defaultHostConfig);
+        domainMasterLifecycleUtil.executeForResult(reloadWithSnapshots);
+        domainMasterLifecycleUtil.awaitHostController(System.currentTimeMillis());
+    }
+
+    private ModelNode getConfigAsFeatures(PathAddress pathAddress) {
+        return domainMasterLifecycleUtil.executeForResult(
+                Util.createEmptyOperation(READ_CONFIG_AS_FEATURES_OPERATION, pathAddress));
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/api/ReadConfigAsFeaturesTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/api/ReadConfigAsFeaturesTestBase.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.management.api;
+
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Before;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+
+import java.util.concurrent.TimeoutException;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ID;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SPEC;
+
+/**
+ * @author <a href="mailto:rjanik@redhat.com">Richard Janík</a>
+ */
+public abstract class ReadConfigAsFeaturesTestBase {
+
+    @Before
+    public void setUp() throws UnsuccessfulOperationException {
+        saveDefaultConfig();
+        saveDefaultResult();
+    }
+
+    @After
+    public void tearDown() throws TimeoutException, InterruptedException {
+        restoreDefaultConfig();
+    }
+
+    protected abstract void saveDefaultConfig() throws UnsuccessfulOperationException;
+
+    protected abstract void saveDefaultResult() throws UnsuccessfulOperationException;
+
+    protected abstract void restoreDefaultConfig() throws TimeoutException, InterruptedException;
+
+    protected ModelNode getFeatureNodeChild(ModelNode node, String spec) {
+        return getListElement(node.get(CHILDREN), spec);
+    }
+
+    protected ModelNode getFeatureNodeChild(ModelNode node, String spec, ModelNode id) {
+        return getListElement(node.get(CHILDREN), spec, id);
+    }
+
+    protected int getFeatureNodeChildIndex(ModelNode node, String spec) {
+        return getListElementIndex(node.get(CHILDREN), spec);
+    }
+
+    protected int getFeatureNodeChildIndex(ModelNode node, String spec, ModelNode id) {
+        return getListElementIndex(node.get(CHILDREN), spec, id);
+    }
+
+    protected ModelNode getListElement(ModelNode list, String spec) {
+        return getListElement(list, spec, null);
+    }
+
+    protected ModelNode getListElement(ModelNode list, String spec, ModelNode id) {
+        for (ModelNode element : list.asList()) {
+            if (element.get(SPEC).asString().equals(spec) &&
+                    (id == null || id.equals(element.get(ID)))) {
+                return element;
+            }
+        }
+
+        throw new IllegalArgumentException("no element for spec " + spec + " and id " + ((id == null) ? "null" : id.toJSONString(true)));
+    }
+
+    protected int getListElementIndex(ModelNode list, String spec) {
+        return getListElementIndex(list, spec, null);
+    }
+
+    protected int getListElementIndex(ModelNode list, String spec, ModelNode id) {
+        for (int i = 0; i < list.asList().size(); i++) {
+            if (list.get(i).get(SPEC).asString().equals(spec) &&
+                    (id == null || id.equals(list.get(i).get(ID)))) {
+                return i;
+            }
+        }
+        throw new IllegalArgumentException("no element for spec " + spec + " and id " + ((id == null) ? "null" : id.toJSONString(true)));
+    }
+}

--- a/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ReadConfigAsFeaturesStandaloneTestCase.java
+++ b/testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ReadConfigAsFeaturesStandaloneTestCase.java
@@ -1,0 +1,294 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.core.test.standalone.mgmt.api.core;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.api.ReadConfigAsFeaturesTestBase;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerController;
+import org.wildfly.core.testrunner.UnsuccessfulOperationException;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+
+/**
+ * Tests operation {@code read-config-as-features} in standalone mode.
+ *
+ * @author <a href="mailto:rjanik@redhat.com">Richard Janík</a>
+ */
+@RunWith(WildflyTestRunner.class)
+public class ReadConfigAsFeaturesStandaloneTestCase extends ReadConfigAsFeaturesTestBase {
+
+    private File defaultConfig;
+    private ModelNode defaultConfigAsFeatures;
+
+    @Inject
+    private ManagementClient managementClient;
+
+    @Inject
+    private static ServerController serverController;
+
+    @Test
+    public void writeParameterTest() throws UnsuccessfulOperationException {
+        ModelNode writeParameterOpertaion = Util.getWriteAttributeOperation(
+                PathAddress.pathAddress(SUBSYSTEM, "request-controller"),
+                "max-requests", 10);
+
+        ModelNode expectedConfigAsFeatures = defaultConfigAsFeatures.clone();
+        ModelNode requestControllerSubsystem = getFeatureNodeChild(expectedConfigAsFeatures.get(0), "subsystem.request-controller");
+        requestControllerSubsystem.get(PARAMS).set(new ModelNode()).get("max-requests").set(10);
+
+        doTest(Collections.singletonList(writeParameterOpertaion), expectedConfigAsFeatures);
+    }
+
+    @Test
+    public void undefineParameterTest() throws UnsuccessfulOperationException {
+        ModelNode undefineParameterOperation = Util.getUndefineAttributeOperation(
+                PathAddress.pathAddress(SUBSYSTEM, "security-manager").append("deployment-permissions", "default"),
+                "maximum-permissions");
+
+        ModelNode expectedConfigAsFeatures = defaultConfigAsFeatures.clone();
+        ModelNode securityManagerSubsystem = getFeatureNodeChild(expectedConfigAsFeatures.get(0), "subsystem.security-manager");
+        securityManagerSubsystem.get(CHILDREN).get(0).remove(PARAMS);
+
+        doTest(Collections.singletonList(undefineParameterOperation), expectedConfigAsFeatures);
+    }
+
+    @Test
+    public void addChildrenTest() throws UnsuccessfulOperationException {
+        ModelNode addChildrenOperation = Util.createAddOperation(
+                PathAddress.pathAddress(SUBSYSTEM, "jmx").append("configuration", "audit-log"));
+        addChildrenOperation.get("enabled").set(true);
+        addChildrenOperation.get("log-boot").set(true);
+        addChildrenOperation.get("log-read-only").set(false);
+
+        ModelNode expectedConfigAsFeatures = defaultConfigAsFeatures.clone();
+        ModelNode jmxSubsystem = getFeatureNodeChild(expectedConfigAsFeatures.get(0), "subsystem.jmx");
+        ModelNode auditLog = new ModelNode();
+        auditLog.get(SPEC).set("subsystem.jmx.configuration.audit-log");
+        auditLog.get(ID).set(new ModelNode()).get("configuration").set("audit-log");
+        ModelNode params = new ModelNode();
+        params.get("log-read-only").set(false);
+        params.get("log-boot").set(true);
+        params.get("enabled").set(true);
+        auditLog.get(PARAMS).set(params);
+        jmxSubsystem.get(CHILDREN).insert(auditLog, 0);
+
+        doTest(Collections.singletonList(addChildrenOperation), expectedConfigAsFeatures);
+    }
+
+    @Test
+    public void removeChildrenTest() throws UnsuccessfulOperationException {
+        ModelNode removeChildrenOperation = Util.createRemoveOperation(
+                PathAddress.pathAddress(SUBSYSTEM, "elytron").append(HTTP_AUTHENTICATION_FACTORY, "management-http-authentication"));
+
+        ModelNode expectedConfigAsFeatures = defaultConfigAsFeatures.clone();
+        ModelNode elytronSubsystem = getFeatureNodeChild(expectedConfigAsFeatures.get(0), "subsystem.elytron");
+        int httpAuthenticationFactoryIndex = getFeatureNodeChildIndex(elytronSubsystem, "subsystem.elytron.http-authentication-factory");
+        elytronSubsystem.get(CHILDREN).remove(httpAuthenticationFactoryIndex);
+
+        doTest(Collections.singletonList(removeChildrenOperation), expectedConfigAsFeatures);
+    }
+
+    @Test
+    public void removeSubsystemTest() throws UnsuccessfulOperationException {
+        ModelNode removeSubsystemOperation = Util.createRemoveOperation(PathAddress.pathAddress(SUBSYSTEM, "discovery"));
+
+        ModelNode expectedConfigAsFeatures = defaultConfigAsFeatures.clone();
+        int discoverySubsystemIndex = getFeatureNodeChildIndex(expectedConfigAsFeatures.get(0), "subsystem.discovery");
+        expectedConfigAsFeatures.get(0).get(CHILDREN).remove(discoverySubsystemIndex);
+
+        doTest(Collections.singletonList(removeSubsystemOperation), expectedConfigAsFeatures);
+    }
+
+    @Test
+    public void coreManagementTest() throws UnsuccessfulOperationException {
+        ModelNode removeSecurityRealm = Util.createRemoveOperation(
+                PathAddress.pathAddress(CORE_SERVICE, MANAGEMENT).append(SECURITY_REALM, "ApplicationRealm"));
+        ModelNode addCustomSecurityRealm = Util.createAddOperation(
+                PathAddress.pathAddress(CORE_SERVICE, MANAGEMENT).append(SECURITY_REALM, "CustomRealm"));
+        addCustomSecurityRealm.get("map-groups-to-roles").set(false);
+        ModelNode configureCustomSecurityRealm = Util.createAddOperation(
+                PathAddress.pathAddress(CORE_SERVICE, MANAGEMENT).append(SECURITY_REALM, "CustomRealm").append("authentication", "local"));
+        configureCustomSecurityRealm.get("default-user").set("john");
+        configureCustomSecurityRealm.get("allowed-users").set("john");
+        configureCustomSecurityRealm.get("skip-group-loading").set(true);
+
+        ModelNode expectedConfigAsFeatures = defaultConfigAsFeatures.clone();
+        ModelNode managementCoreService = getFeatureNodeChild(expectedConfigAsFeatures.get(0), "core-service.management");
+
+        // remove ApplicationRealm
+        ModelNode applicationSecurityRealmId = new ModelNode();
+        applicationSecurityRealmId.get(SECURITY_REALM).set("ApplicationRealm");
+        int applicationSecurityRealmIndex = getFeatureNodeChildIndex(managementCoreService, "core-service.management.security-realm", applicationSecurityRealmId);
+        managementCoreService.get(CHILDREN).remove(applicationSecurityRealmIndex);
+
+        // create model nodes for the new CustomRealm
+        ModelNode customRealmId = new ModelNode();
+        customRealmId.get(SECURITY_REALM).set("CustomRealm");
+        ModelNode customRealmParams = new ModelNode();
+        customRealmParams.get("map-groups-to-roles").set(false);
+
+        // create the authentication model node for the new CustomRealm
+        ModelNode customRealmAuthentication = new ModelNode();
+        customRealmAuthentication.get(SPEC).set("core-service.management.security-realm.authentication.local");
+        ModelNode authenticationId = new ModelNode();
+        authenticationId.get(AUTHENTICATION).set(LOCAL);
+        customRealmAuthentication.get(ID).set(authenticationId);
+        ModelNode authenticationParams = new ModelNode();
+        authenticationParams.get("default-user").set("john");
+        authenticationParams.get("allowed-users").set("john");
+        authenticationParams.get("skip-group-loading").set(true);
+        customRealmAuthentication.get(PARAMS).set(authenticationParams);
+
+        // set up the CustomRealm model node
+        ModelNode customRealm = new ModelNode();
+        customRealm.get(SPEC).set("core-service.management.security-realm");
+        customRealm.get(ID).set(customRealmId);
+        customRealm.get(PARAMS).set(customRealmParams);
+        customRealm.get(CHILDREN).add(customRealmAuthentication);
+
+        // append the CustomRealm model node to the expected model
+        managementCoreService.get(CHILDREN).insert(customRealm, 1);
+
+        doTest(Arrays.asList(removeSecurityRealm, addCustomSecurityRealm, configureCustomSecurityRealm), expectedConfigAsFeatures);
+    }
+
+    @Test
+    public void interfaceTest() throws UnsuccessfulOperationException {
+        ModelNode modifyManagementInterface = Util.getWriteAttributeOperation(PathAddress.pathAddress(INTERFACE, "management"), INET_ADDRESS, "10.10.10.10");
+        ModelNode createCustomInterface = Util.createAddOperation(PathAddress.pathAddress(INTERFACE, "custom"));
+        createCustomInterface.get(ANY_ADDRESS).set(true);
+
+        ModelNode expectedConfigAsFeatures = defaultConfigAsFeatures.clone();
+
+        // modify managemnet interface
+        ModelNode managementInterfaceId = new ModelNode();
+        managementInterfaceId.get(INTERFACE).set("management");
+        ModelNode managementInterface = getFeatureNodeChild(expectedConfigAsFeatures.get(0), INTERFACE, managementInterfaceId);
+        managementInterface.get(PARAMS).get(INET_ADDRESS).set("10.10.10.10");
+
+        // add the custom interface
+        ModelNode customInterfaceParams = new ModelNode();
+        ModelNode customInterfaceId = new ModelNode();
+        customInterfaceParams.get(ANY_ADDRESS).set(true);
+        customInterfaceId.get(INTERFACE).set("custom");
+        ModelNode customInterface = new ModelNode();
+        customInterface.get(SPEC).set(INTERFACE);
+        customInterface.get(ID).set(customInterfaceId);
+        customInterface.get(PARAMS).set(customInterfaceParams);
+        int managementInterfaceIndex = getFeatureNodeChildIndex(expectedConfigAsFeatures.get(0), INTERFACE, managementInterfaceId);
+        expectedConfigAsFeatures.get(0).get(CHILDREN).insert(customInterface, managementInterfaceIndex - 1); // insert right before management interface, list order matters
+
+        doTest(Arrays.asList(modifyManagementInterface, createCustomInterface), expectedConfigAsFeatures);
+
+        ModelNode removeCustomInterface = Util.createRemoveOperation(PathAddress.pathAddress(INTERFACE, "custom"));
+        expectedConfigAsFeatures.get(0).get(CHILDREN).remove(managementInterfaceIndex - 1);
+
+        doTest(Collections.singletonList(removeCustomInterface), expectedConfigAsFeatures);
+    }
+
+    @Test
+    public void socketBindingGroupTest() throws UnsuccessfulOperationException {
+        ModelNode modifyPortOffsetOperation = Util.getWriteAttributeOperation(PathAddress.pathAddress(SOCKET_BINDING_GROUP, "standard-sockets"), PORT_OFFSET, 100);
+        ModelNode addCustomSocketBindingOperation = Util.createAddOperation(PathAddress.pathAddress(SOCKET_BINDING_GROUP, "standard-sockets").append(SOCKET_BINDING, "custom"));
+        addCustomSocketBindingOperation.get(INTERFACE).set("public");
+        addCustomSocketBindingOperation.get(MULTICAST_ADDRESS).set("230.0.0.10");
+        ModelNode removeCustomSocketBindingOperation = Util.createRemoveOperation(PathAddress.pathAddress(SOCKET_BINDING_GROUP, "standard-sockets").append(SOCKET_BINDING, "custom"));
+
+        ModelNode expectedConfigAsFeatures = defaultConfigAsFeatures.clone();
+
+        // modify the port offset
+        ModelNode standardSocketsId = new ModelNode();
+        standardSocketsId.get(SOCKET_BINDING_GROUP).set("standard-sockets");
+        ModelNode standardSocketBindingGroup = getFeatureNodeChild(expectedConfigAsFeatures.get(0), SOCKET_BINDING_GROUP, standardSocketsId);
+        standardSocketBindingGroup.get(PARAMS).get(PORT_OFFSET).set(100);
+
+        // add custom socket-binding
+        ModelNode customSocketBinding = new ModelNode();
+        ModelNode customSocketBindingId = new ModelNode();
+        ModelNode customSocketBindingParams = new ModelNode();
+        customSocketBindingId.get(SOCKET_BINDING).set("custom");
+        customSocketBindingParams.get(INTERFACE).set("public");
+        customSocketBindingParams.get(MULTICAST_ADDRESS).set("230.0.0.10");
+        customSocketBinding.get(SPEC).set("socket-binding-group.socket-binding");
+        customSocketBinding.get(ID).set(customSocketBindingId);
+        customSocketBinding.get(PARAMS).set(customSocketBindingParams);
+        standardSocketBindingGroup.get(CHILDREN).insert(customSocketBinding, 0);
+
+        doTest(Arrays.asList(modifyPortOffsetOperation, addCustomSocketBindingOperation), expectedConfigAsFeatures);
+
+        // remove the custom socket binding
+        standardSocketBindingGroup.get(CHILDREN).remove(0);
+
+        doTest(Collections.singletonList(removeCustomSocketBindingOperation), expectedConfigAsFeatures);
+    }
+
+    private void doTest(List<ModelNode> operations, ModelNode expectedConfigAsFeatures) throws UnsuccessfulOperationException {
+        for (ModelNode operation : operations) {
+            managementClient.executeForResult(operation);
+        }
+        if (!expectedConfigAsFeatures.equals(getConfigAsFeatures())) {
+            // Assert.assertEquals() barfs the whole models to the console, we don't want that
+            System.out.println("Actual:\n" + getConfigAsFeatures().toJSONString(false) + "\nExpected:\n" + expectedConfigAsFeatures.toJSONString(false));
+            Assert.fail("There are differences between the expected and the actual model, see the test output for details");
+        }
+    }
+
+    @Override
+    protected void saveDefaultConfig() throws UnsuccessfulOperationException {
+        if (defaultConfig == null) {
+            ModelNode result = managementClient.executeForResult(
+                    Util.createEmptyOperation(TAKE_SNAPSHOT_OPERATION, PathAddress.EMPTY_ADDRESS));
+            defaultConfig = Paths.get(result.asString()).toFile();
+        }
+    }
+
+    @Override
+    protected void saveDefaultResult() throws UnsuccessfulOperationException {
+        if (defaultConfigAsFeatures == null) {
+            defaultConfigAsFeatures = getConfigAsFeatures();
+        }
+    }
+
+    @Override
+    protected void restoreDefaultConfig() {
+        serverController.reload(defaultConfig.getName());
+    }
+
+    private ModelNode getConfigAsFeatures() throws UnsuccessfulOperationException {
+        return managementClient.executeForResult(
+                Util.createEmptyOperation(READ_CONFIG_AS_FEATURES_OPERATION, PathAddress.EMPTY_ADDRESS));
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3991

This is additional test coverage for the `read-config-as-features` operation. Covers both standalone and domain mode. The difference between these tests and the tests in #3438 is that these make changes on real subsystems, then expect the operation output to change accordingly. The changes made were chosen fairly arbitrarily, but the idea is that each change is done on a different part of the model.

Depends on #3438  

Cc @aloubyansky 