### PR TITLE
[WFCORE-4133] / [WFCORE-4134] Upgrade WildFly Elytron to 1.7.0.CR2 and Elytron Web to 1.3.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-solaris-x86_64>
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
-        <version.org.wildfly.security.elytron>1.7.0.CR1</version.org.wildfly.security.elytron>
+        <version.org.wildfly.security.elytron>1.7.0.CR2</version.org.wildfly.security.elytron>
         <version.org.wildfly.security.elytron-web>1.2.3.Final</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.7.0.CR2</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.2.3.Final</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.3.0.CR1</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <version.org.wildfly.openssl.wildfly-openssl-windows-i386>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-i386>
         <version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>${version.org.wildfly.openssl.natives}</version.org.wildfly.openssl.wildfly-openssl-windows-x86_64>
         <version.org.wildfly.security.elytron>1.7.0.CR2</version.org.wildfly.security.elytron>
-        <version.org.wildfly.security.elytron-web>1.3.0.CR1</version.org.wildfly.security.elytron-web>
+        <version.org.wildfly.security.elytron-web>1.3.0.CR2</version.org.wildfly.security.elytron-web>
         <version.org.wildfly.security.elytron.tool>1.4.0.Final</version.org.wildfly.security.elytron.tool>
         <version.xalan>2.7.1.jbossorg-2</version.xalan>
         <version.xml-resolver>1.2</version.xml-resolver>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4133
https://issues.jboss.org/browse/WFCORE-4134


        Release Notes - WildFly Elytron - Version 1.7.0.CR2
            
<h2>        Enhancement
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1676'>ELY-1676</a>] -         Add missing ARIA encryption to CipherSuiteSelector
</li>
</ul>
                                                            
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1425'>ELY-1425</a>] -         Add support for JASPIC / JSR-196
</li>
</ul>
        
<h2>        Bug
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1427'>ELY-1427</a>] -         Credential store type PKCS12 works fine when using OracleJDK and OpenJDK but doesn&#39;t work using IBM JDK.
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1535'>ELY-1535</a>] -         CipherSuiteSelector does not know about CHACHA20_POLY1305
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1672'>ELY-1672</a>] -         MechanismDatabase should not use AEAD to describe digest (PRF)
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1673'>ELY-1673</a>] -         Draft ciphers in mechanism database
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1674'>ELY-1674</a>] -         MechanismDatabase ECDHE_PSK ciphers use PSK authentication, not ECDHE
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1684'>ELY-1684</a>] -         Release WildFly Elytron 1.7.0.CR2
</li>
</ul>
        
<h2>        Task
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELY-1613'>ELY-1613</a>] -         Add remaining RFC 6209 Cipher Suites
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1656'>ELY-1656</a>] -         Ensure testsuite alone can be built and executed on Java 11
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1657'>ELY-1657</a>] -         Ensure whole project buildable on JDK 11
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1678'>ELY-1678</a>] -         Avoid NPE in AcmeClientSpi#checkContentType() when the content type is null and try to fix intermittent failures in AcmeClientSpiTest
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1681'>ELY-1681</a>] -         Include the thrown exception in the trace logging in SSLUtils#createSslContextFactory()
</li>
<li>[<a href='https://issues.jboss.org/browse/ELY-1683'>ELY-1683</a>] -         Add more trace logging in SSLUtils#createSslContextFactory to indicate which protocols and providers are attempted
</li>
</ul>
                                    


        Release Notes - Elytron Web - Version 1.3.0.CR1
        
<h2>        Component Upgrade
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-20'>ELYWEB-20</a>] -         Upgrade to WildFly Elytron 1.7.0.CR2
</li>
</ul>
                                                                
<h2>        Feature Request
</h2>
<ul>
<li>[<a href='https://issues.jboss.org/browse/ELYWEB-7'>ELYWEB-7</a>] -         Add JASPIC Integration
</li>
</ul>
                                                    