### PR TITLE
[WFCORE-4002] JDK-11 - testsuite - tolerate SocketException packed into SSLException

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HTTPSManagementInterfaceTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/HTTPSManagementInterfaceTestCase.java
@@ -42,6 +42,8 @@ import java.io.IOException;
 import java.net.SocketException;
 import java.net.URL;
 import java.util.concurrent.TimeoutException;
+
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
@@ -247,6 +249,10 @@ public class HTTPSManagementInterfaceTestCase {
             //depending on the OS and the version of HTTP client in use any one of these exceptions may be thrown
             //in particular the SocketException gets thrown on Windows
             // OK
+        } catch (SSLException e) {
+            if (!(e.getCause() instanceof SocketException)) {
+                throw e;
+            }
         }
 
         String responseBody = makeCallWithHttpClient(mgmtURL, httpClient, 200);

--- a/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfaceTestCase.java
+++ b/testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfaceTestCase.java
@@ -43,6 +43,7 @@ import java.net.URL;
 import java.net.UnknownHostException;
 
 import javax.inject.Inject;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
@@ -182,6 +183,10 @@ public class HTTPSManagementInterfaceTestCase {
             //depending on the OS and the version of HTTP client in use any one of these exceptions may be thrown
             //in particular the SocketException gets thrown on Windows
             // OK
+        } catch (SSLException e) {
+            if (!(e.getCause() instanceof SocketException)) {
+                throw e;
+            }
         }
 
         String responseBody = makeCallWithHttpClient(mgmtURL, httpClient, 200);
@@ -215,6 +220,10 @@ public class HTTPSManagementInterfaceTestCase {
             //depending on the OS and the version of HTTP client in use any one of these exceptions may be thrown
             //in particular the SocketException gets thrown on Windows
             // OK
+        } catch (SSLException e) {
+            if (!(e.getCause() instanceof SocketException)) {
+                throw e;
+            }
         }
 
         String responseBody = makeCallWithHttpClient(mgmtURL, httpClient, 200);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4002

JBEAP: https://issues.jboss.org/browse/JBEAP-15400
JBEAP PR: https://github.com/jbossas/wildfly-core-eap/pull/590

SocketException in SSL are in JDK-11 packed as cause into SSLException - SSLException with appropriate cause was allowed where SocketException was allowed before.