### PR TITLE
[WFCORE-4111] Upgrade WildFly Elytron to 1.6.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.6.0.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.6.1.Final</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.3.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4111

        Release Notes - WildFly Elytron - Version 1.6.1.Final
                                                                                
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1640'>ELY-1640</a>] -         Update AcmeClientSpi.changeAccountKey() to no longer send the newKey once the new ACME v2 changes are in production
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1664'>ELY-1664</a>] -         Trace logging in SSLUtils
</li>
</ul>
                        
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1665'>ELY-1665</a>] -         Release WildFly Elytron 1.6.1.Final
</li>
</ul>
                    