### PR TITLE
[WFCORE-4066] Avoid overriding galleon pack properties when core-feature-pack-licenses.html is created

### DIFF
--- a/core-galleon-pack/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
+++ b/core-galleon-pack/src/main/resources/packages/docs.licenses/pm/wildfly/tasks.xml
@@ -2,6 +2,6 @@
 
 <tasks xmlns="urn:wildfly:wildfly-feature-pack-tasks:2.0">
     <copy-path src="docs/licenses/licenses.xsl" relative-to="content" target="docs/licenses/core-licenses.xsl"/>
-    <transform stylesheet="docs/licenses/core-licenses.xsl" src="docs/licenses/core-feature-pack-licenses.xml" output="docs/licenses/core-feature-pack-licenses.html"/>
+    <transform stylesheet="docs/licenses/core-licenses.xsl" src="docs/licenses/core-feature-pack-licenses.xml" output="docs/licenses/core-feature-pack-licenses.html" feature-pack-properties="true"/>
     <delete path="docs/licenses/core-licenses.xsl"/>
 </tasks>


### PR DESCRIPTION
Do not override the feature pack properties for this task so we can get the correct wildfly-core version in the core-feature-pack-licenses.html file when the server is provisioned in wildfly-full.

Jira issue: https://issues.jboss.org/browse/WFCORE-4066

cc: @aloubyansky 