### PR TITLE
[WFCORE-3180] ElytronSubsystemMessages and LocalDescriptions.properties use double quotes within strings

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -259,7 +259,7 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 25, value = "Referenced property file is invalid: %s")
     StartException propertyFileIsInvalid(String message, @Cause Throwable cause);
 
-    //@Message(id = 26, value = "trusted-security-domains cannot contain the security-domain \"%s\" itself")
+    //@Message(id = 26, value = "trusted-security-domains cannot contain the security-domain '%s' itself")
     //OperationFailedException trustedDomainsCannotContainDomainItself(String domain);
 
     @Message(id = 27, value = "Unable to obtain OID for X.500 attribute '%s'")
@@ -314,13 +314,13 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 37, value = "Injected value is not of '%s' type.")
     StartException invalidTypeInjected(final String type);
 
-    @Message(id = 38, value = "Could not load permission class \"%s\"")
+    @Message(id = 38, value = "Could not load permission class '%s'")
     StartException invalidPermissionClass(String className);
 
     @Message(id = 39, value = "Unable to reload CRL file - TrustManager is not reloadable")
     OperationFailedException unableToReloadCRLNotReloadable();
 
-    @Message(id = 40, value = "Unable to load the permission module \"%s\" for the permission mapping")
+    @Message(id = 40, value = "Unable to load the permission module '%s' for the permission mapping")
     StartException invalidPermissionModule(String module, @Cause Throwable cause);
 
     // CREDENTIAL_STORE section
@@ -361,7 +361,7 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = Message.NONE, value = "Reload dependent services which might already have cached the secret value")
     String reloadDependantServices();
 
