### PR TITLE
[WFCORE-4079] Ensure tests pass with internationalized loggers and messages

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -71,6 +71,12 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
         builder.createLegacyKernelServicesBuilder(AdditionalInitialization.MANAGEMENT, controllerVersion, version)
                 .addMavenResourceURL(mavenResourceURLs)
                 .skipReverseControllerCheck()
+                .addParentFirstClassPattern("org.jboss.as.controller.logging.ControllerLogger*")
+                .addParentFirstClassPattern("org.jboss.as.controller.PathAddress")
+                .addParentFirstClassPattern("org.jboss.as.controller.PathElement")
+                .addParentFirstClassPattern("org.jboss.as.server.logging.*")
+                .addParentFirstClassPattern("org.jboss.logging.*")
+                .addParentFirstClassPattern("org.jboss.dmr.*")
                 .dontPersistXml();
 
         KernelServices services = builder.build();
@@ -102,6 +108,12 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
         ));
         builder.createLegacyKernelServicesBuilder(AdditionalInitialization.MANAGEMENT, controllerVersion, elytronVersion)
                 .addMavenResourceURL(controllerVersion.getCoreMavenGroupId() + ":wildfly-elytron-integration:" + controllerVersion.getCoreVersion())
+                .addParentFirstClassPattern("org.jboss.as.controller.logging.ControllerLogger*")
+                .addParentFirstClassPattern("org.jboss.as.controller.PathAddress")
+                .addParentFirstClassPattern("org.jboss.as.controller.PathElement")
+                .addParentFirstClassPattern("org.jboss.as.server.logging.*")
+                .addParentFirstClassPattern("org.jboss.logging.*")
+                .addParentFirstClassPattern("org.jboss.dmr.*")
                 .dontPersistXml();
 
         KernelServices mainServices = builder.build();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeployAllDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeployAllDomainTestCase.java
@@ -187,10 +187,9 @@ public class DeployAllDomainTestCase extends AbstractCliTestBase {
             // Check error message
             assertThat("Error message doesn't contains expected message information!",
                     ex.getMessage(),
-                    allOf(containsString("WFLYCTL0216: Management resource"),
+                    allOf(containsString("WFLYCTL0216"),
                             containsString(sgOne),
-                            containsString(cliTestApp2War.getName()),
-                            containsString("not found")));
+                            containsString(cliTestApp2War.getName())));
             // Verification wrong command execution fail - success
         }
 
@@ -329,10 +328,9 @@ public class DeployAllDomainTestCase extends AbstractCliTestBase {
             // Check error message
             assertThat("Error message doesn't contains expected message information!",
                     ex.getMessage(),
-                    allOf(containsString("WFLYCTL0216: Management resource"),
+                    allOf(containsString("WFLYCTL0216:"),
                             containsString(sgOne),
-                            containsString(cliTestApp2War.getName()),
-                            containsString("not found")));
+                            containsString(cliTestApp2War.getName())));
             // Verification wrong command execution fail - success
         }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DeploymentOverlayTestCase.java
@@ -64,6 +64,7 @@ import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
 import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.domain.controller.logging.DomainControllerLogger;
 import org.jboss.as.test.deployment.trivial.ServiceActivatorDeploymentUtil;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
@@ -220,7 +221,8 @@ public class DeploymentOverlayTestCase {
         ModelNode failingOperation = Operations.createOperation("redeploy-links", PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode());
         failingOperation.get("deployments").setEmptyList();
         failingOperation.get("deployments").add(OTHER_RUNTIME_NAME);
-        executeAsyncForFailure(slaveClient, failingOperation, "WFLYDC0032: Operation redeploy-links for address " + PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH).toModelNode().toString() + " can only be handled by the master Domain Controller; this host is not the master Domain Controller");
+        final String expectedFailureMessage = DomainControllerLogger.ROOT_LOGGER.masterDomainControllerOnlyOperation("redeploy-links", PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH));
+        executeAsyncForFailure(slaveClient, failingOperation, expectedFailureMessage);
         ModelNode removeLinkOp = Operations.createOperation(REMOVE, PathAddress.pathAddress(OTHER_SERVER_GROUP, DEPLOYMENT_OVERLAY_PATH, PathElement.pathElement(DEPLOYMENT, OTHER_RUNTIME_NAME)).toModelNode());
         removeLinkOp.get("redeploy-affected").set(true);
         executeAsyncForResult(masterClient, removeLinkOp);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/WildcardOperationsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/WildcardOperationsTestCase.java
