### PR TITLE
[WFCORE-4065] Correct output diffs between galleon build and legacy build

### DIFF
--- a/core-feature-pack/pom.xml
+++ b/core-feature-pack/pom.xml
@@ -273,6 +273,21 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.galleon-plugins</groupId>
+            <artifactId>wildfly-config-gen</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.galleon-plugins</groupId>
+            <artifactId>wildfly-feature-spec-gen</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.galleon-plugins</groupId>
+            <artifactId>wildfly-galleon-plugins</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-java</artifactId>
         </dependency>

--- a/core-galleon-pack/pom.xml
+++ b/core-galleon-pack/pom.xml
@@ -316,6 +316,21 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly.galleon-plugins</groupId>
+            <artifactId>wildfly-config-gen</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.galleon-plugins</groupId>
+            <artifactId>wildfly-feature-spec-gen</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.galleon-plugins</groupId>
+            <artifactId>wildfly-galleon-plugins</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly.openssl</groupId>
             <artifactId>wildfly-openssl-java</artifactId>
         </dependency>
@@ -643,35 +658,6 @@
                         <configuration>
                             <fork-embedded>true</fork-embedded>
                             <output-dir>${basedir}/target/resources/features</output-dir>
-                            <standalone-extensions>
-                                <extension>org.jboss.as.deployment-scanner</extension>
-                                <extension>org.jboss.as.jmx</extension>
-                                <extension>org.jboss.as.logging</extension>
-                                <extension>org.jboss.as.remoting</extension>
-                                <extension>org.wildfly.extension.core-management</extension>
-                                <extension>org.wildfly.extension.discovery</extension>
-                                <extension>org.wildfly.extension.elytron</extension>
-                                <extension>org.wildfly.extension.io</extension>
-                                <extension>org.wildfly.extension.request-controller</extension>
-                                <extension>org.wildfly.extension.security.manager</extension>
-                            </standalone-extensions>
-                            <domain-extensions>
-                                <extension>org.jboss.as.jmx</extension>
-                                <extension>org.jboss.as.logging</extension>
-                                <extension>org.jboss.as.remoting</extension>
-                                <extension>org.wildfly.extension.core-management</extension>
-                                <extension>org.wildfly.extension.discovery</extension>
-                                <extension>org.wildfly.extension.elytron</extension>
-                                <extension>org.wildfly.extension.io</extension>
-                                <extension>org.wildfly.extension.request-controller</extension>
-                                <extension>org.wildfly.extension.security.manager</extension>
-                            </domain-extensions>
-                            <host-extensions>
-                                <extension>org.jboss.as.jmx</extension>
-                                <extension>org.wildfly.extension.core-management</extension>
-                                <extension>org.wildfly.extension.discovery</extension>
-                                <extension>org.wildfly.extension.elytron</extension>
-                            </host-extensions>
                         </configuration>
                     </execution>
                     <execution>

--- a/core-galleon-pack/src/main/resources/feature_groups/logging.xml
+++ b/core-galleon-pack/src/main/resources/feature_groups/logging.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature-group-spec name="logging" xmlns="urn:jboss:galleon:feature-group:1.0">
     <feature spec="subsystem.logging">
+      <feature spec="subsystem.logging.pattern-formatter">
+        <param name="pattern-formatter" value="PATTERN"/>
+        <param name="pattern" value="&quot;%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n&quot;"/>
+      </feature>
+      <feature spec="subsystem.logging.pattern-formatter">
+        <param name="pattern-formatter" value="COLOR-PATTERN"/>
+        <param name="pattern" value="&quot;%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n&quot;"/>
+      </feature>
       <feature spec="subsystem.logging.console-handler">
         <param name="console-handler" value="CONSOLE"/>
         <param name="level" value="INFO"/>
@@ -29,14 +37,6 @@
       <feature spec="subsystem.logging.root-logger.ROOT">
         <param name="level" value="INFO"/>
         <param name="handlers" value="[CONSOLE,FILE]"/>
-      </feature>
-      <feature spec="subsystem.logging.pattern-formatter">
-        <param name="pattern-formatter" value="PATTERN"/>
-        <param name="pattern" value="&quot;%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n&quot;"/>
-      </feature>
-      <feature spec="subsystem.logging.pattern-formatter">
-        <param name="pattern-formatter" value="COLOR-PATTERN"/>
-        <param name="pattern" value="&quot;%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n&quot;"/>
       </feature>
     </feature>
 </feature-group-spec>

