### PR TITLE
[WFCORE-4035]operation-requires-reload message is missing

### DIFF
--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
@@ -166,7 +166,8 @@ class WorkerResourceDefinition extends PersistentResourceDefinition {
                 new WorkerWriteAttributeHandler(WORKER_TASK_MAX_THREADS){
                     @Override
                     boolean setValue(XnioWorker worker, ModelNode value) throws IOException {
-                        return worker.setOption(Options.WORKER_TASK_MAX_THREADS, value.asInt()) == null;
+                        worker.setOption(Options.WORKER_TASK_MAX_THREADS, value.asInt());
+                        return true;
                     }
                 });
         resourceRegistration.registerReadWriteAttribute(WORKER_TASK_CORE_THREADS,
@@ -182,7 +183,8 @@ class WorkerResourceDefinition extends PersistentResourceDefinition {
                 new WorkerWriteAttributeHandler(WORKER_TASK_KEEPALIVE){
                     @Override
                     boolean setValue(XnioWorker worker, ModelNode value) throws IOException {
-                        return worker.setOption(Options.WORKER_TASK_KEEPALIVE, value.asInt()) == null;
+                        worker.setOption(Options.WORKER_TASK_KEEPALIVE, value.asInt());
+                        return true;
                     }
                 });
         resourceRegistration.registerReadWriteAttribute(STACK_SIZE,

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
@@ -166,7 +166,9 @@ class WorkerResourceDefinition extends PersistentResourceDefinition {
                 new WorkerWriteAttributeHandler(WORKER_TASK_MAX_THREADS){
                     @Override
                     boolean setValue(XnioWorker worker, ModelNode value) throws IOException {
-                        worker.setOption(Options.WORKER_TASK_MAX_THREADS, value.asInt());
+                        if (value.isDefined()) {
+                            worker.setOption(Options.WORKER_TASK_MAX_THREADS, value.asInt());
+                        }
                         return true;
                     }
                 });


### PR DESCRIPTION
when modify values of task-max-threads and task-keepalive,
operation-requires-reload message is not outputed.
these two attributes is processed in XnioWorker#setOption, and have values return,
so it should always return true.

```
[standalone@localhost:9990 /] /subsystem=io/worker=default:write-attribute(name=task-keepalive, value=10000)
{"outcome" => "success"}
[standalone@localhost:9990 /] /subsystem=io/worker=default:write-attribute(name=task-max-threads, value=10000)
{"outcome" => "success"}
[standalone@localhost:9990 /] /subsystem=io/worker=default:write-attribute(name=io-threads, value=10000)
{
    "outcome" => "success",
    "response-headers" => {
        "operation-requires-reload" => true,
        "process-state" => "reload-required"
    }
}
[standalone@localhost:9990 /] /subsystem=io/worker=default:write-attribute(name=task-core-threads, value=10000)
{
    "outcome" => "success",
    "response-headers" => {
        "operation-requires-reload" => true,
        "process-state" => "reload-required"
    }
}
```