### PR TITLE
[WFCORE-4156] Add missing KernelAPIVersion for WildFly 14

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -73,7 +73,7 @@ public class DomainTransformers {
     public static void initializeDomainRegistry(final TransformerRegistry registry) {
 
         //The chains for transforming will be as follows
-        //For JBoss EAP: 5.0.0 -> 4.0.0 -> 1.8.0 -> 1.7.0 -> 1.6.0 -> 1.5.0
+        //For JBoss EAP: 8.0.0 -> 5.0.0 -> 4.0.0 -> 1.8.0 -> 1.7.0 -> 1.6.0 -> 1.5.0
 
         registerRootTransformers(registry);
         registerChainedManagementTransformers(registry);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/KernelAPIVersion.java
@@ -28,8 +28,12 @@ import org.jboss.as.version.Version;
  *
  * @author Brian Stansberry
  */
-enum KernelAPIVersion {
+public enum KernelAPIVersion {
 
+    // EAP 6.2.0
+    VERSION_1_5(1, 5, 0),
+    // EAP 6.3.0
+    VERSION_1_6(1, 6, 0),
     // EAP 6.4.0
     VERSION_1_7(1, 7, 0),
     // EAP 6.4.0 CP07
@@ -42,12 +46,18 @@ enum KernelAPIVersion {
     VERSION_3_0(3, 0, 0),
     //WF 10.0.0
     VERSION_4_0(4, 0, 0),
-    // WildFly 10.1.0, EAP 7.0.0
+    // EAP 7.0.0
     VERSION_4_1(4, 1, 0),
+    // WildFly 10.1.0
+    VERSION_4_2(4, 2, 0),
     // WF 11.0.0, EAP 7.1.0
     VERSION_5_0(5, 0, 0),
     // WF 12.0.0
     VERSION_6_0(6, 0, 0),
+    // WF 13.0.0
+    VERSION_7_0(7, 0, 0),
+    // WF 14.0.0
+    VERSION_8_0(8, 0, 0),
     // Latest
     CURRENT(Version.MANAGEMENT_MAJOR_VERSION, Version.MANAGEMENT_MINOR_VERSION, Version.MANAGEMENT_MICRO_VERSION);
 
@@ -55,6 +65,10 @@ enum KernelAPIVersion {
 
     KernelAPIVersion(int major, int minor, int micro) {
         this.modelVersion = ModelVersion.create(major, minor, micro);
+    }
+
+    public ModelVersion getModelVersion() {
+        return modelVersion;
     }
 
     static ChainedTransformationDescriptionBuilder createChainFromCurrent(PathElement forPath) {


### PR DESCRIPTION
* Add missing VERSION_7 and VERSION_8 to KernelAPIVersion so that domain transformers are
  properly setup for WildFly 13 & 14.
* Use KernelAPIVersion in KnownRelease enum instead of ints so that
  KernelAPIVersion is the only authoritative sources of Kernel versions.
* Fix inconsistency in KernelAPIVersion that was listing VERSION_4_1 for
  WildFly 10.1 while the correct version was VERSION_4_2 (info in
  KnownRelease was correct).

JIRA: https://issues.jboss.org/browse/WFCORE-4156