### PR TITLE
[WFCORE-3404] Elytron audit performance - separated sync and flushing

### DIFF
--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuditLoggingParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuditLoggingParser.java
@@ -43,14 +43,19 @@ class AuditLoggingParser {
             .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT)
             .build();
 
+    private final PersistentResourceXMLDescription fileAuditLogParser_5_0 = builder(PathElement.pathElement(FILE_AUDIT_LOG), null)
+            .setUseElementsForGroups(false)
+            .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.AUTOFLUSH, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT)
+            .build();
+
     private final PersistentResourceXMLDescription periodicRotatingFileAuditLogParser = builder(PathElement.pathElement(PERIODIC_ROTATING_FILE_AUDIT_LOG), null)
             .setUseElementsForGroups(false)
-            .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.PERIODIC_SUFFIX)
+            .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.AUTOFLUSH, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.PERIODIC_SUFFIX)
             .build();
 
     private final PersistentResourceXMLDescription sizeRotatingFileAuditLogParser = builder(PathElement.pathElement(SIZE_ROTATING_FILE_AUDIT_LOG), null)
             .setUseElementsForGroups(false)
-            .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.MAX_BACKUP_INDEX, AuditResourceDefinitions.ROTATE_ON_BOOT, AuditResourceDefinitions.ROTATE_SIZE, AuditResourceDefinitions.SIZE_SUFFIX)
+            .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.AUTOFLUSH, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.MAX_BACKUP_INDEX, AuditResourceDefinitions.ROTATE_ON_BOOT, AuditResourceDefinitions.ROTATE_SIZE, AuditResourceDefinitions.SIZE_SUFFIX)
             .build();
 
     private final PersistentResourceXMLDescription syslogAuditLogParser = builder(PathElement.pathElement(SYSLOG_AUDIT_LOG), null)
@@ -79,6 +84,15 @@ class AuditLoggingParser {
             .addChild(aggregateSecurityEventParser)
             .addChild(customSecurityEventParser) // new
             .addChild(fileAuditLogParser)
+            .addChild(periodicRotatingFileAuditLogParser)
+            .addChild(sizeRotatingFileAuditLogParser)
+            .addChild(syslogAuditLogParser)
+            .build();
+
+    final PersistentResourceXMLDescription parser5_0 = decorator(ElytronDescriptionConstants.AUDIT_LOGGING)
+            .addChild(aggregateSecurityEventParser)
+            .addChild(customSecurityEventParser) // new
+            .addChild(fileAuditLogParser_5_0)
             .addChild(periodicRotatingFileAuditLogParser)
             .addChild(sizeRotatingFileAuditLogParser)
             .addChild(syslogAuditLogParser)

--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuditLoggingParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuditLoggingParser.java
@@ -50,10 +50,20 @@ class AuditLoggingParser {
 
     private final PersistentResourceXMLDescription periodicRotatingFileAuditLogParser = builder(PathElement.pathElement(PERIODIC_ROTATING_FILE_AUDIT_LOG), null)
             .setUseElementsForGroups(false)
+            .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.PERIODIC_SUFFIX)
+            .build();
+
+    private final PersistentResourceXMLDescription periodicRotatingFileAuditLogParser_5_0 = builder(PathElement.pathElement(PERIODIC_ROTATING_FILE_AUDIT_LOG), null)
+            .setUseElementsForGroups(false)
             .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.AUTOFLUSH, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.PERIODIC_SUFFIX)
             .build();
 
     private final PersistentResourceXMLDescription sizeRotatingFileAuditLogParser = builder(PathElement.pathElement(SIZE_ROTATING_FILE_AUDIT_LOG), null)
+            .setUseElementsForGroups(false)
+            .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.MAX_BACKUP_INDEX, AuditResourceDefinitions.ROTATE_ON_BOOT, AuditResourceDefinitions.ROTATE_SIZE, AuditResourceDefinitions.SIZE_SUFFIX)
+            .build();
+
+    private final PersistentResourceXMLDescription sizeRotatingFileAuditLogParser_5_0 = builder(PathElement.pathElement(SIZE_ROTATING_FILE_AUDIT_LOG), null)
             .setUseElementsForGroups(false)
             .addAttributes(AuditResourceDefinitions.PATH, FileAttributeDefinitions.RELATIVE_TO, AuditResourceDefinitions.AUTOFLUSH, AuditResourceDefinitions.SYNCHRONIZED, AuditResourceDefinitions.FORMAT, AuditResourceDefinitions.MAX_BACKUP_INDEX, AuditResourceDefinitions.ROTATE_ON_BOOT, AuditResourceDefinitions.ROTATE_SIZE, AuditResourceDefinitions.SIZE_SUFFIX)
             .build();
