### PR TITLE
[WFCORE-4078]: TimeZone is not correctly taken into account when chec…

### DIFF
--- a/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/KeyStoresTestCase.java
@@ -49,6 +49,7 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAKey;
 import java.security.interfaces.RSAPublicKey;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -354,7 +355,6 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
     }
 
     @BeforeClass
-
     public static void initTests() throws Exception {
         server = new ClientAndServer(4001);
         setUpFiles();
@@ -1079,20 +1079,20 @@ public class KeyStoresTestCase extends AbstractSubsystemTest {
 
     @Test
     public void testShouldRenewCertificateExpiresWithinGivenDays() throws Exception {
-        final ZonedDateTime notValidBeforeDate = ZonedDateTime.now();
-        final ZonedDateTime notValidAfterDate = ZonedDateTime.now().plusDays(60);
+        final ZonedDateTime notValidBeforeDate = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("UTC"));
+        final ZonedDateTime notValidAfterDate = notValidBeforeDate.plusDays(60).plusMinutes(1);
         ModelNode result = shouldRenewCertificate(notValidBeforeDate, notValidAfterDate, 90);
         assertTrue(result.get(ElytronDescriptionConstants.SHOULD_RENEW_CERTIFICATE).asBoolean());
-        assertEquals(59, result.get(ElytronDescriptionConstants.DAYS_TO_EXPIRY).asLong());
+        assertEquals(60, result.get(ElytronDescriptionConstants.DAYS_TO_EXPIRY).asLong());
     }
 
     @Test
     public void testShouldRenewCertificateDoesNotExpireWithinGivenDays() throws Exception {
-        final ZonedDateTime notValidBeforeDate = ZonedDateTime.now();
-        final ZonedDateTime notValidAfterDate = ZonedDateTime.now().plusDays(30);
+        final ZonedDateTime notValidBeforeDate = ZonedDateTime.now().withZoneSameInstant(ZoneId.of("UTC"));
+        final ZonedDateTime notValidAfterDate = notValidBeforeDate.plusDays(30).plusMinutes(1);
         ModelNode result = shouldRenewCertificate(notValidBeforeDate, notValidAfterDate, 15);
         assertFalse(result.get(ElytronDescriptionConstants.SHOULD_RENEW_CERTIFICATE).asBoolean());
-        assertEquals(29, result.get(ElytronDescriptionConstants.DAYS_TO_EXPIRY).asLong());
+        assertEquals(30, result.get(ElytronDescriptionConstants.DAYS_TO_EXPIRY).asLong());
     }
 
     private ModelNode shouldRenewCertificate(ZonedDateTime notValidBeforeDate, ZonedDateTime notValidAfterDate, int expiration) throws Exception {


### PR DESCRIPTION
…king certification expiration

Converting the not After date to the same TimeZone as the current date.

Jira: https://issues.jboss.org/browse/WFCORE-4078