### PR TITLE
[WFCORE-4085] Temporarily use WF14 as the transformation target for EAP

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -66,6 +66,7 @@ public class TransformersTestParameter extends ClassloaderParameter {
         //code legacy controller has some issues atm
         data.add(new TransformersTestParameter(ModelVersion.create(4, 1, 0), ModelTestControllerVersion.EAP_7_0_0));
         data.add(new TransformersTestParameter(ModelVersion.create(5, 0, 0), ModelTestControllerVersion.EAP_7_1_0));
+        data.add(new TransformersTestParameter(ModelVersion.create(8, 0, 0), ModelTestControllerVersion.EAP_7_2_0_TEMP));
 
         return data;
     }

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -43,7 +43,13 @@ public enum ModelTestControllerVersion {
     EAP_6_4_0 ("7.5.0.Final-redhat-21", true, "7.5.0", "6.4.0"), //EAP 6.4 is the earliest version we support for transformers
     EAP_6_4_7 ("7.5.7.Final-redhat-3", true, "7.5.0", "6.4.7"), //this one is special as it has model change in micro release
     EAP_7_0_0 ("7.0.0.GA-redhat-2", true, "10.0.0", "2.1.0.Final", "7.0.0"),
-    EAP_7_1_0 ("7.1.0.GA-redhat-11", true, "11.0.0", "3.0.10.Final", "7.1.0")
+    EAP_7_1_0 ("7.1.0.GA-redhat-11", true, "11.0.0", "3.0.10.Final", "7.1.0"),
+
+    // TODO https://issues.jboss.org/browse/WFCORE-4089 Get rid of EAP_7_2_0_TEMP and enable EAP_7_2_0, once
+    // 7.2.0.GA-redhat-xx version is known
+    EAP_7_2_0_TEMP("11.0.0.Final", false, "14.0.0", "6.0.1.Final", "wf14"),
+    // WildFly legacy test will need to rename the *-wf14.dmr files to *-7.2.0.dmr
+    //EAP_7_2_0("7.2.0.Final-redhat-??", true, "14.0.0", "6.0.1.Final", "7.2.0"),
     ;
 
     private final String mavenGavVersion;

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
         <version.org.wildfly.client.config>1.0.1.Final</version.org.wildfly.client.config>
         <version.org.wildfly.common>1.4.0.Final</version.org.wildfly.common>
         <version.org.wildfly.discovery>1.1.1.Final</version.org.wildfly.discovery>
-        <version.org.wildfly.legacy.test>3.0.0.Final</version.org.wildfly.legacy.test>
+        <version.org.wildfly.legacy.test>4.0.0.Final</version.org.wildfly.legacy.test>
         <version.org.wildfly.openssl>1.0.6.Final</version.org.wildfly.openssl>
         <version.org.wildfly.openssl.natives>${version.org.wildfly.openssl}</version.org.wildfly.openssl.natives>
         <version.org.wildfly.openssl.wildfly-openssl-linux-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-linux-i386>


### PR DESCRIPTION
7.2.0. Once EAP 7.2.0 is released there is a follow up task to switch it
to use EAP 7.2.0 proper in WFCORE-4089

https://issues.jboss.org/browse/WFCORE-4085