### PR TITLE
[WFCORE-4118] Upgrade WildFly Elytron to 1.7.0.CR1

### DIFF
--- a/elytron/src/test/resources/org/wildfly/extension/elytron/ldap.xml
+++ b/elytron/src/test/resources/org/wildfly/extension/elytron/ldap.xml
@@ -73,7 +73,7 @@
    </tls>
    <dir-contexts>
       <dir-context authentication-level="none" authentication-context="ldapAuthContext" name="DirContextInsecure" url="ldap://localhost:11391/"/>
-      <dir-context name="DirContextSsl" authentication-context="ldapAuthContext" referral-mode="THROW" url="ldaps://localhost:11391/" connection-timeout="6000" read-timeout="10000">
+      <dir-context name="DirContextSsl" authentication-context="ldapAuthContext" referral-mode="throw" url="ldaps://localhost:11391/" connection-timeout="6000" read-timeout="10000">
          <properties>
             <property name="java.naming.dns.url" value="dns://dnsserver/wiz.com"/>
          </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.6.1.Final</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.7.0.CR1</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.3.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4118

Also small test fix for https://issues.jboss.org/browse/WFCORE-3971

The test that has been changed was changed as comparison fails once re-marshalled and compared to the original, both upper and lower case still parse successfully.


        Release Notes - WildFly Elytron - Version 1.7.0.CR1
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1637'>ELY-1637</a>] -         Change ReferralMode.toString to return value
</li>
</ul>
                                                                    
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-793'>ELY-793</a>] -         Using @STRENGTH keyword in CipherSuiteSelector.fromString should cause descending sorting
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1595'>ELY-1595</a>] -         Reenable source compatibility check during build
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1634'>ELY-1634</a>] -         LDAPS referrals broken
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1640'>ELY-1640</a>] -         Update AcmeClientSpi.changeAccountKey() to no longer send the newKey once the new ACME v2 changes are in production
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1642'>ELY-1642</a>] -         Compilation error on JDK 11: cannot find class sun.reflect.Reflection
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1660'>ELY-1660</a>] -         EntityTest failure on OpenJDK 9
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1664'>ELY-1664</a>] -         Trace logging in SSLUtils
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1652'>ELY-1652</a>] -         Remove generation time metadata from Javadoc
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1654'>ELY-1654</a>] -         Convert build to create multi-release jar built on Java 9
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1669'>ELY-1669</a>] -         Update Travis CI Configuration to use Java 10
</li>
</ul>
                
<h2>        Release
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1670'>ELY-1670</a>] -         Release WildFly Elytron 1.7.0.CR1
</li>
</ul>
                    