### PR TITLE
[WFCORE-4015] Ensure the certificate-authority-account create-account management operation returns an appropriate failure message if the account already exists

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/CertificateAuthorityAccountDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/CertificateAuthorityAccountDefinition.java
@@ -269,7 +269,10 @@ class CertificateAuthorityAccountDefinition extends SimpleResourceDefinition {
 
             try {
                 acmeAccount.setTermsOfServiceAgreed(agreeToTermsOfService);
-                acmeClient.createAccount(acmeAccount, staging);
+                boolean created = acmeClient.createAccount(acmeAccount, staging);
+                if (! created) {
+                    throw ROOT_LOGGER.certificateAuthorityAccountAlreadyExists(ElytronDescriptionConstants.UPDATE_ACCOUNT, ElytronDescriptionConstants.CHANGE_ACCOUNT_KEY);
+                }
             } catch (AcmeException e) {
                 throw ROOT_LOGGER.unableToCreateAccountWithCertificateAuthority(e, e.getLocalizedMessage());
             }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -538,4 +538,8 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 1055, value = "Invalid key size: %d")
     OperationFailedException invalidKeySize(int keySize);
 
+    @Message(id = 1056, value = "A certificate authority account with this account key already exists. To update the contact" +
+            " information associated with this existing account, use %s. To change the key associated with this existing account, use %s.")
+    OperationFailedException certificateAuthorityAccountAlreadyExists(String updateAccount, String changeAccountKey);
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4015