### PR TITLE
[WFCORE-4145] Add a note about --admin-only being deprecated in favor…

### DIFF
--- a/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/logging/ServerLogger.java
@@ -545,7 +545,7 @@ public interface ServerLogger extends BasicLogger {
      *
      * @return the message.
      */
-    @Message(id = Message.NONE, value = "Set the server's running type to ADMIN_ONLY causing it to open administrative interfaces and accept management requests but not start other runtime services or accept end user requests. Cannot be used in conjunction with --start-mode.")
+    @Message(id = Message.NONE, value = "Set the server's running type to ADMIN_ONLY causing it to open administrative interfaces and accept management requests but not start other runtime services or accept end user requests. Cannot be used in conjunction with --start-mode. Deprecated; use --start-mode=admin-only instead.")
     String argAdminOnly();
 
     /**


### PR DESCRIPTION
… of --start-mode=admin-only to the help output.

https://issues.jboss.org/browse/WFCORE-4145

Note this is a kind of minimal note that this might change in the future; see the comment I''ll file on the JIRA in a minute.