### PR TITLE
[WFCORE-4109] Bump the domain management version to 9.0

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/resources/HostExcludeResourceDefinition.java
@@ -65,7 +65,9 @@ public class HostExcludeResourceDefinition extends SimpleResourceDefinition {
         WILDFLY10_1("WildFly10.1", 4, 2),
         WILDFLY11("WildFly11.0", 5, 0),
         WILDFLY12("WildFly12.0", 6, 0),
-        WILDFLY13("WildFly13.0", 7, 0);
+        WILDFLY13("WildFly13.0", 7, 0),
+        WILDFLY14("WildFly14.0", 8, 0);
+
 
         private static final Map<String, KnownRelease> map = new HashMap<>();
         static {


### PR DESCRIPTION
* add WILDFLY14 to the HostExcludeResourceDefinition.KnownRelease enum
  that corresponds to the WildFly14.0 value added to host-release XML
  definition.

JIRA: https://issues.jboss.org/browse/WFCORE-4109