### PR TITLE
[WFCORE-4033] use jboss community maven universe instead of galleon1 …

### DIFF
--- a/testsuite/vault-test-feature-pack/wildfly-feature-pack-build.xml
+++ b/testsuite/vault-test-feature-pack/wildfly-feature-pack-build.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<build xmlns="urn:wildfly:feature-pack-build:3.0" producer="org.wildfly.core:wildfly-core-vault-test-galleon-pack@galleon1">
+<build xmlns="urn:wildfly:feature-pack-build:3.0" producer="wildfly-core-vault-test@maven(org.jboss.universe:community-universe):current">
     <dependencies>
         <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack" producer="wildfly-core@maven(org.jboss.universe:community-universe):current">
             <name>org.wildfly.core:wildfly-core-galleon-pack</name>


### PR DESCRIPTION
…for wildfly-core-vault-test feature-pack

https://issues.jboss.org/browse/WFCORE-4033