### PR TITLE
[WFCORE-4064] Upgrade log4j-jboss-logmanager from 1.1.5.Final to 1.1.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <version.org.jboss.logmanager.jboss-logmanager>2.1.4.Final</version.org.jboss.logmanager.jboss-logmanager>
-        <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.5.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
+        <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.5.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.8.5.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.4.3.Final</version.org.jboss.msc.jboss-msc>


### PR DESCRIPTION
…6.Final

https://issues.jboss.org/browse/WFCORE-4064

This change only includes a [fix](https://github.com/jboss-logging/log4j-jboss-logmanager/compare/1.1.5.Final...1.1.6.Final) for generating JavaDocs with Java 8. There are no functional changes.