### PR TITLE
[WFCORE-4119] Add exclusions for org.picketbox

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1007,6 +1007,20 @@
                 <groupId>org.picketbox</groupId>
                 <artifactId>picketbox</artifactId>
                 <version>${version.org.picketbox}</version>
+                <exclusions>
+                    <exclusion>
+                         <groupId>org.picketbox</groupId>
+                         <artifactId>jboss-security-spi</artifactId>
+                    </exclusion>
+                    <exclusion>
+                         <groupId>org.picketbox</groupId>
+                         <artifactId>jbosssx</artifactId>
+                    </exclusion>
+                    <exclusion>
+                         <groupId>org.picketbox</groupId>
+                         <artifactId>picketbox-bare</artifactId>
+                    </exclusion>
+                 </exclusions>
             </dependency>
             <!-- This isn't used in WildFly Core but we include it here to keep
                  it's version aligned with the core's use of related picketbox artifacts -->


### PR DESCRIPTION
The productized version of picketbox will include some libraries that must be excluded. Although those libraries are not in the community version, add the exclusions here is harmless and will minimize the required stuff for the product conversion. 

Alternatively, we could have this change in a specific eap-ization commit, but initially, it sounds better to me to have it directly in the upstream.

Jira issue: https://issues.jboss.org/browse/WFCORE-4119