### PR TITLE
[WFCORE-3039] Capability requirement can be lost if two attributes on same resource reference the same capability

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/CapabilityReferenceRecorder.java
+++ b/controller/src/main/java/org/jboss/as/controller/CapabilityReferenceRecorder.java
@@ -199,7 +199,7 @@ public interface CapabilityReferenceRecorder {
                 if (attributeValue != null) {
                     String requirementName = getRequirementName(context, resource, attributeValue);
                     if (remove) {
-                        context.deregisterCapabilityRequirement(requirementName, dependentName);
+                        context.deregisterCapabilityRequirement(requirementName, dependentName, attributeName);
                     } else {
                         context.registerAdditionalCapabilityRequirement(requirementName, dependentName, attributeName);
                     }
@@ -354,7 +354,7 @@ public interface CapabilityReferenceRecorder {
             String dependentName = getDependentName(context.getCurrentAddress());
             String requirementName = getRequirementName(context.getCurrentAddress());
             if (remove) {
-                context.deregisterCapabilityRequirement(requirementName, dependentName);
+                context.deregisterCapabilityRequirement(requirementName, dependentName, attributeName);
             } else {
                 context.registerAdditionalCapabilityRequirement(requirementName, dependentName, attributeName);
             }

--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -938,6 +938,27 @@ public interface OperationContext extends ExpressionResolver {
     void deregisterCapabilityRequirement(String required, String dependent);
 
     /**
+     * Record that a previously registered requirement for a capability will no longer exist.
+     * <p>
+     * <strong>Semantics with "reload-required" and "restart-required":</strong>
+     * Deregistering a capability requirement does not obligate the caller to cease using a
+     * {@link #getCapabilityRuntimeAPI(String, Class) previously obtained} reference to that
+     * capability's {@link org.jboss.as.controller.capability.RuntimeCapability#getRuntimeAPI() runtime API}. But, if
+     * the caller will not cease using the capability, it must put the process in {@link #reloadRequired() reload-required}
+     * or {@link #restartRequired() restart-required} state. This will reflect the fact that the model says the
+     * capability is not required, but in the runtime it still is.
+     * </p>
+     *
+     * @param required  the name of the no longer required capability
+     * @param dependent the name of the capability that no longer has the requirement
+     * @param attribute the name of the attribute that references to the no longer required capability, or {@code null}
+     *                  if there is if no single attribute referring to the required capability.
+     *
+     * @throws java.lang.IllegalStateException if {@link #getCurrentStage() the current stage} is not {@link Stage#MODEL}
+     */
+    void deregisterCapabilityRequirement(String required, String dependent, String attribute);
+
+    /**
      * Record that a previously registered capability will no longer be available. Invoking this operation will also
      * automatically {@link #deregisterCapabilityRequirement(String, String) deregister any requirements} that are
      * associated with this capability, including optional ones.

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -1584,14 +1584,19 @@ final class OperationContextImpl extends AbstractOperationContext {
 
     @Override
     public void deregisterCapabilityRequirement(String required, String dependent) {
-        removeCapabilityRequirement(required, dependent, activeStep);
+        deregisterCapabilityRequirement(required, dependent, null);
     }
 
-    void removeCapabilityRequirement(String required, String dependent, Step step) {
+    @Override
+    public void deregisterCapabilityRequirement(String required, String dependent, String attribute) {
+        removeCapabilityRequirement(required, dependent, activeStep, attribute);
+    }
+
+    void removeCapabilityRequirement(String required, String dependent, Step step, String attributeName) {
         assert isControllingThread();
         assertStageModel(currentStage);
         ensureLocalCapabilityRegistry();
-        RuntimeRequirementRegistration registration = createRequirementRegistration(required, dependent, false, step, null);
+        RuntimeRequirementRegistration registration = createRequirementRegistration(required, dependent, false, step, attributeName);
         managementModel.getCapabilityRegistry().removeCapabilityRequirement(registration);
         removeRequirement(required, registration.getDependentContext(), step);
     }

--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
@@ -369,8 +369,13 @@ class ParallelBootOperationContext extends AbstractOperationContext {
 
     @Override
     public void deregisterCapabilityRequirement(String required, String dependent) {
+        deregisterCapabilityRequirement(required, dependent, null);
+    }
+
+    @Override
+    public void deregisterCapabilityRequirement(String required, String dependent, String attribute) {
         // pass in the step we are executing so it can be failed if there is problem resolving capabilities/requirements
-        primaryContext.removeCapabilityRequirement(required, dependent, activeStep);
+        primaryContext.removeCapabilityRequirement(required, dependent, activeStep, attribute);
     }
 
     @Override

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -395,6 +395,11 @@ class ReadOnlyContext extends AbstractOperationContext {
 
     @Override
     public void deregisterCapabilityRequirement(String required, String dependent) {
+        deregisterCapabilityRequirement(required, dependent, null);
+    }
+
+    @Override
+    public void deregisterCapabilityRequirement(String required, String dependent, String attribute) {
         throw readOnlyContext();
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/capability/registry/RegistrationPoint.java
+++ b/controller/src/main/java/org/jboss/as/controller/capability/registry/RegistrationPoint.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.controller.capability.registry;
 
+import java.util.Objects;
+
 import org.jboss.as.controller.PathAddress;
 
 /**
@@ -66,5 +68,19 @@ public class RegistrationPoint {
         } else {
             return "address=" + address.toString() +";attribute=" + attribute;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RegistrationPoint that = (RegistrationPoint) o;
+        return Objects.equals(address, that.address) &&
+                Objects.equals(attribute, that.attribute);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(address, attribute);
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/access/management/AuthorizedAddressTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/management/AuthorizedAddressTest.java
@@ -542,6 +542,11 @@ public class AuthorizedAddressTest {
 
         @Override
         public void deregisterCapabilityRequirement(String required, String dependent) {
+            deregisterCapabilityRequirement(required, dependent, null);
+        }
+
+        @Override
+        public void deregisterCapabilityRequirement(String required, String dependent, String attribute) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 

--- a/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
+++ b/elytron/src/test/java/org/wildfly/extension/elytron/SubsystemParsingTestCase.java
@@ -614,6 +614,11 @@ public class SubsystemParsingTestCase extends AbstractSubsystemBaseTest {
 
             @Override
             public void deregisterCapabilityRequirement(String required, String dependent) {
+                deregisterCapabilityRequirement(required, dependent, null);
+            }
+
+            @Override
+            public void deregisterCapabilityRequirement(String required, String dependent, String attribute) {
                 throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
             }
 

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -650,6 +650,11 @@ public abstract class AbstractOperationTestCase {
 
         @Override
         public void deregisterCapabilityRequirement(String required, String dependent) {
+            deregisterCapabilityRequirement(required, dependent, null);
+        }
+
+        @Override
+        public void deregisterCapabilityRequirement(String required, String dependent, String attribute) {
             // no-op;
         }
 

--- a/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorResource.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/RemotingConnectorResource.java
@@ -79,7 +79,9 @@ public class RemotingConnectorResource extends SimpleResourceDefinition {
                                 REMOTE_JMX_CAPABILITY.getName(),
                                 USE_MANAGEMENT_ENDPOINT.getName());
                     } else {
-                        context.deregisterCapabilityRequirement(REMOTING_CAPABILITY, REMOTE_JMX_CAPABILITY.getName());
+                        context.deregisterCapabilityRequirement(REMOTING_CAPABILITY,
+                                REMOTE_JMX_CAPABILITY.getName(),
+                                USE_MANAGEMENT_ENDPOINT.getName());
                     }
                 }
             }

--- a/logging/src/main/java/org/jboss/as/logging/capabilities/LoggingProfileCapabilityRecorder.java
+++ b/logging/src/main/java/org/jboss/as/logging/capabilities/LoggingProfileCapabilityRecorder.java
@@ -59,7 +59,7 @@ class LoggingProfileCapabilityRecorder implements CapabilityReferenceRecorder {
         String dependentName = getDependentName(context);
         for (String value : attributeValues) {
             if (value != null) {
-                context.deregisterCapabilityRequirement(getRequirementName(context, value), dependentName);
+                context.deregisterCapabilityRequirement(getRequirementName(context, value), dependentName, attributeName);
             }
         }
     }


### PR DESCRIPTION
This patch adds the possibility to deregister an attribute reference capability for a specific attribute. Before this it was not possible, so undefine an attribute reference capability completely removes the capability from the resource, even if there were other attributes referring to it.

Jira issue: https://issues.jboss.org/browse/WFCORE-3039