### PR TITLE
[WFCORE-4021] Upgrade WildFly Elytron Tool to 1.3.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.5.2.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.1.Final</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.elytron.tool>1.2.2.Final</version.org.wildfly.security.elytron.tool>
+        <version.org.wildfly.security.elytron.tool>1.3.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>
 


### PR DESCRIPTION
WildFly Elytron Tool is a shaded jar containing amongst other things WildFly Elytron, this release is just to update the versions of the components it contains to match those either already in WildFly Core or about to merged to WildFly Core shortly.

https://issues.jboss.org/browse/WFCORE-4021

