### PR TITLE
[WFCORE-4025]:  Intermittent errors on RemoteGitRepositoryTestCase.historyAndManagementOperationsTest

### DIFF
--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/AbstractGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/AbstractGitRepositoryTestCase.java
@@ -60,7 +60,7 @@ public class AbstractGitRepositoryTestCase {
     private final Path jbossServerBaseDir = new File(System.getProperty("jboss.home", System.getenv("JBOSS_HOME"))).toPath().resolve("standalone");
     private static final String TEST_DEPLOYMENT_RUNTIME_NAME = "test.jar";
     private static final ModelNode TEST_SYSTEM_PROPERTY_ADDRESS = new ModelNode().add("system-property", "git-history-property");
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmm");
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmssSSS");
     protected Repository emptyRemoteRepository;
     protected Repository repository;
     private Path emptyRemoteRoot;
@@ -247,9 +247,11 @@ public class AbstractGitRepositoryTestCase {
         container.getClient().executeForResult(op);
     }
 
-    protected void verifyDefaultSnapshotString(String string) {
-        String timestamp = FORMATTER.format(LocalDateTime.now());
-        Assert.assertTrue(string, string.startsWith("Snapshot-" + timestamp));
+    protected void verifyDefaultSnapshotString(LocalDateTime snapshot, String string) {
+        LocalDateTime timestamp = LocalDateTime.parse(string.substring("Snapshot-".length()), FORMATTER);
+        LocalDateTime now = LocalDateTime.now();
+        boolean valid = snapshot.isBefore(now) && snapshot.isBefore(timestamp) && timestamp.isBefore(now);
+        Assert.assertTrue(string + " doesn't start with Snapshot-" + FORMATTER.format(now), valid);
     }
 
     protected Path getDotGitDir() {

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/GitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/GitRepositoryTestCase.java
@@ -17,6 +17,7 @@ package org.jboss.as.test.manualmode.management.persistence;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -245,10 +246,11 @@ public class GitRepositoryTestCase extends AbstractGitRepositoryTestCase {
         Assert.assertEquals(0, tags.size());
 
         // :take-snapshot => tag = timestamp
+        LocalDateTime snapshot = LocalDateTime.now();
         takeSnapshot(null, null);
         tags = listTags(repository);
         Assert.assertEquals(1, tags.size());
-        verifyDefaultSnapshotString(tags.get(0));
+        verifyDefaultSnapshotString(snapshot, tags.get(0));
         // this snapshot is not expected to have commit, as there is no uncommited remove of content data
         commits = listCommits(repository);
         Assert.assertEquals(expectedNumberOfCommits, commits.size());
@@ -274,12 +276,13 @@ public class GitRepositoryTestCase extends AbstractGitRepositoryTestCase {
         }
 
         // :take-snapshot(description=bar) => tag = timestamp, commit msg=bar
+        snapshot = LocalDateTime.now();
         takeSnapshot(null, "bar");
         expectedNumberOfCommits++;
         tags = listTags(repository);
         Assert.assertEquals(3, tags.size());
         // tags are ordered alphabetically, so we want second with default name
-        verifyDefaultSnapshotString(tags.get(1));
+        verifyDefaultSnapshotString(snapshot, tags.get(1));
         commits = listCommits(repository);
         Assert.assertEquals(expectedNumberOfCommits, commits.size());
         Assert.assertEquals("bar", commits.get(0));

--- a/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteGitRepositoryTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/persistence/RemoteGitRepositoryTestCase.java
@@ -15,9 +15,11 @@
  */
 package org.jboss.as.test.manualmode.management.persistence;
 
+
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -147,7 +149,7 @@ public class RemoteGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
         Assert.assertEquals(expectedNumberOfCommits, commits.size());
         Assert.assertEquals("Storing configuration", commits.get(0));
         paths = listFilesInCommit(repository);
-        Assert.assertEquals(1, paths.size());
+        Assert.assertEquals(Arrays.toString(paths.toArray()), 1, paths.size());
         Assert.assertEquals("configuration/standalone.xml", paths.get(0));
 
         // deploy deployment => commit
@@ -236,10 +238,11 @@ public class RemoteGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
         Assert.assertEquals(0, tags.size());
 
         // :take-snapshot => tag = timestamp
+        LocalDateTime snapshot = LocalDateTime.now();
         takeSnapshot(null, null);
         tags = listTags(repository);
         Assert.assertEquals(1, tags.size());
-        verifyDefaultSnapshotString(tags.get(0));
+        verifyDefaultSnapshotString(snapshot, tags.get(0));
         // this snapshot is not expected to have commit, as there is no uncommited remove of content data
         commits = listCommits(repository);
         Assert.assertEquals(expectedNumberOfCommits, commits.size());
@@ -265,12 +268,13 @@ public class RemoteGitRepositoryTestCase extends AbstractGitRepositoryTestCase {
         }
 
         // :take-snapshot(description=bar) => tag = timestamp, commit msg=bar
+        snapshot = LocalDateTime.now();
         takeSnapshot(null, "bar");
         expectedNumberOfCommits++;
         tags = listTags(repository);
         Assert.assertEquals(3, tags.size());
         // tags are ordered alphabetically, so we want second with default name
-        verifyDefaultSnapshotString(tags.get(1));
+        verifyDefaultSnapshotString(snapshot, tags.get(1));
         commits = listCommits(repository);
         Assert.assertEquals(expectedNumberOfCommits, commits.size());
         Assert.assertEquals("bar", commits.get(0));


### PR DESCRIPTION
Trying to test the default Snapshot name in a more robust way.

Jira: https://issues.jboss.org/browse/WFCORE-4025