### PR TITLE
[WFCORE-4061] Upgrade WildFly Elytron to 1.5.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.5.2.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.5.3.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.2.2.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
Bug fix release of WildFly Elytron

https://issues.jboss.org/browse/WFCORE-4016

Release Notes - WildFly Elytron - Version 1.5.3.Final

** Enhancement
    * [ELY-1632] - Fix compiler warnings

** Bug
    * [ELY-1630] - Ignore any blank lines in between the certificates in the certificate chain returned by an ACME server to avoid parsing issues on IBM JDK
    * [ELY-1633] - Incorrect double checked locking in AuthenticationConfiguration

** Release
    * [ELY-1635] - Release WildFly Elytron 1.5.3.Final
