### PR TITLE
[WFCORE-3952] Do not bother with host controllers in standalone module

### DIFF
--- a/testsuite/standalone/enable-elytron.cli
+++ b/testsuite/standalone/enable-elytron.cli
@@ -1,0 +1,12 @@
+embed-server --server-config=standalone.xml
+
+/core-service=management/access=identity:add(security-domain=ManagementDomain)
+/core-service=management/management-interface=http-interface:write-attribute(name=http-upgrade,value={enabled=true, sasl-authentication-factory=management-sasl-authentication})
+/core-service=management/management-interface=http-interface:write-attribute(name=http-authentication-factory,value=management-http-authentication)
+/core-service=management/management-interface=http-interface:undefine-attribute(name=security-realm)
+/core-service=management/security-realm=ManagementRealm:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=local:remove
+/core-service=management/security-realm=ApplicationRealm/authentication=properties:remove
+/core-service=management/security-realm=ApplicationRealm/authorization=properties:remove
+
+stop-embedded-server

--- a/testsuite/standalone/pom.xml
+++ b/testsuite/standalone/pom.xml
@@ -28,7 +28,7 @@
         <jbossas.project.dir>${jbossas.ts.dir}</jbossas.project.dir>
         <wildfly.home>${project.basedir}/target/wildfly-core</wildfly.home>
 
-        <ts.elytron.cli>../shared/enable-elytron.cli</ts.elytron.cli>
+        <ts.elytron.cli>enable-elytron.cli</ts.elytron.cli>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Upstream: https://issues.jboss.org/browse/WFCORE-3952

standalone/enable-elytron.cli is copied from shared/enable-elytron.cli but without domain part.

This reveales test fails, which rely on default configuration. Set of WFCORE issues should be created to fix this test cases. Later in future, once legacy security will be removed, they will have to be fixed anyway.

So far, these tests were identified
```
testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/CLIAuthenticationTestCase.java
testsuite/manualmode/src/test/java/org/jboss/as/test/manualmode/vault/VaultPasswordsInCLITestCase.java
testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSConnectionWithCLITestCase.java
testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/HTTPSManagementInterfaceTestCase.java
testsuite/manualmode/src/test/java/org/wildfly/core/test/standalone/mgmt/RemoveManagementInterfaceTestCase.java
testsuite/standalone/src/test/java/org/jboss/as/test/integration/credential/store/ManagementAuthenticationUsersTestCase.java
testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/ReloadSASLFactoryTestCase.java
testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityAuthCommandsTestCase.java
testsuite/standalone/src/test/java/org/jboss/as/test/integration/management/cli/SecurityCommandsTestCase.java
testsuite/standalone/src/test/java/org/wildfly/core/test/standalone/mgmt/api/core/ReadConfigAsFeaturesStandaloneTestCase.java
```