### PR TITLE
[WFCORE-4040] Deprecate PersistentResourceDefinition.Parameters, remo…

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceDefinition.java
@@ -1,5 +1,9 @@
 package org.jboss.as.controller;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.logging.ControllerLogger;
@@ -7,10 +11,6 @@ import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.OperationEntry.Flag;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * A persistent resource definition. This needs to be combined with {@link PersistentResourceXMLDescription} to
@@ -29,7 +29,7 @@ public abstract class PersistentResourceDefinition extends SimpleResourceDefinit
     }
 
     protected PersistentResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, OperationStepHandler addHandler, OperationStepHandler removeHandler, OperationEntry.Flag addRestartLevel, OperationEntry.Flag removeRestartLevel) {
-        super(new Parameters(pathElement, descriptionResolver)
+        super(new SimpleResourceDefinition.Parameters(pathElement, descriptionResolver)
                         .setAddHandler(addHandler)
                         .setRemoveHandler(removeHandler)
                         .setAddRestartLevel(addRestartLevel)
@@ -39,7 +39,7 @@ public abstract class PersistentResourceDefinition extends SimpleResourceDefinit
 
     protected PersistentResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, OperationStepHandler addHandler,
                                            OperationStepHandler removeHandler, boolean isRuntime) {
-        super(new Parameters(pathElement, descriptionResolver)
+        super(new SimpleResourceDefinition.Parameters(pathElement, descriptionResolver)
                                .setAddHandler(addHandler)
                                .setRemoveHandler(removeHandler)
                                .setRuntime(isRuntime)
@@ -48,7 +48,7 @@ public abstract class PersistentResourceDefinition extends SimpleResourceDefinit
 
     protected PersistentResourceDefinition(PathElement pathElement, ResourceDescriptionResolver descriptionResolver, OperationStepHandler addHandler,
                                            OperationStepHandler removeHandler, OperationEntry.Flag addRestartLevel, OperationEntry.Flag removeRestartLevel, boolean isRuntime) {
-        super(new Parameters(pathElement, descriptionResolver)
+        super(new SimpleResourceDefinition.Parameters(pathElement, descriptionResolver)
                         .setAddHandler(addHandler)
                         .setRemoveHandler(removeHandler)
                         .setAddRestartLevel(addRestartLevel)
@@ -57,7 +57,7 @@ public abstract class PersistentResourceDefinition extends SimpleResourceDefinit
         );
     }
 
-    protected PersistentResourceDefinition(Parameters parameters){
+    protected PersistentResourceDefinition(SimpleResourceDefinition.Parameters parameters){
         super(parameters);
     }
 
@@ -87,6 +87,8 @@ public abstract class PersistentResourceDefinition extends SimpleResourceDefinit
 
     public abstract Collection<AttributeDefinition> getAttributes();
 
+    /** @deprecated Use the superclass */
+    @Deprecated
     public static class Parameters extends SimpleResourceDefinition.Parameters {
 
         /**
@@ -94,7 +96,9 @@ public abstract class PersistentResourceDefinition extends SimpleResourceDefinit
          *
          * @param pathElement         the path element of the created ResourceDefinition. Cannot be {@code null}
          * @param descriptionResolver the description provider. Cannot be {@code null}
+         * @deprecated Use the superclass
          */
+        @Deprecated
         public Parameters(PathElement pathElement, ResourceDescriptionResolver descriptionResolver) {
             super(pathElement, descriptionResolver);
         }

--- a/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/ConfigurationChangeResourceDefinition.java
+++ b/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/ConfigurationChangeResourceDefinition.java
@@ -33,6 +33,7 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
@@ -48,6 +49,7 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.access.AuthorizationResult;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -81,7 +83,7 @@ public class ConfigurationChangeResourceDefinition extends PersistentResourceDef
     public static final ConfigurationChangeResourceDefinition INSTANCE = new ConfigurationChangeResourceDefinition();
 
     private ConfigurationChangeResourceDefinition() {
-        super(new PersistentResourceDefinition.Parameters(PATH, CoreManagementExtension.getResourceDescriptionResolver(CONFIGURATION_CHANGES))
+        super(new SimpleResourceDefinition.Parameters(PATH, CoreManagementExtension.getResourceDescriptionResolver(CONFIGURATION_CHANGES))
                 .setCapabilities(CONFIGURATION_CHANGES_CAPABILITY)
                 .setAddHandler(new ConfigurationChangeResourceAddHandler())
                 .setRemoveHandler(new ConfigurationChangeResourceRemoveHandler()));

--- a/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/ProcessStateListenerResourceDefinition.java
+++ b/core-management/core-management-subsystem/src/main/java/org/wildfly/extension/core/management/ProcessStateListenerResourceDefinition.java
@@ -40,6 +40,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
@@ -91,7 +92,7 @@ public class ProcessStateListenerResourceDefinition extends PersistentResourceDe
     };
 
     ProcessStateListenerResourceDefinition() {
-        super(new Parameters(PROCESS_STATE_LISTENER_PATH, CoreManagementExtension.getResourceDescriptionResolver("process-state-listener"))
+        super(new SimpleResourceDefinition.Parameters(PROCESS_STATE_LISTENER_PATH, CoreManagementExtension.getResourceDescriptionResolver("process-state-listener"))
                 .setOrderedChild()
                 .setCapabilities(PROCESS_STATE_LISTENER_CAPABILITY)
                 .setAddHandler(new ProcessStateListenerResourceDefinition.ProcessStateListenerAddHandler())

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/BufferPoolResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/BufferPoolResourceDefinition.java
@@ -29,6 +29,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import io.undertow.connector.ByteBufferPool;
+import io.undertow.server.XnioByteBufferPool;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
@@ -39,6 +41,7 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -52,9 +55,6 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.xnio.Pool;
-
-import io.undertow.connector.ByteBufferPool;
-import io.undertow.server.XnioByteBufferPool;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
@@ -122,7 +122,7 @@ class BufferPoolResourceDefinition extends PersistentResourceDefinition {
 
 
     private BufferPoolResourceDefinition() {
-        super(new Parameters(IOExtension.BUFFER_POOL_PATH,
+        super(new SimpleResourceDefinition.Parameters(IOExtension.BUFFER_POOL_PATH,
                 IOExtension.getResolver(Constants.BUFFER_POOL))
                 .setAddHandler(new BufferPoolAdd())
                 .setRemoveHandler(new ReloadRequiredRemoveStepHandler())

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/OutboundBindAddressResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/OutboundBindAddressResourceDefinition.java
@@ -31,6 +31,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.operations.validation.InetAddressValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.MaskedAddressValidator;
@@ -70,7 +71,7 @@ public class OutboundBindAddressResourceDefinition extends PersistentResourceDef
     static final OutboundBindAddressResourceDefinition INSTANCE = new OutboundBindAddressResourceDefinition();
 
     private OutboundBindAddressResourceDefinition() {
-        super(new Parameters(PathElement.pathElement(RESOURCE_NAME), IOExtension.getResolver(RESOURCE_NAME))
+        super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(RESOURCE_NAME), IOExtension.getResolver(RESOURCE_NAME))
             .setAddHandler(new OutboundBindAddressAddHandler())
             .setRemoveHandler(new OutboundBindAddressRemoveHandler())
         );

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/RootResourceDefinition.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/dependent/RootResourceDefinition.java
@@ -40,6 +40,7 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ServiceRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -67,7 +68,7 @@ public class RootResourceDefinition extends PersistentResourceDefinition {
     static final PersistentResourceDefinition INSTANCE = new RootResourceDefinition();
 
     private RootResourceDefinition() {
-        super(new Parameters(PathElement.pathElement(SUBSYSTEM, DependentExtension.SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver())
+        super(new SimpleResourceDefinition.Parameters(PathElement.pathElement(SUBSYSTEM, DependentExtension.SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver())
                 .setAddHandler(AddSubsystemHandler.INSTANCE)
                 .setRemoveHandler(new ServiceRemoveStepHandler(AddSubsystemHandler.INSTANCE, RUNTIME_CAPABILITY))
                 .setCapabilities(RUNTIME_CAPABILITY));


### PR DESCRIPTION
…ve its use in core

https://issues.jboss.org/browse/WFCORE-4040

The main point is having the PersistentResourceDefinition constructor accept SimpleResourceDefinition.Parameters, removing any need to use the inconvenient subclass.