### PR TITLE
[WFCORE-4028] Upgrade to WildFly Elytron 1.5.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.5.3.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.5.4.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.3.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4028


Release Notes - WildFly Elytron - Version 1.5.4.Final

** Bug
    * [ELY-1636] - Update AcmeChallenge.Type to be able to handle unknown challenge types

** Release
    * [ELY-1638] - Release WildFly Elytron 1.5.4.Final