@@ -401,6 +401,7 @@ public class WildcardOperationsTestCase {
         final ModelNode operation = new ModelNode();
         operation.get(OP).set(READ_RESOURCE_DESCRIPTION_OPERATION);
         operation.get(OP_ADDR).set(address);
+        operation.get("locale").set("en");
         return operation;
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/deployment/DeploymentInfoUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/deployment/DeploymentInfoUtils.java
@@ -730,8 +730,7 @@ public class DeploymentInfoUtils {
             // Verify error message
             assertThat("Wrong error message for missing deployment " + param.getName() + " in server group " + param.getResult().getServerGroup(),
                     response.get(FAILURE_DESCRIPTION).asString(), allOf(
-                            containsString("WFLYCTL0216: Management resource"),
-                            containsString("not found"),
+                            containsString("WFLYCTL0216:"),
                             containsString(param.getName())
                     )
             );
@@ -790,8 +789,7 @@ public class DeploymentInfoUtils {
         // Verify error message
         assertThat("Wrong error message for missing deployment " + param.getName() + " in server group " + param.getResult().getServerGroup(),
                 response.get(FAILURE_DESCRIPTION).asString(), allOf(
-                        containsString("WFLYCTL0216: Management resource"),
-                        containsString("not found"),
+                        containsString("WFLYCTL0216:"),
                         containsString(param.getName())
                 )
         );

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeployTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/DeployTestCase.java
@@ -477,8 +477,8 @@ public class DeployTestCase extends AbstractCliTestBase{
         } catch (Exception ex) {
             // Check error message
             assertThat("Error message doesn't contains expected message information!"
-                    , ex.getMessage(), containsString("WFLYSRV0150: Cannot create input stream from URL '" +
-                            cliTestApp2War.toURI() + WRONG_PATH_PART + "'"));
+                    , ex.getMessage(), allOf(containsString("WFLYSRV0150:"),
+                            containsString("'" + cliTestApp2War.toURI() + WRONG_PATH_PART + "'")));
             // Verification wrong command execution fail - success
         }
 
@@ -511,7 +511,7 @@ public class DeployTestCase extends AbstractCliTestBase{
         } catch (Exception ex) {
             // Check error message
             assertThat("Error message doesn't contains expected message information!"
-                    , ex.getMessage(), containsString("Path " + tempCliTestAppWar.getPath() + WRONG_PATH_PART + " doesn't exist."));
+                    , ex.getMessage(), containsString(tempCliTestAppWar.getPath() + WRONG_PATH_PART));
             // Verification wrong command execution fail - success
         }
 
@@ -529,7 +529,7 @@ public class DeployTestCase extends AbstractCliTestBase{
         } catch (Exception ex) {
             // Check error message
             assertThat("Error message doesn't contains expected message information!"
-                    , ex.getMessage(), containsString("Unrecognized arguments: [" + wrongArgument + "]"));
+                    , ex.getMessage(), containsString("[" + wrongArgument + "]"));
             // Verification wrong command execution fail - success
         }
 
@@ -560,8 +560,7 @@ public class DeployTestCase extends AbstractCliTestBase{
         } catch (Exception ex) {
             // Check error message
             assertThat("Error message doesn't contains expected message information!"
-                    , ex.getMessage(), containsString("'" + WRONG_DEPLOYMENT +
-                            "' is not found among the registered deployments."));
+                    , ex.getMessage(), containsString("'" + WRONG_DEPLOYMENT + "'"));
             // Verification wrong command execution fail - success
         }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4079

These could be squashed to a single commit. I've only left them separate as each commit belongs to a specific test/test suite that fails.