-    @Message(id = Message.NONE, value = "Update dependent resources as alias \"%s\" does not exist anymore")
+    @Message(id = Message.NONE, value = "Update dependent resources as alias '%s' does not exist anymore")
     String updateDependantServices(String alias);
 
     /*

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -692,7 +692,7 @@ elytron.properties-realm.users-properties=The properties file containing the use
 elytron.properties-realm.users-properties.path=The path to the file containing the users and their passwords. The file should contain realm name declaration.
 elytron.properties-realm.users-properties.relative-to=The pre-defined path the path is relative to.
 elytron.properties-realm.users-properties.digest-realm-name=The default realm name to use for digested passwords if one is not discovered in the properties file.
-elytron.properties-realm.users-properties.plain-text=Are the passwords in properties file stored in plain text or pre-hashed? (Pre-hashed form: HEX( MD5( username ":" realm ":" password ) ) )
+elytron.properties-realm.users-properties.plain-text=Are the passwords in properties file stored in plain text or pre-hashed? (Pre-hashed form: HEX( MD5( username ':' realm ':' password ) ) )
 elytron.properties-realm.groups-properties=The properties file containing the users and their groups.
 elytron.properties-realm.groups-properties.path=The path to the file containing the users and their groups.
 elytron.properties-realm.groups-properties.relative-to=The pre-defined path the path is relative to.
@@ -720,11 +720,11 @@ elytron.ldap-realm.identity-mapping.attribute-mapping.attribute=The configuratio
 elytron.ldap-realm.identity-mapping.from=The name of the LDAP attribute to map to an identity attribute. If not defined, DN of entry is used.
 elytron.ldap-realm.identity-mapping.to=The name of the identity attribute mapped from a specific LDAP attribute. If not provided, the name of the attribute is the same as define in 'from'. If the 'from' is not defined too, value 'dn' is used.
 elytron.ldap-realm.identity-mapping.reference=The name of LDAP attribute containing DN of entry to obtain value from.
-elytron.ldap-realm.identity-mapping.filter=The filter to use to obtain the values for a specific attribute. String "{0}" will be replaced by username, "{1}" by user identity DN.
+elytron.ldap-realm.identity-mapping.filter=The filter to use to obtain the values for a specific attribute. String '{0}' will be replaced by username, '{1}' by user identity DN.
 elytron.ldap-realm.identity-mapping.filter-base-dn=The name of the context where the filter should be performed.
 elytron.ldap-realm.identity-mapping.search-recursive=Indicates if attribute LDAP search queries are recursive.
 elytron.ldap-realm.identity-mapping.role-recursion=Sets recursive roles assignment - value determine maximum depth of recursion. (0 for no recursion)
-elytron.ldap-realm.identity-mapping.role-recursion-name=Determine LDAP attribute of role entry which will be substitute for "{0}" in filter-name when searching roles of role.
+elytron.ldap-realm.identity-mapping.role-recursion-name=Determine LDAP attribute of role entry which will be substitute for '{0}' in filter-name when searching roles of role.
 elytron.ldap-realm.identity-mapping.extract-rdn=The RDN key to use as the value for an attribute, in case the value in its raw form is in X.500 format.
 elytron.ldap-realm.identity-mapping.filter-name=The LDAP filter for getting identity by name. If this is not specified then the default value will be (rdn_identifier={0}). The string '{0}' will be replaced by searched identity name and the 'rdn_identifier' will be the value of the attribute 'rdn-identifier'.
 elytron.ldap-realm.identity-mapping.iterator-filter=The LDAP filter for iterating over identities of the realm.
@@ -770,8 +770,8 @@ elytron.token-realm.remove=The remove operation for the security realm.
 elytron.token-realm.principal-claim=The name of the claim that should be used to obtain the principal's name.
 # JWT Validator Complex Attribute
 elytron.token-realm.jwt=A token validator to be used in conjunction with a token-based realm that handles security tokens based on the JWT/JWS standard.
-elytron.token-realm.jwt.issuer=A list of strings representing the issuers supported by this configuration. During validation JWT tokens must have an "iss" claim that contains one of the values defined here.
-elytron.token-realm.jwt.audience=A list of strings representing the audiences supported by this configuration. During validation JWT tokens must have an "aud" claim that contains one of the values defined here.
+elytron.token-realm.jwt.issuer=A list of strings representing the issuers supported by this configuration. During validation JWT tokens must have an 'iss' claim that contains one of the values defined here.
+elytron.token-realm.jwt.audience=A list of strings representing the audiences supported by this configuration. During validation JWT tokens must have an 'aud' claim that contains one of the values defined here.
 elytron.token-realm.jwt.public-key=A public key in PEM Format. During validation, if a public key is provided, signature will be verified based on the key you provided here.
 elytron.token-realm.jwt.key-store=A key store from where the certificate with a public key should be loaded from.
 elytron.token-realm.jwt.certificate=The name of the certificate with a public key to load from the key store.
@@ -781,7 +781,7 @@ elytron.token-realm.oauth2-introspection.client-id=The identifier of the client 
 elytron.token-realm.oauth2-introspection.client-secret=The secret of the client.
 elytron.token-realm.oauth2-introspection.introspection-url=The URL of token introspection endpoint.
 elytron.token-realm.oauth2-introspection.client-ssl-context=The SSL context to be used if the introspection endpoint is using HTTPS.
-elytron.token-realm.oauth2-introspection.host-name-verification-policy=A policy that defines how host names should be verified when using HTTPS. Allowed values: "ANY".
+elytron.token-realm.oauth2-introspection.host-name-verification-policy=A policy that defines how host names should be verified when using HTTPS. Allowed values: 'ANY'.
 
 # Identity management descriptions
 elytron.modifiable-security-realm.add-identity=Add an identity to a security realm.
@@ -1332,7 +1332,7 @@ elytron.certificate-authority-account.get-metadata=Get the metadata associated w
 elytron.certificate-authority-account.get-metadata.staging=Indicates whether or not the certificate authority's staging URL should be used. The default value is false. This should only be set to true for testing purposes. This should never be set to true in a production environment.
 
 # Configuration Attributes
-elytron.certificate-authority-account.certificate-authority=The name of the certificate authority to use. Allowed values: "LetsEncrypt"
+elytron.certificate-authority-account.certificate-authority=The name of the certificate authority to use. Allowed values: 'LetsEncrypt'
 elytron.certificate-authority-account.contact-urls=A list of URLs that the certificate authority can contact about any issues related to this account.
 elytron.certificate-authority-account.key-store=The keystore that contains the certificate authority account key.
 elytron.certificate-authority-account.alias=The alias of certificate authority account key in the keystore. If the alias does not already exist in the keystore, a certificate authority account key will be automatically generated and stored as a PrivateKeyEntry under the alias.
@@ -1388,10 +1388,10 @@ elytron.dir-context=The configuration to connect to a directory (LDAP) server.
 elytron.dir-context.add=Add the DirContext definition.
 elytron.dir-context.remove=Remove the DirContext definition.
 elytron.dir-context.url=The connection url.
-elytron.dir-context.authentication-level=The authentication level (security level/authentication mechanism) to use. Corresponds to SECURITY_AUTHENTICATION ("java.naming.security.authentication") environment property. Allowed values: "none", "simple", sasl_mech, where sasl_mech is a space-separated list of SASL mechanism names.
-elytron.dir-context.authentication-context=The authentication context to obtain login credentials to connect to the LDAP server. Can be omitted if authentication-level is "none" (anonymous).
-elytron.dir-context.principal=The principal to authenticate and connect to the LDAP server. Can be omitted if authentication-level is "none" (anonymous).
-elytron.dir-context.credential-reference=The credential reference to authenticate and connect to the LDAP server. Can be omitted if authentication-level is "none" (anonymous).
+elytron.dir-context.authentication-level=The authentication level (security level/authentication mechanism) to use. Corresponds to SECURITY_AUTHENTICATION ('java.naming.security.authentication') environment property. Allowed values: 'none', 'simple', sasl_mech, where sasl_mech is a space-separated list of SASL mechanism names.
+elytron.dir-context.authentication-context=The authentication context to obtain login credentials to connect to the LDAP server. Can be omitted if authentication-level is 'none' (anonymous).
+elytron.dir-context.principal=The principal to authenticate and connect to the LDAP server. Can be omitted if authentication-level is 'none' (anonymous).
+elytron.dir-context.credential-reference=The credential reference to authenticate and connect to the LDAP server. Can be omitted if authentication-level is 'none' (anonymous).
 elytron.dir-context.credential-reference.store=The name of the credential store holding the alias to credential.
 elytron.dir-context.credential-reference.alias=The alias which denotes stored secret or credential in the store.
 elytron.dir-context.credential-reference.type=The type of credential this reference is denoting.


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3180