### PR TITLE
[WFCORE-4135] Added new startup property: --disable-configuration-history

### DIFF
--- a/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
+++ b/process-controller/src/main/java/org/jboss/as/process/CommandLineConstants.java
@@ -103,6 +103,10 @@ public class CommandLineConstants {
      * the file is not persisted */
     public static final String READ_ONLY_SERVER_CONFIG = "--read-only-server-config";
 
+    /**
+     * Only in standalone mode, it avoids creation and use of 'standalone_xml_history'
+     */
+    public static final String DISABLE_XML_HISTORY = "--disable-configuration-history";
     /** Address on which the process controller listens */
     public static final String OLD_PROCESS_CONTROLLER_BIND_ADDR = "-bind-addr";
     public static final String PROCESS_CONTROLLER_BIND_ADDR = "--pc-address";
@@ -141,7 +145,6 @@ public class CommandLineConstants {
     public static final String SHORT_HOST = "-H";
     public static final String HOST = "--host";
     public static final String CONNECTION_PROPERTIES = "--ejb-client-properties";
-
 
     private CommandLineConstants() {
     }

--- a/server/src/main/java/org/jboss/as/server/Bootstrap.java
+++ b/server/src/main/java/org/jboss/as/server/Bootstrap.java
@@ -215,10 +215,9 @@ public interface Bootstrap {
                                     runningModeControl.isReloaded());
                         } else {
                            if(configurationFile.getInteractionPolicy().isReadOnly() || (serverEnvironment.isStandalone() && serverEnvironment.isXMLHistoryDisabled() )){
-                           //We reset boot file to choose original one.
-                               configurationFile.resetBootFile(false, null);
+                           //We use original configurationFile. instead of bootFile resolved by 'ConfigurationFile'
                            //And never supressLoad (last false) to allow :reload to work
-                               persister = new XmlConfigurationPersister(configurationFile.getBootFile(), rootElement, parser, parser,false);
+                               persister = new XmlConfigurationPersister(configurationFile.getMainFile(), rootElement, parser, parser,false);
                            }else {
                                 persister = new BackupXmlConfigurationPersister(configurationFile, rootElement, parser, parser,
                                     runningModeControl.isReloaded(), serverEnvironment.getLaunchType() == ServerEnvironment.LaunchType.EMBEDDED);

--- a/server/src/main/java/org/jboss/as/server/Bootstrap.java
+++ b/server/src/main/java/org/jboss/as/server/Bootstrap.java
@@ -214,8 +214,15 @@ public interface Bootstrap {
                             persister = new GitConfigurationPersister(serverEnvironment.getGitRepository(), configurationFile, rootElement, parser, parser,
                                     runningModeControl.isReloaded());
                         } else {
-                            persister = new BackupXmlConfigurationPersister(configurationFile, rootElement, parser, parser,
+                           if(configurationFile.getInteractionPolicy().isReadOnly() || (serverEnvironment.isStandalone() && serverEnvironment.isXMLHistoryDisabled() )){
+                           //We reset boot file to choose original one.
+                               configurationFile.resetBootFile(false, null);
+                           //And never supressLoad (last false) to allow :reload to work
+                               persister = new XmlConfigurationPersister(configurationFile.getBootFile(), rootElement, parser, parser,false);
+                           }else {
+                                persister = new BackupXmlConfigurationPersister(configurationFile, rootElement, parser, parser,
                                     runningModeControl.isReloaded(), serverEnvironment.getLaunchType() == ServerEnvironment.LaunchType.EMBEDDED);
+                            }
                         }
                         for (Namespace namespace : Namespace.domainValues()) {
                             if (!namespace.equals(Namespace.CURRENT)) {

--- a/server/src/main/java/org/jboss/as/server/Main.java
+++ b/server/src/main/java/org/jboss/as/server/Main.java
@@ -153,6 +153,7 @@ public final class Main {
         boolean startSuspended = false;
         boolean removeConfig = false;
         boolean startModeSet = false;
+        boolean disableXMLHistory = false;
         for (int i = 0; i < argsLength; i++) {
             final String arg = args[i];
             try {
@@ -187,6 +188,8 @@ public final class Main {
                         return new ServerEnvironmentWrapper (ServerEnvironmentWrapper.ServerEnvironmentStatus.ERROR);
                     }
                     configInteractionPolicy = ConfigurationFile.InteractionPolicy.READ_ONLY;
+                } else if (arg.equals(CommandLineConstants.DISABLE_XML_HISTORY)) {
+                    disableXMLHistory = true;
                 } else if (arg.startsWith(CommandLineConstants.OLD_SERVER_CONFIG)) {
                     serverConfig = parseValue(arg, CommandLineConstants.OLD_SERVER_CONFIG);
                     if (serverConfig == null) {
@@ -387,7 +390,7 @@ public final class Main {
         productConfig = ProductConfig.fromFilesystemSlot(Module.getBootModuleLoader(), WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.HOME_DIR, null), systemProperties);
         return new ServerEnvironmentWrapper(new ServerEnvironment(hostControllerName, systemProperties, systemEnvironment,
                 serverConfig, configInteractionPolicy, launchType, runningMode, productConfig, startTime, startSuspended,
-                gitRepository, gitBranch, gitAuthConfiguration));
+                gitRepository, gitBranch, gitAuthConfiguration,disableXMLHistory));
     }
 
     private static void assertSingleConfig(String serverConfig) {

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -321,6 +321,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
 
     private final boolean standalone;
     private final boolean allowModelControllerExecutor;
+    private final boolean disableXMLHistory;
     private final RunningMode initialRunningMode;
     private final ProductConfig productConfig;
     private final RunningModeControl runningModeControl;
@@ -333,28 +334,29 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
                              final RunningMode initialRunningMode, ProductConfig productConfig, boolean startSuspended) {
         this(hostControllerName, props, env, serverConfig, configInteractionPolicy, launchType, initialRunningMode, productConfig,
-                System.currentTimeMillis(), startSuspended, null, null, null);
+                System.currentTimeMillis(), startSuspended, null, null, null,false);
     }
 
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
                              final RunningMode initialRunningMode, ProductConfig productConfig) {
         this(hostControllerName, props, env, serverConfig, configInteractionPolicy, launchType, initialRunningMode, productConfig,
-                System.currentTimeMillis(), false, null, null, null);
+                System.currentTimeMillis(), false, null, null, null,false);
     }
 
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
                              final RunningMode initialRunningMode, ProductConfig productConfig, long startTime, String gitRepository, String gitBranch, String gitAuthConfiguration) {
         this(hostControllerName, props, env, serverConfig, configInteractionPolicy, launchType, initialRunningMode, productConfig,
-                startTime, false, gitRepository, gitBranch, gitAuthConfiguration);
+                startTime, false, gitRepository, gitBranch, gitAuthConfiguration,false);
     }
 
     public ServerEnvironment(final String hostControllerName, final Properties props, final Map<String, String> env, final String serverConfig,
                              final ConfigurationFile.InteractionPolicy configInteractionPolicy, final LaunchType launchType,
                              final RunningMode initialRunningMode, ProductConfig productConfig, long startTime, boolean startSuspended,
-                             String gitRepository, String gitBranch, String gitAuthConfiguration) {
+                             String gitRepository, String gitBranch, String gitAuthConfiguration, boolean disableXMLHistory) {
         this.startSuspended = startSuspended;
+        this.disableXMLHistory = disableXMLHistory;
         assert props != null;
 
         this.launchType = launchType;
@@ -981,6 +983,10 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
      */
     public boolean isStartSuspended() {
         return startSuspended;
+    }
+
+    public boolean isXMLHistoryDisabled() {
+        return disableXMLHistory;
     }
 
     private File configureServerTempDir(String path, Properties providedProps) {

--- a/server/src/main/java/org/jboss/as/server/ServerStartTask.java
+++ b/server/src/main/java/org/jboss/as/server/ServerStartTask.java
@@ -131,7 +131,7 @@ public final class ServerStartTask implements ServerTask, Serializable, ObjectIn
         // Create server environment on the server, so that the system properties are getting initialized on the right side
         final ServerEnvironment providedEnvironment = new ServerEnvironment(hostControllerName, properties,
                 WildFlySecurityManager.getSystemEnvironmentPrivileged(), null, null, ServerEnvironment.LaunchType.DOMAIN,
-                RunningMode.NORMAL, productConfig, Module.getStartTime(), suspend, null, null, null);
+                RunningMode.NORMAL, productConfig, Module.getStartTime(), suspend, null, null, null,false);
         DomainServerCommunicationServices.updateOperationID(initialOperationID);
 
         // TODO perhaps have ConfigurationPersisterFactory as a Service


### PR DESCRIPTION
--disable-configuration-history
to do not use backup logic in 'standalone_xml_history'. Useful for using inside immutable containers. Applied by default when Standalone server configuration is in read only mode.
https://issues.jboss.org/browse/WFCORE-4135