### PR TITLE
[WFCORE-4038] Upgrade WildFly Elytron to 1.5.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.5.4.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.5.5.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.1.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.3.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4038

        Release Notes - WildFly Elytron - Version 1.5.5.Final
                                                                        
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1629'>ELY-1629</a>] -         Let&#39;s Encrypt: Upcoming ACME v2 Key Rollover breaking change
</li>
</ul>
                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1641'>ELY-1641</a>] -         Release WildFly Elytron 1.5.5.Final
</li>
</ul>                    