### PR TITLE
[WFCORE-4052] / [WFCORE-4053] / [WFCORE-4054] WildFly Elytron Component Upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.6.0.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.2.2.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.2.3.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>

--- a/pom.xml
+++ b/pom.xml
@@ -209,7 +209,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.6.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.2.Final</version.org.wildfly.security.elytron-web>
-        <version.org.wildfly.security.elytron.tool>1.3.0.Final</version.org.wildfly.security.elytron.tool>
+        <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.5.5.Final</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.2.1.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.2.2.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.3.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.5.5.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.6.0.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.2.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.3.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4052
https://issues.jboss.org/browse/WFCORE-4053
https://issues.jboss.org/browse/WFCORE-4054

The WildFly Elytron minor version bump is due to adding a new version of the client side schema to address the bug reported in ELY-1639.

The WildFly Elytron Tool minor version bump was due to including a version of WildFly Elytron that bumped the minor version.  No other changes made to WildFly Elytron Tool.

        Release Notes - WildFly Elytron - Version 1.6.0.Final
                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1639'>ELY-1639</a>] -         FIPS PKCS11 Client side: only SunJSSE KeyManagers may be used
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1647'>ELY-1647</a>] -         Add some TRACE logging around AuthenticationContext resolution and parsing.
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1651'>ELY-1651</a>] -         Release WildFly Elytron 1.6.0.Final
</li>
</ul>
                    


        Release Notes - Elytron Web - Version 1.2.2.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-9'>ELYWEB-9</a>] -         Update the JBoss Metadata version to 11.0.0.Final 
</li>
</ul>
                                                                                                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-12'>ELYWEB-12</a>] -         Release Elytron Web 1.2.2.Final
</li>
</ul>


        Release Notes - Elytron Web - Version 1.2.3.Final
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-14'>ELYWEB-14</a>] -         Upgrade WildFly Elytron to 1.6.0.Final
</li>
</ul>
                                                                        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-13'>ELYWEB-13</a>] -         Enable constrain driven auth mode during deployment
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-15'>ELYWEB-15</a>] -         Release Elytron Web 1.2.3.Final
</li>
</ul>
                    
                    