--- a/core-galleon-pack/wildfly-feature-pack-build.xml
+++ b/core-galleon-pack/wildfly-feature-pack-build.xml
@@ -123,4 +123,46 @@
     <config name="host-slave.xml" model="host">
         <feature-group name="host-slave"/>
     </config>
+
+    <plugins>
+        <plugin artifact="org.wildfly.galleon-plugins:wildfly-galleon-plugins"/>
+    </plugins>
+
+    <resources>
+        <copy artifact="org.wildfly.galleon-plugins:wildfly-config-gen" to="wildfly/wildfly-config-gen.jar"/>
+    </resources>
+
+    <generate-feature-specs>
+        <extensions>
+            <standalone>
+                <extension>org.jboss.as.deployment-scanner</extension>
+                <extension>org.jboss.as.jmx</extension>
+                <extension>org.jboss.as.logging</extension>
+                <extension>org.jboss.as.remoting</extension>
+                <extension>org.wildfly.extension.core-management</extension>
+                <extension>org.wildfly.extension.discovery</extension>
+                <extension>org.wildfly.extension.elytron</extension>
+                <extension>org.wildfly.extension.io</extension>
+                <extension>org.wildfly.extension.request-controller</extension>
+                <extension>org.wildfly.extension.security.manager</extension>
+            </standalone>
+            <domain>
+                <extension>org.jboss.as.jmx</extension>
+                <extension>org.jboss.as.logging</extension>
+                <extension>org.jboss.as.remoting</extension>
+                <extension>org.wildfly.extension.core-management</extension>
+                <extension>org.wildfly.extension.discovery</extension>
+                <extension>org.wildfly.extension.elytron</extension>
+                <extension>org.wildfly.extension.io</extension>
+                <extension>org.wildfly.extension.request-controller</extension>
+                <extension>org.wildfly.extension.security.manager</extension>
+            </domain>
+            <host>
+                <extension>org.jboss.as.jmx</extension>
+                <extension>org.wildfly.extension.core-management</extension>
+                <extension>org.wildfly.extension.discovery</extension>
+                <extension>org.wildfly.extension.elytron</extension>
+            </host>
+        </extensions>
+    </generate-feature-specs>
 </build>

--- a/pom.xml
+++ b/pom.xml
@@ -101,10 +101,10 @@
 
         <!-- Non-default maven plugin versions and configuration -->
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
-        <version.org.jboss.galleon>2.0.0.Beta1</version.org.jboss.galleon>
+        <version.org.jboss.galleon>2.0.0.Final</version.org.jboss.galleon>
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.galleon-plugins>2.0.0.Beta1</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>2.0.0.Final</version.org.wildfly.galleon-plugins>
         <!-- wildfly plugin-->
         <version.org.wildfly.plugin>1.2.0.Final</version.org.wildfly.plugin>
         <!-- plugins related to wildfly build and tooling -->
@@ -1370,6 +1370,27 @@
                 <groupId>org.wildfly.discovery</groupId>
                 <artifactId>wildfly-discovery-client</artifactId>
                 <version>${version.org.wildfly.discovery}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.galleon-plugins</groupId>
+                <artifactId>wildfly-config-gen</artifactId>
+                <version>${version.org.wildfly.galleon-plugins}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.galleon-plugins</groupId>
+                <artifactId>wildfly-feature-spec-gen</artifactId>
+                <version>${version.org.wildfly.galleon-plugins}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.galleon-plugins</groupId>
+                <artifactId>wildfly-galleon-plugins</artifactId>
+                <version>${version.org.wildfly.galleon-plugins}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>

--- a/testsuite/vault-test-feature-pack/wildfly-feature-pack-build.xml
+++ b/testsuite/vault-test-feature-pack/wildfly-feature-pack-build.xml
@@ -22,7 +22,7 @@
 
 <build xmlns="urn:wildfly:feature-pack-build:3.0" producer="wildfly-core-vault-test@maven(org.jboss.universe:community-universe):current">
     <dependencies>
-        <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack" producer="wildfly-core@maven(org.jboss.universe:community-universe):current">
+        <dependency group-id="org.wildfly.core" artifact-id="wildfly-core-galleon-pack">
             <name>org.wildfly.core:wildfly-core-galleon-pack</name>
             <packages inherit="true">
                 <exclude name="product.conf"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4065

I assume moving the formatters earlier in the logging f-g spec corrects the problem because otherwise the order of the refs to the formatters controls the order of their appearance.