### PR TITLE
WFCORE-4083 org.apache.httpcomponents.core requires org.apache.common…

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/core/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/core/main/module.xml
@@ -36,5 +36,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="org.apache.commons.logging"/>
+        <!-- Following module is available in WildFly full -->
+        <module name="org.apache.commons.codec" optional="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
…s.codec

For a full description of the problem, see:
 - https://issues.jboss.org/browse/WFCORE-4083