### PR TITLE
[WFCORE-4099] Add tests of widely usable utility methods that take a ServiceBuilder param

### DIFF
--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/SecurityRealmServiceUtilTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/SecurityRealmServiceUtilTestCase.java
@@ -1,0 +1,160 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.domain.management.security;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.domain.management.SecurityRealm;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests SecurityRealm.ServiceUtil handling for WFCORE-4099 / MSC-240.
+ *
+ * @author Brian Stansberry
+ */
+public class SecurityRealmServiceUtilTestCase {
+
+    private static final String TESTNAME = SecurityRealmServiceUtilTestCase.class.getSimpleName();
+
+    private ServiceContainer container;
+    private Path tmpDir;
+
+    @Before
+    public void setup() throws IOException {
+        container = ServiceContainer.Factory.create(TESTNAME);
+        tmpDir = Files.createTempDirectory(TESTNAME);
+    }
+
+    @After
+    public void teardown() throws IOException {
+        if (container != null) {
+            container.shutdown();
+            try {
+                container.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            finally {
+                container = null;
+            }
+        }
+        if (tmpDir != null) {
+            Files.walkFileTree(tmpDir, new SimpleFileVisitor<Path>() {
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    FileVisitResult result = super.visitFile(file, attrs);
+                    Files.deleteIfExists(file);
+                    return  result;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    FileVisitResult result = super.postVisitDirectory(dir, exc);
+                    Files.deleteIfExists(dir);
+                    return  result;
+                }
+            });
+        }
+    }
+
+    /**
+     * Tests that SecurityRealm.ServiceUtil's dependency injection works regardless of what
+     * ServiceTarget API was used for creating the target ServiceBuilder.
+     */
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testDifferentServiceBuilderTypes() {
+        ServiceTarget serviceTarget = container.subTarget();
+
+        final SecurityRealmService securityRealmService = new SecurityRealmService(TESTNAME, false);
+        securityRealmService.getTmpDirPathInjector().inject(tmpDir.toAbsolutePath().toString());
+
+        final ServiceName realmServiceName = SecurityRealm.ServiceUtil.createServiceName(TESTNAME);
+        ServiceController<?> realmController = serviceTarget
+                .addService(realmServiceName, securityRealmService)
+                .addAliases(SecurityRealm.ServiceUtil.createLegacyServiceName(TESTNAME))
+                .install();
+
+        TestService legacy = new TestService();
+        ServiceBuilder legacyBuilder = serviceTarget.addService(ServiceName.of("LEGACY"), legacy);
+        SecurityRealm.ServiceUtil.addDependency(legacyBuilder, legacy.injector, TESTNAME);
+        ServiceController<?> legacyController = legacyBuilder.install();
+
+        TestService current = new TestService();
+        ServiceBuilder currentBuilder = serviceTarget.addService(ServiceName.of("CURRENT"));
+        SecurityRealm.ServiceUtil.addDependency(currentBuilder, current.injector, TESTNAME);
+        currentBuilder.setInstance(current);
+        ServiceController<?> currentController = currentBuilder.install();
+
+        try {
+            container.awaitStability(60, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Assert.fail("Interrupted");
+        }
+
+        Assert.assertEquals(ServiceController.State.UP, realmController.getState());
+        Assert.assertEquals(ServiceController.State.UP, legacyController.getState());
+        Assert.assertEquals(ServiceController.State.UP, currentController.getState());
+
+        Assert.assertSame(securityRealmService, legacy.getValue());
+        Assert.assertSame(securityRealmService, current.getValue());
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class TestService implements Service<SecurityRealm>, org.jboss.msc.Service {
+
+        private final InjectedValue<SecurityRealm> injector = new InjectedValue<>();
+
+        private SecurityRealm value;
+
+        @Override
+        public void start(StartContext context) throws StartException {
+            value = injector.getValue();
+        }
+
+        @Override
+        public void stop(StopContext context) {
+            value = null;
+        }
+
+        @Override
+        public SecurityRealm getValue() throws IllegalStateException, IllegalArgumentException {
+            return value;
+        }
+    }
+}

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
@@ -19,15 +19,49 @@
 package org.wildfly.extension.elytron;
 
 
+
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import org.jboss.as.controller.CapabilityServiceTarget;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.access.Action;
+import org.jboss.as.controller.access.AuthorizationResult;
+import org.jboss.as.controller.access.Caller;
+import org.jboss.as.controller.access.Environment;
+import org.jboss.as.controller.access.ResourceAuthorization;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
+import org.jboss.as.controller.capability.RuntimeCapability;
+import org.jboss.as.controller.client.MessageSeverity;
+import org.jboss.as.controller.notification.Notification;
+import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.security.CredentialReference;
+import org.jboss.as.domain.management.connections.ldap.LdapConnectionResourceDefinition;
 
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceNotFoundException;
+import org.jboss.msc.service.ServiceRegistry;
+import org.jboss.msc.service.ServiceTarget;
 import org.junit.Assert;
 import org.junit.Test;
+import org.wildfly.security.auth.server.SecurityIdentity;
 
 
 /**
@@ -132,6 +166,498 @@ public class SubsystemParsingTestCase extends AbstractSubsystemBaseTest {
     @Test
     public void testParseAndMarshalModel_CredentialStores() throws Exception {
         standardSubsystemTest("credential-stores.xml");
+    }
+
+    @Test
+    public void testGetCredentialSourceSupplier() throws Exception {
+        final KernelServices services = super.createKernelServicesBuilder(createAdditionalInitialization()).setSubsystemXml(getSubsystemXml("credential-stores.xml")).build();
+        Assert.assertTrue("Subsystem boot failed!", services.isSuccessfulBoot());
+        ServiceContainer container = services.getContainer();
+        assert container != null;
+        ServiceBuilder builder = container.addService(ServiceName.JBOSS.append("test", "credential-ref"));
+        ModelNode ref = new ModelNode();
+        ref.get(CredentialReference.STORE).set("test1");
+        ref.get(CredentialReference.ALIAS).set("alias");
+        ModelNode model = new ModelNode();
+        model.get(LdapConnectionResourceDefinition.SEARCH_CREDENTIAL_REFERENCE.getName()).set(ref);
+        OperationContext context = new OperationContext() {
+            @Override
+            public void addStep(OperationStepHandler step, OperationContext.Stage stage) throws IllegalArgumentException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addStep(OperationStepHandler step, OperationContext.Stage stage, boolean addFirst) throws IllegalArgumentException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addStep(ModelNode operation, OperationStepHandler step, OperationContext.Stage stage) throws IllegalArgumentException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addStep(ModelNode operation, OperationStepHandler step, OperationContext.Stage stage, boolean addFirst) throws IllegalArgumentException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, OperationContext.Stage stage) throws IllegalArgumentException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addStep(ModelNode response, ModelNode operation, OperationStepHandler step, OperationContext.Stage stage, boolean addFirst) throws IllegalArgumentException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addModelStep(OperationDefinition stepDefinition, OperationStepHandler stepHandler, boolean addFirst) throws IllegalArgumentException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addModelStep(ModelNode response, ModelNode operation, OperationDefinition stepDefinition, OperationStepHandler stepHandler, boolean addFirst) throws IllegalArgumentException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addResponseWarning(Level level, String warning) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addResponseWarning(Level level, ModelNode warning) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public InputStream getAttachmentStream(int index) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public int getAttachmentStreamCount() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ModelNode getResult() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean hasResult() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public String attachResultStream(String mimeType, InputStream stream) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void attachResultStream(String uuid, String mimeType, InputStream stream) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ModelNode getFailureDescription() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean hasFailureDescription() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ModelNode getServerResults() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ModelNode getResponseHeaders() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void completeStep(OperationContext.RollbackHandler rollbackHandler) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void completeStep(OperationContext.ResultHandler resultHandler) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void stepCompleted() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ProcessType getProcessType() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public RunningMode getRunningMode() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean isBooting() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean isNormalServer() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean isRollbackOnly() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void setRollbackOnly() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean isRollbackOnRuntimeFailure() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean isResourceServiceRestartAllowed() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void reloadRequired() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void restartRequired() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void revertReloadRequired() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void revertRestartRequired() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void runtimeUpdateSkipped() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public PathAddress getCurrentAddress() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public String getCurrentAddressValue() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ImmutableManagementResourceRegistration getResourceRegistration() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ManagementResourceRegistration getResourceRegistrationForUpdate() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ImmutableManagementResourceRegistration getRootResourceRegistration() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ServiceRegistry getServiceRegistry(boolean modify) throws UnsupportedOperationException {
+                return new ServiceRegistry() {
+                    @Override
+                    public ServiceController<?> getRequiredService(ServiceName serviceName) throws ServiceNotFoundException {
+                        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                    }
+
+                    @Override
+                    public ServiceController<?> getService(ServiceName serviceName) {
+                        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                    }
+
+                    @Override
+                    public List<ServiceName> getServiceNames() {
+                        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+                    }
+                };
+            }
+
+            @Override
+            public ServiceController<?> removeService(ServiceName name) throws UnsupportedOperationException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void removeService(ServiceController<?> controller) throws UnsupportedOperationException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ServiceTarget getServiceTarget() throws UnsupportedOperationException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public CapabilityServiceTarget getCapabilityServiceTarget() throws UnsupportedOperationException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void acquireControllerLock() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Resource createResource(PathAddress address) throws UnsupportedOperationException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addResource(PathAddress address, Resource toAdd) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void addResource(PathAddress address, int index, Resource toAdd) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Resource readResource(PathAddress relativeAddress) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Resource readResource(PathAddress relativeAddress, boolean recursive) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Resource readResourceFromRoot(PathAddress address) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Resource readResourceFromRoot(PathAddress address, boolean recursive) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Resource readResourceForUpdate(PathAddress relativeAddress) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Resource removeResource(PathAddress relativeAddress) throws UnsupportedOperationException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Resource getOriginalRootResource() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean isModelAffected() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean isResourceRegistryAffected() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean isRuntimeAffected() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public OperationContext.Stage getCurrentStage() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void report(MessageSeverity severity, String message) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean markResourceRestarted(PathAddress resource, Object owner) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean revertResourceRestarted(PathAddress resource, Object owner) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ModelNode resolveExpressions(ModelNode node) throws OperationFailedException {
+                return node;
+            }
+
+            @Override
+            public <T> T getAttachment(OperationContext.AttachmentKey<T> key) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public <T> T attach(OperationContext.AttachmentKey<T> key, T value) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public <T> T attachIfAbsent(OperationContext.AttachmentKey<T> key, T value) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public <T> T detach(OperationContext.AttachmentKey<T> key) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public AuthorizationResult authorize(ModelNode operation) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public AuthorizationResult authorize(ModelNode operation, Set<Action.ActionEffect> effects) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ResourceAuthorization authorizeResource(boolean attributes, boolean isDefaultResource) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public AuthorizationResult authorize(ModelNode operation, String attribute, ModelNode currentValue) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public AuthorizationResult authorize(ModelNode operation, String attribute, ModelNode currentValue, Set<Action.ActionEffect> effects) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public AuthorizationResult authorizeOperation(ModelNode operation) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Caller getCaller() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public SecurityIdentity getSecurityIdentity() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void emit(Notification notification) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public Environment getCallEnvironment() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void registerCapability(RuntimeCapability capability) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void registerAdditionalCapabilityRequirement(String required, String dependent, String attribute) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean hasOptionalCapability(String requested, String dependent, String attribute) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void requireOptionalCapability(String required, String dependent, String attribute) throws OperationFailedException {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void deregisterCapabilityRequirement(String required, String dependent) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public void deregisterCapability(String capabilityName) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public <T> T getCapabilityRuntimeAPI(String capabilityName, Class<T> apiType) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public <T> T getCapabilityRuntimeAPI(String capabilityBaseName, String dynamicPart, Class<T> apiType) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ServiceName getCapabilityServiceName(String capabilityName, Class<?> serviceType) {
+               return ServiceName.parse(capabilityName);
+            }
+
+            @Override
+            public ServiceName getCapabilityServiceName(String capabilityBaseName, String dynamicPart, Class<?> serviceType) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public ServiceName getCapabilityServiceName(String capabilityBaseName, Class<?> serviceType, String... dynamicParts) {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public CapabilityServiceSupport getCapabilityServiceSupport() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+
+            @Override
+            public boolean isDefaultRequiresRuntime() {
+                throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            }
+        };
+        CredentialReference.getCredentialSourceSupplier(context, LdapConnectionResourceDefinition.SEARCH_CREDENTIAL_REFERENCE, model, builder);
+        services.shutdown();
     }
 
     @Override

--- a/server/src/test/java/org/jboss/as/server/AddServerExecutorDependencyTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/AddServerExecutorDependencyTestCase.java
@@ -1,0 +1,165 @@
+/*
+Copyright 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.server;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.service.ValueService;
+import org.jboss.msc.value.ImmediateValue;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.msc.value.Value;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests Services.addServerExecutorDependency handling for WFCORE-4099 / MSC-240.
+ *
+ * @author Brian Stansberry
+ */
+public class AddServerExecutorDependencyTestCase {
+
+    private static final String TESTNAME = AddServerExecutorDependencyTestCase.class.getSimpleName();
+
+    private ServiceContainer container;
+    private Path tmpDir;
+    private ExecutorService executorService;
+
+    @Before
+    public void setup() throws IOException {
+        container = ServiceContainer.Factory.create(TESTNAME);
+        tmpDir = Files.createTempDirectory(TESTNAME);
+        executorService = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void teardown() throws IOException {
+        if (container != null) {
+            container.shutdown();
+            try {
+                container.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            finally {
+                container = null;
+            }
+        }
+        if (tmpDir != null) {
+            Files.walkFileTree(tmpDir, new SimpleFileVisitor<Path>() {
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    FileVisitResult result = super.visitFile(file, attrs);
+                    Files.deleteIfExists(file);
+                    return  result;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    FileVisitResult result = super.postVisitDirectory(dir, exc);
+                    Files.deleteIfExists(dir);
+                    return  result;
+                }
+            });
+        }
+        if (executorService != null) {
+            executorService.shutdownNow();
+        }
+    }
+
+    /**
+     * Tests that Services.addServerExecutorDependency's dependency injection works regardless of what
+     * ServiceTarget API was used for creating the target ServiceBuilder.
+     */
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testDifferentServiceBuilderTypes() {
+        ServiceTarget serviceTarget = container.subTarget();
+
+        final Value<ExecutorService> value = new ImmediateValue<>(executorService);
+        final Service<ExecutorService> mscExecutorService = new ValueService<>(value);
+
+        ServiceController<?> executorController =
+                serviceTarget.addService(ServerService.MANAGEMENT_EXECUTOR, mscExecutorService).install();
+
+        TestService legacy = new TestService();
+        ServiceBuilder<ExecutorService> legacyBuilder = serviceTarget.addService(ServiceName.of("LEGACY"), legacy);
+        ServiceController<?> legacyController =
+                Services.addServerExecutorDependency(legacyBuilder, legacy.injector).install();
+
+        TestService current = new TestService();
+        ServiceBuilder<?> currentBuilder = serviceTarget.addService(ServiceName.of("CURRENT"));
+        ServiceController<?> currentController =
+                Services.addServerExecutorDependency(currentBuilder.setInstance(current), current.injector).install();
+
+        try {
+            container.awaitStability(60, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Assert.fail("Interrupted");
+        }
+
+        Assert.assertEquals(ServiceController.State.UP, executorController.getState());
+        Assert.assertEquals(ServiceController.State.UP, legacyController.getState());
+        Assert.assertEquals(ServiceController.State.UP, currentController.getState());
+
+        Assert.assertSame(executorService, legacy.getValue());
+        Assert.assertSame(executorService, current.getValue());
+    }
+
+    @SuppressWarnings("deprecation")
+    private static class TestService implements Service<ExecutorService>, org.jboss.msc.Service {
+
+        private final InjectedValue<ExecutorService> injector = new InjectedValue<>();
+
+        private ExecutorService value;
+
+        @Override
+        public void start(StartContext context) throws StartException {
+            value = injector.getValue();
+        }
+
+        @Override
+        public void stop(StopContext context) {
+            value = null;
+        }
+
+        @Override
+        public ExecutorService getValue() throws IllegalStateException, IllegalArgumentException {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4099

The actual fix here was MSC-240.

This PR includes the commits from #3512 and #3508. I expect to merge #3512 independently, and then this will basically be test coverage for the critical cases.