### PR TITLE
[WFCORE-4062] Restore legacy constructor, deprecated

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceDefinition.java
@@ -57,6 +57,13 @@ public abstract class PersistentResourceDefinition extends SimpleResourceDefinit
         );
     }
 
+    /** @deprecated Use the {@link #PersistentResourceDefinition(SimpleResourceDefinition.Parameters)} */
+    @Deprecated
+    @SuppressWarnings("deprecation")
+    protected PersistentResourceDefinition(Parameters parameters){
+        this((SimpleResourceDefinition.Parameters)parameters);
+    }
+
     protected PersistentResourceDefinition(SimpleResourceDefinition.Parameters parameters){
         super(parameters);
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4062

Avoid Errors if code that used this constructor call if without first having been recompiled to the current WF Core.