### PR TITLE
[WFCORE-4101][WFCORE-4090][JBEAP-15382] Upgrading MSC to 1.4.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.6.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.8.6.Final</version.org.jboss.modules.jboss-modules>
-        <version.org.jboss.msc.jboss-msc>1.4.3.Final</version.org.jboss.msc.jboss-msc>
+        <version.org.jboss.msc.jboss-msc>1.4.4.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.remoting>5.0.8.Final</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>3.0.0.Final</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.shrinkwrap.shrinkwrap>1.2.6</version.org.jboss.shrinkwrap.shrinkwrap>


### PR DESCRIPTION
Brings in merged service builder implementations. 
Since now on ServiceBuilder methods never throw UnsupportedOperationException.
This pull request addresses the following issues:
 * https://issues.jboss.org/browse/WFCORE-4090
 * https://issues.jboss.org/browse/WFCORE-4101