### PR TITLE
[WFCORE-4085] EAP_7_2_0_TEMP should use 14.0.0.Final as the version

### DIFF
--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -47,7 +47,7 @@ public enum ModelTestControllerVersion {
 
     // TODO https://issues.jboss.org/browse/WFCORE-4089 Get rid of EAP_7_2_0_TEMP and enable EAP_7_2_0, once
     // 7.2.0.GA-redhat-xx version is known
-    EAP_7_2_0_TEMP("11.0.0.Final", false, "14.0.0", "6.0.1.Final", "wf14"),
+    EAP_7_2_0_TEMP("14.0.0.Final", false, "14.0.0", "6.0.1.Final", "wf14"),
     // WildFly legacy test will need to rename the *-wf14.dmr files to *-7.2.0.dmr
     //EAP_7_2_0("7.2.0.Final-redhat-??", true, "14.0.0", "6.0.1.Final", "7.2.0"),
     ;

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -169,7 +169,97 @@ public abstract class ModelTestModelControllerService extends AbstractController
     }
 
     /**
-     * This is the constructor to use for 2.x core model tests
+     * This is the constructor to use for 10.0.x core model tests
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+                                              final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+                                              final DelegatingResourceDefinition rootResourceDefinition, ControlledProcessState processState,
+                                              ExpressionResolver expressionResolver, Controller10x version) {
+        super(processType, runningModeControl, persister,
+                processState == null ? new ControlledProcessState(true) : processState, rootResourceDefinition, null,
+                expressionResolver, AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer());
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
+    /**
+     * This is the constructor to use for 10.0.x subsystem tests
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+                                              final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+                                              final ResourceDefinition resourceDefinition, ControlledProcessState processState, Controller10x version) {
+        super(processType, runningModeControl, persister,
+                processState == null ? new ControlledProcessState(true) : processState, resourceDefinition, null, ExpressionResolver.TEST_RESOLVER);
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
+    /**
+     * This is the constructor to use for 11.0.x core model tests
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+                                              final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+                                              final DelegatingResourceDefinition rootResourceDefinition, ControlledProcessState processState,
+                                              ExpressionResolver expressionResolver, Controller11x version) {
+        super(processType, runningModeControl, persister,
+                processState == null ? new ControlledProcessState(true) : processState, rootResourceDefinition, null,
+                expressionResolver, AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer());
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
+    /**
+     * This is the constructor to use for 11.0.x subsystem tests
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+                                              final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+                                              final ResourceDefinition resourceDefinition, ControlledProcessState processState, Controller11x version) {
+        super(processType, runningModeControl, persister,
+                processState == null ? new ControlledProcessState(true) : processState, resourceDefinition, null, ExpressionResolver.TEST_RESOLVER);
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
+    /**
+     * This is the constructor to use for 14.0.x core model tests
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+                                              final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+                                              final DelegatingResourceDefinition rootResourceDefinition, ControlledProcessState processState,
+                                              ExpressionResolver expressionResolver, Controller14x version) {
+        super(processType, runningModeControl, persister,
+                processState == null ? new ControlledProcessState(true) : processState, rootResourceDefinition, null,
+                expressionResolver, AuditLogger.NO_OP_LOGGER, new DelegatingConfigurableAuthorizer());
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
+    /**
+     * This is the constructor to use for 14.0.x subsystem tests
+     */
+    protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
+                                              final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
+                                              final ResourceDefinition resourceDefinition, ControlledProcessState processState, Controller14x version) {
+        super(processType, runningModeControl, persister,
+                processState == null ? new ControlledProcessState(true) : processState, resourceDefinition, null, ExpressionResolver.TEST_RESOLVER);
+        this.persister = persister;
+        this.transformerRegistry = transformerRegistry;
+        this.validateOpsFilter = validateOpsFilter;
+        this.runningModeControl = runningModeControl;
+    }
+
+    /**
+     * This is the constructor to use for current core model tests
      */
     protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
             final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
@@ -185,7 +275,7 @@ public abstract class ModelTestModelControllerService extends AbstractController
     }
 
     /**
-     * This is the constructor to use for 10.x subsystem tests
+     * This is the constructor to use for current subsystem tests
      */
     protected ModelTestModelControllerService(final ProcessType processType, final RunningModeControl runningModeControl, final TransformerRegistry transformerRegistry,
                                               final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter,
@@ -457,4 +547,15 @@ public abstract class ModelTestModelControllerService extends AbstractController
         }
     }
 
+    public static class Controller11x {
+        public static Controller11x INSTANCE = new Controller11x();
+        private Controller11x() {
+        }
+    }
+
+    public static class Controller14x {
+        public static Controller14x INSTANCE = new Controller14x();
+        private Controller14x() {
+        }
+    }
 }


### PR DESCRIPTION
Follow-up on https://issues.jboss.org/browse/WFCORE-4085

Also https://issues.jboss.org/browse/WFCORE-4114 ‼️ DO NOT RESOLVE ‼️ - it is preparation for something I need to update in wildfly-legacy-test