### PR TITLE
[WFCORE-4105] Add tests for add-user, domain, elytron-tool, jboss-cli…

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -72,6 +72,7 @@
         <module>vault-test-feature-pack</module>
         <module>elytron</module>
         <module>embedded</module>
+        <module>scripts</module>
     </modules>
 
 

--- a/testsuite/scripts/pom.xml
+++ b/testsuite/scripts/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>wildfly-core-testsuite</artifactId>
+        <groupId>org.wildfly.core</groupId>
+        <version>7.0.0.Alpha2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>wildfly-script-tests</artifactId>
+    <description>WildFly Core: Script Tests</description>
+
+    <properties>
+        <!-- By default the scripts and configurations expect an IPv4 address so we should use one by default -->
+        <jboss.test.script.address>127.0.0.1</jboss.test.script.address>
+        <jboss.test.start.timeout>20</jboss.test.start.timeout>
+        <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
+        <test.log.level>INFO</test.log.level>
+        <test.log.file>${project.build.directory}${file.separator}test.log</test.log.file>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <failIfNoTests>false</failIfNoTests>
+                    <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+
+                    <environmentVariables>
+                        <JBOSS_HOME>${wildfly.home}</JBOSS_HOME>
+                    </environmentVariables>
+
+                    <systemPropertyVariables>
+                        <jboss.home>${wildfly.home}</jboss.home>
+                        <jboss.test.start.timeout>${jboss.test.start.timeout}</jboss.test.start.timeout>
+                        <maven.repo.local>${settings.localRepository}</maven.repo.local>
+                        <jboss.bind.address>${jboss.test.script.address}</jboss.bind.address>
+                        <management.address>${jboss.test.script.address}</management.address>
+                        <jboss.test.proc.dir>${project.build.directory}${file.separator}proc</jboss.test.proc.dir>
+                        <test.log.level>${test.log.level}</test.log.level>
+                        <test.log.file>${test.log.file}</test.log.file>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.wildfly.build</groupId>
+                <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>server-provisioning</id>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <config-file>server-provisioning.xml</config-file>
+                            <server-name>wildfly-core</server-name>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>debug-logging</id>
+            <activation>
+                <property>
+                    <name>debug.logging</name>
+                </property>
+            </activation>
+
+            <properties>
+                <test.log.level>DEBUG</test.log.level>
+                <test.log.file>${project.build.directory}${file.separator}test.log</test.log.file>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.logging</groupId>
+                    <artifactId>jboss-logging</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.logmanager</groupId>
+                    <artifactId>jboss-logmanager</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.slf4j</groupId>
+                    <artifactId>slf4j-jboss-logmanager</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <org.jboss.logging.provider>jboss</org.jboss.logging.provider>
+                                <test.log.level>${test.log.level}</test.log.level>
+                                <test.log.file>${test.log.file}</test.log.file>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+</project>