@@ -91,10 +101,10 @@ class AuditLoggingParser {
 
     final PersistentResourceXMLDescription parser5_0 = decorator(ElytronDescriptionConstants.AUDIT_LOGGING)
             .addChild(aggregateSecurityEventParser)
-            .addChild(customSecurityEventParser) // new
+            .addChild(customSecurityEventParser)
             .addChild(fileAuditLogParser_5_0)
-            .addChild(periodicRotatingFileAuditLogParser)
-            .addChild(sizeRotatingFileAuditLogParser)
+            .addChild(periodicRotatingFileAuditLogParser_5_0)
+            .addChild(sizeRotatingFileAuditLogParser_5_0)
             .addChild(syslogAuditLogParser)
             .build();
 

--- a/elytron/src/main/java/org/wildfly/extension/elytron/AuditResourceDefinitions.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/AuditResourceDefinitions.java
@@ -87,6 +87,11 @@ class AuditResourceDefinitions {
             .setRestartAllServices()
             .build();
 
+    static final SimpleAttributeDefinition AUTOFLUSH = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.AUTOFLUSH, ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setRestartAllServices()
+            .build();
+
     static final SimpleAttributeDefinition SYNCHRONIZED = new SimpleAttributeDefinitionBuilder(ElytronDescriptionConstants.SYNCHRONIZED, ModelType.BOOLEAN, true)
             .setAllowExpression(true)
             .setDefaultValue(new ModelNode(true))
@@ -186,7 +191,7 @@ class AuditResourceDefinitions {
     }
 
     static ResourceDefinition getFileAuditLogResourceDefinition() {
-        AttributeDefinition[] attributes = new AttributeDefinition[] {PATH, RELATIVE_TO, SYNCHRONIZED, FORMAT };
+        AttributeDefinition[] attributes = new AttributeDefinition[] { PATH, RELATIVE_TO, AUTOFLUSH, SYNCHRONIZED, FORMAT };
         AbstractAddStepHandler add = new TrivialAddHandler<SecurityEventListener>(SecurityEventListener.class, attributes, SECURITY_EVENT_LISTENER_RUNTIME_CAPABILITY) {
 
             @Override
@@ -195,6 +200,7 @@ class AuditResourceDefinitions {
                     throws OperationFailedException {
 
                 final boolean synv = SYNCHRONIZED.resolveModelAttribute(context, model).asBoolean();
+                final boolean autoflush = AUTOFLUSH.resolveModelAttribute(context, model).asBoolean(synv);
                 final Format format = Format.valueOf(FORMAT.resolveModelAttribute(context, model).asString());
 
                 final InjectedValue<PathManager> pathManager = new InjectedValue<PathManager>();
@@ -222,6 +228,7 @@ class AuditResourceDefinitions {
                         try {
                             endpoint = FileAuditEndpoint.builder().setLocation(resolvedPath.toPath())
                                     .setSyncOnAccept(synv)
+                                    .setFlushOnAccept(autoflush)
                                     .setDateTimeFormatterSupplier(dateTimeFormatterSupplier).build();
                         } catch (IOException e) {
                             throw ROOT_LOGGER.unableToStartService(e);
@@ -241,7 +248,7 @@ class AuditResourceDefinitions {
     }
 
     static ResourceDefinition getPeriodicRotatingFileAuditLogResourceDefinition() {
-        AttributeDefinition[] attributes = new AttributeDefinition[] {PATH, RELATIVE_TO, SYNCHRONIZED, FORMAT, PERIODIC_SUFFIX };
+        AttributeDefinition[] attributes = new AttributeDefinition[] {PATH, RELATIVE_TO, AUTOFLUSH, SYNCHRONIZED, FORMAT, PERIODIC_SUFFIX };
         AbstractAddStepHandler add = new TrivialAddHandler<SecurityEventListener>(SecurityEventListener.class, attributes, SECURITY_EVENT_LISTENER_RUNTIME_CAPABILITY) {
 
             @Override
@@ -250,6 +257,7 @@ class AuditResourceDefinitions {
                     throws OperationFailedException {
 
                 final boolean synv = SYNCHRONIZED.resolveModelAttribute(context, model).asBoolean();
+                final boolean autoflush = AUTOFLUSH.resolveModelAttribute(context, model).asBoolean(synv);
                 final Format format = Format.valueOf(FORMAT.resolveModelAttribute(context, model).asString());
                 final String suffix = PERIODIC_SUFFIX.resolveModelAttribute(context, model).asString();
 
@@ -280,6 +288,7 @@ class AuditResourceDefinitions {
                                     .setSuffix(suffix)
                                     .setLocation(resolvedPath.toPath())
                                     .setSyncOnAccept(synv)
+                                    .setFlushOnAccept(autoflush)
                                     .setDateTimeFormatterSupplier(dateTimeFormatterSupplier);
 
                             endpoint = builder.build();
@@ -301,7 +310,7 @@ class AuditResourceDefinitions {
     }
 
     static ResourceDefinition getSizeRotatingFileAuditLogResourceDefinition() {
-        AttributeDefinition[] attributes = new AttributeDefinition[] {PATH, RELATIVE_TO, SYNCHRONIZED, FORMAT, MAX_BACKUP_INDEX, ROTATE_ON_BOOT, ROTATE_SIZE, SIZE_SUFFIX };
+        AttributeDefinition[] attributes = new AttributeDefinition[] { PATH, RELATIVE_TO, AUTOFLUSH, SYNCHRONIZED, FORMAT, MAX_BACKUP_INDEX, ROTATE_ON_BOOT, ROTATE_SIZE, SIZE_SUFFIX };
         AbstractAddStepHandler add = new TrivialAddHandler<SecurityEventListener>(SecurityEventListener.class, attributes, SECURITY_EVENT_LISTENER_RUNTIME_CAPABILITY) {
 
             @Override
@@ -310,6 +319,7 @@ class AuditResourceDefinitions {
                     throws OperationFailedException {
 
                 final boolean synv = SYNCHRONIZED.resolveModelAttribute(context, model).asBoolean();
+                final boolean autoflush = AUTOFLUSH.resolveModelAttribute(context, model).asBoolean(synv);
                 final Format format = Format.valueOf(FORMAT.resolveModelAttribute(context, model).asString());
                 final int maxBackupIndex = MAX_BACKUP_INDEX.resolveModelAttribute(context, model).asInt(0);
                 final boolean rotateOnBoot = ROTATE_ON_BOOT.resolveModelAttribute(context, model).asBoolean();
@@ -348,6 +358,7 @@ class AuditResourceDefinitions {
                             }
                             builder.setLocation(resolvedPath.toPath())
                                     .setSyncOnAccept(synv)
+                                    .setFlushOnAccept(autoflush)
                                     .setDateTimeFormatterSupplier(dateTimeFormatterSupplier);
 
                             endpoint = builder.build();

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -71,6 +71,7 @@ interface ElytronDescriptionConstants {
     String AUTHORIZATION = "authorization";
     String AUTHORIZATION_NAME = "authorization-name";
     String AUTHORIZATION_REALM = "authorization-realm";
+    String AUTOFLUSH = "autoflush";
     String AVAILABLE_MECHANISMS = "available-mechanisms";
 
     String BCRYPT = "bcrypt";
@@ -190,9 +191,9 @@ interface ElytronDescriptionConstants {
     String FILTERS = "filters";
     String FINAL_PRINCIPAL_TRANSFORMER = "final-principal-transformer";
     String FINAL_PROVIDERS = "final-providers";
-    String FORWARDING_MODE = "forwarding-mode";
     String FIRST = "first";
     String FORMAT = "format";
+    String FORWARDING_MODE = "forwarding-mode";
     String FROM = "from";
 
     String GENERATE_CERTIFICATE_SIGNING_REQUEST = "generate-certificate-signing-request";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser5_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser5_0.java
@@ -18,6 +18,8 @@
 
 package org.wildfly.extension.elytron;
 
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+
 /**
  * The subsystem parser, which uses stax to read and write to and from xml.
  *
@@ -29,6 +31,11 @@ public class ElytronSubsystemParser5_0 extends ElytronSubsystemParser4_0 {
     @Override
     String getNameSpace() {
         return ElytronExtension.NAMESPACE_5_0;
+    }
+
+    @Override
+    PersistentResourceXMLDescription getAuditLoggingParser() {
+        return new AuditLoggingParser().parser5_0;
     }
 
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -17,15 +17,20 @@ limitations under the License.
 package org.wildfly.extension.elytron;
 
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.ALGORITHM;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.AUTOFLUSH;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.FILE_AUDIT_LOG;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SCRAM_MAPPER;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SYNCHRONIZED;
 import static org.wildfly.extension.elytron.ElytronExtension.ELYTRON_1_2_0;
 import static org.wildfly.extension.elytron.ElytronExtension.ELYTRON_2_0_0;
 import static org.wildfly.extension.elytron.ElytronExtension.ELYTRON_3_0_0;
 import static org.wildfly.extension.elytron.ElytronExtension.ELYTRON_4_0_0;
 import static org.wildfly.extension.elytron.ElytronExtension.ELYTRON_5_0_0;
 import static org.wildfly.extension.elytron.JdbcRealmDefinition.PrincipalQueryAttributes.PRINCIPAL_QUERIES;
+import static org.wildfly.extension.elytron._private.ElytronSubsystemMessages.ROOT_LOGGER;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
@@ -73,7 +78,12 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
 
     private static void from5(ChainedTransformationDescriptionBuilder chainedBuilder) {
         ResourceTransformationDescriptionBuilder builder = chainedBuilder.createBuilder(ELYTRON_5_0_0, ELYTRON_4_0_0);
-
+        builder
+               .addChildResource(PathElement.pathElement(FILE_AUDIT_LOG))
+               .getAttributeBuilder()
+               .setDiscard(DISCARD_IF_EQUALS_SYNCHRONIZED, AuditResourceDefinitions.AUTOFLUSH)
+               .addRejectCheck(REJECT_FLUSHED_DIFFERENT_FROM_SYNCHRONIZED, AuditResourceDefinitions.AUTOFLUSH)
+               .end();
     }
 
     private static void from4(ChainedTransformationDescriptionBuilder chainedBuilder) {
@@ -127,6 +137,7 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
             .addRejectCheck(RejectAttributeChecker.DEFINED, KerberosSecurityFactoryDefinition.FAIL_CACHE);
     }
 
+    // converting permission-set reference back to inline permissions
     private static final AttributeConverter MAPPING_PERMISSION_SET_CONVERTER = new AttributeConverter.DefaultAttributeConverter() {
         @Override
         protected void convertAttribute(PathAddress address, String attributeName, ModelNode attributeValue, TransformationContext context) {
@@ -149,6 +160,7 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
         }
     };
 
+    // converting permission-set reference back to inline permissions
     private static final AttributeConverter CONSTANT_PERMISSION_SET_CONVERTER = new AttributeConverter.DefaultAttributeConverter() {
         @Override
         protected void convertAttribute(PathAddress address, String attributeName, ModelNode attributeValue, TransformationContext context) {
@@ -167,4 +179,24 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
         }
     };
 
+    private static final RejectAttributeChecker REJECT_FLUSHED_DIFFERENT_FROM_SYNCHRONIZED = new RejectAttributeChecker.DefaultRejectAttributeChecker() {
+        @Override
+        public String getRejectionLogMessage(Map<String, ModelNode> attributes) {
+            return ROOT_LOGGER.unableToTransformTornAttribute(AUTOFLUSH, SYNCHRONIZED);
+        }
+
+        @Override
+        protected boolean rejectAttribute(PathAddress address, String attributeName, ModelNode attributeValue, TransformationContext context) {
+            boolean synced = context.readResourceFromRoot(address).getModel().get(SYNCHRONIZED).asBoolean();
+            return synced != attributeValue.asBoolean();
+        }
+    };
+
+    private static final DiscardAttributeChecker DISCARD_IF_EQUALS_SYNCHRONIZED = new DiscardAttributeChecker.DefaultDiscardAttributeChecker() {
+        @Override
+        protected boolean isValueDiscardable(PathAddress address, String attributeName, ModelNode attributeValue, TransformationContext context) {
+            boolean synced = context.readResourceFromRoot(address).getModel().get(SYNCHRONIZED).asBoolean();
+            return synced == attributeValue.asBoolean();
+        }
+    };
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/_private/ElytronSubsystemMessages.java
@@ -323,6 +323,9 @@ public interface ElytronSubsystemMessages extends BasicLogger {
     @Message(id = 40, value = "Unable to load the permission module '%s' for the permission mapping")
     StartException invalidPermissionModule(String module, @Cause Throwable cause);
 
+    @Message(id = 41, value = "Unable to transform configuration to the target version - attribute '%s' is different from '%s'")
+    String unableToTransformTornAttribute(String attribute1, String attribute2);
+
     // CREDENTIAL_STORE section
     @Message(id = 909, value = "Credential store '%s' does not support given credential store entry type '%s'")
     OperationFailedException credentialStoreEntryTypeNotSupported(String credentialStoreName, String entryType);

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -123,7 +123,7 @@ elytron.file-audit-log.remove=Remove the audit logger resource.
 #Attributes
 elytron.file-audit-log.path=Path of the file to be written.
 elytron.file-audit-log.relative-to=The relative path to the audit log.
-elytron.file-audit-log.autoflush=Whether every event should be immediately flushed to disk.
+elytron.file-audit-log.autoflush=Whether every event should be immediately flushed to disk (If undefined will default to the value of synchronized).
 elytron.file-audit-log.synchronized=Whether every event should be immediately synchronised to disk.
 elytron.file-audit-log.format=The format to use to record the audit event.
 
@@ -134,7 +134,7 @@ elytron.periodic-rotating-file-audit-log.remove=Remove the audit logger resource
 #Attributes
 elytron.periodic-rotating-file-audit-log.path=Path of the file to be written.
 elytron.periodic-rotating-file-audit-log.relative-to=The relative path to the audit log.
-elytron.periodic-rotating-file-audit-log.autoflush=Whether every event should be immediately flushed to disk.
+elytron.periodic-rotating-file-audit-log.autoflush=Whether every event should be immediately flushed to disk (If undefined will default to the value of synchronized).
 elytron.periodic-rotating-file-audit-log.synchronized=Whether every event should be immediately synchronised to disk.
 elytron.periodic-rotating-file-audit-log.format=The format to use to record the audit event.
 elytron.periodic-rotating-file-audit-log.suffix=The suffix string in a format which can be understood by java.time.format.DateTimeFormatter. The period of the rotation is automatically calculated based on the suffix.
@@ -147,7 +147,7 @@ elytron.size-rotating-file-audit-log.remove=Remove the audit logger resource.
 elytron.size-rotating-file-audit-log.path=Path of the file to be written.
 elytron.size-rotating-file-audit-log.relative-to=The relative path to the audit log.
 elytron.size-rotating-file-audit-log.autoflush=Whether every event should be immediately flushed to disk.
-elytron.size-rotating-file-audit-log.synchronized=Whether every event should be immediately synchronised to disk.
+elytron.size-rotating-file-audit-log.synchronized=Whether every event should be immediately flushed to disk (If undefined will default to the value of synchronized).
 elytron.size-rotating-file-audit-log.format=The format to use to record the audit event.
 elytron.size-rotating-file-audit-log.max-backup-index=The maximum number of files to backup when rotating.
 elytron.size-rotating-file-audit-log.rotate-size=The log file size the file should rotate at.

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -123,6 +123,7 @@ elytron.file-audit-log.remove=Remove the audit logger resource.
 #Attributes
 elytron.file-audit-log.path=Path of the file to be written.
 elytron.file-audit-log.relative-to=The relative path to the audit log.
+elytron.file-audit-log.autoflush=Whether every event should be immediately flushed to disk.
 elytron.file-audit-log.synchronized=Whether every event should be immediately synchronised to disk.
 elytron.file-audit-log.format=The format to use to record the audit event.
 
@@ -133,6 +134,7 @@ elytron.periodic-rotating-file-audit-log.remove=Remove the audit logger resource
 #Attributes
 elytron.periodic-rotating-file-audit-log.path=Path of the file to be written.
 elytron.periodic-rotating-file-audit-log.relative-to=The relative path to the audit log.
+elytron.periodic-rotating-file-audit-log.autoflush=Whether every event should be immediately flushed to disk.
 elytron.periodic-rotating-file-audit-log.synchronized=Whether every event should be immediately synchronised to disk.
 elytron.periodic-rotating-file-audit-log.format=The format to use to record the audit event.
 elytron.periodic-rotating-file-audit-log.suffix=The suffix string in a format which can be understood by java.time.format.DateTimeFormatter. The period of the rotation is automatically calculated based on the suffix.
@@ -144,6 +146,7 @@ elytron.size-rotating-file-audit-log.remove=Remove the audit logger resource.
 #Attributes
 elytron.size-rotating-file-audit-log.path=Path of the file to be written.
 elytron.size-rotating-file-audit-log.relative-to=The relative path to the audit log.
+elytron.size-rotating-file-audit-log.autoflush=Whether every event should be immediately flushed to disk.
 elytron.size-rotating-file-audit-log.synchronized=Whether every event should be immediately synchronised to disk.
 elytron.size-rotating-file-audit-log.format=The format to use to record the audit event.
 elytron.size-rotating-file-audit-log.max-backup-index=The maximum number of files to backup when rotating.

--- a/elytron/src/main/resources/schema/wildfly-elytron_5_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_5_0.xsd
@@ -600,6 +600,14 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="autoflush" type="xs:boolean">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether every event should be immediately flushed to output stream.
+                            When not specified, "synchronized" value is used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
                 <xs:attribute name="format" default="SIMPLE" type="formatType">
                     <xs:annotation>
                         <xs:documentation>

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -87,7 +87,10 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testRejectingTransformersEAP720() throws Exception {
-        testRejectingTransformers(EAP_7_2_0_TEMP, "elytron-transformers-4.0-reject.xml", new FailedOperationTransformationConfig());
+        testRejectingTransformers(EAP_7_2_0_TEMP, "elytron-transformers-4.0-reject.xml", new FailedOperationTransformationConfig()
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.FILE_AUDIT_LOG, "auditUntransformable")),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(AuditResourceDefinitions.AUTOFLUSH)
+                ));
     }
 
     @Test

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -88,7 +88,22 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
     @Test
     public void testRejectingTransformersEAP720() throws Exception {
         testRejectingTransformers(EAP_7_2_0_TEMP, "elytron-transformers-4.0-reject.xml", new FailedOperationTransformationConfig()
-                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.FILE_AUDIT_LOG, "auditUntransformable")),
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.FILE_AUDIT_LOG, "audit1")),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(AuditResourceDefinitions.AUTOFLUSH)
+                )
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.FILE_AUDIT_LOG, "audit2")),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(AuditResourceDefinitions.AUTOFLUSH)
+                )
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.PERIODIC_ROTATING_FILE_AUDIT_LOG, "audit3")),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(AuditResourceDefinitions.AUTOFLUSH)
+                )
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.PERIODIC_ROTATING_FILE_AUDIT_LOG, "audit4")),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(AuditResourceDefinitions.AUTOFLUSH)
+                )
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SIZE_ROTATING_FILE_AUDIT_LOG, "audit5")),
+                        new FailedOperationTransformationConfig.NewAttributesConfig(AuditResourceDefinitions.AUTOFLUSH)
+                )
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SIZE_ROTATING_FILE_AUDIT_LOG, "audit6")),
                         new FailedOperationTransformationConfig.NewAttributesConfig(AuditResourceDefinitions.AUTOFLUSH)
                 ));
     }

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/audit-logging.xml
@@ -8,7 +8,7 @@
             <security-event-listener name="remote-syslog"/>
         </aggregate-security-event-listener>
         <custom-security-event-listener name="a" module="b" class-name="c.D"/>
-        <file-audit-log name="local-file" path="audit.log" relative-to="jboss.home.dir" synchronized="false" format="JSON" />
+        <file-audit-log name="local-file" path="audit.log" relative-to="jboss.home.dir" synchronized="false" autoflush="true" format="JSON" />
         <periodic-rotating-file-audit-log name="periodic-rotating" path="audit.log" relative-to="jboss.server.log.dir" format="JSON" suffix="y-M-d"/>
         <size-rotating-file-audit-log name="size-rotating" path="audit.log" relative-to="jboss.server.log.dir" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d"/>
         <syslog-audit-log name="remote-syslog" server-address="remote-server" port="9898" transport="UDP" format="JSON" host-name="Elytron" />

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-1.2.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-1.2.xml
@@ -27,6 +27,7 @@
         </simple-permission-mapper>
         <simple-permission-mapper name="SimplePermissionMapper" mapping-mode="and">
             <permission-mapping match-all="true">
+                <!-- permission-sets was added in 3.0 - should be inlined -->
                 <permission-set name="my-permission" />
             </permission-mapping>
         </simple-permission-mapper>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -1,2 +1,7 @@
 <subsystem xmlns="urn:wildfly:elytron:5.0">
+    <audit-logging>
+        <!-- flushed was added in 5.0 - should be rejected when different from synchronized -->
+        <file-audit-log name="auditTransformable" path="audit.log" synchronized="false" autoflush="false"/>
+        <file-audit-log name="auditUntransformable" path="audit.log" synchronized="false" autoflush="true"/>
+    </audit-logging>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -1,7 +1,11 @@
 <subsystem xmlns="urn:wildfly:elytron:5.0">
     <audit-logging>
-        <!-- flushed was added in 5.0 - should be rejected when different from synchronized -->
-        <file-audit-log name="auditTransformable" path="audit.log" synchronized="false" autoflush="false"/>
-        <file-audit-log name="auditUntransformable" path="audit.log" synchronized="false" autoflush="true"/>
+        <!-- autoflush was added in 5.0 - should be rejected when different from synchronized -->
+        <file-audit-log name="audit1" path="audit.log" synchronized="true" autoflush="false"/>
+        <file-audit-log name="audit2" path="audit.log" synchronized="false" autoflush="true"/>
+        <periodic-rotating-file-audit-log name="audit3" path="target/audit.log" format="JSON" suffix="y-M-d" synchronized="true" autoflush="false" />
+        <periodic-rotating-file-audit-log name="audit4" path="target/audit.log" format="JSON" suffix="y-M-d" synchronized="false" autoflush="true" />
+        <size-rotating-file-audit-log name="audit5" path="target/audit.log" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d" synchronized="true" autoflush="false" />
+        <size-rotating-file-audit-log name="audit6" path="target/audit.log" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d" synchronized="false" autoflush="true" />
     </audit-logging>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0.xml
@@ -1,2 +1,7 @@
 <subsystem xmlns="urn:wildfly:elytron:5.0">
+    <audit-logging>
+        <!-- flushed was added in 4.0 - should be discarded if identical with synchronized or undefined -->
+        <file-audit-log name="audit1" path="target/audit.log" synchronized="false" autoflush="false" />
+        <file-audit-log name="audit2" path="target/audit.log" synchronized="false" />
+    </audit-logging>
 </subsystem>

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0.xml
@@ -1,7 +1,11 @@
 <subsystem xmlns="urn:wildfly:elytron:5.0">
     <audit-logging>
-        <!-- flushed was added in 4.0 - should be discarded if identical with synchronized or undefined -->
+        <!-- autoflush was added in 5.0 - should be discarded if identical with synchronized or undefined -->
         <file-audit-log name="audit1" path="target/audit.log" synchronized="false" autoflush="false" />
         <file-audit-log name="audit2" path="target/audit.log" synchronized="false" />
+        <periodic-rotating-file-audit-log name="audit3" path="target/audit.log" format="JSON" suffix="y-M-d" synchronized="false" autoflush="false" />
+        <periodic-rotating-file-audit-log name="audit4" path="target/audit.log" format="JSON" suffix="y-M-d" synchronized="false" />
+        <size-rotating-file-audit-log name="audit5" path="target/audit.log" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d" synchronized="false" autoflush="false" />
+        <size-rotating-file-audit-log name="audit6" path="target/audit.log" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d" synchronized="false" />
     </audit-logging>
 </subsystem>


### PR DESCRIPTION
This is a re-submission of https://github.com/wildfly/wildfly-core/pull/3186 ported to version 5 of the WildFly Elytron subsystem's model and schema.

https://issues.jboss.org/browse/WFCORE-3404

Analysis document: wildfly/wildfly-proposals#112

Community documentation https://github.com/wildfly/wildfly/pull/11649