### PR TITLE
Fix for WFCORE-3831, jboss-cli.ps1 return value

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.ps1
@@ -17,3 +17,5 @@ $PROG_ARGS = Get-Java-Arguments -entryModule "org.jboss.as.cli" -serverOpts $SER
 & $JAVA $IBM_TLS_OPT $PROG_ARGS
 
 Env-Clean-Up
+
+exit $LASTEXITCODE


### PR DESCRIPTION
Makes the ps1 script to return the exit code of java process execution.
Manual testing of return value:
Inside a bach: echo %ERRORLEVEL% displays 0 or 1
Inside a powershell console: echo $? display True or False
