### PR TITLE
WFCORE-3873 Support for SNI for server side SSLContext

### DIFF
--- a/core-feature-pack/src/main/resources/modules/system/layers/base/io/undertow/core/main/module.xml
+++ b/core-feature-pack/src/main/resources/modules/system/layers/base/io/undertow/core/main/module.xml
@@ -34,6 +34,7 @@
         <module name="org.jboss.xnio.nio" services="import"/>
         <module name="org.jboss.logging"/>
         <module name="org.wildfly.openssl" optional="true"/>
+        <module name="org.wildfly.security.elytron-web.undertow-server" services="import" />
         <module name="sun.jdk"/>
             <system export="true">
                 <paths>

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDefinition.java
@@ -262,6 +262,7 @@ class ElytronDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerSubModel(SSLDefinitions.getTrustManagerDefinition());
         resourceRegistration.registerSubModel(SSLDefinitions.getServerSSLContextDefinition(serverOrHostController));
         resourceRegistration.registerSubModel(SSLDefinitions.getClientSSLContextDefinition(serverOrHostController));
+        resourceRegistration.registerSubModel(SSLDefinitions.getServerSNISSLContextDefinition());
         resourceRegistration.registerSubModel(new CertificateAuthorityAccountDefinition());
 
         // Credential Store Block

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronDescriptionConstants.java
@@ -153,6 +153,7 @@ interface ElytronDescriptionConstants {
     String DEFAULT_AUTHENTICATION_CONTEXT = "default-authentication-context";
     String DEFAULT_POLICY = "default-policy";
     String DEFAULT_REALM = "default-realm";
+    String DEFAULT_SSL_CONTEXT = "default-ssl-context";
     String DELEGATE_REALM_MAPPER = "delegate-realm-mapper";
     String DESCRIPTION = "description";
     String DIGEST = "digest";
@@ -208,6 +209,7 @@ interface ElytronDescriptionConstants {
     String GROUPS_PROPERTIES = "groups-properties";
 
     String HOST = "host";
+    String HOST_CONTEXT_MAP = "host-context-map";
     String HOST_NAME = "host-name";
     String HOST_NAME_VERIFICATION_POLICY = "host-name-verification-policy";
     String HASH_FROM = "hash-from";
@@ -470,6 +472,8 @@ interface ElytronDescriptionConstants {
     String SERVER_AUTH_MODULES = "server-auth-modules";
     String SERVER_SSL_CONTEXT = "server-ssl-context";
     String SERVER_SSL_CONTEXTS = "server-ssl-contexts";
+    String SERVER_SSL_SNI_CONTEXT = "server-ssl-sni-context";
+    String SERVER_SSL_SNI_CONTEXTS = "server-ssl-sni-contexts";
     String SESSION_TIMEOUT = "session-timeout";
     String SET_PASSWORD = "set-password";
     String SET_SECRET = "set-secret";
@@ -494,6 +498,7 @@ interface ElytronDescriptionConstants {
     String SQL = "sql";
     String SSL_CONTEXT = "ssl-context";
     String SSL_SESSION = "ssl-session";
+    String SNI_MAPPING = "sni-mapping";
     String STAGING = "staging";
     String START_SEGMENT = "start-segment";
     String STATE = "state";

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser5_0.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemParser5_0.java
@@ -78,4 +78,9 @@ public class ElytronSubsystemParser5_0 extends ElytronSubsystemParser4_0 {
         return new AuditLoggingParser().parser5_0;
     }
 
+    @Override
+    PersistentResourceXMLDescription getTlsParser() {
+        return new TlsParser().tlsParser_5_0;
+    }
+
 }

--- a/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/ElytronSubsystemTransformers.java
@@ -87,6 +87,7 @@ public final class ElytronSubsystemTransformers implements ExtensionTransformerR
         transformAutoFlush(builder, FILE_AUDIT_LOG);
         transformAutoFlush(builder, PERIODIC_ROTATING_FILE_AUDIT_LOG);
         transformAutoFlush(builder, SIZE_ROTATING_FILE_AUDIT_LOG);
+        builder.rejectChildResource(PathElement.pathElement(ElytronDescriptionConstants.SERVER_SSL_SNI_CONTEXT));
     }
 
     private static void transformAutoFlush(ResourceTransformationDescriptionBuilder builder, final String resourceName) {

--- a/elytron/src/main/java/org/wildfly/extension/elytron/TlsParser.java
+++ b/elytron/src/main/java/org/wildfly/extension/elytron/TlsParser.java
@@ -19,11 +19,14 @@
 package org.wildfly.extension.elytron;
 
 import static org.jboss.as.controller.PersistentResourceXMLDescription.decorator;
+import static org.jboss.as.controller.parsing.ParseUtils.requireAttributes;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CERTIFICATE_AUTHORITY_ACCOUNT;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CERTIFICATE_AUTHORITY_ACCOUNTS;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CLIENT_SSL_CONTEXT;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.CLIENT_SSL_CONTEXTS;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.FILTERING_KEY_STORE;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.HOST;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SNI_MAPPING;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.KEY_MANAGER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.KEY_MANAGERS;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.KEY_STORE;
@@ -31,14 +34,28 @@ import static org.wildfly.extension.elytron.ElytronDescriptionConstants.KEY_STOR
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.LDAP_KEY_STORE;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SERVER_SSL_CONTEXT;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SERVER_SSL_CONTEXTS;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SERVER_SSL_SNI_CONTEXT;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SERVER_SSL_SNI_CONTEXTS;
+import static org.wildfly.extension.elytron.ElytronDescriptionConstants.SSL_CONTEXT;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.TLS;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.TRUST_MANAGER;
 import static org.wildfly.extension.elytron.ElytronDescriptionConstants.TRUST_MANAGERS;
 
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshallers;
+import org.jboss.as.controller.AttributeParsers;
+import org.jboss.as.controller.MapAttributeDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.PersistentResourceXMLDescription;
 import org.jboss.as.controller.PersistentResourceXMLDescription.PersistentResourceXMLBuilder;
+import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
 
 /**
  * A parser for the TLS related definitions.
@@ -146,6 +163,29 @@ class TlsParser {
             .addAttribute(CertificateAuthorityAccountDefinition.ALIAS)
             .addAttribute(CertificateAuthorityAccountDefinition.CREDENTIAL_REFERENCE);
 
+    private PersistentResourceXMLBuilder serverSslSniContextParser = PersistentResourceXMLDescription.builder(PathElement.pathElement(SERVER_SSL_SNI_CONTEXT))
+            .setXmlWrapperElement(SERVER_SSL_SNI_CONTEXTS)
+            .addAttribute(SSLDefinitions.DEFAULT_SSL_CONTEXT)
+            .addAttribute(SSLDefinitions.HOST_CONTEXT_MAP, new AttributeParsers.MapParser(null, SNI_MAPPING, false) {
+
+                @Override
+                public void parseSingleElement(MapAttributeDefinition attribute, XMLExtendedStreamReader reader, ModelNode operation) throws XMLStreamException {
+                    final String[] array = requireAttributes(reader, HOST, SSL_CONTEXT);
+                    operation.get(attribute.getName()).get(array[0]).set(array[1]);
+                    ParseUtils.requireNoContent(reader);
+                }
+
+            }
+            , new AttributeMarshallers.MapAttributeMarshaller(null, null, false) {
+                @Override
+                public void marshallSingleElement(AttributeDefinition attribute, ModelNode mapping, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
+                    writer.writeEmptyElement(SNI_MAPPING);
+                    Property mappingProperty = mapping.asProperty();
+                    writer.writeAttribute(HOST, mappingProperty.getName());
+                    writer.writeAttribute(SSL_CONTEXT, mappingProperty.getValue().asString());
+                }
+            });
+
     // 1_0 to 3_0
     final PersistentResourceXMLDescription tlsParser = decorator(TLS)
             .addChild(decorator(KEY_STORES)
@@ -165,13 +205,26 @@ class TlsParser {
                     .addChild(keyStoreParser)
                     .addChild(ldapKeyStoreParser)
                     .addChild(filteringKeyStoreParser)
-
             )
             .addChild(keyManagerParser)
             .addChild(trustManagerParser)
             .addChild(serverSslContextParser)
             .addChild(clientSslContextParser)
             .addChild(certificateAuthorityAccountParser) // new
+            .build();
+
+    final PersistentResourceXMLDescription tlsParser_5_0 = decorator(TLS)
+            .addChild(decorator(KEY_STORES)
+                .addChild(keyStoreParser)
+                .addChild(ldapKeyStoreParser)
+                .addChild(filteringKeyStoreParser)
+            )
+            .addChild(keyManagerParser)
+            .addChild(trustManagerParser)
+            .addChild(serverSslContextParser)
+            .addChild(clientSslContextParser)
+            .addChild(certificateAuthorityAccountParser)
+            .addChild(serverSslSniContextParser) // new
             .build();
 
 }

--- a/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
+++ b/elytron/src/main/resources/org/wildfly/extension/elytron/LocalDescriptions.properties
@@ -1359,6 +1359,11 @@ elytron.certificate-authority-account.credential-reference.store=The name of the
 elytron.certificate-authority-account.credential-reference.alias=The alias which denotes stored secret or credential in the store.
 elytron.certificate-authority-account.credential-reference.type=The type of credential this reference is denoting.
 elytron.certificate-authority-account.credential-reference.clear-text=Secret specified using clear text. Check credential store way of supplying credential/secrets to services.
+elytron.server-ssl-sni-context=A server side SNI Aware SSLContext that selects between an underlying context based on the provided SNI name
+elytron.server-ssl-sni-context.add=Adds a SNI context
+elytron.server-ssl-sni-context.remove=Removes a SNI context
+elytron.server-ssl-sni-context.default-ssl-context=The context to use if no SNI information is present, or if it does not match any mappings
+elytron.server-ssl-sni-context.host-context-map=A mapping between a server name an an SSContext
 
 ####################
 # Credential Store #

--- a/elytron/src/main/resources/schema/wildfly-elytron_5_0.xsd
+++ b/elytron/src/main/resources/schema/wildfly-elytron_5_0.xsd
@@ -4072,6 +4072,7 @@
             <xs:element name="server-ssl-contexts" type="serverSSLContextsType" minOccurs="0" />
             <xs:element name="client-ssl-contexts" type="clientSSLContextsType" minOccurs="0" />
             <xs:element name="certificate-authority-accounts" type="certificateAuthorityAccountsType" minOccurs="0" />
+            <xs:element name="server-ssl-sni-contexts" type="serverSSLSNIContextsType" minOccurs="0" />
         </xs:all>
     </xs:complexType>
 
@@ -4251,6 +4252,65 @@
             <xs:annotation>
                 <xs:documentation>
                     The maximum number of non-self-issued intermediate certificates that may exist in a certification path.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serverSSLSNIContextsType">
+        <xs:annotation>
+            <xs:documentation>
+                Container for Server SNI SSLContext definitions.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="server-ssl-sni-context" type="serverSSLSNIContextType" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="serverSSLSNIContextType">
+        <xs:annotation>
+            <xs:documentation>
+                Definitions of a single server side SNI SSLContext.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="sni-mapping" type="serverSSLSNIMappingType" minOccurs="0" maxOccurs="unbounded"  />
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The unique name of this Server side SNI SSLContext.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="default-ssl-context" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The SSLContext to use if SNI is not in use
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="serverSSLSNIMappingType">
+        <xs:annotation>
+            <xs:documentation>
+                Definitions of a single server side SNI SSLContext.
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:attribute name="host" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The host name that this element matches. If it begins with a '*' it is considered a wildcard match.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ssl-context" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The SSLContext to use if the name matches.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemTransformerTestCase.java
@@ -107,7 +107,10 @@ public class SubsystemTransformerTestCase extends AbstractSubsystemBaseTest {
                 )
                 .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SIZE_ROTATING_FILE_AUDIT_LOG, "audit6")),
                         new FailedOperationTransformationConfig.NewAttributesConfig(AuditResourceDefinitions.AUTOFLUSH)
-                ));
+                )
+                .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PathElement.pathElement(ElytronDescriptionConstants.SERVER_SSL_SNI_CONTEXT)),
+                        FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                );
     }
 
     @Test

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-5.0.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-subsystem-5.0.xml
@@ -280,6 +280,10 @@
                                 use-cipher-suites-order="false" maximum-session-cache-size="10"
                                 session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
                                 post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="first"/>
+            <server-ssl-context name="server2" protocols="TLSv1.2" want-client-auth="true" need-client-auth="true" authentication-optional="true"
+                                use-cipher-suites-order="false" maximum-session-cache-size="10"
+                                session-timeout="120" wrap="false" key-manager="serverKey" trust-manager="serverTrust" pre-realm-principal-transformer="a"
+                                post-realm-principal-transformer="b" final-principal-transformer="c" realm-mapper="d" providers="custom-loader" provider-name="first"/>
         </server-ssl-contexts>
         <client-ssl-contexts>
             <client-ssl-context name="client" protocols="TLSv1.3 TLSv1.2" key-manager="clientKey" trust-manager="serverTrust" providers="custom-loader"
@@ -292,6 +296,12 @@
                 </account-key>
             </certificate-authority-account>
         </certificate-authority-accounts>
+        <server-ssl-sni-contexts>
+            <server-ssl-sni-context name="sni" default-ssl-context="server">
+                <sni-mapping host="server" ssl-context="server" />
+                <sni-mapping host="*.server" ssl-context="server2" />
+            </server-ssl-sni-context>
+        </server-ssl-sni-contexts>
     </tls>
     <jaspi>
         <jaspi-configuration name="test" layer="HttpServlet" application-context="default /test" description="Test Definition">

--- a/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/elytron-transformers-4.0-reject.xml
@@ -15,4 +15,24 @@
         <size-rotating-file-audit-log name="audit5" path="target/audit.log" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d" synchronized="true" autoflush="false" />
         <size-rotating-file-audit-log name="audit6" path="target/audit.log" format="JSON" max-backup-index="5" rotate-on-boot="true" rotate-size="5" suffix="y-M-d" synchronized="false" autoflush="true" />
     </audit-logging>
+    <tls>
+        <key-stores>
+            <key-store name="accounts.keystore">
+                <credential-reference clear-text="elytron"/>
+                <implementation type="JKS"/>
+                <file path="accounts.keystore.jks" relative-to="jboss.server.config.dir"/>
+            </key-store>
+        </key-stores>
+        <key-managers>
+            <key-manager name="key1" key-store="accounts.keystore">
+                <credential-reference clear-text="password"/>
+            </key-manager>
+        </key-managers>
+        <server-ssl-contexts>
+            <server-ssl-context name="ctx" key-manager="key1"/>
+        </server-ssl-contexts>
+        <server-ssl-sni-contexts>
+            <server-ssl-sni-context name="test" default-ssl-context="ctx"></server-ssl-sni-context>
+        </server-ssl-sni-contexts>
+    </tls>
 </subsystem>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.7.0.CR2</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.7.0.CR3</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.3.0.CR2</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.7.0.CR3</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.3.0.CR2</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.3.0.CR3</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>

--- a/testsuite/shared/src/main/java/org/wildfly/test/undertow/UndertowSSLService.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/undertow/UndertowSSLService.java
@@ -1,0 +1,70 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.wildfly.test.undertow;
+
+import java.util.function.Supplier;
+
+import javax.net.ssl.SSLContext;
+
+import org.jboss.logging.Logger;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StopContext;
+
+import io.undertow.Undertow;
+import io.undertow.UndertowOptions;
+import io.undertow.server.HttpHandler;
+
+public class UndertowSSLService implements Service<UndertowSSLService> {
+
+    private Undertow undertow;
+    private final String address;
+    private final int port;
+    private final HttpHandler handler;
+    private final Supplier<SSLContext> sslContext;
+
+    public UndertowSSLService(final String address, final int port, final HttpHandler handler, Supplier<SSLContext> sslContext) {
+        this.address = address;
+        this.port = port;
+        this.handler = handler;
+        this.sslContext = sslContext;
+    }
+
+    @Override
+    public synchronized void start(final StartContext context) {
+        undertow = Undertow.builder()
+                .addHttpsListener(port, address, sslContext.get())
+                .setServerOption(UndertowOptions.ENABLE_HTTP2, true)
+                .setHandler(handler)
+                .build();
+        undertow.start();
+        Logger.getLogger(UndertowSSLService.class).infof("Started Undertow on %s:%d", address, port);
+    }
+
+    @Override
+    public synchronized void stop(final StopContext context) {
+        undertow.stop();
+        undertow = null;
+    }
+
+    @Override
+    public UndertowSSLService getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/undertow/UndertowSSLServiceActivator.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/undertow/UndertowSSLServiceActivator.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.wildfly.test.undertow;
+
+import java.util.function.Supplier;
+
+import javax.net.ssl.SSLContext;
+
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+
+import io.undertow.server.HttpHandler;
+
+public class UndertowSSLServiceActivator extends UndertowServiceActivator {
+
+    @Override
+    protected void createService(String address, int port, HttpHandler handler, ServiceBuilder<?> builder) {
+        Supplier<SSLContext> res = builder.requires(ServiceName.parse("org.wildfly.security.ssl-context.test-context"));
+        UndertowSSLService service = new UndertowSSLService("0.0.0.0", port, handler, res);
+        builder.setInstance(service);
+    }
+}

--- a/testsuite/shared/src/main/java/org/wildfly/test/undertow/UndertowServiceActivator.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/undertow/UndertowServiceActivator.java
@@ -32,6 +32,7 @@ import io.undertow.server.HttpServerExchange;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.msc.service.ServiceActivator;
 import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistryException;
 
@@ -109,8 +110,19 @@ public class UndertowServiceActivator implements ServiceActivator {
         assert port > 0 : "port must be greater than 0";
         final HttpHandler handler = getHttpHandler();
         assert handler != null : "A handler is required";
-        final UndertowService service = new UndertowService(address, port, handler);
-        serviceActivatorContext.getServiceTarget().addService(getServiceName(), service).install();
+        ServiceBuilder<?> builder = serviceActivatorContext.getServiceTarget().addService(getServiceName());
+        createService(address, port, handler, builder);
+        builder.install();
+    }
+
+    /**
+     * Create the Undertow service
+     *
+     */
+    protected void createService(String address, int port, HttpHandler handler, ServiceBuilder<?> builder) {
+        UndertowService service =  new UndertowService(address, port, handler);
+        builder.setInstance(service);
+
     }
 
     /**

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/ssl/sni/SNICombinedWithALPNTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/ssl/sni/SNICombinedWithALPNTestCase.java
@@ -1,0 +1,395 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018 Red Hat Inc. and/or its affiliates and other contributors
+ * as indicated by the @authors tag. All rights reserved.
+ * See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ * This copyrighted material is made available to anyone wishing to use,
+ * modify, copy, or redistribute it subject to the terms and conditions
+ * of the GNU Lesser General Public License, v. 2.1.
+ * This program is distributed in the hope that it will be useful, but WITHOUT A
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License,
+ * v.2.1 along with this distribution; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA  02110-1301, USA.
+ */
+
+package org.jboss.as.test.integration.security.ssl.sni;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTENT;
+import static org.jboss.as.controller.client.helpers.ClientConstants.DEPLOYMENT;
+import static org.jboss.as.controller.client.helpers.Operations.createAddOperation;
+import static org.jboss.as.controller.client.helpers.Operations.createAddress;
+import static org.jboss.as.controller.client.helpers.Operations.createRemoveOperation;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.URI;
+import java.security.KeyManagementException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.concurrent.CompletableFuture;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import javax.security.auth.x500.X500Principal;
+
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
+import org.jboss.as.domain.management.logging.DomainManagementLogger;
+import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.wildfly.core.testrunner.ManagementClient;
+import org.wildfly.core.testrunner.ServerSetup;
+import org.wildfly.core.testrunner.ServerSetupTask;
+import org.wildfly.core.testrunner.WildflyTestRunner;
+import org.wildfly.security.x500.cert.X509CertificateBuilder;
+import org.wildfly.test.undertow.UndertowSSLService;
+import org.wildfly.test.undertow.UndertowSSLServiceActivator;
+import org.wildfly.test.undertow.UndertowServiceActivator;
+import org.xnio.OptionMap;
+import org.xnio.Xnio;
+import org.xnio.XnioWorker;
+import org.xnio.ssl.XnioSsl;
+
+import io.undertow.UndertowOptions;
+import io.undertow.client.ClientCallback;
+import io.undertow.client.ClientConnection;
+import io.undertow.client.ClientExchange;
+import io.undertow.client.ClientRequest;
+import io.undertow.client.UndertowClient;
+import io.undertow.protocols.ssl.UndertowXnioSsl;
+import io.undertow.server.DefaultByteBufferPool;
+import io.undertow.util.Headers;
+import io.undertow.util.Methods;
+import io.undertow.util.Protocols;
+import io.undertow.util.StringReadChannelListener;
+
+@RunWith(WildflyTestRunner.class)
+@ServerSetup(SNICombinedWithALPNTestCase.Setup.class)
+public class SNICombinedWithALPNTestCase {
+
+    public static final String SHA_256_WITH_RSA = "SHA256withRSA";
+    private static final String ALIAS = "server";
+    private static final String PASSWORD = "password";
+    private static final String[] HOST_KEY_STORE = {"subsystem", "elytron", "key-store", "host"};
+    private static final String[] IP_KEY_STORE = {"subsystem", "elytron", "key-store", "ip"};
+    private static final String[] HOST_KEY_MANAGER = {"subsystem", "elytron", "key-manager", "host"};
+    private static final String[] IP_KEY_MANAGER = {"subsystem", "elytron", "key-manager", "ip"};
+    private static final String[] HOST_SSL_CONTEXT = {"subsystem", "elytron", "server-ssl-context", "host"};
+    private static final String[] IP_SSL_CONTEXT = {"subsystem", "elytron", "server-ssl-context", "ip"};
+    private static final String[] SNI_SSL_CONTEXT = {"subsystem", "elytron", "server-ssl-sni-context", "test-context"};
+    private static final String TEST_JAR = "test.jar";
+
+    private static File hostNameKeystore;
+    private static File ipKeystore;
+
+    static class Setup implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient) throws Exception {
+
+            hostNameKeystore = File.createTempFile("test", ".keystore");
+            ipKeystore = File.createTempFile("test", ".keystore");
+            generateFileKeyStore(hostNameKeystore, "localhost");
+            generateFileKeyStore(ipKeystore, "127.0.0.1");
+
+            ModelNode credential = new ModelNode();
+            credential.get("clear-text").set("password");
+
+            ModelNode modelNode = createAddOperation(createAddress(HOST_KEY_STORE));
+            modelNode.get("type").set("jks");
+            modelNode.get("path").set(hostNameKeystore.getAbsolutePath());
+            modelNode.get("credential-reference").set(credential);
+            managementClient.executeForResult(modelNode);
+
+            modelNode = createAddOperation(createAddress(IP_KEY_STORE));
+            modelNode.get("type").set("jks");
+            modelNode.get("path").set(ipKeystore.getAbsolutePath());
+            modelNode.get("credential-reference").set(credential);
+            managementClient.executeForResult(modelNode);
+
+            modelNode = createAddOperation(createAddress(HOST_KEY_MANAGER));
+            modelNode.get("algorithm").set("SunX509");
+            modelNode.get("key-store").set("host");
+            modelNode.get("credential-reference").set(credential);
+            managementClient.executeForResult(modelNode);
+
+            modelNode = createAddOperation(createAddress(IP_KEY_MANAGER));
+            modelNode.get("algorithm").set("SunX509");
+            modelNode.get("key-store").set("ip");
+            modelNode.get("credential-reference").set(credential);
+            managementClient.executeForResult(modelNode);
+
+            modelNode = createAddOperation(createAddress(HOST_SSL_CONTEXT));
+            modelNode.get("key-manager").set("host");
+            modelNode.get("protocols").set(new ModelNode().add("TLSv1.2"));
+            managementClient.executeForResult(modelNode);
+
+            modelNode = createAddOperation(createAddress(IP_SSL_CONTEXT));
+            modelNode.get("key-manager").set("ip");
+            modelNode.get("protocols").set(new ModelNode().add("TLSv1.2"));
+            managementClient.executeForResult(modelNode);
+
+            modelNode = createAddOperation(createAddress(SNI_SSL_CONTEXT));
+            modelNode.get("default-ssl-context").set("host");
+            ModelNode hostContextMap = new ModelNode();
+            hostContextMap.get("127.0.0.1").set("ip");
+            modelNode.get("host-context-map").set(hostContextMap);
+            managementClient.executeForResult(modelNode);
+
+            JavaArchive jar = ShrinkWrap.create(JavaArchive.class, TEST_JAR)
+                    .addClasses(UndertowServiceActivator.DEPENDENCIES)
+                    .addClasses(UndertowSSLService.class)
+                    .addAsResource(new StringAsset("Dependencies: io.undertow.core"), "META-INF/MANIFEST.MF")
+                    .addAsServiceProviderAndClasses(ServiceActivator.class, UndertowSSLServiceActivator.class);
+            deploy(jar, managementClient);
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient) throws Exception {
+            hostNameKeystore.delete();
+            ipKeystore.delete();
+
+            managementClient.executeForResult(createRemoveOperation(createAddress(SNI_SSL_CONTEXT)));
+            managementClient.executeForResult(createRemoveOperation(createAddress(IP_SSL_CONTEXT)));
+            managementClient.executeForResult(createRemoveOperation(createAddress(HOST_SSL_CONTEXT)));
+            managementClient.executeForResult(createRemoveOperation(createAddress(IP_KEY_MANAGER)));
+            managementClient.executeForResult(createRemoveOperation(createAddress(HOST_KEY_MANAGER)));
+            managementClient.executeForResult(createRemoveOperation(createAddress(IP_KEY_STORE)));
+            managementClient.executeForResult(createRemoveOperation(createAddress(HOST_KEY_STORE)));
+            undeploy(managementClient, TEST_JAR);
+            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+
+        }
+    }
+
+    @Test
+    public void testSimpleViaHostname() throws Exception {
+        XnioSsl ssl = createClientSSL(hostNameKeystore);
+        UndertowClient client = UndertowClient.getInstance();
+        DefaultByteBufferPool pool = new DefaultByteBufferPool(false, 1024);
+        ClientConnection connection = client.connect(new URI("https", null, "localhost", TestSuiteEnvironment.getHttpPort(), "", null, null), XnioWorker.getContextManager().get(), ssl, pool, OptionMap.create(UndertowOptions.ENABLE_HTTP2, true)).get();
+        performSimpleTest(pool, connection);
+    }
+
+    @Test
+    public void testHttpsViaIp() throws Exception {
+        XnioSsl ssl = createClientSSL(ipKeystore);
+        UndertowClient client = UndertowClient.getInstance();
+        DefaultByteBufferPool pool = new DefaultByteBufferPool(false, 1024);
+        ClientConnection connection = client.connect(new URI("https", null, "127.0.0.1", TestSuiteEnvironment.getHttpPort(), "", null, null), XnioWorker.getContextManager().get(), ssl, pool, OptionMap.create(UndertowOptions.ENABLE_HTTP2, true)).get();
+        performSimpleTest(pool, connection);
+    }
+
+    private void performSimpleTest(DefaultByteBufferPool pool, ClientConnection connection) throws InterruptedException, java.util.concurrent.ExecutionException {
+        ClientRequest cr = new ClientRequest()
+                .setPath("/")
+                .setProtocol(Protocols.HTTP_1_1)
+                .setMethod(Methods.GET);
+        cr.getRequestHeaders().add(Headers.HOST, "localhost");
+        CompletableFuture<String> future = new CompletableFuture<>();
+        connection.sendRequest(cr, new ClientCallback<ClientExchange>() {
+            @Override
+            public void completed(ClientExchange result) {
+                result.setResponseListener(new ClientCallback<ClientExchange>() {
+                    @Override
+                    public void completed(ClientExchange result) {
+                        new StringReadChannelListener(pool) {
+                            @Override
+                            protected void stringDone(String string) {
+                                future.complete(string + ":" + result.getResponse().getProtocol());
+                            }
+
+                            @Override
+                            protected void error(IOException e) {
+                                future.completeExceptionally(e);
+                            }
+                        }.setup(result.getResponseChannel());
+                    }
+
+                    @Override
+                    public void failed(IOException e) {
+                        future.completeExceptionally(e);
+                    }
+                });
+            }
+
+            @Override
+            public void failed(IOException e) {
+                future.completeExceptionally(e);
+            }
+        });
+        Assert.assertEquals("Response sent:HTTP/2.0", future.get());
+    }
+
+    private XnioSsl createClientSSL(File hostNameKeystore) throws NoSuchAlgorithmException, KeyStoreException, IOException, CertificateException, UnrecoverableKeyException, KeyManagementException {
+        SSLContext clientContext = SSLContext.getInstance("TLS");
+        KeyStore store = KeyStore.getInstance("jks");
+        try (FileInputStream in = new FileInputStream(hostNameKeystore)) {
+            store.load(in, PASSWORD.toCharArray());
+        }
+        KeyManagerFactory km = KeyManagerFactory.getInstance("SunX509");
+        km.init(store, PASSWORD.toCharArray());
+        TrustManagerFactory tm = TrustManagerFactory.getInstance("SunX509");
+        tm.init(store);
+        clientContext.init(km.getKeyManagers(), tm.getTrustManagers(), new SecureRandom());
+        return new UndertowXnioSsl(Xnio.getInstance(), OptionMap.EMPTY, clientContext);
+    }
+
+
+    static void generateFileKeyStore(File path, String hostName) {
+        try {
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+            keyGen.initialize(2048, new SecureRandom());
+            KeyPair pair = keyGen.generateKeyPair();
+            X509Certificate cert = generateCertificate(pair, hostName);
+
+            KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keyStore.load(null, PASSWORD.toCharArray());
+
+            //Generate self signed certificate
+            X509Certificate[] chain = new X509Certificate[1];
+            chain[0] = cert;
+            keyStore.setKeyEntry(ALIAS, pair.getPrivate(), PASSWORD.toCharArray(), chain);
+            try (FileOutputStream stream = new FileOutputStream(path)) {
+                keyStore.store(stream, PASSWORD.toCharArray());
+            }
+            path.setReadable(false, false);
+            path.setReadable(true, true);
+            path.setWritable(false, false);
+            path.setWritable(true, true);
+
+            DomainManagementLogger.SECURITY_LOGGER.keystoreHasBeenCreated(path.toString(), getSha1Fingerprint(cert, "SHA-1"), getSha1Fingerprint(cert, "SHA-256"));
+
+        } catch (Exception e) {
+            throw DomainManagementLogger.SECURITY_LOGGER.failedToGenerateSelfSignedCertificate(e);
+        }
+    }
+
+    static X509Certificate generateCertificate(KeyPair pair, String hostName) throws Exception {
+        PrivateKey privkey = pair.getPrivate();
+        X509CertificateBuilder builder = new X509CertificateBuilder();
+        Date from = new Date();
+        Date to = new Date(from.getTime() + (1000L * 60L * 60L * 24L * 365L * 10L));
+        BigInteger sn = new BigInteger(64, new SecureRandom());
+
+        builder.setNotValidAfter(ZonedDateTime.ofInstant(Instant.ofEpochMilli(to.getTime()), TimeZone.getDefault().toZoneId()));
+        builder.setNotValidBefore(ZonedDateTime.ofInstant(Instant.ofEpochMilli(from.getTime()), TimeZone.getDefault().toZoneId()));
+        builder.setSerialNumber(sn);
+        X500Principal owner = new X500Principal("CN=" + hostName);
+        builder.setSubjectDn(owner);
+        builder.setIssuerDn(owner);
+        builder.setPublicKey(pair.getPublic());
+        builder.setVersion(3);
+        builder.setSignatureAlgorithmName(SHA_256_WITH_RSA);
+        builder.setSigningKey(privkey);
+        return builder.build();
+    }
+
+    private static String getSha1Fingerprint(X509Certificate cert, String algo) throws Exception {
+        MessageDigest md = MessageDigest.getInstance(algo);
+        byte[] der = cert.getEncoded();
+        md.update(der);
+        byte[] digest = md.digest();
+        return hexify(digest);
+
+    }
+
+    private static String hexify(byte[] bytes) {
+        char[] hexDigits = {'0', '1', '2', '3', '4', '5', '6', '7',
+                '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+        StringBuffer buf = new StringBuffer(bytes.length * 2);
+        for (int i = 0; i < bytes.length; ++i) {
+            if (i > 0) {
+                buf.append(":");
+            }
+            buf.append(hexDigits[(bytes[i] & 0xf0) >> 4]);
+            buf.append(hexDigits[bytes[i] & 0x0f]);
+        }
+        return buf.toString();
+    }
+
+
+    /**
+     * Deploys the archive to the running server.
+     *
+     * @param archive the archive to deploy
+     * @throws IOException if an error occurs deploying the archive
+     */
+    public static void deploy(final Archive<?> archive, ManagementClient managementClient) throws IOException {
+        // Use an operation to allow overriding the runtime name
+        final ModelNode address = Operations.createAddress(DEPLOYMENT, archive.getName());
+        final ModelNode addOp = createAddOperation(address);
+        addOp.get("enabled").set(true);
+        // Create the content for the add operation
+        final ModelNode contentNode = addOp.get(CONTENT);
+        final ModelNode contentItem = contentNode.get(0);
+        contentItem.get(ClientConstants.INPUT_STREAM_INDEX).set(0);
+
+        // Create an operation and add the input archive
+        final OperationBuilder builder = OperationBuilder.create(addOp);
+        builder.addInputStream(archive.as(ZipExporter.class).exportAsInputStream());
+
+        // Deploy the content and check the results
+        final ModelNode result = managementClient.getControllerClient().execute(builder.build());
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.fail(String.format("Failed to deploy %s: %s", archive, Operations.getFailureDescription(result).asString()));
+        }
+    }
+
+    public static void undeploy(ManagementClient client, final String runtimeName) throws ServerDeploymentHelper.ServerDeploymentException {
+        final ServerDeploymentHelper helper = new ServerDeploymentHelper(client.getControllerClient());
+        final Collection<Throwable> errors = new ArrayList<>();
+        try {
+            final ModelNode op = Operations.createReadResourceOperation(Operations.createAddress("deployment", runtimeName));
+            final ModelNode result = client.getControllerClient().execute(op);
+            if (Operations.isSuccessfulOutcome(result))
+                helper.undeploy(runtimeName);
+        } catch (Exception e) {
+            errors.add(e);
+        }
+        if (!errors.isEmpty()) {
+            final RuntimeException e = new RuntimeException("Error undeploying: " + runtimeName);
+            for (Throwable error : errors) {
+                e.addSuppressed(error);
+            }
+            throw e;
+        }
+    }
+}

--- a/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/ssl/sni/SNICombinedWithALPNTestCase.java
+++ b/testsuite/standalone/src/test/java/org/jboss/as/test/integration/security/ssl/sni/SNICombinedWithALPNTestCase.java
@@ -27,7 +27,9 @@ import static org.jboss.as.controller.client.helpers.Operations.createRemoveOper
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FilePermission;
 import java.io.IOException;
+import java.lang.reflect.ReflectPermission;
 import java.math.BigInteger;
 import java.net.URI;
 import java.security.KeyManagementException;
@@ -61,6 +63,7 @@ import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.client.helpers.standalone.ServerDeploymentHelper;
 import org.jboss.as.domain.management.logging.DomainManagementLogger;
 import org.jboss.as.test.integration.management.util.ServerReload;
+import org.jboss.as.test.shared.PermissionUtils;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceActivator;
@@ -175,6 +178,11 @@ public class SNICombinedWithALPNTestCase {
                     .addClasses(UndertowServiceActivator.DEPENDENCIES)
                     .addClasses(UndertowSSLService.class)
                     .addAsResource(new StringAsset("Dependencies: io.undertow.core"), "META-INF/MANIFEST.MF")
+                    .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(UndertowServiceActivator.appendPermissions(new FilePermission("-", "read"),
+                            new RuntimePermission("getClassLoader"),
+                            new RuntimePermission("accessDeclaredMembers"),
+                            new RuntimePermission("accessClassInPackage.sun.security.ssl"),
+                            new ReflectPermission("suppressAccessChecks"))), "permissions.xml")
                     .addAsServiceProviderAndClasses(ServiceActivator.class, UndertowSSLServiceActivator.class);
             deploy(jar, managementClient);
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-3873
This pull request follows up on the following PR and ports the changes on top of version 5 of the WildFly Elytron subsystem's model and schema: -

https://github.com/wildfly/wildfly-core/pull/3424

Additionally the WildFly Elytron subsystem follows a flat model hierarchy without parents depending on their children so I have flattened the model.

I did also have a general chat with Brian if we should be using alternative capability names to avoid circular referencing and in the end decided we didn't need to go to that level of enforcement in the model - we also have other resources that could potentially be configured with impossible cycles so this resource is not unique.

Finally the original discussion that we had regarding this feature was that we would provide a general implementation within WildFly Elytron which is the reason it is exposed by the Elytron subsystem so I have ported the implementation over with the following two PRs: -

https://github.com/wildfly-security/wildfly-elytron/pull/1188
https://github.com/wildfly-security/elytron-web/pull/139

Documentation PR: -

https://github.com/wildfly/wildfly/pull/11659