### PR TITLE
[WFCORE-4151] Upgrade jboss-logmanager from 2.1.4.Final to 2.1.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
         <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
-        <version.org.jboss.logmanager.jboss-logmanager>2.1.4.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.org.jboss.logmanager.jboss-logmanager>2.1.5.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.1.6.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>2.0.6.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.modules.jboss-modules>1.8.6.Final</version.org.jboss.modules.jboss-modules>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFCORE-4151

<h1>Release Notes for JBoss Log Manager</h1>

<h3>Version 2.1.5.Final</h3>
<hr />

<h2>Bug</h2>
<ul>
  <li>[ <a href="https://issues.jboss.org/browse/LOGMGR-200">LOGMGR-200</a> ] SSLProtocolException: Connection reset on JDK11</li>
  <li>[ <a href="https://issues.jboss.org/browse/LOGMGR-201">LOGMGR-201</a> ] SysLogHandler doesn't log null or empty message</li>
  <li>[ <a href="https://issues.jboss.org/browse/LOGMGR-202">LOGMGR-202</a> ] Some fields are not copied by the copy constructor of ExtLogRecord</li>
  <li>[ <a href="https://issues.jboss.org/browse/LOGMGR-203">LOGMGR-203</a> ] LogManager stops any logging output after changing "encoding" attribute to file-handler</li>
  <li>[ <a href="https://issues.jboss.org/browse/LOGMGR-204">LOGMGR-204</a> ] Short host name format yields last part of name instead of first part</li>
  <li>[ <a href="https://issues.jboss.org/browse/LOGMGR-206">LOGMGR-206</a> ] Qualified host name should use right based precision instead of left</li>
</ul>