--- a/testsuite/scripts/server-provisioning.xml
+++ b/testsuite/scripts/server-provisioning.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~
+  ~ Copyright 2018 Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" copy-module-artifacts="false">
+    <feature-packs>
+        <feature-pack groupId="org.wildfly.core" artifactId="wildfly-core-feature-pack" version="${project.version}" />
+    </feature-packs>
+</server-provisioning>

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/AddUserTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/AddUserTestCase.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.scripts.test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Properties;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Assert;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class AddUserTestCase extends ScriptTestCase {
+
+    public AddUserTestCase() {
+        super("add-user");
+    }
+
+    @Override
+    void testScript(final ScriptProcess script) throws InterruptedException, TimeoutException, IOException {
+        final Path standaloneMgmtUsers = Environment.getStandaloneConfig("mgmt-users.properties");
+        final Path standaloneMgmtGroups = Environment.getStandaloneConfig("mgmt-groups.properties");
+        final Path domainMgmtUsers = Environment.getDomainConfig("mgmt-users.properties");
+        final Path domainMgmtGroups = Environment.getDomainConfig("mgmt-groups.properties");
+
+        script.start(MAVEN_JAVA_OPTS, "-p", "test.12345", "-u", "test-admin", "-g", "test-admin-1,test-admin-2");
+        validateProcess(script);
+
+        // Test standalone
+        validateValueAndClear(script, standaloneMgmtUsers, "test-admin", "4f973bec3e473f467b1b92d58909eeb5");
+        validateValueAndClear(script, standaloneMgmtGroups, "test-admin", "test-admin-1,test-admin-2");
+
+        // Test domain
+        validateValueAndClear(script, domainMgmtUsers, "test-admin", "4f973bec3e473f467b1b92d58909eeb5");
+        validateValueAndClear(script, domainMgmtGroups, "test-admin", "test-admin-1,test-admin-2");
+    }
+
+    private void validateValueAndClear(final ScriptProcess script, final Path propertiesFile,
+                                       @SuppressWarnings("SameParameterValue") final String key,
+                                       final String expectedValue) throws IOException {
+        Properties properties = load(propertiesFile);
+        String password = properties.getProperty(key);
+        Assert.assertEquals(script.getErrorMessage(String.format("Expected %s got %s", expectedValue, password)), expectedValue, password);
+
+        // Clear the files
+        clearFile(propertiesFile);
+    }
+
+    @SuppressWarnings("EmptyTryBlock")
+    private static void clearFile(final Path file) throws IOException {
+        try (OutputStream ignored = Files.newOutputStream(file, StandardOpenOption.TRUNCATE_EXISTING)) {
+            // do nothing, just clear the file
+        }
+        Assert.assertTrue(Files.readAllLines(file).isEmpty());
+    }
+
+    private static Properties load(final Path file) throws IOException {
+        final Properties result = new Properties();
+        try (Reader reader = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            result.load(reader);
+        }
+        return result;
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/CliScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/CliScriptTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.scripts.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class CliScriptTestCase extends ScriptTestCase {
+
+    public CliScriptTestCase() {
+        super("jboss-cli");
+    }
+
+    @Override
+    void testScript(final ScriptProcess script) throws InterruptedException, TimeoutException, IOException {
+        // Read an attribute
+        script.start(MAVEN_JAVA_OPTS, "--commands=embed-server,:read-attribute(name=server-state),exit");
+        Assert.assertNotNull("The process is null and may have failed to start.", script);
+        Assert.assertTrue("The process is not running and should be", script.isAlive());
+
+        validateProcess(script);
+
+        // Read the output lines which should be valid DMR
+        try (InputStream in = Files.newInputStream(script.getStdout())) {
+            final ModelNode result = ModelNode.fromStream(in);
+            if (!Operations.isSuccessfulOutcome(result)) {
+                Assert.fail(result.asString());
+            }
+            Assert.assertEquals(ClientConstants.CONTROLLER_PROCESS_STATE_RUNNING, Operations.readResult(result).asString());
+        }
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/DomainScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/DomainScriptTestCase.java
@@ -1,0 +1,128 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.scripts.test;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STARTING;
+import static org.jboss.as.controller.client.helpers.ClientConstants.CONTROLLER_PROCESS_STATE_STOPPING;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.client.helpers.domain.ServerIdentity;
+import org.jboss.as.controller.client.helpers.domain.ServerStatus;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class DomainScriptTestCase extends ScriptTestCase {
+
+    @SuppressWarnings("Convert2Lambda")
+    private static final Function<ModelControllerClient, Boolean> HOST_CONTROLLER_CHECK = new Function<ModelControllerClient, Boolean>() {
+        @Override
+        public Boolean apply(final ModelControllerClient client) {
+            final DomainClient domainClient = (client instanceof DomainClient ? (DomainClient) client : DomainClient.Factory.create(client));
+            try {
+                // Check for admin-only
+                final ModelNode hostAddress = determineHostAddress(domainClient);
+                final Operations.CompositeOperationBuilder builder = Operations.CompositeOperationBuilder.create()
+                                                                                                         .addStep(Operations.createReadAttributeOperation(hostAddress, "running-mode"))
+                                                                                                         .addStep(Operations.createReadAttributeOperation(hostAddress, "host-state"));
+                ModelNode response = domainClient.execute(builder.build());
+                if (Operations.isSuccessfulOutcome(response)) {
+                    response = Operations.readResult(response);
+                    if ("ADMIN_ONLY".equals(Operations.readResult(response.get("step-1")).asString())) {
+                        if (Operations.isSuccessfulOutcome(response.get("step-2"))) {
+                            final String state = Operations.readResult(response).asString();
+                            return !CONTROLLER_PROCESS_STATE_STARTING.equals(state)
+                                    && !CONTROLLER_PROCESS_STATE_STOPPING.equals(state);
+                        }
+                    }
+                }
+                final Map<ServerIdentity, ServerStatus> servers = new HashMap<>();
+                final Map<ServerIdentity, ServerStatus> statuses = domainClient.getServerStatuses();
+                for (ServerIdentity id : statuses.keySet()) {
+                    final ServerStatus status = statuses.get(id);
+                    switch (status) {
+                        case DISABLED:
+                        case STARTED: {
+                            servers.put(id, status);
+                            break;
+                        }
+                    }
+                }
+                return statuses.size() == servers.size();
+            } catch (IllegalStateException | IOException ignore) {
+            }
+            return false;
+        }
+    };
+
+    public DomainScriptTestCase() {
+        super("domain", HOST_CONTROLLER_CHECK);
+    }
+
+    @BeforeClass
+    public static void updateConf() throws Exception {
+        // Likely not needed in the PC, but also won't hurt
+        appendConf("domain", "PROCESS_CONTROLLER_JAVA_OPTS");
+        appendConf("domain", "HOST_CONTROLLER_JAVA_OPTS");
+    }
+
+    @Override
+    void testScript(final ScriptProcess script) throws InterruptedException, TimeoutException, IOException {
+        script.start(DEFAULT_SERVER_JAVA_OPTS);
+
+        Assert.assertNotNull("The process is null and may have failed to start.", script);
+        Assert.assertTrue("The process is not running and should be", script.isAlive());
+
+        // Shutdown the server
+        @SuppressWarnings("Convert2Lambda")
+        final Callable<ModelNode> callable = new Callable<ModelNode>() {
+            @Override
+            public ModelNode call() throws Exception {
+                try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+                    return executeOperation(client, Operations.createOperation("shutdown", determineHostAddress(client)));
+                }
+            }
+        };
+        execute(callable);
+        validateProcess(script);
+    }
+
+    private static ModelNode determineHostAddress(final ModelControllerClient client) throws IOException {
+        final ModelNode op = Operations.createReadAttributeOperation(EMPTY_ADDRESS, "local-host-name");
+        ModelNode response = client.execute(op);
+        if (Operations.isSuccessfulOutcome(response)) {
+            return Operations.createAddress("host", Operations.readResult(response).asString());
+        }
+        throw new IOException("Failed to determine host name: " + Operations.readResult(response).asString());
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ElytronToolScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ElytronToolScriptTestCase.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.scripts.test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Assert;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ElytronToolScriptTestCase extends ScriptTestCase {
+
+    public ElytronToolScriptTestCase() {
+        super("elytron-tool");
+    }
+
+    @Override
+    void testScript(final ScriptProcess script) throws InterruptedException, TimeoutException, IOException {
+        try {
+            // Read an attribute
+            script.start("mask", "--salt", "12345678", "--iteration", "123", "--secret", "supersecretstorepassword");
+            Assert.assertNotNull("The process is null and may have failed to start.", script);
+            Assert.assertTrue("The process is not running and should be", script.isAlive());
+
+            validateProcess(script);
+
+            // Get the output and test the masked password
+            final List<String> allLines = Files.readAllLines(script.getStdout());
+            // We should only have one line
+            Assert.assertEquals("Expected only one entry: " + allLines.toString(), 1, allLines.size());
+            Assert.assertEquals("MASK-8VzWsSNwBaR676g8ujiIDdFKwSjOBHCHgnKf17nun3v;12345678;123", allLines.get(0));
+        } finally {
+            script.close();
+        }
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/Environment.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/Environment.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.scripts.test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Locale;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("StaticMethodOnlyUsedInOneClass")
+public class Environment {
+
+    static final Path JBOSS_HOME;
+    static final Path PROC_DIR;
+    private static final long TIMEOUT;
+    private static final boolean IS_WINDOWS;
+
+    static {
+        String jbossHome = System.getProperty("jboss.home");
+        if (isNullOrEmpty(jbossHome)) {
+            jbossHome = System.getenv("JBOSS_HOME");
+        }
+
+        if (isNullOrEmpty(jbossHome)) {
+            throw new RuntimeException("Failed to configure environment. No jboss.home system property or JBOSS_HOME " +
+                    "environment variable set.");
+        }
+        JBOSS_HOME = Paths.get(jbossHome).toAbsolutePath();
+        final String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+        IS_WINDOWS = os.contains("win");
+
+        PROC_DIR = Paths.get(System.getProperty("jboss.test.proc.dir"));
+        try {
+            Files.createDirectories(PROC_DIR);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create the log directory", e);
+        }
+        final String timeoutString = System.getProperty("jboss.test.start.timeout", "20");
+        TIMEOUT = TimeoutUtil.adjust(Integer.parseInt(timeoutString));
+    }
+
+    static boolean isWindows() {
+        return IS_WINDOWS;
+    }
+
+    static Path getStandaloneConfig(final String configFile) {
+        return JBOSS_HOME.resolve("standalone").resolve("configuration").resolve(configFile);
+    }
+
+    static Path getDomainConfig(final String configFile) {
+        return JBOSS_HOME.resolve("domain").resolve("configuration").resolve(configFile);
+    }
+
+    static long getTimeout() {
+        return TIMEOUT;
+    }
+
+    static long getTimeoutInMillis() {
+        return TIMEOUT * 1000;
+    }
+
+    private static boolean isNullOrEmpty(final String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptProcess.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptProcess.java
@@ -1,0 +1,293 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.scripts.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.logging.Logger;
+
+/**
+ * Represents a script. Note that this is not thread-safe.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class ScriptProcess extends Process implements AutoCloseable {
+    private static final Logger LOGGER = Logger.getLogger(ScriptProcess.class);
+
+    private static final Function<String, String> WINDOWS_ARG_FORMATTER = s -> "\"" + s + "\"";
+    private final Path script;
+    private final Path stdoutLog;
+    private final Path input;
+    private final Function<ModelControllerClient, Boolean> check;
+    private final Collection<String> prefixCmds;
+    private Process delegate;
+    private String lastExecutedCmd;
+
+    ScriptProcess(final Path script, final Function<ModelControllerClient, Boolean> check, final String... prefixCmds) throws IOException {
+        this.script = script;
+        this.check = check;
+        this.prefixCmds = new ArrayList<>(Arrays.asList(prefixCmds));
+        final String baseFileName = script.getFileName().toString().replace('.', '-');
+        stdoutLog = Environment.PROC_DIR.resolve(baseFileName + "-out.txt");
+        input = Environment.PROC_DIR.resolve(baseFileName + "-in.txt");
+        // Delete and create the input file
+        Files.deleteIfExists(input);
+        Files.createFile(input);
+        lastExecutedCmd = "";
+    }
+
+    void start(final String... arguments) throws IOException, TimeoutException, InterruptedException {
+        start(Arrays.asList(arguments));
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    void start(final Collection<String> arguments) throws IOException, TimeoutException, InterruptedException {
+        start(Collections.emptyMap(), arguments);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    void start(final Map<String, String> env, final String... arguments) throws IOException, TimeoutException, InterruptedException {
+        start(env, Arrays.asList(arguments));
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    void start(final Map<String, String> env, final Collection<String> arguments) throws IOException, TimeoutException, InterruptedException {
+        if (delegate != null) {
+            throw new IllegalStateException("This process has already been started and has not exited.");
+        }
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debugf("Attempting to start: %s", getCommandString(arguments));
+        }
+        lastExecutedCmd = getCommandString(arguments);
+        final ProcessBuilder builder = new ProcessBuilder(getCommand(arguments))
+                .directory(Environment.JBOSS_HOME.toFile())
+                .redirectInput(input.toFile())
+                .redirectErrorStream(true)
+                .redirectOutput(stdoutLog.toFile());
+        // The Windows scripts should not pause at the requiring user input
+        if (Environment.isWindows()) {
+            builder.environment().put("NOPAUSE", "true");
+        }
+        // Add any other environment variables
+        if (env != null && !env.isEmpty()) {
+            builder.environment().putAll(env);
+        }
+        final Process process = builder.start();
+        if (check != null) {
+            waitFor(process, check);
+        }
+        this.delegate = process;
+    }
+
+    @SuppressWarnings("unused")
+    Path getScript() {
+        return script;
+    }
+
+    Path getStdout() {
+        return stdoutLog;
+    }
+
+    @SuppressWarnings("unused")
+    Path getInput() {
+        return input;
+    }
+
+    String getErrorMessage(final String msg) {
+        final StringBuilder errorMessage = new StringBuilder(msg)
+                .append(System.lineSeparator())
+                .append("Command Executed:")
+                .append(System.lineSeparator())
+                .append(lastExecutedCmd)
+                .append(System.lineSeparator())
+                .append("Environment:")
+                .append(System.lineSeparator())
+                .append("Output:")
+                .append(System.lineSeparator());
+        try {
+            for (String line : Files.readAllLines(stdoutLog)) {
+                errorMessage.append(line)
+                            .append(System.lineSeparator());
+            }
+        } catch (IOException ignore) {
+        }
+        return errorMessage.toString();
+    }
+
+    private List<String> getCommand(final Collection<String> arguments) {
+        final List<String> cmd = new ArrayList<>(prefixCmds);
+        cmd.add(script.toString());
+        if (Environment.isWindows()) {
+            for (String arg : arguments) {
+                cmd.add(WINDOWS_ARG_FORMATTER.apply(arg));
+            }
+        } else {
+            cmd.addAll(arguments);
+        }
+        return cmd;
+    }
+
+    @Override
+    public void close() {
+        if (delegate != null) {
+            delegate.destroyForcibly();
+            delegate = null;
+        }
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        checkStatus();
+        return delegate.getOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        checkStatus();
+        return delegate.getInputStream();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+        checkStatus();
+        return delegate.getErrorStream();
+    }
+
+    @Override
+    public int waitFor() throws InterruptedException {
+        checkStatus();
+        return delegate.waitFor();
+    }
+
+    @Override
+    public boolean waitFor(final long timeout, final TimeUnit unit) throws InterruptedException {
+        checkStatus();
+        return delegate.waitFor(timeout, unit);
+    }
+
+    @Override
+    public int exitValue() {
+        checkStatus();
+        return delegate.exitValue();
+    }
+
+    @Override
+    public void destroy() {
+        checkStatus();
+        delegate.destroy();
+    }
+
+    @Override
+    public Process destroyForcibly() {
+        checkStatus();
+        return delegate.destroyForcibly();
+    }
+
+    @Override
+    public boolean isAlive() {
+        checkStatus();
+        return delegate.isAlive();
+    }
+
+    @Override
+    public String toString() {
+        return getCommandString(Collections.emptyList());
+    }
+
+    private String getCommandString(final Collection<String> arguments) {
+        final List<String> cmd = getCommand(arguments);
+        final StringBuilder result = new StringBuilder();
+        final Iterator<String> iter = cmd.iterator();
+        while (iter.hasNext()) {
+            result.append(iter.next());
+            if (iter.hasNext()) {
+                result.append(' ');
+            }
+        }
+        return result.toString();
+    }
+
+    private void checkStatus() {
+        if (delegate == null) {
+            throw new IllegalStateException("The script has not yet been started.");
+        }
+    }
+
+    private void waitFor(final Process process, final Function<ModelControllerClient, Boolean> check) throws TimeoutException, InterruptedException {
+        @SuppressWarnings("Convert2Lambda")
+        final Callable<Boolean> callable = new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws InterruptedException, IOException {
+                long timeout = Environment.getTimeoutInMillis();
+                final long sleep = 100L;
+                try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+                    while (timeout > 0) {
+                        if (!process.isAlive()) {
+                            return false;
+                        }
+                        long before = System.currentTimeMillis();
+                        if (check.apply(client)) {
+                            return true;
+                        }
+                        timeout -= (System.currentTimeMillis() - before);
+                        TimeUnit.MILLISECONDS.sleep(sleep);
+                        timeout -= sleep;
+                    }
+                }
+                return false;
+            }
+        };
+        final ExecutorService service = Executors.newSingleThreadExecutor();
+        try {
+            final Future<Boolean> future = service.submit(callable);
+            if (!future.get()) {
+                if (process != null) {
+                    process.destroyForcibly();
+                }
+                throw new TimeoutException(getErrorMessage(String.format("The %s did not start within %d seconds.", script.getFileName(), Environment.getTimeout())));
+            }
+        } catch (ExecutionException e) {
+            throw new RuntimeException(getErrorMessage(String.format("Failed to determine if the %s server is running.", script.getFileName())), e);
+        } finally {
+            service.shutdownNow();
+        }
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/ScriptTestCase.java
@@ -1,0 +1,297 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.scripts.test;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.Operation;
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@SuppressWarnings("Convert2Lambda")
+public abstract class ScriptTestCase {
+
+    static final ModelNode EMPTY_ADDRESS = new ModelNode().addEmptyList();
+    static final String[] DEFAULT_SERVER_JAVA_OPTS = {
+            "-Djboss.management.http.port=" + TestSuiteEnvironment.getServerPort(),
+            "-Djboss.bind.address.management=" + TestSuiteEnvironment.getServerAddress(),
+    };
+
+    static final Map<String, String> MAVEN_JAVA_OPTS = new LinkedHashMap<>();
+
+    private static final String[] POWER_SHELL_PREFIX = {
+            "powershell",
+            "-NonInteractive",
+            "-File"
+    };
+
+    static {
+        EMPTY_ADDRESS.protect();
+    }
+
+    private final String scriptBaseName;
+    private final Function<ModelControllerClient, Boolean> check;
+    private ExecutorService service;
+
+
+    ScriptTestCase(final String scriptBaseName) {
+        this(scriptBaseName, null);
+    }
+
+    ScriptTestCase(final String scriptBaseName, final Function<ModelControllerClient, Boolean> check) {
+        this.scriptBaseName = scriptBaseName;
+        this.check = check;
+    }
+
+    @BeforeClass
+    public static void configureEnvironment() {
+        final String localRepo = System.getProperty("maven.repo.local");
+        if (localRepo != null) {
+            MAVEN_JAVA_OPTS.put("JAVA_OPTS", "-Dmaven.repo.local=" + localRepo);
+        }
+    }
+
+    @Before
+    public void setup() {
+        service = Executors.newCachedThreadPool();
+    }
+
+    @After
+    public void cleanup() {
+        service.shutdownNow();
+    }
+
+    @Test
+    public void testBatchScript() throws Exception {
+        Assume.assumeTrue(Environment.isWindows());
+        try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".bat"), check)) {
+            testScript(script);
+        }
+    }
+
+    @Test
+    public void testPowerShellScript() throws Exception {
+        Assume.assumeTrue(Environment.isWindows() && isShellSupported("powershell", "-Help"));
+        try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".ps1"), check, POWER_SHELL_PREFIX)) {
+            testScript(script);
+        }
+    }
+
+    @Test
+    public void testBashScript() throws Exception {
+        Assume.assumeTrue(!Environment.isWindows() && isShellSupported("bash", "-c", "echo", "test"));
+        try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".sh"), check)) {
+            testScript(script);
+        }
+    }
+
+    @Test
+    @Ignore("Current tests do not work with csh")
+    public void testCshScript() throws Exception {
+        Assume.assumeTrue(!Environment.isWindows() && isShellSupported("csh", "-c", "echo", "test"));
+        try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".sh"), check, "csh")) {
+            testScript(script);
+        }
+    }
+
+
+    @Test
+    public void testDashScript() throws Exception {
+        Assume.assumeTrue(!Environment.isWindows() && isShellSupported("dash", "-c", "echo", "test"));
+        try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".sh"), check, "dash")) {
+            testScript(script);
+        }
+    }
+
+    @Test
+    @Ignore("Current tests do not work with fish")
+    public void testFishScript() throws Exception {
+        Assume.assumeTrue(!Environment.isWindows() && isShellSupported("fish", "-c", "echo", "test"));
+        try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".sh"), check, "fish")) {
+            testScript(script);
+        }
+    }
+
+    @Test
+    public void testKshScript() throws Exception {
+        Assume.assumeTrue(!Environment.isWindows() && isShellSupported("ksh", "-c", "echo", "test"));
+        try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".sh"), check, "ksh")) {
+            testScript(script);
+        }
+    }
+
+    @Test
+    @Ignore("Current tests do not work with tcsh")
+    public void testTcshScript() throws Exception {
+        Assume.assumeTrue(!Environment.isWindows() && isShellSupported("tcsh", "-c", "echo", "test"));
+        try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".sh"), check, "tcsh")) {
+            testScript(script);
+        }
+    }
+
+    @Test
+    @Ignore("Current tests do not work with zsh")
+    public void testZshScript() throws Exception {
+        Assume.assumeTrue(!Environment.isWindows() && isShellSupported("zsh", "-c", "echo", "test"));
+        try (ScriptProcess script = new ScriptProcess(getExecutable(scriptBaseName + ".sh"), check, "zsh")) {
+            testScript(script);
+        }
+    }
+
+    abstract void testScript(ScriptProcess script) throws InterruptedException, TimeoutException, IOException;
+
+    @SuppressWarnings("UnusedReturnValue")
+    <T> Future<T> execute(final Callable<T> callable) {
+        return service.submit(callable);
+    }
+
+    void validateProcess(final ScriptProcess script) throws InterruptedException, IOException {
+        if (script.waitFor(TimeoutUtil.adjust(10), TimeUnit.SECONDS)) {
+            // The script has exited, validate the exit code is valid
+            final int exitValue = script.exitValue();
+            if (exitValue != 0) {
+                Assert.fail(script.getErrorMessage(String.format("Expected an exit value 0f 0 got %d", exitValue)));
+            }
+        } else {
+            Assert.fail(script.getErrorMessage("The script process did not exit within 10 seconds."));
+        }
+    }
+
+    static void appendConf(final String baseName, final String envName) throws IOException {
+        // Add the local maven repository to the conf file
+        final String localRepo = System.getProperty("maven.repo.local");
+        if (localRepo != null) {
+            final Path binDir = Environment.JBOSS_HOME.resolve("bin");
+            if (Environment.isWindows()) {
+                // Batch conf
+                Path conf = binDir.resolve(baseName + ".conf.bat");
+                try (BufferedWriter writer = Files.newBufferedWriter(conf, StandardOpenOption.APPEND)) {
+                    writer.newLine();
+                    writer.write("set \"");
+                    writer.write(envName);
+                    writer.write("=-Dmaven.repo.local=");
+                    writer.write(localRepo);
+                    writer.write(" %");
+                    writer.write(envName);
+                    writer.write("%\"");
+                    writer.newLine();
+                }
+                // Powershell conf
+                conf = binDir.resolve(baseName + ".conf.ps1");
+                try (BufferedWriter writer = Files.newBufferedWriter(conf, StandardOpenOption.APPEND)) {
+                    writer.newLine();
+                    writer.write('$');
+                    writer.write(envName);
+                    writer.write(" += '-Dmaven.repo.local=");
+                    writer.write(localRepo);
+                    writer.write("'");
+                    writer.newLine();
+                }
+            } else {
+                final Path conf = binDir.resolve(baseName + ".conf");
+                try (BufferedWriter writer = Files.newBufferedWriter(conf, StandardOpenOption.APPEND)) {
+                    writer.newLine();
+                    writer.write(envName);
+                    writer.write("=\"-Dmaven.repo.local=");
+                    writer.write(localRepo);
+                    writer.write(" $");
+                    writer.write(envName);
+                    writer.write('"');
+                    writer.newLine();
+                }
+            }
+        }
+    }
+
+    static ModelNode executeOperation(final ModelControllerClient client, final ModelNode op) throws IOException {
+        return executeOperation(client, OperationBuilder.create(op).build());
+    }
+
+    private static ModelNode executeOperation(final ModelControllerClient client, final Operation op) throws IOException {
+        final ModelNode result = client.execute(op);
+        if (!Operations.isSuccessfulOutcome(result)) {
+            Assert.fail(String.format("Failed to execute op: %s%nFailure Description: %s", op, Operations.getFailureDescription(result)));
+        }
+        return Operations.readResult(result);
+    }
+
+    private Path getExecutable(final String exe) {
+        final Path fullExe = Environment.JBOSS_HOME.resolve("bin").resolve(exe).toAbsolutePath();
+        Assert.assertTrue(String.format("Path %s does not exist", fullExe), Files.exists(fullExe));
+        return fullExe;
+    }
+
+    private static boolean isShellSupported(final String name, final String... args) throws IOException, InterruptedException {
+        final List<String> cmd = new ArrayList<>();
+        cmd.add(name);
+        if (args != null && args.length > 0) {
+            cmd.addAll(Arrays.asList(args));
+        }
+        final Path stdout = Files.createTempFile(name + "-supported", ".log");
+        final ProcessBuilder builder = new ProcessBuilder(cmd)
+                .redirectErrorStream(true)
+                .redirectOutput(stdout.toFile());
+        Process process = null;
+        try {
+            process = builder.start();
+            if (!process.waitFor(Environment.getTimeout(), TimeUnit.SECONDS)) {
+                return false;
+            }
+            return process.exitValue() == 0;
+        } catch (IOException e) {
+            return false;
+        } finally {
+            if (process != null) {
+                process.destroyForcibly();
+            }
+            Files.deleteIfExists(stdout);
+        }
+    }
+}

--- a/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
+++ b/testsuite/scripts/src/test/java/org/wildfly/scripts/test/StandaloneScriptTestCase.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2018 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wildfly.scripts.test;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class StandaloneScriptTestCase extends ScriptTestCase {
+
+    private static final Function<ModelControllerClient, Boolean> STANDALONE_CHECK = new Function<ModelControllerClient, Boolean>() {
+        private final ModelNode op = Operations.createReadAttributeOperation(EMPTY_ADDRESS, "server-state");
+
+        @Override
+        public Boolean apply(final ModelControllerClient client) {
+
+            try {
+                final ModelNode result = client.execute(op);
+                if (Operations.isSuccessfulOutcome(result) &&
+                        ClientConstants.CONTROLLER_PROCESS_STATE_RUNNING.equals(Operations.readResult(result).asString())) {
+                    return true;
+                }
+            } catch (IllegalStateException | IOException ignore) {
+            }
+            return false;
+        }
+    };
+
+    public StandaloneScriptTestCase() {
+        super("standalone", STANDALONE_CHECK);
+    }
+
+    @BeforeClass
+    public static void updateConf() throws Exception {
+        appendConf("standalone", "JAVA_OPTS");
+    }
+
+    @Override
+    void testScript(final ScriptProcess script) throws InterruptedException, TimeoutException, IOException {
+        script.start(DEFAULT_SERVER_JAVA_OPTS);
+        Assert.assertNotNull("The process is null and may have failed to start.", script);
+        Assert.assertTrue("The process is not running and should be", script.isAlive());
+
+        // Shutdown the server
+        @SuppressWarnings("Convert2Lambda")
+        final Callable<ModelNode> callable = new Callable<ModelNode>() {
+            @Override
+            public ModelNode call() throws Exception {
+                try (ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient()) {
+                    return executeOperation(client, Operations.createOperation("shutdown"));
+                }
+            }
+        };
+        execute(callable);
+        validateProcess(script);
+    }
+}

--- a/testsuite/scripts/src/test/resources/logging.properties
+++ b/testsuite/scripts/src/test/resources/logging.properties
@@ -1,0 +1,44 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2010, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+# Additional logger names to configure (root logger is always configured)
+loggers=org.wildfly.scripts.test
+logger.org.wildfly.scripts.test.level=${test.log.level:DEBUG}
+
+# Root logger level
+logger.level=INFO
+
+# Root logger handlers
+logger.handlers=FILE
+
+# File handler configuration
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.properties=autoFlush,append,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=${test.log.file:./target/test.log}
+handler.FILE.formatter=PATTERN
+handler.FILE.append=true
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n


### PR DESCRIPTION
… and standalone scripts.

https://issues.jboss.org/browse/WFCORE-4105

There are some ignored tests in this PR for shells the scripts do not seem to work in. If there is no intention of the scripts to work with these shells we can remove the tests all together. Otherwise we should consider attempting to fixing the scripts.

I also discovered there PowerShell is available for other platforms, https://github.com/PowerShell/PowerShell#get-powershell. Our scripts do not work however as we hard-code the path separator (`\`) which didn't seem to work on Linux. We could attempt to fix that so the `*.ps1` scripts could be tested on other platforms. However these tests may be enough since they'll run on the Windows PR runs.