### PR TITLE
[WFCORE-4014] Using DelegatingTrustManager correctly to ensure new TrustManager will be used on re-initialization by existing SSLContexts

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/SSLDefinitions.java
@@ -524,6 +524,7 @@ class SSLDefinitions {
                     return createX509CRLExtendedTrustManager(serviceBuilder, context, algorithm, providerName, providersInjector, keyStoreInjector, crlNode);
                 }
 
+                DelegatingTrustManager delegatingTrustManager = new DelegatingTrustManager();
                 return () -> {
                     Provider[] providers = providersInjector.getOptionalValue();
 
@@ -547,7 +548,6 @@ class SSLDefinitions {
                         throw new StartException(e);
                     }
 
-                    DelegatingTrustManager delegatingTrustManager = new DelegatingTrustManager();
                     TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
                     for (TrustManager trustManager : trustManagers) {
                         if (trustManager instanceof X509ExtendedTrustManager) {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/TlsTestCase.java
@@ -403,9 +403,6 @@ public class TlsTestCase extends AbstractSubsystemTest {
         operation.get(ClientConstants.OP).set(ElytronDescriptionConstants.INIT);
         Assert.assertEquals(services.executeOperation(operation).get(OUTCOME).asString(), SUCCESS);
 
-        serviceName = Capabilities.TRUST_MANAGER_RUNTIME_CAPABILITY.getCapabilityServiceName(INIT_TEST_TRUSTMANAGER);
-        trustManager = (X509ExtendedTrustManager) services.getContainer().getService(serviceName).getValue();
-        Assert.assertNotNull(trustManager);
         Assert.assertEquals(trustManager.getAcceptedIssuers().length, 1);
 
         // See if the trust manager contains the new certificate


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFCORE-4014