### PR TITLE
[WFCORE-4059] Add missing attribute 'always-send-client-cert' to configuration schemas.

### DIFF
--- a/server/src/main/resources/schema/wildfly-config_5_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_5_0.xsd
@@ -363,6 +363,17 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="always-send-client-cert" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Where an LDAPS connection is established for the purpose of validating the provided credential by default the local servers certificate is not sent to 
+                    avoid inadvertently authenticating as the server.
+
+                    This attribute can be set to true to ensure the local servers certificate is always sent where this is required independently of the authentication 
+                    based on the credential.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="urlListType">

--- a/server/src/main/resources/schema/wildfly-config_6_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_6_0.xsd
@@ -359,6 +359,17 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="always-send-client-cert" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Where an LDAPS connection is established for the purpose of validating the provided credential by default the local servers certificate is not sent to 
+                    avoid inadvertently authenticating as the server.
+
+                    This attribute can be set to true to ensure the local servers certificate is always sent where this is required independently of the authentication 
+                    based on the credential.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="urlListType">

--- a/server/src/main/resources/schema/wildfly-config_7_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_7_0.xsd
@@ -359,6 +359,17 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="always-send-client-cert" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Where an LDAPS connection is established for the purpose of validating the provided credential by default the local servers certificate is not sent to 
+                    avoid inadvertently authenticating as the server.
+
+                    This attribute can be set to true to ensure the local servers certificate is always sent where this is required independently of the authentication 
+                    based on the credential.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="urlListType">

--- a/server/src/main/resources/schema/wildfly-config_8_0.xsd
+++ b/server/src/main/resources/schema/wildfly-config_8_0.xsd
@@ -359,6 +359,17 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="always-send-client-cert" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Where an LDAPS connection is established for the purpose of validating the provided credential by default the local servers certificate is not sent to 
+                    avoid inadvertently authenticating as the server.
+
+                    This attribute can be set to true to ensure the local servers certificate is always sent where this is required independently of the authentication 
+                    based on the credential.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="urlListType">


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4059

This attribute was added in the PR https://github.com/wildfly/wildfly-core/pull/2331 but the schema was not updated.