### PR TITLE
[WFCORE-4164] Add fixed requirements to the read-feature-description output

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -345,10 +345,12 @@ public abstract class AbstractControllerService implements Service<ModelControll
         if (isExposingClientServicesAllowed()) {
             capabilityRegistry.registerCapability(
                     new RuntimeCapabilityRegistration(CLIENT_FACTORY_CAPABILITY, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
-            capabilityRegistry.registerPossibleCapability(CLIENT_FACTORY_CAPABILITY, PathAddress.EMPTY_ADDRESS);
             capabilityRegistry.registerCapability(
                     new RuntimeCapabilityRegistration(NOTIFICATION_REGISTRY_CAPABILITY, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
-            capabilityRegistry.registerPossibleCapability(NOTIFICATION_REGISTRY_CAPABILITY, PathAddress.EMPTY_ADDRESS);
+            // Record the core capabilities with the root MRR so reads of it will show it as their provider
+            // This also gets them recorded as 'possible capabilities' in the capability registry
+            rootResourceRegistration.registerCapability(CLIENT_FACTORY_CAPABILITY);
+            rootResourceRegistration.registerCapability(NOTIFICATION_REGISTRY_CAPABILITY);
             ModelControllerClientFactory clientFactory = new ModelControllerClientFactoryImpl(controller, securityIdentitySupplier);
             target.addService(CLIENT_FACTORY_CAPABILITY.getCapabilityServiceName(),
                     new ValueService<ModelControllerClientFactory>(new ImmediateValue<ModelControllerClientFactory>(clientFactory)))

--- a/controller/src/test/java/org/jboss/as/controller/test/ReadFeatureDescriptionTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/ReadFeatureDescriptionTestCase.java
@@ -91,6 +91,8 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
     private static final String MAIN_RESOURCE_PACKAGE_NAME = "main-resource-package";
     private static final String ROOT_CAPABILITY_NAME = "root-capability";
     private static final String DYNAMIC_CAPABILITY_NAME = "dynamic-capability";
+    private static final String CLIENT_FACTORY_CAPABILITY_NAME = "org.wildfly.management.model-controller-client-factory";
+    private static final String NOTIFICATION_REGISTRY_CAPABILITY_NAME = "org.wildfly.management.notification-handler-registry";
 
     private static final OperationStepHandler WRITE_HANDLER = new ModelOnlyWriteAttributeHandler();
 
@@ -378,13 +380,15 @@ public class ReadFeatureDescriptionTestCase extends AbstractControllerTestBase {
 
         // capabilities
         ModelNode provides = feature.require(PROVIDES);
-        Assert.assertEquals(2, provides.asList().size());
-        Set<String> providedCaps = new HashSet<>(2);
+        Assert.assertEquals(4, provides.asList().size());
+        Set<String> providedCaps = new HashSet<>(4);
         for(ModelNode providedCap : provides.asList()) {
             providedCaps.add(providedCap.asString());
         }
         Assert.assertTrue(providedCaps.contains(ROOT_CAPABILITY_NAME));
         Assert.assertTrue(providedCaps.contains(DYNAMIC_CAPABILITY_NAME));
+        Assert.assertTrue(providedCaps.contains(CLIENT_FACTORY_CAPABILITY_NAME));
+        Assert.assertTrue(providedCaps.contains(NOTIFICATION_REGISTRY_CAPABILITY_NAME));
     }
 
     /**

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -60,7 +60,6 @@ import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorize
 import org.jboss.as.controller.access.management.ManagementSecurityIdentitySupplier;
 import org.jboss.as.controller.audit.ManagedAuditLogger;
 import org.jboss.as.controller.capability.registry.CapabilityScope;
-import org.jboss.as.controller.capability.registry.PossibleCapabilityRegistry;
 import org.jboss.as.controller.capability.registry.RegistrationPoint;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
@@ -69,6 +68,7 @@ import org.jboss.as.controller.notification.Notification;
 import org.jboss.as.controller.notification.NotificationHandlerRegistry;
 import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
 import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.PlaceholderResource;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.PathManager;
@@ -458,12 +458,11 @@ public final class ServerService extends AbstractControllerService {
         capabilityRegistry.registerCapability(
                 new RuntimeCapabilityRegistration(EXECUTOR_CAPABILITY, CapabilityScope.GLOBAL, new RegistrationPoint(PathAddress.EMPTY_ADDRESS, null)));
 
-        // TODO consider having ManagementModel provide CapabilityRegistry instead of just RuntimeCapabilityRegistry
-        if (capabilityRegistry instanceof PossibleCapabilityRegistry) {
-            ((PossibleCapabilityRegistry) capabilityRegistry).registerPossibleCapability(PATH_MANAGER_CAPABILITY, PathAddress.EMPTY_ADDRESS);
-            ((PossibleCapabilityRegistry) capabilityRegistry).registerPossibleCapability(EXECUTOR_CAPABILITY, PathAddress.EMPTY_ADDRESS);
-        }
-
+        // Record the core capabilities with the root MRR so reads of it will show it as their provider
+        // This also gets them recorded as 'possible capabilities' in the capability registry
+        ManagementResourceRegistration rootRegistration = managementModel.getRootResourceRegistration();
+        rootRegistration.registerCapability(PATH_MANAGER_CAPABILITY);
+        rootRegistration.registerCapability(EXECUTOR_CAPABILITY);
     }
 
     @Override


### PR DESCRIPTION
Also, register the core capabilities with the root MRR so Galleon will know they are provided when it sees requirements for them.

https://issues.jboss.org/browse/WFCORE-4164