### PR TITLE
[WFCORE-4078]: TimeZone is not correctly taken into account when checking certification expiration

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AdvancedModifiableKeyStoreDecorator.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AdvancedModifiableKeyStoreDecorator.java
@@ -50,7 +50,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -940,9 +939,9 @@ class AdvancedModifiableKeyStoreDecorator extends ModifiableKeyStoreDecorator {
                 if (certificate == null) {
                     throw ROOT_LOGGER.unableToObtainCertificate(alias);
                 }
-                Date current = new Date();
-                Date notAfter = certificate.getNotAfter();
-                long difference = notAfter.getTime() - current.getTime();
+                ZonedDateTime current = ZonedDateTime.now();
+                ZonedDateTime notAfter = ZonedDateTime.ofInstant(certificate.getNotAfter().toInstant(), ZoneId.of("UTC"));
+                long difference = notAfter.toInstant().toEpochMilli() - current.toInstant().toEpochMilli();
                 long daysToExpiry = 0;
                 ModelNode result = context.getResult();
                 if (difference <= 0) {

--- a/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
@@ -1080,16 +1080,16 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
     @Test
     public void testShouldRenewCertificateExpiresWithinGivenDays() throws Exception {
         final ZonedDateTime notValidBeforeDate = ZonedDateTime.now();
-        final ZonedDateTime notValidAfterDate = ZonedDateTime.now().plusDays(60);
+        final ZonedDateTime notValidAfterDate = notValidBeforeDate.plusDays(60);
         ModelNode result = shouldRenewCertificate(notValidBeforeDate, notValidAfterDate, 90);
         assertTrue(result.get(ElytronDescriptionConstants.SHOULD_RENEW_CERTIFICATE).asBoolean());
-        assertEquals(59, result.get(ElytronDescriptionConstants.DAYS_TO_EXPIRY).asLong());
+        assertEquals(60, result.get(ElytronDescriptionConstants.DAYS_TO_EXPIRY).asLong());
     }
 
     @Test
     public void testShouldRenewCertificateDoesNotExpireWithinGivenDays() throws Exception {
         final ZonedDateTime notValidBeforeDate = ZonedDateTime.now();
-        final ZonedDateTime notValidAfterDate = ZonedDateTime.now().plusDays(30);
+        final ZonedDateTime notValidAfterDate = notValidBeforeDate.plusDays(30);
         ModelNode result = shouldRenewCertificate(notValidBeforeDate, notValidAfterDate, 15);
         assertFalse(result.get(ElytronDescriptionConstants.SHOULD_RENEW_CERTIFICATE).asBoolean());
         assertEquals(29, result.get(ElytronDescriptionConstants.DAYS_TO_EXPIRY).asLong());


### PR DESCRIPTION
Converting the not After date to the same TimeZone as the current date.

JIRA: https://issues.jboss.org/browse/WFCORE-4078